### PR TITLE
STAR-451 override unsupported DSE compaction strategies

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
+++ b/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
@@ -69,7 +69,7 @@ public class PropertyDefinitions
         return (String)val;
     }
 
-    protected Map<String, String> getMap(String name) throws SyntaxException
+    public Map<String, String> getMap(String name) throws SyntaxException
     {
         Object val = properties.get(name);
         if (val == null)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -372,6 +372,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
     @Override
     public Set<String> clientWarnings(KeyspacesDiff diff)
     {
+        Set<String> warnings = new HashSet<>();
+
         int tableCount = Schema.instance.getNumberOfTables();
         if (tableCount > DatabaseDescriptor.tableCountWarnThreshold())
         {
@@ -379,9 +381,17 @@ public final class CreateTableStatement extends AlterSchemaStatement
                                        tableCount,
                                        Schema.instance.getKeyspaces().size());
             logger.warn(msg);
-            return ImmutableSet.of(msg);
+            warnings.add(msg);
         }
-        return ImmutableSet.of();
+
+        if (attrs.hasUnsupportedDseCompaction())
+        {
+            warnings.add("The given compactin strategy is not supported. The compaction strategy parameter was " +
+                         String.format("overriden with the default (%s). ", CompactionParams.DEFAULT.toString()) +
+                         "Inspect your schema and adjust other table properties if needed.");
+        }
+
+        return warnings;
     }
 
     private static class DefaultNames

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -386,8 +386,11 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         if (attrs.hasUnsupportedDseCompaction())
         {
-            warnings.add("The given compactin strategy is not supported. The compaction strategy parameter was " +
-                         String.format("overriden with the default (%s). ", CompactionParams.DEFAULT.toString()) +
+            Map<String, String> compactionOptions = attrs.getMap(TableParams.Option.COMPACTION.toString());
+            String strategy = compactionOptions.get(CompactionParams.Option.CLASS.toString());
+            warnings.add(String.format("The given compaction strategy (%s) is not supported. ", strategy) +
+                         "The compaction strategy parameter was overridden with the default " +
+                         String.format("(%s). ", CompactionParams.DEFAULT.klass().getCanonicalName()) +
                          "Inspect your schema and adjust other table properties if needed.");
         }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -43,6 +43,13 @@ public final class TableAttributes extends PropertyDefinitions
     private static final Set<String> validKeywords;
     private static final Set<String> obsoleteKeywords;
 
+    private static final Set<String> UNSUPPORTED_DSE_COMPACTION_STRATEGIES = ImmutableSet.of(
+        "org.apache.cassandra.db.compaction.TieredCompactionStrategy",
+        "TieredCompactionStrategy",
+        "org.apache.cassandra.db.compaction.MemoryOnlyStrategy",
+        "MemoryOnlyStrategy"
+    );
+
     static
     {
         ImmutableSet.Builder<String> validBuilder = ImmutableSet.builder();
@@ -84,6 +91,24 @@ public final class TableAttributes extends PropertyDefinitions
         }
     }
 
+    /**
+     * Returs `true` if this attributes instance has a COMPACTION option with a recognized unsupported compaction
+     * strategy class (coming from DSE). `false` otherwise.
+     */
+    boolean hasUnsupportedDseCompaction()
+    {
+        if (hasOption(Option.COMPACTION))
+        {
+            Map<String, String> compactionOptions = getMap(Option.COMPACTION);
+            String strategy = compactionOptions.get(CompactionParams.Option.CLASS.toString());
+            return UNSUPPORTED_DSE_COMPACTION_STRATEGIES.contains(strategy);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     private TableParams build(TableParams.Builder builder)
     {
         if (hasOption(Option.BLOOM_FILTER_FP_CHANCE))
@@ -95,8 +120,12 @@ public final class TableAttributes extends PropertyDefinitions
         if (hasOption(Option.COMMENT))
             builder.comment(getString(Option.COMMENT));
 
-        if (hasOption(Option.COMPACTION))
-            builder.compaction(CompactionParams.fromMap(getMap(Option.COMPACTION)));
+        if (hasOption(Option.COMPACTION)){
+            if (hasUnsupportedDseCompaction())
+                builder.compaction(CompactionParams.DEFAULT);
+            else
+                builder.compaction(CompactionParams.fromMap(getMap(Option.COMPACTION)));
+        }
 
         if (hasOption(Option.COMPRESSION))
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -120,7 +120,8 @@ public final class TableAttributes extends PropertyDefinitions
         if (hasOption(Option.COMMENT))
             builder.comment(getString(Option.COMMENT));
 
-        if (hasOption(Option.COMPACTION)){
+        if (hasOption(Option.COMPACTION))
+        {
             if (hasUnsupportedDseCompaction())
                 builder.compaction(CompactionParams.DEFAULT);
             else

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.schema.CompactionParams;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class CreateTableStatementTest extends CQLTester
+{
+    @Parameterized.Parameters(name = "compactionStrategy = {0}")
+    public static Set<String> strategies()
+    {
+        return ImmutableSet.of(
+            "{'class': 'org.apache.cassandra.db.compaction.MemoryOnlyStrategy', 'max_threshold': '32', 'min_threshold': '4'}",
+            "{'class': 'MemoryOnlyStrategy', 'max_threshold': '32', 'min_threshold': '4'}",
+            "{'class': 'org.apache.cassandra.db.compaction.TieredCompactionStrategy', 'tiering_strategy': 'TimeWindowStorageStrategy', 'config': 'strategy1', 'max_tier_ages': '3600,7200'}",
+            "{'class': 'TieredCompactionStrategy', 'tiering_strategy': 'TimeWindowStorageStrategy', 'config': 'strategy1', 'max_tier_ages': '3600,7200'}"
+        );
+    }
+
+    @Parameterized.Parameter()
+    public String compactionStrategy;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.createKeyspace("ks", KeyspaceParams.simple(1));
+    }
+
+    @Test
+    public void dseCompactionStrategyShouldBeIgnoredWithWarning() throws Throwable
+    {
+        String tableName = createTableName();
+
+        // should not throw
+        ResultSet rows = executeNet(String.format("CREATE TABLE ks.%s (k int PRIMARY KEY, v int) WITH " +
+                                                  "compaction = %s;", tableName, compactionStrategy));
+
+        assertTrue(rows.wasApplied());
+
+        String warning = rows.getAllExecutionInfo().get(0).getWarnings().get(0);
+        assertTrue("DSE compaction strategy should cause a warning",
+                   warning.contains("The given compactin strategy is not supported"));
+
+        assertDefaultCompactionStrategy(tableName);
+    }
+
+    private void assertDefaultCompactionStrategy(String tableName) throws Throwable
+    {
+        ResultSet result = executeNet("DESCRIBE TABLE ks." + tableName);
+
+        String createStatement = result.one().getString("create_statement");
+
+        Assert.assertTrue(createStatement.contains(CompactionParams.DEFAULT.klass().getCanonicalName()));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementTest.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.cql3.statements;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +32,8 @@ import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.schema.CompactionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
@@ -70,8 +71,7 @@ public class CreateTableStatementTest extends CQLTester
         assertTrue(rows.wasApplied());
 
         String warning = rows.getAllExecutionInfo().get(0).getWarnings().get(0);
-        assertTrue("DSE compaction strategy should cause a warning",
-                   warning.contains("The given compactin strategy is not supported"));
+        assertThat(warning, containsString("The compaction strategy parameter was overridden with the default"));
 
         assertDefaultCompactionStrategy(tableName);
     }
@@ -81,7 +81,6 @@ public class CreateTableStatementTest extends CQLTester
         ResultSet result = executeNet("DESCRIBE TABLE ks." + tableName);
 
         String createStatement = result.one().getString("create_statement");
-
-        Assert.assertTrue(createStatement.contains(CompactionParams.DEFAULT.klass().getCanonicalName()));
+        assertThat(createStatement, containsString(CompactionParams.DEFAULT.klass().getCanonicalName()));
     }
 }


### PR DESCRIPTION
Create table command overrides a recognized unsupported DSE
compaction strategy (MemoryOnlyStrategy and TieredCompactionStrategy)
with default Compaction Strategy (SizeTiered atm).
The table is created successfully, applied == true.
Additional warning is returned to the caller.