### PR TITLE
STAR-565  Use the indexed item type as backing table key validator

### DIFF
--- a/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
@@ -742,7 +742,7 @@ public abstract class CassandraIndex implements Index
             TableMetadata.builder(baseCfsMetadata.keyspace, baseCfsMetadata.indexTableName(indexMetadata), baseCfsMetadata.id)
                          .kind(TableMetadata.Kind.INDEX)
                          .partitioner(new LocalPartitioner(indexedValueType))
-                         .addPartitionKeyColumn(indexedColumn.name, indexedColumn.type)
+                         .addPartitionKeyColumn(indexedColumn.name, indexedValueType)
                          .addClusteringColumn("partition_key", baseCfsMetadata.partitioner.partitionOrdering());
 
         // Adding clustering columns, which depends on the index type.


### PR DESCRIPTION
... of 2i on collections

Co-authored-by: Andrés de la Peña andres.de_la_pena_garcia@datastax.com
