### PR TITLE
STAR-511 Port guardrails: ignore table properties

### DIFF
--- a/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.db.marshal.*;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.pager.QueryPager;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.AbstractIterator;
@@ -62,11 +62,11 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
     @VisibleForTesting
     public static UntypedResultSet create(SelectStatement select,
                                           ConsistencyLevel cl,
-                                          ClientState clientState,
+                                          QueryState queryState,
                                           QueryPager pager,
                                           int pageSize)
     {
-        return new FromDistributedPager(select, cl, clientState, pager, pageSize);
+        return new FromDistributedPager(select, cl, queryState, pager, pageSize);
     }
 
     public boolean isEmpty()
@@ -227,19 +227,19 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
     {
         private final SelectStatement select;
         private final ConsistencyLevel cl;
-        private final ClientState clientState;
+        private final QueryState queryState;
         private final QueryPager pager;
         private final int pageSize;
         private final List<ColumnSpecification> metadata;
 
         private FromDistributedPager(SelectStatement select,
                                      ConsistencyLevel cl,
-                                     ClientState clientState,
+                                     QueryState queryState,
                                      QueryPager pager, int pageSize)
         {
             this.select = select;
             this.cl = cl;
-            this.clientState = clientState;
+            this.queryState = queryState;
             this.pager = pager;
             this.pageSize = pageSize;
             this.metadata = select.getResultMetadata().requestNames();
@@ -269,7 +269,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
                         if (pager.isExhausted())
                             return endOfData();
 
-                        try (PartitionIterator iter = pager.fetchPage(pageSize, cl, clientState, System.nanoTime()))
+                        try (PartitionIterator iter = pager.fetchPage(pageSize, cl, queryState, System.nanoTime()))
                         {
                             currentPage = select.process(iter, nowInSec).rows.iterator();
                         }

--- a/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
+++ b/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
@@ -151,4 +151,9 @@ public class PropertyDefinitions
     {
         return properties.keySet();
     }
+
+    public void removeProperty(String name)
+    {
+        properties.remove(name);
+    }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -230,34 +230,34 @@ public class SelectStatement implements CQLStatement
         // Nothing to do, all validation has been done by RawStatement.prepare()
     }
 
-    private void validateQueryOptions(QueryOptions options)
+    private void validateQueryOptions(QueryState queryState, QueryOptions options)
     {
         if (SchemaConstants.isUserKeyspace(table.keyspace))
-            Guardrails.disallowedWriteConsistencies.ensureAllowed(options.getConsistency());
+            Guardrails.disallowedWriteConsistencies.ensureAllowed(options.getConsistency(), queryState);
     }
 
-    public ResultMessage.Rows execute(QueryState state, QueryOptions options, long queryStartNanoTime)
+    public ResultMessage.Rows execute(QueryState queryState, QueryOptions options, long queryStartNanoTime)
     {
         ConsistencyLevel cl = options.getConsistency();
         checkNotNull(cl, "Invalid empty consistency level");
 
         cl.validateForRead(keyspace());
-        validateQueryOptions(options);
+        validateQueryOptions(queryState, options);
 
-        int nowInSec = options.getNowInSeconds(state);
+        int nowInSec = options.getNowInSeconds(queryState);
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
         int pageSize = options.getPageSize();
 
         Selectors selectors = selection.newSelectors(options);
-        ReadQuery query = getQuery(state, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, pageSize);
+        ReadQuery query = getQuery(queryState, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, pageSize);
 
         if (aggregationSpec == null && (pageSize <= 0 || (query.limits().count() <= pageSize)))
-            return execute(query, options, state, selectors, nowInSec, userLimit, queryStartNanoTime);
+            return execute(query, options, queryState, selectors, nowInSec, userLimit, queryStartNanoTime);
 
         QueryPager pager = getPager(query, options);
 
-        return execute(Pager.forDistributedQuery(pager, cl, state.getClientState()),
+        return execute(Pager.forDistributedQuery(pager, cl, queryState),
                        options,
                        selectors,
                        pageSize,
@@ -297,12 +297,12 @@ public class SelectStatement implements CQLStatement
 
     private ResultMessage.Rows execute(ReadQuery query,
                                        QueryOptions options,
-                                       QueryState state,
+                                       QueryState queryState,
                                        Selectors selectors,
                                        int nowInSec,
                                        int userLimit, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
     {
-        try (PartitionIterator data = query.execute(options.getConsistency(), state.getClientState(), queryStartNanoTime))
+        try (PartitionIterator data = query.execute(options.getConsistency(), queryState, queryStartNanoTime))
         {
             return processResults(data, options, selectors, nowInSec, userLimit);
         }
@@ -329,9 +329,9 @@ public class SelectStatement implements CQLStatement
             return new InternalPager(pager, executionController);
         }
 
-        public static Pager forDistributedQuery(QueryPager pager, ConsistencyLevel consistency, ClientState clientState)
+        public static Pager forDistributedQuery(QueryPager pager, ConsistencyLevel consistency, QueryState queryState)
         {
-            return new NormalPager(pager, consistency, clientState);
+            return new NormalPager(pager, consistency, queryState);
         }
 
         public boolean isExhausted()
@@ -349,18 +349,18 @@ public class SelectStatement implements CQLStatement
         public static class NormalPager extends Pager
         {
             private final ConsistencyLevel consistency;
-            private final ClientState clientState;
+            private final QueryState queryState;
 
-            private NormalPager(QueryPager pager, ConsistencyLevel consistency, ClientState clientState)
+            private NormalPager(QueryPager pager, ConsistencyLevel consistency, QueryState queryState)
             {
                 super(pager);
                 this.consistency = consistency;
-                this.clientState = clientState;
+                this.queryState = queryState;
             }
 
             public PartitionIterator fetchPage(int pageSize, long queryStartNanoTime)
             {
-                return pager.fetchPage(pageSize, consistency, clientState, queryStartNanoTime);
+                return pager.fetchPage(pageSize, consistency, queryState, queryStartNanoTime);
             }
         }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -413,6 +413,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             super.validate(state);
 
             Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
+            Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);
         }
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
@@ -66,6 +66,7 @@ public final class AlterViewStatement extends AlterSchemaStatement
         attrs.validate();
 
         Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
+        Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);
 
         TableParams params = attrs.asAlteredTableParams(view.metadata.params);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -103,8 +103,9 @@ public final class CreateTableStatement extends AlterSchemaStatement
         // require the server to be initialized, so skipping them if it isn't.
         if (Guardrails.ready())
         {
-            // Guardrail on table properties
+            // Guardrails on table properties
             Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
+            Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);
 
             // Guardrail on columns per table
             Guardrails.columnsPerTable.guard(rawColumns.size(), tableName, state);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -151,8 +151,9 @@ public final class CreateViewStatement extends AlterSchemaStatement
         if (table.isView())
             throw ire("Materialized views cannot be created against other materialized views");
 
-        // Guardrail on table properties
+        // Guardrails on table properties
         Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
+        Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);
 
         // guardrails to limit number of mvs per table.
         Set<ViewMetadata> baseTableViews = StreamSupport.stream(keyspace.views.forTable(table.id).spliterator(), false)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import org.apache.cassandra.cql3.statements.PropertyDefinitions;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -110,6 +111,11 @@ public final class TableAttributes extends PropertyDefinitions
         {
             return false;
         }
+    }
+
+    public static Set<String> allKeywords()
+    {
+        return Sets.union(validKeywords, obsoleteKeywords);
     }
 
     private TableParams build(TableParams.Builder builder)

--- a/src/java/org/apache/cassandra/db/ConsistencyLevel.java
+++ b/src/java/org/apache/cassandra/db/ConsistencyLevel.java
@@ -231,10 +231,10 @@ public enum ConsistencyLevel
     }
 
     // This is the same than validateForWrite really, but we include a slightly different error message for SERIAL/LOCAL_SERIAL
-    public void validateForCasCommit(String keyspaceName) throws InvalidRequestException
+    public void validateForCasCommit(String keyspaceName, QueryState queryState) throws InvalidRequestException
     {
         if (SchemaConstants.isUserKeyspace(keyspaceName))
-            Guardrails.disallowedWriteConsistencies.ensureAllowed(this);
+            Guardrails.disallowedWriteConsistencies.ensureAllowed(this, queryState);
 
         switch (this)
         {
@@ -247,10 +247,10 @@ public enum ConsistencyLevel
         }
     }
 
-    public void validateForCas(String keyspaceName) throws InvalidRequestException
+    public void validateForCas(String keyspaceName, QueryState queryState) throws InvalidRequestException
     {
         if (SchemaConstants.isUserKeyspace(keyspaceName))
-            Guardrails.disallowedWriteConsistencies.ensureAllowed(this);
+            Guardrails.disallowedWriteConsistencies.ensureAllowed(this, queryState);
 
         if (!isSerialConsistency())
             throw new InvalidRequestException("Invalid consistency for conditional update. Must be one of SERIAL or LOCAL_SERIAL");

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -43,7 +43,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.service.pager.QueryPager;
 import org.apache.cassandra.service.reads.ReadCallback;
@@ -335,7 +335,7 @@ public class MultiRangeReadCommand extends ReadCommand
     }
 
     @Override
-    public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+    public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         // MultiRangeReadCommand should only be executed on the replica side
         throw new UnsupportedOperationException();

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -41,7 +41,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.metrics.TableMetrics;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.tracing.Tracing;
 
@@ -263,7 +263,7 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         return dataRange.isReversed();
     }
 
-    public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+    public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime);
     }

--- a/src/java/org/apache/cassandra/db/ReadQuery.java
+++ b/src/java/org/apache/cassandra/db/ReadQuery.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.pager.QueryPager;
 import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -48,7 +48,7 @@ public interface ReadQuery
                 return ReadExecutionController.empty();
             }
 
-            public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+            public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
             {
                 return EmptyIterators.partition();
             }
@@ -140,12 +140,12 @@ public interface ReadQuery
      * Executes the query at the provided consistency level.
      *
      * @param consistency the consistency level to achieve for the query.
-     * @param clientState the {@code ClientState} for the query. In practice, this can be null unless
+     * @param queryState the {@code QueryState} for the query. In practice, this can be null unless
      * {@code consistency} is a serial consistency.
      *
      * @return the result of the query.
      */
-    public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException;
+    public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException;
 
     /**
      * Execute the query for internal queries (that is, it basically executes the query locally).

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -382,12 +382,12 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
                       lastReturned == null ? clusteringIndexFilter() : clusteringIndexFilter.forPaging(metadata().comparator, lastReturned, false));
     }
 
-    public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+    public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         if (clusteringIndexFilter.isEmpty(metadata().comparator))
             return EmptyIterators.partition();
 
-        return StorageProxy.read(Group.one(this), consistency, clientState, queryStartNanoTime);
+        return StorageProxy.read(Group.one(this), consistency, queryState, queryStartNanoTime);
     }
 
     protected void recordLatency(TableMetrics metric, long latencyNanos)
@@ -1120,9 +1120,9 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
             return new Group(Collections.singletonList(command), command.limits());
         }
 
-        public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+        public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
         {
-            return StorageProxy.read(this, consistency, clientState, queryStartNanoTime);
+            return StorageProxy.read(this, consistency, queryState, queryStartNanoTime);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/VirtualTableReadQuery.java
+++ b/src/java/org/apache/cassandra/db/VirtualTableReadQuery.java
@@ -24,7 +24,7 @@ import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 
 /**
  * Base class for the {@code ReadQuery} implementations use to query virtual tables.
@@ -48,7 +48,7 @@ public abstract class VirtualTableReadQuery extends AbstractReadQuery
 
     @Override
     public PartitionIterator execute(ConsistencyLevel consistency,
-                                     ClientState clientState,
+                                     QueryState queryState,
                                      long queryStartNanoTime) throws RequestExecutionException
     {
         return executeInternal(executionController());

--- a/src/java/org/apache/cassandra/db/VirtualTableSinglePartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/VirtualTableSinglePartitionReadQuery.java
@@ -34,7 +34,7 @@ import org.apache.cassandra.db.virtual.VirtualTable;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 
 /**
  * A read query that selects a (part of a) single partition of a virtual table.
@@ -181,13 +181,13 @@ public class VirtualTableSinglePartitionReadQuery extends VirtualTableReadQuery 
             return new Group(Collections.singletonList(query), query.limits());
         }
 
-        public PartitionIterator execute(ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestExecutionException
+        public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
         {
             if (queries.size() == 1)
-                return queries.get(0).execute(consistency, clientState, queryStartNanoTime);
+                return queries.get(0).execute(consistency, queryState, queryStartNanoTime);
 
             return PartitionIterators.concat(queries.stream()
-                                                    .map(q -> q.execute(consistency, clientState, queryStartNanoTime))
+                                                    .map(q -> q.execute(consistency, queryState, queryStartNanoTime))
                                                     .collect(Collectors.toList()));
         }
     }

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.guardrails.Guardrail.DisableFlag;
 import org.apache.cassandra.guardrails.Guardrail.DisallowedValues;
+import org.apache.cassandra.guardrails.Guardrail.IgnoredValues;
 import org.apache.cassandra.guardrails.Guardrail.PercentageThreshold;
 import org.apache.cassandra.guardrails.Guardrail.Predicates;
 import org.apache.cassandra.guardrails.Guardrail.SizeThreshold;
@@ -88,6 +89,11 @@ public abstract class Guardrails
                                                                                                     () -> config.table_properties_disallowed,
                                                                                                     String::toLowerCase,
                                                                                                     "Table Properties");
+
+    public static final IgnoredValues<String> ignoredTableProperties = new IgnoredValues<>("ignored_table_properties",
+                                                                                                               () -> config.table_properties_ignored,
+                                                                                                               String::toLowerCase,
+                                                                                                               "Table Properties");
 
     @SuppressWarnings("unchecked")
     public static final Predicates<InetAddressAndPort> replicaDiskUsage =

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -73,6 +73,7 @@ public class GuardrailsConfig
     public Long tables_warn_threshold;
     public Long tables_failure_threshold;
     public Set<String> table_properties_disallowed;
+    public Set<String> table_properties_ignored;
 
     public Boolean user_timestamps_enabled;
 
@@ -122,6 +123,7 @@ public class GuardrailsConfig
         validateStrictlyPositiveInteger(in_select_cartesian_product_failure_threshold, "in_select_cartesian_product_failure_threshold");
 
         validateDisallowedTableProperties();
+        validateIgnoredTableProperties();
 
         validateDiskUsageThreshold();
 
@@ -164,6 +166,11 @@ public class GuardrailsConfig
         enforceDefault(table_properties_disallowed,
                        v -> table_properties_disallowed = v,
                        Collections.<String>emptySet(),
+                       Collections.<String>emptySet());
+
+        enforceDefault(table_properties_ignored,
+                       v -> table_properties_ignored = v,
+                       Collections.<String>emptySet(),
                        new LinkedHashSet<>(TableAttributes.allKeywords().stream()
                                                           .sorted()
                                                           .filter(p -> !p.equals("default_time_to_live"))
@@ -191,6 +198,16 @@ public class GuardrailsConfig
 
         if (!diff.isEmpty())
             throw new ConfigurationException(format("Invalid value for table_properties_disallowed guardrail: "
+                                                    + "'%s' do not parse as valid table properties", diff.toString()));
+    }
+
+    private void validateIgnoredTableProperties()
+    {
+        Set<String> diff = Sets.difference(table_properties_ignored.stream().map(String::toLowerCase).collect(Collectors.toSet()),
+                                           TableAttributes.allKeywords());
+
+        if (!diff.isEmpty())
+            throw new ConfigurationException(format("Invalid value for table_properties_ignored guardrail: "
                                                     + "'%s' do not parse as valid table properties", diff.toString()));
     }
 

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -164,7 +164,10 @@ public class GuardrailsConfig
         enforceDefault(table_properties_disallowed,
                        v -> table_properties_disallowed = v,
                        Collections.<String>emptySet(),
-                       new LinkedHashSet<>(TableAttributes.validKeywords.stream().sorted().filter(p -> !p.equals("default_time_to_live")).collect(Collectors.toList())));
+                       new LinkedHashSet<>(TableAttributes.allKeywords().stream()
+                                                          .sorted()
+                                                          .filter(p -> !p.equals("default_time_to_live"))
+                                                          .collect(Collectors.toList())));
 
         enforceDefault(partition_size_warn_threshold_in_mb, v -> partition_size_warn_threshold_in_mb = v, 100, 100);
         enforceDefault(partition_keys_in_select_failure_threshold, v -> partition_keys_in_select_failure_threshold = v, NO_LIMIT.intValue(), 20);
@@ -184,7 +187,7 @@ public class GuardrailsConfig
     private void validateDisallowedTableProperties()
     {
         Set<String> diff = Sets.difference(table_properties_disallowed.stream().map(String::toLowerCase).collect(Collectors.toSet()),
-                                           TableAttributes.validKeywords);
+                                           TableAttributes.allKeywords());
 
         if (!diff.isEmpty())
             throw new ConfigurationException(format("Invalid value for table_properties_disallowed guardrail: "

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -289,8 +289,8 @@ public class StorageProxy implements StorageProxyMBean
         try
         {
             TableMetadata metadata = Schema.instance.validateTable(keyspaceName, cfName);
-            consistencyForPaxos.validateForCas(keyspaceName);
-            consistencyForCommit.validateForCasCommit(keyspaceName);
+            consistencyForPaxos.validateForCas(keyspaceName, state);
+            consistencyForCommit.validateForCasCommit(keyspaceName, state);
 
             Supplier<Pair<PartitionUpdate, RowIterator>> updateProposer = () ->
             {
@@ -336,7 +336,7 @@ public class StorageProxy implements StorageProxyMBean
                            consistencyForPaxos,
                            consistencyForCommit,
                            consistencyForCommit,
-                           state.getClientState(),
+                           state,
                            queryStartNanoTime,
                            casWriteMetrics,
                            updateProposer);
@@ -409,7 +409,7 @@ public class StorageProxy implements StorageProxyMBean
      *     {@link ConsistencyLevel#LOCAL_SERIAL}).
      * @param consistencyForReplayCommits the consistency for the commit phase of "replayed" in-progress operations.
      * @param consistencyForCommit the consistency for the commit phase of _this_ operation update.
-     * @param state the client state.
+     * @param queryState the query state.
      * @param queryStartNanoTime the nano time for the start of the query this is part of. This is the base time for
      *     timeouts.
      * @param casMetrics the metrics to update for this operation.
@@ -425,7 +425,7 @@ public class StorageProxy implements StorageProxyMBean
                                        ConsistencyLevel consistencyForPaxos,
                                        ConsistencyLevel consistencyForReplayCommits,
                                        ConsistencyLevel consistencyForCommit,
-                                       ClientState state,
+                                       QueryState queryState,
                                        long queryStartNanoTime,
                                        CASClientRequestMetrics casMetrics,
                                        Supplier<Pair<PartitionUpdate, RowIterator>> createUpdateProposal)
@@ -435,9 +435,9 @@ public class StorageProxy implements StorageProxyMBean
         Keyspace keyspace = Keyspace.open(metadata.keyspace);
         try
         {
-            consistencyForPaxos.validateForCas(metadata.keyspace);
-            consistencyForReplayCommits.validateForCasCommit(metadata.keyspace);
-            consistencyForCommit.validateForCasCommit(metadata.keyspace);
+            consistencyForPaxos.validateForCas(metadata.keyspace, queryState);
+            consistencyForReplayCommits.validateForCasCommit(metadata.keyspace, queryState);
+            consistencyForCommit.validateForCasCommit(metadata.keyspace, queryState);
 
             long timeoutNanos = DatabaseDescriptor.getCasContentionTimeout(NANOSECONDS);
             while (System.nanoTime() - queryStartNanoTime < timeoutNanos)
@@ -451,7 +451,7 @@ public class StorageProxy implements StorageProxyMBean
                                                                     consistencyForPaxos,
                                                                     consistencyForReplayCommits,
                                                                     casMetrics,
-                                                                    state);
+                                                                    queryState.getClientState());
 
                 final UUID ballot = pair.ballot;
                 contentions += pair.contentions;
@@ -1697,10 +1697,10 @@ public class StorageProxy implements StorageProxyMBean
         return readOne(command, consistencyLevel, null, queryStartNanoTime);
     }
 
-    public static RowIterator readOne(SinglePartitionReadCommand command, ConsistencyLevel consistencyLevel, ClientState state, long queryStartNanoTime)
+    public static RowIterator readOne(SinglePartitionReadCommand command, ConsistencyLevel consistencyLevel, QueryState queryState, long queryStartNanoTime)
     throws UnavailableException, IsBootstrappingException, ReadFailureException, ReadTimeoutException, InvalidRequestException
     {
-        return PartitionIterators.getOnlyElement(read(SinglePartitionReadCommand.Group.one(command), consistencyLevel, state, queryStartNanoTime), command);
+        return PartitionIterators.getOnlyElement(read(SinglePartitionReadCommand.Group.one(command), consistencyLevel, queryState, queryStartNanoTime), command);
     }
 
     public static PartitionIterator read(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, long queryStartNanoTime)
@@ -1715,7 +1715,7 @@ public class StorageProxy implements StorageProxyMBean
      * Performs the actual reading of a row out of the StorageService, fetching
      * a specific set of column names from a given column family.
      */
-    public static PartitionIterator read(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, ClientState state, long queryStartNanoTime)
+    public static PartitionIterator read(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, QueryState queryState, long queryStartNanoTime)
     throws UnavailableException, IsBootstrappingException, ReadFailureException, ReadTimeoutException, InvalidRequestException
     {
         if (StorageService.instance.isBootstrapMode() && !systemKeyspaceQuery(group.queries))
@@ -1726,14 +1726,14 @@ public class StorageProxy implements StorageProxyMBean
         }
 
         return consistencyLevel.isSerialConsistency()
-             ? readWithPaxos(group, consistencyLevel, state, queryStartNanoTime)
+             ? readWithPaxos(group, consistencyLevel, queryState, queryStartNanoTime)
              : readRegular(group, consistencyLevel, queryStartNanoTime);
     }
 
-    private static PartitionIterator readWithPaxos(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, ClientState state, long queryStartNanoTime)
+    private static PartitionIterator readWithPaxos(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, QueryState queryState, long queryStartNanoTime)
     throws InvalidRequestException, UnavailableException, ReadFailureException, ReadTimeoutException
     {
-        assert state != null;
+        assert queryState != null;
         if (group.queries.size() > 1)
             throw new InvalidRequestException("SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time");
 
@@ -1766,7 +1766,7 @@ public class StorageProxy implements StorageProxyMBean
                         consistencyLevel,
                         consistencyForReplayCommitsOrFetch,
                         ConsistencyLevel.ANY,
-                        state,
+                        queryState,
                         start,
                         casReadMetrics,
                         updateProposer);

--- a/src/java/org/apache/cassandra/service/pager/AbstractQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/AbstractQueryPager.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.ProtocolVersion;
 
 abstract class AbstractQueryPager<T extends ReadQuery> implements QueryPager
@@ -59,7 +59,7 @@ abstract class AbstractQueryPager<T extends ReadQuery> implements QueryPager
         return query.executionController();
     }
 
-    public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime)
+    public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime)
     {
         if (isExhausted())
             return EmptyIterators.partition();
@@ -72,7 +72,7 @@ abstract class AbstractQueryPager<T extends ReadQuery> implements QueryPager
             exhausted = true;
             return EmptyIterators.partition();
         }
-        return Transformation.apply(readQuery.execute(consistency, clientState, queryStartNanoTime), pager);
+        return Transformation.apply(readQuery.execute(consistency, queryState, queryStartNanoTime), pager);
     }
 
     public PartitionIterator fetchPageInternal(int pageSize, ReadExecutionController executionController)

--- a/src/java/org/apache/cassandra/service/pager/QueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/QueryPager.java
@@ -24,7 +24,7 @@ import org.apache.cassandra.db.EmptyIterators;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.RequestValidationException;
-import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
 
 /**
  * Perform a query, paging it by page of a given size.
@@ -54,7 +54,7 @@ public interface QueryPager
             return ReadExecutionController.empty();
         }
 
-        public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
+        public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
         {
             return EmptyIterators.partition();
         }
@@ -90,11 +90,11 @@ public interface QueryPager
      *
      * @param pageSize the maximum number of elements to return in the next page.
      * @param consistency the consistency level to achieve for the query.
-     * @param clientState the {@code ClientState} for the query. In practice, this can be null unless
+     * @param queryState the {@code QueryState} for the query. In practice, this can be null unless
      * {@code consistency} is a serial consistency.
      * @return the page of result.
      */
-    public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException;
+    public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException;
 
     /**
      * Starts a new read operation.


### PR DESCRIPTION
These changes mainly come from  [DB-4909](https://datastax.jira.com/browse/DB-4909) [DSE PR 19467](https://github.com/riptano/bdp/pull/19467/files)

Some pre-reqs come from [DB-3795](https://datastax.jira.com/browse/DB-3795) [DSE PR 16648](https://github.com/riptano/bdp/pull/16648/files)