### PR TITLE
STAR-527 ignore DSE specific keywords in UDF creation

### DIFF
--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -209,6 +209,8 @@ K_INPUT:       I N P U T;
 K_LANGUAGE:    L A N G U A G E;
 K_OR:          O R;
 K_REPLACE:     R E P L A C E;
+K_DETERMINISTIC: D E T E R M I N I S T I C;
+K_MONOTONIC:   M O N O T O N I C;
 
 K_JSON:        J S O N;
 K_DEFAULT:     D E F A U L T;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -654,6 +654,7 @@ createAggregateStatement returns [CreateAggregateStatement.Raw stmt]
     @init {
         boolean orReplace = false;
         boolean ifNotExists = false;
+        boolean deterministic = false;
 
         List<CQL3Type.Raw> argTypes = new ArrayList<>();
     }
@@ -675,7 +676,10 @@ createAggregateStatement returns [CreateAggregateStatement.Raw stmt]
       (
         K_INITCOND ival = term
       )?
-      { $stmt = new CreateAggregateStatement.Raw(fn, argTypes, stype, sfunc, ffunc, ival, orReplace, ifNotExists); }
+      (
+        K_DETERMINISTIC { deterministic = true; }
+      )?
+      { $stmt = new CreateAggregateStatement.Raw(fn, argTypes, stype, sfunc, ffunc, ival, orReplace, ifNotExists, deterministic); }
     ;
 
 dropAggregateStatement returns [DropAggregateStatement.Raw stmt]

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
@@ -59,6 +59,8 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
     private final String body;
     private final boolean orReplace;
     private final boolean ifNotExists;
+    private final boolean deterministic;
+    private final boolean monotonic;
 
     public CreateFunctionStatement(String keyspaceName,
                                    String functionName,
@@ -69,7 +71,9 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
                                    String language,
                                    String body,
                                    boolean orReplace,
-                                   boolean ifNotExists)
+                                   boolean ifNotExists,
+                                   boolean deterministic,
+                                   boolean monotonic)
     {
         super(keyspaceName);
         this.functionName = functionName;
@@ -81,6 +85,8 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
         this.body = body;
         this.orReplace = orReplace;
         this.ifNotExists = ifNotExists;
+        this.deterministic = deterministic;
+        this.monotonic = monotonic;
     }
 
     // TODO: replace affected aggregates !!
@@ -198,6 +204,24 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
         return new AuditLogContext(AuditLogEntryType.CREATE_FUNCTION, keyspaceName, functionName);
     }
 
+    @Override
+    Set<String> clientWarnings(KeyspacesDiff diff)
+    {
+        ImmutableSet.Builder<String> warnings = ImmutableSet.builder();
+
+        if (monotonic)
+        {
+            warnings.add("Unsupported function property was ignored (MONOTONIC)");
+        }
+
+        if (deterministic)
+        {
+            warnings.add("Unsupported function property was ignored (DETERMINISTIC)");
+        }
+
+        return warnings.build();
+    }
+
     public String toString()
     {
         return String.format("%s (%s, %s)", getClass().getSimpleName(), keyspaceName, functionName);
@@ -214,6 +238,8 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
         private final String body;
         private final boolean orReplace;
         private final boolean ifNotExists;
+        private final boolean deterministic;
+        private final boolean monotonic;
 
         public Raw(FunctionName name,
                    List<ColumnIdentifier> argumentNames,
@@ -223,7 +249,9 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
                    String language,
                    String body,
                    boolean orReplace,
-                   boolean ifNotExists)
+                   boolean ifNotExists,
+                   boolean deterministic,
+                   boolean monotonic)
         {
             this.name = name;
             this.argumentNames = argumentNames;
@@ -234,6 +262,8 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
             this.body = body;
             this.orReplace = orReplace;
             this.ifNotExists = ifNotExists;
+            this.deterministic = deterministic;
+            this.monotonic = monotonic;
         }
 
         public CreateFunctionStatement prepare(ClientState state)
@@ -249,7 +279,9 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
                                                language,
                                                body,
                                                orReplace,
-                                               ifNotExists);
+                                               ifNotExists,
+                                               deterministic,
+                                               monotonic);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateAggregateStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateAggregateStatementTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+public class CreateAggregateStatementTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.createKeyspace("ks", KeyspaceParams.simple(1));
+    }
+
+    @Test
+    public void ignoreUnsupportedKeywordsInAggregateCreationCommand() throws Throwable
+    {
+        String aggregateName = createAggregateName("ks");
+        String functionName = createFunctionName("ks");
+
+        executeNet(String.format("CREATE OR REPLACE FUNCTION %s(state double, val double) " +
+                                 "  RETURNS NULL ON NULL INPUT " +
+                                 "  RETURNS double " +
+                                 "  LANGUAGE javascript " +
+                                 "  AS '\"string\";';", functionName));
+
+        // should not throw
+        ResultSet rows = executeNet(String.format("CREATE OR REPLACE AGGREGATE %s(double) " +
+                                    "SFUNC %s " +
+                                    "STYPE double " +
+                                    "INITCOND 0 " +
+                                    "DETERMINISTIC", aggregateName, shortFunctionName(functionName)));
+
+        assertTrue(rows.wasApplied());
+
+        String warning = rows.getAllExecutionInfo().get(0).getWarnings().get(0);
+        assertThat(warning, containsString("Unsupported aggregate property was ignored (DETERMINISTIC)"));
+
+        assertNoUnsupportedProperties(aggregateName);
+    }
+
+    private void assertNoUnsupportedProperties(String aggregateName) throws Throwable
+    {
+        ResultSet result = executeNet("DESCRIBE AGGREGATE " + aggregateName);
+
+        String createStatement = result.one().getString("create_statement");
+        assertThat(createStatement, not(containsStringIgnoringCase("DETERMINISTIC")));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/statements/CreateFunctionStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/CreateFunctionStatementTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class CreateFunctionStatementTest extends CQLTester
+{
+    private static final String[] DETERMINISTIC_WARN =
+        new String[] { "Unsupported function property was ignored (DETERMINISTIC)" };
+    private static final String[] MONOTONIC_WARN =
+        new String[] { "Unsupported function property was ignored (MONOTONIC)" };
+    private static final String[] BOTH_WARNS = ArrayUtils.addAll(DETERMINISTIC_WARN, MONOTONIC_WARN);
+
+    @Parameterized.Parameters(name = "functionProperties = {0}, warnings = {1}")
+    public static Set<Object[]> functionProperties()
+    {
+        return ImmutableSet.of(
+            new Object[]{ "detERMINistic", DETERMINISTIC_WARN },
+            new Object[]{ "DETERMINISTIC", DETERMINISTIC_WARN },
+            new Object[]{ "MONOTONIC", MONOTONIC_WARN },
+            new Object[]{ "MONOTONIC ON num", MONOTONIC_WARN },
+            new Object[]{ "DETERMINISTIC MONOTONIC", BOTH_WARNS },
+            new Object[]{ "DETERMINISTIC MONOTONIC ON num", BOTH_WARNS }
+        );
+    }
+
+    @Parameterized.Parameter(0)
+    public String functionProperty;
+    @Parameterized.Parameter(1)
+    public String[] warnings;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.createKeyspace("ks", KeyspaceParams.simple(1));
+    }
+
+    @Test
+    public void ignoreUnsupportedKeywordsInFunctionCreationCommand() throws Throwable
+    {
+        String functionName = createFunctionName("ks");
+
+        // should not throw
+        ResultSet rows = executeNet(String.format("CREATE OR REPLACE FUNCTION %s (" +
+                                                  "  column text, num int ) " +
+                                                  "  RETURNS NULL ON NULL INPUT " +
+                                                  "  RETURNS text " +
+                                                  "  %s " +
+                                                  "  LANGUAGE javascript AS " +
+                                                  "    $$" +
+                                                  "      column.substring(0, num)" +
+                                                  "    $$;", functionName, functionProperty));
+
+        assertTrue(rows.wasApplied());
+
+        List<String> executionWarns = rows.getAllExecutionInfo().get(0).getWarnings();
+        assertThat(executionWarns, containsInAnyOrder(warnings));
+
+        assertNoUnsupportedProperties(functionName);
+    }
+
+    private void assertNoUnsupportedProperties(String functionName) throws Throwable
+    {
+        ResultSet result = executeNet("DESCRIBE FUNCTION " + functionName);
+
+        String createStatement = result.one().getString("create_statement");
+        assertThat(createStatement, not(containsStringIgnoringCase("DETERMINISTIC")));
+        assertThat(createStatement, not(containsStringIgnoringCase("MONOTONIC")));
+    }
+}


### PR DESCRIPTION
The keywords are ignored, the function is created successfully
(applied == true), a warning is issued to the caller.