### PR TITLE
STAR-674: Enable trickle_fsync option by default

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -633,7 +633,7 @@ index_summary_resize_interval_in_minutes: 60
 # buffers. Enable this to avoid sudden dirty buffer flushing from
 # impacting read latencies. Almost always a good idea on SSDs; not
 # necessarily on platters.
-trickle_fsync: false
+trickle_fsync: true
 trickle_fsync_interval_in_kb: 10240
 
 # TCP port, for commands and data

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -292,7 +292,7 @@ public class Config
     public ParameterizedClass hints_compression;
 
     public volatile boolean incremental_backups = false;
-    public boolean trickle_fsync = false;
+    public boolean trickle_fsync = true;
     public int trickle_fsync_interval_in_kb = 10240;
 
     public volatile int sstable_preemptive_open_interval_in_mb = 50;


### PR DESCRIPTION
DSE already has this option enabled by default since it can help performance when the host machine hasn't configure the VM dirty settings properly. I saw no improvement when running tests with this patch, and crucially, no performance regressions either:

- https://fallout.sjc.dsinternal.org/performance/matt.fleming@datastax.com/report/becb9cd1-6c46-47b9-aa11-61e75d65b470
- https://fallout.sjc.dsinternal.org/performance/matt.fleming@datastax.com/report/6ee5821a-0b1f-4e4e-8fd8-25124aab43ff