### PR TITLE
STAR-455 ignore VERTEX|EDGE LABEL in CREATE TABLE statement

### DIFF
--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -215,6 +215,10 @@ K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
+K_EDGE:        E D G E;
+K_VERTEX:      V E R T E X;
+K_LABEL:       L A B E L;
+
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');
 fragment B: ('b'|'B');

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -797,6 +797,11 @@ tableProperty[CreateTableStatement.Raw stmt]
     : property[stmt.attrs]
     | K_COMPACT K_STORAGE { $stmt.setCompactStorage(); }
     | K_CLUSTERING K_ORDER K_BY '(' tableClusteringOrder[stmt] (',' tableClusteringOrder[stmt])* ')'
+    | K_VERTEX K_LABEL ( noncol_ident )? {stmt.attrs.addProperty("dse_vertex_label_property", "vertex");}
+    | K_EDGE K_LABEL ( noncol_ident ) ?
+             K_FROM noncol_ident '(' ident (',' ident)* ')'
+             K_TO noncol_ident '(' ident (',' ident)* ')'
+             {stmt.attrs.addProperty("dse_edge_label_property", "edge");}
     ;
 
 tableClusteringOrder[CreateTableStatement.Raw stmt]
@@ -1900,5 +1905,8 @@ basic_unreserved_keyword returns [String str]
         | K_MBEANS
         | K_REPLACE
         | K_UNSET
+        | K_EDGE
+        | K_VERTEX
+        | K_LABEL
         ) { $str = $k.text; }
     ;

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
@@ -133,6 +133,11 @@ public final class CreateKeyspaceStatement extends AlterSchemaStatement
             clientWarnings.add(msg);
         }
 
+        if (attrs.hasProperty("graph_engine"))
+        {
+            clientWarnings.add("The unsupported graph property 'graph_engine' was ignored.");
+        }
+
         return clientWarnings;
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -427,6 +427,16 @@ public final class CreateTableStatement extends AlterSchemaStatement
             warnings.add("The unsupported 'nodesync' table option was ignored.");
         }
 
+        if (attrs.hasProperty("dse_vertex_label_property"))
+        {
+            warnings.add("The unsupported graph table property was ignored (VERTEX LABEL).");
+        }
+
+        if (attrs.hasProperty("dse_edge_label_property"))
+        {
+            warnings.add("The unsupported graph table property was ignored (EDGE LABEL).");
+        }
+
         return warnings.build();
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/KeyspaceAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/KeyspaceAttributes.java
@@ -38,7 +38,7 @@ public final class KeyspaceAttributes extends PropertyDefinitions
         for (Option option : Option.values())
             validBuilder.add(option.toString());
         validKeywords = validBuilder.build();
-        obsoleteKeywords = ImmutableSet.of();
+        obsoleteKeywords = ImmutableSet.of("graph_engine");
     }
 
     public void validate()

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -42,7 +42,9 @@ public final class TableAttributes extends PropertyDefinitions
     public static final String ID = "id";
     public static final Set<String> validKeywords;
     private static final Set<String> obsoleteKeywords = ImmutableSet.of(
-        "nodesync"
+        "nodesync",
+        "dse_vertex_label_property",
+        "dse_edge_label_property"
     );
 
     private static final Set<String> UNSUPPORTED_DSE_COMPACTION_STRATEGIES = ImmutableSet.of(

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateKeyspaceStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateKeyspaceStatementTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CreateKeyspaceStatementTest extends CQLTester
+{
+    @Test
+    public void ignoreUnsupportedGraphEngineProperty() throws Throwable
+    {
+        String keyspaceName = createKeyspaceName();
+        String keyspaceOptions = "graph_engine = 'Core'";
+
+        // should not throw
+        ResultSet rows = executeNet(String.format("CREATE KEYSPACE %s WITH REPLICATION = " +
+                                                  "{ 'class' : 'SimpleStrategy', 'replication_factor' : '1' } AND %s",
+                                                  keyspaceName, keyspaceOptions));
+
+        assertTrue(rows.wasApplied());
+
+        String warning = rows.getAllExecutionInfo().get(0).getWarnings().get(0);
+        assertThat(warning, containsString("The unsupported graph property 'graph_engine' was ignored."));
+
+        assertNoGraphEngineKeyspaceProperty(keyspaceName);
+    }
+
+    private void assertNoGraphEngineKeyspaceProperty(String tableName) throws Throwable
+    {
+        ResultSet result = executeNet("DESCRIBE KEYSPACE " + tableName);
+
+        String createStatement = result.one().getString("create_statement");
+        assertThat(createStatement, not(containsString("graph_engine")));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementGraphTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateTableStatementGraphTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class CreateTableStatementGraphTest extends CQLTester
+{
+    @Parameterized.Parameters(name = "tableOptions = {0}")
+    public static Set<String> tableOptions()
+    {
+        return ImmutableSet.of(
+            "VERTEX LABEL",
+            "vertex label",
+            "VERTEX LABEL person_label",
+            "VERTEX LABEL personlabel",
+            "VERTEX LABEL \"personlabel\"",
+            "VERTEX LABEL personlabel AND CLUSTERING ORDER BY (v DESC)",
+            "CLUSTERING ORDER BY (v DESC) AND VERTEX LABEL",
+            "EDGE LABEL person_authored_book FROM person(name,person_id) TO book(name, book_id,  cover)",
+            "EDGE LABEL person_authored_book FROM person(name) TO book(cover)",
+            "VERTEX LABEL AND EDGE LABEL person_authored_book FROM person(name) TO book(cover)"
+        );
+    }
+
+    @Parameterized.Parameter()
+    public String tableOptions;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.createKeyspace("ks", KeyspaceParams.simple(1));
+    }
+
+    @Test
+    public void dseGraphShouldBeIgnoredWithWarning() throws Throwable
+    {
+        String tableName = createTableName();
+
+        // should not throw
+        ResultSet rows = executeNet(String.format("CREATE TABLE ks.%s (k int, v int, PRIMARY KEY (k, v)) WITH %s", tableName, tableOptions));
+
+        assertTrue(rows.wasApplied());
+
+        String warning = rows.getAllExecutionInfo().get(0).getWarnings().get(0);
+        assertThat(warning, containsString("The unsupported graph table property was ignored"));
+
+        assertNoGraphLabels(tableName);
+    }
+
+    private void assertNoGraphLabels(String tableName) throws Throwable
+    {
+        ResultSet result = executeNet("DESCRIBE TABLE ks." + tableName);
+
+        String createStatement = result.one().getString("create_statement");
+        assertThat(createStatement.toUpperCase(), not(containsString("LABEL")));
+    }
+}


### PR DESCRIPTION
The DSE-specific graph properties are added to CQL syntax.
Once detected, a hint about them is provided to the node
via table properties: dse_vertex_label_property and
dse_edge_label_property.
The node returns a warning to the caller, ignores the
properties and creates the table.