### PR TITLE
STAR-570 Synchronize schema pull handling

### DIFF
--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -393,7 +393,7 @@ public final class SchemaKeyspace
         return PartitionRangeReadCommand.allDataRead(cfs.metadata(), FBUtilities.nowInSeconds());
     }
 
-    static Collection<Mutation> convertSchemaToMutations()
+    static synchronized Collection<Mutation> convertSchemaToMutations()
     {
         Map<DecoratedKey, Mutation.PartitionUpdateCollector> mutationMap = new HashMap<>();
 


### PR DESCRIPTION
Synchronize schema pull handling with applying new schema changes

There's a race condition around pulling schema changes, that can occur
in case the schema changes push/propagation mechanism is not
immediately effective (e.g. because of network delay, or because of
the pulling node being down, etc.).

If schema changes happen on node 1, these changes do not reach node 2
immediately through the SCHEMA.PUSH mechanism, and are first
recognized during gossiping, the corresponding SCHEMA.PULL request
from node 2 can catch the node 1 schema in the middle of it being
modified by another schema change request. This can easily lead to
problems (e.g. if a new table is being added, and the node 2 request
reads the changes that need to be applied to system_schema.tables, but
not the ones that need to be applied to system_schema.columns).

This PR addresses that by synchronizing the SCHEMA.PULL "RPC call"
executed in node 1 by a request from node 2 with the method for
applying schema changes in node 1.

It also adds debug level logging tracking SCHEMA.PUSH and SCHEMA.PULL
messages, as there were some unexpected findings around these that may
need further investigation.

E.g. during my investigations, seemingly redundant SCHEMA.PULL
messages were sent multiple times from node 1 to node 2, even though
no schema changes were made at node 2, and node 2 did not go offline.

Co-authored-by: Dimitar Dimitrov
Port of https://github.com/riptano/apollo/pull/488