### PR TITLE
DSP-20634 Enabled composite partition key indexing for SAI.

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -278,11 +278,6 @@ public class StorageAttachedIndex implements Index
             throw new InvalidRequestException("Complex columns are not yet supported by storage-attached indexes.");
         }
 
-        if (target.left.isPartitionKey())
-        {
-            throw new InvalidRequestException("Partition key columns are not yet supported by storage-attached indexes.");
-        }
-
         if (!SUPPORTED_TYPES.contains(target.left.cellValueType().asCQL3Type()))
         {
             throw new InvalidRequestException("Unsupported type: " + target.left.cellValueType().asCQL3Type());

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableIndexWriter.java
@@ -86,7 +86,7 @@ public class SSTableIndexWriter implements ColumnIndexWriter
         if (maybeAbort())
             return;
 
-        ByteBuffer value = ColumnContext.getValueOf(column, row, nowInSec);
+        ByteBuffer value = context.getValueOf(column, rowKey, row, nowInSec);
         if (value != null)
         {
             if (currentBuilder == null)
@@ -187,7 +187,7 @@ public class SSTableIndexWriter implements ColumnIndexWriter
             }
 
             // Builder memory is released against the limiter at the conclusion of a successful
-            // flush. Note that any failure that occurs before this (even in term addition) will 
+            // flush. Note that any failure that occurs before this (even in term addition) will
             // actuate this column writer's abort logic from the parent SSTable-level writer, and
             // that abort logic will release the current builder's memory against the limiter.
             long globalBytesUsed = currentBuilder.release(indexComponents);
@@ -257,7 +257,7 @@ public class SSTableIndexWriter implements ColumnIndexWriter
         // It's possible for the current builder to be unassigned after we flush a final segment.
         if (currentBuilder != null)
         {
-            // If an exception is thrown out of any writer operation prior to successful segment 
+            // If an exception is thrown out of any writer operation prior to successful segment
             // flush, we will end up here, and we need to free up builder memory tracked by the limiter:
             long allocated = currentBuilder.totalBytesAllocated();
             long globalBytesUsed = currentBuilder.release(indexComponents);

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
@@ -77,9 +78,9 @@ public class Operation extends RangeIterator
         this.controller = controller;
     }
 
-    public boolean satisfiedBy(Unfiltered currentCluster, Row staticRow, boolean allowMissingColumns)
+    public boolean satisfiedBy(DecoratedKey key, Unfiltered currentCluster, Row staticRow, boolean allowMissingColumns)
     {
-        return filterTree.satisfiedBy(currentCluster, staticRow, allowMissingColumns);
+        return filterTree.satisfiedBy(key, currentCluster, staticRow, allowMissingColumns);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -97,10 +97,10 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
 
         /*
          * postIndexFilter comprised by those expressions in the read command row filter that can't be handled by
-         * {@link FilterTree#satisfiedBy(Unfiltered, Row, boolean)}. That includes expressions targeted to any partition
-         * key column, and {@link RowFilter.UserExpression}s like those used by RLAC.
+         * {@link FilterTree#satisfiedBy(Unfiltered, Row, boolean)}. That includes expressions targeted
+         * at {@link RowFilter.UserExpression}s like those used by RLAC.
          */
-        RowFilter postIndexFilter = rowFilter.with(e -> e.column().isPartitionKey() || e.isUserDefined());
+        RowFilter postIndexFilter = rowFilter.with(e -> e.isUserDefined());
         return new StorageAttachedIndexQueryPlan(cfs, queryMetrics, postIndexFilter, acceptedExpressions, selectedIndexes);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -167,14 +167,14 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 Unfiltered row = partition.next();
 
                 queryContext.rowsFiltered++;
-                if (tree.satisfiedBy(row, staticRow, true))
+                if (tree.satisfiedBy(partition.partitionKey(), row, staticRow, true))
                     clusters.add(row);
             }
 
             if (clusters.isEmpty())
             {
                 queryContext.rowsFiltered++;
-                if (tree.satisfiedBy(staticRow, staticRow, true))
+                if (tree.satisfiedBy(partition.partitionKey(), staticRow, staticRow, true))
                     clusters.add(staticRow);
             }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.index.cql;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CompositePartitionKeyIndexTest extends CQLTester
+{
+    @Before
+    public void createTableAndIndex()
+    {
+        requireNetwork();
+
+        createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, PRIMARY KEY((pk1, pk2)))");
+        createIndex("CREATE CUSTOM INDEX ON %s(pk1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(pk2) USING 'StorageAttachedIndex'");
+
+        disableCompaction();
+    }
+
+    private void insertData1() throws Throwable
+    {
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (1, '1', 1)");
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (2, '2', 2)");
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (3, '3', 3)");
+    }
+
+    private void insertData2() throws Throwable
+    {
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (4, '4', 4)");
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (5, '5', 5)");
+        execute("INSERT INTO %s (pk1, pk2, val) VALUES (6, '6', 6)");
+    }
+
+    @Test
+    public void queryFromMemtable() throws Throwable
+    {
+        insertData1();
+        insertData2();
+        runQueries();
+    }
+
+    @Test
+    public void queryFromSingleSSTable() throws Throwable
+    {
+        insertData1();
+        insertData2();
+        flush();
+        runQueries();
+    }
+
+    @Test
+    public void queryFromMultipleSSTables() throws Throwable
+    {
+        insertData1();
+        flush();
+        insertData2();
+        flush();
+        runQueries();
+    }
+
+    @Test
+    public void queryFromMemtableAndSSTables() throws Throwable
+    {
+        insertData1();
+        flush();
+        insertData2();
+        runQueries();
+    }
+
+    @Test
+    public void queryFromCompactedSSTable() throws Throwable
+    {
+        insertData1();
+        flush();
+        insertData2();
+        flush();
+        compact();
+        runQueries();
+    }
+
+    private Object[] expectedRow(int index) {
+        return row(index, Integer.toString(index), index);
+    }
+
+    private void runQueries() throws Throwable
+    {
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 = 2"),
+                expectedRow(2));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 > 1"),
+                expectedRow(2),
+                expectedRow(3),
+                expectedRow(4),
+                expectedRow(5),
+                expectedRow(6));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 >= 3"),
+                expectedRow(3),
+                expectedRow(4),
+                expectedRow(5),
+                expectedRow(6));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 < 3"),
+                expectedRow(1),
+                expectedRow(2));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 <= 3"),
+                expectedRow(1),
+                expectedRow(2),
+                expectedRow(3));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk2 = '2'"),
+                expectedRow(2));
+
+        //Note that this should eventually not require ALLOW FILTERING. Detection of filtering requirments for indexes
+        //is being handled separately in CASSANDRA-15913.
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 > 1 AND pk2 = '2' ALLOW FILTERING"),
+                expectedRow(2));
+
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 = -1 AND pk2 = '2'"));
+
+        assertThatThrownBy(()->execute("SELECT * FROM %s WHERE pk1 = -1 AND val = 2"))
+                .hasMessageContaining("use ALLOW FILTERING");
+
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
@@ -213,7 +213,7 @@ public interface DataModel
 
         public void createIndexes(SAITester tester) throws Throwable
         {
-            String template = "CREATE CUSTOM INDEX ndi_%s_index_%s ON %%s (%s) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'";
+            String template = "CREATE CUSTOM INDEX sai_%s_index_%s ON %%s (%s) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'";
 
             for (Pair<String, String> column : columns)
             {
@@ -447,6 +447,21 @@ public interface DataModel
             nonIndexedTable = tester.createTable(String.format(template, keyColumnDefs, normalColumnDefs, primaryKey));
         }
 
+        public void createIndexes(SAITester tester) throws Throwable
+        {
+            super.createIndexes(tester);
+            String template = "CREATE CUSTOM INDEX sai_%s_2i_index_%s ON %%s (%s) USING 'StorageAttachedIndex'";
+
+            for (Pair<String, String> column : keyColumns)
+            {
+                if (!skipColumns.contains(column.left))
+                {
+                    executeLocalIndexed(tester, String.format(template, column.left, indexedTable, column.left));
+                    tester.waitForCompactions();
+                }
+            }
+        }
+
         @Override
         public void insertRows(SAITester tester) throws Throwable
         {
@@ -465,8 +480,8 @@ public interface DataModel
             executeLocal(tester, String.format("UPDATE %%s SET %s = 27429638 WHERE p1 = 3 AND p2 = 0", INT_COLUMN));
             executeLocal(tester, String.format("UPDATE %%s SET %s = 31 WHERE p1 = 3 AND p2 = 1", SMALLINT_COLUMN));
             executeLocal(tester, String.format("UPDATE %%s SET %s = 116 WHERE p1 = 4 AND p2 = 0", TINYINT_COLUMN));
-            executeLocal(tester, String.format("UPDATE %%s SET %s = 'State of Michigan' WHERE p1 = 4 AND p2 = 1", TEXT_COLUMN));
-            executeLocal(tester, String.format("UPDATE %%s SET %s = '00:20:26' WHERE p1 = 5 AND p2 = 0", TIME_COLUMN));
+            executeLocal(tester, String.format("UPDATE %%s SET %s = 'State of Michigan' WHERE p1 = 4 AND p2 = 2", TEXT_COLUMN));
+            executeLocal(tester, String.format("UPDATE %%s SET %s = '00:20:26' WHERE p1 = 5 AND p2 = 3", TIME_COLUMN));
             executeLocal(tester, String.format("UPDATE %%s SET %s = '2009-07-16T00:00:00' WHERE p1 = 5 AND p2 = 1", TIMESTAMP_COLUMN));
             executeLocal(tester, String.format("UPDATE %%s SET %s = e37394dc-d17b-11e8-a8d5-f2801f1b9fd1 WHERE p1 = 6 AND p2 = 0", UUID_COLUMN));
             executeLocal(tester, String.format("UPDATE %%s SET %s = 1fc81a4c-d17d-11e8-a8d5-f2801f1b9fd1 WHERE p1 = 6 AND p2 = 1", TIMEUUID_COLUMN));

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -151,6 +151,15 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
+    public void shouldFailCreationOnPartitionKey() throws Exception
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+        assertThatThrownBy(() -> executeNet("CREATE CUSTOM INDEX ON %s(id) USING 'StorageAttachedIndex'"))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("Cannot create secondary index on the only partition key column id");
+    }
+
+    @Test
     public void shouldFailCreationUsingMode()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeQueryTest.java
@@ -26,7 +26,10 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
 
+import static org.apache.cassandra.index.sai.cql.DataModel.*;
 import org.apache.cassandra.inject.Injections;
+
+import com.google.common.collect.ImmutableList;
 
 public class SingleNodeQueryTest extends AbstractIndexQueryTest
 {
@@ -44,13 +47,17 @@ public class SingleNodeQueryTest extends AbstractIndexQueryTest
     {
         List<Object[]> scenarios = new LinkedList<>();
 
-        scenarios.add(new Object[]{ new DataModel.BaseDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA), BASE_QUERY_SETS });
+        scenarios.add(new Object[]{ new DataModel.BaseDataModel(NORMAL_COLUMNS, NORMAL_COLUMN_DATA), BASE_QUERY_SETS });
 
-        scenarios.add(new Object[]{ new DataModel.CompoundKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA), BASE_QUERY_SETS });
+        scenarios.add(new Object[]{ new DataModel.CompoundKeyDataModel(NORMAL_COLUMNS, NORMAL_COLUMN_DATA), BASE_QUERY_SETS });
 
-        scenarios.add(new Object[]{ new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA), STATIC_QUERY_SETS });
+        scenarios.add(new Object[]{ new DataModel.CompoundKeyWithStaticsDataModel(STATIC_COLUMNS, STATIC_COLUMN_DATA), STATIC_QUERY_SETS });
 
-        scenarios.add(new Object[]{ new DataModel.CompositePartitionKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA), BASE_QUERY_SETS });
+        scenarios.add(new Object[]{ new DataModel.CompositePartitionKeyDataModel(NORMAL_COLUMNS, NORMAL_COLUMN_DATA), ImmutableList.builder()
+                .addAll(BASE_QUERY_SETS)
+                .addAll(COMPOSITE_PARTITION_QUERY_SETS)
+                .build()
+        });
 
         return scenarios;
     }


### PR DESCRIPTION
All of the machinery was already present, changes were:
* Remove validation that prevented the creation of indexes.
* Add logic to allow extraction of partition key components if the key type is compound.