### PR TITLE
STAR-564 Check only MODIFY on base when updating table with MV

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+Future version (tbd)
+ * Require only MODIFY permission on base when updating table with MV (STAR-564)
+
 4.0-rc2
  * cqlsh: fix DESC TYPE with non-ascii character in the identifier (CASSANDRA-16400)
  * Remove drivers dependency and bring cql_keywords_reserved on server side (CASSANDRA-16659)

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -244,17 +244,7 @@ public abstract class ModificationStatement implements CQLStatement
         if (hasConditions())
             state.ensureTablePermission(metadata, Permission.SELECT);
 
-        // MV updates need to get the current state from the table, and might update the views
-        // Require Permission.SELECT on the base table, and Permission.MODIFY on the views
-        Iterator<ViewMetadata> views = View.findAll(keyspace(), columnFamily()).iterator();
-        if (views.hasNext())
-        {
-            state.ensureTablePermission(metadata, Permission.SELECT);
-            do
-            {
-                state.ensureTablePermission(views.next().metadata, Permission.MODIFY);
-            } while (views.hasNext());
-        }
+        // Modification on base table with MV should skip SELECT access control to base table and WRITE access control to view table.
 
         for (Function function : getFunctions())
             state.ensurePermission(Permission.EXECUTE, function);


### PR DESCRIPTION
If a user has only MODIFY permission on a table and there is a 
materialized view built on the same table an insert will fail 
with the following error:
Unauthorized: Error from server: code=2100 [Unauthorized]

Only base MODIFY permission is required to update base with MV