### PR TITLE
STAR-429 cqlsh disable cqlsh_history logging

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -234,6 +234,7 @@ parser.add_option("-t", "--tty", action='store_true', dest='tty',
                   help='Force tty mode (command prompt).')
 parser.add_option("--no-file-io", action='store_true', dest='no_file_io',
                   help='Disable cqlsh commands that perform file I/O.')
+parser.add_option('--disable-history', action='store_true', help='Disable saving of history', default=False)
 
 optvalues = optparse.Values()
 (options, arguments) = parser.parse_args(sys.argv[1:], values=optvalues)
@@ -2180,6 +2181,7 @@ def read_options(cmdlineargs, environment):
     optvalues.request_timeout = option_with_default(configs.getint, 'connection', 'request_timeout', DEFAULT_REQUEST_TIMEOUT_SECONDS)
     optvalues.execute = None
     optvalues.no_file_io = option_with_default(configs.getboolean, 'ui', 'no_file_io', DEFAULT_NO_FILE_IO)
+    optvalues.disable_history = option_with_default(configs.getboolean, 'history', 'disabled', False)
 
     (options, arguments) = parser.parse_args(cmdlineargs, values=optvalues)
     # Make sure some user values read from the command line are in unicode
@@ -2264,8 +2266,8 @@ def init_history():
         readline.set_completer_delims(delims)
 
 
-def save_history():
-    if readline is not None:
+def save_history(history_disabled=False):
+    if readline is not None and not history_disabled:
         try:
             readline.write_history_file(HISTORY)
         except IOError:
@@ -2371,7 +2373,7 @@ def main(options, hostname, port):
         signal.signal(signal.SIGHUP, handle_sighup)
 
     shell.cmdloop()
-    save_history()
+    save_history(options.disable_history)
 
     if shell.batch_mode and shell.statement_error:
         sys.exit(2)


### PR DESCRIPTION
We can disable saving of the history either via command-line parameter
--disable-history, or by setting disabled = True in the history section of the
cqlshrc. Both options will read existing history, and just won't save new commands.

Co-authored-by: Alex Ott alexott@gmail.com