### PR TITLE
STAR-27: Implements inverse byte-ordered translation

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Tuples.java
+++ b/src/java/org/apache/cassandra/cql3/Tuples.java
@@ -154,14 +154,14 @@ public class Tuples
 
         public static Value fromSerialized(ByteBuffer bytes, TupleType type)
         {
-            ByteBuffer[] values = type.split(bytes);
+            ByteBuffer[] values = type.split(ByteBufferAccessor.instance, bytes);
             if (values.length > type.size())
             {
                 throw new InvalidRequestException(String.format(
                         "Tuple value contained too many fields (expected %s, got %s)", type.size(), values.length));
             }
 
-            return new Value(type.split(bytes));
+            return new Value(type.split(ByteBufferAccessor.instance, bytes));
         }
 
         public ByteBuffer get(ProtocolVersion protocolVersion)
@@ -272,7 +272,8 @@ public class Tuples
                 // type.split(bytes)
                 List<List<ByteBuffer>> elements = new ArrayList<>(l.size());
                 for (Object element : l)
-                    elements.add(Arrays.asList(tupleType.split(type.getElementsType().decompose(element))));
+                    elements.add(Arrays.asList(tupleType.split(ByteBufferAccessor.instance,
+                                                               type.getElementsType().decompose(element))));
                 return new InValue(elements);
             }
             catch (MarshalException e)

--- a/src/java/org/apache/cassandra/cql3/UserTypes.java
+++ b/src/java/org/apache/cassandra/cql3/UserTypes.java
@@ -217,7 +217,7 @@ public abstract class UserTypes
         public static Value fromSerialized(ByteBuffer bytes, UserType type)
         {
             type.validate(bytes);
-            return new Value(type, type.split(bytes));
+            return new Value(type, type.split(ByteBufferAccessor.instance, bytes));
         }
 
         public ByteBuffer get(ProtocolVersion protocolVersion)

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -612,10 +612,16 @@ public abstract class ColumnCondition
                 return cell == null ? null : cell.buffer();
             }
 
-            Cell<?> cell = getCell(row, column);
+            // getCell returns Cell<?>, which requires a method call to properly convert.
+            return getCellBuffer(getCell(row, column), userType);
+        }
+
+        private <V> ByteBuffer getCellBuffer(Cell<V> cell, UserType userType)
+        {
             return cell == null
                       ? null
-                      : userType.split(cell.buffer())[userType.fieldPosition(field)];
+                      : ByteBufferAccessor.instance.convert(userType.split(cell.accessor(), cell.value())[userType.fieldPosition(field)],
+                                                            cell.accessor());
         }
 
         private boolean isSatisfiedBy(ByteBuffer rowValue)

--- a/src/java/org/apache/cassandra/cql3/selection/FieldSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/FieldSelector.java
@@ -23,6 +23,7 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -89,7 +90,7 @@ final class FieldSelector extends Selector
         ByteBuffer value = selected.getOutput(protocolVersion);
         if (value == null)
             return null;
-        ByteBuffer[] buffers = type.split(value);
+        ByteBuffer[] buffers = type.split(ByteBufferAccessor.instance, value);
         return field < buffers.length ? buffers[field] : null;
     }
 

--- a/src/java/org/apache/cassandra/db/BufferDecoratedKey.java
+++ b/src/java/org/apache/cassandra/db/BufferDecoratedKey.java
@@ -19,7 +19,9 @@ package org.apache.cassandra.db;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 public class BufferDecoratedKey extends DecoratedKey
 {
@@ -35,5 +37,29 @@ public class BufferDecoratedKey extends DecoratedKey
     public ByteBuffer getKey()
     {
         return key;
+    }
+
+    /**
+     * A factory method that translates the given byte-comparable representation to a {@link BufferDecoratedKey}
+     * instance. If the given byte comparable doesn't represent the encoding of a buffer decorated key, anything from a
+     * wide variety of throwables may be thrown (e.g. {@link AssertionError}, {@link IndexOutOfBoundsException},
+     * {@link IllegalStateException}, etc.).
+     *
+     * @param byteComparable A byte-comparable representation (presumably of a {@link BufferDecoratedKey} instance).
+     * @param version The encoding version used for the given byte comparable.
+     * @param partitioner The partitioner of the encoded decorated key. Needed in order to correctly decode the token
+     *                    bytes of the key.
+     * @return A new {@link BufferDecoratedKey} instance, corresponding to the given byte-comparable representation. If
+     * we were to call {@link #asComparableBytes(Version)} on the returned object, we should get a {@link ByteSource}
+     * equal to the one of the input byte comparable.
+     */
+    public static BufferDecoratedKey fromByteComparable(ByteComparable byteComparable,
+                                                        Version version,
+                                                        IPartitioner partitioner)
+    {
+        return DecoratedKey.fromByteComparable(byteComparable,
+                                               version,
+                                               partitioner,
+                                               (token, keyBytes) -> new BufferDecoratedKey(token, ByteBuffer.wrap(keyBytes)));
     }
 }

--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -35,8 +35,8 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable.Version;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 /**
  * A clustering prefix is the unit of what a {@link ClusteringComparator} can compare.
@@ -70,7 +70,7 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
         EXCL_END_INCL_START_BOUNDARY(0, -1, v -> ByteSource.LT_NEXT_COMPONENT),
         STATIC_CLUSTERING           (1, -1, v -> v == Version.LEGACY
                                                  ? ByteSource.LT_NEXT_COMPONENT + 1
-                                                 : ByteSource.TERMINATOR - 1),
+                                                 : ByteSource.EXCLUDED),
         CLUSTERING                  (2,  0, v -> v == Version.LEGACY
                                                  ? ByteSource.NEXT_COMPONENT
                                                  : ByteSource.TERMINATOR),

--- a/src/java/org/apache/cassandra/db/DecoratedKey.java
+++ b/src/java/org/apache/cassandra/db/DecoratedKey.java
@@ -19,12 +19,15 @@ package org.apache.cassandra.db;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.function.BiFunction;
 
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.dht.Token.KeyBound;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.cassandra.utils.IFilter.FilterKey;
 import org.apache.cassandra.utils.MurmurHash;
 
@@ -153,5 +156,34 @@ public abstract class DecoratedKey implements PartitionPosition, FilterKey
     {
         ByteBuffer key = getKey();
         MurmurHash.hash3_x64_128(key, key.position(), key.remaining(), 0, dest);
+    }
+
+    /**
+     * A template factory method for creating decorated keys from their byte-comparable representation.
+     */
+    static <T extends DecoratedKey> T fromByteComparable(ByteComparable byteComparable,
+                                                         Version version,
+                                                         IPartitioner partitioner,
+                                                         BiFunction<Token, byte[], T> decoratedKeyFactory)
+    {
+        ByteSource.Peekable peekable = byteComparable.asPeekableBytes(version);
+        // Decode the token from the first component of the multi-component sequence representing the whole decorated key.
+        Token token = partitioner.getTokenFactory().fromComparableBytes(ByteSourceInverse.nextComponentSource(peekable), version);
+        // Decode the key bytes from the second component.
+        byte[] keyBytes = ByteSourceInverse.getUnescapedBytes(ByteSourceInverse.nextComponentSource(peekable));
+        // Instantiate a decorated key from the decoded token and key bytes, using the provided factory method.
+        return decoratedKeyFactory.apply(token, keyBytes);
+    }
+
+    public static byte[] keyFromByteComparable(ByteComparable byteComparable,
+                                               Version version,
+                                               IPartitioner partitioner)
+    {
+        ByteSource.Peekable peekable = byteComparable.asPeekableBytes(version);
+        // Decode the token from the first component of the multi-component sequence representing the whole decorated key.
+        // We won't use it, but the decoding also positions the byte source after it.
+        partitioner.getTokenFactory().fromComparableBytes(ByteSourceInverse.nextComponentSource(peekable), version);
+        // Decode the key bytes from the second component.
+        return ByteSourceInverse.getUnescapedBytes(ByteSourceInverse.nextComponentSource(peekable));
     }
 }

--- a/src/java/org/apache/cassandra/db/PartitionPosition.java
+++ b/src/java/org/apache/cassandra/db/PartitionPosition.java
@@ -24,8 +24,8 @@ import java.nio.ByteBuffer;
 import org.apache.cassandra.dht.*;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public interface PartitionPosition extends RingPosition<PartitionPosition>, ByteComparable
 {

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -39,11 +39,11 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.github.jamm.Unmetered;
 
-import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.BYTE_ORDER;
 import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM;
 
 /**
@@ -598,17 +598,49 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * Depending on the type, this method can be called for null or empty input, in which case the output is allowed to
      * be null (the clustering/tuple encoding will accept and handle it).
      */
-    public ByteSource asComparableBytes(ByteBuffer byteBuffer, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V value, ByteComparable.Version version)
     {
-        if (comparisonType == BYTE_ORDER)
+        if (isByteOrderComparable)
         {
             // When a type is byte-ordered on its own, we only need to escape it, so that we can include it in
             // multi-component types and make the encoding weakly-prefix-free.
-            return ByteSource.of(byteBuffer, version);
+            return ByteSource.of(accessor, value, version);
         }
         else
             // default is only good for byte-comparables
             throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement asComparableBytes");
+    }
+
+    public final ByteSource asComparableBytes(ByteBuffer byteBuffer, ByteComparable.Version version)
+    {
+        return asComparableBytes(ByteBufferAccessor.instance, byteBuffer, version);
+    }
+
+    /**
+     * Translates the given byte-ordered representation to the common, non-byte-ordered binary representation of a
+     * payload for this abstract type (the latter, common binary representation is what we mostly work with in the
+     * storage engine internals). If the given bytes don't correspond to the encoding of some payload value for this
+     * abstract type, an {@link IllegalArgumentException} may be thrown.
+     *
+     * @param accessor value accessor used to construct the value.
+     * @param comparableBytes A byte-ordered representation (presumably of a payload for this abstract type).
+     * @param version The byte-comparable version used to construct the representation.
+     * @return A of a payload for this abstract type, corresponding to the given byte-ordered representation,
+     *         constructed using the supplied value accessor.
+     *
+     * @see #asComparableBytes
+     */
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        if (isByteOrderComparable)
+            return accessor.valueOf(ByteSourceInverse.getUnescapedBytes(comparableBytes));
+        else
+            throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement fromComparableBytes");
+    }
+
+    public final ByteBuffer fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return fromComparableBytes(ByteBufferAccessor.instance, comparableBytes, version);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/ByteArrayAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteArrayAccessor.java
@@ -235,6 +235,13 @@ public class ByteArrayAccessor implements ValueAccessor<byte[]>
     }
 
     @Override
+    public int putByte(byte[] dst, int offset, byte value)
+    {
+        dst[offset] = value;
+        return TypeSizes.BYTE_SIZE;
+    }
+
+    @Override
     public int putShort(byte[] dst, int offset, short value)
     {
         ByteArrayUtil.putShort(dst, offset, value);

--- a/src/java/org/apache/cassandra/db/marshal/ByteArrayObjectFactory.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteArrayObjectFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.marshal;
 
+import org.apache.cassandra.db.AbstractArrayClusteringPrefix;
 import org.apache.cassandra.db.ArrayClustering;
 import org.apache.cassandra.db.ArrayClusteringBound;
 import org.apache.cassandra.db.ArrayClusteringBoundary;
@@ -33,11 +34,32 @@ import org.apache.cassandra.schema.TableMetadata;
 
 class ByteArrayObjectFactory implements ValueAccessor.ObjectFactory<byte[]>
 {
-    private static final Clustering<byte[]> EMPTY_CLUSTERING = new ArrayClustering()
+    private static final Clustering<byte[]> EMPTY_CLUSTERING = new ArrayClustering(AbstractArrayClusteringPrefix.EMPTY_VALUES_ARRAY)
     {
         public String toString(TableMetadata metadata)
         {
             return "EMPTY";
+        }
+    };
+
+    public static final Clustering<byte[]> STATIC_CLUSTERING = new ArrayClustering(AbstractArrayClusteringPrefix.EMPTY_VALUES_ARRAY)
+    {
+        @Override
+        public Kind kind()
+        {
+            return Kind.STATIC_CLUSTERING;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "STATIC";
+        }
+
+        @Override
+        public String toString(TableMetadata metadata)
+        {
+            return toString();
         }
     };
 
@@ -46,9 +68,11 @@ class ByteArrayObjectFactory implements ValueAccessor.ObjectFactory<byte[]>
     private ByteArrayObjectFactory() {}
 
     /** The smallest start bound, i.e. the one that starts before any row. */
-    private static final ArrayClusteringBound BOTTOM_BOUND = new ArrayClusteringBound(ClusteringPrefix.Kind.INCL_START_BOUND, new byte[0][]);
+    private static final ArrayClusteringBound BOTTOM_BOUND = new ArrayClusteringBound(ClusteringPrefix.Kind.INCL_START_BOUND,
+                                                                                      AbstractArrayClusteringPrefix.EMPTY_VALUES_ARRAY);
     /** The biggest end bound, i.e. the one that ends after any row. */
-    private static final ArrayClusteringBound TOP_BOUND = new ArrayClusteringBound(ClusteringPrefix.Kind.INCL_END_BOUND, new byte[0][]);
+    private static final ArrayClusteringBound TOP_BOUND = new ArrayClusteringBound(ClusteringPrefix.Kind.INCL_END_BOUND,
+                                                                                   AbstractArrayClusteringPrefix.EMPTY_VALUES_ARRAY);
 
     public Cell<byte[]> cell(ColumnMetadata column, long timestamp, int ttl, int localDeletionTime, byte[] value, CellPath path)
     {
@@ -63,6 +87,11 @@ class ByteArrayObjectFactory implements ValueAccessor.ObjectFactory<byte[]>
     public Clustering<byte[]> clustering()
     {
         return EMPTY_CLUSTERING;
+    }
+
+    public Clustering<byte[]> staticClustering()
+    {
+        return STATIC_CLUSTERING;
     }
 
     public ClusteringBound<byte[]> bound(ClusteringPrefix.Kind kind, byte[]... values)

--- a/src/java/org/apache/cassandra/db/marshal/ByteBufferAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteBufferAccessor.java
@@ -239,6 +239,13 @@ public class ByteBufferAccessor implements ValueAccessor<ByteBuffer>
     }
 
     @Override
+    public int putByte(ByteBuffer dst, int offset, byte value)
+    {
+        dst.put(dst.position() + offset, value);
+        return TypeSizes.BYTE_SIZE;
+    }
+
+    @Override
     public int putShort(ByteBuffer dst, int offset, short value)
     {
         dst.putShort(dst.position() + offset, value);

--- a/src/java/org/apache/cassandra/db/marshal/ByteBufferObjectFactory.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteBufferObjectFactory.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.db.AbstractBufferClusteringPrefix;
 import org.apache.cassandra.db.BufferClustering;
 import org.apache.cassandra.db.BufferClusteringBound;
 import org.apache.cassandra.db.BufferClusteringBoundary;
@@ -31,24 +32,15 @@ import org.apache.cassandra.db.rows.BufferCell;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.schema.TableMetadata;
 
 class ByteBufferObjectFactory implements ValueAccessor.ObjectFactory<ByteBuffer>
 {
-    /** Empty clustering for tables having no clustering columns. */
-    private static final Clustering<ByteBuffer> EMPTY_CLUSTERING = new BufferClustering()
-    {
-        @Override
-        public String toString(TableMetadata metadata)
-        {
-            return "EMPTY";
-        }
-    };
-
     /** The smallest start bound, i.e. the one that starts before any row. */
-    private static final BufferClusteringBound BOTTOM_BOUND = new BufferClusteringBound(ClusteringPrefix.Kind.INCL_START_BOUND, new ByteBuffer[0]);
+    private static final BufferClusteringBound BOTTOM_BOUND = new BufferClusteringBound(ClusteringPrefix.Kind.INCL_START_BOUND,
+                                                                                        AbstractBufferClusteringPrefix.EMPTY_VALUES_ARRAY);
     /** The biggest end bound, i.e. the one that ends after any row. */
-    private static final BufferClusteringBound TOP_BOUND = new BufferClusteringBound(ClusteringPrefix.Kind.INCL_END_BOUND, new ByteBuffer[0]);
+    private static final BufferClusteringBound TOP_BOUND = new BufferClusteringBound(ClusteringPrefix.Kind.INCL_END_BOUND,
+                                                                                     AbstractBufferClusteringPrefix.EMPTY_VALUES_ARRAY);
 
     static final ValueAccessor.ObjectFactory<ByteBuffer> instance = new ByteBufferObjectFactory();
 
@@ -66,7 +58,11 @@ class ByteBufferObjectFactory implements ValueAccessor.ObjectFactory<ByteBuffer>
 
     public Clustering<ByteBuffer> clustering()
     {
-        return EMPTY_CLUSTERING;
+        return Clustering.EMPTY;
+    }
+
+    public Clustering<ByteBuffer> staticClustering() {
+        return Clustering.STATIC_CLUSTERING;
     }
 
     public ClusteringBound<ByteBuffer> bound(ClusteringPrefix.Kind kind, ByteBuffer... values)

--- a/src/java/org/apache/cassandra/db/marshal/DateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DateType.java
@@ -31,8 +31,9 @@ import org.apache.cassandra.serializers.TimestampSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 /**
  * This is the old version of TimestampType, but has been replaced as it wasn't comparing pre-epoch timestamps
@@ -53,10 +54,16 @@ public class DateType extends AbstractType<Date>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
         // While BYTE_ORDER would still work for this type, making use of the fixed length is more efficient.
-        return ByteSource.optionalFixedLength(buf);
+        return ByteSource.optionalFixedLength(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalFixedLength(accessor, comparableBytes, 8);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DecimalType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DecimalType.java
@@ -34,8 +34,8 @@ import org.apache.cassandra.serializers.DecimalSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class DecimalType extends NumberType<BigDecimal>
 {
@@ -50,6 +50,10 @@ public class DecimalType extends NumberType<BigDecimal>
     private static final int POSITIVE_DECIMAL_HEADER_MASK = 0x80;
     private static final int NEGATIVE_DECIMAL_HEADER_MASK = 0x00;
     private static final int DECIMAL_EXPONENT_LENGTH_HEADER_MASK = 0x40;
+    private static final byte DECIMAL_LAST_BYTE = (byte) 0x00;
+    private static final BigInteger HUNDRED = BigInteger.valueOf(100);
+
+    private static final ByteBuffer ZERO_BUFFER = instance.decompose(BigDecimal.ZERO);
 
     DecimalType() {super(ComparisonType.CUSTOM);} // singleton
 
@@ -106,53 +110,63 @@ public class DecimalType extends NumberType<BigDecimal>
      *
      */
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        BigDecimal value = compose(buf);
+        BigDecimal value = compose(data, accessor);
         if (value == null)
             return null;
         if (value.compareTo(BigDecimal.ZERO) == 0)  // Note: 0.equals(0.0) returns false!
             return ByteSource.oneByte(POSITIVE_DECIMAL_HEADER_MASK);
+
         long scale = (((long) value.scale()) - value.precision()) & ~1;
         boolean negative = value.signum() < 0;
-        final int negmul = negative ? -1 : 1;
-        // This should always fit into an int
-        final long exponent = (-scale * negmul) / 2;
+        // Make a base-100 exponent (this will always fit in an int).
+        int exponent = Math.toIntExact(-scale >> 1);
+        // Flip the exponent sign for negative numbers, so that ones with larger magnitudes are propely treated as smaller.
+        final int modulatedExponent = negative ? -exponent : exponent;
         // We should never have scale > Integer.MAX_VALUE, as we're always subtracting the non-negative precision of
         // the encoded BigDecimal, and furthermore we're rounding to negative infinity.
-        if (scale > Integer.MAX_VALUE || scale < Integer.MIN_VALUE)
+        assert scale <= Integer.MAX_VALUE;
+        // However, we may end up overflowing on the negative side.
+        if (scale < Integer.MIN_VALUE)
         {
-            // We are practically out of range here, but let's handle that anyway
-            int mv = Long.signum(scale) * Integer.MAX_VALUE;
+            // As scaleByPowerOfTen needs an int scale, do the scaling in two steps.
+            int mv = Integer.MIN_VALUE;
             value = value.scaleByPowerOfTen(mv);
             scale -= mv;
         }
         final BigDecimal mantissa = value.scaleByPowerOfTen(Ints.checkedCast(scale)).stripTrailingZeros();
+        // We now have a smaller-than-one signed mantissa, and a signed and modulated base-100 exponent.
         assert mantissa.abs().compareTo(BigDecimal.ONE) < 0;
 
         return new ByteSource()
         {
-            int posInExp = 0;
+            // Start with up to 5 bytes for sign + exponent.
+            int exponentBytesLeft = 5;
             BigDecimal current = mantissa;
 
             @Override
             public int next()
             {
-                if (posInExp < 5)
+                if (exponentBytesLeft > 0)
                 {
-                    if (posInExp == 0)
+                    --exponentBytesLeft;
+                    if (exponentBytesLeft == 4)
                     {
-                        int absexp = (int) (exponent < 0 ? -exponent : exponent);
-                        while (posInExp < 5 && absexp >> (32 - ++posInExp * 8) == 0) {}
-                        int explen = DECIMAL_EXPONENT_LENGTH_HEADER_MASK + (exponent < 0 ? -1 : 1) * (5 - posInExp);
+                        // Skip leading zero bytes in the modulatedExponent.
+                        exponentBytesLeft -= Integer.numberOfLeadingZeros(Math.abs(modulatedExponent)) / 8;
+                        // Now prepare the leading byte which includes the sign of the number plus the sign and length of the modulatedExponent.
+                        int explen = DECIMAL_EXPONENT_LENGTH_HEADER_MASK + (modulatedExponent < 0 ? -exponentBytesLeft : exponentBytesLeft);
                         return explen + (negative ? NEGATIVE_DECIMAL_HEADER_MASK : POSITIVE_DECIMAL_HEADER_MASK);
                     }
                     else
-                        return (int) ((exponent >> (32 - posInExp++ * 8))) & 0xFF;
+                        return (modulatedExponent >> (exponentBytesLeft * 8)) & 0xFF;
                 }
-                if (current == null)
+                else if (current == null)
+                {
                     return END_OF_STREAM;
-                if (current.compareTo(BigDecimal.ZERO) == 0)
+                }
+                else if (current.compareTo(BigDecimal.ZERO) == 0)
                 {
                     current = null;
                     return 0x00;
@@ -166,6 +180,87 @@ public class DecimalType extends NumberType<BigDecimal>
                 }
             }
         };
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        if (comparableBytes == null)
+            return accessor.empty();
+
+        int headerBits = comparableBytes.next();
+        if (headerBits == POSITIVE_DECIMAL_HEADER_MASK)
+            return accessor.valueOf(ZERO_BUFFER);
+
+        // I. Extract the exponent.
+        // The sign of the decimal, and the sign and the length (in bytes) of the decimal exponent, are all encoded in
+        // the first byte.
+        // Get the sign of the decimal...
+        boolean isNegative = headerBits < POSITIVE_DECIMAL_HEADER_MASK;
+        headerBits -= isNegative ? NEGATIVE_DECIMAL_HEADER_MASK : POSITIVE_DECIMAL_HEADER_MASK;
+        headerBits -= DECIMAL_EXPONENT_LENGTH_HEADER_MASK;
+        // Get the sign and the length of the exponent (the latter is encoded as its negative if the sign of the
+        // exponent is negative)...
+        boolean isExponentNegative = headerBits < 0;
+        headerBits = isExponentNegative ? -headerBits : headerBits;
+        // Now consume the exponent bytes. If the exponent is negative and uses less than 4 bytes, the remaining bytes
+        // should be padded with 1s, in order for the constructed int to contain the correct (negative) exponent value.
+        // So, if the exponent is negative, we can just start with all bits set to 1 (i.e. we can start with -1).
+        int exponent = isExponentNegative ? -1 : 0;
+        for (int i = 0; i < headerBits; ++i)
+            exponent = (exponent << 8) | comparableBytes.next();
+        // The encoded exponent also contains the decimal sign, in order to correctly compare exponents in case of
+        // negative decimals (e.g. x * 10^y > x * 10^z if x < 0 && y < z). After the decimal sign is "removed", what's
+        // left is a base-100 exponent following BigDecimal's convention for the exponent sign.
+        exponent = isNegative ? -exponent : exponent;
+
+        // II. Extract the mantissa as a BigInteger value. It was encoded as a BigDecimal value between 0 and 1, in
+        // order to be used for comparison (after the sign of the decimal and the sign and the value of the exponent),
+        // but when decoding we don't need that property on the transient mantissa value.
+        BigInteger mantissa = BigInteger.ZERO;
+        int curr = comparableBytes.next();
+        while (curr != DECIMAL_LAST_BYTE)
+        {
+            // The mantissa value is constructed by a standard positional notation value calculation.
+            // The value of the next digit is the next most-significant mantissa byte as an unsigned integer,
+            // offset by a predetermined value (in this case, 0x80)...
+            int currModified = curr - 0x80;
+            // ...multiply the current value by the base (in this case, 100)...
+            mantissa = mantissa.multiply(HUNDRED);
+            // ...then add the next digit to the modified current value...
+            mantissa = mantissa.add(BigInteger.valueOf(currModified));
+            // ...and finally, adjust the base-100, BigDecimal format exponent accordingly.
+            --exponent;
+            curr = comparableBytes.next();
+        }
+
+        // III. Construct the final BigDecimal value, by combining the mantissa and the exponent, guarding against
+        // underflow or overflow when exponents are close to their boundary values.
+        long base10NonBigDecimalFormatExp = 2L * exponent;
+        // When expressing a sufficiently big decimal, BigDecimal's internal scale value will be negative with very
+        // big absolute value. To compute the encoded exponent, this internal scale has the number of digits of the
+        // unscaled value subtracted from it, after which it's divided by 2, rounding down to negative infinity
+        // (before accounting for the decimal sign). When decoding, this exponent is converted to a base-10 exponent in
+        // non-BigDecimal format, which means that it can very well overflow Integer.MAX_VALUE.
+        // For example, see how <code>new BigDecimal(BigInteger.TEN, Integer.MIN_VALUE)</code> is encoded and decoded.
+        if (base10NonBigDecimalFormatExp > Integer.MAX_VALUE)
+        {
+            // If the base-10 exponent will result in an overflow, some of its powers of 10 need to be absorbed by the
+            // mantissa. How much exactly? As little as needed, in order to avoid complex BigInteger operations, which
+            // means exactly as much as to have a scale of -Integer.MAX_VALUE.
+            int exponentReduction = (int) (base10NonBigDecimalFormatExp - Integer.MAX_VALUE);
+            mantissa = mantissa.multiply(BigInteger.TEN.pow(exponentReduction));
+            base10NonBigDecimalFormatExp = Integer.MAX_VALUE;
+        }
+        assert base10NonBigDecimalFormatExp >= Integer.MIN_VALUE && base10NonBigDecimalFormatExp <= Integer.MAX_VALUE;
+        // Here we negate the exponent, as we are not using BigDecimal.scaleByPowerOfTen, where a positive number means
+        // "multiplying by a positive power of 10", but to BigDecimal's internal scale representation, where a positive
+        // number means "dividing by a positive power of 10".
+        byte[] mantissaBytes = mantissa.toByteArray();
+        V resultBuf = accessor.allocate(4 + mantissaBytes.length);
+        accessor.putInt(resultBuf, 0, (int) -base10NonBigDecimalFormatExp);
+        accessor.copyByteArrayTo(mantissaBytes, 0, resultBuf, 4, mantissaBytes.length);
+        return resultBuf;
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DoubleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DoubleType.java
@@ -27,8 +27,9 @@ import org.apache.cassandra.serializers.DoubleSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 public class DoubleType extends NumberType<Double>
 {
@@ -53,9 +54,15 @@ public class DoubleType extends NumberType<Double>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ByteSource.optionalSignedFixedLengthFloat(buf);
+        return ByteSource.optionalSignedFixedLengthFloat(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLengthFloat(accessor, comparableBytes, 8);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
@@ -21,11 +21,14 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +41,9 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable.Version;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 import static com.google.common.collect.Iterables.any;
 
@@ -70,6 +74,7 @@ public class DynamicCompositeType extends AbstractCompositeType
     private static final String REVERSED_TYPE = ReversedType.class.getSimpleName();
 
     private final Map<Byte, AbstractType<?>> aliases;
+    private final Map<AbstractType<?>, Byte> inverseMapping;
 
     // interning instances
     private static final ConcurrentHashMap<Map<Byte, AbstractType<?>>, DynamicCompositeType> instances = new ConcurrentHashMap<>();
@@ -90,6 +95,9 @@ public class DynamicCompositeType extends AbstractCompositeType
     private DynamicCompositeType(Map<Byte, AbstractType<?>> aliases)
     {
         this.aliases = aliases;
+        this.inverseMapping = new HashMap<>();
+        for (Map.Entry<Byte, AbstractType<?>> en : aliases.entrySet())
+            this.inverseMapping.put(en.getValue(), en.getKey());
     }
 
     protected <V> boolean readIsStatic(V value, ValueAccessor<V> accessor)
@@ -206,25 +214,25 @@ public class DynamicCompositeType extends AbstractCompositeType
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer byteBuffer, Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, Version version)
     {
         List<ByteSource> srcs = new ArrayList<>();
-        ByteBuffer bb = byteBuffer.duplicate();
+        int length = accessor.size(data);
 
         // statics go first
-        boolean isStatic = readIsStatic(bb, ByteBufferAccessor.instance);
+        boolean isStatic = readIsStatic(data, accessor);
+        int offset = startingOffset(isStatic);
         srcs.add(isStatic ? null : ByteSource.EMPTY);
-        bb.position(bb.position() + startingOffset(isStatic));
 
         byte lastEoc = 0;
-        while (bb.remaining() > 0)
+        while (offset < length)
         {
             // Only the end-of-component byte of the last component of this composite can be non-zero, so the
             // component before can't have a non-zero end-of-component byte.
             assert lastEoc == 0 : lastEoc;
 
-            AbstractType<?> comp = getComparator(bb, ByteBufferAccessor.instance, 0);
-            bb.position(bb.position() + getComparatorSize(bb, ByteBufferAccessor.instance, 0));
+            AbstractType<?> comp = getComparator(data, accessor, offset);
+            offset += getComparatorSize(data, accessor, offset);
             // The comparable bytes for the component need to ensure comparisons consistent with
             // AbstractCompositeType.compareCustom(ByteBuffer, ByteBuffer) and
             // DynamicCompositeType.getComparator(int, ByteBuffer, ByteBuffer):
@@ -246,9 +254,13 @@ public class DynamicCompositeType extends AbstractCompositeType
                 srcs.add(ByteSource.of(reversedComp.baseType.getClass().getName(), version));
             }
             // Only then the payload of the component gets encoded.
-            srcs.add(comp.asComparableBytes(ByteBufferUtil.readBytesWithShortLength(bb), version));
+            int componentLength = accessor.getUnsignedShort(data, offset);
+            offset += 2;
+            srcs.add(comp.asComparableBytes(accessor, accessor.slice(data, offset, componentLength), version));
+            offset += componentLength;
             // The end-of-component byte also takes part in the comparison, and therefore needs to be encoded.
-            lastEoc = bb.get();
+            lastEoc = accessor.getByte(data, offset);
+            offset += 1;
             srcs.add(ByteSource.oneByte(version == Version.LEGACY ? lastEoc : lastEoc & 0xFF ^ 0x80));
         }
 
@@ -256,13 +268,79 @@ public class DynamicCompositeType extends AbstractCompositeType
                                          srcs.toArray(EMPTY_BYTE_SOURCE_ARRAY));
     }
 
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, Version version)
+    {
+        // For ByteComparable.Version.LEGACY the terminator byte is ByteSource.END_OF_STREAM. Just like with
+        // CompositeType, this means that in multi-component sequences the terminator may be transformed to a regular
+        // component separator, but unlike CompositeType (where we have the expected number of types/components),
+        // this can make the end of the whole dynamic composite type indistinguishable from the end of a component
+        // somewhere in the middle of the dynamic composite type. Because of that, DynamicCompositeType elements
+        // cannot always be safely decoded using that encoding version.
+        // Even more so than with CompositeType, we just take advantage of the fact that we don't need to decode from
+        // Version.LEGACY, assume that we never do that, and assert it here.
+        assert version != Version.LEGACY;
+
+        if (comparableBytes == null)
+            return accessor.empty();
+
+        // The first byte is the isStatic flag which we don't need but must consume to continue past it.
+        comparableBytes.next();
+
+        List<AbstractType<?>> types = new ArrayList<>();
+        List<V> values = new ArrayList<>();
+        byte lastEoc = 0;
+
+        for (int separator = comparableBytes.next(); separator != ByteSource.TERMINATOR; separator = comparableBytes.next())
+        {
+            // Solely the end-of-component byte of the last component of this composite can be non-zero.
+            assert lastEoc == 0 : lastEoc;
+
+            boolean isReversed = false;
+            // Decode the next type's simple class name that is encoded before its fully qualified class name (in order
+            // for comparisons to work correctly).
+            String simpleClassName = ByteSourceInverse.getString(ByteSourceInverse.nextComponentSource(comparableBytes, separator));
+            if (REVERSED_TYPE.equals(simpleClassName))
+            {
+                // Special-handle if the type is reversed (and decode the actual base type simple class name).
+                isReversed = true;
+                simpleClassName = ByteSourceInverse.getString(ByteSourceInverse.nextComponentSource(comparableBytes));
+            }
+
+            // Decode the type's fully qualified class name and parse the actual type from it.
+            String fullClassName = ByteSourceInverse.getString(ByteSourceInverse.nextComponentSource(comparableBytes));
+            assert fullClassName.endsWith(simpleClassName);
+            AbstractType<?> type = isReversed ? ReversedType.getInstance(TypeParser.parse(fullClassName))
+                                              : TypeParser.parse(fullClassName);
+            assert type != null;
+            types.add(type);
+
+            // Decode the payload from this type.
+            V value = type.fromComparableBytes(accessor, ByteSourceInverse.nextComponentSource(comparableBytes), version);
+            values.add(value);
+
+            // Also decode the corresponding end-of-component byte - the last one we decode will be taken into
+            // account when we deserialize the decoded data into an object.
+            lastEoc = ByteSourceInverse.getSignedByte(ByteSourceInverse.nextComponentSource(comparableBytes));
+        }
+        return build(accessor, types, inverseMapping, values, lastEoc);
+    }
+
     public static ByteBuffer build(List<String> types, List<ByteBuffer> values)
     {
-        return build(types, values, (byte) 0);
+        return build(ByteBufferAccessor.instance,
+                     Lists.transform(types, TypeParser::parse),
+                     Collections.emptyMap(),
+                     values,
+                     (byte) 0);
     }
 
     @VisibleForTesting
-    public static ByteBuffer build(List<String> types, List<ByteBuffer> values, byte lastEoc)
+    public static <V> V build(ValueAccessor<V> accessor,
+                              List<AbstractType<?>> types,
+                              Map<AbstractType<?>, Byte> inverseMapping,
+                              List<V> values,
+                              byte lastEoc)
     {
         assert types.size() == values.size();
 
@@ -271,35 +349,54 @@ public class DynamicCompositeType extends AbstractCompositeType
         int totalLength = 0;
         for (int i = 0; i < numComponents; ++i)
         {
-            int typeNameLength = types.get(i).getBytes(StandardCharsets.UTF_8).length;
+            AbstractType<?> type = types.get(i);
+            Byte alias = inverseMapping.get(type);
+            int typeNameLength = alias == null ? type.toString().getBytes(StandardCharsets.UTF_8).length : 0;
             // The type data will be stored by means of the type's fully qualified name, not by aliasing, so:
             //   1. The type data header should be the fully qualified name length in bytes.
             //   2. The length should be small enough so that it fits in 15 bits (2 bytes with the first bit zero).
             assert typeNameLength <= 0x7FFF;
-            int valueLength = values.get(i).remaining();
+            int valueLength = accessor.size(values.get(i));
             // The value length should also expect its first bit to be 0, as the length should be stored as a signed
             // 2-byte value (short).
             assert valueLength <= 0x7FFF;
             totalLength += 2 + typeNameLength + 2 + valueLength + 1;
         }
 
-        ByteBuffer result = ByteBuffer.allocate(totalLength);
+        V result = accessor.allocate(totalLength);
+        int offset = 0;
         for (int i = 0; i < numComponents; ++i)
         {
-            // Write the type data (2-byte length header + the fully qualified type name in UTF-8).
-            byte[] typeNameBytes = types.get(i).getBytes(StandardCharsets.UTF_8);
-            ByteBufferUtil.writeShortLength(result, typeNameBytes.length);
-            result.put(ByteBuffer.wrap(typeNameBytes));
+            AbstractType<?> type = types.get(i);
+            Byte alias = inverseMapping.get(type);
+            if (alias == null)
+            {
+                // Write the type data (2-byte length header + the fully qualified type name in UTF-8).
+                byte[] typeNameBytes = type.toString().getBytes(StandardCharsets.UTF_8);
+                accessor.putShort(result,
+                                  offset,
+                                  (short) typeNameBytes.length); // this should work fine also if length >= 32768
+                offset += 2;
+                accessor.copyByteArrayTo(typeNameBytes, 0, result, offset, typeNameBytes.length);
+                offset += typeNameBytes.length;
+            }
+            else
+            {
+                accessor.putShort(result, offset, (short) (alias | 0x8000));
+                offset += 2;
+            }
 
             // Write the type payload data (2-byte length header + the payload).
-            ByteBuffer value = values.get(i);
-            int bytesToCopy = value.remaining();
-            ByteBufferUtil.writeShortLength(result, bytesToCopy);
-            ByteBufferUtil.arrayCopy(value, value.position(), result, result.position(), bytesToCopy);
-            result.position(result.position() + bytesToCopy);
+            V value = values.get(i);
+            int bytesToCopy = accessor.size(value);
+            accessor.putShort(result, offset, (short) bytesToCopy);
+            offset += 2;
+            accessor.copyTo(value, 0, result, accessor, offset, bytesToCopy);
+            offset += bytesToCopy;
 
             // Write the end-of-component byte.
-            result.put(i != numComponents - 1 ? (byte) 0 : lastEoc);
+            accessor.putByte(result, offset, i != numComponents - 1 ? (byte) 0 : lastEoc);
+            offset += 1;
         }
         return result;
     }

--- a/src/java/org/apache/cassandra/db/marshal/EmptyType.java
+++ b/src/java/org/apache/cassandra/db/marshal/EmptyType.java
@@ -33,8 +33,8 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 /**
@@ -71,9 +71,15 @@ public class EmptyType extends AbstractType<Void>
     private EmptyType() {super(ComparisonType.CUSTOM);} // singleton
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
         return null;
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return accessor.empty();
     }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)

--- a/src/java/org/apache/cassandra/db/marshal/FloatType.java
+++ b/src/java/org/apache/cassandra/db/marshal/FloatType.java
@@ -27,8 +27,9 @@ import org.apache.cassandra.serializers.FloatSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 
 public class FloatType extends NumberType<Float>
@@ -54,9 +55,15 @@ public class FloatType extends NumberType<Float>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ByteSource.optionalSignedFixedLengthFloat(buf);
+        return ByteSource.optionalSignedFixedLengthFloat(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLengthFloat(accessor, comparableBytes, 4);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/Int32Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/Int32Type.java
@@ -28,8 +28,9 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 public class Int32Type extends NumberType<Integer>
 {
@@ -58,9 +59,15 @@ public class Int32Type extends NumberType<Integer>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ByteSource.optionalSignedFixedLengthNumber(buf);
+        return ByteSource.optionalSignedFixedLengthNumber(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLength(accessor, comparableBytes, 4);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/IntegerType.java
+++ b/src/java/org/apache/cassandra/db/marshal/IntegerType.java
@@ -30,8 +30,8 @@ import org.apache.cassandra.serializers.IntegerSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public final class IntegerType extends NumberType<BigInteger>
 {
@@ -42,6 +42,8 @@ public final class IntegerType extends NumberType<BigInteger>
     private static final int POSITIVE_VARINT_HEADER = 0x80;
     private static final int NEGATIVE_VARINT_LENGTH_HEADER = 0x00;
     private static final int POSITIVE_VARINT_LENGTH_HEADER = 0xFF;
+    private static final byte BIG_INTEGER_NEGATIVE_LEADING_ZERO = (byte) 0xFF;
+    private static final byte BIG_INTEGER_POSITIVE_LEADING_ZERO = (byte) 0x00;
 
     private static <V> int findMostSignificantByte(V value, ValueAccessor<V> accessor)
     {
@@ -146,8 +148,11 @@ public final class IntegerType extends NumberType<BigInteger>
      * where a length_byte is:
      *    - 0x80 + (length - 1) for positive numbers (so that longer length sorts bigger)
      *    - 0x7F - (length - 1) for negative numbers (so that longer length sorts smaller)
-     * we don't need to sign-invert the first significant byte as the order there is already determined by the length
-     * byte.
+     *
+     * Because we include the sign in the length byte:
+     * - unlike fixed-length ints, we don't need to sign-invert the first significant byte,
+     * - unlike BigInteger, we don't need to include 0x00 prefix for positive integers whose first byte is >= 0x80
+     *   or 0xFF prefix for negative integers whose first byte is < 0x80.
      *
      * The representations are prefix-free, because representations of different length always have length bytes that
      * differ.
@@ -162,17 +167,24 @@ public final class IntegerType extends NumberType<BigInteger>
      *    2^33          as 840100000000
      */
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        int p = buf.position();
-        final int limit = buf.limit();
+        int p = 0;
+        final int limit = accessor.size(data);
         if (p == limit)
             return null;
 
-        // skip padding
-        final byte signbyte = buf.get(p);
-        if (signbyte == (byte) POSITIVE_VARINT_LENGTH_HEADER || signbyte == (byte) NEGATIVE_VARINT_LENGTH_HEADER)
-            while (p + 1 < limit && buf.get(++p) == signbyte) {}
+        // skip any leading sign-only byte(s)
+        final byte signbyte = accessor.getByte(data, p);
+        if (signbyte == BIG_INTEGER_NEGATIVE_LEADING_ZERO || signbyte == BIG_INTEGER_POSITIVE_LEADING_ZERO)
+        {
+            while (p + 1 < limit)
+            {
+                if (accessor.getByte(data, ++p) != signbyte)
+                    break;
+            }
+        }
+
         final int startpos = p;
 
         return new ByteSource()
@@ -185,23 +197,85 @@ public final class IntegerType extends NumberType<BigInteger>
             {
                 if (!sizeReported)
                 {
-                    int v = sizeToReport;
-                    if (v >= 128)
-                        v = 128;
+                    if (sizeToReport >= 128)
+                    {
+                        sizeToReport -= 128;
+                        return signbyte >= 0
+                               ? POSITIVE_VARINT_LENGTH_HEADER
+                               : NEGATIVE_VARINT_LENGTH_HEADER;
+                    }
                     else
+                    {
                         sizeReported = true;
-
-                    sizeToReport -= v;
-                    return signbyte >= 0
-                           ? POSITIVE_VARINT_HEADER + (v - 1)
-                           : POSITIVE_VARINT_HEADER - v;
+                        return signbyte >= 0
+                               ? POSITIVE_VARINT_HEADER + (sizeToReport - 1)
+                               : POSITIVE_VARINT_HEADER - sizeToReport;
+                    }
                 }
+
                 if (pos == limit)
                     return END_OF_STREAM;
 
-                return buf.get(pos++) & 0xFF;
+                return accessor.getByte(data, pos++) & 0xFF;
             }
         };
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        if (comparableBytes == null)
+            return accessor.empty();
+
+        int valueBytes;
+        byte signedZero;
+        // Consume the first byte to determine whether the encoded number is positive and
+        // start iterating through the length header bytes and collecting the number of value bytes.
+        int curr = comparableBytes.next();
+        if (curr >= POSITIVE_VARINT_HEADER) // positive number
+        {
+            valueBytes = curr - POSITIVE_VARINT_HEADER + 1;
+            while (curr == POSITIVE_VARINT_LENGTH_HEADER)
+            {
+                curr = comparableBytes.next();
+                valueBytes += curr - POSITIVE_VARINT_HEADER + 1;
+            }
+            signedZero = 0;
+        }
+        else // negative number
+        {
+            valueBytes = POSITIVE_VARINT_HEADER - curr;
+            while (curr == NEGATIVE_VARINT_LENGTH_HEADER)
+            {
+                curr = comparableBytes.next();
+                valueBytes += POSITIVE_VARINT_HEADER - curr;
+            }
+            signedZero = -1;
+        }
+
+        int writtenBytes = 0;
+        V buf;
+        // Add "leading zero" if needed (i.e. in case the leading byte of a positive number corresponds to a negative
+        // value, or in case the leading byte of a negative number corresponds to a non-negative value).
+        // Size the array containing all the value bytes accordingly.
+        curr = comparableBytes.next();
+        if ((curr & 0x80) != (signedZero & 0x80))
+        {
+            ++valueBytes;
+            buf = accessor.allocate(valueBytes);
+            accessor.putByte(buf, writtenBytes++, signedZero);
+        }
+        else
+            buf = accessor.allocate(valueBytes);
+        // Don't forget to add the first consumed value byte after determining whether leading zero should be added
+        // and sizing the value bytes array.
+        accessor.putByte(buf, writtenBytes++, (byte) curr);
+
+        // Consume exactly the number of expected value bytes.
+        while (writtenBytes < valueBytes)
+            accessor.putByte(buf, writtenBytes++, (byte) comparableBytes.next());
+
+        return buf;
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -36,8 +36,9 @@ import org.apache.cassandra.serializers.CollectionSerializer;
 import org.apache.cassandra.serializers.ListSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
-import org.apache.cassandra.utils.ByteComparable.Version;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 public class ListType<T> extends CollectionType<List<T>>
 {
@@ -202,28 +203,60 @@ public class ListType<T> extends CollectionType<List<T>>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer b, Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, Version version)
     {
-        return asComparableBytesListOrSet(getElementsType(), b, version);
+        return asComparableBytesListOrSet(getElementsType(), accessor, data, version);
     }
 
-    static ByteSource asComparableBytesListOrSet(AbstractType<?> elementsComparator, ByteBuffer b, Version version)
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, Version version)
     {
-        if (!b.hasRemaining())
+        return fromComparableBytesListOrSet(accessor, comparableBytes, version, getElementsType());
+    }
+
+    static <V> ByteSource asComparableBytesListOrSet(AbstractType<?> elementsComparator,
+                                                     ValueAccessor<V> accessor,
+                                                     V data,
+                                                     Version version)
+    {
+        if (accessor.isEmpty(data))
             return null;
 
-        b = b.duplicate();
         int offset = 0;
-        int size = CollectionSerializer.readCollectionSize(b, ByteBufferAccessor.instance, ProtocolVersion.V3);
+        int size = CollectionSerializer.readCollectionSize(data, accessor, ProtocolVersion.V3);
         offset += CollectionSerializer.sizeOfCollectionSize(size, ProtocolVersion.V3);
         ByteSource[] srcs = new ByteSource[size];
         for (int i = 0; i < size; ++i)
         {
-            ByteBuffer v = CollectionSerializer.readValue(b, ByteBufferAccessor.instance, offset, ProtocolVersion.V3);
-            offset += CollectionSerializer.sizeOfValue(v, ByteBufferAccessor.instance, ProtocolVersion.V3);
-            srcs[i] = elementsComparator.asComparableBytes(v, version);
+            V v = CollectionSerializer.readValue(data, accessor, offset, ProtocolVersion.V3);
+            offset += CollectionSerializer.sizeOfValue(v, accessor, ProtocolVersion.V3);
+            srcs[i] = elementsComparator.asComparableBytes(accessor, v, version);
         }
         return ByteSource.withTerminator(version == Version.LEGACY ? 0x00 : ByteSource.TERMINATOR, srcs);
+    }
+
+    static <V> V fromComparableBytesListOrSet(ValueAccessor<V> accessor,
+                                              ByteSource.Peekable comparableBytes,
+                                              Version version,
+                                              AbstractType<?> elementType)
+    {
+        if (comparableBytes == null)
+            return accessor.empty();
+
+        List<V> buffers = new ArrayList<>();
+        int terminator = version == Version.LEGACY
+                         ? 0x00
+                         : ByteSource.TERMINATOR;
+        int separator = comparableBytes.next();
+        while (separator != terminator)
+        {
+            if (!ByteSourceInverse.nextComponentNull(separator))
+                buffers.add(elementType.fromComparableBytes(accessor, comparableBytes, version));
+            else
+                buffers.add(null);
+            separator = comparableBytes.next();
+        }
+        return CollectionSerializer.pack(buffers, accessor, buffers.size(), ProtocolVersion.V3);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/LongType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LongType.java
@@ -28,8 +28,9 @@ import org.apache.cassandra.serializers.LongSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 public class LongType extends NumberType<Long>
 {
@@ -60,9 +61,15 @@ public class LongType extends NumberType<Long>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ByteSource.optionalSignedFixedLengthNumber(buf);
+        return ByteSource.optionalSignedFixedLengthNumber(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLength(accessor, comparableBytes, 8);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
+++ b/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
@@ -22,15 +22,15 @@ import java.util.Iterator;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.transport.ProtocolVersion;
-import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteComparable.Version;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 
 /** for sorting columns representing row keys in the row ordering as determined by a partitioner.
@@ -98,8 +98,10 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, Version version)
     {
+        // Partitioners work with ByteBuffers only.
+        ByteBuffer buf = ByteBufferAccessor.instance.convert(data, accessor);
         if (version != Version.LEGACY)
         {
             // For ByteComparable.Version.OSS41 and above we encode an empty key with a null byte source. This
@@ -110,6 +112,16 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
             return buf.hasRemaining() ? partitioner.decorateKey(buf).asComparableBytes(version) : null;
         }
         return PartitionPosition.ForKey.get(buf, partitioner).asComparableBytes(version);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        assert version != Version.LEGACY;
+        if (comparableBytes == null)
+            return accessor.empty();
+        byte[] keyBytes = DecoratedKey.keyFromByteComparable(v -> comparableBytes, version, partitioner);
+        return accessor.valueOf(keyBytes);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -28,8 +28,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class ReversedType<T> extends AbstractType<T>
 {
@@ -66,9 +66,9 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        ByteSource src = baseType.asComparableBytes(b, version);
+        ByteSource src = baseType.asComparableBytes(accessor, data, version);
         if (src == null)    // Note: this will only compare correctly if used within a sequence
             return null;
         // Invert all bytes.
@@ -83,6 +83,12 @@ public class ReversedType<T> extends AbstractType<T>
                 return v;
             return v ^ 0xFF;
         };
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return baseType.fromComparableBytes(accessor, ReversedPeekableByteSource.of(comparableBytes), version);
     }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -30,8 +30,8 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.SetSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class SetType<T> extends CollectionType<Set<T>>
 {
@@ -160,9 +160,15 @@ public class SetType<T> extends CollectionType<Set<T>>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ListType.asComparableBytesListOrSet(getElementsType(), b, version);
+        return ListType.asComparableBytesListOrSet(getElementsType(), accessor, data, version);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ListType.fromComparableBytesListOrSet(accessor, comparableBytes, version, getElementsType());
     }
 
     public SetSerializer<T> getSerializer()

--- a/src/java/org/apache/cassandra/db/marshal/ShortType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ShortType.java
@@ -28,8 +28,9 @@ import org.apache.cassandra.serializers.ShortSerializer;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 public class ShortType extends NumberType<Short>
 {
@@ -49,11 +50,16 @@ public class ShortType extends NumberType<Short>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return version == ByteComparable.Version.LEGACY
-               ? ByteSource.signedFixedLengthNumber(buf)
-               : ByteSource.optionalSignedFixedLengthNumber(buf);
+        // This type does not allow non-present values, but we do just to avoid future complexity.
+        return ByteSource.optionalSignedFixedLengthNumber(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLength(accessor, comparableBytes, 2);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
@@ -28,9 +28,10 @@ import org.apache.cassandra.serializers.SimpleDateSerializer;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteComparable.Version;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -41,12 +42,17 @@ public class SimpleDateType extends TemporalType<Integer>
     SimpleDateType() {super(ComparisonType.BYTE_ORDER);} // singleton
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, Version version)
     {
         // While BYTE_ORDER would still work for this type, making use of the fixed length is more efficient.
-        return version == Version.LEGACY
-               ? ByteSource.fixedLength(buf)
-               : ByteSource.optionalFixedLength(buf);
+        // This type does not allow non-present values, but we do just to avoid future complexity.
+        return ByteSource.optionalFixedLength(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalFixedLength(accessor, comparableBytes, 4);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/TimestampType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimestampType.java
@@ -32,8 +32,9 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TimestampSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -63,9 +64,15 @@ public class TimestampType extends TemporalType<Date>
     }
 
     @Override
-    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
-        return ByteSource.optionalSignedFixedLengthNumber(buf);
+        return ByteSource.optionalSignedFixedLengthNumber(accessor, data);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        return ByteSourceInverse.getOptionalSignedFixedLength(accessor, comparableBytes, 8);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -258,7 +258,7 @@ public class UserType extends TupleType implements SchemaElement
     @Override
     public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
     {
-        ByteBuffer[] buffers = split(buffer);
+        ByteBuffer[] buffers = split(ByteBufferAccessor.instance, buffer);
         StringBuilder sb = new StringBuilder("{");
         for (int i = 0; i < types.size(); i++)
         {

--- a/src/java/org/apache/cassandra/db/marshal/ValueAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/ValueAccessor.java
@@ -66,6 +66,7 @@ public interface ValueAccessor<V>
         Cell<V> cell(ColumnMetadata column, long timestamp, int ttl, int localDeletionTime, V value, CellPath path);
         Clustering<V> clustering(V... values);
         Clustering<V> clustering();
+        Clustering<V> staticClustering();
         ClusteringBound<V> bound(ClusteringPrefix.Kind kind, V... values);
         ClusteringBound<V> bound(ClusteringPrefix.Kind kind);
         ClusteringBoundary<V> boundary(ClusteringPrefix.Kind kind, V... values);
@@ -103,7 +104,6 @@ public interface ValueAccessor<V>
         {
             return boundary(reversed ? INCL_END_EXCL_START_BOUNDARY : EXCL_END_INCL_START_BOUNDARY, boundValues);
         }
-
     }
     /**
      * @return the size of the given value
@@ -321,6 +321,12 @@ public interface ValueAccessor<V>
 
     /** returns a UUID from offset 0 */
     UUID toUUID(V value);
+
+    /**
+     * writes the byte value {@param value} to {@param dst} at offset {@param offset}
+     * @return the number of bytes written to {@param value}
+     */
+    int putByte(V dst, int offset, byte value);
 
     /**
      * writes the short value {@param value} to {@param dst} at offset {@param offset}

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -26,8 +26,9 @@ import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Hex;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -39,7 +40,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -231,6 +231,11 @@ public class ByteOrderedPartitioner implements IPartitioner
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
     {
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            return new BytesToken(ByteSourceInverse.getUnescapedBytes(comparableBytes));
+        }
+
         public ByteBuffer toByteArray(Token token)
         {
             BytesToken bytesToken = (BytesToken) token;

--- a/src/java/org/apache/cassandra/dht/LocalPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/LocalPartitioner.java
@@ -26,9 +26,10 @@ import java.util.Random;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.CachedHashDecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.memory.HeapAllocator;
 
@@ -85,6 +86,12 @@ public class LocalPartitioner implements IPartitioner
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
     {
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            ByteBuffer tokenData = comparator.fromComparableBytes(ByteBufferAccessor.instance, comparableBytes, version);
+            return new LocalToken(tokenData);
+        }
+
         public ByteBuffer toByteArray(Token token)
         {
             return ((LocalToken)token).token;
@@ -179,7 +186,7 @@ public class LocalPartitioner implements IPartitioner
         @Override
         public ByteSource asComparableBytes(ByteComparable.Version version)
         {
-            return comparator.asComparableBytes(token, version);
+            return comparator.asComparableBytes(ByteBufferAccessor.instance, token, version);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -33,8 +33,9 @@ import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.cassandra.utils.MurmurHash;
 import org.apache.cassandra.utils.ObjectSizes;
 
@@ -324,6 +325,12 @@ public class Murmur3Partitioner implements IPartitioner
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
     {
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            long tokenData = ByteSourceInverse.getSignedLong(comparableBytes);
+            return new LongToken(tokenData);
+        }
+
         public ByteBuffer toByteArray(Token token)
         {
             LongToken longToken = (LongToken) token;

--- a/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
@@ -33,8 +33,9 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.Pair;
@@ -130,6 +131,11 @@ public class OrderPreservingPartitioner implements IPartitioner
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
     {
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            return new StringToken(ByteSourceInverse.getString(comparableBytes));
+        }
+
         public ByteBuffer toByteArray(Token token)
         {
             StringToken stringToken = (StringToken) token;

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -27,6 +27,8 @@ import java.util.*;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.CachedHashDecoratedKey;
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -34,8 +36,8 @@ import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.db.marshal.PartitionerDefinedOrder;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.GuidGenerator;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -160,6 +162,11 @@ public class RandomPartitioner implements IPartitioner
 
     private final Token.TokenFactory tokenFactory = new Token.TokenFactory()
     {
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            return fromByteArray(IntegerType.instance.fromComparableBytes(ByteBufferAccessor.instance, comparableBytes, version));
+        }
+
         public ByteBuffer toByteArray(Token token)
         {
             BigIntegerToken bigIntegerToken = (BigIntegerToken) token;
@@ -249,7 +256,7 @@ public class RandomPartitioner implements IPartitioner
         @Override
         public ByteSource asComparableBytes(ByteComparable.Version version)
         {
-            return IntegerType.instance.asComparableBytes(ByteBuffer.wrap(token.toByteArray()), version);
+            return IntegerType.instance.asComparableBytes(ByteArrayAccessor.instance, token.toByteArray(), version);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -26,8 +26,8 @@ import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.DataOutputPlus;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public abstract class Token implements RingPosition<Token>, Serializable
 {
@@ -39,8 +39,38 @@ public abstract class Token implements RingPosition<Token>, Serializable
     {
         public abstract ByteBuffer toByteArray(Token token);
         public abstract Token fromByteArray(ByteBuffer bytes);
+
+        /**
+         * Produce a weakly prefix-free byte-comparable representation of the token, i.e. such a sequence of bytes that any
+         * pair x, y of valid tokens of this type and any bytes b1, b2 between 0x10 and 0xEF,
+         * (+ stands for concatenation)
+         *   compare(x, y) == compareLexicographicallyUnsigned(asByteComparable(x)+b1, asByteComparable(y)+b2)
+         * (i.e. the values compare like the original type, and an added 0x10-0xEF byte at the end does not change that) and:
+         *   asByteComparable(x)+b1 is not a prefix of asByteComparable(y)      (weakly prefix free)
+         * (i.e. a valid representation of a value may be a prefix of another valid representation of a value only if the
+         * following byte in the latter is smaller than 0x10 or larger than 0xEF). These properties are trivially true if
+         * the encoding compares correctly and is prefix free, but also permits a little more freedom that enables somewhat
+         * more efficient encoding of arbitrary-length byte-comparable blobs.
+         */
+        public ByteSource asComparableBytes(Token token, ByteComparable.Version version)
+        {
+            return token.asComparableBytes(version);
+        }
+
+        /**
+         * Translates the given byte-comparable representation to a token instance. If the given bytes don't correspond
+         * to the encoding of an instance of the expected token type, an {@link IllegalArgumentException} may be thrown.
+         *
+         * @param comparableBytes A byte-comparable representation (presumably of a token of some expected token type).
+         * @return A new {@link Token} instance, corresponding to the given byte-ordered representation. If we were
+         * to call {@link #asComparableBytes(ByteComparable.Version)} on the returned object, we should get a
+         * {@link ByteSource} equal to the input one as a result.
+         */
+        public abstract Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version);
+
         public abstract String toString(Token token); // serialize as string, not necessarily human-readable
         public abstract Token fromString(String string); // deserialize
+
         public abstract void validate(String token) throws ConfigurationException;
 
         public void serialize(Token token, DataOutputPlus out) throws IOException
@@ -144,7 +174,7 @@ public abstract class Token implements RingPosition<Token>, Serializable
 
     /*
      * A token corresponds to the range of all the keys having this token.
-     * A token is thus no comparable directly to a key. But to be able to select
+     * A token is thus not comparable directly to a key. But to be able to select
      * keys given tokens, we introduce two "fake" keys for each token T:
      *   - lowerBoundKey: a "fake" key representing the lower bound T represents.
      *                    In other words, lowerBoundKey is the smallest key that

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
@@ -48,6 +48,7 @@ public class SSTableIterator extends AbstractBigTableIterator
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
+    @SuppressWarnings("resource") // caller to close
     protected RowReader createReaderInternal(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
     {
         return indexEntry.isIndexed()

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
@@ -52,6 +52,7 @@ public class SSTableReversedIterator extends AbstractBigTableIterator
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
+    @SuppressWarnings("resource") // caller to close
     protected Reader createReaderInternal(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
     {
         return indexEntry.isIndexed()

--- a/src/java/org/apache/cassandra/serializers/BooleanSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/BooleanSerializer.java
@@ -24,8 +24,8 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 
 public class BooleanSerializer extends TypeSerializer<Boolean>
 {
-    private static final ByteBuffer TRUE = ByteBuffer.wrap(new byte[] {1});
-    private static final ByteBuffer FALSE = ByteBuffer.wrap(new byte[] {0});
+    public static final ByteBuffer TRUE = ByteBuffer.wrap(new byte[] {1});
+    public static final ByteBuffer FALSE = ByteBuffer.wrap(new byte[] {0});
 
     public static final BooleanSerializer instance = new BooleanSerializer();
 

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.utils;
+package org.apache.cassandra.utils.bytecomparable;
 
 import java.nio.ByteBuffer;
-
-import static org.apache.cassandra.utils.ByteSource.END_OF_STREAM;
 
 /**
  * Interface indicating a value can be represented/identified by a comparable {@link ByteSource}.
@@ -54,7 +52,7 @@ public interface ByteComparable
         ByteSource stream = asComparableBytes(version);
         if (stream == null)
             return "null";
-        for (int b = stream.next(); b != END_OF_STREAM; b = stream.next())
+        for (int b = stream.next(); b != ByteSource.END_OF_STREAM; b = stream.next())
             builder.append(Integer.toHexString((b >> 4) & 0xF)).append(Integer.toHexString(b & 0xF));
         return builder.toString();
     }
@@ -119,7 +117,7 @@ public interface ByteComparable
     {
         int l = 0;
         ByteSource s = src.asComparableBytes(version);
-        while (s.next() != END_OF_STREAM)
+        while (s.next() != ByteSource.END_OF_STREAM)
             ++l;
         return l;
     }
@@ -159,7 +157,7 @@ public interface ByteComparable
         ByteSource s2 = bytes2.asComparableBytes(version);
         int pos = 1;
         int b;
-        while ((b = s1.next()) == s2.next() && b != END_OF_STREAM)
+        while ((b = s1.next()) == s2.next() && b != ByteSource.END_OF_STREAM)
             ++pos;
         return pos;
     }

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.md
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.md
@@ -1,0 +1,590 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Byte-comparable translation of types (ByteComparable/ByteSource)
+
+## Problem / Motivation
+
+Cassandra has a very heavy reliance on comparisons — they are used throughout read and write paths, coordination,
+compaction, etc. to be able to order and merge results. It also supports a range of types which often require the 
+compared object to be completely in memory to order correctly, which in turn has necessitated interfaces where 
+comparisons can only be applied if the compared objects are completely loaded.
+
+This has some rather painful implications on the performance of the database, both in terms of the time it takes to load,
+compare and garbage collect, as well as in terms of the space required to hold complete keys in on-disk indices and
+deserialized versions in in-memory data structures. In addition to this, the reliance on comparisons forces Cassandra to
+use only comparison-based structures, which aren’t the most efficient.
+
+There is no way to escape the need to compare and order objects in Cassandra, but the machinery for doing this can be
+done much more smartly if we impose some simple structure in the objects we deal with — byte ordering.
+
+The term “byte order” as used in this document refers to the property of being ordered via lexicographic compare on the
+unsigned values of the byte contents. Some of the types in Cassandra already have this property (e.g. strings, blobs),
+but other most heavily used ones (e.g. integers, uuids) don’t.
+
+When byte order is universally available for the types used for keys, several key advantages can be put to use:
+- Comparisons can be done using a single simple method, core machinery doesn’t need to know anything about types.
+- Prefix differences are enough to define order; unique prefixes can be used instead of complete keys.
+- Tries can be used to store, query and iterate over ranges of keys, providing fast lookup and prefix compression.
+- Merging can be performed by merging tries, significantly reducing the number of necessary comparisons.
+
+## Ordering the types
+
+As we want to keep all existing functionality in Cassandra, we need to be able to deal with existing
+non-byte-order-comparable types. This requires some form of conversion of each value to a sequence of bytes that can be 
+byte-order compared (also called "byte-comparable"), as well as the inverse conversion from byte-comparable to value.
+
+As one of the main advantages of byte order is the ability to decide comparisons early, without having to read the whole
+of the input sequence, byte-ordered interpretations of values are represented as sources of bytes with unknown length, 
+using the interface `ByteSource`. The interface declares one method, `next()` which produces the next byte of the
+stream, or `ByteSource.END_OF_STREAM` if the stream is exhausted.
+
+`END_OF_STREAM` is chosen as `-1` (`(int) -1`, which is outside the range of possible byte values), to make comparing 
+two byte sources as trivial (and thus fast) as possible.
+  
+To be able to completely abstract type information away from the storage machinery, we also flatten complex types into
+single byte sequences. To do this, we add separator bytes in front, between components, and at the end and do some 
+encoding of variable-length sequences.
+
+The other interface provided by this package `ByteComparable`, is an entity whose byte-ordered interpretation can be
+requested. The interface is implemented by `DecoratedKey`, and can be requested for clustering keys and bounds using
+`ClusteringComparator.asByteComparable`. The inverse translation is provided by 
+`Buffer/NativeDecoratedKey.fromByteComparable` and `ClusteringComparator.clustering/bound/boundaryFromByteComparable`.
+
+The (rather technical) paragraphs below detail the encoding we have chosen for the various types. For simplicity we
+only discuss the bidirectional `OSS41` version of the translation. The implementations in code of the various mappings
+are in the releavant `AbstractType` subclass.
+
+### Desired properties
+
+Generally, we desire the following two properties from the byte-ordered translations of values we use in the database:
+- Comparison equivalence (1):  
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <semantics>
+        <mstyle displaystyle="true">
+          <mo>&#x2200;</mo>
+          <mi>x</mi>
+          <mo>,</mo>
+          <mi>y</mi>
+          <mo>&#x2208;</mo>
+          <mi>T</mi>
+          <mo>,</mo>
+          <mrow>
+            <mtext>compareBytesUnsigned</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>T</mi>
+            <mo>.</mo>
+            <mrow>
+              <mtext>byteOrdered</mtext>
+            </mrow>
+            <mrow>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mrow>
+            <mo>,</mo>
+            <mi>T</mi>
+            <mo>.</mo>
+            <mrow>
+              <mtext>byteOrdered</mtext>
+            </mrow>
+            <mrow>
+              <mo>(</mo>
+              <mi>y</mi>
+              <mo>)</mo>
+            </mrow>
+            <mo>)</mo>
+          </mrow>
+          <mo>=</mo>
+          <mi>T</mi>
+          <mo>.</mo>
+          <mrow>
+            <mtext>compare</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>,</mo>
+            <mi>y</mi>
+            <mo>)</mo>
+          </mrow>
+        </mstyle>
+        <!-- <annotation encoding="text/x-asciimath">forall x,y in T, "compareBytesUnsigned"(T."byteOrdered"(x), T."byteOrdered"(y))=T."compare"(x, y)</annotation> -->
+      </semantics>
+    </math>
+- Prefix-freedom (2):  
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <semantics>
+        <mstyle displaystyle="true">
+          <mo>&#x2200;</mo>
+          <mi>x</mi>
+          <mo>,</mo>
+          <mi>y</mi>
+          <mo>&#x2208;</mo>
+          <mi>T</mi>
+          <mo>,</mo>
+          <mi>T</mi>
+          <mo>.</mo>
+          <mrow>
+            <mtext>byteOrdered</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>)</mo>
+          </mrow>
+          <mrow>
+            <mspace width="1ex" />
+            <mtext> is not a prefix of </mtext>
+            <mspace width="1ex" />
+          </mrow>
+          <mi>T</mi>
+          <mo>.</mo>
+          <mrow>
+            <mtext>byteOrdered</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>y</mi>
+            <mo>)</mo>
+          </mrow>
+        </mstyle>
+        <!-- <annotation encoding="text/x-asciimath">forall x,y in T, T."byteOrdered"(x) " is not a prefix of " T."byteOrdered"(y)</annotation> -->
+      </semantics>
+    </math>
+   
+The former is the essential requirement, and the latter allows construction of encodings of sequences of multiple
+values, as well as a little more efficiency in the data structures.
+
+To more efficiently encode byte-ordered blobs, however, we use a slightly tweaked version of the above requirements:
+
+- Comparison equivalence (3):  
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <semantics>
+        <mstyle displaystyle="true">
+          <mo>&#x2200;</mo>
+          <mi>x</mi>
+          <mo>,</mo>
+          <mi>y</mi>
+          <mo>&#x2208;</mo>
+          <mi>T</mi>
+          <mo>,</mo>
+          <mo>&#x2200;</mo>
+          <msub>
+            <mi>b</mi>
+            <mn>1</mn>
+          </msub>
+          <mo>,</mo>
+          <msub>
+            <mi>b</mi>
+            <mn>2</mn>
+          </msub>
+          <mo>&#x2208;</mo>
+          <mrow>
+            <mo>[</mo>
+            <mn>0x10</mn>
+            <mo>-</mo>
+            <mn>0xEF</mn>
+            <mo>]</mo>
+          </mrow>
+          <mo>,</mo>
+            <mtext><br/></mtext>
+          <mrow>
+            <mtext>compareBytesUnsigned</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>T</mi>
+            <mo>.</mo>
+            <mrow>
+              <mtext>byteOrdered</mtext>
+            </mrow>
+            <mrow>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mrow>
+            <mo>+</mo>
+            <msub>
+              <mi>b</mi>
+              <mn>1</mn>
+            </msub>
+            <mo>,</mo>
+            <mi>T</mi>
+            <mo>.</mo>
+            <mrow>
+              <mtext>byteOrdered</mtext>
+            </mrow>
+            <mrow>
+              <mo>(</mo>
+              <mi>y</mi>
+              <mo>)</mo>
+            </mrow>
+            <mo>+</mo>
+            <msub>
+              <mi>b</mi>
+              <mn>2</mn>
+            </msub>
+            <mo>)</mo>
+          </mrow>
+          <mo>=</mo>
+          <mi>T</mi>
+          <mo>.</mo>
+          <mrow>
+            <mtext>compare</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>,</mo>
+            <mi>y</mi>
+            <mo>)</mo>
+          </mrow>
+        </mstyle>
+        <!-- <annotation encoding="text/x-asciimath">forall x,y in T, forall b_1, b_2 in [0x10-0xEF],
+    "compareBytesUnsigned"(T."byteOrdered"(x)+b_1, T."byteOrdered"(y)+b_2)=T."compare"(x, y)</annotation> -->
+      </semantics>
+    </math>
+- Weak prefix-freedom (4):  
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <semantics>
+        <mstyle displaystyle="true">
+          <mo>&#x2200;</mo>
+          <mi>x</mi>
+          <mo>,</mo>
+          <mi>y</mi>
+          <mo>&#x2208;</mo>
+          <mi>T</mi>
+          <mo>,</mo>
+          <mo>&#x2200;</mo>
+          <mi>b</mi>
+          <mo>&#x2208;</mo>
+          <mrow>
+            <mo>[</mo>
+            <mn>0x10</mn>
+            <mo>-</mo>
+            <mn>0xEF</mn>
+            <mo>]</mo>
+          </mrow>
+          <mo>,</mo>
+            <mtext><br/></mtext>
+          <mrow>
+            <mo>(</mo>
+            <mi>T</mi>
+            <mo>.</mo>
+            <mrow>
+              <mtext>byteOrdered</mtext>
+            </mrow>
+            <mrow>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mrow>
+            <mo>+</mo>
+            <mi>b</mi>
+            <mo>)</mo>
+          </mrow>
+          <mrow>
+            <mspace width="1ex" />
+            <mtext> is not a prefix of </mtext>
+            <mspace width="1ex" />
+          </mrow>
+          <mi>T</mi>
+          <mo>.</mo>
+          <mrow>
+            <mtext>byteOrdered</mtext>
+          </mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>y</mi>
+            <mo>)</mo>
+          </mrow>
+        </mstyle>
+        <!-- <annotation encoding="text/x-asciimath">forall x,y in T, forall b in [0x10-0xEF],
+    (T."byteOrdered"(x)+b) " is not a prefix of " T."byteOrdered"(y)</annotation> -->
+      </semantics>
+    </math>
+
+These versions allow the addition of a separator byte after each value, and guarantee that the combination with 
+separator fulfills the original requirements. (3) is somewhat stronger than (1) but is necessarily true if (2) is also 
+in force, while (4) trivially follows from (2).
+
+## Fixed length unsigned integers (Murmur token, date/time)
+
+This is the trivial case, as we can simply use the input bytes in big-endian order. The comparison result is the same, 
+and fixed length values are trivially prefix free, i.e. (1) and (2) are satisfied, and thus (3) and (4) follow from the
+observation above.
+
+## Fixed-length signed integers (byte, short, int, bigint)
+
+As above, but we need to invert the sign bit of the number to put negative numbers before positives. This maps 
+`MIN_VALUE` to `0x00`..., `-1` to `0x7F…`, `0` to `0x80…`, and `MAX_VALUE` to `0xFF…`; comparing the resulting number 
+as an unsigned integer has the same effect as comparing the source signed.
+
+Examples:
+
+|Type and value|bytes|encodes as|
+|--------------|-----|----------|
+|int 1         |00 00 00 01|             80 00 00 01
+|short -1      |FF FF      |             7F FF
+|byte 0        |00         |             80
+|int MAX_VALUE |7F FF FF FF|             FF FF FF FF
+|long MIN_VALUE|80 00 00 00 00 00 00 00| 00 00 00 00 00 00 00 00
+
+## Fixed-size floating-point numbers (float, double)
+
+IEEE-754 was designed with byte-by-byte comparisons in mind, and provides an important guarantee about the bytes of a
+floating point number:  
+* If x and y are of the same sign, bytes(x) ≥ bytes(y) ⇔ |x| ≥ |y|.
+
+Thus, to be able to order floating point numbers as unsigned integers, we can:
+* Flip the sign bit so negatives are smaller than positive numbers.
+* If the number was negative, also flip all the other bits so larger magnitudes become smaller integers.
+
+This matches exactly the behaviour of `Double.compare`, which doesn’t fully agree with numerical comparisons (see spec) 
+in order to define a natural order over the floating point numbers.
+
+Examples:
+
+|Type and value|bytes|encodes as|
+|---|---|---|
+|float +1.0|            3F 80 00 00|               BF 80 00 00|
+|float +0.0|            00 00 00 00|               80 00 00 00|
+|float -0.0|            80 00 00 00|               7F FF FF FF|
+|float -1.0|            BF 80 00 00|               40 7F FF FF|
+|double +1.0|           3F F0 00 00 00 00 00 00|   BF F0 00 00 00 00 00 00|
+|double +Inf|           7F F0 00 00 00 00 00 00|   FF F0 00 00 00 00 00 00|
+|double -Inf|           FF F0 00 00 00 00 00 00|   00 0F FF FF FF FF FF FF|
+|double NaN|            7F F8 00 00 00 00 00 00|   FF F8 00 00 00 00 00 00|
+
+## UUIDs
+UUIDs are fixed-length unsigned integers, where the UUID version/type is compared first, and where bits need to be 
+reordered for the time UUIDs. To create a byte-ordered representation, we reorder the bytes: pull the version digit 
+first, then the rest of the digits, using the special time order if the version is equal to one.
+
+Examples:
+
+|Type and value|bytes|encodes as|
+|---|---|---|
+|Random (v4)|    cc520882-9507-44fb-8fc9-b349ecdee658 |    4cc52088295074fb8fc9b349ecdee658
+|Time (v1)  |    2a92d750-d8dc-11e6-a2de-cf8ecd4cf053 |    11e6d8dc2a92d750a2decf8ecd4cf053
+
+## Multi-component sequences (Partition or Clustering keys, tuples), bounds and nulls
+
+As mentioned above, we encode sequences by adding separator bytes in front, between components, and a terminator at the
+end. The values we chose for the separator and terminator are `0x40` and `0x38`, and they serve several purposes:
+- Permits partially specified bounds, with strict/exclusive or non-strict/inclusive semantics. This is done by finishing
+  a bound with a terminator value that is smaller/greater than the separator and terminator. We can use `0x20` for </≥
+  and `0x60` for ≤/>.
+- Permits encoding of `null` values. We use `0x3F` as the separator in this case, followed by no value bytes. This is 
+  always smaller than a sequence with non-null value for this component, but not smaller than a sequence that ends in
+  this component.
+- Helps identify the ending of variable-length components (see below).
+
+Examples:
+
+|Types and values|bytes|encodes as|
+|---|---|---|
+|(short 1, float 1.0)    |    00 01, 3F 80 00 00    |   40·80 01·40·BF 80 00 00·38
+|(short -1, null)        |    FF FF, —              |   40·7F FF·3F·38
+|≥ (short 0, float -Inf) |    00 00, FF 80 00 00, >=|   40·80 00·40·00 7F FF FF·20
+|< (short MIN)           |    80 00, <=             |   40·00 00·20
+|\> (null)               |                          |   3F·60
+|BOTTOM                  |                          |   20
+|TOP                     |                          |   60
+
+(The middle dot · doesn't exist in the encoding, it’s just a visualisation of the boundaries in the examples.)
+
+Since:
+- all separators in use are within `0x10`-`0xEF`, and
+- we use the same separator for internal components, with the exception of nulls which we encode with a smaller 
+  separator
+- the sequence has a fixed number of components or we use a different trailing value whenever it can be shorter
+
+the properties (3) and (4) guarantee that the byte comparison of the encoding goes in the same direction as the
+lexicographical comparison of the sequence. In combination with the third point above, (4) also ensures that no encoding 
+is a prefix of another. Since we have (1) and (2), (3) and (4) are also satisfied.
+
+Note that this means that the encodings of all partition and clustering keys used in the database will be prefix-free.
+
+## Variable-length byte comparables (ASCII, UTF-8 strings, blobs, InetAddress)
+
+In isolation, these can be compared directly without reinterpretation. However, once we place these inside a flattened
+sequence of values we need to clearly define the boundaries between values while maintaining order. To do this we use an
+end-of-value marker; since shorter values must be smaller than longer, this marker must be 0 and we need to find a way 
+to encode/escape actual 0s in the input sequence.
+
+The method we chose for this is the following:
+- If the input does not end on `00`, a `00` byte is appended at the end.
+- If the input contains a `00` byte, it is encoded as `00 FF`.
+- If the input contains a sequence of *n* `00` bytes, they are encoded as `00` `FE` (*n*-1 times) `FF`  
+  (so that we don’t double the size of `00` blobs).
+- If the input ends in `00`, the last `FF` is changed to `FE`  
+  (to ensure it’s smaller than the same value with `00` appended).
+
+Examples:
+
+|bytes/sequence|encodes as|
+|---|----|
+|22 00                |        22 00 FE
+|22 00 00 33          |        22 00 FE FF 33 00
+|22 00 11             |        22 00 FF 11 00
+|(blob 22, short 0)   |        40·22 00·40·80 00·40
+| ≥ (blob 22 00)      |        40·22 00 FE·20
+| ≤ (blob 22 00 00)   |        40·22 00 FE FE·60
+
+Within the encoding, a `00` byte can only be followed by a `FE` or `FF` byte, and hence if an encoding is a prefix of 
+another, the latter has to have a `FE` or `FF` as the next byte, which ensures both (4) (adding `10`-`EF` to the former 
+makes it no longer a prefix of the latter) and (3) (adding `10`-`EF` to the former makes it smaller than the latter; in
+this case the original value of the former is a prefix of the original value of the latter).
+
+## Variable-length integers (varint, RandomPartitioner token)
+
+If integers of unbounded length are guaranteed to start with a non-zero digit, to compare them we can first use a signed
+length, as numbers with longer representations have higher magnitudes. Only if the lengths match we need to compare the
+sequence of digits, which now has a known length.
+
+(Note: The meaning of “digit” here is not the same as “decimal digit”. We operate with numbers stored as bytes, thus it
+makes most sense to treat the numbers as encoded in base-256, where each digit is a byte.)
+
+This translates to the following encoding of varints:
+- Strip any leading zeros. Note that for negative numbers, `BigInteger` encodes leading 0 as `0xFF`.
+- If the length is 128 or greater, lead with a byte of `0xFF` (positive) or `0x00` (negative) for every 128 until there
+  are less than 128 left.
+- Encode the sign and (remaining) length of the number as a byte:
+  - `0x80 + (length - 1)` for positive numbers (so that greater magnitude is higher);
+  - `0x7F - (length - 1)` for negative numbers (so that greater magnitude is lower, and all negatives are lower than
+    positives).
+- Paste the bytes of the number, 2’s complement encoded for negative numbers (`BigInteger` already applies the 2’s
+  complement).
+
+Since when comparing two numbers we either have a difference in the length prefix, or the lengths are the same if we 
+need to compare the content bytes, there is no risk that a longer number can be confused with a shorter combined in a
+multi-component sequence. In other words, no value can be a prefix of another, thus we have (1) and (2) and thus (3) and (4)
+as well.
+
+Examples:
+
+|value|bytes|encodes as|
+|---:|---|---|
+|0      |    00              | 80·00
+|1      |    01              | 80·01
+|-1     |    FF              | 7F·FF
+|255    |    00 FF           | 80·FF
+|-256   |    FF 00           | 7F·00
+|2^16   |    01 00 00        | 82·01 00 00
+|-2^32  |    FF 00 00 00 00  | 7C·00 00 00 00
+|2^1024 |    01 00(128 times)| FF 80·01 00(128 times)
+|-2^2048|    FF 00(256 times)| 00 00 80·00(256 times)
+
+(Middle dot · shows the transition point between length and digits.)
+
+## Variable-length floating-point decimals (decimal)
+
+Variable-length floats are more complicated, but we can treat them similarly to IEEE-754 floating point numbers, by
+normalizing them by splitting them into sign, mantissa and signed exponent such that the mantissa is a number below 1 
+with a non-zero leading digit. We can then compare sign, exponent and mantissa in sequence (where the comparison of
+exponent and mantissa are with reversed meaning if the sign is negative) and that gives us the decimal ordering.
+
+A bit of extra care must be exercised when encoding decimals. Since fractions like `0.1` cannot be perfectly encoded in
+binary, decimals (and mantissas) cannot be encoded in binary or base-256 correctly. A decimal base must be used; since 
+we deal with bytes, it makes most sense to make things a little more efficient by using base-100. Floating-point 
+encoding and the comparison idea from the previous paragraph work in any number base.
+
+`BigDecimal` presents a further challenge, as it encodes decimals using a mixture of bases: numbers have a binary-
+encoded integer part and a decimal power-of-ten scale. The bytes produced by a `BigDecimal` are thus not suitable for 
+direct conversion to byte comparable and we must first instantiate the bytes as a `BigDecimal`, and then apply the 
+class’s methods to operate on it as a number.
+
+We then use the following encoding:
+- If the number is 0, the encoding is a single `0x80` byte.
+- Convert the input to signed mantissa and signed exponent in base-100. If the value is negative, invert the sign of the
+  exponent.
+- Output a byte encoding:
+  - the sign of the number encoded as `0x80` if positive and `0x00` if negative,
+  - the exponent length (stripping leading 0s) in bytes as `0x40 + exponent_length * exponent_sign`.
+- Output `exponent_length` of exponent, 2’s complement encoded so that negative values are correctly ordered.
+- Output `0x80 + leading signed byte of mantissa`, which is obtained by multiplying the mantissa by 100 and rounding to
+  -∞. The rounding is done so that the remainder of the mantissa becomes positive, and thus every new byte adds some 
+  value to it, making shorter sequences lower in value.
+- Update the mantissa to be the remainder after the rounding above. The result is guaranteed to be 0 or greater.
+- While the mantissa is non-zero, output `0x80 + leading byte` as above and update the mantissa to be the remainder.
+- Output `0x00`.
+
+As a description of how this produces the correct ordering, consider the result of comparison in the first differing 
+byte:
+- Difference in the first byte can be caused by:
+  - Difference in sign of the number or being zero, which yields the correct ordering because
+    - Negative numbers start with `0x3c` - `0x44`
+    - Zero starts with `0x80`
+    - Positive numbers start with `0xbc` - `0xc4`
+  - Difference in sign of the exponent modulated with the sign of the number. In a positive number negative exponents 
+    mean smaller values, while in a negative number it’s the opposite, thus the modulation with the number’s sign 
+    ensures the correct ordering. 
+  - Difference in modulated length of the exponent: again, since we gave the length a sign that is formed from both 
+    the sign of the exponent and the sign of the number, smaller numbers mean smaller exponent in the positive number 
+    case, and bigger exponent in the negative number case. In either case this provides the correct ordering.
+- Difference in one of the bytes of the modulated exponent (whose length and sign are now equal for both compared
+  numbers):
+  - Smaller byte means a smaller modulated exponent. In the positive case this means a smaller exponent, thus a smaller 
+    number. In the negative case this means the exponent is bigger, the absolute value of the number as well, and thus 
+    the number is smaller.
+- It is not possible for the difference to mix one number’s exponent with another’s mantissa (as such numbers would have
+  different leading bytes).
+- Difference in a mantissa byte present in both inputs:
+  - Smaller byte means smaller signed mantissa and hence smaller number when the exponents are equal.
+- One mantissa ending before another:
+  - This will result in the shorter being treated as smaller (since the trailing byte is `00`).
+  - Since all mantissas have at least one byte, this can’t happen in the leading mantissa byte.
+  - Thus the other number’s bytes from here on are not negative, and at least one of them must be non-zero, which means 
+    its mantissa is bigger and thus it encodes a bigger number.
+    
+Examples:
+
+|value|mexp|mantissa|mantissa in bytes|encodes as|
+|---:|---:|---|---|---|
+|1.1        | 1    | 0.0110 |.  01 10  |    C1·01·81 8A·00
+|1          | 1    | 0.01   |.  01     |    C1·01·81·00
+|0.01       | 0    | 0.01   |.  01     |    C0·81·00
+|0          |      |        |          |    80
+|-0.01      | 0    | -0.01  |. -01     |    40·81·00
+|-1         | -1   | -0.01  |. -01     |    3F·FF·7F·00
+|-1.1       | -1   | -0.0110|. -02 90  |    3F·FF·7E DA·00
+|-98.9      | -1   | -0.9890|. -99 10  |    3F·FF·1D 8A·00
+|-99        | -1   | -0.99  |. -99     |    3F·FF·1D·00
+|-99.9      | -1   | -0.9990|.-100 10  |    3F·FF·1C 8A·00
+|-8.1e2000  | -1001| -0.0810|. -09 90  |    3E·FC 17·77 DA·00
+|-8.1e-2000 | 999  | -0.0810|. -09 90  |    42·03 E7·77 DA·00
+|8.1e-2000  | -999 | 0.0810 |.  08 10  |    BE·FC 19·88 8A·00
+|8.1e2000   | 1001 | 0.0810 |.  08 10  |    C2·03 E9·88 8A·00
+(mexp stands for “modulated exponent”, i.e. exponent * sign)
+
+The values are prefix-free, because no exponent’s encoding can be a prefix of another, and the mantissas can never have
+a `00` byte at any place other than the last byte, and thus all (1)-(4) are satisfied.
+
+## Reversed types
+
+Reversing a type is straightforward: flip all bits of the encoded byte sequence. Since the source type encoding must
+satisfy (3) and (4), the flipped bits also do for the reversed comparator. (It is also true that if the source type 
+satisfies (1)-(2), the reversed will satisfy these too.)
+
+In a sequence we also must correct the `null` encoding for a reversed type (since it must be greater than all values).
+Instead of `0x3F` we use `0x41` as the separator byte.
+

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteSourceInverse.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteSourceInverse.java
@@ -1,0 +1,448 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.cassandra.db.marshal.ValueAccessor;
+
+/**
+ * Contains inverse transformation utilities for {@link ByteSource}s.
+ *
+ * See ByteComparable.md for details about the encoding scheme.
+ */
+public final class ByteSourceInverse
+{
+    private static final int INITIAL_BUFFER_CAPACITY = 32;
+    private static final int BYTE_ALL_BITS = 0xFF;
+    private static final int BYTE_NO_BITS = 0x00;
+    private static final int BYTE_SIGN_BIT = 1 << 7;
+    private static final int SHORT_SIGN_BIT = 1 << 15;
+    private static final int INT_SIGN_BIT = 1 << 31;
+    private static final long LONG_SIGN_BIT = 1L << 63;
+
+    /**
+     * Get the given number of bytes and produce a long from them, effectively treating the bytes as a big-endian
+     * unsigned encoding of the number.
+     */
+    public static long getUnsignedFixedLengthAsLong(ByteSource byteSource, int length)
+    {
+        if (byteSource == null)
+            throw new IllegalArgumentException("Unexpected null ByteSource");
+        if (length < 1 || length > 8)
+            throw new IllegalArgumentException("Between 1 and 8 bytes can be read at a time");
+
+        long result = 0;
+        for (int i = 0; i < length; ++i)
+        {
+            int data = byteSource.next();
+            if (data == ByteSource.END_OF_STREAM)
+                throw new IllegalArgumentException(
+                        String.format("Unexpected end of stream reached after %d bytes (expected >= %d)", i, length));
+            assertValidByte(data);
+            result = (result << 8) | data;
+        }
+        return result;
+    }
+
+    /**
+     * Produce the bytes for an encoded signed fixed-length number.
+     * The first byte has its sign bit inverted, and the rest are passed unchanged.
+     */
+    public static <V> V getSignedFixedLength(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        if (byteSource == null)
+            throw new IllegalArgumentException("Unexpected null ByteSource");
+        if (length < 1)
+            throw new IllegalArgumentException("At least 1 byte should be read");
+
+        V result = accessor.allocate(length);
+        // The first byte needs to have its sign flipped
+        accessor.putByte(result, 0, (byte) (byteSource.next() ^ BYTE_SIGN_BIT));
+        // and the rest can be retrieved unchanged.
+        for (int i = 1; i < length; ++i)
+        {
+            int data = byteSource.next();
+            if (data == ByteSource.END_OF_STREAM)
+                throw new IllegalArgumentException(
+                        String.format("Unexpected end of stream reached after %d bytes (expected >= %d)", i, length));
+            assertValidByte(data);
+            accessor.putByte(result, i, (byte) data);
+        }
+        return result;
+    }
+
+    /**
+     * Produce the bytes for an encoded signed fixed-length number, also translating null to empty buffer.
+     * The first byte has its sign bit inverted, and the rest are passed unchanged.
+     */
+    public static <V> V getOptionalSignedFixedLength(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        return byteSource == null ? accessor.empty() : getSignedFixedLength(accessor, byteSource, length);
+    }
+
+    /**
+     * Produce the bytes for an encoded signed fixed-length floating-point number.
+     * If sign bit is on, returns negated bytes. If not, clears the sign bit and passes the rest of the bytes unchanged.
+     */
+    public static <V> V getSignedFixedLengthFloat(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        if (byteSource == null)
+            throw new IllegalArgumentException("Unexpected null ByteSource");
+        if (length < 1)
+            throw new IllegalArgumentException("At least 1 byte should be read");
+
+        V result = accessor.allocate(length);
+
+        int xor;
+        int first = byteSource.next();
+        assertValidByte(first);
+        if (first < 0x80)
+        {
+            // Negative number. Invert all bits.
+            xor = BYTE_ALL_BITS;
+            first ^= xor;
+        }
+        else
+        {
+            // Positive number. Invert only the sign bit.
+            xor = BYTE_NO_BITS;
+            first ^= BYTE_SIGN_BIT;
+        }
+        accessor.putByte(result, 0, (byte) first);
+
+        // xor is now applied to the rest of the bytes to flip their bits if necessary.
+        for (int i = 1; i < length; ++i)
+        {
+            int data = byteSource.next();
+            if (data == ByteSource.END_OF_STREAM)
+                throw new IllegalArgumentException(
+                String.format("Unexpected end of stream reached after %d bytes (expected >= %d)", i, length));
+            assertValidByte(data);
+            data ^= xor;
+            accessor.putByte(result, i, (byte) data);
+        }
+        return result;
+    }
+
+    /**
+     * Produce the bytes for an encoded signed fixed-length floating-point number, also translating null to an empty
+     * buffer.
+     * If sign bit is on, returns negated bytes. If not, clears the sign bit and passes the rest of the bytes unchanged.
+     */
+    public static <V> V getOptionalSignedFixedLengthFloat(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        return byteSource == null ? accessor.empty() : getSignedFixedLengthFloat(accessor, byteSource, length);
+    }
+
+    /**
+     * Get the next length bytes from the source unchanged.
+     */
+    public static <V> V getFixedLength(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        if (byteSource == null)
+            throw new IllegalArgumentException("Unexpected null ByteSource");
+        if (length < 1)
+            throw new IllegalArgumentException("At least 1 byte should be read");
+
+        V result = accessor.allocate(length);
+        for (int i = 0; i < length; ++i)
+        {
+            int data = byteSource.next();
+            if (data == ByteSource.END_OF_STREAM)
+                throw new IllegalArgumentException(
+                        String.format("Unexpected end of stream reached after %d bytes (expected >= %d)", i, length));
+            assertValidByte(data);
+            accessor.putByte(result, i, (byte) data);
+        }
+        return result;
+    }
+
+    /**
+     * Get the next length bytes from the source unchanged, also translating null to an empty buffer.
+     */
+    public static <V> V getOptionalFixedLength(ValueAccessor<V> accessor, ByteSource byteSource, int length)
+    {
+        return byteSource == null ? accessor.empty() : getFixedLength(accessor, byteSource, length);
+    }
+
+    /**
+     * Gets the next {@code int} from the current position of the given {@link ByteSource}. The source position is
+     * modified accordingly (moved 4 bytes forward).
+     * <p>
+     * The source is not strictly required to represent just the encoding of an {@code int} value, so theoretically
+     * this API could be used for reading data in 4-byte strides. Nevertheless its usage is fairly limited because:
+     * <ol>
+     *     <li>...it presupposes signed fixed-length encoding for the encoding of the original value</li>
+     *     <li>...it decodes the data returned on each stride as an {@code int} (i.e. it inverts its leading bit)</li>
+     *     <li>...it doesn't provide any meaningful guarantees (with regard to throwing) in case there are not enough
+     *     bytes to read, in case a special escape value was not interpreted as such, etc.</li>
+     * </ol>
+     * </p>
+     *
+     * @param byteSource A non-null byte source, containing at least 4 bytes.
+     */
+    public static int getSignedInt(ByteSource byteSource)
+    {
+        return (int) getUnsignedFixedLengthAsLong(byteSource, 4) ^ INT_SIGN_BIT;
+    }
+
+    /**
+     * Gets the next {@code long} from the current position of the given {@link ByteSource}. The source position is
+     * modified accordingly (moved 8 bytes forward).
+     * <p>
+     * The source is not strictly required to represent just the encoding of a {@code long} value, so theoretically
+     * this API could be used for reading data in 8-byte strides. Nevertheless its usage is fairly limited because:
+     * <ol>
+     *     <li>...it presupposes signed fixed-length encoding for the encoding of the original value</li>
+     *     <li>...it decodes the data returned on each stride as a {@code long} (i.e. it inverts its leading bit)</li>
+     *     <li>...it doesn't provide any meaningful guarantees (with regard to throwing) in case there are not enough
+     *     bytes to read, in case a special escape value was not interpreted as such, etc.</li>
+     * </ol>
+     * </p>
+     *
+     * @param byteSource A non-null byte source, containing at least 8 bytes.
+     */
+    public static long getSignedLong(ByteSource byteSource)
+    {
+        return getUnsignedFixedLengthAsLong(byteSource, 8) ^ LONG_SIGN_BIT;
+    }
+
+    /**
+     * Converts the given {@link ByteSource} to a {@code byte}.
+     *
+     * @param byteSource A non-null byte source, containing at least 1 byte.
+     */
+    public static byte getSignedByte(ByteSource byteSource)
+    {
+        if (byteSource == null)
+            throw new IllegalArgumentException("Unexpected null ByteSource");
+        int theByte = byteSource.next();
+        if (theByte == ByteSource.END_OF_STREAM)
+            throw new IllegalArgumentException("Unexpected ByteSource with length 0 instead of 1");
+
+        return (byte) (theByte ^ BYTE_SIGN_BIT);
+    }
+
+    /**
+     * Converts the given {@link ByteSource} to a {@code short}. All terms and conditions valid for
+     * {@link #getSignedInt(ByteSource)} and {@link #getSignedLong(ByteSource)} translate to this as well.
+     *
+     * @param byteSource A non-null byte source, containing at least 2 bytes.
+     *
+     * @see #getSignedInt(ByteSource)
+     * @see #getSignedLong(ByteSource)
+     */
+    public static short getSignedShort(ByteSource byteSource)
+    {
+        return (short) (getUnsignedFixedLengthAsLong(byteSource, 2) ^ SHORT_SIGN_BIT);
+    }
+
+    /**
+     * Reads a single variable-length byte sequence (blob, string, ...) encoded according to the scheme described
+     * in ByteSource.md, decoding it back to its original, unescaped form.
+     *
+     * @param byteSource The source of the variable-length bytes sequence.
+     * @return A byte array containing the original, unescaped bytes of the given source. Unescaped here means
+     * not including any of the escape sequences of the encoding scheme used for variable-length byte sequences.
+     */
+    public static byte[] getUnescapedBytes(ByteSource.Peekable byteSource)
+    {
+        return byteSource == null ? null : readBytes(unescape(byteSource));
+    }
+
+    /**
+     * As above, but converts the result to a ByteSource.
+     */
+    public static ByteSource unescape(ByteSource.Peekable byteSource)
+    {
+        return new ByteSource() {
+            boolean escaped = false;
+
+            public int next()
+            {
+                if (!escaped)
+                {
+                    int data = byteSource.next(); // we consume this byte no matter what it is
+                    if (data > ByteSource.ESCAPE)
+                        return data;        // most used path leads here
+
+                    assert data != ByteSource.END_OF_STREAM : "Invalid escaped byte sequence";
+                    escaped = true;
+                }
+
+                int next = byteSource.peek();
+                switch (next)
+                {
+                    case END_OF_STREAM:
+                        // The end of a byte-comparable outside of a multi-component sequence. No matter what we have
+                        // seen or peeked before, we should stop now.
+                        byteSource.next();
+                        return END_OF_STREAM;
+                    case ESCAPED_0_DONE:
+                        // The end of 1 or more consecutive 0x00 value bytes.
+                        escaped = false;
+                        byteSource.next();
+                        return ESCAPE;
+                    case ESCAPED_0_CONT:
+                        // Escaped sequence continues
+                        byteSource.next();
+                        return ESCAPE;
+                    default:
+                        // An ESCAPE or ESCAPED_0_CONT won't be followed by either another ESCAPED_0_CONT, an
+                        // ESCAPED_0_DONE, or an END_OF_STREAM only when the byte-comparable is part of a multi-component
+                        // sequence and we have reached the end of the encoded byte-comparable. In this case, the byte
+                        // we have just peeked is the separator or terminator byte between or at the end of components
+                        // (which by contact must be 0x10 - 0xFE, which cannot conflict with our special bytes).
+                        assert next >= ByteSource.MIN_SEPARATOR && next <= ByteSource.MAX_SEPARATOR : next;
+                        // Unlike above, we don't consume this byte (the sequence decoding needs it).
+                        return END_OF_STREAM;
+                }
+            }
+        };
+    }
+
+    /**
+     * Reads the bytes of the given source into a byte array. Doesn't do any transformation on the bytes, just reads
+     * them until it reads an {@link ByteSource#END_OF_STREAM} byte, after which it returns an array of all the read
+     * bytes, <strong>excluding the {@link ByteSource#END_OF_STREAM}</strong>.
+     * <p>
+     * This method sizes a tentative internal buffer array at {@code initialBufferCapacity}.  However, if
+     * {@code byteSource} exceeds this size, the buffer array is recreated with doubled capacity as many times as
+     * necessary.  If, after {@code byteSource} is fully exhausted, the number of bytes read from it does not exactly
+     * match the current size of the tentative buffer array, then it is copied into another array sized to fit the
+     * number of bytes read; otherwise, it is returned without that final copy step.
+     *
+     * @param byteSource The source which bytes we're interested in.
+     * @param initialBufferCapacity The initial size of the internal buffer.
+     * @return A byte array containing exactly all the read bytes. In case of a {@code null} source, the returned byte
+     * array will be empty.
+     */
+    public static byte[] readBytes(ByteSource byteSource, final int initialBufferCapacity)
+    {
+        if (byteSource == null)
+            return new byte[0];
+
+        int readBytes = 0;
+        byte[] buf = new byte[initialBufferCapacity];
+        int data;
+        while ((data = byteSource.next()) != ByteSource.END_OF_STREAM)
+        {
+            buf = ensureCapacity(buf, readBytes);
+            buf[readBytes++] = (byte) data;
+        }
+
+        if (readBytes != buf.length)
+        {
+            buf = Arrays.copyOf(buf, readBytes);
+        }
+        return buf;
+    }
+
+    /**
+     * Reads the bytes of the given source into a byte array. Doesn't do any transformation on the bytes, just reads
+     * them until it reads an {@link ByteSource#END_OF_STREAM} byte, after which it returns an array of all the read
+     * bytes, <strong>excluding the {@link ByteSource#END_OF_STREAM}</strong>.
+     * <p>
+     * This is equivalent to {@link #readBytes(ByteSource, int)} where the second actual parameter is
+     * {@linkplain #INITIAL_BUFFER_CAPACITY} ({@value INITIAL_BUFFER_CAPACITY}).
+     *
+     * @param byteSource The source which bytes we're interested in.
+     * @return A byte array containing exactly all the read bytes. In case of a {@code null} source, the returned byte
+     * array will be empty.
+     */
+    public static byte[] readBytes(ByteSource byteSource)
+    {
+        return readBytes(byteSource, INITIAL_BUFFER_CAPACITY);
+    }
+
+    /**
+     * Ensures the given buffer has capacity for taking data with the given length - if it doesn't, it returns a copy
+     * of the buffer, but with double the capacity.
+     */
+    private static byte[] ensureCapacity(byte[] buf, int dataLengthInBytes)
+    {
+        if (dataLengthInBytes == buf.length)
+            // We won't gain much with guarding against overflow. We'll overflow when dataLengthInBytes >= 1 << 30,
+            // and if we do guard, we'll be able to extend the capacity to Integer.MAX_VALUE (which is 1 << 31 - 1).
+            // Controlling the exception that will be thrown shouldn't matter that much, and  in practice, we almost
+            // surely won't be reading gigabytes of ByteSource data at once.
+            return Arrays.copyOf(buf, dataLengthInBytes * 2);
+        else
+            return buf;
+    }
+
+    /**
+     * Converts the given {@link ByteSource} to a UTF-8 {@link String}.
+     *
+     * @param byteSource The source we're interested in.
+     * @return A UTF-8 string corresponding to the given source.
+     */
+    public static String getString(ByteSource.Peekable byteSource)
+    {
+        if (byteSource == null)
+            return null;
+
+        byte[] data = getUnescapedBytes(byteSource);
+
+        return new String(data, StandardCharsets.UTF_8);
+    }
+
+    /*
+     * Multi-component sequence utilities.
+     */
+
+    /**
+     * A utility for consuming components from a peekable multi-component sequence.
+     * It uses the component separators, so the given sequence needs to have its last component fully consumed, in
+     * order for the next consumable byte to be a separator. Identifying the end of the component that will then be
+     * consumed is the responsibility of the consumer (the user of this method).
+     * @param source A peekable multi-component sequence, which next byte is a component separator.
+     * @return the given multi-component sequence if its next component is not null, or {@code null} if it is.
+     */
+    public static ByteSource.Peekable nextComponentSource(ByteSource.Peekable source)
+    {
+        int separator = source.next();
+        return nextComponentNull(separator)
+               ? null
+               : source;
+    }
+
+    /**
+     * A utility for consuming components from a peekable multi-component sequence, very similar to
+     * {@link #nextComponentSource(ByteSource.Peekable)} - the difference being that here the separator can be passed
+     * in case it had to be consumed beforehand.
+     */
+    public static ByteSource.Peekable nextComponentSource(ByteSource.Peekable source, int separator)
+    {
+        return nextComponentNull(separator)
+               ? null
+               : source;
+    }
+
+    public static boolean nextComponentNull(int separator)
+    {
+        return separator == ByteSource.NEXT_COMPONENT_NULL || separator == ByteSource.NEXT_COMPONENT_NULL_REVERSED;
+    }
+
+    private static void assertValidByte(int data)
+    {
+        assert data >= BYTE_NO_BITS && data <= BYTE_ALL_BITS;
+    }
+}

--- a/test/bin/jmh
+++ b/test/bin/jmh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jvmoptions_variant="-server"
+export CASSANDRA_HOME=`dirname "$0"`/../../
+. $CASSANDRA_HOME/bin/cassandra.in.sh
+
+# Use JAVA_HOME if set, otherwise look for java in PATH
+if [ -n "$JAVA_HOME" ]; then
+    # Why we can't have nice things: Solaris combines x86 and x86_64
+    # installations in the same tree, using an unconventional path for the
+    # 64bit JVM.  Since we prefer 64bit, search the alternate path first,
+    # (see https://issues.apache.org/jira/browse/CASSANDRA-4638).
+    for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+        if [ -x "$java" ]; then
+            JAVA="$java"
+            break
+        fi
+    done
+else
+    JAVA=java
+fi
+
+if [ -z $JAVA ] ; then
+    echo Unable to find java executable. Check JAVA_HOME and PATH environment variables. >&2
+    exit 1;
+fi
+
+# If numactl is available, use it. For Cassandra, the priority is to
+# avoid disk I/O. Even for the purpose of CPU efficiency, we don't
+# really have CPU<->data affinity anyway. Also, empirically test that numactl
+# works before trying to use it (CASSANDRA-3245).
+NUMACTL_ARGS=${NUMACTL_ARGS:-"--localalloc"}
+if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
+then
+    NUMACTL="numactl $NUMACTL_ARGS"
+else
+    NUMACTL=""
+fi
+
+if [ -z "$CASSANDRA_CONF" -o -z "$CLASSPATH" ]; then
+    echo "You must set the CASSANDRA_CONF and CLASSPATH vars" >&2
+    exit 1
+fi
+
+if [ -f "$CASSANDRA_CONF/cassandra-env.sh" ]; then
+    . "$CASSANDRA_CONF/cassandra-env.sh"
+fi
+
+# Special-case path variables.
+case "`uname`" in
+    CYGWIN*)
+        CLASSPATH=`cygpath -p -w "$CLASSPATH"`
+        CASSANDRA_CONF=`cygpath -p -w "$CASSANDRA_CONF"`
+    ;;
+esac
+
+# Cassandra uses an installed jemalloc via LD_PRELOAD / DYLD_INSERT_LIBRARIES by default to improve off-heap
+# memory allocation performance. The following code searches for an installed libjemalloc.dylib/.so/.1.so using
+# Linux and OS-X specific approaches.
+# To specify your own libjemalloc in a different path, configure the fully qualified path in CASSANDRA_LIBJEMALLOC.
+# To disable jemalloc preload at all, set CASSANDRA_LIBJEMALLOC=-
+#
+#CASSANDRA_LIBJEMALLOC=
+#
+find_library()
+{
+    pattern=$1
+    path=$(echo ${2} | tr ":" " ")
+
+    find $path -regex "$pattern" -print 2>/dev/null | head -n 1
+}
+case "`uname -s`" in
+    Linux)
+        if [ -z $CASSANDRA_LIBJEMALLOC ] ; then
+            which ldconfig > /dev/null 2>&1
+            if [ $? = 0 ] ; then
+                # e.g. for CentOS
+                dirs="/lib64 /lib /usr/lib64 /usr/lib `ldconfig -v 2>/dev/null | grep -v '^\s' | sed 's/^\([^:]*\):.*$/\1/'`"
+            else
+                # e.g. for Debian, OpenSUSE
+                dirs="/lib64 /lib /usr/lib64 /usr/lib `cat /etc/ld.so.conf /etc/ld.so.conf.d/*.conf | grep '^/'`"
+            fi
+            dirs=`echo $dirs | tr " " ":"`
+            CASSANDRA_LIBJEMALLOC=$(find_library '.*/libjemalloc\.so\(\.1\)*' $dirs)
+        fi
+        if [ ! -z $CASSANDRA_LIBJEMALLOC ] ; then
+            export JVM_OPTS="$JVM_OPTS -Dcassandra.libjemalloc=$CASSANDRA_LIBJEMALLOC"
+            if [ "-" != "$CASSANDRA_LIBJEMALLOC" ] ; then
+                export LD_PRELOAD=$CASSANDRA_LIBJEMALLOC
+            fi
+        fi
+    ;;
+    Darwin)
+        if [ -z $CASSANDRA_LIBJEMALLOC ] ; then
+            CASSANDRA_LIBJEMALLOC=$(find_library '.*/libjemalloc\.dylib' $DYLD_LIBRARY_PATH:${DYLD_FALLBACK_LIBRARY_PATH-$HOME/lib:/usr/local/lib:/lib:/usr/lib})
+        fi
+        if [ ! -z $CASSANDRA_LIBJEMALLOC ] ; then
+            export JVM_OPTS="$JVM_OPTS -Dcassandra.libjemalloc=$CASSANDRA_LIBJEMALLOC"
+            if [ "-" != "$CASSANDRA_LIBJEMALLOC" ] ; then
+                export DYLD_INSERT_LIBRARIES=$CASSANDRA_LIBJEMALLOC
+            fi
+        fi
+    ;;
+esac
+
+cassandra_parms="-Dlogback.configurationFile=$CASSANDRA_HOME/test/conf/logback-jmh.xml"
+cassandra_parms="$cassandra_parms -Dcassandra.logdir=$CASSANDRA_HOME/logs"
+cassandra_parms="$cassandra_parms -Dcassandra.storagedir=$cassandra_storagedir"
+cassandra_parms="$cassandra_parms -Dcassandra-foreground=yes"
+cassandra_parms="$cassandra_parms -XX:+PreserveFramePointer"
+
+# Create log directory, some tests require that
+mkdir -p $CASSANDRA_HOME/logs
+
+if [ ! -f $CASSANDRA_HOME/build/test/benchmarks.jar ] ; then
+    echo "$CASSANDRA_HOME/build/test/benchmarks.jar does not exist - execute 'ant build-jmh'"
+    exit 1
+fi
+
+exec $NUMACTL "$JAVA" -cp "$CLASSPATH:$CASSANDRA_HOME/build/test/benchmarks.jar:$CASSANDRA_HOME/build/test/deps.jar" org.openjdk.jmh.Main -jvmArgs="$cassandra_parms $JVM_OPTS" $@
+
+# vi:ai sw=4 ts=4 tw=0 et

--- a/test/conf/logback-jmh.xml
+++ b/test/conf/logback-jmh.xml
@@ -1,0 +1,101 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<!--
+In order to disable debug.log, comment-out the ASYNCDEBUGLOG
+appender reference in the root level section below.
+-->
+
+<configuration scan="false" scanPeriod="60 seconds">
+  <jmxConfigurator />
+  <!-- No shutdown hook; we run it ourselves in StorageService after shutdown -->
+
+  <!-- SYSTEMLOG rolling file appender to system.log (INFO level) -->
+
+  <appender name="SYSTEMLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <file>${cassandra.logdir}/system.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>${cassandra.logdir}/system.log.%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+      <!-- each file should be at most 50MB, keep 7 days worth of history, but at most 5GB -->
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>7</maxHistory>
+      <totalSizeCap>5GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- DEBUGLOG rolling file appender to debug.log (all levels) -->
+
+  <appender name="DEBUGLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${cassandra.logdir}/debug.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>${cassandra.logdir}/debug.log.%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+      <!-- each file should be at most 50MB, keep 7 days worth of history, but at most 5GB -->
+      <maxFileSize>50MB</maxFileSize>
+      <maxHistory>7</maxHistory>
+      <totalSizeCap>5GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- ASYNCLOG assynchronous appender to debug.log (all levels) -->
+  <appender name="ASYNCDEBUGLOG" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>1024</queueSize>
+    <discardingThreshold>0</discardingThreshold>
+    <includeCallerData>true</includeCallerData>
+    <appender-ref ref="DEBUGLOG" />
+  </appender>
+
+  <!-- NOTE: For JMH we disable the STDOUT logging to avoid noise in output -->
+  <!-- STDOUT console appender to stdout (INFO level)
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+    </encoder>
+  </appender-->
+
+  <!-- Uncomment bellow and corresponding appender-ref to activate logback metrics
+  <appender name="LogbackMetrics" class="com.codahale.metrics.logback.InstrumentedAppender" />
+   -->
+
+  <root level="INFO">
+    <appender-ref ref="SYSTEMLOG" />
+    <!-- appender-ref ref="STDOUT" /-->
+    <appender-ref ref="ASYNCDEBUGLOG" /> <!-- Comment this line to disable debug.log -->
+    <!--
+    <appender-ref ref="LogbackMetrics" />
+    -->
+  </root>
+
+  <logger name="org.apache.cassandra" level="DEBUG"/>
+  <logger name="com.datastax.bdp.db" level="DEBUG"/>
+</configuration>

--- a/test/microbench/org/apache/cassandra/test/microbench/AbstractTypeByteSourceDecodingBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/AbstractTypeByteSourceDecodingBench.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.DecimalType;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.TypeParser;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1,jvmArgsAppend = { "-Xmx4G", "-Xms4G", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Threads(1)
+@State(Scope.Benchmark)
+public class AbstractTypeByteSourceDecodingBench
+{
+
+    private static final ByteComparable.Version LATEST = ByteComparable.Version.OSS41;
+
+    private static final Map<AbstractType, BiFunction<Random, Integer, ByteSource.Peekable>> PEEKABLE_GENERATOR_BY_TYPE = new HashMap<>();
+    static
+    {
+        PEEKABLE_GENERATOR_BY_TYPE.put(UTF8Type.instance, (prng, length) ->
+        {
+            byte[] randomBytes = new byte[length];
+            prng.nextBytes(randomBytes);
+            return ByteSource.peekable(ByteSource.of(new String(randomBytes, StandardCharsets.UTF_8), LATEST));
+        });
+        PEEKABLE_GENERATOR_BY_TYPE.put(BytesType.instance, (prng, length) ->
+        {
+            byte[] randomBytes = new byte[length];
+            prng.nextBytes(randomBytes);
+            return ByteSource.peekable(ByteSource.of(randomBytes, LATEST));
+        });
+        PEEKABLE_GENERATOR_BY_TYPE.put(IntegerType.instance, (prng, length) ->
+        {
+            BigInteger randomVarint = BigInteger.valueOf(prng.nextLong());
+            for (int i = 1; i < length / 8; ++i)
+                randomVarint = randomVarint.multiply(BigInteger.valueOf(prng.nextLong()));
+            return ByteSource.peekable(IntegerType.instance.asComparableBytes(IntegerType.instance.decompose(randomVarint), LATEST));
+        });
+        PEEKABLE_GENERATOR_BY_TYPE.put(DecimalType.instance, (prng, length) ->
+        {
+            BigInteger randomMantissa = BigInteger.valueOf(prng.nextLong());
+            for (int i = 1; i < length / 8; ++i)
+                randomMantissa = randomMantissa.multiply(BigInteger.valueOf(prng.nextLong()));
+            int randomScale = prng.nextInt(Integer.MAX_VALUE >> 1) + Integer.MAX_VALUE >> 1;
+            BigDecimal randomDecimal = new BigDecimal(randomMantissa, randomScale);
+            return ByteSource.peekable(DecimalType.instance.asComparableBytes(DecimalType.instance.decompose(randomDecimal), LATEST));
+        });
+    }
+
+    private Random prng = new Random();
+
+    @Param({"32", "128", "512"})
+    private int length;
+
+    @Param({"UTF8Type", "BytesType", "IntegerType", "DecimalType"})
+    private String abstractTypeName;
+
+    private AbstractType abstractType;
+    private BiFunction<Random, Integer, ByteSource.Peekable> peekableGenerator;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        abstractType = TypeParser.parse(abstractTypeName);
+        peekableGenerator = PEEKABLE_GENERATOR_BY_TYPE.get(abstractType);
+    }
+
+    @Inline
+    private ByteSource.Peekable randomPeekableBytes()
+    {
+        return peekableGenerator.apply(prng, length);
+    }
+
+    @Benchmark
+    public int baseline()
+    {
+        // Getting the source is not enough as its content is produced on next() calls.
+        ByteSource.Peekable source = randomPeekableBytes();
+        int count = 0;
+        while (source.next() != ByteSource.END_OF_STREAM)
+            ++count;
+        return count;
+    }
+
+    @Benchmark
+    public ByteBuffer fromComparableBytes()
+    {
+        ByteSource.Peekable peekableBytes = randomPeekableBytes();
+        return abstractType.fromComparableBytes(peekableBytes, ByteComparable.Version.OSS41);
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.SchemaCQLHelper;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.utils.AbstractTypeGenerators.TypeSupport;
 import org.quicktheories.core.Gen;
@@ -267,7 +268,7 @@ public class TupleTypeTest extends CQLTester
             for (ByteBuffer value : testcase.uniqueRows)
             {
                 map.put(value, count);
-                ByteBuffer[] tupleBuffers = tupleType.split(value);
+                ByteBuffer[] tupleBuffers = tupleType.split(ByteBufferAccessor.instance, value);
 
                 // use cast to avoid warning
                 execute("INSERT INTO %s (id, value) VALUES (?, ?)", tuple((Object[]) tupleBuffers), count);
@@ -306,7 +307,7 @@ public class TupleTypeTest extends CQLTester
             for (ByteBuffer value : testcase.uniqueRows)
             {
                 map.put(value, count);
-                ByteBuffer[] tupleBuffers = tupleType.split(value);
+                ByteBuffer[] tupleBuffers = tupleType.split(ByteBufferAccessor.instance, value);
 
                 // use cast to avoid warning
                 execute("INSERT INTO %s (pk, ck, value) VALUES (?, ?, ?)", 1, tuple((Object[]) tupleBuffers), count);

--- a/test/unit/org/apache/cassandra/db/marshal/TypeValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TypeValidationTest.java
@@ -184,7 +184,7 @@ public class TypeValidationTest
         qt().forAll(tupleWithValueGen(baseGen)).checkAssert(pair -> {
             TupleType tuple = pair.left;
             ByteBuffer value = pair.right;
-            Assertions.assertThat(TupleType.buildValue(tuple.split(value)))
+            Assertions.assertThat(TupleType.buildValue(tuple.split(ByteBufferAccessor.instance, value)))
                       .as("TupleType.buildValue(split(value)) == value")
                       .isEqualTo(value);
         });

--- a/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
+++ b/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
@@ -37,8 +37,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.ByteComparable;
-import org.apache.cassandra.utils.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 
 /**

--- a/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
+++ b/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
@@ -34,6 +34,8 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class LengthPartitioner implements IPartitioner
 {
@@ -93,6 +95,11 @@ public class LengthPartitioner implements IPartitioner
         public Token fromByteArray(ByteBuffer bytes)
         {
             return new BigIntegerToken(new BigInteger(ByteBufferUtil.getArray(bytes)));
+        }
+
+        public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+        {
+            return fromByteArray(IntegerType.instance.fromComparableBytes(comparableBytes, version));
         }
 
         public String toString(Token token)

--- a/test/unit/org/apache/cassandra/transport/SerDeserTest.java
+++ b/test/unit/org/apache/cassandra/transport/SerDeserTest.java
@@ -224,7 +224,7 @@ public class SerDeserTest
 
         ByteBuffer serialized = t.bindAndGet(options);
 
-        ByteBuffer[] fields = udt.split(serialized);
+        ByteBuffer[] fields = udt.split(ByteBufferAccessor.instance, serialized);
 
         assertEquals(4, fields.length);
 

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/AbstractTypeByteSourceTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/AbstractTypeByteSourceTest.java
@@ -1,0 +1,1018 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.db.marshal.*;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.Duration;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.LengthPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.serializers.MarshalException;
+import org.apache.cassandra.serializers.SimpleDateSerializer;
+import org.apache.cassandra.serializers.TypeSerializer;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.UUIDGen;
+
+@RunWith(Parameterized.class)
+public class AbstractTypeByteSourceTest
+{
+    private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()";
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static Iterable<ByteComparable.Version> versions()
+    {
+        return ImmutableList.of(ByteComparable.Version.OSS41);
+    }
+
+    private final ByteComparable.Version version;
+
+    public AbstractTypeByteSourceTest(ByteComparable.Version version)
+    {
+        this.version = version;
+    }
+
+    private <T> void testValuesForType(AbstractType<T> type, T... values)
+    {
+        testValuesForType(type, Arrays.asList(values));
+    }
+
+    private <T> void testValuesForType(AbstractType<T> type, List<T> values)
+    {
+        for (T initial : values)
+            decodeAndAssertEquals(type, initial);
+        if (IntegerType.instance.equals(type))
+            // IntegerType tests go through A LOT of values, so short of randomly picking up to, let's say 1000
+            // values to combine with, we'd rather skip the comparison tests for them.
+            return;
+        for (int i = 0; i < values.size(); ++i)
+        {
+            for (int j = i + 1; j < values.size(); ++j)
+            {
+                ByteBuffer left = type.decompose(values.get(i));
+                ByteBuffer right = type.decompose(values.get(j));
+                int compareBuffers = Integer.signum(type.compare(left, right));
+                ByteSource leftSource = type.asComparableBytes(left.duplicate(), version);
+                ByteSource rightSource = type.asComparableBytes(right.duplicate(), version);
+                int compareBytes = Integer.signum(ByteComparable.compare(v -> leftSource, v -> rightSource, version));
+                Assert.assertEquals(compareBuffers, compareBytes);
+            }
+        }
+    }
+
+    private <T> void testValuesForType(AbstractType<T> type, Stream<T> values)
+    {
+        values.forEach(initial -> decodeAndAssertEquals(type, initial));
+    }
+
+    private <T> void decodeAndAssertEquals(AbstractType<T> type, T initial)
+    {
+        ByteBuffer initialBuffer = type.decompose(initial);
+        // Assert that fromComparableBytes decodes correctly.
+        ByteSource.Peekable peekableBytes = ByteSource.peekable(type.asComparableBytes(initialBuffer, version));
+        ByteBuffer decodedBuffer = type.fromComparableBytes(peekableBytes, version);
+        Assert.assertEquals("For " + ByteSourceComparisonTest.safeStr(initial),
+                            ByteBufferUtil.bytesToHex(initialBuffer),
+                            ByteBufferUtil.bytesToHex(decodedBuffer));
+        // Assert that the value composed from fromComparableBytes is the correct one.
+        peekableBytes = ByteSource.peekable(type.asComparableBytes(initialBuffer, version));
+        T decoded = type.compose(type.fromComparableBytes(peekableBytes, version));
+        Assert.assertEquals(initial, decoded);
+    }
+
+    private static String newRandomAlphanumeric(Random prng, int length)
+    {
+        StringBuilder random = new StringBuilder(length);
+        for (int i = 0; i < length; ++i)
+            random.append(ALPHABET.charAt(prng.nextInt(ALPHABET.length())));
+        return random.toString();
+    }
+
+    @Test
+    public void testAsciiType()
+    {
+        String[] asciiStrings = new String[]
+        {
+                "",
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890",
+                "!@#$%^&*()",
+        };
+        testValuesForType(AsciiType.instance, asciiStrings);
+
+        Random prng = new Random();
+        Stream<String> asciiStream = Stream.generate(() -> newRandomAlphanumeric(prng, 10)).limit(1000);
+        testValuesForType(AsciiType.instance, asciiStream);
+    }
+
+    @Test
+    public void testBooleanType()
+    {
+        testValuesForType(BooleanType.instance, Boolean.TRUE, Boolean.FALSE, null);
+    }
+
+    @Test
+    public void testBytesType()
+    {
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        Random prng = new Random();
+        byte[] byteArray;
+        int[] arrayLengths = new int[] {1, 10, 100, 1000};
+        for (int length : arrayLengths)
+        {
+            byteArray = new byte[length];
+            for (int i = 0; i < 1000; ++i)
+            {
+                prng.nextBytes(byteArray);
+                byteBuffers.add(ByteBuffer.wrap(byteArray));
+            }
+        }
+        testValuesForType(BytesType.instance, byteBuffers.toArray(new ByteBuffer[0]));
+    }
+
+    @Test
+    public void testByteType()
+    {
+        testValuesForType(ByteType.instance, new Byte[] { null });
+
+        Stream<Byte> allBytes = IntStream.range(Byte.MIN_VALUE, Byte.MAX_VALUE + 1)
+                                         .mapToObj(value -> (byte) value);
+        testValuesForType(ByteType.instance, allBytes);
+    }
+
+    @Test
+    public void testCompositeType()
+    {
+        CompositeType compType = CompositeType.getInstance(UTF8Type.instance, TimeUUIDType.instance, IntegerType.instance);
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        Random prng = new Random();
+        // Test with complete CompositeType rows
+        for (int i = 0; i < 1000; ++i)
+        {
+            String randomString = newRandomAlphanumeric(prng, 10);
+            UUID randomUuid = UUIDGen.getTimeUUID();
+            BigInteger randomVarint = BigInteger.probablePrime(80, prng);
+            byteBuffers.add(compType.decompose(randomString, randomUuid, randomVarint));
+        }
+        // Test with incomplete CompositeType rows, where only the first element is present
+        ByteBuffer[] incompleteComposite = new ByteBuffer[1];
+        incompleteComposite[0] = UTF8Type.instance.decompose(newRandomAlphanumeric(prng, 10));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite));
+        // ...and the last end-of-component byte is not 0.
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite, (byte) 1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite, (byte) 1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite, (byte) -1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite, (byte) -1));
+        // Test with incomplete CompositeType rows, where only the last element is not present
+        incompleteComposite = new ByteBuffer[2];
+        incompleteComposite[0] = UTF8Type.instance.decompose(newRandomAlphanumeric(prng, 10));
+        incompleteComposite[1] = TimeUUIDType.instance.decompose(UUIDGen.getTimeUUID());
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite));
+        // ...and the last end-of-component byte is not 0.
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite, (byte) 1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite, (byte) 1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, true, incompleteComposite, (byte) -1));
+        byteBuffers.add(CompositeType.build(ByteBufferAccessor.instance, false, incompleteComposite, (byte) -1));
+
+        testValuesForType(compType, byteBuffers.toArray(new ByteBuffer[0]));
+    }
+
+    @Test
+    public void testDateType()
+    {
+        Stream<Date> dates = Stream.of(null,
+                                       new Date(Long.MIN_VALUE),
+                                       new Date(Long.MAX_VALUE),
+                                       new Date());
+        testValuesForType(DateType.instance, dates);
+
+        dates = new Random().longs(1000).mapToObj(Date::new);
+        testValuesForType(DateType.instance, dates);
+    }
+
+    @Test
+    public void testDecimalType()
+    {
+        // We won't be using testValuesForType for DecimalType (i.e. we won't also be comparing the initial and decoded
+        // ByteBuffer values). That's because the same BigDecimal value can be represented with a couple of different,
+        // even if equivalent pairs of <mantissa, scale> (e.g. 0.1 is 1 * e-1, as well as 10 * e-2, as well as...).
+        // And in practice it's easier to just convert to BigDecimals and then compare, instead of trying to manually
+        // decode and convert to canonical representations, which then to compare. For example of generating canonical
+        // decimals in the first place, see testReversedType().
+        Consumer<BigDecimal> bigDecimalConsumer = initial ->
+        {
+            ByteSource byteSource = DecimalType.instance.asComparableBytes(DecimalType.instance.decompose(initial), version);
+            BigDecimal decoded = DecimalType.instance.compose(DecimalType.instance.fromComparableBytes(ByteSource.peekable(byteSource), version));
+            if (initial == null)
+                Assert.assertNull(decoded);
+            else
+                Assert.assertEquals(0, initial.compareTo(decoded));
+        };
+        // Test some interesting predefined BigDecimal values.
+        Stream.of(null,
+                  BigDecimal.ZERO,
+                  BigDecimal.ONE,
+                  BigDecimal.ONE.add(BigDecimal.ONE),
+                  BigDecimal.TEN,
+                  BigDecimal.valueOf(0.0000000000000000000000000000000001),
+                  BigDecimal.valueOf(-0.0000000000000000000000000000000001),
+                  BigDecimal.valueOf(0.0000000000000001234567891011121314),
+                  BigDecimal.valueOf(-0.0000000000000001234567891011121314),
+                  BigDecimal.valueOf(12345678910111213.141516171819202122),
+                  BigDecimal.valueOf(-12345678910111213.141516171819202122),
+                  new BigDecimal(BigInteger.TEN, Integer.MIN_VALUE),
+                  new BigDecimal(BigInteger.TEN.negate(), Integer.MIN_VALUE),
+                  new BigDecimal(BigInteger.TEN, Integer.MAX_VALUE),
+                  new BigDecimal(BigInteger.TEN.negate(), Integer.MAX_VALUE),
+                  new BigDecimal(BigInteger.TEN.pow(1000), Integer.MIN_VALUE),
+                  new BigDecimal(BigInteger.TEN.pow(1000).negate(), Integer.MIN_VALUE),
+                  new BigDecimal(BigInteger.TEN.pow(1000), Integer.MAX_VALUE),
+                  new BigDecimal(BigInteger.TEN.pow(1000).negate(), Integer.MAX_VALUE))
+              .forEach(bigDecimalConsumer);
+        // Test BigDecimals created from random double values with predefined range modifiers.
+        double[] bounds = {
+                Double.MIN_VALUE,
+                -1_000_000_000.0,
+                -100_000.0,
+                -1.0,
+                1.0,
+                100_000.0,
+                1_000_000_000.0,
+                Double.MAX_VALUE};
+        for (double bound : bounds)
+        {
+            new Random().doubles(1000)
+                        .mapToObj(initial -> BigDecimal.valueOf(initial * bound))
+                        .forEach(bigDecimalConsumer);
+        }
+    }
+
+    @Test
+    public void testDoubleType()
+    {
+        Stream<Double> doubles = Stream.of(null,
+                                           Double.NaN,
+                                           Double.POSITIVE_INFINITY,
+                                           Double.NEGATIVE_INFINITY,
+                                           Double.MAX_VALUE,
+                                           Double.MIN_VALUE,
+                                           +0.0,
+                                           -0.0,
+                                           +1.0,
+                                           -1.0,
+                                           +12345678910.111213141516,
+                                           -12345678910.111213141516);
+        testValuesForType(DoubleType.instance, doubles);
+
+        doubles = new Random().doubles(1000).boxed();
+        testValuesForType(DoubleType.instance, doubles);
+    }
+
+    @Test
+    public void testDurationType()
+    {
+        Random prng = new Random();
+        Stream<Duration> posDurations = Stream.generate(() ->
+                                                        {
+                                                            int months = prng.nextInt(12) + 1;
+                                                            int days = prng.nextInt(28) + 1;
+                                                            long nanos = (Math.abs(prng.nextLong() % 86_400_000_000_000L)) + 1;
+                                                            return Duration.newInstance(months, days, nanos);
+                                                        })
+                                              .limit(1000);
+        testValuesForType(DurationType.instance, posDurations);
+        Stream<Duration> negDurations = Stream.generate(() ->
+                                                        {
+                                                            int months = prng.nextInt(12) + 1;
+                                                            int days = prng.nextInt(28) + 1;
+                                                            long nanos = (Math.abs(prng.nextLong() % 86_400_000_000_000L)) + 1;
+                                                            return Duration.newInstance(-months, -days, -nanos);
+                                                        })
+                                              .limit(1000);
+        testValuesForType(DurationType.instance, negDurations);
+    }
+
+    @Test
+    public void testDynamicCompositeType()
+    {
+        DynamicCompositeType dynamicCompType = DynamicCompositeType.getInstance(new HashMap<>());
+        ImmutableList<String> allTypes = ImmutableList.of("org.apache.cassandra.db.marshal.BytesType",
+                                                          "org.apache.cassandra.db.marshal.TimeUUIDType",
+                                                          "org.apache.cassandra.db.marshal.IntegerType");
+        List<ByteBuffer> allValues = new ArrayList<>();
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        Random prng = new Random();
+        for (int i = 0; i < 10; ++i)
+        {
+            String randomString = newRandomAlphanumeric(prng, 10);
+            allValues.add(ByteBufferUtil.bytes(randomString));
+            UUID randomUuid = UUIDGen.getTimeUUID();
+            allValues.add(ByteBuffer.wrap(UUIDGen.decompose(randomUuid)));
+            byte randomByte = (byte) prng.nextInt();
+            allValues.add(ByteBuffer.allocate(1).put(randomByte));
+
+            // Three-component key with aliased and non-aliased types and end-of-component byte varying (0, 1, -1).
+            byteBuffers.add(DynamicCompositeType.build(allTypes, allValues));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, randomUuid, randomByte, (byte) 1));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, randomUuid, randomByte, (byte) -1));
+
+            // Two-component key with aliased and non-aliased types and end-of-component byte varying (0, 1, -1).
+            byteBuffers.add(DynamicCompositeType.build(allTypes.subList(0, 2), allValues.subList(0, 2)));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, randomUuid, -1, (byte) 1));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, randomUuid, -1, (byte) -1));
+
+            // One-component key with aliased and non-aliased type and end-of-component byte varying (0, 1, -1).
+            byteBuffers.add(DynamicCompositeType.build(allTypes.subList(0, 1), allValues.subList(0, 1)));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, null, -1, (byte) 1));
+            byteBuffers.add(createStringUuidVarintDynamicCompositeKey(randomString, null, -1, (byte) -1));
+
+            allValues.clear();
+        }
+        testValuesForType(dynamicCompType, byteBuffers.toArray(new ByteBuffer[0]));
+    }
+
+    // Similar to DynamicCompositeTypeTest.createDynamicCompositeKey(string, uuid, i, true, false), but not using any
+    // aliased types, in order to do an exact comparison of the unmarshalled DynamicCompositeType payload with the
+    // input one. If aliased types are used, due to DynamicCompositeType.build(List<String>, List<ByteBuffer>)
+    // always including the full type info in the newly constructed payload, an exact comparison won't work.
+    private static ByteBuffer createStringUuidVarintDynamicCompositeKey(String string, UUID uuid, int i, byte lastEocByte)
+    {
+        // 1. Calculate how many bytes do we need for a key of this DynamicCompositeType
+        String bytesType = "org.apache.cassandra.db.marshal.BytesType";
+        String timeUuidType = "org.apache.cassandra.db.marshal.TimeUUIDType";
+        String varintType = "org.apache.cassandra.db.marshal.IntegerType";
+        ByteBuffer bytes = ByteBufferUtil.bytes(string);
+        int totalSize = 0;
+        if (string != null)
+        {
+            // Take into account the string component data (BytesType is aliased)
+            totalSize += 2 + bytesType.length() + 2 + bytes.remaining() + 1;
+            if (uuid != null)
+            {
+                // Take into account the UUID component data (TimeUUIDType is aliased)
+                totalSize += 2 + timeUuidType.length() + 2 + 16 + 1;
+                if (i != -1)
+                {
+                    // Take into account the varint component data (IntegerType is _not_ aliased).
+                    // Notice that we account for a single byte of varint data, so we'll downcast the int payload
+                    // to byte and use only that as the actual varint payload.
+                    totalSize += 2 + varintType.length() + 2 + 1 + 1;
+                }
+            }
+        }
+
+        // 2. Allocate a buffer with that many bytes
+        ByteBuffer bb = ByteBuffer.allocate(totalSize);
+
+        // 3. Write the key data for each component in the allocated buffer
+        if (string != null)
+        {
+            bb.putShort((short) bytesType.length());
+            bb.put(ByteBufferUtil.bytes(bytesType));
+            bb.putShort((short) bytes.remaining());
+            bb.put(bytes);
+            // Make the end-of-component byte 1 if requested and the time-UUID component is null.
+            bb.put(uuid == null ? lastEocByte : (byte) 0);
+            if (uuid != null)
+            {
+                bb.putShort((short) timeUuidType.length());
+                bb.put(ByteBufferUtil.bytes(timeUuidType));
+                bb.putShort((short) 16);
+                bb.put(UUIDGen.decompose(uuid));
+                // Set the end-of-component byte if requested and the varint component is null.
+                bb.put(i == -1 ? lastEocByte : (byte) 0);
+                if (i != -1)
+                {
+                    bb.putShort((short) varintType.length());
+                    bb.put(ByteBufferUtil.bytes(varintType));
+                    bb.putShort((short) 1);
+                    bb.put((byte) i);
+                    bb.put(lastEocByte);
+                }
+            }
+        }
+        bb.rewind();
+        return bb;
+    }
+
+    @Test
+    public void testFloatType()
+    {
+        Stream<Float> floats = Stream.of(null,
+                                         Float.NaN,
+                                         Float.POSITIVE_INFINITY,
+                                         Float.NEGATIVE_INFINITY,
+                                         Float.MAX_VALUE,
+                                         Float.MIN_VALUE,
+                                         +0.0F,
+                                         -0.0F,
+                                         +1.0F,
+                                         -1.0F,
+                                         +123456.7891011F,
+                                         -123456.7891011F);
+        testValuesForType(FloatType.instance, floats);
+
+        floats = new Random().ints(1000).mapToObj(Float::intBitsToFloat);
+        testValuesForType(FloatType.instance, floats);
+    }
+
+    @Test
+    public void testInetAddressType() throws UnknownHostException
+    {
+        Stream<InetAddress> inetAddresses = Stream.of(null,
+                                                      InetAddress.getLocalHost(),
+                                                      InetAddress.getLoopbackAddress(),
+                                                      InetAddress.getByName("0.0.0.0"),
+                                                      InetAddress.getByName("10.0.0.1"),
+                                                      InetAddress.getByName("172.16.1.1"),
+                                                      InetAddress.getByName("192.168.2.2"),
+                                                      InetAddress.getByName("224.3.3.3"),
+                                                      InetAddress.getByName("255.255.255.255"),
+                                                      InetAddress.getByName("0000:0000:0000:0000:0000:0000:0000:0000"),
+                                                      InetAddress.getByName("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+                                                      InetAddress.getByName("fe80:1:23:456:7890:1:23:456"));
+        testValuesForType(InetAddressType.instance, inetAddresses);
+
+        Random prng = new Random();
+        byte[] ipv4Bytes = new byte[4];
+        byte[] ipv6Bytes = new byte[16];
+        InetAddress[] addresses = new InetAddress[2000];
+        for (int i = 0; i < addresses.length / 2; ++i)
+        {
+            prng.nextBytes(ipv4Bytes);
+            addresses[2 * i] = InetAddress.getByAddress(ipv4Bytes);
+            addresses[2 * i + 1] = InetAddress.getByAddress(ipv6Bytes);
+        }
+        testValuesForType(InetAddressType.instance, addresses);
+
+    }
+
+    @Test
+    public void testInt32Type()
+    {
+        Stream<Integer> ints = Stream.of(null,
+                                         Integer.MIN_VALUE,
+                                         Integer.MIN_VALUE + 1,
+                                         -256, -255, -128, -127, -1,
+                                         0,
+                                         1, 127, 128, 255, 256,
+                                         Integer.MAX_VALUE - 1,
+                                         Integer.MAX_VALUE);
+        testValuesForType(Int32Type.instance, ints);
+
+        ints = new Random().ints(1000).boxed();
+        testValuesForType(Int32Type.instance, ints);
+    }
+
+    @Test
+    public void testIntegerType()
+    {
+        Stream<BigInteger> varints = IntStream.range(-1000000, 1000000).mapToObj(BigInteger::valueOf);
+        testValuesForType(IntegerType.instance, varints);
+
+        varints = Stream.of(null,
+                            BigInteger.valueOf(12345678910111213L),
+                            BigInteger.valueOf(12345678910111213L).negate(),
+                            BigInteger.valueOf(Long.MAX_VALUE),
+                            BigInteger.valueOf(Long.MAX_VALUE).negate(),
+                            BigInteger.valueOf(Long.MAX_VALUE - 1).multiply(BigInteger.valueOf(Long.MAX_VALUE - 1)),
+                            BigInteger.valueOf(Long.MAX_VALUE - 1).multiply(BigInteger.valueOf(Long.MAX_VALUE - 1)).negate());
+        testValuesForType(IntegerType.instance, varints);
+
+        List<BigInteger> varintList = new ArrayList<>();
+        for (int i = 0; i < 10000; ++i)
+        {
+            BigInteger initial = BigInteger.ONE.shiftLeft(i);
+            varintList.add(initial);
+            BigInteger plusOne = initial.add(BigInteger.ONE);
+            varintList.add(plusOne);
+            varintList.add(plusOne.negate());
+            BigInteger minusOne = initial.subtract(BigInteger.ONE);
+            varintList.add(minusOne);
+            varintList.add(minusOne.negate());
+        }
+        testValuesForType(IntegerType.instance, varintList.toArray(new BigInteger[0]));
+    }
+
+    @Test
+    public void testUuidTypes()
+    {
+        Random prng = new Random();
+        UUID[] testUuids = new UUID[3001];
+        for (int i = 0; i < testUuids.length / 3; ++i)
+        {
+            testUuids[3 * i] = UUID.randomUUID();
+            testUuids[3 * i + 1] = UUIDGen.getTimeUUID();
+            testUuids[3 * i + 2] = UUIDGen.getRandomTimeUUIDFromMicros(prng.nextLong());
+        }
+        testUuids[testUuids.length - 1] = null;
+        testValuesForType(UUIDType.instance, testUuids);
+        testValuesForType(LexicalUUIDType.instance, testUuids);
+        testValuesForType(TimeUUIDType.instance, Arrays.stream(testUuids).filter(u -> u == null || u.version() == 1));
+    }
+
+    private static <E, C extends Collection<E>> List<C> newRandomElementCollections(Supplier<? extends C> collectionProducer,
+                                                                                    Supplier<? extends E> elementProducer,
+                                                                                    int numCollections,
+                                                                                    int numElementsInCollection)
+    {
+        List<C> result = new ArrayList<>();
+        for (int i = 0; i < numCollections; ++i)
+        {
+            C coll = collectionProducer.get();
+            for (int j = 0; j < numElementsInCollection; ++j)
+            {
+                coll.add(elementProducer.get());
+            }
+            result.add(coll);
+        }
+        return result;
+    }
+
+    @Test
+    public void testListType()
+    {
+        // Test lists with element components not having known/computable length (e.g. strings).
+        Random prng = new Random();
+        List<List<String>> stringLists = newRandomElementCollections(ArrayList::new,
+                                                                     () -> newRandomAlphanumeric(prng, 10),
+                                                                     100,
+                                                                     100);
+        testValuesForType(ListType.getInstance(UTF8Type.instance, false), stringLists);
+        testValuesForType(ListType.getInstance(UTF8Type.instance, true), stringLists);
+        // Test lists with element components with known/computable length (e.g. 128-bit UUIDs).
+        List<List<UUID>> uuidLists = newRandomElementCollections(ArrayList::new,
+                                                                 UUID::randomUUID,
+                                                                 100,
+                                                                 100);
+        testValuesForType(ListType.getInstance(UUIDType.instance, false), uuidLists);
+        testValuesForType(ListType.getInstance(UUIDType.instance, true), uuidLists);
+    }
+
+    @Test
+    public void testLongType()
+    {
+        Stream<Long> longs = Stream.of(null,
+                                       Long.MIN_VALUE,
+                                       Long.MIN_VALUE + 1,
+                                       (long) Integer.MIN_VALUE - 1,
+                                       -256L, -255L, -128L, -127L, -1L,
+                                       0L,
+                                       1L, 127L, 128L, 255L, 256L,
+                                       (long) Integer.MAX_VALUE + 1,
+                                       Long.MAX_VALUE - 1,
+                                       Long.MAX_VALUE);
+        testValuesForType(LongType.instance, longs);
+
+        longs = new Random().longs(1000).boxed();
+        testValuesForType(LongType.instance, longs);
+    }
+
+    private static <K, V> List<Map<K, V>> newRandomEntryMaps(Supplier<? extends K> keyProducer,
+                                                             Supplier<? extends V> valueProducer,
+                                                             int numMaps,
+                                                             int numEntries)
+    {
+        List<Map<K, V>> result = new ArrayList<>();
+        for (int i = 0; i < numMaps; ++i)
+        {
+            Map<K, V> map = new HashMap<>();
+            for (int j = 0; j < numEntries; ++j)
+            {
+                K key = keyProducer.get();
+                V value = valueProducer.get();
+                map.put(key, value);
+            }
+            result.add(map);
+        }
+        return result;
+    }
+
+    @Test
+    public void testMapType()
+    {
+        Random prng = new Random();
+        List<Map<String, UUID>> stringToUuidMaps = newRandomEntryMaps(() -> newRandomAlphanumeric(prng, 10),
+                                                                      UUID::randomUUID,
+                                                                      100,
+                                                                      100);
+        testValuesForType(MapType.getInstance(UTF8Type.instance, UUIDType.instance, false), stringToUuidMaps);
+        testValuesForType(MapType.getInstance(UTF8Type.instance, UUIDType.instance, true), stringToUuidMaps);
+
+        List<Map<UUID, String>> uuidToStringMaps = newRandomEntryMaps(UUID::randomUUID,
+                                                                      () -> newRandomAlphanumeric(prng, 10),
+                                                                      100,
+                                                                      100);
+        testValuesForType(MapType.getInstance(UUIDType.instance, UTF8Type.instance, false), uuidToStringMaps);
+        testValuesForType(MapType.getInstance(UUIDType.instance, UTF8Type.instance, true), uuidToStringMaps);
+    }
+
+    @Test
+    public void testPartitionerDefinedOrder()
+    {
+        Random prng = new Random();
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        byteBuffers.add(ByteBufferUtil.EMPTY_BYTE_BUFFER);
+        for (int i = 0; i < 1000; ++i)
+        {
+            String randomString = newRandomAlphanumeric(prng, 10);
+            byteBuffers.add(UTF8Type.instance.decompose(randomString));
+            int randomInt = prng.nextInt();
+            byteBuffers.add(Int32Type.instance.decompose(randomInt));
+            double randomDouble = prng.nextDouble();
+            byteBuffers.add(DoubleType.instance.decompose(randomDouble));
+            BigInteger randomishVarint = BigInteger.probablePrime(100, prng);
+            byteBuffers.add(IntegerType.instance.decompose(randomishVarint));
+            BigDecimal randomishDecimal = BigDecimal.valueOf(prng.nextLong(), prng.nextInt(100) - 50);
+            byteBuffers.add(DecimalType.instance.decompose(randomishDecimal));
+        }
+
+        byte[] bytes = new byte[100];
+        prng.nextBytes(bytes);
+        ByteBuffer exhausted = ByteBuffer.wrap(bytes);
+        ByteBufferUtil.readBytes(exhausted, 100);
+
+        List<IPartitioner> partitioners = Arrays.asList(
+                Murmur3Partitioner.instance,
+                RandomPartitioner.instance,
+                LengthPartitioner.instance
+                // NOTE LocalPartitioner, OrderPreservingPartitioner, and ByteOrderedPartitioner don't need a dedicated
+                // PartitionerDefinedOrder.
+                //   1) LocalPartitioner uses its inner AbstractType
+                //   2) OrderPreservingPartitioner uses UTF8Type
+                //   3) ByteOrderedPartitioner uses BytesType
+        );
+        for (IPartitioner partitioner : partitioners)
+        {
+            AbstractType<?> partitionOrdering = partitioner.partitionOrdering();
+            Assert.assertTrue(partitionOrdering instanceof PartitionerDefinedOrder);
+            for (ByteBuffer input : byteBuffers)
+            {
+                ByteSource byteSource = partitionOrdering.asComparableBytes(input, version);
+                ByteBuffer output = partitionOrdering.fromComparableBytes(ByteSource.peekable(byteSource), version);
+                Assert.assertEquals("For partitioner " + partitioner.getClass().getSimpleName(),
+                                    ByteBufferUtil.bytesToHex(input),
+                                    ByteBufferUtil.bytesToHex(output));
+            }
+            ByteSource byteSource = partitionOrdering.asComparableBytes(exhausted, version);
+            ByteBuffer output = partitionOrdering.fromComparableBytes(ByteSource.peekable(byteSource), version);
+            Assert.assertEquals(ByteBufferUtil.EMPTY_BYTE_BUFFER, output);
+        }
+    }
+
+    @Test
+    public void testReversedType()
+    {
+        // Test how ReversedType handles null ByteSource.Peekable - here the choice of base type is important, as
+        // the base type should also be able to handle null ByteSource.Peekable.
+        ReversedType<BigInteger> reversedVarintType = (ReversedType<BigInteger>) ReversedType.getInstance(IntegerType.instance);
+        ByteBuffer decodedNull = reversedVarintType.fromComparableBytes(null, ByteComparable.Version.OSS41);
+        Assert.assertEquals(ByteBufferUtil.EMPTY_BYTE_BUFFER, decodedNull);
+
+        // Test how ReversedType handles random data with some common and important base types.
+        Map<AbstractType, BiFunction<Random, Integer, ByteBuffer>> bufferGeneratorByType = new HashMap<>();
+        bufferGeneratorByType.put(UTF8Type.instance, (prng, length) -> UTF8Type.instance.decompose(newRandomAlphanumeric(prng, length)));
+        bufferGeneratorByType.put(BytesType.instance, (prng, length) ->
+        {
+            byte[] randomBytes = new byte[length];
+            prng.nextBytes(randomBytes);
+            return ByteBuffer.wrap(randomBytes);
+        });
+        bufferGeneratorByType.put(IntegerType.instance, (prng, length) ->
+        {
+            BigInteger randomVarint = BigInteger.valueOf(prng.nextLong());
+            for (int i = 1; i < length / 8; ++i)
+                randomVarint = randomVarint.multiply(BigInteger.valueOf(prng.nextLong()));
+            return IntegerType.instance.decompose(randomVarint);
+        });
+        bufferGeneratorByType.put(DecimalType.instance, (prng, length) ->
+        {
+            BigInteger randomMantissa = BigInteger.valueOf(prng.nextLong());
+            for (int i = 1; i < length / 8; ++i)
+                randomMantissa = randomMantissa.multiply(BigInteger.valueOf(prng.nextLong()));
+            // Remove all trailing zeros from the mantissa and use an even scale, in order to have a "canonically
+            // represented" (in the context of DecimalType's encoding) decimal, i.e. one which wouldn't be re-scaled to
+            // conform with the "compacted mantissa between 0 and 1, scale as a power of 100" rule.
+            while (randomMantissa.remainder(BigInteger.TEN).equals(BigInteger.ZERO))
+                randomMantissa = randomMantissa.divide(BigInteger.TEN);
+            int randomScale = prng.nextInt() & -2;
+            BigDecimal randomDecimal = new BigDecimal(randomMantissa, randomScale);
+            return DecimalType.instance.decompose(randomDecimal);
+        });
+        Random prng = new Random();
+        for (Map.Entry<AbstractType, BiFunction<Random, Integer, ByteBuffer>> entry : bufferGeneratorByType.entrySet())
+        {
+            ReversedType reversedType = (ReversedType) ReversedType.getInstance(entry.getKey());
+            for (int length = 32; length <= 512; length *= 4)
+            {
+                for (int i = 0; i < 100; ++i)
+                {
+                    ByteBuffer initial = entry.getValue().apply(prng, length);
+                    ByteSource.Peekable reversedPeekable = ByteSource.peekable(reversedType.asComparableBytes(initial, ByteComparable.Version.OSS41));
+                    ByteBuffer decoded = reversedType.fromComparableBytes(reversedPeekable, ByteComparable.Version.OSS41);
+                    Assert.assertEquals(initial, decoded);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSetType()
+    {
+        // Test sets with element components not having known/computable length (e.g. strings).
+        Random prng = new Random();
+        List<Set<String>> stringSets = newRandomElementCollections(HashSet::new,
+                                                                   () -> newRandomAlphanumeric(prng, 10),
+                                                                   100,
+                                                                   100);
+        testValuesForType(SetType.getInstance(UTF8Type.instance, false), stringSets);
+        testValuesForType(SetType.getInstance(UTF8Type.instance, true), stringSets);
+        // Test sets with element components with known/computable length (e.g. 128-bit UUIDs).
+        List<Set<UUID>> uuidSets = newRandomElementCollections(HashSet::new,
+                                                               UUID::randomUUID,
+                                                               100,
+                                                               100);
+        testValuesForType(SetType.getInstance(UUIDType.instance, false), uuidSets);
+        testValuesForType(SetType.getInstance(UUIDType.instance, true), uuidSets);
+    }
+
+    @Test
+    public void testShortType()
+    {
+        testValuesForType(ShortType.instance, new Short[] { null });
+
+        Stream<Short> allShorts = IntStream.range(Short.MIN_VALUE, Short.MAX_VALUE + 1)
+                                           .mapToObj(value -> (short) value);
+        testValuesForType(ShortType.instance, allShorts);
+    }
+
+    @Test
+    public void testSimpleDateType()
+    {
+        testValuesForType(SimpleDateType.instance, new Integer[] { null });
+
+        testValuesForType(SimpleDateType.instance, new Random().ints(1000).boxed());
+
+        // Test by manually creating and manually interpreting simple dates from random millis.
+        new Random().ints(1000).forEach(initialMillis ->
+                                         {
+                                             initialMillis = Math.abs(initialMillis);
+                                             Integer initialDays = SimpleDateSerializer.timeInMillisToDay(initialMillis);
+                                             ByteBuffer simpleDateBuffer = SimpleDateType.instance.fromTimeInMillis(initialMillis);
+                                             ByteSource byteSource = SimpleDateType.instance.asComparableBytes(simpleDateBuffer, version);
+                                             Integer decodedDays = SimpleDateType.instance.compose(SimpleDateType.instance.fromComparableBytes(ByteSource.peekable(byteSource), version));
+                                             Assert.assertEquals(initialDays, decodedDays);
+                                         });
+
+        // Test by manually creating and manually interpreting simple dates from strings.
+        String[] simpleDateStrings = new String[]
+                                             {
+                                                     "1970-01-01",
+                                                     "1970-01-02",
+                                                     "1969-12-31",
+                                                     "-0001-01-02",
+                                                     "-5877521-01-02",
+                                                     "2014-01-01",
+                                                     "+5881580-01-10",
+                                                     "1920-12-01",
+                                                     "1582-10-19"
+                                             };
+        for (String simpleDate : simpleDateStrings)
+        {
+            ByteBuffer simpleDataBuffer = SimpleDateType.instance.fromString(simpleDate);
+            ByteSource byteSource = SimpleDateType.instance.asComparableBytes(simpleDataBuffer, version);
+            Integer decodedDays = SimpleDateType.instance.compose(SimpleDateType.instance.fromComparableBytes(ByteSource.peekable(byteSource), version));
+            String decodedDate = SimpleDateSerializer.instance.toString(decodedDays);
+            Assert.assertEquals(simpleDate, decodedDate);
+        }
+    }
+
+    @Test
+    public void testTimestampType()
+    {
+        Date[] dates = new Date[]
+                               {
+                                       null,
+                                       new Date(),
+                                       new Date(0L),
+                                       new Date(-1L),
+                                       new Date(Long.MAX_VALUE),
+                                       new Date(Long.MIN_VALUE)
+                               };
+        testValuesForType(TimestampType.instance, dates);
+        testValuesForType(TimestampType.instance, new Random().longs(1000).mapToObj(Date::new));
+    }
+
+    @Test
+    public void testTimeType()
+    {
+        testValuesForType(TimeType.instance, new Long[] { null });
+
+        testValuesForType(TimeType.instance, new Random().longs(1000).boxed());
+    }
+
+    @Test
+    public void testTupleType()
+    {
+        TupleType tt = new TupleType(Arrays.asList(UTF8Type.instance,
+                                                   DecimalType.instance,
+                                                   IntegerType.instance,
+                                                   BytesType.instance));
+        Random prng = new Random();
+        List<ByteBuffer> tuplesData = new ArrayList<>();
+        String[] utf8Values = new String[]
+                                      {
+                                              "a",
+                                              "©",
+                                              newRandomAlphanumeric(prng, 10),
+                                              newRandomAlphanumeric(prng, 100)
+                                      };
+        BigDecimal[] decimalValues = new BigDecimal[]
+                                             {
+                                                     null,
+                                                     BigDecimal.ZERO,
+                                                     BigDecimal.ONE,
+                                                     BigDecimal.valueOf(1234567891011121314L, 50),
+                                                     BigDecimal.valueOf(1234567891011121314L, 50).negate()
+                                             };
+        BigInteger[] varintValues = new BigInteger[]
+                                            {
+                                                    null,
+                                                    BigInteger.ZERO,
+                                                    BigInteger.TEN.pow(1000),
+                                                    BigInteger.TEN.pow(1000).negate()
+                                            };
+        byte[] oneByte = new byte[1];
+        byte[] tenBytes = new byte[10];
+        byte[] hundredBytes = new byte[100];
+        byte[] thousandBytes = new byte[1000];
+        prng.nextBytes(oneByte);
+        prng.nextBytes(tenBytes);
+        prng.nextBytes(hundredBytes);
+        prng.nextBytes(thousandBytes);
+        byte[][] bytesValues = new byte[][]
+                                       {
+                                               new byte[0],
+                                               oneByte,
+                                               tenBytes,
+                                               hundredBytes,
+                                               thousandBytes
+                                       };
+        for (String utf8 : utf8Values)
+        {
+            for (BigDecimal decimal : decimalValues)
+            {
+                for (BigInteger varint : varintValues)
+                {
+                    for (byte[] bytes : bytesValues)
+                    {
+                        ByteBuffer tupleData = TupleType.buildValue(UTF8Type.instance.decompose(utf8),
+                                                                    decimal != null ? DecimalType.instance.decompose(decimal) : null,
+                                                                    varint != null ? IntegerType.instance.decompose(varint) : null,
+                                                                    // We could also use the wrapped bytes directly
+                                                                    BytesType.instance.decompose(ByteBuffer.wrap(bytes)));
+                        tuplesData.add(tupleData);
+                    }
+                }
+            }
+        }
+        testValuesForType(tt, tuplesData.toArray(new ByteBuffer[0]));
+    }
+
+    @Test
+    public void testUtf8Type()
+    {
+        Random prng = new Random();
+        testValuesForType(UTF8Type.instance, Stream.generate(() -> newRandomAlphanumeric(prng, 100)).limit(1000));
+    }
+
+    @Test
+    public void testTypeWithByteOrderedComparison()
+    {
+        Random prng = new Random();
+        byte[] singleByte = new byte[] { (byte) prng.nextInt() };
+        byte[] tenBytes = new byte[10];
+        prng.nextBytes(tenBytes);
+        byte[] hundredBytes = new byte[100];
+        prng.nextBytes(hundredBytes);
+        byte[] thousandBytes = new byte[1000];
+        prng.nextBytes(thousandBytes);
+        // No null here, as the default asComparableBytes(ByteBuffer, Version) implementation (and more specifically
+        // the ByteSource.of(ByteBuffer, Version) encoding) would throw then.
+        testValuesForType(ByteOrderedType.instance, Stream.of(ByteBufferUtil.EMPTY_BYTE_BUFFER,
+                                                              ByteBuffer.wrap(singleByte),
+                                                              ByteBuffer.wrap(tenBytes),
+                                                              ByteBuffer.wrap(hundredBytes),
+                                                              ByteBuffer.wrap(thousandBytes)));
+    }
+
+    private static class ByteOrderedType extends AbstractType<ByteBuffer>
+    {
+        public static final ByteOrderedType instance = new ByteOrderedType();
+
+        private ByteOrderedType()
+        {
+            super(ComparisonType.BYTE_ORDER);
+        }
+
+        @Override
+        public ByteBuffer fromString(String source) throws MarshalException
+        {
+            return null;
+        }
+
+        @Override
+        public Term fromJSONObject(Object parsed) throws MarshalException
+        {
+            return null;
+        }
+
+        @Override
+        public TypeSerializer<ByteBuffer> getSerializer()
+        {
+            return ByteOrderedSerializer.instance;
+        }
+
+        static class ByteOrderedSerializer extends TypeSerializer<ByteBuffer>
+        {
+
+            static final ByteOrderedSerializer instance = new ByteOrderedSerializer();
+
+            @Override
+            public ByteBuffer serialize(ByteBuffer value)
+            {
+                return value != null ? value.duplicate() : null;
+            }
+
+            @Override
+            public <V> ByteBuffer deserialize(V bytes, ValueAccessor<V> accessor)
+            {
+                return accessor.toBuffer(bytes);
+            }
+
+            @Override
+            public <V> void validate(V bytes, ValueAccessor<V> accessor) throws MarshalException
+            {
+
+            }
+
+            @Override
+            public String toString(ByteBuffer value)
+            {
+                return ByteBufferUtil.bytesToHex(value);
+            }
+
+            @Override
+            public Class<ByteBuffer> getType()
+            {
+                return ByteBuffer.class;
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
@@ -1,0 +1,718 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.LocalPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+
+import static org.apache.cassandra.utils.bytecomparable.ByteSourceComparisonTest.decomposeForTuple;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that the result of forward + backward ByteSource translation is the same as the original.
+ */
+public class ByteSourceConversionTest extends ByteSourceTestBase
+{
+    private final static Logger logger = LoggerFactory.getLogger(ByteSourceConversionTest.class);
+    public static final Version VERSION = Version.OSS41;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testStringsAscii()
+    {
+        testType(AsciiType.instance, Arrays.stream(testStrings)
+                                           .filter(s -> s.equals(new String(s.getBytes(StandardCharsets.US_ASCII),
+                                                                            StandardCharsets.US_ASCII)))
+                                           .toArray());
+    }
+
+    @Test
+    public void testStringsUTF8()
+    {
+        testType(UTF8Type.instance, testStrings);
+        testDirect(x -> ByteSource.of(x, VERSION), ByteSourceInverse::getString, testStrings);
+    }
+
+    @Test
+    public void testBooleans()
+    {
+        testType(BooleanType.instance, testBools);
+    }
+
+    @Test
+    public void testInts()
+    {
+        testType(Int32Type.instance, testInts);
+        testDirect(ByteSource::of, ByteSourceInverse::getSignedInt, testInts);
+    }
+
+    @Test
+    public void randomTestInts()
+    {
+        Random rand = new Random();
+        for (int i=0; i<10000; ++i)
+        {
+            int i1 = rand.nextInt();
+            assertConvertsSame(Int32Type.instance, i1);
+        }
+
+    }
+
+    @Test
+    public void testLongs()
+    {
+        testType(LongType.instance, testLongs);
+        testDirect(ByteSource::of, ByteSourceInverse::getSignedLong, testLongs);
+    }
+
+    @Test
+    public void testShorts()
+    {
+        testType(ShortType.instance, testShorts);
+    }
+
+    @Test
+    public void testBytes()
+    {
+        testType(ByteType.instance, testBytes);
+    }
+
+    @Test
+    public void testDoubles()
+    {
+        testType(DoubleType.instance, testDoubles);
+    }
+
+    @Test
+    public void testFloats()
+    {
+        testType(FloatType.instance, testFloats);
+    }
+
+    @Test
+    public void testBigInts()
+    {
+        testType(IntegerType.instance, testBigInts);
+    }
+
+    @Test
+    public void testBigDecimals()
+    {
+        testTypeBuffers(DecimalType.instance, testBigDecimals);
+    }
+
+    @Test
+    public void testUUIDs()
+    {
+        testType(UUIDType.instance, testUUIDs);
+    }
+
+    @Test
+    public void testTimeUUIDs()
+    {
+        testType(TimeUUIDType.instance, Arrays.stream(testUUIDs).filter(x -> x == null || x.version() == 1).toArray());
+    }
+
+    @Test
+    public void testLexicalUUIDs()
+    {
+        testType(LexicalUUIDType.instance, testUUIDs);
+    }
+
+    @Test
+    public void testSimpleDate()
+    {
+        testType(SimpleDateType.instance, Arrays.stream(testInts).filter(x -> x != null).toArray());
+    }
+
+    @Test
+    public void testTimeType()
+    {
+        testType(TimeType.instance, Arrays.stream(testLongs).filter(x -> x != null && x >= 0 && x <= 24L * 60 * 60 * 1000 * 1000 * 1000).toArray());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDateType()
+    {
+        testType(DateType.instance, testDates);
+    }
+
+    @Test
+    public void testTimestampType()
+    {
+        testType(TimestampType.instance, testDates);
+    }
+
+    @Test
+    public void testBytesType()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testType(BytesType.instance, values.toArray());
+    }
+
+    @Test
+    public void testInetAddressType() throws UnknownHostException
+    {
+        testType(InetAddressType.instance, testInets);
+    }
+
+    @Test
+    public void testEmptyType()
+    {
+        testType(EmptyType.instance, new Void[] { null });
+    }
+
+    @Test
+    public void testPatitionerDefinedOrder()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testBuffers(new PartitionerDefinedOrder(Murmur3Partitioner.instance), values);
+        testBuffers(new PartitionerDefinedOrder(RandomPartitioner.instance), values);
+        testBuffers(new PartitionerDefinedOrder(ByteOrderedPartitioner.instance), values);
+    }
+
+    @Test
+    public void testPatitionerOrder()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testDecoratedKeys(Murmur3Partitioner.instance, values);
+        testDecoratedKeys(RandomPartitioner.instance, values);
+        testDecoratedKeys(ByteOrderedPartitioner.instance, values);
+    }
+
+    @Test
+    public void testLocalPatitionerOrder()
+    {
+        for (int i = 0; i < testValues.length; ++i)
+        {
+            final AbstractType testType = testTypes[i];
+            testDecoratedKeys(new LocalPartitioner(testType), Lists.transform(Arrays.asList(testValues[i]),
+                                                                                            v -> testType.decompose(v)));
+        }
+    }
+
+    interface PairTester
+    {
+        void test(AbstractType t1, AbstractType t2, Object o1, Object o2);
+    }
+
+    void testCombinationSampling(Random rand, PairTester tester)
+    {
+        for (int i=0;i<testTypes.length;++i)
+            for (int j=0;j<testTypes.length;++j)
+            {
+                Object[] tv1 = new Object[3];
+                Object[] tv2 = new Object[3];
+                for (int t=0; t<tv1.length; ++t)
+                {
+                    tv1[t] = testValues[i][rand.nextInt(testValues[i].length)];
+                    tv2[t] = testValues[j][rand.nextInt(testValues[j].length)];
+                }
+
+                for (Object o1 : tv1)
+                    for (Object o2 : tv2)
+
+                {
+                    tester.test(testTypes[i], testTypes[j], o1, o2);
+                }
+            }
+    }
+
+    @Test
+    public void testCombinations()
+    {
+        Random rand = new Random(0);
+        testCombinationSampling(rand, this::assertClusteringPairConvertsSame);
+    }
+
+    void assertClusteringPairConvertsSame(AbstractType t1, AbstractType t2, Object o1, Object o2)
+    {
+        for (ValueAccessor<?> accessor : ValueAccessors.ACCESSORS)
+            assertClusteringPairConvertsSame(accessor, t1, t2, o1, o2);
+    }
+
+    <V> void assertClusteringPairConvertsSame(ValueAccessor<V> accessor, AbstractType t1, AbstractType t2, Object o1, Object o2)
+    {
+        boolean checkEquals = t1 != DecimalType.instance && t2 != DecimalType.instance;
+        for (ClusteringPrefix.Kind k1 : ClusteringPrefix.Kind.values())
+            {
+                ClusteringComparator comp = new ClusteringComparator(t1, t2);
+                V[] b = accessor.createArray(2);
+                b[0] = accessor.valueOf(t1.decompose(o1));
+                b[1] = accessor.valueOf(t2.decompose(o2));
+                ClusteringPrefix<V> c = ByteSourceComparisonTest.makeBound(accessor.factory(), k1, b);
+                final ByteComparable bsc = comp.asByteComparable(c);
+                logger.info("Clustering {} bytesource {}", c.clusteringString(comp.subtypes()), bsc.byteComparableAsString(VERSION));
+                ClusteringPrefix<V> converted = getClusteringPrefix(accessor, k1, comp, bsc);
+                assertEquals(String.format("Failed compare(%s, converted %s ByteSource %s) == 0\ntype %s",
+                                           safeStr(c.clusteringString(comp.subtypes())),
+                                           safeStr(converted.clusteringString(comp.subtypes())),
+                                           bsc.byteComparableAsString(VERSION),
+                                           comp),
+                             0, comp.compare(c, converted));
+                if (checkEquals)
+                    assertEquals(String.format("Failed equals %s, got %s ByteSource %s\ntype %s",
+                                               safeStr(c.clusteringString(comp.subtypes())),
+                                               safeStr(converted.clusteringString(comp.subtypes())),
+                                               bsc.byteComparableAsString(VERSION),
+                                               comp),
+                                 c, converted);
+
+                ClusteringComparator compR = new ClusteringComparator(ReversedType.getInstance(t1), ReversedType.getInstance(t2));
+                final ByteComparable bsrc = compR.asByteComparable(c);
+                converted = getClusteringPrefix(accessor, k1, compR, bsrc);
+                assertEquals(String.format("Failed reverse compare(%s, converted %s ByteSource %s) == 0\ntype %s",
+                                           safeStr(c.clusteringString(compR.subtypes())),
+                                           safeStr(converted.clusteringString(compR.subtypes())),
+                                           bsrc.byteComparableAsString(VERSION),
+                                           compR),
+                             0, compR.compare(c, converted));
+                if (checkEquals)
+                    assertEquals(String.format("Failed reverse equals %s, got %s ByteSource %s\ntype %s",
+                                               safeStr(c.clusteringString(compR.subtypes())),
+                                               safeStr(converted.clusteringString(compR.subtypes())),
+                                               bsrc.byteComparableAsString(VERSION),
+                                               compR),
+                                 c, converted);
+            }
+    }
+
+    private static <V> ClusteringPrefix<V> getClusteringPrefix(ValueAccessor<V> accessor,
+                                                               ClusteringPrefix.Kind k1,
+                                                               ClusteringComparator comp,
+                                                               ByteComparable bsc)
+    {
+        switch (k1)
+        {
+        case STATIC_CLUSTERING:
+        case CLUSTERING:
+            return comp.clusteringFromByteComparable(accessor, bsc);
+        case EXCL_END_BOUND:
+        case INCL_END_BOUND:
+            return comp.boundFromByteComparable(accessor, bsc, true);
+        case INCL_START_BOUND:
+        case EXCL_START_BOUND:
+            return comp.boundFromByteComparable(accessor, bsc, false);
+        case EXCL_END_INCL_START_BOUNDARY:
+        case INCL_END_EXCL_START_BOUNDARY:
+            return comp.boundaryFromByteComparable(accessor, bsc);
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private static ByteSource.Peekable source(ByteComparable bsc)
+    {
+        if (bsc == null)
+            return null;
+        return ByteSource.peekable(bsc.asComparableBytes(VERSION));
+    }
+
+    @Test
+    public void testTupleType()
+    {
+        Random rand = ThreadLocalRandom.current();
+        testCombinationSampling(rand, this::assertTupleConvertsSame);
+    }
+
+    @Test
+    public void testTupleTypeNonFull()
+    {
+        TupleType tt = new TupleType(ImmutableList.of(UTF8Type.instance, Int32Type.instance));
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(UTF8Type.instance, ""),
+                                                                                decomposeAndRandomPad(Int32Type.instance, 0)}),
+            // Note: a decomposed null (e.g. decomposeAndRandomPad(Int32Type.instance, null)) should not reach a tuple
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(UTF8Type.instance, ""),
+                                                                                null}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {null,
+                                                                                decomposeAndRandomPad(Int32Type.instance, 0)}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(UTF8Type.instance, "")}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {null}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[0])
+            );
+        testBuffers(tt, tests);
+    }
+
+    void assertTupleConvertsSame(AbstractType t1, AbstractType t2, Object o1, Object o2)
+    {
+        TupleType tt = new TupleType(ImmutableList.of(t1, t2));
+        ByteBuffer b1 = TupleType.buildValue(ByteBufferAccessor.instance,
+                                             new ByteBuffer[]
+                                             {
+                                                decomposeForTuple(t1, o1),
+                                                decomposeForTuple(t2, o2)
+                                             });
+        assertConvertsSameBuffers(tt, b1);
+    }
+
+    @Test
+    public void testCompositeType()
+    {
+        Random rand = new Random(0);
+        testCombinationSampling(rand, this::assertCompositeConvertsSame);
+    }
+
+    @Test
+    public void testCompositeTypeNonFull()
+    {
+        CompositeType tt = CompositeType.getInstance(UTF8Type.instance, Int32Type.instance);
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(UTF8Type.instance, ""), decomposeAndRandomPad(Int32Type.instance, 0)),
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(UTF8Type.instance, ""), decomposeAndRandomPad(Int32Type.instance, null)),
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(UTF8Type.instance, "")),
+            CompositeType.build(ByteBufferAccessor.instance),
+            CompositeType.build(ByteBufferAccessor.instance, true, decomposeAndRandomPad(UTF8Type.instance, "")),
+            CompositeType.build(ByteBufferAccessor.instance,true)
+            );
+        for (ByteBuffer b : tests)
+            tt.validate(b);
+        testBuffers(tt, tests);
+    }
+
+    void assertCompositeConvertsSame(AbstractType t1, AbstractType t2, Object o1, Object o2)
+    {
+        CompositeType tt = CompositeType.getInstance(t1, t2);
+        ByteBuffer b1 = CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(t1, o1), decomposeAndRandomPad(t2, o2));
+        assertConvertsSameBuffers(tt, b1);
+    }
+
+    @Test
+    public void testDynamicComposite()
+    {
+        DynamicCompositeType tt = DynamicCompositeType.getInstance(DynamicCompositeTypeTest.aliases);
+        UUID[] uuids = DynamicCompositeTypeTest.uuids;
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", null, -1, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", uuids[0], 24, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", uuids[0], 42, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test2", uuids[0], -1, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test2", uuids[1], 42, false, true)
+            );
+        for (ByteBuffer b : tests)
+            tt.validate(b);
+        testBuffers(tt, tests);
+    }
+
+    @Test
+    public void testListTypeString()
+    {
+        testCollection(ListType.getInstance(UTF8Type.instance, true), testStrings, () -> new ArrayList<>(), new Random());
+    }
+
+    @Test
+    public void testListTypeLong()
+    {
+        testCollection(ListType.getInstance(LongType.instance, true), testLongs, () -> new ArrayList<>(), new Random());
+    }
+
+    @Test
+    public void testSetTypeString()
+    {
+        testCollection(SetType.getInstance(UTF8Type.instance, true), testStrings, () -> new HashSet<>(), new Random());
+    }
+
+    @Test
+    public void testSetTypeLong()
+    {
+        testCollection(SetType.getInstance(LongType.instance, true), testLongs, () -> new HashSet<>(), new Random());
+    }
+
+    <T, CT extends Collection<T>> void testCollection(CollectionType<CT> tt, T[] values, Supplier<CT> gen, Random rand)
+    {
+        int cnt = 0;
+        List<CT> tests = new ArrayList<>();
+        tests.add(gen.get());
+        for (int c = 1; c <= 3; ++c)
+            for (int j = 0; j < 5; ++j)
+            {
+                CT l = gen.get();
+                for (int i = 0; i < c; ++i)
+                {
+                    T value = values[cnt++ % values.length];
+                    if (value != null)
+                        l.add(value);
+                }
+
+                tests.add(l);
+            }
+        testType(tt, tests.toArray());
+    }
+
+    @Test
+    public void testMapTypeStringLong()
+    {
+        testMap(MapType.getInstance(UTF8Type.instance, LongType.instance, true), testStrings, testLongs, () -> new HashMap<>(), new Random());
+    }
+
+    @Test
+    public void testMapTypeStringLongTree()
+    {
+        testMap(MapType.getInstance(UTF8Type.instance, LongType.instance, true), testStrings, testLongs, () -> new TreeMap<>(), new Random());
+    }
+
+    <K, V, M extends Map<K, V>> void testMap(MapType<K, V> tt, K[] keys, V[] values, Supplier<M> gen, Random rand)
+    {
+        List<M> tests = new ArrayList<>();
+        tests.add(gen.get());
+        for (int c = 1; c <= 3; ++c)
+            for (int j = 0; j < 5; ++j)
+            {
+                M l = gen.get();
+                for (int i = 0; i < c; ++i)
+                {
+                    V value = values[rand.nextInt(values.length)];
+                    if (value != null)
+                        l.put(keys[rand.nextInt(keys.length)], value);
+                }
+
+                tests.add(l);
+            }
+        testType(tt, tests.toArray());
+    }
+
+    /*
+     * Convert type to a comparable.
+     */
+    private ByteComparable typeToComparable(AbstractType type, ByteBuffer value)
+    {
+        return new ByteComparable()
+        {
+            @Override
+            public ByteSource asComparableBytes(Version v)
+            {
+                return type.asComparableBytes(value, v);
+            }
+
+            @Override
+            public String toString()
+            {
+                return type.getString(value);
+            }
+        };
+    }
+
+    public void testType(AbstractType type, Object[] values)
+    {
+        for (Object i : values) {
+            ByteBuffer b = decomposeAndRandomPad(type, i);
+            logger.info("Value {} ({}) bytes {} ByteSource {}",
+                              safeStr(i),
+                              safeStr(type.getSerializer().toCQLLiteral(b)),
+                              safeStr(ByteBufferUtil.bytesToHex(b)),
+                              typeToComparable(type, b).byteComparableAsString(VERSION));
+        }
+        for (Object i : values)
+            assertConvertsSame(type, i);
+        if (!type.isReversed())
+            testType(ReversedType.getInstance(type), values);
+    }
+
+    public void testTypeBuffers(AbstractType type, Object[] values)
+    {
+        // Main difference with above is that we use type.compare instead of checking equals
+        testBuffers(type, Arrays.stream(values)
+                                .map(value -> decomposeAndRandomPad(type, value))
+                                .collect(Collectors.toList()));
+
+    }
+    public void testBuffers(AbstractType type, List<ByteBuffer> values)
+    {
+        try
+        {
+            for (ByteBuffer b : values) {
+                logger.info("Value {} bytes {} ByteSource {}",
+                            safeStr(type.getSerializer().toCQLLiteral(b)),
+                            safeStr(ByteBufferUtil.bytesToHex(b)),
+                            typeToComparable(type, b).byteComparableAsString(VERSION));
+            }
+        }
+        catch (UnsupportedOperationException e)
+        {
+            // Continue without listing values.
+        }
+
+        for (ByteBuffer i : values)
+            assertConvertsSameBuffers(type, i);
+    }
+
+    void assertConvertsSameBuffers(AbstractType type, ByteBuffer b1)
+    {
+        final ByteComparable bs1 = typeToComparable(type, b1);
+
+        ByteBuffer actual = type.fromComparableBytes(source(bs1), VERSION);
+        assertEquals(String.format("Failed compare(%s, converted %s (bytesource %s))",
+                                   ByteBufferUtil.bytesToHex(b1),
+                                   ByteBufferUtil.bytesToHex(actual),
+                                   bs1.byteComparableAsString(VERSION)),
+                     0,
+                     type.compare(b1, actual));
+    }
+
+    public void testDecoratedKeys(IPartitioner type, List<ByteBuffer> values)
+    {
+        for (ByteBuffer i : values)
+            assertConvertsSameDecoratedKeys(type, i);
+    }
+
+    void assertConvertsSameDecoratedKeys(IPartitioner type, ByteBuffer b1)
+    {
+        DecoratedKey k1 = type.decorateKey(b1);
+        DecoratedKey actual = BufferDecoratedKey.fromByteComparable(k1, VERSION, type);
+
+        assertEquals(String.format("Failed compare(%s[%s bs %s], %s[%s bs %s])\npartitioner %s",
+                                   k1,
+                                   ByteBufferUtil.bytesToHex(b1),
+                                   k1.byteComparableAsString(VERSION),
+                                   actual,
+                                   ByteBufferUtil.bytesToHex(actual.getKey()),
+                                   actual.byteComparableAsString(VERSION),
+                                   type),
+                     0,
+                     k1.compareTo(actual));
+        assertEquals(String.format("Failed equals(%s[%s bs %s], %s[%s bs %s])\npartitioner %s",
+                                   k1,
+                                   ByteBufferUtil.bytesToHex(b1),
+                                   k1.byteComparableAsString(VERSION),
+                                   actual,
+                                   ByteBufferUtil.bytesToHex(actual.getKey()),
+                                   actual.byteComparableAsString(VERSION),
+                                   type),
+                     k1,
+                     actual);
+    }
+
+    static Object safeStr(Object i)
+    {
+        if (i == null)
+            return null;
+        if (i instanceof ByteBuffer)
+        {
+            ByteBuffer buf = (ByteBuffer) i;
+            i = ByteBufferUtil.bytesToHex(buf);
+        }
+        String s = i.toString();
+        if (s.length() > 100)
+            s = s.substring(0, 100) + "...";
+        return s.replaceAll("\0", "<0>");
+    }
+
+    public <T> void testDirect(Function<T, ByteSource> convertor, Function<ByteSource.Peekable, T> inverse, T[] values)
+    {
+        for (T i : values) {
+            if (i == null)
+                continue;
+
+            logger.info("Value {} ByteSource {}\n",
+                              safeStr(i),
+                              convertor.apply(i));
+
+        }
+        for (T i : values)
+            if (i != null)
+                assertConvertsSame(convertor, inverse, i);
+    }
+
+    <T> void assertConvertsSame(Function<T, ByteSource> convertor, Function<ByteSource.Peekable, T> inverse, T v1)
+    {
+        ByteComparable b1 = v -> convertor.apply(v1);
+        T actual = inverse.apply(source(b1));
+        assertEquals(String.format("ByteSource %s", b1.byteComparableAsString(VERSION)), v1, actual);
+    }
+
+    void assertConvertsSame(AbstractType type, Object v1)
+    {
+        ByteBuffer b1 = decomposeAndRandomPad(type, v1);
+        final ByteComparable bc1 = typeToComparable(type, b1);
+        ByteBuffer convertedBuffer = type.fromComparableBytes(source(bc1), VERSION);
+        Object actual = type.compose(convertedBuffer);
+
+        assertEquals(String.format("Failed equals %s(%s bs %s), got %s",
+                                   safeStr(v1),
+                                   ByteBufferUtil.bytesToHex(b1),
+                                   safeStr(bc1.byteComparableAsString(VERSION)),
+                                   safeStr(actual)),
+                     v1,
+                     actual);
+    }
+
+    ByteBuffer decomposeAndRandomPad(AbstractType type, Object v)
+    {
+        ByteBuffer b = type.decompose(v);
+        Random rand = new Random(0);
+        int padBefore = rand.nextInt(16);
+        int padAfter = rand.nextInt(16);
+        int paddedCapacity = b.remaining() + padBefore + padAfter;
+        ByteBuffer padded = allocateBuffer(paddedCapacity);
+        rand.ints(padBefore).forEach(x -> padded.put((byte) x));
+        padded.put(b.duplicate());
+        rand.ints(padAfter).forEach(x -> padded.put((byte) x));
+        padded.clear().limit(padded.capacity() - padAfter).position(padBefore);
+        return padded;
+    }
+
+    protected ByteBuffer allocateBuffer(int paddedCapacity)
+    {
+        return ByteBuffer.allocate(paddedCapacity);
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceInverseTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceInverseTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.utils.*;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
+import java.util.stream.*;
+
+import com.google.common.collect.ImmutableList;
+
+@RunWith(Parameterized.class)
+public class ByteSourceInverseTest
+{
+    private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()";
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static Iterable<ByteComparable.Version> versions()
+    {
+        return ImmutableList.of(ByteComparable.Version.OSS41);
+    }
+
+    private final ByteComparable.Version version;
+
+    public ByteSourceInverseTest(ByteComparable.Version version)
+    {
+        this.version = version;
+    }
+
+    @Test
+    public void testGetSignedInt()
+    {
+        IntConsumer intConsumer = initial ->
+        {
+            ByteSource byteSource = ByteSource.of(initial);
+            int decoded = ByteSourceInverse.getSignedInt(byteSource);
+            Assert.assertEquals(initial, decoded);
+        };
+
+        IntStream.of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1,
+                     -256, -255, -128, -127, -1, 0, 1, 127, 128, 255, 256,
+                     Integer.MAX_VALUE - 1, Integer.MAX_VALUE)
+                 .forEach(intConsumer);
+        new Random().ints(1000)
+                    .forEach(intConsumer);
+    }
+
+    @Test
+    public void testNextInt()
+    {
+        // The high and low 32 bits of this long differ only in the first and last bit (in the high 32 bits they are
+        // both 0s instead of 1s). The first bit difference will be negated by the bit flipping when writing down a
+        // fixed length signed number, so the only remaining difference will be in the last bit.
+        int hi = 0b0001_0010_0011_0100_0101_0110_0111_1000;
+        int lo = hi | 1 | 1 << 31;
+        long l1 = Integer.toUnsignedLong(hi) << 32 | Integer.toUnsignedLong(lo);
+
+        ByteSource byteSource = ByteSource.of(l1);
+        int i1 = ByteSourceInverse.getSignedInt(byteSource);
+        int i2 = ByteSourceInverse.getSignedInt(byteSource);
+        Assert.assertEquals(i1 + 1, i2);
+
+        try
+        {
+            ByteSourceInverse.getSignedInt(byteSource);
+            Assert.fail();
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected.
+        }
+
+        byteSource = ByteSource.of(l1);
+        int iFirst = ByteSourceInverse.getSignedInt(byteSource);
+        Assert.assertEquals(i1, iFirst);
+        int iNext = ByteSourceInverse.getSignedInt(byteSource);
+        Assert.assertEquals(i2, iNext);
+    }
+
+    @Test
+    public void testGetSignedLong()
+    {
+        LongConsumer longConsumer = initial ->
+        {
+            ByteSource byteSource = ByteSource.of(initial);
+            long decoded = ByteSourceInverse.getSignedLong(byteSource);
+            Assert.assertEquals(initial, decoded);
+        };
+
+        LongStream.of(Long.MIN_VALUE, Long.MIN_VALUE + 1, Integer.MIN_VALUE - 1L,
+                      -256L, -255L, -128L, -127L, -1L, 0L, 1L, 127L, 128L, 255L, 256L,
+                      Integer.MAX_VALUE + 1L, Long.MAX_VALUE - 1, Long.MAX_VALUE)
+                  .forEach(longConsumer);
+        new Random().longs(1000)
+                    .forEach(longConsumer);
+    }
+
+    @Test
+    public void testGetSignedByte()
+    {
+        Consumer<Byte> byteConsumer = boxedByte ->
+        {
+            byte initial = boxedByte;
+            ByteBuffer byteBuffer = ByteType.instance.decompose(initial);
+            ByteSource byteSource = ByteType.instance.asComparableBytes(byteBuffer, version);
+            byte decoded = ByteSourceInverse.getSignedByte(byteSource);
+            Assert.assertEquals(initial, decoded);
+        };
+
+        IntStream.range(Byte.MIN_VALUE, Byte.MAX_VALUE + 1)
+                 .forEach(byteInteger -> byteConsumer.accept((byte) byteInteger));
+    }
+
+    @Test
+    public void testGetSignedShort()
+    {
+        Consumer<Short> shortConsumer = boxedShort ->
+        {
+            short initial = boxedShort;
+            ByteBuffer shortBuffer = ShortType.instance.decompose(initial);
+            ByteSource byteSource = ShortType.instance.asComparableBytes(shortBuffer, version);
+            short decoded = ByteSourceInverse.getSignedShort(byteSource);
+            Assert.assertEquals(initial, decoded);
+        };
+
+        IntStream.range(Short.MIN_VALUE, Short.MAX_VALUE + 1)
+                 .forEach(shortInteger -> shortConsumer.accept((short) shortInteger));
+    }
+
+    @Test
+    public void testBadByteSourceForFixedLengthNumbers()
+    {
+        Stream.of("getSignedInt",
+                  "getSignedLong",
+                  "getSignedByte",
+                  "getSignedShort")
+              .map(methodName ->
+                   {
+                       try
+                       {
+                           return ByteSourceInverse.class.getMethod(methodName, ByteSource.class);
+                       }
+                       catch (NoSuchMethodException e)
+                       {
+                           Assert.fail("Expected ByteSourceInverse to have method called " + methodName
+                                               + " with a single parameter of type ByteSource");
+                       }
+                       return null;
+                   })
+              .forEach(fixedLengthNumberMethod ->
+                       {
+                           for (ByteSource badSource : Arrays.asList(null, ByteSource.EMPTY))
+                           {
+                               try
+                               {
+                                   fixedLengthNumberMethod.invoke(ByteSourceInverse.class, badSource);
+                                   Assert.fail("Expected IllegalArgumentException not thrown");
+                               }
+                               catch (Throwable maybe)
+                               {
+                                   if (!(maybe instanceof IllegalArgumentException
+                                           || maybe.getCause() instanceof IllegalArgumentException))
+                                       Assert.fail("Unexpected throwable " + maybe + " with cause " + maybe.getCause());
+                               }
+                           }
+                       });
+    }
+
+    @Test
+    public void testGetString()
+    {
+        Consumer<String> stringConsumer = initial ->
+        {
+            ByteSource.Peekable byteSource = initial == null ? null : ByteSource.peekable(ByteSource.of(initial, version));
+            String decoded = ByteSourceInverse.getString(byteSource);
+            Assert.assertEquals(initial, decoded);
+        };
+
+        Stream.of(null, "© 2018 DataStax", "", "\n", "\0", "\0\0", "\001", "0", "0\0", "00", "1")
+              .forEach(stringConsumer);
+
+        Random prng = new Random();
+        int stringLength = 10;
+        String random;
+        for (int i = 0; i < 1000; ++i)
+        {
+            random = newRandomAlphanumeric(prng, stringLength);
+            stringConsumer.accept(random);
+        }
+    }
+
+    private static String newRandomAlphanumeric(Random prng, int length)
+    {
+        StringBuilder random = new StringBuilder(length);
+        for (int i = 0; i < length; ++i)
+            random.append(ALPHABET.charAt(prng.nextInt(ALPHABET.length())));
+        return random.toString();
+    }
+
+    @Test
+    public void testGetByteBuffer()
+    {
+        Consumer<ByteBuffer> byteBufferConsumer = initial ->
+        {
+            ByteSource.Peekable byteSource = ByteSource.peekable(ByteSource.of(initial, version));
+            byte[] decodedBytes = ByteSourceInverse.getUnescapedBytes(byteSource);
+            byte[] initialBytes = ByteBufferUtil.getArray(initial);
+            Assert.assertTrue(Arrays.equals(initialBytes, decodedBytes));
+        };
+
+        Arrays.asList(
+                // ESCAPE - leading, in the middle, trailing
+                new byte[] {0, 2, 3, 4, 5}, new byte[] {1, 2, 0, 4, 5}, new byte[] {1, 2, 3, 4, 0},
+                // END_OF_STREAM/ESCAPED_0_DONE - leading, in the middle, trailing
+                new byte[] {-1, 2, 3, 4, 5}, new byte[] {1, 2, -1, 4, 5}, new byte[] {1, 2, 3, 4, -1},
+                // ESCAPED_0_CONT - leading, in the middle, trailing
+                new byte[] {-2, 2, 3, 4, 5}, new byte[] {1, 2, -2, 4, 5}, new byte[] {1, 2, 3, 4, -2},
+                // ESCAPE + ESCAPED_0_DONE - leading, in the middle, trailing
+                new byte[] {0, -1, 3, 4, 5}, new byte[] {1, 0, -1, 4, 5}, new byte[] {1, 2, 3, 0, -1},
+                // ESCAPE + ESCAPED_0_CONT + ESCAPED_0_DONE - leading, in the middle, trailing
+                new byte[] {0, -2, -1, 4, 5}, new byte[] {1, 0, -2, -1, 5}, new byte[] {1, 2, 0, -2, -1})
+              .forEach(tricky -> byteBufferConsumer.accept(ByteBuffer.wrap(tricky)));
+
+        byte[] bytes = new byte[1000];
+        Random prng = new Random();
+        for (int i = 0; i < 1000; ++i)
+        {
+            prng.nextBytes(bytes);
+            byteBufferConsumer.accept(ByteBuffer.wrap(bytes));
+        }
+
+        int stringLength = 10;
+        String random;
+        for (int i = 0; i < 1000; ++i)
+        {
+            random = newRandomAlphanumeric(prng, stringLength);
+            byteBufferConsumer.accept(ByteBufferUtil.bytes(random));
+        }
+    }
+
+    @Test
+    public void testReadBytes()
+    {
+        Map<Class<?>, Function<Object, ByteSource>> generatorPerType = new HashMap<>();
+        List<Object> originalValues = new ArrayList<>();
+        Random prng = new Random();
+
+        generatorPerType.put(String.class, s ->
+        {
+            String string = (String) s;
+            return ByteSource.of(string, version);
+        });
+        for (int i = 0; i < 100; ++i)
+            originalValues.add(newRandomAlphanumeric(prng, 10));
+
+        generatorPerType.put(Integer.class, i ->
+        {
+            Integer integer = (Integer) i;
+            return ByteSource.of(integer);
+        });
+        for (int i = 0; i < 100; ++i)
+            originalValues.add(prng.nextInt());
+
+        generatorPerType.put(Long.class, l ->
+        {
+            Long looong = (Long) l;
+            return ByteSource.of(looong);
+        });
+        for (int i = 0; i < 100; ++i)
+            originalValues.add(prng.nextLong());
+
+        generatorPerType.put(UUID.class, u ->
+        {
+            UUID uuid = (UUID) u;
+            ByteBuffer uuidBuffer = UUIDType.instance.decompose(uuid);
+            return UUIDType.instance.asComparableBytes(uuidBuffer, version);
+        });
+        for (int i = 0; i < 100; ++i)
+            originalValues.add(UUID.randomUUID());
+
+        for (Object value : originalValues)
+        {
+            Class<?> type = value.getClass();
+            Function<Object, ByteSource> generator = generatorPerType.get(type);
+            ByteSource originalSource = generator.apply(value);
+            ByteSource originalSourceCopy = generator.apply(value);
+            byte[] bytes = ByteSourceInverse.readBytes(originalSource);
+            // The best way to test the read bytes seems to be to assert that just directly using them as a
+            // ByteSource (using ByteSource.fixedLength(byte[])) they compare as equal to another ByteSource obtained
+            // from the same original value.
+            int compare = ByteComparable.compare(v -> originalSourceCopy, v -> ByteSource.fixedLength(bytes), version);
+            Assert.assertEquals(0, compare);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceSequenceTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceSequenceTest.java
@@ -1,0 +1,781 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.cassandra.db.BufferClusteringBound;
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.utils.UUIDGen;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.CachedHashDecoratedKey;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.LocalPartitioner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+public class ByteSourceSequenceTest
+{
+
+    private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()";
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static Iterable<ByteComparable.Version> versions()
+    {
+        return ImmutableList.of(ByteComparable.Version.OSS41);
+    }
+
+    private final ByteComparable.Version version;
+
+    public ByteSourceSequenceTest(ByteComparable.Version version)
+    {
+        this.version = version;
+    }
+
+    @Test
+    public void testNullsSequence()
+    {
+        ByteSource.Peekable comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, null, null
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+    }
+
+    @Test
+    public void testNullsAndUnknownLengthsSequence()
+    {
+        ByteSource.Peekable comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, ByteSource.of("b", version), ByteSource.of("c", version)
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "b");
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "c");
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of("a", version), null, ByteSource.of("c", version)
+        ));
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "a");
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "c");
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of("a", version), ByteSource.of("b", version), null
+        ));
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "a");
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "b");
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of("a", version), null, null
+        ));
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "a");
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, null, ByteSource.of("c", version)
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getString, "c");
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+    }
+
+    private static void expectNextComponentNull(ByteSource.Peekable comparableBytes)
+    {
+        // We expect null-signifying separator, followed by a null ByteSource component
+        ByteSource.Peekable next = ByteSourceInverse.nextComponentSource(comparableBytes);
+        assertNull(next);
+    }
+
+    private static <T> void expectNextComponentValue(ByteSource.Peekable comparableBytes,
+                                                     Function<ByteSource.Peekable, T> decoder,
+                                                     T expected)
+    {
+        // We expect a regular separator, followed by a ByteSource component corresponding to the expected value
+        ByteSource.Peekable next = ByteSourceInverse.nextComponentSource(comparableBytes);
+        assertNotNull(next);
+        T decoded = decoder.apply(next);
+        assertEquals(expected, decoded);
+    }
+
+    @Test
+    public void testNullsAndKnownLengthsSequence()
+    {
+        int intValue = 42;
+        BigInteger varintValue = BigInteger.valueOf(2018L);
+        ByteSource.Peekable comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, ByteSource.of(intValue), varintToByteSource(varintValue)
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getSignedInt, intValue);
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(intValue), null, varintToByteSource(varintValue)
+        ));
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getSignedInt, intValue);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(intValue), varintToByteSource(varintValue), null
+        ));
+        expectNextComponentValue(comparableBytes, ByteSourceInverse::getSignedInt, intValue);
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, null, varintToByteSource(varintValue)
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                null, varintToByteSource(varintValue), null
+        ));
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                varintToByteSource(varintValue), null, null
+        ));
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        Boolean boolValue = new Random().nextBoolean();
+        ByteSource boolSource = BooleanType.instance.asComparableBytes(BooleanType.instance.decompose(boolValue), version);
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                varintToByteSource(varintValue), boolSource, null
+        ));
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        expectNextComponentValue(comparableBytes, BooleanType.instance, boolValue);
+        expectNextComponentNull(comparableBytes);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+
+        boolSource = BooleanType.instance.asComparableBytes(BooleanType.instance.decompose(boolValue), version);
+        comparableBytes = ByteSource.peekable(ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                varintToByteSource(varintValue), null, boolSource
+        ));
+        expectNextComponentValue(comparableBytes, VARINT, varintValue);
+        expectNextComponentNull(comparableBytes);
+        expectNextComponentValue(comparableBytes, BooleanType.instance, boolValue);
+        assertEquals(ByteSource.TERMINATOR, comparableBytes.next());
+    }
+
+    @Test
+    public void testOptionalSignedFixedLengthTypesSequence()
+    {
+        Random prng = new Random();
+        String randomString = newRandomAlphanumeric(prng, 10);
+        byte randomByte = (byte) prng.nextInt();
+        short randomShort = (short) prng.nextInt();
+        int randomInt = prng.nextInt();
+        long randomLong = prng.nextLong();
+        BigInteger randomVarint = BigInteger.probablePrime(80, prng);
+
+        Map<AbstractType<?>, ByteBuffer> valuesByType = new HashMap<AbstractType<?>, ByteBuffer>()
+        {{
+            put(ByteType.instance, ByteType.instance.decompose(randomByte));
+            put(ShortType.instance, ShortType.instance.decompose(randomShort));
+            put(SimpleDateType.instance, SimpleDateType.instance.decompose(randomInt));
+            put(TimeType.instance, TimeType.instance.decompose(randomLong));
+        }};
+
+        for (Map.Entry<AbstractType<?>, ByteBuffer> entry : valuesByType.entrySet())
+        {
+            AbstractType<?> type = entry.getKey();
+            ByteBuffer value = entry.getValue();
+
+            ByteSource byteSource = type.asComparableBytes(value, version);
+            ByteSource.Peekable sequence = ByteSource.peekable(ByteSource.withTerminator(
+                    ByteSource.TERMINATOR,
+                    ByteSource.of(randomString, version), byteSource, varintToByteSource(randomVarint)
+            ));
+            expectNextComponentValue(sequence, ByteSourceInverse::getString, randomString);
+            expectNextComponentValue(sequence, type, value);
+            expectNextComponentValue(sequence, VARINT, randomVarint);
+            assertEquals(ByteSource.TERMINATOR, sequence.next());
+
+            byteSource = type.asComparableBytes(type.decompose(null), version);
+            sequence = ByteSource.peekable(ByteSource.withTerminator(
+                    ByteSource.TERMINATOR,
+                    ByteSource.of(randomString, version), byteSource, varintToByteSource(randomVarint)
+            ));
+            expectNextComponentValue(sequence, ByteSourceInverse::getString, randomString);
+            expectNextComponentNull(sequence);
+            expectNextComponentValue(sequence, VARINT, randomVarint);
+            assertEquals(ByteSource.TERMINATOR, sequence.next());
+        }
+    }
+
+    private ByteSource varintToByteSource(BigInteger value)
+    {
+        ByteBuffer valueByteBuffer = VARINT.decompose(value);
+        return VARINT.asComparableBytes(valueByteBuffer, version);
+    }
+
+    private static final UTF8Type UTF8 = UTF8Type.instance;
+    private static final DecimalType DECIMAL = DecimalType.instance;
+    private static final IntegerType VARINT = IntegerType.instance;
+
+    // A regular comparator using the natural ordering for all types.
+    private static final ClusteringComparator COMP = new ClusteringComparator(Arrays.asList(
+            UTF8,
+            DECIMAL,
+            VARINT
+    ));
+    // A comparator that reverses the ordering for the first unknown length type
+    private static final ClusteringComparator COMP_REVERSED_UNKNOWN_LENGTH = new ClusteringComparator(Arrays.asList(
+            ReversedType.getInstance(UTF8),
+            DECIMAL,
+            VARINT
+    ));
+    // A comparator that reverses the ordering for the second unknown length type
+    private static final ClusteringComparator COMP_REVERSED_UNKNOWN_LENGTH_2 = new ClusteringComparator(Arrays.asList(
+            UTF8,
+            ReversedType.getInstance(DECIMAL),
+            VARINT
+    ));
+    // A comparator that reverses the ordering for the sole known/computable length type
+    private static final ClusteringComparator COMP_REVERSED_KNOWN_LENGTH = new ClusteringComparator(Arrays.asList(
+            UTF8,
+            DECIMAL,
+            ReversedType.getInstance(VARINT)
+    ));
+    // A comparator that reverses the ordering for all types
+    private static final ClusteringComparator COMP_ALL_REVERSED = new ClusteringComparator(Arrays.asList(
+            ReversedType.getInstance(UTF8),
+            ReversedType.getInstance(DECIMAL),
+            ReversedType.getInstance(VARINT)
+    ));
+
+    @Test
+    public void testClusteringPrefixBoundNormalAndReversed()
+    {
+        String stringValue = "Lorem ipsum dolor sit amet";
+        BigDecimal decimalValue = BigDecimal.valueOf(123456789, 20);
+        BigInteger varintValue = BigInteger.valueOf(2018L);
+
+        // Create some non-null clustering key values that will be encoded and decoded to byte-ordered representation
+        // with different types of clustering comparators (and in other tests with different types of prefixes).
+        ByteBuffer[] clusteringKeyValues = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                VARINT.decompose(varintValue)
+        };
+
+        for (ClusteringPrefix.Kind prefixKind : ClusteringPrefix.Kind.values())
+        {
+            if (prefixKind.isBoundary())
+                continue;
+
+            ClusteringPrefix prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            // Use the regular comparator.
+            ByteSource.Peekable comparableBytes = COMP.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentValue(comparableBytes, DECIMAL, decimalValue);
+            expectNextComponentValue(comparableBytes, VARINT, varintValue);
+
+            prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            // Use the comparator reversing the ordering for the first unknown length type.
+            comparableBytes = COMP_REVERSED_UNKNOWN_LENGTH.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(UTF8), stringValue);
+            expectNextComponentValue(comparableBytes, DECIMAL, decimalValue);
+            expectNextComponentValue(comparableBytes, VARINT, varintValue);
+
+            prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            // Use the comparator reversing the ordering for the second unknown length type.
+            comparableBytes = COMP_REVERSED_UNKNOWN_LENGTH_2.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(DECIMAL), decimalValue);
+            expectNextComponentValue(comparableBytes, VARINT, varintValue);
+
+            prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            // Use the comparator reversing the ordering for the known/computable length type.
+            comparableBytes = COMP_REVERSED_KNOWN_LENGTH.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentValue(comparableBytes, DECIMAL, decimalValue);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(VARINT), varintValue);
+
+            prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            // Use the all-reversing comparator.
+            comparableBytes = COMP_ALL_REVERSED.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(UTF8), stringValue);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(DECIMAL), decimalValue);
+            expectNextComponentValue(comparableBytes, ReversedType.getInstance(VARINT), varintValue);
+        }
+    }
+
+    @Test
+    public void testClusteringPrefixBoundNulls()
+    {
+        String stringValue = "Lorem ipsum dolor sit amet";
+        BigDecimal decimalValue = BigDecimal.valueOf(123456789, 20);
+        BigInteger varintValue = BigInteger.valueOf(2018L);
+
+        // Create clustering key values where the component for an unknown length type is null.
+        ByteBuffer[] unknownLengthNull = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(null),
+                VARINT.decompose(varintValue)
+        };
+        // Create clustering key values where the component for a known/computable length type is null.
+        ByteBuffer[] knownLengthNull = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                VARINT.decompose(null)
+        };
+
+        for (ClusteringPrefix.Kind prefixKind : ClusteringPrefix.Kind.values())
+        {
+            if (prefixKind.isBoundary())
+                continue;
+
+            // Test the decoding of a null component of a non-reversed unknown length type.
+            ClusteringPrefix prefix = BufferClusteringBound.create(prefixKind, unknownLengthNull);
+            ByteSource.Peekable comparableBytes = COMP.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentNull(comparableBytes);
+            expectNextComponentValue(comparableBytes, VARINT, varintValue);
+            // Test the decoding of a null component of a reversed unknown length type.
+            prefix = BufferClusteringBound.create(prefixKind, unknownLengthNull);
+            comparableBytes = COMP_REVERSED_UNKNOWN_LENGTH_2.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentNull(comparableBytes);
+            expectNextComponentValue(comparableBytes, VARINT, varintValue);
+
+            // Test the decoding of a null component of a non-reversed known/computable length type.
+            prefix = BufferClusteringBound.create(prefixKind, knownLengthNull);
+            comparableBytes = COMP.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentValue(comparableBytes, DECIMAL, decimalValue);
+            expectNextComponentNull(comparableBytes);
+            // Test the decoding of a null component of a reversed known/computable length type.
+            prefix = BufferClusteringBound.create(prefixKind, knownLengthNull);
+            comparableBytes = COMP_REVERSED_KNOWN_LENGTH.asByteComparable(prefix).asPeekableBytes(version);
+            expectNextComponentValue(comparableBytes, UTF8, stringValue);
+            expectNextComponentValue(comparableBytes, DECIMAL, decimalValue);
+            expectNextComponentNull(comparableBytes);
+        }
+    }
+
+    private <T> void expectNextComponentValue(ByteSource.Peekable comparableBytes,
+                                              AbstractType<T> type,
+                                              T expected)
+    {
+        // We expect a regular separator, followed by a ByteSource component corresponding to the expected value
+        ByteSource.Peekable next = ByteSourceInverse.nextComponentSource(comparableBytes);
+        T decoded = type.compose(type.fromComparableBytes(next, version));
+        assertEquals(expected, decoded);
+    }
+
+    private void expectNextComponentValue(ByteSource.Peekable comparableBytes,
+                                          AbstractType<?> type,
+                                          ByteBuffer expected)
+    {
+        // We expect a regular separator, followed by a ByteSource component corresponding to the expected value
+        ByteSource.Peekable next = ByteSourceInverse.nextComponentSource(comparableBytes);
+        assertEquals(expected, type.fromComparableBytes(next, version));
+    }
+
+    @Test
+    public void testGetBoundFromPrefixTerminator()
+    {
+        String stringValue = "Lorem ipsum dolor sit amet";
+        BigDecimal decimalValue = BigDecimal.valueOf(123456789, 20);
+        BigInteger varintValue = BigInteger.valueOf(2018L);
+
+        ByteBuffer[] clusteringKeyValues = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                VARINT.decompose(varintValue)
+        };
+        ByteBuffer[] nullValueBeforeTerminator = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                VARINT.decompose(null)
+        };
+
+        for (ClusteringPrefix.Kind prefixKind : ClusteringPrefix.Kind.values())
+        {
+            // NOTE dimitar.dimitrov I assume there's a sensible explanation why does STATIC_CLUSTERING use a custom
+            // terminator that's not one of the common separator values, but I haven't spent enough time to get it.
+            if (prefixKind.isBoundary())
+                continue;
+
+            // Test that the read terminator value is exactly the encoded value of this prefix' bound.
+            ClusteringPrefix prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            ByteSource.Peekable comparableBytes = COMP.asByteComparable(prefix).asPeekableBytes(version);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            ByteSourceInverse.getString(comparableBytes);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            DECIMAL.fromComparableBytes(comparableBytes, version);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            VARINT.fromComparableBytes(comparableBytes, version);
+            // Expect the last separator (i.e. the terminator) to be the one specified by the prefix kind.
+            assertEquals(prefixKind.asByteComparableValue(version), comparableBytes.next());
+
+            // Test that the read terminator value is exactly the encoded value of this prefix' bound, when the
+            // terminator is preceded by a null value.
+            prefix = BufferClusteringBound.create(prefixKind, nullValueBeforeTerminator);
+            comparableBytes = COMP.asByteComparable(prefix).asPeekableBytes(version);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            ByteSourceInverse.getString(comparableBytes);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            DECIMAL.fromComparableBytes(comparableBytes, version);
+            // Expect null-signifying separator here.
+            assertEquals(ByteSource.NEXT_COMPONENT_NULL, comparableBytes.next());
+            // No varint to read
+            // Expect the last separator (i.e. the terminator) to be the one specified by the prefix kind.
+            assertEquals(prefixKind.asByteComparableValue(version), comparableBytes.next());
+
+            // Test that the read terminator value is exactly the encoded value of this prefix' bound, when the
+            // terminator is preceded by a reversed null value.
+            prefix = BufferClusteringBound.create(prefixKind, nullValueBeforeTerminator);
+            // That's the comparator that will reverse the ordering of the type of the last value in the prefix (the
+            // one before the terminator). In other tests we're more interested in the fact that values of this type
+            // have known/computable length, which is why we've named it so...
+            comparableBytes = COMP_REVERSED_KNOWN_LENGTH.asByteComparable(prefix).asPeekableBytes(version);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            ByteSourceInverse.getString(comparableBytes);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            DECIMAL.fromComparableBytes(comparableBytes, version);
+            // Expect reversed null-signifying separator here.
+            assertEquals(ByteSource.NEXT_COMPONENT_NULL_REVERSED, comparableBytes.next());
+            // No varint to read
+            // Expect the last separator (i.e. the terminator) to be the one specified by the prefix kind.
+            assertEquals(prefixKind.asByteComparableValue(version), comparableBytes.next());
+        }
+    }
+
+    @Test
+    public void testReversedTypesInClusteringKey()
+    {
+        String stringValue = "Lorem ipsum dolor sit amet";
+        BigDecimal decimalValue = BigDecimal.valueOf(123456789, 20);
+
+        AbstractType<String> reversedStringType = ReversedType.getInstance(UTF8);
+        AbstractType<BigDecimal> reversedDecimalType = ReversedType.getInstance(DECIMAL);
+
+        final ClusteringComparator comparator = new ClusteringComparator(Arrays.asList(
+                // unknown length type
+                UTF8,
+                // known length type
+                DECIMAL,
+                // reversed unknown length type
+                reversedStringType,
+                // reversed known length type
+                reversedDecimalType
+        ));
+        ByteBuffer[] clusteringKeyValues = new ByteBuffer[] {
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue)
+        };
+
+        final ClusteringComparator comparator2 = new ClusteringComparator(Arrays.asList(
+                // known length type
+                DECIMAL,
+                // unknown length type
+                UTF8,
+                // reversed known length type
+                reversedDecimalType,
+                // reversed unknown length type
+                reversedStringType
+        ));
+        ByteBuffer[] clusteringKeyValues2 = new ByteBuffer[] {
+                DECIMAL.decompose(decimalValue),
+                UTF8.decompose(stringValue),
+                DECIMAL.decompose(decimalValue),
+                UTF8.decompose(stringValue)
+        };
+
+        for (ClusteringPrefix.Kind prefixKind : ClusteringPrefix.Kind.values())
+        {
+            if (prefixKind.isBoundary())
+                continue;
+
+            ClusteringPrefix prefix = BufferClusteringBound.create(prefixKind, clusteringKeyValues);
+            ByteSource.Peekable comparableBytes = comparator.asByteComparable(prefix).asPeekableBytes(version);
+
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            assertEquals(getComponentValue(UTF8, comparableBytes), stringValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            assertEquals(getComponentValue(DECIMAL, comparableBytes), decimalValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            assertEquals(getComponentValue(reversedStringType, comparableBytes), stringValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+            assertEquals(getComponentValue(reversedDecimalType, comparableBytes), decimalValue);
+
+            assertEquals(prefixKind.asByteComparableValue(version), comparableBytes.next());
+            assertEquals(ByteSource.END_OF_STREAM, comparableBytes.next());
+
+            ClusteringPrefix prefix2 = BufferClusteringBound.create(prefixKind, clusteringKeyValues2);
+            ByteSource.Peekable comparableBytes2 = comparator2.asByteComparable(prefix2).asPeekableBytes(version);
+
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes2.next());
+            assertEquals(getComponentValue(DECIMAL, comparableBytes2), decimalValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes2.next());
+            assertEquals(getComponentValue(UTF8, comparableBytes2), stringValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes2.next());
+            assertEquals(getComponentValue(reversedDecimalType, comparableBytes2), decimalValue);
+            assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes2.next());
+            assertEquals(getComponentValue(reversedStringType, comparableBytes2), stringValue);
+
+            assertEquals(prefixKind.asByteComparableValue(version), comparableBytes2.next());
+            assertEquals(ByteSource.END_OF_STREAM, comparableBytes2.next());
+        }
+    }
+
+    private <T extends AbstractType<E>, E> E getComponentValue(T type, ByteSource.Peekable comparableBytes)
+    {
+        return type.compose(type.fromComparableBytes(comparableBytes, version));
+    }
+
+    @Test
+    public void testReadingNestedSequence_Simple()
+    {
+        String padding1 = "A string";
+        String padding2 = "Another string";
+
+        BigInteger varint1 = BigInteger.valueOf(0b10000000);
+        BigInteger varint2 = BigInteger.valueOf(1 >> 30);
+        BigInteger varint3 = BigInteger.valueOf(0x10000000L);
+        BigInteger varint4 = BigInteger.valueOf(Long.MAX_VALUE);
+
+        String string1 = "Testing byte sources";
+        String string2 = "is neither easy nor fun;";
+        String string3 = "But do it we must.";
+        String string4 = "— DataStax, 2018";
+
+        MapType<BigInteger, String> varintStringMapType = MapType.getInstance(VARINT, UTF8, false);
+        Map<BigInteger, String> varintStringMap = new TreeMap<>();
+        varintStringMap.put(varint1, string1);
+        varintStringMap.put(varint2, string2);
+        varintStringMap.put(varint3, string3);
+        varintStringMap.put(varint4, string4);
+
+        ByteSource sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(padding1, version),
+                varintStringMapType.asComparableBytes(varintStringMapType.decompose(varintStringMap), version),
+                ByteSource.of(padding2, version)
+        );
+        ByteSource.Peekable comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(varintStringMapType, comparableBytes), varintStringMap);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+        sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                varintStringMapType.asComparableBytes(varintStringMapType.decompose(varintStringMap), version),
+                ByteSource.of(padding1, version),
+                ByteSource.of(padding2, version)
+        );
+        comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(varintStringMapType, comparableBytes), varintStringMap);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+        sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(padding1, version),
+                ByteSource.of(padding2, version),
+                varintStringMapType.asComparableBytes(varintStringMapType.decompose(varintStringMap), version)
+        );
+        comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(varintStringMapType, comparableBytes), varintStringMap);
+
+        MapType<String, BigInteger> stringVarintMapType = MapType.getInstance(UTF8, VARINT, false);
+        Map<String, BigInteger> stringVarintMap = new HashMap<>();
+        stringVarintMap.put(string1, varint1);
+        stringVarintMap.put(string2, varint2);
+        stringVarintMap.put(string3, varint3);
+        stringVarintMap.put(string4, varint4);
+
+        sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(padding1, version),
+                stringVarintMapType.asComparableBytes(stringVarintMapType.decompose(stringVarintMap), version),
+                ByteSource.of(padding2, version)
+        );
+        comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(stringVarintMapType, comparableBytes), stringVarintMap);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+
+        MapType<String, String> stringStringMapType = MapType.getInstance(UTF8, UTF8, false);
+        Map<String, String> stringStringMap = new HashMap<>();
+        stringStringMap.put(string1, string4);
+        stringStringMap.put(string2, string3);
+        stringStringMap.put(string3, string2);
+        stringStringMap.put(string4, string1);
+
+        sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(padding1, version),
+                stringStringMapType.asComparableBytes(stringStringMapType.decompose(stringStringMap), version),
+                ByteSource.of(padding2, version)
+        );
+        comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(stringStringMapType, comparableBytes), stringStringMap);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+
+        MapType<BigInteger, BigInteger> varintVarintMapType = MapType.getInstance(VARINT, VARINT, false);
+        Map<BigInteger, BigInteger> varintVarintMap = new HashMap<>();
+        varintVarintMap.put(varint1, varint4);
+        varintVarintMap.put(varint2, varint3);
+        varintVarintMap.put(varint3, varint2);
+        varintVarintMap.put(varint4, varint1);
+
+        sequence = ByteSource.withTerminator(
+                ByteSource.TERMINATOR,
+                ByteSource.of(padding1, version),
+                varintVarintMapType.asComparableBytes(varintVarintMapType.decompose(varintVarintMap), version),
+                ByteSource.of(padding2, version)
+        );
+        comparableBytes = ByteSource.peekable(sequence);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding1);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(varintVarintMapType, comparableBytes), varintVarintMap);
+        assertEquals(ByteSource.NEXT_COMPONENT, comparableBytes.next());
+        assertEquals(getComponentValue(UTF8, comparableBytes), padding2);
+    }
+
+    @Test
+    public void testReadingNestedSequence_DecoratedKey()
+    {
+        Random prng = new Random();
+
+        MapType<String, BigDecimal> stringDecimalMapType = MapType.getInstance(UTF8, DECIMAL, false);
+        Map<String, BigDecimal> stringDecimalMap = new HashMap<>();
+        for (int i = 0; i < 4; ++i)
+            stringDecimalMap.put(newRandomAlphanumeric(prng, 10), BigDecimal.valueOf(prng.nextDouble()));
+        ByteBuffer key = stringDecimalMapType.decompose(stringDecimalMap);
+        testDecodingKeyWithLocalPartitionerForType(key, stringDecimalMapType);
+
+        MapType<BigDecimal, String> decimalStringMapType = MapType.getInstance(DECIMAL, UTF8, false);
+        Map<BigDecimal, String> decimalStringMap = new HashMap<>();
+        for (int i = 0; i < 4; ++i)
+            decimalStringMap.put(BigDecimal.valueOf(prng.nextDouble()), newRandomAlphanumeric(prng, 10));
+        key = decimalStringMapType.decompose(decimalStringMap);
+        testDecodingKeyWithLocalPartitionerForType(key, decimalStringMapType);
+
+        if (version != ByteComparable.Version.LEGACY)
+        {
+            CompositeType stringDecimalCompType = CompositeType.getInstance(UTF8, DECIMAL);
+            key = stringDecimalCompType.decompose(newRandomAlphanumeric(prng, 10), BigDecimal.valueOf(prng.nextDouble()));
+            testDecodingKeyWithLocalPartitionerForType(key, stringDecimalCompType);
+
+            CompositeType decimalStringCompType = CompositeType.getInstance(DECIMAL, UTF8);
+            key = decimalStringCompType.decompose(BigDecimal.valueOf(prng.nextDouble()), newRandomAlphanumeric(prng, 10));
+            testDecodingKeyWithLocalPartitionerForType(key, decimalStringCompType);
+
+            DynamicCompositeType dynamicCompType = DynamicCompositeType.getInstance(DynamicCompositeTypeTest.aliases);
+            key = DynamicCompositeTypeTest.createDynamicCompositeKey(
+                    newRandomAlphanumeric(prng, 10), UUIDGen.getTimeUUID(), 42, true, false);
+            testDecodingKeyWithLocalPartitionerForType(key, dynamicCompType);
+
+            key = DynamicCompositeTypeTest.createDynamicCompositeKey(
+                    newRandomAlphanumeric(prng, 10), UUIDGen.getTimeUUID(), 42, true, true);
+            testDecodingKeyWithLocalPartitionerForType(key, dynamicCompType);
+        }
+    }
+
+    private static String newRandomAlphanumeric(Random prng, int length)
+    {
+        StringBuilder random = new StringBuilder(length);
+        for (int i = 0; i < length; ++i)
+            random.append(ALPHABET.charAt(prng.nextInt(ALPHABET.length())));
+        return random.toString();
+    }
+
+    private <T> void testDecodingKeyWithLocalPartitionerForType(ByteBuffer key, AbstractType<T> type)
+    {
+        IPartitioner partitioner = new LocalPartitioner(type);
+        CachedHashDecoratedKey initial = (CachedHashDecoratedKey) partitioner.decorateKey(key);
+        BufferDecoratedKey base = BufferDecoratedKey.fromByteComparable(initial, version, partitioner);
+        CachedHashDecoratedKey decoded = new CachedHashDecoratedKey(base.getToken(), base.getKey());
+        Assert.assertEquals(initial, decoded);
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceTestBase.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceTestBase.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.BooleanType;
+import org.apache.cassandra.db.marshal.DecimalType;
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.utils.UUIDGen;
+
+public class ByteSourceTestBase
+{
+    String[] testStrings = new String[]{ "", "\0", "\0\0", "\001", "A\0\0B", "A\0B\0", "0", "0\0", "00", "1", "\377" };
+    Integer[] testInts = new Integer[]{ null,
+                                        Integer.MIN_VALUE,
+                                        Integer.MIN_VALUE + 1,
+                                        -256,
+                                        -255,
+                                        -128,
+                                        -127,
+                                        -1,
+                                        0,
+                                        1,
+                                        127,
+                                        128,
+                                        255,
+                                        256,
+                                        Integer.MAX_VALUE - 1,
+                                        Integer.MAX_VALUE };
+    Byte[] testBytes = new Byte[]{ -128, -127, -1, 0, 1, 127 };
+    Short[] testShorts = new Short[]{ Short.MIN_VALUE,
+                                      Short.MIN_VALUE + 1,
+                                      -256,
+                                      -255,
+                                      -128,
+                                      -127,
+                                      -1,
+                                      0,
+                                      1,
+                                      127,
+                                      128,
+                                      255,
+                                      256,
+                                      Short.MAX_VALUE - 1,
+                                      Short.MAX_VALUE };
+    Long[] testLongs = new Long[]{ null,
+                                   Long.MIN_VALUE,
+                                   Long.MIN_VALUE + 1,
+                                   Integer.MIN_VALUE - 1L,
+                                   -256L,
+                                   -255L,
+                                   -128L,
+                                   -127L,
+                                   -1L,
+                                   0L,
+                                   1L,
+                                   127L,
+                                   128L,
+                                   255L,
+                                   256L,
+                                   Integer.MAX_VALUE + 1L,
+                                   Long.MAX_VALUE - 1,
+                                   Long.MAX_VALUE };
+    Double[] testDoubles = new Double[]{ null,
+                                         Double.NEGATIVE_INFINITY,
+                                         -Double.MAX_VALUE,
+                                         -1e+200,
+                                         -1e3,
+                                         -1e0,
+                                         -1e-3,
+                                         -1e-200,
+                                         -Double.MIN_VALUE,
+                                         -0.0,
+                                         0.0,
+                                         Double.MIN_VALUE,
+                                         1e-200,
+                                         1e-3,
+                                         1e0,
+                                         1e3,
+                                         1e+200,
+                                         Double.MAX_VALUE,
+                                         Double.POSITIVE_INFINITY,
+                                         Double.NaN };
+    Float[] testFloats = new Float[]{ null,
+                                      Float.NEGATIVE_INFINITY,
+                                      -Float.MAX_VALUE,
+                                      -1e+30f,
+                                      -1e3f,
+                                      -1e0f,
+                                      -1e-3f,
+                                      -1e-30f,
+                                      -Float.MIN_VALUE,
+                                      -0.0f,
+                                      0.0f,
+                                      Float.MIN_VALUE,
+                                      1e-30f,
+                                      1e-3f,
+                                      1e0f,
+                                      1e3f,
+                                      1e+30f,
+                                      Float.MAX_VALUE,
+                                      Float.POSITIVE_INFINITY,
+                                      Float.NaN };
+    Boolean[] testBools = new Boolean[]{ null, false, true };
+    UUID[] testUUIDs = new UUID[]{ null,
+                                   UUIDGen.getTimeUUID(),
+                                   UUID.randomUUID(),
+                                   UUID.randomUUID(),
+                                   UUID.randomUUID(),
+                                   UUIDGen.getTimeUUID(123, 234),
+                                   UUIDGen.getTimeUUID(123, 234),
+                                   UUIDGen.getTimeUUID(123),
+                                   UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"),
+                                   UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                                   UUID.fromString("e902893a-9d22-3c7e-a7b8-d6e313b71d9f"),
+                                   UUID.fromString("74738ff5-5367-5958-9aee-98fffdcd1876"),
+                                   UUID.fromString("52df1bb0-6a2f-11e6-b6e4-a6dea7a01b67"),
+                                   UUID.fromString("52df1bb0-6a2f-11e6-362d-aff2143498ea"),
+                                   UUID.fromString("52df1bb0-6a2f-11e6-b62d-aff2143498ea") };
+    // Instant.MIN/MAX fail Date.from.
+    Date[] testDates = new Date[]{ null,
+                                   Date.from(Instant.ofEpochSecond(Integer.MIN_VALUE)),
+                                   Date.from(Instant.ofEpochSecond(Short.MIN_VALUE)),
+                                   Date.from(Instant.ofEpochMilli(-2000)),
+                                   Date.from(Instant.EPOCH),
+                                   Date.from(Instant.ofEpochMilli(2000)),
+                                   Date.from(Instant.ofEpochSecond(Integer.MAX_VALUE)),
+                                   Date.from(Instant.now()) };
+    InetAddress[] testInets;
+    {
+        try
+        {
+            testInets = new InetAddress[]{ null,
+                                           InetAddress.getLocalHost(),
+                                           InetAddress.getLoopbackAddress(),
+                                           InetAddress.getByName("192.168.0.1"),
+                                           InetAddress.getByName("fe80::428d:5cff:fe53:1dc9"),
+                                           InetAddress.getByName("2001:610:3:200a:192:87:36:2"),
+                                           InetAddress.getByName("10.0.0.1"),
+                                           InetAddress.getByName("0a00:0001::"),
+                                           InetAddress.getByName("::10.0.0.1") };
+        }
+        catch (UnknownHostException e)
+        {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    BigInteger[] testBigInts;
+
+    {
+        Set<BigInteger> bigs = new TreeSet<>();
+        for (Long l : testLongs)
+            if (l != null)
+                bigs.add(BigInteger.valueOf(l));
+        for (int i = 0; i < 11; ++i)
+        {
+            bigs.add(BigInteger.valueOf(i));
+            bigs.add(BigInteger.valueOf(-i));
+
+            bigs.add(BigInteger.valueOf((1L << 4 * i) - 1));
+            bigs.add(BigInteger.valueOf((1L << 4 * i)));
+            bigs.add(BigInteger.valueOf(-(1L << 4 * i) - 1));
+            bigs.add(BigInteger.valueOf(-(1L << 4 * i)));
+            String p = exp10(i);
+            bigs.add(new BigInteger(p));
+            bigs.add(new BigInteger("-" + p));
+            p = exp10(1 << i);
+            bigs.add(new BigInteger(p));
+            bigs.add(new BigInteger("-" + p));
+
+            BigInteger base = BigInteger.ONE.shiftLeft(512 * i);
+            bigs.add(base);
+            bigs.add(base.add(BigInteger.ONE));
+            bigs.add(base.subtract(BigInteger.ONE));
+            base = base.negate();
+            bigs.add(base);
+            bigs.add(base.add(BigInteger.ONE));
+            bigs.add(base.subtract(BigInteger.ONE));
+        }
+        testBigInts = bigs.toArray(new BigInteger[0]);
+    }
+
+    static String exp10(int pow)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append('1');
+        for (int i=0; i<pow; ++i)
+            builder.append('0');
+        return builder.toString();
+    }
+
+    BigDecimal[] testBigDecimals;
+    {
+        String vals = "0, 1, 1.1, 21, 98.9, 99, 99.9, 100, 100.1, 101, 331, 0.4, 0.07, 0.0700, 0.005, " +
+                      "6e4, 7e200, 6e-300, 8.1e2000, 8.1e-2000, 9e2000000000, " +
+                      "123456789012.34567890e-1000000000, 123456.78901234, 1234.56789012e2, " +
+                      "1.0000, 0.01e2, 100e-2, 00, 0.000, 0E-18, 0E+18";
+        List<BigDecimal> decs = new ArrayList<>();
+        for (String s : vals.split(", "))
+        {
+            decs.add(new BigDecimal(s));
+            decs.add(new BigDecimal("-" + s));
+        }
+        testBigDecimals = decs.toArray(new BigDecimal[0]);
+    }
+
+    Object[][] testValues = new Object[][]{ testStrings,
+                                            testInts,
+                                            testBools,
+                                            testDoubles,
+                                            testBigInts,
+                                            testBigDecimals };
+
+    AbstractType[] testTypes = new AbstractType[]{ UTF8Type.instance,
+                                                   Int32Type.instance,
+                                                   BooleanType.instance,
+                                                   DoubleType.instance,
+                                                   IntegerType.instance,
+                                                   DecimalType.instance };
+}

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/DecoratedKeyByteSourceTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/DecoratedKeyByteSourceTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils.bytecomparable;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+
+@RunWith(Parameterized.class)
+public class DecoratedKeyByteSourceTest
+{
+    private static final int NUM_ITERATIONS = 100;
+    private static final int RANDOM_BYTES_LENGTH = 100;
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static Iterable<ByteComparable.Version> versions()
+    {
+        return ImmutableList.of(ByteComparable.Version.OSS41);
+    }
+
+    private final ByteComparable.Version version;
+
+    public DecoratedKeyByteSourceTest(ByteComparable.Version version)
+    {
+        this.version = version;
+    }
+
+    @Test
+    public void testDecodeBufferDecoratedKey()
+    {
+        for (int i = 0; i < NUM_ITERATIONS; ++i)
+        {
+            BufferDecoratedKey initialBuffer =
+                    (BufferDecoratedKey) ByteOrderedPartitioner.instance.decorateKey(newRandomBytesBuffer());
+            BufferDecoratedKey decodedBuffer = BufferDecoratedKey.fromByteComparable(
+                    initialBuffer, version, ByteOrderedPartitioner.instance);
+            Assert.assertEquals(initialBuffer, decodedBuffer);
+        }
+    }
+
+    @Test
+    public void testDecodeKeyBytes()
+    {
+        for (int i = 0; i < NUM_ITERATIONS; ++i)
+        {
+            BufferDecoratedKey initialBuffer =
+                    (BufferDecoratedKey) ByteOrderedPartitioner.instance.decorateKey(newRandomBytesBuffer());
+            byte[] keyBytes = DecoratedKey.keyFromByteComparable(initialBuffer, version, ByteOrderedPartitioner.instance);
+            Assert.assertArrayEquals(initialBuffer.getKey().array(), keyBytes);
+        }
+    }
+
+    private static ByteBuffer newRandomBytesBuffer()
+    {
+        byte[] randomBytes = new byte[RANDOM_BYTES_LENGTH];
+        new Random().nextBytes(randomBytes);
+        return ByteBuffer.wrap(randomBytes);
+    }
+}


### PR DESCRIPTION
Also adds `ValueAccessor` support, fixes minor `TupleType` and `DynamicCompositeType` problems and adds documentation.