### PR TITLE
Rebase trunk 20210119

### DIFF
--- a/src/java/org/apache/cassandra/cql3/CQL3Type.java
+++ b/src/java/org/apache/cassandra/cql3/CQL3Type.java
@@ -196,7 +196,7 @@ public interface CQL3Type
 
             StringBuilder target = new StringBuilder();
             buffer = buffer.duplicate();
-            int size = CollectionSerializer.readCollectionSize(buffer, version);
+            int size = CollectionSerializer.readCollectionSize(buffer, ByteBufferAccessor.instance, version);
             buffer.position(buffer.position() + CollectionSerializer.sizeOfCollectionSize(size, version));
 
             switch (type.kind)

--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -30,7 +30,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.serializers.MarshalException;
 
-import org.apache.cassandra.io.sstable.IndexInfo;
+import org.apache.cassandra.io.sstable.format.big.IndexInfo;
 import org.apache.cassandra.utils.ByteComparable;
 import org.apache.cassandra.utils.ByteSource;
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1704,7 +1704,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
             for (SSTableReader sstr : select(View.select(SSTableSet.LIVE, dk)).sstables)
             {
                 // check if the key actually exists in this sstable, without updating cache and stats
-                if (sstr.getPosition(dk, SSTableReader.Operator.EQ, false) != null)
+                if (sstr.checkEntryExists(dk, SSTableReader.Operator.EQ, false))
                     files.add(sstr.getFilename());
             }
             return files;

--- a/src/java/org/apache/cassandra/db/PartitionPosition.java
+++ b/src/java/org/apache/cassandra/db/PartitionPosition.java
@@ -24,8 +24,10 @@ import java.nio.ByteBuffer;
 import org.apache.cassandra.dht.*;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
-public interface PartitionPosition extends RingPosition<PartitionPosition>
+public interface PartitionPosition extends RingPosition<PartitionPosition>, ByteComparable
 {
     public static enum Kind
     {
@@ -53,6 +55,20 @@ public interface PartitionPosition extends RingPosition<PartitionPosition>
 
     public Kind kind();
     public boolean isMinimum();
+
+    /**
+     * Produce a prefix-free byte-comparable representation of the key, i.e. such a sequence of bytes that any pair x, y
+     * of valid positions (with the same key column types and partitioner),
+     *   x.compareTo(y) == compareLexicographicallyUnsigned(x.asComparableBytes(), y.asComparableBytes())
+     * and
+     *   x.asComparableBytes() is not a prefix of y.asComparableBytes()
+     *
+     * We use a two-component tuple for decorated keys, and a one-component tuple for key bounds, where the terminator
+     * byte is chosen to yield the correct comparison result. No decorated key can be a prefix of another (per the tuple
+     * encoding), and no key bound can be a prefix of one because it uses a terminator byte that is different from the
+     * tuple separator.
+     */
+    public abstract ByteSource asComparableBytes(Version version);
 
     public static class RowPositionSerializer implements IPartitionerDependentSerializer<PartitionPosition>
     {

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.db.transform.RTBoundValidator;
 import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.util.DataInputPlus;

--- a/src/java/org/apache/cassandra/db/compaction/Scrubber.java
+++ b/src/java/org/apache/cassandra/db/compaction/Scrubber.java
@@ -22,9 +22,9 @@ import java.io.*;
 import java.util.*;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 
+import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
@@ -56,18 +56,12 @@ public class Scrubber implements Closeable
     private final long expectedBloomFilterSize;
 
     private final RandomAccessReader dataFile;
-    private final RandomAccessReader indexFile;
+    private final PartitionIndexIterator indexIterator;
     private final ScrubInfo scrubInfo;
-    private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
 
     private int goodRows;
     private int badRows;
     private int emptyRows;
-
-    private ByteBuffer currentIndexKey;
-    private ByteBuffer nextIndexKey;
-    long currentRowPositionFromIndex;
-    long nextRowPositionFromIndex;
 
     private NegativeLocalDeletionInfoMetrics negativeLocalDeletionInfoMetrics = new NegativeLocalDeletionInfoMetrics();
 
@@ -107,9 +101,6 @@ public class Scrubber implements Closeable
         this.outputHandler = outputHandler;
         this.skipCorrupted = skipCorrupted;
         this.reinsertOverflowedTTLRows = reinsertOverflowedTTLRows;
-        this.rowIndexEntrySerializer = sstable.descriptor.version.getSSTableFormat().getIndexSerializer(cfs.metadata(),
-                                                                                                        sstable.descriptor.version,
-                                                                                                        sstable.header);
 
         List<SSTableReader> toScrub = Collections.singletonList(sstable);
 
@@ -136,17 +127,27 @@ public class Scrubber implements Closeable
                         ? sstable.openDataReader()
                         : sstable.openDataReader(CompactionManager.instance.getRateLimiter());
 
-        this.indexFile = hasIndexFile
-                ? RandomAccessReader.open(new File(sstable.descriptor.filenameFor(Component.PRIMARY_INDEX)))
-                : null;
+        this.indexIterator = hasIndexFile
+                             ? openIndexIterator()
+                             : null;
 
         this.scrubInfo = new ScrubInfo(dataFile, sstable);
 
-        this.currentRowPositionFromIndex = 0;
-        this.nextRowPositionFromIndex = 0;
-
         if (reinsertOverflowedTTLRows)
             outputHandler.output("Starting scrub with reinsert overflowed TTL option");
+    }
+
+    private PartitionIndexIterator openIndexIterator()
+    {
+        try
+        {
+            return sstable.allKeysIterator();
+        }
+        catch (IOException e)
+        {
+            outputHandler.warn("Index is unreadable.");
+        }
+        return null;
     }
 
     private UnfilteredRowIterator withValidation(UnfilteredRowIterator iter, String filename)
@@ -162,13 +163,7 @@ public class Scrubber implements Closeable
         try (SSTableRewriter writer = SSTableRewriter.construct(cfs, transaction, false, sstable.maxDataAge);
              Refs<SSTableReader> refs = Refs.ref(Collections.singleton(sstable)))
         {
-            nextIndexKey = indexAvailable() ? ByteBufferUtil.readWithShortLength(indexFile) : null;
-            if (indexAvailable())
-            {
-                // throw away variable so we don't have a side effect in the assert
-                long firstRowPositionFromIndex = rowIndexEntrySerializer.deserializePositionAndSkip(indexFile);
-                assert firstRowPositionFromIndex == 0 : firstRowPositionFromIndex;
-            }
+            assert !indexAvailable() || indexIterator.dataPosition() == 0 : indexIterator.dataPosition();
 
             StatsMetadata metadata = sstable.getSSTableMetadata();
             writer.switchWriter(CompactionManager.createWriter(cfs, destination, expectedBloomFilterSize, metadata.repairedAt, metadata.pendingRepair, metadata.isTransient, sstable, transaction));
@@ -194,16 +189,16 @@ public class Scrubber implements Closeable
                     // check for null key below
                 }
 
-                updateIndexKey();
-
                 long dataStart = dataFile.getFilePointer();
 
                 long dataStartFromIndex = -1;
                 long dataSizeFromIndex = -1;
+                ByteBuffer currentIndexKey = indexIterator != null ? indexIterator.key() : null;
                 if (currentIndexKey != null)
                 {
-                    dataStartFromIndex = currentRowPositionFromIndex + 2 + currentIndexKey.remaining();
-                    dataSizeFromIndex = nextRowPositionFromIndex - dataStartFromIndex;
+                    dataStartFromIndex = indexIterator.dataPosition() + TypeSizes.SHORT_SIZE + currentIndexKey.remaining();
+                    if (advanceIndexNoThrow())
+                        dataSizeFromIndex = indexIterator.dataPosition() - dataStartFromIndex;
                 }
 
                 // avoid an NPE if key is null
@@ -224,10 +219,10 @@ public class Scrubber implements Closeable
                                 "_too big_", ByteBufferUtil.bytesToHex(currentIndexKey))));
                     }
 
-                    if (indexFile != null && dataSizeFromIndex > dataFile.length())
+                    if (indexIterator != null && dataSizeFromIndex > dataFile.length())
                         throw new IOError(new IOException("Impossible row size (greater than file length): " + dataSizeFromIndex));
 
-                    if (indexFile != null && dataStart != dataStartFromIndex)
+                    if (indexIterator != null && dataStart != dataStartFromIndex)
                         outputHandler.warn(String.format("Data file row position %d differs from index file row position %d", dataStart, dataStartFromIndex));
 
                     if (tryAppend(prevKey, key, writer))
@@ -292,10 +287,6 @@ public class Scrubber implements Closeable
             // finish obsoletes the old sstable
             finished.addAll(writer.setRepairedAt(badRows > 0 ? ActiveRepairService.UNREPAIRED_SSTABLE : sstable.getSSTableMetadata().repairedAt).finish());
             completed = true;
-        }
-        catch (IOException e)
-        {
-            throw Throwables.propagate(e);
         }
         finally
         {
@@ -365,49 +356,41 @@ public class Scrubber implements Closeable
                                                                                     negativeLocalDeletionInfoMetrics) : rowMergingIterator;
     }
 
-    private void updateIndexKey()
+    private boolean advanceIndexNoThrow()
     {
-        currentIndexKey = nextIndexKey;
-        currentRowPositionFromIndex = nextRowPositionFromIndex;
         try
         {
-            nextIndexKey = !indexAvailable() ? null : ByteBufferUtil.readWithShortLength(indexFile);
-
-            nextRowPositionFromIndex = !indexAvailable()
-                    ? dataFile.length()
-                    : rowIndexEntrySerializer.deserializePositionAndSkip(indexFile);
+            return indexAvailable() && indexIterator.advance();
         }
         catch (Throwable th)
         {
             JVMStabilityInspector.inspectThrowable(th);
             outputHandler.warn("Error reading index file", th);
-            nextIndexKey = null;
-            nextRowPositionFromIndex = dataFile.length();
+            indexIterator.close();
+            return false;
         }
     }
 
     private boolean indexAvailable()
     {
-        return indexFile != null && !indexFile.isEOF();
+        return indexIterator != null && !indexIterator.isExhausted();
     }
 
     private void seekToNextRow()
     {
-        while(nextRowPositionFromIndex < dataFile.length())
-        {
-            try
-            {
-                dataFile.seek(nextRowPositionFromIndex);
-                return;
-            }
-            catch (Throwable th)
-            {
-                throwIfFatal(th);
-                outputHandler.warn(String.format("Failed to seek to next row position %d", nextRowPositionFromIndex), th);
-                badRows++;
-            }
+        long nextRowPositionFromIndex = indexIterator.isExhausted()
+                                        ? dataFile.length()
+                                        : indexIterator.dataPosition();
 
-            updateIndexKey();
+        try
+        {
+            dataFile.seek(nextRowPositionFromIndex);
+        }
+        catch (Throwable th)
+        {
+            throwIfFatal(th);
+            outputHandler.warn(String.format("Failed to seek to next row position %d", nextRowPositionFromIndex), th);
+            badRows++;
         }
     }
 
@@ -447,7 +430,7 @@ public class Scrubber implements Closeable
     public void close()
     {
         FileUtils.closeQuietly(dataFile);
-        FileUtils.closeQuietly(indexFile);
+        FileUtils.closeQuietly(indexIterator);
     }
 
     public CompactionInfo.Holder getScrubInfo()

--- a/src/java/org/apache/cassandra/db/compaction/Verifier.java
+++ b/src/java/org/apache/cassandra/db/compaction/Verifier.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.IndexSummary;
 import org.apache.cassandra.io.sstable.KeyIterator;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
+import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
@@ -71,9 +72,7 @@ public class Verifier implements Closeable
 
 
     private final RandomAccessReader dataFile;
-    private final RandomAccessReader indexFile;
     private final VerifyInfo verifyInfo;
-    private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
     private final Options options;
     private final boolean isOffline;
     /**
@@ -98,14 +97,12 @@ public class Verifier implements Closeable
         this.cfs = cfs;
         this.sstable = sstable;
         this.outputHandler = outputHandler;
-        this.rowIndexEntrySerializer = sstable.descriptor.version.getSSTableFormat().getIndexSerializer(cfs.metadata(), sstable.descriptor.version, sstable.header);
 
         this.controller = new VerifyController(cfs);
 
         this.dataFile = isOffline
                         ? sstable.openDataReader()
                         : sstable.openDataReader(CompactionManager.instance.getRateLimiter());
-        this.indexFile = RandomAccessReader.open(new File(sstable.descriptor.filenameFor(Component.PRIMARY_INDEX)));
         this.verifyInfo = new VerifyInfo(dataFile, sstable);
         this.options = options;
         this.isOffline = isOffline;
@@ -179,7 +176,7 @@ public class Verifier implements Closeable
         if (options.checkOwnsTokens && !isOffline)
         {
             outputHandler.debug("Checking that all tokens are owned by the current node");
-            try (KeyIterator iter = new KeyIterator(sstable.descriptor, sstable.metadata()))
+            try (KeyIterator iter = KeyIterator.forSSTable(sstable))
             {
                 List<Range<Token>> ownedRanges = Range.normalize(tokenLookup.apply(cfs.metadata.keyspace));
                 if (ownedRanges.isEmpty())
@@ -233,14 +230,10 @@ public class Verifier implements Closeable
 
         outputHandler.output("Extended Verify requested, proceeding to inspect values");
 
-        try
+        try(PartitionIndexIterator indexIterator = sstable.allKeysIterator())
         {
-            ByteBuffer nextIndexKey = ByteBufferUtil.readWithShortLength(indexFile);
-            {
-                long firstRowPositionFromIndex = rowIndexEntrySerializer.deserializePositionAndSkip(indexFile);
-                if (firstRowPositionFromIndex != 0)
-                    markAndThrow();
-            }
+            if (indexIterator.dataPosition() != 0)
+                markAndThrow();
 
             List<Range<Token>> ownedRanges = isOffline ? Collections.emptyList() : Range.normalize(tokenLookup.apply(cfs.metadata().keyspace));
             RangeOwnHelper rangeOwnHelper = new RangeOwnHelper(ownedRanges);
@@ -279,14 +272,18 @@ public class Verifier implements Closeable
                     }
                 }
 
-                ByteBuffer currentIndexKey = nextIndexKey;
+                ByteBuffer currentIndexKey = indexIterator.key();
                 long nextRowPositionFromIndex = 0;
                 try
                 {
-                    nextIndexKey = indexFile.isEOF() ? null : ByteBufferUtil.readWithShortLength(indexFile);
-                    nextRowPositionFromIndex = indexFile.isEOF()
-                                             ? dataFile.length()
-                                             : rowIndexEntrySerializer.deserializePositionAndSkip(indexFile);
+                    if (indexIterator.advance())
+                    {
+                        nextRowPositionFromIndex = indexIterator.dataPosition();
+                    }
+                    else
+                    {
+                        nextRowPositionFromIndex = dataFile.length();
+                    }
                 }
                 catch (Throwable th)
                 {
@@ -302,8 +299,6 @@ public class Verifier implements Closeable
                 // avoid an NPE if key is null
                 String keyName = key == null ? "(unreadable key)" : ByteBufferUtil.bytesToHex(key.getKey());
                 outputHandler.debug(String.format("row %s is %s", keyName, FBUtilities.prettyPrintMemory(dataSize)));
-
-                assert currentIndexKey != null || indexFile.isEOF();
 
                 try
                 {
@@ -407,15 +402,9 @@ public class Verifier implements Closeable
 
     private void deserializeIndex(SSTableReader sstable) throws IOException
     {
-        try (RandomAccessReader primaryIndex = RandomAccessReader.open(new File(sstable.descriptor.filenameFor(Component.PRIMARY_INDEX))))
-        {
-            long indexSize = primaryIndex.length();
-
-            while ((primaryIndex.getFilePointer()) != indexSize)
-            {
-                ByteBuffer key = ByteBufferUtil.readWithShortLength(primaryIndex);
-                RowIndexEntry.Serializer.skip(primaryIndex, sstable.descriptor.version);
-            }
+        try (PartitionIndexIterator it = sstable.allKeysIterator()) {
+            //noinspection StatementWithEmptyBody
+            while (it.advance()); // no-op, just check if index is readable
         }
     }
 
@@ -446,7 +435,6 @@ public class Verifier implements Closeable
     public void close()
     {
         FileUtils.closeQuietly(dataFile);
-        FileUtils.closeQuietly(indexFile);
     }
 
     private void throwIfFatal(Throwable th)

--- a/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.db.compaction.LeveledManifest;
@@ -82,7 +82,7 @@ public class MajorLeveledCompactionWriter extends CompactionAwareWriter
     @SuppressWarnings("resource")
     public boolean realAppend(UnfilteredRowIterator partition)
     {
-        RowIndexEntry rie = sstableWriter.append(partition);
+        BigTableRowIndexEntry rie = sstableWriter.append(partition);
         partitionsWritten++;
         long totalWrittenInCurrentWriter = sstableWriter.currentWriter().getEstimatedOnDiskBytesWritten();
         if (totalWrittenInCurrentWriter > maxSSTableSize)

--- a/src/java/org/apache/cassandra/db/compaction/writers/MaxSSTableSizeWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/MaxSSTableSizeWriter.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -94,7 +94,7 @@ public class MaxSSTableSizeWriter extends CompactionAwareWriter
 
     protected boolean realAppend(UnfilteredRowIterator partition)
     {
-        RowIndexEntry rie = sstableWriter.append(partition);
+        BigTableRowIndexEntry rie = sstableWriter.append(partition);
         if (sstableWriter.currentWriter().getEstimatedOnDiskBytesWritten() > maxSSTableSize)
         {
             switchCompactionLocation(sstableDirectory);

--- a/src/java/org/apache/cassandra/db/compaction/writers/SplittingSizeTieredCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/SplittingSizeTieredCompactionWriter.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
@@ -86,7 +86,7 @@ public class SplittingSizeTieredCompactionWriter extends CompactionAwareWriter
     @Override
     public boolean realAppend(UnfilteredRowIterator partition)
     {
-        RowIndexEntry rie = sstableWriter.append(partition);
+        BigTableRowIndexEntry rie = sstableWriter.append(partition);
         if (sstableWriter.currentWriter().getEstimatedOnDiskBytesWritten() > currentBytesToWrite && currentRatioIndex < ratios.length - 1) // if we underestimate how many keys we have, the last sstable might get more than we expect
         {
             currentRatioIndex++;

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -62,8 +62,8 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         while (!accessorL.isEmptyFromOffset(left, offsetL) && !accessorR.isEmptyFromOffset(right, offsetL))
         {
             AbstractType<?> comparator = getComparator(i, left, accessorL, right, accessorR, offsetL, offsetR);
-            offsetL += getComparatorSize(i, left, accessorL, offsetL);
-            offsetR += getComparatorSize(i, right, accessorR, offsetR);
+            offsetL += getComparatorSize(left, accessorL, offsetL);
+            offsetR += getComparatorSize(right, accessorR, offsetR);
 
             VL value1 = accessorL.sliceWithShortLength(left, offsetL);
             offsetL += accessorL.sizeWithShortLength(value1);
@@ -106,10 +106,9 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         boolean isStatic = readIsStatic(bb, ByteBufferAccessor.instance);
         int offset = startingOffset(isStatic);
 
-        int i = 0;
         while (!ByteBufferAccessor.instance.isEmptyFromOffset(bb, offset))
         {
-            offset += getComparatorSize(i++, bb, ByteBufferAccessor.instance, offset);
+            offset += getComparatorSize(bb, ByteBufferAccessor.instance, offset);
             ByteBuffer value = ByteBufferAccessor.instance.sliceWithShortLength(bb, offset);
             offset += ByteBufferAccessor.instance.sizeWithShortLength(value);
             l.add(value);
@@ -188,7 +187,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
                 sb.append(":");
 
             AbstractType<?> comparator = getAndAppendComparator(i, input, accessor, sb, offset);
-            offset += getComparatorSize(i, input, accessor, offset);
+            offset += getComparatorSize(input, accessor, offset);
             V value = accessor.sliceWithShortLength(input, offset);
             offset += accessor.sizeWithShortLength(value);
 
@@ -285,7 +284,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         while (!accessor.isEmptyFromOffset(input, offset))
         {
             AbstractType<?> comparator = validateComparator(i, input, accessor, offset);
-            offset += getComparatorSize(i, input, accessor, offset);
+            offset += getComparatorSize(input, accessor, offset);
 
             if (accessor.sizeFromOffset(input, offset) < 2)
                 throw new MarshalException("Not enough bytes to read value size of component " + i);
@@ -317,7 +316,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         return BytesSerializer.instance;
     }
 
-    abstract protected <V> int getComparatorSize(int i, V value, ValueAccessor<V> accessor, int offset);
+    abstract protected <V> int getComparatorSize(V value, ValueAccessor<V> accessor, int offset);
     /**
      * @return the comparator for the given component. static CompositeType will consult
      * @param i DynamicCompositeType will read the type information from @param bb

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -54,6 +54,8 @@ import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM
 @Unmetered
 public abstract class AbstractType<T> implements Comparator<ByteBuffer>, AssignmentTestable
 {
+    private final static int VARIABLE_LENGTH = -1;
+
     public final Comparator<ByteBuffer> reverseComparator;
 
     public enum ComparisonType
@@ -419,11 +421,28 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * The length of values for this type if all values are of fixed length, -1 otherwise.
+     * The length of values for this type if all values are of fixed length, -1 otherwise. This has an impact on
+     * serialization.
+     * <lu>
+     *  <li> see {@link #writeValue} </li>
+     *  <li> see {@link #read} </li>
+     *  <li> see {@link #writtenLength} </li>
+     *  <li> see {@link #skipValue} </li>
+     * </lu>
      */
     public int valueLengthIfFixed()
     {
-        return -1;
+        return VARIABLE_LENGTH;
+    }
+
+    /**
+     * Checks if all values are of fixed length.
+     *
+     * @return {@code true} if all values are of fixed length, {@code false} otherwise.
+     */
+    public final boolean isValueLengthFixed()
+    {
+        return valueLengthIfFixed() != VARIABLE_LENGTH;
     }
 
     // This assumes that no empty values are passed

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -39,8 +39,11 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.github.jamm.Unmetered;
 
+import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.BYTE_ORDER;
 import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM;
 
 /**
@@ -575,6 +578,37 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
             return AssignmentTestable.TestResult.WEAKLY_ASSIGNABLE;
 
         return AssignmentTestable.TestResult.NOT_ASSIGNABLE;
+    }
+
+    /**
+     * Produce a byte-comparable representation of the given value, i.e. a sequence of bytes that compares the same way
+     * using lexicographical unsigned byte comparison as the original value using the type's comparator.
+     *
+     * We use a slightly stronger requirement to be able to use the types in tuples. Precisely, for any pair x, y of
+     * non-equal valid values of this type and any bytes b1, b2 between 0x10 and 0xEF,
+     * (+ stands for concatenation)
+     *   compare(x, y) == compareLexicographicallyUnsigned(asByteComparable(x)+b1, asByteComparable(y)+b2)
+     * (i.e. the values compare like the original type, and an added 0x10-0xEF byte at the end does not change that) and:
+     *   asByteComparable(x)+b1 is not a prefix of asByteComparable(y)      (weakly prefix free)
+     * (i.e. a valid representation of a value may be a prefix of another valid representation of a value only if the
+     * following byte in the latter is smaller than 0x10 or larger than 0xEF). These properties are trivially true if
+     * the encoding compares correctly and is prefix free, but also permits a little more freedom that enables somewhat
+     * more efficient encoding of arbitrary-length byte-comparable blobs.
+     *
+     * Depending on the type, this method can be called for null or empty input, in which case the output is allowed to
+     * be null (the clustering/tuple encoding will accept and handle it).
+     */
+    public ByteSource asComparableBytes(ByteBuffer byteBuffer, ByteComparable.Version version)
+    {
+        if (comparisonType == BYTE_ORDER)
+        {
+            // When a type is byte-ordered on its own, we only need to escape it, so that we can include it in
+            // multi-component types and make the encoding weakly-prefix-free.
+            return ByteSource.of(byteBuffer, version);
+        }
+        else
+            // default is only good for byte-comparables
+            throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement asComparableBytes");
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/BooleanType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BooleanType.java
@@ -26,6 +26,8 @@ import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.serializers.BooleanSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +54,17 @@ public class BooleanType extends AbstractType<Boolean>
         int v1 = accessorL.getByte(left, 0) == 0 ? 0 : 1;
         int v2 = accessorR.getByte(right, 0) == 0 ? 0 : 1;
         return v1 - v2;
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        if (!buf.hasRemaining())
+            return null;
+        byte b = buf.get(buf.position());
+        if (b != 0)
+            b = 1;
+        return ByteSource.oneByte(b);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/ByteType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteType.java
@@ -27,6 +27,9 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteComparable.Version;
+import org.apache.cassandra.utils.ByteSource;
 
 public class ByteType extends NumberType<Byte>
 {
@@ -40,6 +43,14 @@ public class ByteType extends NumberType<Byte>
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return accessorL.getByte(left, 0) - accessorR.getByte(right, 0);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, Version version)
+    {
+        return version == Version.LEGACY
+               ? ByteSource.signedFixedLengthNumber(buf)
+               : ByteSource.optionalSignedFixedLengthNumber(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/CompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CompositeType.java
@@ -177,7 +177,7 @@ public class CompositeType extends AbstractCompositeType
         return types.get(i);
     }
 
-    protected <V> int getComparatorSize(int i, V value, ValueAccessor<V> accessor, int offset)
+    protected <V> int getComparatorSize(V value, ValueAccessor<V> accessor, int offset)
     {
         return 0;
     }

--- a/src/java/org/apache/cassandra/db/marshal/DateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DateType.java
@@ -31,6 +31,8 @@ import org.apache.cassandra.serializers.TimestampSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 /**
  * This is the old version of TimestampType, but has been replaced as it wasn't comparing pre-epoch timestamps
@@ -48,6 +50,13 @@ public class DateType extends AbstractType<Date>
     public boolean isEmptyValueMeaningless()
     {
         return true;
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        // While BYTE_ORDER would still work for this type, making use of the fixed length is more efficient.
+        return ByteSource.optionalFixedLength(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DoubleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DoubleType.java
@@ -27,6 +27,8 @@ import org.apache.cassandra.serializers.DoubleSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class DoubleType extends NumberType<Double>
 {
@@ -48,6 +50,12 @@ public class DoubleType extends NumberType<Double>
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return compareComposed(left, accessorL, right, accessorR, this);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return ByteSource.optionalSignedFixedLengthFloat(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
@@ -94,7 +94,7 @@ public class DynamicCompositeType extends AbstractCompositeType
         return 0;
     }
 
-    protected <V> int getComparatorSize(int i, V value, ValueAccessor<V> accessor, int offset)
+    protected <V> int getComparatorSize(V value, ValueAccessor<V> accessor, int offset)
     {
         int header = accessor.getShort(value, offset);
         if ((header & 0x8000) == 0)
@@ -114,7 +114,6 @@ public class DynamicCompositeType extends AbstractCompositeType
             int header = accessor.getShort(value, offset);
             if ((header & 0x8000) == 0)
             {
-
                 String name = accessor.toString(accessor.slice(value, offset + 2, header));
                 return TypeParser.parse(name);
             }

--- a/src/java/org/apache/cassandra/db/marshal/EmptyType.java
+++ b/src/java/org/apache/cassandra/db/marshal/EmptyType.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 /**
@@ -67,6 +69,12 @@ public class EmptyType extends AbstractType<Void>
     public static final EmptyType instance = new EmptyType();
 
     private EmptyType() {super(ComparisonType.CUSTOM);} // singleton
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    {
+        return null;
+    }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {

--- a/src/java/org/apache/cassandra/db/marshal/FloatType.java
+++ b/src/java/org/apache/cassandra/db/marshal/FloatType.java
@@ -27,6 +27,8 @@ import org.apache.cassandra.serializers.FloatSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 
 public class FloatType extends NumberType<Float>
@@ -49,6 +51,12 @@ public class FloatType extends NumberType<Float>
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return compareComposed(left, accessorL, right, accessorR, this);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return ByteSource.optionalSignedFixedLengthFloat(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/Int32Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/Int32Type.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class Int32Type extends NumberType<Integer>
 {
@@ -53,6 +55,12 @@ public class Int32Type extends NumberType<Integer>
             return diff;
 
         return ValueAccessor.compare(left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return ByteSource.optionalSignedFixedLengthNumber(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -245,7 +245,7 @@ public class ListType<T> extends CollectionType<List<T>>
     {
         ByteBuffer value = buffer.duplicate();
         StringBuilder sb = new StringBuilder("[");
-        int size = CollectionSerializer.readCollectionSize(value, protocolVersion);
+        int size = CollectionSerializer.readCollectionSize(value, ByteBufferAccessor.instance, protocolVersion);
         int offset = CollectionSerializer.sizeOfCollectionSize(size, protocolVersion);
         for (int i = 0; i < size; i++)
         {

--- a/src/java/org/apache/cassandra/db/marshal/LongType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LongType.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.serializers.LongSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class LongType extends NumberType<Long>
 {
@@ -55,6 +57,12 @@ public class LongType extends NumberType<Long>
             return diff;
 
         return ValueAccessor.compare(left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return ByteSource.optionalSignedFixedLengthNumber(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -286,7 +286,7 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
     {
         ByteBuffer value = buffer.duplicate();
         StringBuilder sb = new StringBuilder("{");
-        int size = CollectionSerializer.readCollectionSize(value, protocolVersion);
+        int size = CollectionSerializer.readCollectionSize(value, ByteBufferAccessor.instance, protocolVersion);
         int offset = CollectionSerializer.sizeOfCollectionSize(size, protocolVersion);
         for (int i = 0; i < size; i++)
         {

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class ReversedType<T> extends AbstractType<T>
 {
@@ -61,6 +63,26 @@ public class ReversedType<T> extends AbstractType<T>
     public boolean isEmptyValueMeaningless()
     {
         return baseType.isEmptyValueMeaningless();
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    {
+        ByteSource src = baseType.asComparableBytes(b, version);
+        if (src == null)    // Note: this will only compare correctly if used within a sequence
+            return null;
+        // Invert all bytes.
+        // The comparison requirements for the original type ensure that this encoding will compare correctly with
+        // respect to the reversed comparator function (and, specifically, prefixes of escaped byte-ordered types will
+        // compare as larger). Additionally, the weak prefix-freedom requirement ensures this encoding will also be
+        // weakly prefix-free.
+        return () ->
+        {
+            int v = src.next();
+            if (v == ByteSource.END_OF_STREAM)
+                return v;
+            return v ^ 0xFF;
+        };
     }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
@@ -161,5 +183,39 @@ public class ReversedType<T> extends AbstractType<T>
     public String toString()
     {
         return getClass().getName() + "(" + baseType + ")";
+    }
+
+    private static final class ReversedPeekableByteSource extends ByteSource.Peekable
+    {
+        private final ByteSource.Peekable original;
+
+        static ByteSource.Peekable of(ByteSource.Peekable original)
+        {
+            return original != null ? new ReversedPeekableByteSource(original) : null;
+        }
+
+        private ReversedPeekableByteSource(ByteSource.Peekable original)
+        {
+            super(null);
+            this.original = original;
+        }
+
+        @Override
+        public int next()
+        {
+            int v = original.next();
+            if (v != END_OF_STREAM)
+                return v ^ 0xFF;
+            return END_OF_STREAM;
+        }
+
+        @Override
+        public int peek()
+        {
+            int v = original.peek();
+            if (v != END_OF_STREAM)
+                return v ^ 0xFF;
+            return END_OF_STREAM;
+        }
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -30,6 +30,8 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.SetSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class SetType<T> extends CollectionType<Set<T>>
 {
@@ -155,6 +157,12 @@ public class SetType<T> extends CollectionType<Set<T>>
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return ListType.compareListOrSet(elements, left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer b, ByteComparable.Version version)
+    {
+        return ListType.asComparableBytesListOrSet(getElementsType(), b, version);
     }
 
     public SetSerializer<T> getSerializer()

--- a/src/java/org/apache/cassandra/db/marshal/ShortType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ShortType.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.serializers.ShortSerializer;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 public class ShortType extends NumberType<Short>
 {
@@ -44,6 +46,14 @@ public class ShortType extends NumberType<Short>
         if (diff != 0)
             return diff;
         return ValueAccessor.compare(left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return version == ByteComparable.Version.LEGACY
+               ? ByteSource.signedFixedLengthNumber(buf)
+               : ByteSource.optionalSignedFixedLengthNumber(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
@@ -23,12 +23,14 @@ import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.Duration;
 import org.apache.cassandra.cql3.Term;
-import org.apache.cassandra.cql3.statements.RequestValidations;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.SimpleDateSerializer;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteComparable.Version;
+import org.apache.cassandra.utils.ByteSource;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -37,6 +39,15 @@ public class SimpleDateType extends TemporalType<Integer>
     public static final SimpleDateType instance = new SimpleDateType();
 
     SimpleDateType() {super(ComparisonType.BYTE_ORDER);} // singleton
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, Version version)
+    {
+        // While BYTE_ORDER would still work for this type, making use of the fixed length is more efficient.
+        return version == Version.LEGACY
+               ? ByteSource.fixedLength(buf)
+               : ByteSource.optionalFixedLength(buf);
+    }
 
     public ByteBuffer fromString(String source) throws MarshalException
     {

--- a/src/java/org/apache/cassandra/db/marshal/TimeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimeType.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 
 import org.apache.cassandra.cql3.Constants;
@@ -29,6 +28,9 @@ import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteComparable.Version;
+import org.apache.cassandra.utils.ByteSource;
 
 /**
  * Nanosecond resolution time values
@@ -41,6 +43,15 @@ public class TimeType extends TemporalType<Long>
     public ByteBuffer fromString(String source) throws MarshalException
     {
         return decompose(TimeSerializer.timeStringToLong(source));
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, Version version)
+    {
+        // While BYTE_ORDER would still work for this type, making use of the fixed length is more efficient.
+        return version == Version.LEGACY
+               ? ByteSource.fixedLength(buf)
+               : ByteSource.optionalFixedLength(buf);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/TimestampType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimestampType.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.Duration;
 import org.apache.cassandra.cql3.Term;
-import org.apache.cassandra.cql3.statements.RequestValidations;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +32,8 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TimestampSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -59,6 +60,12 @@ public class TimestampType extends TemporalType<Date>
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return LongType.compareLongs(left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteBuffer buf, ByteComparable.Version version)
+    {
+        return ByteSource.optionalSignedFixedLengthNumber(buf);
     }
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorSerializer.java
+++ b/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorSerializer.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.io.sstable.format.big.ColumnIndex;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.schema.TableMetadata;

--- a/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorWithLowerBound.java
+++ b/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorWithLowerBound.java
@@ -26,12 +26,13 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.transform.RTBoundValidator;
-import org.apache.cassandra.io.sstable.IndexInfo;
+import org.apache.cassandra.io.sstable.format.big.IndexInfo;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
@@ -189,11 +190,11 @@ public class UnfilteredRowIteratorWithLowerBound extends LazilyInitializedUnfilt
         if (!canUseMetadataLowerBound())
             maybeInit();
 
-        RowIndexEntry rowIndexEntry = sstable.getCachedPosition(partitionKey(), false);
+        BigTableRowIndexEntry rowIndexEntry = sstable.getCachedPosition(partitionKey(), false);
         if (rowIndexEntry == null || !rowIndexEntry.indexOnHeap())
             return null;
 
-        try (RowIndexEntry.IndexInfoRetriever onHeapRetriever = rowIndexEntry.openWithIndex(null))
+        try (BigTableRowIndexEntry.IndexInfoRetriever onHeapRetriever = rowIndexEntry.openWithIndex(null))
         {
             IndexInfo column = onHeapRetriever.columnsIndex(filter.isReversed() ? rowIndexEntry.columnsIndexCount() - 1 : 0);
             ClusteringPrefix<?> lowerBoundPrefix = filter.isReversed() ? column.lastName : column.firstName;

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -26,6 +26,8 @@ import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Hex;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -100,6 +102,12 @@ public class ByteOrderedPartitioner implements IPartitioner
             BytesToken other = (BytesToken) obj;
 
             return Arrays.equals(token, other.token);
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return ByteSource.of(token, version);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/LocalPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/LocalPartitioner.java
@@ -27,6 +27,8 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.CachedHashDecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.memory.HeapAllocator;
 
@@ -172,6 +174,12 @@ public class LocalPartitioner implements IPartitioner
                 return false;
             LocalToken other = (LocalToken) obj;
             return token.equals(other.token);
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return comparator.asComparableBytes(token, version);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.MurmurHash;
 import org.apache.cassandra.utils.ObjectSizes;
 
@@ -174,6 +176,12 @@ public class Murmur3Partitioner implements IPartitioner
         public int compareTo(Token o)
         {
             return Long.compare(token, ((LongToken) o).token);
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return ByteSource.of(token);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/OrderPreservingPartitioner.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.Pair;
@@ -193,6 +195,12 @@ public class OrderPreservingPartitioner implements IPartitioner
         public long getHeapSize()
         {
             return EMPTY_SIZE + ObjectSizes.sizeOf(token);
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return ByteSource.of((String) token, version);
         }
     }
 

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -34,6 +34,8 @@ import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.db.marshal.PartitionerDefinedOrder;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.GuidGenerator;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -242,6 +244,12 @@ public class RandomPartitioner implements IPartitioner
         public BigIntegerToken(String token)
         {
             this(new BigInteger(token));
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return IntegerType.instance.asComparableBytes(ByteBuffer.wrap(token.toByteArray()), version);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -215,6 +215,13 @@ public abstract class Token implements RingPosition<Token>, Serializable
                 return ((pos instanceof KeyBound) && !((KeyBound)pos).isMinimumBound) ? 0 : 1;
         }
 
+        @Override
+        public ByteSource asComparableBytes(Version version)
+        {
+            int terminator = isMinimumBound ? ByteSource.LT_NEXT_COMPONENT : ByteSource.GT_NEXT_COMPONENT;
+            return ByteSource.withTerminator(terminator, token.asComparableBytes(version));
+        }
+
         public IPartitioner getPartitioner()
         {
             return getToken().getPartitioner();

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
@@ -24,10 +24,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.compaction.CompactionInfo;
 import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.OperationType;
@@ -78,7 +78,7 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
                 PerSSTableIndexWriter indexWriter = SASIIndex.newWriter(keyValidator, sstable.descriptor, indexes, OperationType.COMPACTION);
 
                 long previousKeyPosition = 0;
-                try (KeyIterator keys = new KeyIterator(sstable.descriptor, cfs.metadata()))
+                try (KeyIterator keys = KeyIterator.forSSTable(sstable))
                 {
                     while (keys.hasNext())
                     {
@@ -90,25 +90,18 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
 
                         indexWriter.startPartition(key, keyPosition);
 
-                        try
-                        {
-                            RowIndexEntry indexEntry = sstable.getPosition(key, SSTableReader.Operator.EQ);
-                            dataFile.seek(indexEntry.position);
-                            ByteBufferUtil.readWithShortLength(dataFile); // key
+                        RowIndexEntry<?> indexEntry = sstable.getPosition(key, SSTableReader.Operator.EQ);
+                        dataFile.seek(indexEntry.position);
+                        ByteBufferUtil.readWithShortLength(dataFile); // key
 
-                            try (SSTableIdentityIterator partition = SSTableIdentityIterator.create(sstable, dataFile, key))
-                            {
-                                // if the row has statics attached, it has to be indexed separately
-                                if (cfs.metadata().hasStaticColumns())
-                                    indexWriter.nextUnfilteredCluster(partition.staticRow());
-
-                                while (partition.hasNext())
-                                    indexWriter.nextUnfilteredCluster(partition.next());
-                            }
-                        }
-                        catch (IOException ex)
+                        try (SSTableIdentityIterator partition = SSTableIdentityIterator.create(sstable, dataFile, key))
                         {
-                            throw new FSReadError(ex, sstable.getFilename());
+                            // if the row has statics attached, it has to be indexed separately
+                            if (cfs.metadata().hasStaticColumns())
+                                indexWriter.nextUnfilteredCluster(partition.staticRow());
+
+                            while (partition.hasNext())
+                                indexWriter.nextUnfilteredCluster(partition.next());
                         }
 
                         bytesProcessed += keyPosition - previousKeyPosition;
@@ -116,6 +109,10 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
                     }
 
                     completeSSTable(indexWriter, sstable, indexes.values());
+                }
+                catch (IOException ex)
+                {
+                    throw new FSReadError(ex, sstable.getFilename());
                 }
             }
         }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.io.sstable;
 
 import java.io.*;
 
+import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.rows.*;

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -27,7 +27,8 @@ import org.apache.cassandra.cache.KeyCacheKey;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -68,7 +69,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
     private final boolean keepOriginals; // true if we do not want to obsolete the originals
 
     private SSTableWriter writer;
-    private Map<DecoratedKey, RowIndexEntry> cachedKeys = new HashMap<>();
+    private Map<DecoratedKey, BigTableRowIndexEntry> cachedKeys = new HashMap<>();
 
     // for testing (TODO: remove when have byteman setup)
     private boolean throwEarly, throwLate;
@@ -127,12 +128,12 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         return writer;
     }
 
-    public RowIndexEntry append(UnfilteredRowIterator partition)
+    public BigTableRowIndexEntry append(UnfilteredRowIterator partition)
     {
         // we do this before appending to ensure we can resetAndTruncate() safely if the append fails
         DecoratedKey key = partition.partitionKey();
         maybeReopenEarly(key);
-        RowIndexEntry index = writer.append(partition);
+        BigTableRowIndexEntry index = writer.append(partition);
         if (DatabaseDescriptor.shouldMigrateKeycacheOnCompaction())
         {
             if (!transaction.isOffline() && index != null)
@@ -151,7 +152,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
     }
 
     // attempts to append the row, if fails resets the writer position
-    public RowIndexEntry tryAppend(UnfilteredRowIterator partition)
+    public BigTableRowIndexEntry tryAppend(UnfilteredRowIterator partition)
     {
         writer.mark();
         try
@@ -173,7 +174,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             {
                 for (SSTableReader reader : transaction.originals())
                 {
-                    RowIndexEntry index = reader.getPosition(key, SSTableReader.Operator.GE);
+                    RowIndexEntry<?> index = reader.getPosition(key, SSTableReader.Operator.GE);
                     NativeLibrary.trySkipCache(reader.getFilename(), 0, index == null ? 0 : index.position);
                 }
             }
@@ -233,7 +234,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         if (!cachedKeys.isEmpty())
         {
             invalidateKeys = new ArrayList<>(cachedKeys.size());
-            for (Map.Entry<DecoratedKey, RowIndexEntry> cacheKey : cachedKeys.entrySet())
+            for (Map.Entry<DecoratedKey, BigTableRowIndexEntry> cacheKey : cachedKeys.entrySet())
             {
                 invalidateKeys.add(cacheKey.getKey());
                 newReader.cacheKey(cacheKey.getKey(), cacheKey.getValue());

--- a/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
 
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -45,7 +45,7 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
 
     public boolean append(UnfilteredRowIterator partition)
     {
-        RowIndexEntry<?> indexEntry = writer.append(partition);
+        BigTableRowIndexEntry indexEntry = writer.append(partition);
         return indexEntry != null;
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/AbstractSSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/AbstractSSTableIterator.java
@@ -15,10 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.db.columniterator;
+package org.apache.cassandra.io.sstable.format;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -26,15 +26,12 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.*;
-import org.apache.cassandra.io.sstable.IndexInfo;
-import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.util.FileDataInput;
-import org.apache.cassandra.io.util.DataPosition;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
-public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
+public abstract class AbstractSSTableIterator<E extends RowIndexEntry<?>> implements UnfilteredRowIterator
 {
     protected final SSTableReader sstable;
     // We could use sstable.metadata(), but that can change during execution so it's good hygiene to grab an immutable instance
@@ -59,7 +56,7 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
     protected AbstractSSTableIterator(SSTableReader sstable,
                                       FileDataInput file,
                                       DecoratedKey key,
-                                      RowIndexEntry indexEntry,
+                                      E indexEntry,
                                       Slices slices,
                                       ColumnFilter columnFilter,
                                       FileHandle ifile)
@@ -176,9 +173,9 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
         }
     }
 
-    protected abstract Reader createReaderInternal(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile);
+    protected abstract Reader createReaderInternal(E indexEntry, FileDataInput file, boolean shouldCloseFile);
 
-    private Reader createReader(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+    private Reader createReader(E indexEntry, FileDataInput file, boolean shouldCloseFile)
     {
         return slices.isEmpty() ? new NoRowsReader(file, shouldCloseFile)
                                 : createReaderInternal(indexEntry, file, shouldCloseFile);
@@ -255,7 +252,7 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
                 e.addSuppressed(suppressed);
             }
             sstable.markSuspect();
-            throw new CorruptSSTableException(e, reader.file.getPath());
+            throw new CorruptSSTableException(e, reader.toString());
         }
     }
 
@@ -286,53 +283,19 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
         catch (IOException e)
         {
             sstable.markSuspect();
-            throw new CorruptSSTableException(e, reader.file.getPath());
+            throw new CorruptSSTableException(e, reader.toString());
         }
     }
 
-    protected abstract class Reader implements Iterator<Unfiltered>
+    protected abstract class Reader implements Iterator<Unfiltered>, Closeable
     {
-        private final boolean shouldCloseFile;
         public FileDataInput file;
-
-        protected UnfilteredDeserializer deserializer;
-
-        // Records the currently open range tombstone (if any)
-        protected DeletionTime openMarker = null;
+        protected final boolean shouldCloseFile;
 
         protected Reader(FileDataInput file, boolean shouldCloseFile)
         {
             this.file = file;
             this.shouldCloseFile = shouldCloseFile;
-
-            if (file != null)
-                createDeserializer();
-        }
-
-        private void createDeserializer()
-        {
-            assert file != null && deserializer == null;
-            deserializer = UnfilteredDeserializer.create(metadata, file, sstable.header, helper);
-        }
-
-        protected void seekToPosition(long position) throws IOException
-        {
-            // This may be the first time we're actually looking into the file
-            if (file == null)
-            {
-                file = sstable.getFileDataInput(position);
-                createDeserializer();
-            }
-            else
-            {
-                file.seek(position);
-            }
-        }
-
-        protected void updateOpenMarker(RangeTombstoneMarker marker)
-        {
-            // Note that we always read index blocks in forward order so this method is always called in forward order
-            openMarker = marker.isOpen(false) ? marker.openDeletionTime(false) : null;
         }
 
         public boolean hasNext()
@@ -352,7 +315,7 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
                     e.addSuppressed(suppressed);
                 }
                 sstable.markSuspect();
-                throw new CorruptSSTableException(e, reader.file.getPath());
+                throw new CorruptSSTableException(e, toString());
             }
         }
 
@@ -373,7 +336,7 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
                     e.addSuppressed(suppressed);
                 }
                 sstable.markSuspect();
-                throw new CorruptSSTableException(e, reader.file.getPath());
+                throw new CorruptSSTableException(e, toString());
             }
         }
 
@@ -381,26 +344,34 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
         public abstract void setForSlice(Slice slice) throws IOException;
 
         protected abstract boolean hasNextInternal() throws IOException;
+
         protected abstract Unfiltered nextInternal() throws IOException;
 
+        @Override
         public void close() throws IOException
         {
             if (shouldCloseFile && file != null)
                 file.close();
         }
+
+        @Override
+        public String toString()
+        {
+            return file != null ? file.getPath() : "null";
+        }
     }
 
     // Reader for when we have Slices.NONE but need to read static row or partition level deletion
-    private class NoRowsReader extends AbstractSSTableIterator.Reader
+    private class NoRowsReader extends Reader
     {
-        private NoRowsReader(FileDataInput file, boolean shouldCloseFile)
+        public NoRowsReader(FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
         }
 
         public void setForSlice(Slice slice) throws IOException
         {
-            return;
+            // no-op
         }
 
         protected boolean hasNextInternal() throws IOException
@@ -411,201 +382,6 @@ public abstract class AbstractSSTableIterator implements UnfilteredRowIterator
         protected Unfiltered nextInternal() throws IOException
         {
             throw new NoSuchElementException();
-        }
-    }
-
-    // Used by indexed readers to store where they are of the index.
-    public static class IndexState implements AutoCloseable
-    {
-        private final Reader reader;
-        private final ClusteringComparator comparator;
-
-        private final RowIndexEntry indexEntry;
-        private final RowIndexEntry.IndexInfoRetriever indexInfoRetriever;
-        private final boolean reversed;
-
-        private int currentIndexIdx;
-
-        // Marks the beginning of the block corresponding to currentIndexIdx.
-        private DataPosition mark;
-
-        public IndexState(Reader reader, ClusteringComparator comparator, RowIndexEntry indexEntry, boolean reversed, FileHandle indexFile)
-        {
-            this.reader = reader;
-            this.comparator = comparator;
-            this.indexEntry = indexEntry;
-            this.indexInfoRetriever = indexEntry.openWithIndex(indexFile);
-            this.reversed = reversed;
-            this.currentIndexIdx = reversed ? indexEntry.columnsIndexCount() : -1;
-        }
-
-        public boolean isDone()
-        {
-            return reversed ? currentIndexIdx < 0 : currentIndexIdx >= indexEntry.columnsIndexCount();
-        }
-
-        // Sets the reader to the beginning of blockIdx.
-        public void setToBlock(int blockIdx) throws IOException
-        {
-            if (blockIdx >= 0 && blockIdx < indexEntry.columnsIndexCount())
-            {
-                reader.seekToPosition(columnOffset(blockIdx));
-                mark = reader.file.mark();
-                reader.deserializer.clearState();
-            }
-
-            currentIndexIdx = blockIdx;
-            reader.openMarker = blockIdx > 0 ? index(blockIdx - 1).endOpenMarker : null;
-        }
-
-        private long columnOffset(int i) throws IOException
-        {
-            return indexEntry.position + index(i).offset;
-        }
-
-        public int blocksCount()
-        {
-            return indexEntry.columnsIndexCount();
-        }
-
-        // Update the block idx based on the current reader position if we're past the current block.
-        // This only makes sense for forward iteration (for reverse ones, when we reach the end of a block we
-        // should seek to the previous one, not update the index state and continue).
-        public void updateBlock() throws IOException
-        {
-            assert !reversed;
-
-            // If we get here with currentBlockIdx < 0, it means setToBlock() has never been called, so it means
-            // we're about to read from the beginning of the partition, but haven't "prepared" the IndexState yet.
-            // Do so by setting us on the first block.
-            if (currentIndexIdx < 0)
-            {
-                setToBlock(0);
-                return;
-            }
-
-            while (currentIndexIdx + 1 < indexEntry.columnsIndexCount() && isPastCurrentBlock())
-            {
-                reader.openMarker = currentIndex().endOpenMarker;
-                ++currentIndexIdx;
-
-                // We have to set the mark, and we have to set it at the beginning of the block. So if we're not at the beginning of the block, this forces us to a weird seek dance.
-                // This can only happen when reading old file however.
-                long startOfBlock = columnOffset(currentIndexIdx);
-                long currentFilePointer = reader.file.getFilePointer();
-                if (startOfBlock == currentFilePointer)
-                {
-                    mark = reader.file.mark();
-                }
-                else
-                {
-                    reader.seekToPosition(startOfBlock);
-                    mark = reader.file.mark();
-                    reader.seekToPosition(currentFilePointer);
-                }
-            }
-        }
-
-        // Check if we've crossed an index boundary (based on the mark on the beginning of the index block).
-        public boolean isPastCurrentBlock() throws IOException
-        {
-            assert reader.deserializer != null;
-            return reader.file.bytesPastMark(mark) >= currentIndex().width;
-        }
-
-        public int currentBlockIdx()
-        {
-            return currentIndexIdx;
-        }
-
-        public IndexInfo currentIndex() throws IOException
-        {
-            return index(currentIndexIdx);
-        }
-
-        public IndexInfo index(int i) throws IOException
-        {
-            return indexInfoRetriever.columnsIndex(i);
-        }
-
-        // Finds the index of the first block containing the provided bound, starting at the provided index.
-        // Will be -1 if the bound is before any block, and blocksCount() if it is after every block.
-        public int findBlockIndex(ClusteringBound<?> bound, int fromIdx) throws IOException
-        {
-            if (bound.isBottom())
-                return -1;
-            if (bound.isTop())
-                return blocksCount();
-
-            return indexFor(bound, fromIdx);
-        }
-
-        public int indexFor(ClusteringPrefix<?> name, int lastIndex) throws IOException
-        {
-            IndexInfo target = new IndexInfo(name, name, 0, 0, null);
-            /*
-            Take the example from the unit test, and say your index looks like this:
-            [0..5][10..15][20..25]
-            and you look for the slice [13..17].
-
-            When doing forward slice, we are doing a binary search comparing 13 (the start of the query)
-            to the lastName part of the index slot. You'll end up with the "first" slot, going from left to right,
-            that may contain the start.
-
-            When doing a reverse slice, we do the same thing, only using as a start column the end of the query,
-            i.e. 17 in this example, compared to the firstName part of the index slots.  bsearch will give us the
-            first slot where firstName > start ([20..25] here), so we subtract an extra one to get the slot just before.
-            */
-            int startIdx = 0;
-            int endIdx = indexEntry.columnsIndexCount() - 1;
-
-            if (reversed)
-            {
-                if (lastIndex < endIdx)
-                {
-                    endIdx = lastIndex;
-                }
-            }
-            else
-            {
-                if (lastIndex > 0)
-                {
-                    startIdx = lastIndex;
-                }
-            }
-
-            int index = binarySearch(target, comparator.indexComparator(reversed), startIdx, endIdx);
-            return (index < 0 ? -index - (reversed ? 2 : 1) : index);
-        }
-
-        private int binarySearch(IndexInfo key, Comparator<IndexInfo> c, int low, int high) throws IOException
-        {
-            while (low <= high)
-            {
-                int mid = (low + high) >>> 1;
-                IndexInfo midVal = index(mid);
-                int cmp = c.compare(midVal, key);
-
-                if (cmp < 0)
-                    low = mid + 1;
-                else if (cmp > 0)
-                    high = mid - 1;
-                else
-                    return mid;
-            }
-            return -(low + 1);
-        }
-
-        @Override
-        public String toString()
-        {
-            return String.format("IndexState(indexSize=%d, currentBlock=%d, reversed=%b)", indexEntry.columnsIndexCount(), currentIndexIdx, reversed);
-        }
-
-        @Override
-        public void close() throws IOException
-        {
-            indexInfoRetriever.close();
         }
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/format/PartitionIndexIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/PartitionIndexIterator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable.format;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Iterator over the partitions of an sstable.
+ * <p>
+ * The index iterator starts with a key/position ready. advance() should be used to move to the next key; iteration
+ * completes when key() == null.
+ */
+public interface PartitionIndexIterator extends Closeable
+{
+    /**
+     * Current key
+     */
+    public ByteBuffer key();
+
+    /**
+     * Position in the data file where the associated content resides
+     */
+    public long dataPosition();
+
+    /**
+     * Moves the iterator forward. Returns false if we reach EOF and there nothing more to read
+     */
+    public boolean advance() throws IOException;
+
+    /**
+     * Closes the iterator quietly
+     */
+    public void close();
+
+    /**
+     * Returns true if we reach EOF
+     */
+    boolean isExhausted();
+
+    /**
+     * Returns the current position in index file (which along with {@link #indexLength()}
+     * can be used to track iteration progress
+     */
+    long indexPosition();
+
+    /**
+     * Sets the current position in index file
+     */
+    void indexPosition(long position) throws IOException;
+
+    /**
+     * Returns length of the index file
+     */
+    long indexLength();
+
+    /**
+     * Resets the iterator to the initial position
+     */
+    void reset() throws IOException;
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/RowIndexEntry.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/RowIndexEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable.format;
+
+import org.apache.cassandra.cache.IMeasurableMemory;
+import org.apache.cassandra.db.DeletionTime;
+
+public abstract class RowIndexEntry<T> implements IMeasurableMemory
+{
+    public final long position;
+
+    public RowIndexEntry(long position)
+    {
+        this.position = position;
+    }
+
+    /**
+     * @return true if this index entry contains the row-level tombstone and column summary.  Otherwise,
+     * caller should fetch these from the row header.
+     */
+    public boolean isIndexed()
+    {
+        return columnsIndexCount() > 1;
+    }
+
+    public abstract DeletionTime deletionTime();
+
+    public int columnsIndexCount()
+    {
+        return 0;
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -19,9 +19,6 @@ package org.apache.cassandra.io.sstable.format;
 
 import com.google.common.base.CharMatcher;
 
-import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.db.RowIndexEntry;
-import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.io.sstable.format.big.BigFormat;
 
 /**
@@ -31,6 +28,7 @@ public interface SSTableFormat
 {
     static boolean enableSSTableDevelopmentTestMode = Boolean.getBoolean("cassandra.test.sstableformatdevelopment");
 
+    Type getType();
 
     Version getLatestVersion();
     Version getVersion(String version);
@@ -38,9 +36,7 @@ public interface SSTableFormat
     SSTableWriter.Factory getWriterFactory();
     SSTableReader.Factory getReaderFactory();
 
-    RowIndexEntry.IndexSerializer<?> getIndexSerializer(TableMetadata metadata, Version version, SerializationHeader header);
-
-    public static enum Type
+    public enum Type
     {
         //The original sstable format
         BIG("big", BigFormat.instance);
@@ -53,7 +49,7 @@ public interface SSTableFormat
             return BIG;
         }
 
-        private Type(String name, SSTableFormat info)
+        Type(String name, SSTableFormat info)
         {
             //Since format comes right after generation
             //we disallow formats with numeric names

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -24,6 +24,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
@@ -57,6 +58,7 @@ import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.*;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.metadata.*;
 import org.apache.cassandra.io.util.*;
 import org.apache.cassandra.metrics.RestorableMeter;
@@ -64,6 +66,7 @@ import org.apache.cassandra.schema.CachingParams;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.CacheService;
@@ -204,9 +207,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     protected final IFilter bf;
     public final IndexSummary indexSummary;
 
-    protected final RowIndexEntry.IndexSerializer<?> rowIndexEntrySerializer;
-
-    protected InstrumentingCache<KeyCacheKey, RowIndexEntry> keyCache;
+    protected InstrumentingCache<KeyCacheKey, BigTableRowIndexEntry> keyCache;
 
     protected final BloomFilterTracker bloomFilterTracker = new BloomFilterTracker();
 
@@ -658,7 +659,6 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         this.bf = bf;
         this.maxDataAge = maxDataAge;
         this.openReason = openReason;
-        this.rowIndexEntrySerializer = descriptor.version.getSSTableFormat().getIndexSerializer(metadata.get(), desc.version, header);
         tidy = new InstanceTidier(descriptor, metadata.id);
         selfRef = new Ref<>(this, tidy);
     }
@@ -680,6 +680,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return sum;
     }
 
+    public abstract PartitionIndexIterator allKeysIterator() throws IOException;
+
     public boolean equals(Object that)
     {
         return that instanceof SSTableReader && ((SSTableReader) that).descriptor.equals(this.descriptor);
@@ -700,7 +702,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         // under normal operation we can do this at any time, but SSTR is also used outside C* proper,
         // e.g. by BulkLoader, which does not initialize the cache.  As a kludge, we set up the cache
         // here when we know we're being wired into the rest of the server infrastructure.
-        InstrumentingCache<KeyCacheKey, RowIndexEntry> maybeKeyCache = CacheService.instance.keyCache;
+        InstrumentingCache<KeyCacheKey, BigTableRowIndexEntry> maybeKeyCache = CacheService.instance.keyCache;
         if (maybeKeyCache.getCapacity() > 0)
             keyCache = maybeKeyCache;
 
@@ -994,25 +996,13 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     private IndexSummary buildSummaryAtLevel(int newSamplingLevel) throws IOException
     {
         // we read the positions in a BRAF so we don't have to worry about an entry spanning a mmap boundary.
-        RandomAccessReader primaryIndex = RandomAccessReader.open(new File(descriptor.filenameFor(Component.PRIMARY_INDEX)));
-        try
+        try (KeyIterator iterator = KeyIterator.forSSTable(this);
+             IndexSummaryBuilder summaryBuilder = new IndexSummaryBuilder(estimatedKeys(), metadata().params.minIndexInterval, newSamplingLevel))
         {
-            long indexSize = primaryIndex.length();
-            try (IndexSummaryBuilder summaryBuilder = new IndexSummaryBuilder(estimatedKeys(), metadata().params.minIndexInterval, newSamplingLevel))
-            {
-                long indexPosition;
-                while ((indexPosition = primaryIndex.getFilePointer()) != indexSize)
-                {
-                    summaryBuilder.maybeAddEntry(decorateKey(ByteBufferUtil.readWithShortLength(primaryIndex)), indexPosition);
-                    RowIndexEntry.Serializer.skip(primaryIndex, descriptor.version);
-                }
+            while (iterator.hasNext())
+                summaryBuilder.maybeAddEntry(iterator.next(), iterator.getKeyPosition());
 
-                return summaryBuilder.build(getPartitioner());
-            }
-        }
-        finally
-        {
-            FileUtils.closeQuietly(primaryIndex);
+            return summaryBuilder.build(getPartitioner());
         }
     }
 
@@ -1313,7 +1303,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return new KeyCacheKey(metadata(), descriptor, key.getKey());
     }
 
-    public void cacheKey(DecoratedKey key, RowIndexEntry info)
+    public void cacheKey(DecoratedKey key, BigTableRowIndexEntry info)
     {
         CachingParams caching = metadata().params.caching;
 
@@ -1325,20 +1315,20 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         keyCache.put(cacheKey, info);
     }
 
-    public RowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats)
+    public BigTableRowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats)
     {
         if (isKeyCacheEnabled())
             return getCachedPosition(new KeyCacheKey(metadata(), descriptor, key.getKey()), updateStats);
         return null;
     }
 
-    protected RowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats)
+    protected BigTableRowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats)
     {
         if (isKeyCacheEnabled())
         {
             if (updateStats)
             {
-                RowIndexEntry cachedEntry = keyCache.get(unifiedKey);
+                BigTableRowIndexEntry cachedEntry = keyCache.get(unifiedKey);
                 keyCacheRequest.incrementAndGet();
                 if (cachedEntry != null)
                 {
@@ -1366,28 +1356,16 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
      * allow key selection by token bounds but only if op != * EQ
      * @param op The Operator defining matching keys: the nearest key to the target matching the operator wins.
      */
-    public final RowIndexEntry getPosition(PartitionPosition key, Operator op)
+    public final RowIndexEntry<?> getPosition(PartitionPosition key, Operator op)
     {
-        return getPosition(key, op, SSTableReadsListener.NOOP_LISTENER);
+        return getPosition(key, op, true, false, SSTableReadsListener.NOOP_LISTENER);
     }
 
-    /**
-     * Retrieves the position while updating the key cache and the stats.
-     * @param key The key to apply as the rhs to the given Operator. A 'fake' key is allowed to
-     * allow key selection by token bounds but only if op != * EQ
-     * @param op The Operator defining matching keys: the nearest key to the target matching the operator wins.
-     * @param listener the {@code SSTableReaderListener} that must handle the notifications.
-     */
-    public final RowIndexEntry getPosition(PartitionPosition key, Operator op, SSTableReadsListener listener)
+    public final boolean checkEntryExists(PartitionPosition key,
+                                          Operator op,
+                                          boolean updateCacheAndStats)
     {
-        return getPosition(key, op, true, false, listener);
-    }
-
-    public final RowIndexEntry getPosition(PartitionPosition key,
-                                           Operator op,
-                                           boolean updateCacheAndStats)
-    {
-        return getPosition(key, op, updateCacheAndStats, false, SSTableReadsListener.NOOP_LISTENER);
+        return getPosition(key, op, updateCacheAndStats, false, SSTableReadsListener.NOOP_LISTENER) != null;
     }
 
     /**
@@ -1398,11 +1376,11 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
      * @param listener a listener used to handle internal events
      * @return The index entry corresponding to the key, or null if the key is not present
      */
-    protected abstract RowIndexEntry getPosition(PartitionPosition key,
-                                                 Operator op,
-                                                 boolean updateCacheAndStats,
-                                                 boolean permitMatchPastLast,
-                                                 SSTableReadsListener listener);
+    protected abstract RowIndexEntry<?> getPosition(PartitionPosition key,
+                                                    Operator op,
+                                                    boolean updateCacheAndStats,
+                                                    boolean permitMatchPastLast,
+                                                    SSTableReadsListener listener);
 
     public abstract UnfilteredRowIterator iterator(DecoratedKey key,
                                                    Slices slices,
@@ -1410,9 +1388,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
                                                    boolean reversed,
                                                    SSTableReadsListener listener);
 
-    public abstract UnfilteredRowIterator iterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, Slices slices, ColumnFilter selectedColumns, boolean reversed);
-
-    public abstract UnfilteredRowIterator simpleIterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, boolean tombstoneOnly);
+    public abstract UnfilteredRowIterator simpleIterator(Supplier<FileDataInput> dfile, DecoratedKey key, boolean tombstoneOnly);
 
     /**
      * Finds and returns the first key beyond a given token in this SSTable or null if no such key exists.
@@ -1427,24 +1403,22 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         if (ifile == null)
             return null;
 
-        String path = null;
-        try (FileDataInput in = ifile.createReader(sampledPosition))
+        try (PartitionIndexIterator iterator = allKeysIterator())
         {
-            path = in.getPath();
-            while (!in.isEOF())
+            iterator.indexPosition(sampledPosition);
+            KeyIterator keyIterator = new KeyIterator(iterator, getPartitioner());
+
+            while (keyIterator.hasNext())
             {
-                ByteBuffer indexKey = ByteBufferUtil.readWithShortLength(in);
-                DecoratedKey indexDecoratedKey = decorateKey(indexKey);
+                DecoratedKey indexDecoratedKey = keyIterator.next();
                 if (indexDecoratedKey.compareTo(token) > 0)
                     return indexDecoratedKey;
-
-                RowIndexEntry.Serializer.skip(in, descriptor.version);
             }
         }
         catch (IOException e)
         {
             markSuspect();
-            throw new CorruptSSTableException(e, path);
+            throw new CorruptSSTableException(e, ifile.path());
         }
 
         return null;
@@ -1617,25 +1591,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return sstableMetadata.repairedAt != ActiveRepairService.UNREPAIRED_SSTABLE;
     }
 
-    public DecoratedKey keyAt(long indexPosition) throws IOException
-    {
-        DecoratedKey key;
-        try (FileDataInput in = ifile.createReader(indexPosition))
-        {
-            if (in.isEOF())
-                return null;
-
-            key = decorateKey(ByteBufferUtil.readWithShortLength(in));
-
-            // hint read path about key location if caching is enabled
-            // this saves index summary lookup and index file iteration which whould be pretty costly
-            // especially in presence of promoted column indexes
-            if (isKeyCacheEnabled())
-                cacheKey(key, rowIndexEntrySerializer.deserialize(in));
-        }
-
-        return key;
-    }
+    public abstract DecoratedKey keyAt(long indexPosition) throws IOException;
 
     public boolean isPendingRepair()
     {
@@ -1714,7 +1670,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return bloomFilterTracker.getRecentTruePositiveCount();
     }
 
-    public InstrumentingCache<KeyCacheKey, RowIndexEntry> getKeyCache()
+    public InstrumentingCache<KeyCacheKey, BigTableRowIndexEntry> getKeyCache()
     {
         return keyCache;
     }
@@ -1943,7 +1899,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return selfRef.ref();
     }
 
-    void setup(boolean trackHotness)
+    protected void setup(boolean trackHotness)
     {
         tidy.setup(this, trackHotness);
         this.readMeter = tidy.global.readMeter;
@@ -2189,9 +2145,11 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         GlobalTidy.lookup.clear();
     }
 
-    public static abstract class Factory
+    public interface Factory
     {
-        public abstract SSTableReader open(SSTableReaderBuilder builder);
+        SSTableReader open(SSTableReaderBuilder builder);
+
+        PartitionIndexIterator indexIterator(Descriptor descriptor, TableMetadata metadata);
     }
 
     public static class PartitionPositionBounds

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReadsListener.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReadsListener.java
@@ -17,7 +17,7 @@
  */
 package org.apache.cassandra.io.sstable.format;
 
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 
 /**
  * Listener for receiving notifications associated with reading SSTables.

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -35,6 +34,7 @@ import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
@@ -59,7 +59,6 @@ public abstract class SSTableWriter extends SSTable implements Transactional
     protected long maxDataAge = -1;
     protected final long keyCount;
     protected final MetadataCollector metadataCollector;
-    protected final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
     protected final SerializationHeader header;
     protected final TransactionalProxy txnProxy = txnProxy();
     protected final Collection<SSTableFlushObserver> observers;
@@ -91,7 +90,6 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         this.isTransient = isTransient;
         this.metadataCollector = metadataCollector;
         this.header = header;
-        this.rowIndexEntrySerializer = descriptor.version.getSSTableFormat().getIndexSerializer(metadata.get(), descriptor.version, header);
         this.observers = observers == null ? Collections.emptySet() : observers;
     }
 
@@ -209,7 +207,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
      *
      * @throws FSWriteError if a write to the dataFile fails
      */
-    public abstract RowIndexEntry append(UnfilteredRowIterator iterator);
+    public abstract BigTableRowIndexEntry append(UnfilteredRowIterator iterator);
 
     public abstract long getFilePointer();
 

--- a/src/java/org/apache/cassandra/io/sstable/format/big/AbstractBigTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/AbstractBigTableIterator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable.format.big;
+
+import java.io.IOException;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.db.UnfilteredDeserializer;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableIterator;
+import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.rows.RangeTombstoneMarker;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.FileDataInput;
+import org.apache.cassandra.io.util.FileHandle;
+
+public abstract class AbstractBigTableIterator extends AbstractSSTableIterator<BigTableRowIndexEntry>
+{
+    protected AbstractBigTableIterator(SSTableReader sstable,
+                                       FileDataInput file,
+                                       DecoratedKey key,
+                                       BigTableRowIndexEntry indexEntry,
+                                       Slices slices,
+                                       ColumnFilter columnFilter,
+                                       FileHandle ifile)
+    {
+        super(sstable, file, key, indexEntry, slices, columnFilter, ifile);
+    }
+
+    protected abstract class RowReader extends Reader {
+        protected UnfilteredDeserializer deserializer;
+
+        // Records the currently open range tombstone (if any)
+        protected DeletionTime openMarker;
+
+        protected RowReader(FileDataInput file, boolean shouldCloseFile)
+        {
+            super(file, shouldCloseFile);
+
+            if (file != null)
+                createDeserializer();
+        }
+
+        private void createDeserializer()
+        {
+            assert file != null && deserializer == null;
+            deserializer = UnfilteredDeserializer.create(metadata, file, sstable.header, helper);
+        }
+
+        public void seekToPosition(long position) throws IOException
+        {
+            // This may be the first time we're actually looking into the file
+            if (file == null)
+            {
+                file = sstable.getFileDataInput(position);
+                createDeserializer();
+            }
+            else
+            {
+                file.seek(position);
+            }
+        }
+
+        protected void updateOpenMarker(RangeTombstoneMarker marker)
+        {
+            // Note that we always read index blocks in forward order so this method is always called in forward order
+            openMarker = marker.isOpen(false) ? marker.openDeletionTime(false) : null;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -17,13 +17,15 @@
  */
 package org.apache.cassandra.io.sstable.format.big;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.UUID;
 
 import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
+import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
-import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.io.sstable.Descriptor;
@@ -44,6 +46,12 @@ public class BigFormat implements SSTableFormat
     private BigFormat()
     {
 
+    }
+
+    @Override
+    public Type getType()
+    {
+        return Type.BIG;
     }
 
     @Override
@@ -70,12 +78,6 @@ public class BigFormat implements SSTableFormat
         return readerFactory;
     }
 
-    @Override
-    public RowIndexEntry.IndexSerializer getIndexSerializer(TableMetadata metadata, Version version, SerializationHeader header)
-    {
-        return new RowIndexEntry.Serializer(version, header);
-    }
-
     static class WriterFactory extends SSTableWriter.Factory
     {
         @Override
@@ -95,12 +97,29 @@ public class BigFormat implements SSTableFormat
         }
     }
 
-    static class ReaderFactory extends SSTableReader.Factory
+    static class ReaderFactory implements SSTableReader.Factory
     {
         @Override
         public SSTableReader open(SSTableReaderBuilder builder)
         {
             return new BigTableReader(builder);
+        }
+
+        @Override
+        public PartitionIndexIterator indexIterator(Descriptor descriptor, TableMetadata metadata)
+        {
+            try (FileHandle iFile = SSTableReaderBuilder.defaultIndexHandleBuilder(descriptor).complete()) {
+                SerializationHeader.Component headerComponent = (SerializationHeader.Component)
+                                                                descriptor.getMetadataSerializer()
+                                                                          .deserialize(descriptor, MetadataType.HEADER);
+                SerializationHeader header = headerComponent.toHeader(metadata);
+                BigTableRowIndexEntry.Serializer serializer = new BigTableRowIndexEntry.Serializer(descriptor.version, header);
+                return BigTablePartitionIndexIterator.create(iFile, serializer);
+            }
+            catch (IOException ex)
+            {
+                throw new RuntimeException(ex);
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTablePartitionIndexIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTablePartitionIndexIterator.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable.format.big;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry.IndexSerializer;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+@NotThreadSafe
+public class BigTablePartitionIndexIterator implements PartitionIndexIterator
+{
+    private final FileHandle indexFile;
+    private final RandomAccessReader reader;
+    private final IndexSerializer<IndexInfo> rowIndexEntrySerializer;
+    private final long initialPosition;
+
+    private ByteBuffer key;
+    private long dataPosition;
+
+    private BigTablePartitionIndexIterator(FileHandle indexFile,
+                                           RandomAccessReader reader,
+                                           IndexSerializer<IndexInfo> rowIndexEntrySerializer)
+    {
+        this.indexFile = indexFile;
+        this.reader = reader;
+        this.rowIndexEntrySerializer = rowIndexEntrySerializer;
+        this.initialPosition = reader.getFilePointer();
+    }
+
+    public static BigTablePartitionIndexIterator create(RandomAccessReader reader, IndexSerializer<IndexInfo> serializer)
+    throws IOException
+    {
+        BigTablePartitionIndexIterator iterator = new BigTablePartitionIndexIterator(null, reader, serializer);
+        try
+        {
+            iterator.advance();
+            return iterator;
+        }
+        catch (IOException | RuntimeException ex)
+        {
+            iterator.close();
+            throw ex;
+        }
+    }
+
+    @SuppressWarnings({ "resource" })
+    public static BigTablePartitionIndexIterator create(FileHandle indexFile, IndexSerializer<IndexInfo> serializer)
+    throws IOException
+    {
+        FileHandle iFile = null;
+        RandomAccessReader reader = null;
+        BigTablePartitionIndexIterator iterator = null;
+        try
+        {
+            iFile = indexFile.sharedCopy();
+            reader = iFile.createReader();
+            iterator = new BigTablePartitionIndexIterator(iFile, reader, serializer);
+            iterator.advance();
+            return iterator;
+        }
+        catch (IOException | RuntimeException ex)
+        {
+            if (iterator != null)
+            {
+                iterator.close();
+            }
+            else
+            {
+                FileUtils.closeQuietly(reader);
+                FileUtils.closeQuietly(iFile);
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        key = null;
+        dataPosition = -1;
+        FileUtils.closeQuietly(reader);
+        FileUtils.closeQuietly(indexFile);
+    }
+
+    @Override
+    public boolean advance() throws IOException
+    {
+        if (!reader.isEOF())
+        {
+            key = ByteBufferUtil.readWithShortLength(reader);
+            dataPosition = rowIndexEntrySerializer.deserializePositionAndSkip(reader);
+            return true;
+        }
+        else
+        {
+            dataPosition = -1;
+            key = null;
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isExhausted()
+    {
+        return key == null && dataPosition < 0;
+    }
+
+    @Override
+    public ByteBuffer key()
+    {
+        return key;
+    }
+
+    @Override
+    public long dataPosition()
+    {
+        return dataPosition;
+    }
+
+    @Override
+    public long indexPosition()
+    {
+        return reader.getFilePointer();
+    }
+
+    @Override
+    public void indexPosition(long position) throws IOException
+    {
+        if (position > indexLength())
+            throw new IndexOutOfBoundsException("The requested position exceeds the index length");
+        reader.seek(position);
+        key = null;
+        dataPosition = 0;
+        advance();
+    }
+
+    @Override
+    public long indexLength()
+    {
+        return reader.length();
+    }
+
+    @Override
+    public void reset() throws IOException
+    {
+        reader.seek(initialPosition);
+        key = null;
+        dataPosition = 0;
+        advance();
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -20,14 +20,14 @@ package org.apache.cassandra.io.sstable.format.big;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.function.Supplier;
 
+import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReaderBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.*;
-import org.apache.cassandra.db.columniterator.SSTableIterator;
-import org.apache.cassandra.db.columniterator.SSTableReversedIterator;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.Rows;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -52,9 +52,18 @@ public class BigTableReader extends SSTableReader
 {
     private static final Logger logger = LoggerFactory.getLogger(BigTableReader.class);
 
+    protected final BigTableRowIndexEntry.IndexSerializer<IndexInfo> rowIndexEntrySerializer;
+
     BigTableReader(SSTableReaderBuilder builder)
     {
         super(builder);
+        this.rowIndexEntrySerializer = new BigTableRowIndexEntry.Serializer(descriptor.version, header);
+    }
+
+    @Override
+    public PartitionIndexIterator allKeysIterator() throws IOException
+    {
+        return BigTablePartitionIndexIterator.create(getIndexFile(), rowIndexEntrySerializer);
     }
 
     public UnfilteredRowIterator iterator(DecoratedKey key,
@@ -63,12 +72,12 @@ public class BigTableReader extends SSTableReader
                                           boolean reversed,
                                           SSTableReadsListener listener)
     {
-        RowIndexEntry rie = getPosition(key, SSTableReader.Operator.EQ, listener);
+        BigTableRowIndexEntry rie = getPosition(key, SSTableReader.Operator.EQ, true, false, listener);
         return iterator(null, key, rie, slices, selectedColumns, reversed);
     }
 
     @SuppressWarnings("resource")
-    public UnfilteredRowIterator iterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, Slices slices, ColumnFilter selectedColumns, boolean reversed)
+    public UnfilteredRowIterator iterator(FileDataInput file, DecoratedKey key, BigTableRowIndexEntry indexEntry, Slices slices, ColumnFilter selectedColumns, boolean reversed)
     {
         if (indexEntry == null)
             return UnfilteredRowIterators.noRowsIterator(metadata(), key, Rows.EMPTY_STATIC_ROW, DeletionTime.LIVE, reversed);
@@ -121,9 +130,12 @@ public class BigTableReader extends SSTableReader
 
     @SuppressWarnings("resource") // caller to close
     @Override
-    public UnfilteredRowIterator simpleIterator(FileDataInput dfile, DecoratedKey key, RowIndexEntry position, boolean tombstoneOnly)
+    public UnfilteredRowIterator simpleIterator(Supplier<FileDataInput> dfile, DecoratedKey key, boolean tombstoneOnly)
     {
-        return SSTableIdentityIterator.create(this, dfile, position, key, tombstoneOnly);
+        BigTableRowIndexEntry position = getPosition(key, SSTableReader.Operator.EQ, true, false, SSTableReadsListener.NOOP_LISTENER);
+        if (position == null)
+            return null;
+        return SSTableIdentityIterator.create(this, dfile.get(), position, key, tombstoneOnly);
     }
 
     /**
@@ -133,11 +145,11 @@ public class BigTableReader extends SSTableReader
      * @param updateCacheAndStats true if updating stats and cache
      * @return The index entry corresponding to the key, or null if the key is not present
      */
-    protected RowIndexEntry getPosition(PartitionPosition key,
-                                        Operator op,
-                                        boolean updateCacheAndStats,
-                                        boolean permitMatchPastLast,
-                                        SSTableReadsListener listener)
+    protected BigTableRowIndexEntry getPosition(PartitionPosition key,
+                                                Operator op,
+                                                boolean updateCacheAndStats,
+                                                boolean permitMatchPastLast,
+                                                SSTableReadsListener listener)
     {
         if (op == Operator.EQ)
         {
@@ -154,7 +166,7 @@ public class BigTableReader extends SSTableReader
         if ((op == Operator.EQ || op == Operator.GE) && (key instanceof DecoratedKey))
         {
             DecoratedKey decoratedKey = (DecoratedKey) key;
-            RowIndexEntry cachedPosition = getCachedPosition(decoratedKey, updateCacheAndStats);
+            BigTableRowIndexEntry cachedPosition = getCachedPosition(decoratedKey, updateCacheAndStats);
             if (cachedPosition != null)
             {
                 listener.onSSTableSelected(this, cachedPosition, SelectionReason.KEY_CACHE_HIT);
@@ -243,7 +255,7 @@ public class BigTableReader extends SSTableReader
                 if (opSatisfied)
                 {
                     // read data position from index entry
-                    RowIndexEntry indexEntry = rowIndexEntrySerializer.deserialize(in);
+                    BigTableRowIndexEntry indexEntry = rowIndexEntrySerializer.deserialize(in);
                     if (exactMatch && updateCacheAndStats)
                     {
                         assert key instanceof DecoratedKey; // key can be == to the index key only if it's a true row key
@@ -270,7 +282,7 @@ public class BigTableReader extends SSTableReader
                     return indexEntry;
                 }
 
-                RowIndexEntry.Serializer.skip(in, descriptor.version);
+                BigTableRowIndexEntry.Serializer.skip(in, descriptor.version);
             }
         }
         catch (IOException e)
@@ -287,4 +299,24 @@ public class BigTableReader extends SSTableReader
     }
 
 
+    @Override
+    public DecoratedKey keyAt(long indexPosition) throws IOException
+    {
+        DecoratedKey key;
+        try (FileDataInput in = ifile.createReader(indexPosition))
+        {
+            if (in.isEOF())
+                return null;
+
+            key = decorateKey(ByteBufferUtil.readWithShortLength(in));
+
+            // hint read path about key location if caching is enabled
+            // this saves index summary lookup and index file iteration which whould be pretty costly
+            // especially in presence of promoted column indexes
+            if (isKeyCacheEnabled())
+                cacheKey(key, rowIndexEntrySerializer.deserialize(in));
+        }
+
+        return key;
+    }
 }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/ColumnIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/ColumnIndex.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.db;
+package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -25,9 +25,14 @@ import java.util.*;
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.SerializationHeader;
+import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.io.ISerializer;
-import org.apache.cassandra.io.sstable.IndexInfo;
+import org.apache.cassandra.io.sstable.format.big.IndexInfo;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -37,7 +42,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 /**
  * Column index builder used by {@link org.apache.cassandra.io.sstable.format.big.BigTableWriter}.
  * For index entries that exceed {@link org.apache.cassandra.config.Config#column_index_cache_size_in_kb},
- * this uses the serialization logic as in {@link RowIndexEntry}.
+ * this uses the serialization logic as in {@link BigTableRowIndexEntry}.
  */
 public class ColumnIndex
 {
@@ -288,7 +293,7 @@ public class ColumnIndex
         // in indexOffsets[]. buffer is != null, if it exceeds Config.column_index_cache_size_in_kb.
         // In the other case, when buffer==null, the offsets are serialized in RowIndexEntry.IndexedEntry.serialize().
         if (buffer != null)
-            RowIndexEntry.Serializer.serializeOffsets(buffer, indexOffsets, columnIndexCount);
+            BigTableRowIndexEntry.Serializer.serializeOffsets(buffer, indexOffsets, columnIndexCount);
 
         // we should always have at least one computed index block, but we only write it out if there is more than that.
         assert columnIndexCount > 0 && headerLength >= 0;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/IndexInfo.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/IndexInfo.java
@@ -16,18 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.io.sstable;
+package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
 import java.util.List;
 
 import org.apache.cassandra.db.ClusteringPrefix;
 import org.apache.cassandra.db.DeletionTime;
-import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.io.ISerializer;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -35,7 +33,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.ObjectSizes;
 
 /**
- * {@code IndexInfo} is embedded in the indexed version of {@link RowIndexEntry}.
+ * {@code IndexInfo} is embedded in the indexed version of {@link BigTableRowIndexEntry}.
  * Each instance roughly covers a range of {@link org.apache.cassandra.config.Config#column_index_size_in_kb column_index_size_in_kb} kB
  * and contains the first and last clustering value (or slice bound), its offset in the data file and width in the data file.
  * <p>

--- a/src/java/org/apache/cassandra/io/sstable/format/big/IndexState.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/IndexState.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable.format.big;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+import org.apache.cassandra.db.ClusteringBound;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.io.sstable.format.big.AbstractBigTableIterator.RowReader;
+import org.apache.cassandra.io.util.DataPosition;
+import org.apache.cassandra.io.util.FileHandle;
+
+// Used by indexed readers to store where they are of the index.
+public class IndexState implements AutoCloseable
+{
+    private final RowReader reader;
+    private final ClusteringComparator comparator;
+
+    private final BigTableRowIndexEntry indexEntry;
+    private final BigTableRowIndexEntry.IndexInfoRetriever indexInfoRetriever;
+    private final boolean reversed;
+
+    private int currentIndexIdx;
+
+    // Marks the beginning of the block corresponding to currentIndexIdx.
+    private DataPosition mark;
+
+    public IndexState(RowReader reader,
+                      ClusteringComparator comparator,
+                      BigTableRowIndexEntry indexEntry,
+                      boolean reversed,
+                      FileHandle indexFile)
+    {
+        this.reader = reader;
+        this.comparator = comparator;
+        this.indexEntry = indexEntry;
+        this.indexInfoRetriever = indexEntry.openWithIndex(indexFile);
+        this.reversed = reversed;
+        this.currentIndexIdx = reversed ? indexEntry.columnsIndexCount() : -1;
+    }
+
+    public boolean isDone()
+    {
+        return reversed ? currentIndexIdx < 0 : currentIndexIdx >= indexEntry.columnsIndexCount();
+    }
+
+    // Sets the reader to the beginning of blockIdx.
+    public void setToBlock(int blockIdx) throws IOException
+    {
+        if (blockIdx >= 0 && blockIdx < indexEntry.columnsIndexCount())
+        {
+            reader.seekToPosition(columnOffset(blockIdx));
+            mark = reader.file.mark();
+            reader.deserializer.clearState();
+        }
+
+        currentIndexIdx = blockIdx;
+        reader.openMarker = blockIdx > 0 ? index(blockIdx - 1).endOpenMarker : null;
+    }
+
+    private long columnOffset(int i) throws IOException
+    {
+        return indexEntry.position + index(i).offset;
+    }
+
+    public int blocksCount()
+    {
+        return indexEntry.columnsIndexCount();
+    }
+
+    // Update the block idx based on the current reader position if we're past the current block.
+    // This only makes sense for forward iteration (for reverse ones, when we reach the end of a block we
+    // should seek to the previous one, not update the index state and continue).
+    public void updateBlock() throws IOException
+    {
+        assert !reversed;
+
+        // If we get here with currentBlockIdx < 0, it means setToBlock() has never been called, so it means
+        // we're about to read from the beginning of the partition, but haven't "prepared" the IndexState yet.
+        // Do so by setting us on the first block.
+        if (currentIndexIdx < 0)
+        {
+            setToBlock(0);
+            return;
+        }
+
+        while (currentIndexIdx + 1 < indexEntry.columnsIndexCount() && isPastCurrentBlock())
+        {
+            reader.openMarker = currentIndex().endOpenMarker;
+            ++currentIndexIdx;
+
+            // We have to set the mark, and we have to set it at the beginning of the block. So if we're not at the beginning of the block, this forces us to a weird seek dance.
+            // This can only happen when reading old file however.
+            long startOfBlock = columnOffset(currentIndexIdx);
+            long currentFilePointer = reader.file.getFilePointer();
+            if (startOfBlock == currentFilePointer)
+            {
+                mark = reader.file.mark();
+            }
+            else
+            {
+                reader.seekToPosition(startOfBlock);
+                mark = reader.file.mark();
+                reader.seekToPosition(currentFilePointer);
+            }
+        }
+    }
+
+    // Check if we've crossed an index boundary (based on the mark on the beginning of the index block).
+    public boolean isPastCurrentBlock() throws IOException
+    {
+        assert reader.deserializer != null;
+        return reader.file.bytesPastMark(mark) >= currentIndex().width;
+    }
+
+    public int currentBlockIdx()
+    {
+        return currentIndexIdx;
+    }
+
+    public IndexInfo currentIndex() throws IOException
+    {
+        return index(currentIndexIdx);
+    }
+
+    public IndexInfo index(int i) throws IOException
+    {
+        return indexInfoRetriever.columnsIndex(i);
+    }
+
+    // Finds the index of the first block containing the provided bound, starting at the provided index.
+    // Will be -1 if the bound is before any block, and blocksCount() if it is after every block.
+    public int findBlockIndex(ClusteringBound<?> bound, int fromIdx) throws IOException
+    {
+        if (bound.isBottom())
+            return -1;
+        if (bound.isTop())
+            return blocksCount();
+
+        return indexFor(bound, fromIdx);
+    }
+
+    public int indexFor(ClusteringPrefix<?> name, int lastIndex) throws IOException
+    {
+        IndexInfo target = new IndexInfo(name, name, 0, 0, null);
+        /*
+        Take the example from the unit test, and say your index looks like this:
+        [0..5][10..15][20..25]
+        and you look for the slice [13..17].
+
+        When doing forward slice, we are doing a binary search comparing 13 (the start of the query)
+        to the lastName part of the index slot. You'll end up with the "first" slot, going from left to right,
+        that may contain the start.
+
+        When doing a reverse slice, we do the same thing, only using as a start column the end of the query,
+        i.e. 17 in this example, compared to the firstName part of the index slots.  bsearch will give us the
+        first slot where firstName > start ([20..25] here), so we subtract an extra one to get the slot just before.
+        */
+        int startIdx = 0;
+        int endIdx = indexEntry.columnsIndexCount() - 1;
+
+        if (reversed)
+        {
+            if (lastIndex < endIdx)
+            {
+                endIdx = lastIndex;
+            }
+        }
+        else
+        {
+            if (lastIndex > 0)
+            {
+                startIdx = lastIndex;
+            }
+        }
+
+        int index = binarySearch(target, comparator.indexComparator(reversed), startIdx, endIdx);
+        return (index < 0 ? -index - (reversed ? 2 : 1) : index);
+    }
+
+    private int binarySearch(IndexInfo key, Comparator<IndexInfo> c, int low, int high) throws IOException
+    {
+        while (low <= high)
+        {
+            int mid = (low + high) >>> 1;
+            IndexInfo midVal = index(mid);
+            int cmp = c.compare(midVal, key);
+
+            if (cmp < 0)
+                low = mid + 1;
+            else if (cmp > 0)
+                high = mid - 1;
+            else
+                return mid;
+        }
+        return -(low + 1);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("IndexState(indexSize=%d, currentBlock=%d, reversed=%b)", indexEntry.columnsIndexCount(), currentIndexIdx, reversed);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        indexInfoRetriever.close();
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.db.columniterator;
+package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
@@ -30,7 +30,7 @@ import org.apache.cassandra.io.util.FileHandle;
 /**
  *  A Cell Iterator over SSTable
  */
-public class SSTableIterator extends AbstractSSTableIterator
+public class SSTableIterator extends AbstractBigTableIterator
 {
     /**
      * The index of the slice being processed.
@@ -40,7 +40,7 @@ public class SSTableIterator extends AbstractSSTableIterator
     public SSTableIterator(SSTableReader sstable,
                            FileDataInput file,
                            DecoratedKey key,
-                           RowIndexEntry indexEntry,
+                           BigTableRowIndexEntry indexEntry,
                            Slices slices,
                            ColumnFilter columns,
                            FileHandle ifile)
@@ -48,7 +48,7 @@ public class SSTableIterator extends AbstractSSTableIterator
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    protected Reader createReaderInternal(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+    protected RowReader createReaderInternal(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
     {
         return indexEntry.isIndexed()
              ? new ForwardIndexedReader(indexEntry, file, shouldCloseFile)
@@ -72,7 +72,7 @@ public class SSTableIterator extends AbstractSSTableIterator
         return false;
     }
 
-    private class ForwardReader extends Reader
+    private class ForwardReader extends RowReader
     {
         // The start of the current slice. This will be null as soon as we know we've passed that bound.
         protected ClusteringBound<?> start;
@@ -211,7 +211,7 @@ public class SSTableIterator extends AbstractSSTableIterator
 
         private int lastBlockIdx; // the last index block that has data for the current query
 
-        private ForwardIndexedReader(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+        private ForwardIndexedReader(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
             this.indexState = new IndexState(this, metadata.comparator, indexEntry, false, ifile);

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.db.columniterator;
+package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
 import java.util.*;
@@ -34,7 +34,7 @@ import org.apache.cassandra.utils.btree.BTree;
 /**
  *  A Cell Iterator in reversed clustering order over SSTable
  */
-public class SSTableReversedIterator extends AbstractSSTableIterator
+public class SSTableReversedIterator extends AbstractBigTableIterator
 {
     /**
      * The index of the slice being processed.
@@ -44,7 +44,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator
     public SSTableReversedIterator(SSTableReader sstable,
                                    FileDataInput file,
                                    DecoratedKey key,
-                                   RowIndexEntry indexEntry,
+                                   BigTableRowIndexEntry indexEntry,
                                    Slices slices,
                                    ColumnFilter columns,
                                    FileHandle ifile)
@@ -52,7 +52,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    protected Reader createReaderInternal(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+    protected Reader createReaderInternal(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
     {
         return indexEntry.isIndexed()
              ? new ReverseIndexedReader(indexEntry, file, shouldCloseFile)
@@ -76,7 +76,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator
         return slice < slices.size();
     }
 
-    private class ReverseReader extends Reader
+    private class ReverseReader extends RowReader
     {
         protected ReusablePartitionData buffer;
         protected Iterator<Unfiltered> iterator;
@@ -262,7 +262,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator
         // The last index block to consider for the slice
         private int lastBlockIdx;
 
-        private ReverseIndexedReader(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+        private ReverseIndexedReader(BigTableRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
             this.indexState = new IndexState(this, metadata.comparator, indexEntry, true, ifile);

--- a/src/java/org/apache/cassandra/serializers/CollectionSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/CollectionSerializer.java
@@ -91,11 +91,6 @@ public abstract class CollectionSerializer<T> extends TypeSerializer<T>
         output.putInt(elements);
     }
 
-    public static int readCollectionSize(ByteBuffer input, ProtocolVersion version)
-    {
-        return readCollectionSize(input, ByteBufferAccessor.instance, version);
-    }
-
     public static <V> int readCollectionSize(V value, ValueAccessor<V> accessor, ProtocolVersion version)
     {
         return accessor.toInt(value);

--- a/src/java/org/apache/cassandra/serializers/MapSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/MapSerializer.java
@@ -149,7 +149,7 @@ public class MapSerializer<K, V> extends CollectionSerializer<Map<K, V>>
         try
         {
             ByteBuffer input = collection.duplicate();
-            int n = readCollectionSize(input, ProtocolVersion.V3);
+            int n = readCollectionSize(input, ByteBufferAccessor.instance, ProtocolVersion.V3);
             int offset = sizeOfCollectionSize(n, ProtocolVersion.V3);
             for (int i = 0; i < n; i++)
             {
@@ -185,7 +185,7 @@ public class MapSerializer<K, V> extends CollectionSerializer<Map<K, V>>
         try
         {
             ByteBuffer input = collection.duplicate();
-            int n = readCollectionSize(input, ProtocolVersion.V3);
+            int n = readCollectionSize(input, ByteBufferAccessor.instance, ProtocolVersion.V3);
             input.position(input.position() + sizeOfCollectionSize(n, ProtocolVersion.V3));
             int startPos = input.position();
             int count = 0;

--- a/src/java/org/apache/cassandra/serializers/SetSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/SetSerializer.java
@@ -157,7 +157,7 @@ public class SetSerializer<T> extends CollectionSerializer<Set<T>>
     {
         try
         {
-            int n = readCollectionSize(input, ProtocolVersion.V3);
+            int n = readCollectionSize(input, ByteBufferAccessor.instance, ProtocolVersion.V3);
             int offset = sizeOfCollectionSize(n, ProtocolVersion.V3);
 
             for (int i = 0; i < n; i++)
@@ -193,7 +193,7 @@ public class SetSerializer<T> extends CollectionSerializer<Set<T>>
         try
         {
             ByteBuffer input = collection.duplicate();
-            int n = readCollectionSize(input, ProtocolVersion.V3);
+            int n = readCollectionSize(input, ByteBufferAccessor.instance, ProtocolVersion.V3);
             input.position(input.position() + sizeOfCollectionSize(n, ProtocolVersion.V3));
             int startPos = input.position();
             int count = 0;

--- a/src/java/org/apache/cassandra/service/CacheService.java
+++ b/src/java/org/apache/cassandra/service/CacheService.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.partitions.CachedBTreePartition;
 import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.db.rows.*;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -79,7 +80,7 @@ public class CacheService implements CacheServiceMBean
 
     public final static CacheService instance = new CacheService();
 
-    public final AutoSavingCache<KeyCacheKey, RowIndexEntry> keyCache;
+    public final AutoSavingCache<KeyCacheKey, BigTableRowIndexEntry> keyCache;
     public final AutoSavingCache<RowCacheKey, IRowCacheEntry> rowCache;
     public final AutoSavingCache<CounterCacheKey, ClockAndCount> counterCache;
 
@@ -95,7 +96,7 @@ public class CacheService implements CacheServiceMBean
     /**
      * @return auto saving cache object
      */
-    private AutoSavingCache<KeyCacheKey, RowIndexEntry> initKeyCache()
+    private AutoSavingCache<KeyCacheKey, BigTableRowIndexEntry> initKeyCache()
     {
         logger.info("Initializing key cache with capacity of {} MBs.", DatabaseDescriptor.getKeyCacheSizeInMB());
 
@@ -103,9 +104,9 @@ public class CacheService implements CacheServiceMBean
 
         // as values are constant size we can use singleton weigher
         // where 48 = 40 bytes (average size of the key) + 8 bytes (size of value)
-        ICache<KeyCacheKey, RowIndexEntry> kc;
+        ICache<KeyCacheKey, BigTableRowIndexEntry> kc;
         kc = CaffeineCache.create(keyCacheInMemoryCapacity);
-        AutoSavingCache<KeyCacheKey, RowIndexEntry> keyCache = new AutoSavingCache<>(kc, CacheType.KEY_CACHE, new KeyCacheSerializer());
+        AutoSavingCache<KeyCacheKey, BigTableRowIndexEntry> keyCache = new AutoSavingCache<>(kc, CacheType.KEY_CACHE, new KeyCacheSerializer());
 
         int keyCacheKeysToSave = DatabaseDescriptor.getKeyCacheKeysToSave();
 
@@ -411,11 +412,11 @@ public class CacheService implements CacheServiceMBean
         }
     }
 
-    public static class KeyCacheSerializer implements CacheSerializer<KeyCacheKey, RowIndexEntry>
+    public static class KeyCacheSerializer implements CacheSerializer<KeyCacheKey, BigTableRowIndexEntry>
     {
         public void serialize(KeyCacheKey key, DataOutputPlus out, ColumnFamilyStore cfs) throws IOException
         {
-            RowIndexEntry entry = CacheService.instance.keyCache.getInternal(key);
+            BigTableRowIndexEntry entry = CacheService.instance.keyCache.getInternal(key);
             if (entry == null)
                 return;
 
@@ -427,10 +428,10 @@ public class CacheService implements CacheServiceMBean
             out.writeBoolean(true);
 
             SerializationHeader header = new SerializationHeader(false, cfs.metadata(), cfs.metadata().regularAndStaticColumns(), EncodingStats.NO_STATS);
-            key.desc.getFormat().getIndexSerializer(cfs.metadata(), key.desc.version, header).serializeForCache(entry, out);
+            new BigTableRowIndexEntry.Serializer(key.desc.version, header).serializeForCache(entry, out);
         }
 
-        public Future<Pair<KeyCacheKey, RowIndexEntry>> deserialize(DataInputPlus input, ColumnFamilyStore cfs) throws IOException
+        public Future<Pair<KeyCacheKey, BigTableRowIndexEntry>> deserialize(DataInputPlus input, ColumnFamilyStore cfs) throws IOException
         {
             //Keyspace and CF name are deserialized by AutoSaving cache and used to fetch the CFS provided as a
             //parameter so they aren't deserialized here, even though they are serialized by this serializer
@@ -450,13 +451,11 @@ public class CacheService implements CacheServiceMBean
                 // wrong is during upgrade, in which case we fail at deserialization. This is not a huge deal however since 1) this is unlikely enough that
                 // this won't affect many users (if any) and only once, 2) this doesn't prevent the node from starting and 3) CASSANDRA-10219 shows that this
                 // part of the code has been broken for a while without anyone noticing (it is, btw, still broken until CASSANDRA-10219 is fixed).
-                RowIndexEntry.Serializer.skipForCache(input);
+                BigTableRowIndexEntry.Serializer.skipForCache(input);
                 return null;
             }
-            RowIndexEntry.IndexSerializer<?> indexSerializer = reader.descriptor.getFormat().getIndexSerializer(reader.metadata(),
-                                                                                                                reader.descriptor.version,
-                                                                                                                reader.header);
-            RowIndexEntry<?> entry = indexSerializer.deserializeForCache(input);
+            BigTableRowIndexEntry.IndexSerializer<?> indexSerializer = new BigTableRowIndexEntry.Serializer(reader.descriptor.version, reader.header);
+            BigTableRowIndexEntry entry = indexSerializer.deserializeForCache(input);
             return Futures.immediateFuture(Pair.create(new KeyCacheKey(cfs.metadata(), reader.descriptor, key), entry));
         }
 

--- a/src/java/org/apache/cassandra/tools/SSTableExport.java
+++ b/src/java/org/apache/cassandra/tools/SSTableExport.java
@@ -142,9 +142,11 @@ public class SSTableExport
         try
         {
             TableMetadata metadata = Util.metadataFromSSTable(desc);
+            SSTableReader sstable = SSTableReader.openNoValidation(desc, TableMetadataRef.forOfflineTools(metadata));
+            IPartitioner partitioner = sstable.getPartitioner();
             if (cmd.hasOption(ENUMERATE_KEYS_OPTION))
             {
-                try (KeyIterator iter = new KeyIterator(desc, metadata))
+                try (KeyIterator iter = KeyIterator.forSSTable(sstable))
                 {
                     JsonTransformer.keysToJson(null, Util.iterToStream(iter),
                                                cmd.hasOption(RAW_TIMESTAMPS),
@@ -154,8 +156,6 @@ public class SSTableExport
             }
             else
             {
-                SSTableReader sstable = SSTableReader.openNoValidation(desc, TableMetadataRef.forOfflineTools(metadata));
-                IPartitioner partitioner = sstable.getPartitioner();
                 final ISSTableScanner currentScanner;
                 if ((keys != null) && (keys.length > 0))
                 {

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -296,6 +296,26 @@ public class ByteBufferUtil
         FastByteOperations.copy(src, srcPos, dst, dstPos, length);
     }
 
+    /**
+     * Transfer bytes from one ByteBuffer to another.
+     * This function acts as System.arrayCopy() but for ByteBuffers.
+     *
+     * @param src the source ByteBuffer
+     * @param srcPos starting position in the source ByteBuffer
+     * @param dst the destination ByteBuffer
+     * @param dstPos starting position in the destination ByteBuffer
+     * @param length the number of bytes to copy
+     */
+    public static void arrayCopy(ByteBuffer src, int srcPos, ByteBuffer dst, int dstPos, int length)
+    {
+        FastByteOperations.copy(src, srcPos, dst, dstPos, length);
+    }
+
+    public static void arrayCopy(ByteBuffer src, int srcPos, byte[] dst, int dstPos, int length)
+    {
+        FastByteOperations.copy(src, srcPos, dst, dstPos, length);
+    }
+
     public static int put(ByteBuffer src, ByteBuffer trg)
     {
         int length = Math.min(src.remaining(), trg.remaining());

--- a/src/java/org/apache/cassandra/utils/ByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/ByteComparable.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.nio.ByteBuffer;
+
+import static org.apache.cassandra.utils.ByteSource.END_OF_STREAM;
+
+/**
+ * Interface indicating a value can be represented/identified by a comparable {@link ByteSource}.
+ */
+public interface ByteComparable
+{
+    /**
+     * Returns a source that generates the byte-comparable representation of the value byte by byte.
+     */
+    ByteSource asComparableBytes(Version version);
+
+    default ByteSource.Peekable asPeekableBytes(Version version)
+    {
+        return ByteSource.peekable(asComparableBytes(version));
+    }
+
+    enum Version
+    {
+        LEGACY,
+        OSS41,  // CASSANDRA 4.1 encoding, used in trie-based indices
+    }
+
+    ByteComparable EMPTY = (Version version) -> ByteSource.EMPTY;
+
+    /**
+     * Construct a human-readable string from the byte-comparable representation. Used for debugging.
+     */
+    default String byteComparableAsString(Version version)
+    {
+        StringBuilder builder = new StringBuilder();
+        ByteSource stream = asComparableBytes(version);
+        if (stream == null)
+            return "null";
+        for (int b = stream.next(); b != END_OF_STREAM; b = stream.next())
+            builder.append(Integer.toHexString((b >> 4) & 0xF)).append(Integer.toHexString(b & 0xF));
+        return builder.toString();
+    }
+
+    // Simple factories used for testing
+
+    static ByteComparable of(String s)
+    {
+        return v -> ByteSource.of(s, v);
+    }
+
+    static ByteComparable of(long value)
+    {
+        return v -> ByteSource.of(value);
+    }
+
+    static ByteComparable of(int value)
+    {
+        return v -> ByteSource.of(value);
+    }
+
+    static ByteComparable fixedLength(ByteBuffer bytes)
+    {
+        return v -> ByteSource.fixedLength(bytes);
+    }
+
+    static ByteComparable fixedLength(byte[] bytes)
+    {
+        return v -> ByteSource.fixedLength(bytes);
+    }
+
+    /**
+     * Returns a separator for two byte sources, i.e. something that is definitely > prevMax, and <= currMin, assuming
+     * prevMax < currMin.
+     * This returns the shortest prefix of currMin that is greater than prevMax.
+     */
+    static ByteComparable separatorPrefix(ByteComparable prevMax, ByteComparable currMin)
+    {
+        return version -> ByteSource.separatorPrefix(prevMax.asComparableBytes(version), currMin.asComparableBytes(version));
+    }
+
+    /**
+     * Returns a separator for two byte comparable, i.e. something that is definitely > prevMax, and <= currMin, assuming
+     * prevMax < currMin.
+     * This is a stream of length 1 longer than the common prefix of the two streams, with last byte one higher than the
+     * prevMax stream.
+     */
+    static ByteComparable separatorGt(ByteComparable prevMax, ByteComparable currMin)
+    {
+        return version -> ByteSource.separatorGt(prevMax.asComparableBytes(version), currMin.asComparableBytes(version));
+    }
+
+    static ByteComparable cut(ByteComparable src, int cutoff)
+    {
+        return version -> ByteSource.cut(src.asComparableBytes(version), cutoff);
+    }
+
+    /**
+     * Return the length of a byte comparable, not including the terminator byte.
+     */
+    static int length(ByteComparable src, Version version)
+    {
+        int l = 0;
+        ByteSource s = src.asComparableBytes(version);
+        while (s.next() != END_OF_STREAM)
+            ++l;
+        return l;
+    }
+
+    /**
+     * Compare two byte-comparable values by their byte-comparable representation. Used for tests.
+     *
+     * @return the result of the lexicographic unsigned byte comparison of the byte-comparable representations of the
+     *         two arguments
+     */
+    static int compare(ByteComparable bytes1, ByteComparable bytes2, Version version)
+    {
+        ByteSource s1 = bytes1.asComparableBytes(version);
+        ByteSource s2 = bytes2.asComparableBytes(version);
+
+        if (s1 == null || s2 == null)
+            return Boolean.compare(s1 != null, s2 != null);
+
+        while (true)
+        {
+            int b1 = s1.next();
+            int b2 = s2.next();
+            int cmp = Integer.compare(b1, b2);
+            if (cmp != 0)
+                return cmp;
+            if (b1 == ByteSource.END_OF_STREAM)
+                return 0;
+        }
+    }
+
+    /**
+     * Returns the length of the minimum prefix that differentiates the two given byte-comparable representations.
+     */
+    static int diffPoint(ByteComparable bytes1, ByteComparable bytes2, Version version)
+    {
+        ByteSource s1 = bytes1.asComparableBytes(version);
+        ByteSource s2 = bytes2.asComparableBytes(version);
+        int pos = 1;
+        int b;
+        while ((b = s1.next()) == s2.next() && b != END_OF_STREAM)
+            ++pos;
+        return pos;
+    }
+}

--- a/src/java/org/apache/cassandra/utils/ByteSource.java
+++ b/src/java/org/apache/cassandra/utils/ByteSource.java
@@ -1,0 +1,699 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.cassandra.utils.ByteComparable.Version;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A stream of byte, used for byte-order-comparable representations of data.
+ */
+public interface ByteSource
+{
+    /** Get the next byte, unsigned. Must be between 0 and 255, or END_OF_STREAM if there are no more bytes. */
+    int next();
+
+    /** Value returned if at the end of the stream. */
+    int END_OF_STREAM = -1;
+
+    ByteSource EMPTY = () -> END_OF_STREAM;
+
+    /**
+     * Escape value. Used, among other things, to mark the end of subcomponents (so that shorter compares before anything longer).
+     * Actual zeros in input need to be escaped if this is in use (see BufferReinterpreter).
+     */
+    int ESCAPE = 0x00;
+
+    // Zeros are encoded as a sequence of ESCAPE, 0 or more of ESCAPED_0_CONT, ESCAPED_0_DONE so zeroed spaces only grow by 1 byte
+    int ESCAPED_0_CONT = 0xFE;
+    int ESCAPED_0_DONE = 0xFF;
+
+    // All separators must be within these bounds
+    int MIN_SEPARATOR = 0x10;
+    int MAX_SEPARATOR = 0xEF;
+
+    // Next component marker.
+    int NEXT_COMPONENT = 0x40;
+    int NEXT_COMPONENT_NULL = 0x3F;
+    int NEXT_COMPONENT_NULL_REVERSED = 0x41;
+    // Default terminator byte in sequences. Smaller than NEXT_COMPONENT_NULL, but larger than LT_NEXT_COMPONENT to
+    // ensure lexicographic compares go in the correct direction
+    int TERMINATOR = 0x38;
+    // These are special endings, for exclusive/inclusive bounds (i.e. smaller than anything with more components, bigger than anything with more components)
+    int LT_NEXT_COMPONENT = 0x20;
+    int GT_NEXT_COMPONENT = 0x60;
+
+    /**
+     * Reinterprets a byte buffer as a byte-comparable source that has 0s escaped and finishes in an escape.
+     * This provides a weakly-prefix-free byte-comparable version of the content to use in sequences.
+     * (See ByteSource.BufferReinterpreter/Multi for explanation.)
+     */
+    static ByteSource of(ByteBuffer buf, Version version)
+    {
+        return new BufferReinterpreter(buf, version);
+    }
+
+    /**
+     * Reinterprets a byte array as a byte-comparable source that has 0s escaped and finishes in an escape.
+     * This provides a prefix-free byte-comparable version of the content to use in sequences.
+     * (See ByteSource.BufferReinterpreter/Multi for explanation.)
+     */
+    static ByteSource of(byte[] buf, Version version)
+    {
+        return new ReinterpreterArray(buf, version);
+    }
+
+    /**
+     * Combines a chain of sources, turning their weak-prefix-free byte-comparable representation into the combination's
+     * prefix-free byte-comparable representation, with the included terminator character.
+     * For correctness, the terminator must be within MIN-MAX_SEPARATOR and different from NEXT_COMPONENT+/-1.
+     * Typically TERMINATOR, or LT/GT_NEXT_COMPONENT if used for partially specified bounds.
+     */
+    static ByteSource withTerminator(int terminator, ByteSource... srcs)
+    {
+        return new Multi(srcs, terminator);
+    }
+
+    static ByteSource of(String s, Version version)
+    {
+        return new ReinterpreterArray(s.getBytes(StandardCharsets.UTF_8), version);
+    }
+
+    static ByteSource of(long value)
+    {
+        return new Number(value ^ (1L<<63), 8);
+    }
+
+    static ByteSource of(int value)
+    {
+        return new Number(value ^ (1L<<31), 4);
+    }
+
+    /**
+     * Produce a source for a signed fixed-length number, also translating empty to null.
+     * The first byte has its sign bit inverted, and the rest are passed unchanged.
+     * Presumes that the length of the buffer is always either 0 or constant for the type, which permits decoding and
+     * ensures the representation is prefix-free.
+     */
+    static ByteSource optionalSignedFixedLengthNumber(ByteBuffer b)
+    {
+        return b.hasRemaining() ? signedFixedLengthNumber(b) : null;
+    }
+
+    /**
+     * Produce a source for a signed fixed-length number.
+     * The first byte has its sign bit inverted, and the rest are passed unchanged.
+     * Presumes that the length of the buffer is always constant for the type.
+     */
+    static ByteSource signedFixedLengthNumber(ByteBuffer b)
+    {
+        return new SignedFixedLengthNumber(b);
+    }
+
+    /**
+     * Produce a source for a signed fixed-length floating-point number, also translating empty to null.
+     * If sign bit is on, returns negated bytes. If not, add the sign bit value.
+     * (Sign of IEEE floats is the highest bit, the rest can be compared in magnitude by byte comparison.)
+     * Presumes that the length of the buffer is always either 0 or constant for the type, which permits decoding and
+     * ensures the representation is prefix-free.
+     */
+    static ByteSource optionalSignedFixedLengthFloat(ByteBuffer b)
+    {
+        return b.hasRemaining() ? signedFixedLengthFloat(b) : null;
+    }
+
+    /**
+     * Produce a source for a signed fixed-length floating-point number.
+     * If sign bit is on, returns negated bytes. If not, add the sign bit value.
+     * (Sign of IEEE floats is the highest bit, the rest can be compared in magnitude by byte comparison.)
+     * Presumes that the length of the buffer is always constant for the type.
+     */
+    static ByteSource signedFixedLengthFloat(ByteBuffer b)
+    {
+        return new SignedFixedLengthFloat(b);
+    }
+
+    /**
+     * Returns a separator for two byte sources, i.e. something that is definitely > prevMax, and <= currMin, assuming
+     * prevMax < currMin.
+     * This returns the shortest prefix of currMin that is greater than prevMax.
+     */
+    public static ByteSource separatorPrefix(ByteSource prevMax, ByteSource currMin)
+    {
+        return new Separator(prevMax, currMin, true);
+    }
+
+    /**
+     * Returns a separator for two byte sources, i.e. something that is definitely > prevMax, and <= currMin, assuming
+     * prevMax < currMin.
+     * This is a source of length 1 longer than the common prefix of the two sources, with last byte one higher than the
+     * prevMax source.
+     */
+    public static ByteSource separatorGt(ByteSource prevMax, ByteSource currMin)
+    {
+        return new Separator(prevMax, currMin, false);
+    }
+
+    public static ByteSource oneByte(int i)
+    {
+        assert i >= 0 && i <= 0xFF;
+        return new ByteSource()
+        {
+            boolean given = false;
+            public int next()
+            {
+                if (given)
+                    return END_OF_STREAM;
+                given = true;
+                return i;
+            }
+        };
+    }
+
+    public static ByteSource cut(ByteSource src, int cutoff)
+    {
+        return new ByteSource()
+        {
+            int pos = 0;
+
+            @Override
+            public int next()
+            {
+                return pos++ < cutoff ? src.next() : END_OF_STREAM;
+            }
+        };
+    }
+
+    /**
+     * Wrap a ByteSource in a length-fixing facade.
+     *
+     * If the length of {@code src} is less than {@code cutoff}, then pad it on the right with {@code padding} until
+     * the overall length equals {@code cutoff}.  If the length of {@code src} is greater than {@code cutoff}, then
+     * truncate {@code src} to that size.  Effectively a noop if {@code src} happens to have length {@code cutoff}.
+     *
+     * @param src the input source to wrap
+     * @param cutoff the size of the source returned
+     * @param padding a padding byte (an int subject to a 0xFF mask)
+     * @return
+     */
+    public static ByteSource cutOrRightPad(ByteSource src, int cutoff, int padding)
+    {
+        return new ByteSource()
+        {
+            int pos = 0;
+
+            @Override
+            public int next()
+            {
+                if (pos++ >= cutoff)
+                {
+                    return END_OF_STREAM;
+                }
+                int next = src.next();
+                return next == END_OF_STREAM ? padding : next;
+            }
+        };
+    }
+
+
+    static ByteSource MAX = new ByteSource()
+    {
+        public int next()
+        {
+            return 0xFF;
+        }
+
+        public String toString()
+        {
+            return "MAX";
+        }
+    };
+
+    /**
+     * Returns a maximal ByteSource, i.e. something that compares greater to any other byte source.
+     * This is an infinite sequence of 0xFF.
+     *
+     * Note that since the sequence is infinite, trying to calculate this item's length, copying it, trying
+     * to store it in a trie, or comparing it to another max will result in an infinite loop.
+     */
+    public static ByteSource max()
+    {
+        return MAX;
+    }
+
+    /**
+     * Variable-length encoding. Escapes 0s as ESCAPE + zero or more ESCAPED_0_CONT + ESCAPED_0_DONE.
+     * Finishes with an escape value (to which Multi will add non-zero component separator)
+     * E.g. A00B translates to 4100FEFF4200
+     *      A0B0               4100FF4200FE (+00 for {@link Version#LEGACY})
+     *      A0                 4100FE       (+00 for {@link Version#LEGACY})
+     *
+     * If in a single byte source, the bytes could be simply passed unchanged, but this would not allow us to
+     * combine components. This translation preserves order, and since the encoding for 0 is higher than the separator
+     * also makes sure shorter components are treated as smaller.
+     *
+     * The encoding is not prefix-free, since e.g. the encoding of "A" (4100) is a prefix of the encoding of "A0"
+     * (4100FE), but the byte following the prefix is guaranteed to be FE or FF, which makes the encoding weakly
+     * prefix-free. Additionally, any such prefix sequence will compare smaller than the value to which it is a prefix,
+     * because any permitted separator byte will be smaller than the byte following the prefix.
+     */
+    static abstract class AbstractReinterpreter implements ByteSource
+    {
+        final Version version;
+        int bufpos;
+        boolean escaped;
+
+        AbstractReinterpreter(int position, Version version)
+        {
+            this.bufpos = position;
+            this.version = version;
+        }
+
+        public final int next()
+        {
+            if (bufpos >= limit())
+            {
+                if (bufpos > limit())
+                    return END_OF_STREAM;
+
+                ++bufpos;
+                if (escaped)
+                {
+                    escaped = false;
+                    if (version == Version.LEGACY)
+                        --bufpos; // place an ESCAPE at the end of sequence ending in ESCAPE
+                    return ESCAPED_0_CONT;
+                }
+                return ESCAPE;
+            }
+
+            int index = bufpos++;
+            int b = get(index) & 0xFF;
+            if (!escaped)
+            {
+                if (b == ESCAPE)
+                    escaped = true;
+                return b;
+            }
+            else
+            {
+                if (b == ESCAPE)
+                    return ESCAPED_0_CONT;
+                --bufpos;
+                escaped = false;
+                return ESCAPED_0_DONE;
+            }
+        }
+
+        protected abstract byte get(int index);
+
+        protected abstract int limit();
+    }
+
+    static class BufferReinterpreter extends AbstractReinterpreter
+    {
+        final ByteBuffer buf;
+
+        private BufferReinterpreter(ByteBuffer buf, Version version)
+        {
+            super(buf.position(), version);
+            this.buf = buf;
+        }
+
+        protected int limit()
+        {
+            return buf.limit();
+        }
+
+        protected byte get(int index)
+        {
+            return buf.get(index);
+        }
+    }
+
+    static class ReinterpreterArray extends AbstractReinterpreter
+    {
+        final byte[] buf;
+
+        private ReinterpreterArray(byte[] buf, Version version)
+        {
+            super(0, version);
+            this.buf = buf;
+        }
+
+        @Override
+        protected byte get(int index)
+        {
+            return buf[index];
+        }
+
+        @Override
+        protected int limit()
+        {
+            return buf.length;
+        }
+    }
+
+    /**
+     * Fixed length signed number encoding. Inverts first bit (so that neg < pos), then just posts all bytes from the
+     * buffer. Assumes buffer is of correct length.
+     */
+    static class SignedFixedLengthNumber implements ByteSource
+    {
+        ByteBuffer buf;
+        int bufpos;
+
+        public SignedFixedLengthNumber(ByteBuffer buf)
+        {
+            this.buf = buf;
+            bufpos = buf.position();
+        }
+
+        public int next()
+        {
+            if (bufpos >= buf.limit())
+                return END_OF_STREAM;
+            int v = buf.get(bufpos) & 0xFF;
+            if (bufpos == buf.position())
+                v ^= 0x80;
+            ++bufpos;
+            return v;
+        }
+    }
+
+    static class Number implements ByteSource
+    {
+        final long value;
+        int pos;
+
+        public Number(long value, int length)
+        {
+            this.value = value;
+            this.pos = length;
+        }
+
+        public int next()
+        {
+            if (pos == 0)
+                return END_OF_STREAM;
+            return (int) ((value >> (--pos * 8)) & 0xFF);
+        }
+    }
+
+    /**
+     * Fixed length signed floating point number encoding. First bit is sign. If positive, add sign bit value to make
+     * greater than all negatives. If not, invert all content to make negatives with bigger magnitude smaller.
+     */
+    static class SignedFixedLengthFloat implements ByteSource
+    {
+        final ByteBuffer buf;
+        int bufpos;
+        boolean invert;
+
+        public SignedFixedLengthFloat(ByteBuffer buf)
+        {
+            this.buf = buf;
+            this.bufpos = buf.position();
+        }
+
+        public int next()
+        {
+            if (bufpos >= buf.limit())
+                return END_OF_STREAM;
+            int v = buf.get(bufpos) & 0xFF;
+            if (bufpos == buf.position())
+            {
+                invert = v >= 0x80;
+                v |= 0x80;
+            }
+            if (invert)
+                v = v ^ 0xFF;
+            ++bufpos;
+            return v;
+        }
+    }
+
+    /**
+     * Combination of multiple byte sources. Adds NEXT_COMPONENT before sources, or NEXT_COMPONENT_NULL if next is null.
+     */
+    static class Multi implements ByteSource
+    {
+        final ByteSource[] srcs;
+        int srcnum = -1;
+        int terminator;
+
+        Multi(ByteSource[] srcs, int terminator)
+        {
+            this.srcs = srcs;
+            this.terminator = terminator;
+        }
+
+        public int next()
+        {
+            if (srcnum == srcs.length)
+                return END_OF_STREAM;
+
+            int b = END_OF_STREAM;
+            if (srcnum >= 0 && srcs[srcnum] != null)
+                b = srcs[srcnum].next();
+            if (b > END_OF_STREAM)
+                return b;
+
+            ++srcnum;
+            if (srcnum == srcs.length)
+                return terminator;
+            if (srcs[srcnum] == null)
+                return NEXT_COMPONENT_NULL;
+            return NEXT_COMPONENT;
+        }
+    }
+
+    /**
+     * Construct the shortest common prefix of prevMax and currMin that separates those two byte streams.
+     * If {@code useCurr == true} the last byte of the returned stream comes from {@code currMin} and is the first
+     * byte which is greater than byte on the corresponding position of {@code prevMax}.
+     * Otherwise, the last byte of the returned stream comes from {@code prevMax} and is incremented by one, still
+     * guaranteeing that it is <= than the byte on the corresponding position of {@code currMin}.
+     */
+    static class Separator implements ByteSource
+    {
+        final ByteSource prev;
+        final ByteSource curr;
+        boolean done = false;
+        final boolean useCurr;
+
+        Separator(ByteSource prevMax, ByteSource currMin, boolean useCurr)
+        {
+            this.prev = prevMax;
+            this.curr = currMin;
+            this.useCurr = useCurr;
+        }
+
+        public int next()
+        {
+            if (done)
+                return END_OF_STREAM;
+            int p = prev.next();
+            int c = curr.next();
+            assert p <= c : prev + " not less than " + curr;
+            if (p == c)
+                return c;
+            done = true;
+            return useCurr ? c : p + 1;
+        }
+    }
+
+    static ByteSource optionalFixedLength(ByteBuffer b)
+    {
+        return b.hasRemaining() ? fixedLength(b) : null;
+    }
+
+    /**
+     * A byte source of the given bytes without any encoding.
+     * The resulting source is only guaranteed to give correct comparison results and be prefix-free if the
+     * underlying type has a fixed length.
+     * In tests, this method is also used to generate non-escaped test cases.
+     */
+    public static ByteSource fixedLength(ByteBuffer b)
+    {
+        return new ByteSource()
+        {
+            int pos = b.position() - 1;
+
+            @Override
+            public int next()
+            {
+                return ++pos < b.limit() ? b.get(pos) & 0xFF : -1;
+            }
+        };
+    }
+
+    /**
+     * A byte source of the given bytes without any encoding.
+     * If used in a sequence, the resulting source is only guaranteed to give correct comparison results if the
+     * underlying type has a fixed length.
+     * In tests, this method is also used to generate non-escaped test cases.
+     */
+    public static ByteSource fixedLength(byte[] b)
+    {
+        return fixedLength(b, 0, b.length);
+    }
+
+    public static ByteSource fixedLength(byte[] b, int offset, int length)
+    {
+        checkArgument(offset >= 0 && offset <= b.length);
+        checkArgument(length >= 0 && offset + length <= b.length);
+
+        return new ByteSource()
+        {
+            int pos = offset - 1;
+
+            @Override
+            public int next()
+            {
+                return ++pos < offset + length ? b[pos] & 0xFF : END_OF_STREAM;
+            }
+        };
+    }
+
+    public static ByteSource fourBit(ByteSource s)
+    {
+        return new ByteSource()
+        {
+            int pos = 0;
+            int v = 0;
+
+            @Override
+            public int next()
+            {
+                if ((pos++ & 1) == 0)
+                {
+                    v = s.next();
+                    if (v == END_OF_STREAM)
+                        return END_OF_STREAM;
+                    return (v >> 4) & 0xF;
+                }
+                else
+                    return v & 0xF;
+            }
+        };
+    }
+
+    /**
+     * Splits each byte into portions of bitCount bits.
+     * @param s source
+     * @param bitCount number of bits to issue at a time, 1-4 make sense
+     */
+    public static ByteSource splitBytes(ByteSource s, int bitCount)
+    {
+        return new ByteSource()
+        {
+            int pos = 8;
+            int v = 0;
+            int mask = (1 << bitCount) - 1;
+
+            @Override
+            public int next()
+            {
+                if ((pos += bitCount) >= 8)
+                {
+                    pos = 0;
+                    v = s.next();
+                    if (v == END_OF_STREAM)
+                        return END_OF_STREAM;
+                }
+                v <<= bitCount;
+                return (v >> 8) & mask;
+            }
+        };
+    }
+
+    /**
+     * Returns the key that is immediately after src in the topology.
+     * @param src
+     * @return src with added 00 byte at the end
+     */
+    public static ByteSource nextKey(ByteSource src)
+    {
+        return new ByteSource()
+        {
+            boolean done = false;
+
+            @Override
+            public int next()
+            {
+                if (done)
+                    return END_OF_STREAM;
+                int n = src.next();
+                if (n != END_OF_STREAM)
+                    return n;
+
+                done = true;
+                return 0;
+            }
+        };
+    }
+
+    public class Peekable implements ByteSource
+    {
+        static final int NONE = Integer.MIN_VALUE;
+
+        final ByteSource wrapped;
+        int peeked = NONE;
+
+        public Peekable(ByteSource wrapped)
+        {
+            this.wrapped = wrapped;
+        }
+
+        public int next()
+        {
+            if (peeked != NONE)
+            {
+                int val = peeked;
+                peeked = NONE;
+                return val;
+            }
+            else
+                return wrapped.next();
+        }
+
+        public int peek()
+        {
+            if (peeked == NONE)
+                peeked = wrapped.next();
+            return peeked;
+        }
+    }
+
+    public static Peekable peekable(ByteSource p)
+    {
+        // When given a null source, we're better off not wrapping it and just returning null. This way existing
+        // code that doesn't know about ByteSource.Peekable, but handles correctly null ByteSources won't be thrown
+        // off by a non-null instance that semantically should have been null.
+        if (p == null)
+            return null;
+        return (p instanceof Peekable)
+               ? (Peekable) p
+               : new Peekable(p);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/StatusLogger.java
+++ b/src/java/org/apache/cassandra/utils/StatusLogger.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.CacheService;
@@ -92,7 +92,7 @@ public class StatusLogger
                                   "MessagingService", "n/a", pendingLargeMessages + "/" + pendingSmallMessages));
 
         // Global key/row cache information
-        AutoSavingCache<KeyCacheKey, RowIndexEntry> keyCache = CacheService.instance.keyCache;
+        AutoSavingCache<KeyCacheKey, BigTableRowIndexEntry> keyCache = CacheService.instance.keyCache;
         AutoSavingCache<RowCacheKey, IRowCacheEntry> rowCache = CacheService.instance.rowCache;
 
         int keyCacheKeysToSave = DatabaseDescriptor.getKeyCacheKeysToSave();

--- a/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.distributed.impl.InstanceKiller;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.format.ForwardingSSTableReader;
+import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.util.ChannelProxy;
@@ -271,6 +272,12 @@ public class FailingRepairTest extends TestBaseImpl implements Serializable
         private FailingSSTableReader(SSTableReader delegate)
         {
             super(delegate);
+        }
+
+        @Override
+        public PartitionIndexIterator allKeysIterator() throws IOException
+        {
+            throw new IOException("Fail");
         }
 
         public ISSTableScanner getScanner()

--- a/test/distributed/org/apache/cassandra/distributed/test/JVMStabilityInspectorCorruptSSTableExceptionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/JVMStabilityInspectorCorruptSSTableExceptionTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.config.Config.DiskFailurePolicy;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -188,12 +188,6 @@ public class JVMStabilityInspectorCorruptSSTableExceptionTest extends TestBaseIm
 
         @Override
         public UnfilteredRowIterator iterator(DecoratedKey key, Slices slices, ColumnFilter selectedColumns, boolean reversed, SSTableReadsListener listener)
-        {
-            throw throwCorrupted();
-        }
-
-        @Override
-        public UnfilteredRowIterator iterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, Slices slices, ColumnFilter selectedColumns, boolean reversed)
         {
             throw throwCorrupted();
         }

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import com.google.common.util.concurrent.RateLimiter;
 
@@ -33,7 +34,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.EncodingStats;
@@ -46,6 +46,7 @@ import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.FileDataInput;
@@ -70,6 +71,12 @@ public abstract class ForwardingSSTableReader extends SSTableReader
         this.delegate = delegate;
         this.first = delegate.first;
         this.last = delegate.last;
+    }
+
+    @Override
+    public PartitionIndexIterator allKeysIterator() throws IOException
+    {
+        return delegate.allKeysIterator();
     }
 
     @Override
@@ -253,19 +260,19 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    public void cacheKey(DecoratedKey key, RowIndexEntry info)
+    public void cacheKey(DecoratedKey key, BigTableRowIndexEntry info)
     {
         delegate.cacheKey(key, info);
     }
 
     @Override
-    public RowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats)
+    public BigTableRowIndexEntry getCachedPosition(DecoratedKey key, boolean updateStats)
     {
         return delegate.getCachedPosition(key, updateStats);
     }
 
     @Override
-    protected RowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats)
+    protected BigTableRowIndexEntry getCachedPosition(KeyCacheKey unifiedKey, boolean updateStats)
     {
         return delegate.getCachedPosition(unifiedKey, updateStats);
     }
@@ -277,9 +284,9 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    protected RowIndexEntry getPosition(PartitionPosition key, Operator op, boolean updateCacheAndStats, boolean permitMatchPastLast, SSTableReadsListener listener)
+    protected BigTableRowIndexEntry getPosition(PartitionPosition key, Operator op, boolean updateCacheAndStats, boolean permitMatchPastLast, SSTableReadsListener listener)
     {
-        return delegate.getPosition(key, op, updateCacheAndStats, permitMatchPastLast, listener);
+        return (BigTableRowIndexEntry) delegate.getPosition(key, op, updateCacheAndStats, permitMatchPastLast, listener);
     }
 
     @Override
@@ -289,15 +296,9 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    public UnfilteredRowIterator iterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, Slices slices, ColumnFilter selectedColumns, boolean reversed)
+    public UnfilteredRowIterator simpleIterator(Supplier<FileDataInput> dfile, DecoratedKey key, boolean tombstoneOnly)
     {
-        return delegate.iterator(file, key, indexEntry, slices, selectedColumns, reversed);
-    }
-
-    @Override
-    public UnfilteredRowIterator simpleIterator(FileDataInput file, DecoratedKey key, RowIndexEntry indexEntry, boolean tombstoneOnly)
-    {
-        return delegate.simpleIterator(file, key, indexEntry, tombstoneOnly);
+        return delegate.simpleIterator(dfile, key, tombstoneOnly);
     }
 
     @Override
@@ -475,7 +476,7 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    public InstrumentingCache<KeyCacheKey, RowIndexEntry> getKeyCache()
+    public InstrumentingCache<KeyCacheKey, BigTableRowIndexEntry> getKeyCache()
     {
         return delegate.getKeyCache();
     }
@@ -673,7 +674,7 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    void setup(boolean trackHotness)
+    protected void setup(boolean trackHotness)
     {
         delegate.setup(trackHotness);
     }

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOError;
+import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -42,7 +43,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import afu.org.checkerframework.checker.oigj.qual.O;
 import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
 import org.apache.cassandra.db.compaction.CompactionTasks;
 import org.apache.cassandra.db.compaction.OperationType;
@@ -86,7 +86,6 @@ import org.apache.cassandra.utils.FilterFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class Util
@@ -775,6 +774,199 @@ public class Util
             }
         }
         assertEquals(expectedSSTableCount, fileCount);
+    }
+
+    public static ByteBuffer generateMurmurCollision(ByteBuffer original, byte... bytesToAdd)
+    {
+        // Round size up to 16, and add another 16 bytes
+        ByteBuffer collision = ByteBuffer.allocate((original.remaining() + bytesToAdd.length + 31) & -16);
+        collision.put(original);    // we can use this as a copy of original with 0s appended at the end
+
+        original.flip();
+
+        long c1 = 0x87c37b91114253d5L;
+        long c2 = 0x4cf5ad432745937fL;
+
+        long h1 = 0;
+        long h2 = 0;
+
+        // Get hash of original
+        int index = 0;
+        final int length = original.limit();
+        while (index <= length - 16)
+        {
+            long k1 = Long.reverseBytes(collision.getLong(index + 0));
+            long k2 = Long.reverseBytes(collision.getLong(index + 8));
+
+            // 16 bytes
+            k1 *= c1;
+            k1 = rotl64(k1, 31);
+            k1 *= c2;
+            h1 ^= k1;
+            h1 = rotl64(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729;
+            k2 *= c2;
+            k2 = rotl64(k2, 33);
+            k2 *= c1;
+            h2 ^= k2;
+            h2 = rotl64(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5;
+
+            index += 16;
+        }
+
+        long oh1 = h1;
+        long oh2 = h2;
+
+        // Process final unfilled chunk, but only adjust the original hash value
+        if (index < length)
+        {
+            long k1 = Long.reverseBytes(collision.getLong(index + 0));
+            long k2 = Long.reverseBytes(collision.getLong(index + 8));
+
+            // 16 bytes
+            k1 *= c1;
+            k1 = rotl64(k1, 31);
+            k1 *= c2;
+            oh1 ^= k1;
+
+            k2 *= c2;
+            k2 = rotl64(k2, 33);
+            k2 *= c1;
+            oh2 ^= k2;
+        }
+
+        // These are the hashes the original would provide, before final mixing
+        oh1 ^= original.capacity();
+        oh2 ^= original.capacity();
+
+        // Fill in the remaining bytes before the last 16 and get their hash
+        collision.put(bytesToAdd);
+        while ((collision.position() & 0x0f) != 0)
+            collision.put((byte) 0);
+
+        while (index < collision.position())
+        {
+            long k1 = Long.reverseBytes(collision.getLong(index + 0));
+            long k2 = Long.reverseBytes(collision.getLong(index + 8));
+
+            // 16 bytes
+            k1 *= c1;
+            k1 = rotl64(k1, 31);
+            k1 *= c2;
+            h1 ^= k1;
+            h1 = rotl64(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729;
+            k2 *= c2;
+            k2 = rotl64(k2, 33);
+            k2 *= c1;
+            h2 ^= k2;
+            h2 = rotl64(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5;
+
+            index += 16;
+        }
+
+        // Working backwards, we must get this hash pair
+        long th1 = h1;
+        long th2 = h2;
+
+        // adjust ohx with length
+        h1 = oh1 ^ collision.capacity();
+        h2 = oh2 ^ collision.capacity();
+
+        // Get modulo-long inverses of the multipliers used in the computation
+        long i5i = inverse(5L);
+        long c1i = inverse(c1);
+        long c2i = inverse(c2);
+
+        // revert one step
+        h2 -= 0x38495ab5;
+        h2 *= i5i;
+        h2 -= h1;
+        h2 = rotl64(h2, 33);
+
+        h1 -= 0x52dce729;
+        h1 *= i5i;
+        h1 -= th2;  // use h2 before it's adjusted with k2
+        h1 = rotl64(h1, 37);
+
+        // extract the required modifiers and applies the inverse of their transformation
+        long k1 = h1 ^ th1;
+        k1 = c2i * k1;
+        k1 = rotl64(k1, 33);
+        k1 = c1i * k1;
+
+        long k2 = h2 ^ th2;
+        k2 = c1i * k2;
+        k2 = rotl64(k2, 31);
+        k2 = c2i * k2;
+
+        collision.putLong(Long.reverseBytes(k1));
+        collision.putLong(Long.reverseBytes(k2));
+        collision.flip();
+
+        return collision;
+    }
+
+    // Assumes a and b are positive
+    private static BigInteger[] xgcd(BigInteger a, BigInteger b) {
+        BigInteger x = a, y = b;
+        BigInteger[] qrem;
+        BigInteger[] result = new BigInteger[3];
+        BigInteger x0 = BigInteger.ONE, x1 = BigInteger.ZERO;
+        BigInteger y0 = BigInteger.ZERO, y1 = BigInteger.ONE;
+        while (true)
+        {
+            qrem = x.divideAndRemainder(y);
+            x = qrem[1];
+            x0 = x0.subtract(y0.multiply(qrem[0]));
+            x1 = x1.subtract(y1.multiply(qrem[0]));
+            if (x.equals(BigInteger.ZERO))
+            {
+                result[0] = y;
+                result[1] = y0;
+                result[2] = y1;
+                return result;
+            }
+
+            qrem = y.divideAndRemainder(x);
+            y = qrem[1];
+            y0 = y0.subtract(x0.multiply(qrem[0]));
+            y1 = y1.subtract(x1.multiply(qrem[0]));
+            if (y.equals(BigInteger.ZERO))
+            {
+                result[0] = x;
+                result[1] = x0;
+                result[2] = x1;
+                return result;
+            }
+        }
+    }
+
+    /**
+     * Find a mupltiplicative inverse for the given multiplier for long, i.e.
+     * such that x * inverse(x) = 1 where * is long multiplication.
+     * In other words, such an integer that x * inverse(x) == 1 (mod 2^64).
+     */
+    public static long inverse(long multiplier)
+    {
+        final BigInteger modulus = BigInteger.ONE.shiftLeft(64);
+        // Add the modulus to the multiplier to avoid problems with negatives (a + m == a (mod m))
+        BigInteger[] gcds = xgcd(BigInteger.valueOf(multiplier).add(modulus), modulus);
+        // xgcd gives g, a and b, such that ax + bm = g
+        // ie, ax = g (mod m). Return a
+        assert gcds[0].equals(BigInteger.ONE) : "Even number " + multiplier + " has no long inverse";
+        return gcds[1].longValueExact();
+    }
+
+    public static long rotl64(long v, int n)
+    {
+        return ((v << n) | (v >>> (64 - n)));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cache/AutoSavingCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/AutoSavingCacheTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.cache;
 
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -83,7 +84,7 @@ public class AutoSavingCacheTest
         for (SSTableReader sstable : cfs.getLiveSSTables())
             sstable.getPosition(Util.dk("key1"), SSTableReader.Operator.EQ);
 
-        AutoSavingCache<KeyCacheKey, RowIndexEntry> keyCache = CacheService.instance.keyCache;
+        AutoSavingCache<KeyCacheKey, BigTableRowIndexEntry> keyCache = CacheService.instance.keyCache;
 
         // serialize to file
         keyCache.submitWrite(keyCache.size()).get();

--- a/test/unit/org/apache/cassandra/cql3/QueryWithIndexedSSTableTest.java
+++ b/test/unit/org/apache/cassandra/cql3/QueryWithIndexedSSTableTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.Util;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -59,7 +59,7 @@ public class QueryWithIndexedSSTableTest extends CQLTester
         boolean hasIndexed = false;
         for (SSTableReader sstable : getCurrentColumnFamilyStore().getLiveSSTables())
         {
-            RowIndexEntry indexEntry = sstable.getPosition(dk, SSTableReader.Operator.EQ);
+            BigTableRowIndexEntry indexEntry = (BigTableRowIndexEntry) sstable.getPosition(dk, SSTableReader.Operator.EQ);
             hasIndexed |= indexEntry != null && indexEntry.isIndexed();
         }
         assert hasIndexed;

--- a/test/unit/org/apache/cassandra/cql3/TombstonesWithIndexedSSTableTest.java
+++ b/test/unit/org/apache/cassandra/cql3/TombstonesWithIndexedSSTableTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -76,12 +77,12 @@ public class TombstonesWithIndexedSSTableTest extends CQLTester
             {
                 // The line below failed with key caching off (CASSANDRA-11158)
                 @SuppressWarnings("unchecked")
-                RowIndexEntry indexEntry = sstable.getPosition(dk, SSTableReader.Operator.EQ);
+                BigTableRowIndexEntry indexEntry = (BigTableRowIndexEntry) sstable.getPosition(dk, SSTableReader.Operator.EQ);
                 if (indexEntry != null && indexEntry.isIndexed())
                 {
                     try (FileDataInput reader = sstable.openIndexReader())
                     {
-                        RowIndexEntry.IndexInfoRetriever infoRetriever = indexEntry.openWithIndex(sstable.getIndexFile());
+                        BigTableRowIndexEntry.IndexInfoRetriever infoRetriever = indexEntry.openWithIndex(sstable.getIndexFile());
                         ClusteringPrefix<?> firstName = infoRetriever.columnsIndex(1).firstName;
                         if (firstName.kind().isBoundary())
                             break deletionLoop;

--- a/test/unit/org/apache/cassandra/db/KeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/db/KeyspaceTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -408,7 +409,7 @@ public class KeyspaceTest extends CQLTester
 
         // verify that we do indeed have multiple index entries
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
-        RowIndexEntry<?> indexEntry = sstable.getPosition(Util.dk("0"), SSTableReader.Operator.EQ);
+        BigTableRowIndexEntry indexEntry = (BigTableRowIndexEntry) sstable.getPosition(Util.dk("0"), SSTableReader.Operator.EQ);
         assert indexEntry.columnsIndexCount() > 2;
 
         validateSliceLarge(cfs);

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraOutgoingFileTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraOutgoingFileTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.streaming;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -98,7 +99,7 @@ public class CassandraOutgoingFileTest
     }
 
     @Test
-    public void validateFullyContainedIn_PartialOverlap_Fails()
+    public void validateFullyContainedIn_PartialOverlap_Fails() throws IOException
     {
         List<Range<Token>> requestedRanges = Arrays.asList(new Range<>(store.getPartitioner().getMinimumToken(), getTokenAtIndex(2)));
 
@@ -111,7 +112,7 @@ public class CassandraOutgoingFileTest
     }
 
     @Test
-    public void validateFullyContainedIn_SplitRange_Succeeds()
+    public void validateFullyContainedIn_SplitRange_Succeeds() throws IOException
     {
         List<Range<Token>> requestedRanges = Arrays.asList(new Range<>(store.getPartitioner().getMinimumToken(), getTokenAtIndex(4)),
                                                          new Range<>(getTokenAtIndex(2), getTokenAtIndex(6)),
@@ -126,12 +127,12 @@ public class CassandraOutgoingFileTest
         assertTrue(cof.contained(sections, sstable));
     }
 
-    private DecoratedKey getKeyAtIndex(int i)
+    private DecoratedKey getKeyAtIndex(int i) throws IOException
     {
         int count = 0;
         DecoratedKey key;
 
-        try (KeyIterator iter = new KeyIterator(sstable.descriptor, sstable.metadata()))
+        try (KeyIterator iter = KeyIterator.forSSTable(sstable))
         {
             do
             {
@@ -142,7 +143,7 @@ public class CassandraOutgoingFileTest
         return key;
     }
 
-    private Token getTokenAtIndex(int i)
+    private Token getTokenAtIndex(int i) throws IOException
     {
         return getKeyAtIndex(i).getToken();
     }

--- a/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
+++ b/test/unit/org/apache/cassandra/dht/KeyCollisionTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
@@ -36,6 +37,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteComparable;
+import org.apache.cassandra.utils.ByteSource;
 import org.apache.cassandra.utils.FBUtilities;
 
 /**
@@ -123,6 +126,12 @@ public class KeyCollisionTest
         public long getHeapSize()
         {
             return 0;
+        }
+
+        @Override
+        public ByteSource asComparableBytes(ByteComparable.Version version)
+        {
+            return IntegerType.instance.asComparableBytes(IntegerType.instance.decompose(token), version);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/format/columniterator/SSTableReverseIteratorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/columniterator/SSTableReverseIteratorTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.db.columniterator;
+package org.apache.cassandra.io.sstable.format.columniterator;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -33,7 +33,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.KeyspaceParams;
@@ -84,7 +84,7 @@ public class SSTableReverseIteratorTest
         tbl.forceBlockingFlush();
         SSTableReader sstable = Iterables.getOnlyElement(tbl.getLiveSSTables());
         DecoratedKey dk = tbl.getPartitioner().decorateKey(Int32Type.instance.decompose(key));
-        RowIndexEntry indexEntry = sstable.getPosition(dk, SSTableReader.Operator.EQ);
+        BigTableRowIndexEntry indexEntry = (BigTableRowIndexEntry) sstable.getPosition(dk, SSTableReader.Operator.EQ);
         Assert.assertTrue(indexEntry.isIndexed());
         Assert.assertTrue(indexEntry.columnsIndexCount() > 2);
 

--- a/test/unit/org/apache/cassandra/utils/ByteSourceTest.java
+++ b/test/unit/org/apache/cassandra/utils/ByteSourceTest.java
@@ -1,0 +1,1026 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ClusteringPrefix;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BooleanType;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import org.apache.cassandra.db.marshal.ByteType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.CompositeType;
+import org.apache.cassandra.db.marshal.DateType;
+import org.apache.cassandra.db.marshal.DecimalType;
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.DynamicCompositeType;
+import org.apache.cassandra.db.marshal.DynamicCompositeTypeTest;
+import org.apache.cassandra.db.marshal.EmptyType;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.InetAddressType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.LexicalUUIDType;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.PartitionerDefinedOrder;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.db.marshal.SetType;
+import org.apache.cassandra.db.marshal.ShortType;
+import org.apache.cassandra.db.marshal.SimpleDateType;
+import org.apache.cassandra.db.marshal.TimeType;
+import org.apache.cassandra.db.marshal.TimeUUIDType;
+import org.apache.cassandra.db.marshal.TimestampType;
+import org.apache.cassandra.db.marshal.TupleType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.LocalPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.utils.ByteComparable.Version;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteSourceTest
+{
+    private final static Logger logger = LoggerFactory.getLogger(ByteSourceTest.class);
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    String[] testStrings = new String[] { "", "\0", "\0\0", "\001", "A\0\0B", "A\0B\0", "0", "0\0", "00", "1", "\377" };
+    Integer[] testInts = new Integer[] { null, Integer.MIN_VALUE, Integer.MIN_VALUE + 1, -256, -255, -128, -127, -1, 0, 1, 127, 128, 255, 256, Integer.MAX_VALUE - 1, Integer.MAX_VALUE };
+    Byte[] testBytes = new Byte[] { -128, -127, -1, 0, 1, 127 };
+    Short[] testShorts = new Short[] { Short.MIN_VALUE, Short.MIN_VALUE + 1, -256, -255, -128, -127, -1, 0, 1, 127, 128, 255, 256, Short.MAX_VALUE - 1, Short.MAX_VALUE };
+    Long[] testLongs = new Long[] { null, Long.MIN_VALUE, Long.MIN_VALUE + 1, Integer.MIN_VALUE - 1L, -256L, -255L, -128L, -127L, -1L, 0L, 1L, 127L, 128L, 255L, 256L, Integer.MAX_VALUE + 1L, Long.MAX_VALUE - 1, Long.MAX_VALUE };
+    Double[] testDoubles = new Double[] { null, Double.NEGATIVE_INFINITY, -Double.MAX_VALUE, -1e+200, -1e3, -1e0, -1e-3, -1e-200, -Double.MIN_VALUE, -0.0, 0.0, Double.MIN_VALUE, 1e-200, 1e-3, 1e0, 1e3, 1e+200, Double.MAX_VALUE, Double.POSITIVE_INFINITY, Double.NaN };
+    Float[] testFloats = new Float[] { null, Float.NEGATIVE_INFINITY, -Float.MAX_VALUE, -1e+30f, -1e3f, -1e0f, -1e-3f, -1e-30f, -Float.MIN_VALUE, -0.0f, 0.0f, Float.MIN_VALUE, 1e-30f, 1e-3f, 1e0f, 1e3f, 1e+30f, Float.MAX_VALUE, Float.POSITIVE_INFINITY, Float.NaN };
+    Boolean[] testBools = new Boolean[] { null, false, true };
+    UUID[] testUUIDs = new UUID[] { null, UUIDGen.getTimeUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                                    UUIDGen.getTimeUUID(123, 234), UUIDGen.getTimeUUID(123, 234), UUIDGen.getTimeUUID(123),
+                                    UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"),
+                                    UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                                    UUID.fromString("e902893a-9d22-3c7e-a7b8-d6e313b71d9f"),
+                                    UUID.fromString("74738ff5-5367-5958-9aee-98fffdcd1876"),
+                                    UUID.fromString("52df1bb0-6a2f-11e6-b6e4-a6dea7a01b67"),
+                                    UUID.fromString("52df1bb0-6a2f-11e6-362d-aff2143498ea"),
+                                    UUID.fromString("52df1bb0-6a2f-11e6-b62d-aff2143498ea")};
+    // Instant.MIN/MAX fail Date.from.
+    Date[] testDates = new Date[] { null,
+                                    Date.from(Instant.ofEpochSecond(Integer.MIN_VALUE)),
+                                    Date.from(Instant.ofEpochSecond(Short.MIN_VALUE)),
+                                    Date.from(Instant.ofEpochMilli(-2000)),
+                                    Date.from(Instant.EPOCH),
+                                    Date.from(Instant.ofEpochMilli(2000)),
+                                    Date.from(Instant.ofEpochSecond(Integer.MAX_VALUE)),
+                                    Date.from(Instant.now()) };
+    BigInteger[] testBigInts;
+
+    {
+        Set<BigInteger> bigs = new TreeSet<>();
+        for (Long l : testLongs)
+            if (l != null)
+                bigs.add(BigInteger.valueOf(l));
+        for (int i = 0; i < 11; ++i)
+        {
+            bigs.add(BigInteger.valueOf(i));
+            bigs.add(BigInteger.valueOf(-i));
+
+            bigs.add(BigInteger.valueOf((1L << 4 * i) - 1));
+            bigs.add(BigInteger.valueOf((1L << 4 * i)));
+            bigs.add(BigInteger.valueOf(-(1L << 4 * i) - 1));
+            bigs.add(BigInteger.valueOf(-(1L << 4 * i)));
+            String p = exp10(i);
+            bigs.add(new BigInteger(p));
+            bigs.add(new BigInteger("-" + p));
+            p = exp10(1 << i);
+            bigs.add(new BigInteger(p));
+            bigs.add(new BigInteger("-" + p));
+
+            BigInteger base = BigInteger.ONE.shiftLeft(512 * i);
+            bigs.add(base);
+            bigs.add(base.add(BigInteger.ONE));
+            bigs.add(base.subtract(BigInteger.ONE));
+            base = base.negate();
+            bigs.add(base);
+            bigs.add(base.add(BigInteger.ONE));
+            bigs.add(base.subtract(BigInteger.ONE));
+        }
+        testBigInts = bigs.toArray(new BigInteger[0]);
+    }
+    BigDecimal[] testBigDecimals;
+    {
+        String vals = "0, 1, 1.1, 21, 98.9, 99, 99.9, 100, 100.1, 101, 331, 0.4, 0.07, 0.0700, 0.005, " +
+                      "6e4, 7e200, 6e-300, 8.1e2000, 8.1e-2000, 9e2000, " +
+                      "123456789012.34567890e-1000, 123456.78901234, 1234.56789012e2, " +
+                      "1.0000, 0.01e2, 100e-2, 00, 0.000, 0E-18, 0E+18";
+        List<BigDecimal> decs = new ArrayList<>();
+        for (String s : vals.split(", "))
+        {
+            decs.add(new BigDecimal(s));
+            decs.add(new BigDecimal("-" + s));
+        }
+        testBigDecimals = decs.toArray(new BigDecimal[0]);
+    }
+
+    static String exp10(int pow)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append('1');
+        for (int i=0; i<pow; ++i)
+            builder.append('0');
+        return builder.toString();
+    }
+
+    Object[][] testValues = new Object[][] { testStrings, testInts, testBools, testDoubles, testBigInts, testBigDecimals };
+    AbstractType[] testTypes = new AbstractType[] {
+                               AsciiType.instance,
+                               Int32Type.instance,
+                               BooleanType.instance,
+                               DoubleType.instance,
+                               IntegerType.instance,
+                               DecimalType.instance };
+
+    @Test
+    public void testStringsAscii()
+    {
+        testType(AsciiType.instance, testStrings);
+    }
+
+    @Test
+    public void testStringsUTF8()
+    {
+        testType(UTF8Type.instance, testStrings);
+    }
+
+    @Test
+    public void testBooleans()
+    {
+        testType(BooleanType.instance, testBools);
+    }
+
+    @Test
+    public void testInts()
+    {
+        testType(Int32Type.instance, testInts);
+        testDirect(x -> ByteSource.of(x), Integer::compare, testInts);
+    }
+
+    @Test
+    public void randomTestInts()
+    {
+        Random rand = new Random();
+        for (int i=0; i<10000; ++i)
+        {
+            int i1 = rand.nextInt();
+            int i2 = rand.nextInt();
+            assertComparesSame(Int32Type.instance, i1, i2);
+        }
+
+    }
+
+    @Test
+    public void testLongs()
+    {
+        testType(LongType.instance, testLongs);
+        testDirect(x -> ByteSource.of(x), Long::compare, testLongs);
+    }
+
+    @Test
+    public void testShorts()
+    {
+        testType(ShortType.instance, testShorts);
+    }
+
+    @Test
+    public void testBytes()
+    {
+        testType(ByteType.instance, testBytes);
+    }
+
+    @Test
+    public void testDoubles()
+    {
+        testType(DoubleType.instance, testDoubles);
+    }
+
+    @Test
+    public void testFloats()
+    {
+        testType(FloatType.instance, testFloats);
+    }
+
+    @Test
+    public void testBigInts()
+    {
+        testType(IntegerType.instance, testBigInts);
+    }
+
+    @Test
+    public void testBigDecimals()
+    {
+        testType(DecimalType.instance, testBigDecimals);
+    }
+
+    @Test
+    public void testBigDecimalInCombination()
+    {
+        BigDecimal b1 = new BigDecimal("123456.78901201");
+        BigDecimal b2 = new BigDecimal("123456.789012");
+        Boolean b = false;
+
+        assertClusteringPairComparesSame(DecimalType.instance, BooleanType.instance, b1, b, b2, b);
+        assertClusteringPairComparesSame(BooleanType.instance, DecimalType.instance, b, b1, b, b2);
+
+        b1 = b1.negate();
+        b2 = b2.negate();
+
+        assertClusteringPairComparesSame(DecimalType.instance, BooleanType.instance, b1, b, b2, b);
+        assertClusteringPairComparesSame(BooleanType.instance, DecimalType.instance, b, b1, b, b2);
+
+        b1 = new BigDecimal("-123456.78901289");
+        b2 = new BigDecimal("-123456.789012");
+
+        assertClusteringPairComparesSame(DecimalType.instance, BooleanType.instance, b1, b, b2, b);
+        assertClusteringPairComparesSame(BooleanType.instance, DecimalType.instance, b, b1, b, b2);
+
+        b1 = new BigDecimal("1");
+        b2 = new BigDecimal("1.1");
+
+        assertClusteringPairComparesSame(DecimalType.instance, BooleanType.instance, b1, b, b2, b);
+        assertClusteringPairComparesSame(BooleanType.instance, DecimalType.instance, b, b1, b, b2);
+
+        b1 = b1.negate();
+        b2 = b2.negate();
+
+        assertClusteringPairComparesSame(DecimalType.instance, BooleanType.instance, b1, b, b2, b);
+        assertClusteringPairComparesSame(BooleanType.instance, DecimalType.instance, b, b1, b, b2);
+    }
+
+    @Test
+    public void testUUIDs()
+    {
+        testType(UUIDType.instance, testUUIDs);
+    }
+
+    @Test
+    public void testTimeUUIDs()
+    {
+        testType(TimeUUIDType.instance, Arrays.stream(testUUIDs).filter(x -> x == null || x.version() == 1).toArray());
+    }
+
+    @Test
+    public void testLexicalUUIDs()
+    {
+        testType(LexicalUUIDType.instance, testUUIDs);
+    }
+
+    @Test
+    public void testSimpleDate()
+    {
+        testType(SimpleDateType.instance, Arrays.stream(testInts).filter(x -> x != null).toArray());
+    }
+
+    @Test
+    public void testTimeType()
+    {
+        testType(TimeType.instance, Arrays.stream(testLongs).filter(x -> x != null && x >= 0 && x <= 24L * 60 * 60 * 1000 * 1000 * 1000).toArray());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDateType()
+    {
+        testType(DateType.instance, testDates);
+    }
+
+    @Test
+    public void testTimestampType()
+    {
+        testType(TimestampType.instance, testDates);
+    }
+
+    @Test
+    public void testBytesType()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testType(BytesType.instance, values.toArray());
+    }
+
+    @Test
+    public void testInetAddressType() throws UnknownHostException
+    {
+        InetAddress[] testInets = new InetAddress[] { null,
+                                                      InetAddress.getLocalHost(),
+                                                      InetAddress.getLoopbackAddress(),
+                                                      InetAddress.getByName("192.168.0.1"),
+                                                      InetAddress.getByName("fe80::428d:5cff:fe53:1dc9"),
+                                                      InetAddress.getByName("2001:610:3:200a:192:87:36:2"),
+                                                      InetAddress.getByName("10.0.0.1"),
+                                                      InetAddress.getByName("0a00:0001::"),
+                                                      InetAddress.getByName("::10.0.0.1") };
+        testType(InetAddressType.instance, testInets);
+    }
+
+    @Test
+    public void testEmptyType()
+    {
+        testType(EmptyType.instance, new Void[] { null });
+    }
+
+    @Test
+    public void testPatitionerDefinedOrder()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testBuffers(new PartitionerDefinedOrder(Murmur3Partitioner.instance), values);
+        testBuffers(new PartitionerDefinedOrder(RandomPartitioner.instance), values);
+        testBuffers(new PartitionerDefinedOrder(ByteOrderedPartitioner.instance), values);
+    }
+
+    @Test
+    public void testPatitionerOrder()
+    {
+        List<ByteBuffer> values = new ArrayList<>();
+        for (int i = 0; i < testValues.length; ++i)
+            for (Object o : testValues[i])
+                values.add(testTypes[i].decompose(o));
+
+        testDecoratedKeys(Murmur3Partitioner.instance, values);
+        testDecoratedKeys(RandomPartitioner.instance, values);
+        testDecoratedKeys(ByteOrderedPartitioner.instance, values);
+    }
+
+    @Test
+    public void testLocalPatitionerOrder()
+    {
+        for (int i = 0; i < testValues.length; ++i)
+        {
+            final AbstractType testType = testTypes[i];
+            testDecoratedKeys(new LocalPartitioner(testType), Lists.transform(Arrays.asList(testValues[i]),
+                                                                                            v -> testType.decompose(v)));
+        }
+    }
+
+    ClusteringPrefix.Kind[] kinds = new ClusteringPrefix.Kind[] {
+    ClusteringPrefix.Kind.INCL_START_BOUND,
+    ClusteringPrefix.Kind.CLUSTERING,
+    ClusteringPrefix.Kind.EXCL_START_BOUND,
+    };
+
+    interface PairTester
+    {
+        void test(AbstractType t1, AbstractType t2, Object o1, Object o2, Object o3, Object o4);
+    }
+
+    void testCombinationSampling(Random rand, PairTester tester)
+    {
+        for (int i=0;i<testTypes.length;++i)
+            for (int j=0;j<testTypes.length;++j)
+            {
+                Object[] tv1 = new Object[3];
+                Object[] tv2 = new Object[3];
+                for (int t=0; t<tv1.length; ++t)
+                {
+                    tv1[t] = testValues[i][rand.nextInt(testValues[i].length)];
+                    tv2[t] = testValues[j][rand.nextInt(testValues[j].length)];
+                }
+
+                for (Object o1 : tv1)
+                    for (Object o2 : tv2)
+                        for (Object o3 : tv1)
+                            for (Object o4 : tv2)
+
+                {
+                    tester.test(testTypes[i], testTypes[j], o1, o2, o3, o4);
+                }
+            }
+    }
+
+    @Test
+    public void testCombinations()
+    {
+        Random rand = new Random(0);
+        testCombinationSampling(rand, this::assertClusteringPairComparesSame);
+    }
+
+    void assertClusteringPairComparesSame(AbstractType t1, AbstractType t2, Object o1, Object o2, Object o3, Object o4)
+    {
+        for (Version v : Version.values())
+            for (ClusteringPrefix.Kind k1 : kinds)
+                for (ClusteringPrefix.Kind k2 : kinds)
+                {
+                    ClusteringComparator comp = new ClusteringComparator(t1, t2);
+                    ByteBuffer[] b = new ByteBuffer[2];
+                    ByteBuffer[] d = new ByteBuffer[2];
+                    b[0] = t1.decompose(o1);
+                    b[1] = t2.decompose(o2);
+                    d[0] = t1.decompose(o3);
+                    d[1] = t2.decompose(o4);
+                    ClusteringPrefix<ByteBuffer> c = ByteBufferAccessor.instance.factory().bound(k1, b);
+                    ClusteringPrefix<ByteBuffer> e = ByteBufferAccessor.instance.factory().bound(k2, d);
+                    final ByteComparable bsc = comp.asByteComparable(c);
+                    final ByteComparable bse = comp.asByteComparable(e);
+                    int expected = Integer.signum(comp.compare(c, e));
+                    assertEquals(String.format("Failed comparing %s and %s, %s vs %s version %s",
+                                               safeStr(c.clusteringString(comp.subtypes())),
+                                               safeStr(e.clusteringString(comp.subtypes())), bsc, bse, v),
+                                 expected, Integer.signum(ByteComparable.compare(bsc, bse, v)));
+                    maybeCheck41Properties(expected, bsc, bse, v);
+                    maybeAssertNotPrefix(bsc, bse, v);
+
+                    ClusteringComparator compR = new ClusteringComparator(ReversedType.getInstance(t1), ReversedType.getInstance(t2));
+                    final ByteComparable bsrc = compR.asByteComparable(c);
+                    final ByteComparable bsre = compR.asByteComparable(e);
+                    int expectedR = Integer.signum(compR.compare(c, e));
+                    assertEquals(String.format("Failed comparing reversed %s and %s, %s vs %s version %s",
+                                               safeStr(c.clusteringString(comp.subtypes())),
+                                               safeStr(e.clusteringString(comp.subtypes())), bsrc, bsre, v),
+                                 expectedR, Integer.signum(ByteComparable.compare(bsrc, bsre, v)));
+                    maybeCheck41Properties(expectedR, bsrc, bsre, v);
+                    maybeAssertNotPrefix(bsrc, bsre, v);
+                }
+    }
+
+    @Test
+    public void testTupleType()
+    {
+        Random rand = ThreadLocalRandom.current();
+        testCombinationSampling(rand, this::assertTupleComparesSame);
+    }
+
+    @Test
+    public void testTupleTypeNonFull()
+    {
+        TupleType tt = new TupleType(ImmutableList.of(AsciiType.instance, Int32Type.instance));
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(AsciiType.instance, ""),
+                                                                                decomposeAndRandomPad(Int32Type.instance, 0)}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(AsciiType.instance, ""),
+                                                                                decomposeAndRandomPad(Int32Type.instance, null)}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {decomposeAndRandomPad(AsciiType.instance, "")}),
+            TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[0])
+            );
+        testBuffers(tt, tests);
+    }
+
+    void assertTupleComparesSame(AbstractType t1, AbstractType t2, Object o1, Object o2, Object o3, Object o4)
+    {
+        TupleType tt = new TupleType(ImmutableList.of(t1, t2));
+        ByteBuffer b1 = TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {t1.decompose(o1), t2.decompose(o2)});
+        ByteBuffer b2 = TupleType.buildValue(ByteBufferAccessor.instance, new ByteBuffer[] {t1.decompose(o3), t2.decompose(o4)});
+        assertComparesSame(tt, b1, b2);
+    }
+
+    @Test
+    public void testCompositeType()
+    {
+        Random rand = new Random(0);
+        testCombinationSampling(rand, this::assertCompositeComparesSame);
+    }
+
+    @Test
+    public void testCompositeTypeNonFull()
+    {
+        CompositeType tt = CompositeType.getInstance(AsciiType.instance, Int32Type.instance);
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(AsciiType.instance, ""), decomposeAndRandomPad(Int32Type.instance, 0)),
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(AsciiType.instance, ""), decomposeAndRandomPad(Int32Type.instance, null)),
+            CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(AsciiType.instance, "")),
+            CompositeType.build(ByteBufferAccessor.instance),
+            CompositeType.build(ByteBufferAccessor.instance, true, decomposeAndRandomPad(AsciiType.instance, "")),
+            CompositeType.build(ByteBufferAccessor.instance,true)
+            );
+        for (ByteBuffer b : tests)
+            tt.validate(b);
+        testBuffers(tt, tests);
+    }
+
+    void assertCompositeComparesSame(AbstractType t1, AbstractType t2, Object o1, Object o2, Object o3, Object o4)
+    {
+        CompositeType tt = CompositeType.getInstance(t1, t2);
+        ByteBuffer b1 = CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(t1, o1), decomposeAndRandomPad(t2, o2));
+        ByteBuffer b2 = CompositeType.build(ByteBufferAccessor.instance, decomposeAndRandomPad(t1, o3), decomposeAndRandomPad(t2, o4));
+        assertComparesSame(tt, b1, b2);
+    }
+
+    @Test
+    public void testDynamicComposite()
+    {
+        DynamicCompositeType tt = DynamicCompositeType.getInstance(DynamicCompositeTypeTest.aliases);
+        UUID[] uuids = DynamicCompositeTypeTest.uuids;
+        List<ByteBuffer> tests = ImmutableList.of
+            (
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", null, -1, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", uuids[0], 24, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test1", uuids[0], 42, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test2", uuids[0], -1, false, true),
+            DynamicCompositeTypeTest.createDynamicCompositeKey("test2", uuids[1], 42, false, true)
+            );
+        for (ByteBuffer b : tests)
+            tt.validate(b);
+        testBuffers(tt, tests);
+    }
+
+    @Test
+    public void testListTypeString()
+    {
+        testCollection(ListType.getInstance(AsciiType.instance, true), testStrings, () -> new ArrayList<>(), new Random());
+    }
+
+    @Test
+    public void testListTypeLong()
+    {
+        testCollection(ListType.getInstance(LongType.instance, true), testLongs, () -> new ArrayList<>(), new Random());
+    }
+
+    @Test
+    public void testSetTypeString()
+    {
+        testCollection(SetType.getInstance(AsciiType.instance, true), testStrings, () -> new HashSet<>(), new Random());
+    }
+
+    @Test
+    public void testSetTypeLong()
+    {
+        testCollection(SetType.getInstance(LongType.instance, true), testLongs, () -> new HashSet<>(), new Random());
+    }
+
+    <T, CT extends Collection<T>> void testCollection(CollectionType<CT> tt, T[] values, Supplier<CT> gen, Random rand)
+    {
+        int cnt = 0;
+        List<CT> tests = new ArrayList<>();
+        tests.add(gen.get());
+        for (int c = 1; c <= 3; ++c)
+            for (int j = 0; j < 5; ++j)
+            {
+                CT l = gen.get();
+                for (int i = 0; i < c; ++i)
+                    l.add(values[cnt++ % values.length]);
+
+                tests.add(l);
+            }
+        testType(tt, tests.toArray());
+    }
+
+    @Test
+    public void testMapTypeStringLong()
+    {
+        testMap(MapType.getInstance(AsciiType.instance, LongType.instance, true), testStrings, testLongs, () -> new HashMap<>(), new Random());
+    }
+
+    @Test
+    public void testMapTypeStringLongTree()
+    {
+        testMap(MapType.getInstance(AsciiType.instance, LongType.instance, true), testStrings, testLongs, () -> new TreeMap<>(), new Random());
+    }
+
+    @Test
+    public void testDecoratedKeyPrefixesVOSS41()
+    {
+        // This should pass with the OSS 4.1 encoding
+        testDecoratedKeyPrefixes(Version.OSS41);
+    }
+
+    @Test
+    public void testDecoratedKeyPrefixesVLegacy()
+    {
+        // ... and fail with the legacy encoding
+        try
+        {
+            testDecoratedKeyPrefixes(Version.LEGACY);
+        }
+        catch (AssertionError e)
+        {
+            // Correct path, test failing.
+            return;
+        }
+        Assert.fail("Test expected to fail.");
+    }
+
+    @Test
+    public void testFixedLengthWithOffset()
+    {
+        byte[] bytes = new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        ByteSource source = ByteSource.fixedLength(bytes, 0, 1);
+        assertEquals(1, source.next());
+        assertEquals(ByteSource.END_OF_STREAM, source.next());
+
+        source = ByteSource.fixedLength(bytes, 4, 5);
+        assertEquals(5, source.next());
+        assertEquals(6, source.next());
+        assertEquals(7, source.next());
+        assertEquals(8, source.next());
+        assertEquals(9, source.next());
+        assertEquals(ByteSource.END_OF_STREAM, source.next());
+
+        ByteSource.fixedLength(bytes, 9, 0);
+        assertEquals(ByteSource.END_OF_STREAM, source.next());
+    }
+
+    @Test
+    public void testFixedLengthNegativeLength()
+    {
+        byte[] bytes = new byte[]{ 1, 2, 3 };
+
+        expectedException.expect(IllegalArgumentException.class);
+        ByteSource.fixedLength(bytes, 0, -1);
+    }
+
+    @Test
+    public void testFixedLengthNegativeOffset()
+    {
+        byte[] bytes = new byte[]{ 1, 2, 3 };
+
+        expectedException.expect(IllegalArgumentException.class);
+        ByteSource.fixedLength(bytes, -1, 1);
+    }
+
+    @Test
+    public void testFixedLengthOutOfBounds()
+    {
+        byte[] bytes = new byte[]{ 1, 2, 3 };
+
+        expectedException.expect(IllegalArgumentException.class);
+        ByteSource.fixedLength(bytes, 0, 4);
+    }
+
+    @Test
+    public void testFixedOffsetOutOfBounds()
+    {
+        byte[] bytes = new byte[]{ 1, 2, 3 };
+
+        expectedException.expect(IllegalArgumentException.class);
+        ByteSource.fixedLength(bytes, 4, 1);
+    }
+
+    public void testDecoratedKeyPrefixes(Version version)
+    {
+        testDecoratedKeyPrefixes("012345678BCDE\0", "", version);
+        testDecoratedKeyPrefixes("012345678ABCDE\0", "ABC", version);
+        testDecoratedKeyPrefixes("0123456789ABCDE\0", "\0AB", version);
+        testDecoratedKeyPrefixes("0123456789ABCDEF\0", "\0", version);
+
+        testDecoratedKeyPrefixes("0123456789ABCDEF0", "ABC", version);
+        testDecoratedKeyPrefixes("0123456789ABCDEF", "", version);
+        testDecoratedKeyPrefixes("0123456789ABCDE", "", version);
+        testDecoratedKeyPrefixes("0123456789ABCD", "\0AB", version);
+        testDecoratedKeyPrefixes("0123456789ABC", "\0", version);
+
+    }
+
+    public void testDecoratedKeyPrefixes(String key, String append, Version version)
+    {
+        logger.info("Testing {} + {}", safeStr(key), safeStr(append));
+        IPartitioner partitioner = Murmur3Partitioner.instance;
+        ByteBuffer original = ByteBufferUtil.bytes(key);
+        ByteBuffer collision = Util.generateMurmurCollision(original, append.getBytes(StandardCharsets.UTF_8));
+
+        long[] hash = new long[2];
+        MurmurHash.hash3_x64_128(original, 0, original.limit(), 0, hash);
+        logger.info(String.format("Original hash  %016x,%016x", hash[0], hash[1]));
+        MurmurHash.hash3_x64_128(collision, 0, collision.limit(), 0, hash);
+        logger.info(String.format("Collision hash %016x,%016x", hash[0], hash[1]));
+
+        DecoratedKey kk1 = partitioner.decorateKey(original);
+        DecoratedKey kk2 = partitioner.decorateKey(collision);
+        logger.info("{}\n{}\n{}\n{}", kk1, kk2, kk1.byteComparableAsString(version), kk2.byteComparableAsString(version));
+
+        final ByteSource s1 = kk1.asComparableBytes(version);
+        final ByteSource s2 = kk2.asComparableBytes(version);
+        logger.info("{}\n{}", s1, s2);
+
+        // Check that the representations compare correctly
+        Assert.assertEquals(Long.signum(kk1.compareTo(kk2)), ByteComparable.compare(kk1, kk2, version));
+        // s1 must not be a prefix of s2
+        assertNotPrefix(s1, s2);
+    }
+
+    private void assertNotPrefix(ByteSource s1, ByteSource s2)
+    {
+        int c1, c2;
+        do
+        {
+            c1 = s1.next();
+            c2 = s2.next();
+        }
+        while (c1 == c2 && c1 != ByteSource.END_OF_STREAM);
+
+        // Equal is ok
+        if (c1 == c2)
+            return;
+
+        Assert.assertNotEquals("ByteComparable is a prefix of other", ByteSource.END_OF_STREAM, c1);
+        Assert.assertNotEquals("ByteComparable is a prefix of other", ByteSource.END_OF_STREAM, c2);
+    }
+
+    private int compare(ByteSource s1, ByteSource s2)
+    {
+        int c1, c2;
+        do
+        {
+            c1 = s1.next();
+            c2 = s2.next();
+        }
+        while (c1 == c2 && c1 != ByteSource.END_OF_STREAM);
+
+        return Integer.compare(c1, c2);
+    }
+
+    private void maybeAssertNotPrefix(ByteComparable s1, ByteComparable s2, Version version)
+    {
+        if (version == Version.OSS41)
+            assertNotPrefix(s1.asComparableBytes(version), s2.asComparableBytes(version));
+    }
+
+    private void maybeCheck41Properties(int expectedComparison, ByteComparable s1, ByteComparable s2, Version version)
+    {
+        if (version != Version.OSS41)
+            return;
+
+        if (s1 == null || s2 == null || 0 == expectedComparison)
+            return;
+        int b1 = ThreadLocalRandom.current().nextInt(ByteSource.MIN_SEPARATOR, ByteSource.MAX_SEPARATOR + 1);
+        int b2 = ThreadLocalRandom.current().nextInt(ByteSource.MIN_SEPARATOR, ByteSource.MAX_SEPARATOR + 1);
+        assertEquals(String.format("Comparison failed for %s(%s + %02x) and %s(%s + %02x)", s1, s1.byteComparableAsString(version), b1, s2, s2.byteComparableAsString(version), b2),
+                expectedComparison, Integer.signum(compare(ByteSource.withTerminator(b1, s1.asComparableBytes(version)), ByteSource.withTerminator(b2, s2.asComparableBytes(version)))));
+        assertNotPrefix(ByteSource.withTerminator(b1, s1.asComparableBytes(version)), ByteSource.withTerminator(b2, s2.asComparableBytes(version)));
+    }
+
+    <K, V, M extends Map<K, V>> void testMap(MapType<K, V> tt, K[] keys, V[] values, Supplier<M> gen, Random rand)
+    {
+        List<M> tests = new ArrayList<>();
+        tests.add(gen.get());
+        for (int c = 1; c <= 3; ++c)
+            for (int j = 0; j < 5; ++j)
+            {
+                M l = gen.get();
+                for (int i = 0; i < c; ++i)
+                    l.put(keys[rand.nextInt(keys.length)], values[rand.nextInt(values.length)]);
+
+                tests.add(l);
+            }
+        testType(tt, tests.toArray());
+    }
+
+    /*
+     * Convert type to a comparable.
+     */
+    private ByteComparable typeToComparable(AbstractType type, ByteBuffer value)
+    {
+        return new ByteComparable()
+        {
+            @Override
+            public ByteSource asComparableBytes(Version v)
+            {
+                return type.asComparableBytes(value, v);
+            }
+
+            @Override
+            public String toString()
+            {
+                return type.getString(value);
+            }
+        };
+    }
+
+    public void testType(AbstractType type, Object[] values)
+    {
+        for (Object i : values) {
+            ByteBuffer b = decomposeAndRandomPad(type, i);
+            logger.info("Value {} ({}) bytes {} ByteSource {}",
+                              safeStr(i),
+                              safeStr(type.getSerializer().toCQLLiteral(b)),
+                              safeStr(ByteBufferUtil.bytesToHex(b)),
+                              typeToComparable(type, b).byteComparableAsString(Version.OSS41));
+        }
+        for (Object i : values)
+            for (Object j : values)
+                assertComparesSame(type, i, j);
+        if (!type.isReversed())
+            testType(ReversedType.getInstance(type), values);
+    }
+
+    public void testBuffers(AbstractType type, List<ByteBuffer> values)
+    {
+        try
+        {
+            for (Object i : values) {
+                ByteBuffer b = decomposeAndRandomPad(type, i);
+                logger.info("Value {} bytes {} ByteSource {}",
+                                  safeStr(type.getSerializer().toCQLLiteral(b)),
+                                  safeStr(ByteBufferUtil.bytesToHex(b)),
+                                  typeToComparable(type, b).byteComparableAsString(Version.OSS41));
+            }
+        }
+        catch (UnsupportedOperationException e)
+        {
+            // Continue without listing values.
+        }
+
+        for (ByteBuffer i : values)
+            for (ByteBuffer j : values)
+                assertComparesSameBuffers(type, i, j);
+    }
+
+    void assertComparesSameBuffers(AbstractType type, ByteBuffer b1, ByteBuffer b2)
+    {
+        int expected = Integer.signum(type.compare(b1, b2));
+        final ByteComparable bs1 = typeToComparable(type, b1);
+        final ByteComparable bs2 = typeToComparable(type, b2);
+
+        for (Version version : Version.values())
+        {
+            int actual = Integer.signum(ByteComparable.compare(bs1, bs2, version));
+            assertEquals(String.format("Failed comparing %s(%s) and %s(%s)", ByteBufferUtil.bytesToHex(b1), bs1.byteComparableAsString(version), ByteBufferUtil.bytesToHex(b2), bs2.byteComparableAsString(version)),
+                         expected,
+                         actual);
+            maybeCheck41Properties(expected, bs1, bs2, version);
+        }
+    }
+
+    public void testDecoratedKeys(IPartitioner type, List<ByteBuffer> values)
+    {
+        for (ByteBuffer i : values)
+            for (ByteBuffer j : values)
+                assertComparesSameDecoratedKeys(type, i, j);
+    }
+
+    void assertComparesSameDecoratedKeys(IPartitioner type, ByteBuffer b1, ByteBuffer b2)
+    {
+        DecoratedKey k1 = type.decorateKey(b1);
+        DecoratedKey k2 = type.decorateKey(b2);
+        int expected = Integer.signum(k1.compareTo(k2));
+
+        for (Version version : Version.values())
+        {
+            int actual = Integer.signum(ByteComparable.compare(k1, k2, version));
+            assertEquals(String.format("Failed comparing %s[%s](%s) and %s[%s](%s)\npartitioner %s version %s",
+                                       ByteBufferUtil.bytesToHex(b1),
+                                       k1,
+                                       k1.byteComparableAsString(version),
+                                       ByteBufferUtil.bytesToHex(b2),
+                                       k2,
+                                       k2.byteComparableAsString(version),
+                                       type,
+                                       version),
+                         expected,
+                         actual);
+            maybeAssertNotPrefix(k1, k2, version);
+        }
+    }
+
+    private Object safeStr(Object i)
+    {
+        if (i == null)
+            return null;
+        String s = i.toString();
+        if (s.length() > 100)
+            s = s.substring(0, 100) + "...";
+        return s.replaceAll("\0", "<0>");
+    }
+
+    public <T> void testDirect(Function<T, ByteSource> convertor, BiFunction<T, T, Integer> comparator, T[] values)
+    {
+        for (T i : values) {
+            if (i == null)
+                continue;
+
+            logger.info("Value {} ByteSource {}\n",
+                              safeStr(i),
+                              convertor.apply(i));
+        }
+        for (T i : values)
+            if (i != null)
+                for (T j : values)
+                    if (j != null)
+                        assertComparesSame(convertor, comparator, i, j);
+    }
+
+    <T> void assertComparesSame(Function<T, ByteSource> convertor, BiFunction<T, T, Integer> comparator, T v1, T v2)
+    {
+        ByteComparable b1 = v -> convertor.apply(v1);
+        ByteComparable b2 = v -> convertor.apply(v2);
+        int expected = Integer.signum(comparator.apply(v1, v2));
+        int actual = Integer.signum(ByteComparable.compare(b1, b2, null));  // version ignored above
+        assertEquals(String.format("Failed comparing %s and %s", v1, v2), expected, actual);
+    }
+
+    void assertComparesSame(AbstractType type, Object v1, Object v2)
+    {
+        ByteBuffer b1 = decomposeAndRandomPad(type, v1);
+        ByteBuffer b2 = decomposeAndRandomPad(type, v2);
+        int expected = Integer.signum(type.compare(b1, b2));
+        final ByteComparable bc1 = typeToComparable(type, b1);
+        final ByteComparable bc2 = typeToComparable(type, b2);
+
+        for (Version version : Version.values())
+        {
+            int actual = Integer.signum(ByteComparable.compare(bc1, bc2, version));
+            if (expected != actual)
+            {
+                if (type.isReversed())
+                {
+                    // This can happen for reverse of nulls and prefixes. Check that it's ok within multi-component
+                    ClusteringComparator cc = new ClusteringComparator(type);
+                    ByteComparable c1 = cc.asByteComparable(Clustering.make(b1));
+                    ByteComparable c2 = cc.asByteComparable(Clustering.make(b2));
+                    int actualcc = Integer.signum(ByteComparable.compare(c1, c2, version));
+                    if (actualcc == expected)
+                        return;
+                    assertEquals(String.format("Failed comparing reversed %s(%s, %s) and %s(%s, %s) direct (%d) and as clustering", safeStr(v1), ByteBufferUtil.bytesToHex(b1), c1, safeStr(v2), ByteBufferUtil.bytesToHex(b2), c2, actual), expected, actualcc);
+                }
+                else
+                    assertEquals(String.format("Failed comparing %s(%s) and %s(%s)", safeStr(v1), ByteBufferUtil.bytesToHex(b1), safeStr(v2), ByteBufferUtil.bytesToHex(b2)), expected, actual);
+            }
+            maybeCheck41Properties(expected, bc1, bc2, version);
+        }
+    }
+
+    ByteBuffer decomposeAndRandomPad(AbstractType type, Object v)
+    {
+        ByteBuffer b = type.decompose(v);
+        Random rand = new Random(0);
+        int padBefore = rand.nextInt(16);
+        int padAfter = rand.nextInt(16);
+        int paddedCapacity = b.remaining() + padBefore + padAfter;
+        ByteBuffer padded = allocateBuffer(paddedCapacity);
+        rand.ints(padBefore).forEach(x -> padded.put((byte) x));
+        padded.put(b);
+        rand.ints(padAfter).forEach(x -> padded.put((byte) x));
+        padded.clear().limit(padded.capacity() - padAfter).position(padBefore);
+        return padded;
+    }
+
+    protected ByteBuffer allocateBuffer(int paddedCapacity)
+    {
+        return ByteBuffer.allocate(paddedCapacity);
+    }
+}


### PR DESCRIPTION
PR comparing apache/trunk 7214794e3f86b67d96371c78815c1ce03b3a5d6b code with ds-trunk rebased on it.

See https://github.com/datastax/cassandra/pull/53 for merge-trunk-20210119 comparison. 

The rebased branch and merged branch have the same end result code:
```
[jeremiah]:~/github/riptano/cassandra  (merge-trunk-20210119)$ git diff rebase-trunk-20210119
[jeremiah]:~/github/riptano/cassandra  (merge-trunk-20210119)$
```

dtest update here https://github.com/datastax/cassandra-dtest/pull/2