### PR TITLE
STAR-745: Recreate BF on fp chance change and limit the total memory usage

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/Verifier.java
+++ b/src/java/org/apache/cassandra/db/compaction/Verifier.java
@@ -43,7 +43,7 @@ import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.utils.BloomFilterSerializer;
+import org.apache.cassandra.utils.BloomFilter;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.IFilter;
@@ -448,7 +448,7 @@ public class Verifier implements Closeable
         if (Files.exists(bfPath))
         {
             try (DataInputStream stream = new DataInputStream(new BufferedInputStream(Files.newInputStream(bfPath)));
-                 IFilter bf = BloomFilterSerializer.deserialize(stream, sstable.descriptor.version.hasOldBfFormat()))
+                 IFilter bf = BloomFilter.serializer.deserialize(stream, sstable.descriptor.version.hasOldBfFormat()))
             {
             }
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -740,7 +740,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         File filterFile = new File(descriptor.filenameFor(Component.FILTER));
         try (DataOutputStreamPlus stream = new BufferedDataOutputStreamPlus(new FileOutputStream(filterFile)))
         {
-            BloomFilterSerializer.serialize((BloomFilter) filter, stream);
+            BloomFilter.serializer.serialize((BloomFilter) filter, stream);
             stream.flush();
         }
         catch (IOException e)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -235,7 +235,7 @@ public abstract class SSTableReaderBuilder
     {
         try (DataInputStream stream = new DataInputStream(new BufferedInputStream(Files.newInputStream(Paths.get(descriptor.filenameFor(Component.FILTER))))))
         {
-            return BloomFilterSerializer.deserialize(stream, descriptor.version.hasOldBfFormat());
+            return BloomFilter.serializer.deserialize(stream, descriptor.version.hasOldBfFormat());
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.RowIndexEntry;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.io.sstable.*;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
 import org.apache.cassandra.io.util.DiskOptimizationStrategy;
@@ -43,9 +44,16 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+import static org.apache.cassandra.utils.BloomFilter.fpChanceTolerance;
 
 public abstract class SSTableReaderBuilder
 {
@@ -226,17 +234,29 @@ public abstract class SSTableReaderBuilder
         }
     }
 
-    /**
-     * Load bloom filter from Filter.db file.
-     *
-     * @throws IOException
-     */
-    IFilter loadBloomFilter() throws IOException
+    public static IFilter loadBloomFilter(Path path, boolean oldFormat)
     {
-        try (DataInputStream stream = new DataInputStream(new BufferedInputStream(Files.newInputStream(Paths.get(descriptor.filenameFor(Component.FILTER))))))
+        if (Files.exists(path))
         {
-            return BloomFilter.serializer.deserialize(stream, descriptor.version.hasOldBfFormat());
+            IFilter filter = null;
+            try (DataInputStream stream = new DataInputStream(new BufferedInputStream(Files.newInputStream(path))))
+            {
+                filter = BloomFilter.serializer.deserialize(stream, oldFormat);
+                return filter;
+            }
+            catch (Throwable t)
+            {
+                JVMStabilityInspector.inspectThrowable(t);
+                logger.error("Failed to deserialize Bloom filter: {}", t.getMessage());
+                if (filter != null)
+                    filter.close();
+            }
         }
+        else
+        {
+            logger.error("Bloom filter {} not found", path);
+        }
+        return null;
     }
 
     public static class ForWriter extends SSTableReaderBuilder
@@ -381,11 +401,10 @@ public abstract class SSTableReaderBuilder
                           DiskOptimizationStrategy optimizationStrategy,
                           StatsMetadata statsMetadata) throws IOException
         {
-            if (metadata.params.bloomFilterFpChance == 1.0)
+            if (!BloomFilter.shouldUseBloomFilter(metadata.params.bloomFilterFpChance))
             {
                 // bf is disabled.
                 load(false, !isOffline, optimizationStrategy, statsMetadata, components);
-                bf = FilterFactory.AlwaysPresent;
             }
             else if (!components.contains(Component.PRIMARY_INDEX)) // What happens if filter component and primary index is missing?
             {
@@ -397,15 +416,21 @@ public abstract class SSTableReaderBuilder
             {
                 // bf is enabled, but filter component is missing.
                 load(!isOffline, !isOffline, optimizationStrategy, statsMetadata, components);
-                if (isOffline)
-                    bf = FilterFactory.AlwaysPresent;
+            }
+            else if (!BloomFilter.isFPChanceDiffNeglectable(metadata.params.bloomFilterFpChance, validationMetadata.bloomFilterFPChance) && BloomFilter.recreateOnFPChanceChange)
+            {
+                // bf is enabled, but fp chance changed
+                load(!isOffline, !isOffline, optimizationStrategy, statsMetadata, components);
             }
             else
             {
                 // bf is enabled and fp chance matches the currently configured value.
-                load(false, !isOffline, optimizationStrategy, statsMetadata, components);
-                bf = loadBloomFilter();
+                bf = loadBloomFilter(Paths.get(descriptor.filenameFor(Component.FILTER)), descriptor.version.hasOldBfFormat());
+                load(bf == null, !isOffline, optimizationStrategy, statsMetadata, components);
             }
+            // if the filter was neither loaded nor created, or we encountered some problems, we fallback to pass-through filter
+            if (bf == null)
+                bf = FilterFactory.AlwaysPresent;
         }
 
         /**
@@ -448,7 +473,11 @@ public abstract class SSTableReaderBuilder
                     if (saveSummaryIfCreated)
                         SSTableReader.saveSummary(descriptor, first, last, summary);
                     if (recreateBloomFilter)
+                    {
                         SSTableReader.saveBloomFilter(descriptor, bf);
+                        ValidationMetadata updatedValidationMetadata = new ValidationMetadata(validationMetadata.partitioner, metadata.params.bloomFilterFpChance);
+                        descriptor.getMetadataSerializer().updateSSTableMetadata(descriptor, ImmutableMap.of(MetadataType.VALIDATION, updatedValidationMetadata));
+                    }
                 }
             }
             catch (Throwable t)
@@ -461,6 +490,12 @@ public abstract class SSTableReaderBuilder
                 if (dfile != null)
                 {
                     dfile.close();
+                }
+
+                if (bf != null)
+                {
+                    bf.close();
+                    bf = null;
                 }
 
                 if (summary != null)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -46,14 +46,10 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-
-import static org.apache.cassandra.utils.BloomFilter.fpChanceTolerance;
 
 public abstract class SSTableReaderBuilder
 {
@@ -96,30 +92,6 @@ public abstract class SSTableReaderBuilder
     }
 
     public abstract SSTableReader build();
-
-    public SSTableReaderBuilder dfile(FileHandle dfile)
-    {
-        this.dfile = dfile;
-        return this;
-    }
-
-    public SSTableReaderBuilder ifile(FileHandle ifile)
-    {
-        this.ifile = ifile;
-        return this;
-    }
-
-    public SSTableReaderBuilder bf(IFilter bf)
-    {
-        this.bf = bf;
-        return this;
-    }
-
-    public SSTableReaderBuilder summary(IndexSummary summary)
-    {
-        this.summary = summary;
-        return this;
-    }
 
     /**
      * Load index summary, first key and last key from Summary.db file if it exists.
@@ -272,6 +244,30 @@ public abstract class SSTableReaderBuilder
             super(descriptor, metadataRef, maxDataAge, components, statsMetadata, openReason, header);
         }
 
+        public SSTableReaderBuilder.ForWriter dfile(FileHandle dfile)
+        {
+            this.dfile = dfile;
+            return this;
+        }
+
+        public SSTableReaderBuilder.ForWriter ifile(FileHandle ifile)
+        {
+            this.ifile = ifile;
+            return this;
+        }
+
+        public SSTableReaderBuilder.ForWriter bf(IFilter bf)
+        {
+            this.bf = bf;
+            return this;
+        }
+
+        public SSTableReaderBuilder.ForWriter summary(IndexSummary summary)
+        {
+            this.summary = summary;
+            return this;
+        }
+
         @Override
         public SSTableReader build()
         {
@@ -296,6 +292,7 @@ public abstract class SSTableReaderBuilder
         @Override
         public SSTableReader build()
         {
+            assert dfile == null && ifile == null && summary == null && bf == null;
             String dataFilePath = descriptor.filenameFor(Component.DATA);
             long fileLength = new File(dataFilePath).length();
             logger.info("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));
@@ -366,6 +363,7 @@ public abstract class SSTableReaderBuilder
         @Override
         public SSTableReader build()
         {
+            assert dfile == null && ifile == null && summary == null && bf == null;
             String dataFilePath = descriptor.filenameFor(Component.DATA);
             long fileLength = new File(dataFilePath).length();
             logger.info("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -539,7 +539,7 @@ public class BigTableWriter extends SSTableWriter
                      DataOutputStreamPlus stream = new BufferedDataOutputStreamPlus(fos))
                 {
                     // bloom filter
-                    BloomFilterSerializer.serialize((BloomFilter) bf, stream);
+                    BloomFilter.serializer.serialize((BloomFilter) bf, stream);
                     stream.flush();
                     SyncUtil.sync(fos);
                 }

--- a/src/java/org/apache/cassandra/io/sstable/metadata/IMetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/IMetadataSerializer.java
@@ -100,4 +100,11 @@ public interface IMetadataSerializer
      * Replace the sstable metadata file ({@code -Statistics.db}) with the given components.
      */
     void rewriteSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> currentComponents) throws IOException;
+
+    /**
+     * Updates the sstable metadata components (works similarly to {@link #rewriteSSTableMetadata(Descriptor, Map)} but
+     * only updates the provided components rather than replacing the whole metadata map).
+     */
+    void updateSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> updatedComponents) throws IOException;
+
 }

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -279,4 +279,12 @@ public class MetadataSerializer implements IMetadataSerializer
         FileUtils.renameWithConfirm(filePath, descriptor.filenameFor(Component.STATS));
 
     }
+
+    public void updateSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> updatedComponents) throws IOException
+    {
+        Map<MetadataType, MetadataComponent> currentComponents = deserialize(descriptor, EnumSet.allOf(MetadataType.class));
+        currentComponents.putAll(updatedComponents);
+        rewriteSSTableMetadata(descriptor, currentComponents);
+    }
+
 }

--- a/src/java/org/apache/cassandra/utils/BloomFilter.java
+++ b/src/java/org/apache/cassandra/utils/BloomFilter.java
@@ -21,8 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import net.nicoulaj.compilecommand.annotations.Inline;
-import org.apache.cassandra.io.sstable.metadata.MetadataType;
-import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.WrappedSharedCloseable;
 import org.apache.cassandra.utils.obs.IBitSet;
@@ -30,13 +29,31 @@ import org.apache.cassandra.utils.obs.MemoryLimiter;
 
 public class BloomFilter extends WrappedSharedCloseable implements IFilter
 {
-    private static final long maxMemory = Long.getLong("cassandra.bf.max_memory_mb", 0) << 20;
+    /**
+     * The maximum memory to be used by all loaded bloom filters. If the limit is exceeded, pass-through filter will be
+     * used until some filters get unloaded.
+     */
+    public final static String MAX_MEMORY_MB_PROP = Config.PROPERTY_PREFIX + "bf.max_memory_mb";
+
+    /**
+     * A minimal relative change of the fase-positive chance so that it is considered as a reason to recreate the bloom
+     * filter. If the change is smaller than this, it will be ignored.
+     */
+    public final static String FP_CHANCE_TOLERANCE_PROP = Config.PROPERTY_PREFIX + "bf.fp_chance_tolerance";
+
+    /**
+     * If the false-positive chance has changed since the last compaction (for example by alter table statement), and
+     * the node is restarted - the bloom filter can get rebuilt if this property jest set to true.
+     */
+    public final static String RECREATE_ON_FP_CHANCE_CHANGE = Config.PROPERTY_PREFIX + "bf.recreate_on_fp_chance_change";
+
+    private static final long maxMemory = Long.getLong(MAX_MEMORY_MB_PROP, 0) << 20;
 
     @VisibleForTesting
-    public static double fpChanceTolerance = Double.parseDouble(System.getProperty("cassandra.bf.fp_chance_tolerance", "0.000001"));
+    public static double fpChanceTolerance = Double.parseDouble(System.getProperty(FP_CHANCE_TOLERANCE_PROP, "0.000001"));
 
     @VisibleForTesting
-    public static boolean recreateOnFPChanceChange = Boolean.getBoolean("cassandra.bf.recreate_on_fp_chance_change");
+    public static boolean recreateOnFPChanceChange = Boolean.getBoolean(RECREATE_ON_FP_CHANCE_CHANGE);
 
     public static final MemoryLimiter memoryLimiter = new MemoryLimiter(maxMemory != 0 ? maxMemory : Long.MAX_VALUE,
                                                                         "Allocating %s for Bloom filter would reach max of %s (current %s)");

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -33,7 +33,7 @@ public class FilterFactory
 
     /**
      * @return A BloomFilter with the lowest practical false positive
-     * probability for the given number of elements.
+     *         probability for the given number of elements.
      */
     public static IFilter getFilter(long numElements, int targetBucketsPerElem)
     {

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.utils.obs.IBitSet;
+import org.apache.cassandra.utils.obs.MemoryLimiter;
 import org.apache.cassandra.utils.obs.OffHeapBitSet;
 
 public class FilterFactory
@@ -32,9 +33,14 @@ public class FilterFactory
 
     /**
      * @return A BloomFilter with the lowest practical false positive
-     *         probability for the given number of elements.
+     * probability for the given number of elements.
      */
     public static IFilter getFilter(long numElements, int targetBucketsPerElem)
+    {
+        return getFilter(numElements, targetBucketsPerElem, BloomFilter.memoryLimiter);
+    }
+
+    public static IFilter getFilter(long numElements, int targetBucketsPerElem, MemoryLimiter memoryLimiter)
     {
         int maxBucketsPerElement = Math.max(1, BloomCalculations.maxBucketsPerElement(numElements));
         int bucketsPerElement = Math.min(targetBucketsPerElem, maxBucketsPerElement);
@@ -43,31 +49,46 @@ public class FilterFactory
             logger.warn("Cannot provide an optimal BloomFilter for {} elements ({}/{} buckets per element).", numElements, bucketsPerElement, targetBucketsPerElem);
         }
         BloomCalculations.BloomSpecification spec = BloomCalculations.computeBloomSpec(bucketsPerElement);
-        return createFilter(spec.K, numElements, spec.bucketsPerElement);
+        return createFilter(spec.K, numElements, spec.bucketsPerElement, memoryLimiter);
     }
 
     /**
      * @return The smallest BloomFilter that can provide the given false
-     *         positive probability rate for the given number of elements.
-     *
-     *         Asserts that the given probability can be satisfied using this
-     *         filter.
+     * positive probability rate for the given number of elements.
+     * <p>
+     * Asserts that the given probability can be satisfied using this
+     * filter.
      */
     public static IFilter getFilter(long numElements, double maxFalsePosProbability)
     {
+        return getFilter(numElements, maxFalsePosProbability, BloomFilter.memoryLimiter);
+    }
+
+    public static IFilter getFilter(long numElements, double maxFalsePosProbability, MemoryLimiter memoryLimiter)
+    {
         assert maxFalsePosProbability <= 1.0 : "Invalid probability";
         if (maxFalsePosProbability == 1.0)
-            return new AlwaysPresentFilter();
+            return AlwaysPresent;
         int bucketsPerElement = BloomCalculations.maxBucketsPerElement(numElements);
         BloomCalculations.BloomSpecification spec = BloomCalculations.computeBloomSpec(bucketsPerElement, maxFalsePosProbability);
-        return createFilter(spec.K, numElements, spec.bucketsPerElement);
+        return createFilter(spec.K, numElements, spec.bucketsPerElement, memoryLimiter);
     }
 
     @SuppressWarnings("resource")
-    private static IFilter createFilter(int hash, long numElements, int bucketsPer)
+    private static IFilter createFilter(int hash, long numElements, int bucketsPer, MemoryLimiter memoryLimiter)
     {
-        long numBits = (numElements * bucketsPer) + BITSET_EXCESS;
-        IBitSet bitset = new OffHeapBitSet(numBits);
-        return new BloomFilter(hash, bitset);
+        try
+        {
+            long numBits = (numElements * bucketsPer) + BITSET_EXCESS;
+            IBitSet bitset = new OffHeapBitSet(numBits, memoryLimiter);
+            return new BloomFilter(hash, bitset);
+        }
+        catch (MemoryLimiter.ReachedMemoryLimitException | OutOfMemoryError e)
+        {
+            logger.error("Failed to create new Bloom filter with {} elements: ({}) - " +
+                         "continuing but this will have severe performance implications, consider increasing FP chance or" +
+                         "lowering number of sstables through compaction", numElements, e.getMessage());
+            return AlwaysPresent;
+        }
     }
 }

--- a/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
+++ b/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.obs;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.cassandra.utils.FBUtilities;
+
+public class MemoryLimiter
+{
+    public final long maxMemory;
+    private final AtomicLong currentMemory;
+    private final String exceptionFormat;
+
+    public MemoryLimiter(long maxMemory, String exceptionFormat)
+    {
+        this.maxMemory = maxMemory;
+        this.currentMemory = new AtomicLong();
+        this.exceptionFormat = exceptionFormat;
+    }
+
+    public void increment(long bytesCount) throws ReachedMemoryLimitException
+    {
+        long bytesCountAfterAllocation = this.currentMemory.addAndGet(bytesCount);
+        if (bytesCountAfterAllocation >= maxMemory)
+        {
+            this.currentMemory.addAndGet(-bytesCount);
+
+            throw new ReachedMemoryLimitException(String.format(exceptionFormat,
+                                                                FBUtilities.prettyPrintMemory(bytesCount),
+                                                                FBUtilities.prettyPrintMemory(maxMemory),
+                                                                FBUtilities.prettyPrintMemory(bytesCountAfterAllocation - bytesCount)));
+        }
+    }
+
+    public void decrement(long value)
+    {
+        long result = this.currentMemory.addAndGet(-value);
+        assert result >= 0;
+    }
+
+    public long memoryAllocated()
+    {
+        return currentMemory.get();
+    }
+
+    public static class ReachedMemoryLimitException extends Exception
+    {
+        public ReachedMemoryLimitException(String message)
+        {
+            super(message);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
+++ b/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
@@ -37,6 +37,7 @@ public class MemoryLimiter
 
     public void increment(long bytesCount) throws ReachedMemoryLimitException
     {
+        assert bytesCount >= 0;
         long bytesCountAfterAllocation = this.currentMemory.addAndGet(bytesCount);
         if (bytesCountAfterAllocation >= maxMemory)
         {
@@ -49,9 +50,10 @@ public class MemoryLimiter
         }
     }
 
-    public void decrement(long value)
+    public void decrement(long bytesCount)
     {
-        long result = this.currentMemory.addAndGet(-value);
+        assert bytesCount >= 0;
+        long result = this.currentMemory.addAndGet(-bytesCount);
         assert result >= 0;
     }
 

--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -17,9 +17,7 @@
  */
 package org.apache.cassandra.utils.obs;
 
-import java.io.DataInput;
 import java.io.DataInputStream;
-import java.io.DataOutput;
 import java.io.IOException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -37,18 +35,25 @@ import org.apache.cassandra.utils.concurrent.Ref;
  */
 public class OffHeapBitSet implements IBitSet
 {
+    /** The maximum memory that can be used by bloom filters, in megabytes, overall.
+     * The default is unlimited, a limit should only be set as a last resort measure. */
+    @VisibleForTesting
+//    public static final long maxMemory = SizeUnit.MEGABYTES.toBytes(PropertyConfiguration.getLong("cassandra.max_bf_memory_mb", Long.MAX_VALUE));
+//    private static final AtomicLong memoryAllocated = new AtomicLong(0);
     private final Memory bytes;
+    private final MemoryLimiter memoryLimiter;
 
-    public OffHeapBitSet(long numBits)
+    public OffHeapBitSet(long numBits, MemoryLimiter memoryLimiter) throws MemoryLimiter.ReachedMemoryLimitException
     {
-        /** returns the number of 64 bit words it would take to hold numBits */
+        this.memoryLimiter = memoryLimiter;
+        // returns the number of 64 bit words it would take to hold numBits
         long wordCount = (((numBits - 1) >>> 6) + 1);
         if (wordCount > Integer.MAX_VALUE)
             throw new UnsupportedOperationException("Bloom filter size is > 16GB, reduce the bloom_filter_fp_chance");
         try
         {
             long byteCount = wordCount * 8L;
-            bytes = Memory.allocate(byteCount);
+            bytes = allocate(byteCount, memoryLimiter);
         }
         catch (OutOfMemoryError e)
         {
@@ -58,9 +63,31 @@ public class OffHeapBitSet implements IBitSet
         clear();
     }
 
-    private OffHeapBitSet(Memory bytes)
+    private OffHeapBitSet(Memory bytes, MemoryLimiter memoryLimiter)
     {
+        this.memoryLimiter = memoryLimiter;
         this.bytes = bytes;
+    }
+
+    private static Memory allocate(long byteCount, MemoryLimiter memoryLimiter) throws MemoryLimiter.ReachedMemoryLimitException
+    {
+        memoryLimiter.increment(byteCount);
+        try
+        {
+            return Memory.allocate(byteCount);
+        }
+        catch (OutOfMemoryError e)
+        {
+            memoryLimiter.decrement(byteCount);
+            throw e;
+        }
+    }
+
+    private static void release(Memory memory, MemoryLimiter memoryLimiter)
+    {
+        long size = memory.size();
+        memory.free();
+        memoryLimiter.decrement(size);
     }
 
     public long capacity()
@@ -145,10 +172,10 @@ public class OffHeapBitSet implements IBitSet
     }
 
     @SuppressWarnings("resource")
-    public static OffHeapBitSet deserialize(DataInputStream in, boolean oldBfFormat) throws IOException
+    public static OffHeapBitSet deserialize(DataInputStream in, boolean oldBfFormat, MemoryLimiter memoryLimiter) throws IOException, MemoryLimiter.ReachedMemoryLimitException
     {
         long byteCount = in.readInt() * 8L;
-        Memory memory = Memory.allocate(byteCount);
+        Memory memory = allocate(byteCount, memoryLimiter);
         if (oldBfFormat)
         {
             for (long i = 0; i < byteCount; )
@@ -168,12 +195,12 @@ public class OffHeapBitSet implements IBitSet
         {
             FBUtilities.copy(in, new MemoryOutputStream(memory), byteCount);
         }
-        return new OffHeapBitSet(memory);
+        return new OffHeapBitSet(memory, memoryLimiter);
     }
 
     public void close()
     {
-        bytes.free();
+        release(bytes, memoryLimiter);
     }
 
     @Override
@@ -202,6 +229,6 @@ public class OffHeapBitSet implements IBitSet
 
     public String toString()
     {
-        return "[OffHeapBitSet]";
+        return String.format("[OffHeapBitSet %s]", FBUtilities.prettyPrintMemory(serializedSize()));
     }
 }

--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -35,11 +35,11 @@ import org.apache.cassandra.utils.concurrent.Ref;
  */
 public class OffHeapBitSet implements IBitSet
 {
-    /** The maximum memory that can be used by bloom filters, in megabytes, overall.
-     * The default is unlimited, a limit should only be set as a last resort measure. */
+    /**
+     * The maximum memory that can be used by bloom filters, in megabytes, overall.
+     * The default is unlimited, a limit should only be set as a last resort measure.
+     */
     @VisibleForTesting
-//    public static final long maxMemory = SizeUnit.MEGABYTES.toBytes(PropertyConfiguration.getLong("cassandra.max_bf_memory_mb", Long.MAX_VALUE));
-//    private static final AtomicLong memoryAllocated = new AtomicLong(0);
     private final Memory bytes;
     private final MemoryLimiter memoryLimiter;
 
@@ -219,7 +219,7 @@ public class OffHeapBitSet implements IBitSet
     {
         // Similar to open bitset.
         long h = 0;
-        for (long i = bytes.size(); --i >= 0;)
+        for (long i = bytes.size(); --i >= 0; )
         {
             h ^= bytes.getByte(i);
             h = (h << 1) | (h >>> 63); // rotate left

--- a/test/microbench/org/apache/cassandra/test/microbench/BloomFilterSerializerBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/BloomFilterSerializerBench.java
@@ -81,12 +81,12 @@ public class BloomFilterSerializerBench
             if (oldBfFormat)
                 SerializationsTest.serializeOldBfFormat(filter, out);
             else
-                BloomFilterSerializer.serialize(filter, out);
+                BloomFilter.serializer.serialize(filter, out);
             out.close();
             filter.close();
 
             DataInputStream in = new DataInputStream(new FileInputStream(file));
-            BloomFilter filter2 = BloomFilterSerializer.deserialize(in, oldBfFormat);
+            IFilter filter2 = BloomFilter.serializer.deserialize(in, oldBfFormat);
             FileUtils.closeQuietly(in);
             filter2.close();
         }

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -19,12 +19,12 @@ package org.apache.cassandra;
  *
  */
 
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.File;
-import java.io.IOError;
+import java.io.*;
+import java.lang.reflect.Field;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.file.*;
+import java.nio.file.attribute.FileTime;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -42,7 +42,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import afu.org.checkerframework.checker.oigj.qual.O;
 import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
 import org.apache.cassandra.db.compaction.CompactionTasks;
 import org.apache.cassandra.db.compaction.OperationType;
@@ -95,6 +94,8 @@ public class Util
     private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
     private static List<UUID> hostIdPool = new ArrayList<>();
+
+    public final static TimeUnit supportedMTimeGranularity = getSupportedMTimeGranularity();
 
     public static IPartitioner testPartitioner()
     {
@@ -818,5 +819,21 @@ public class Util
         Gossiper.instance.addLocalApplicationState(ApplicationState.RELEASE_VERSION,
                                                    VersionedValue.unsafeMakeVersionedValue(version, v + 1));
         Gossiper.instance.expireUpgradeFromVersion();
+    }
+
+    private static TimeUnit getSupportedMTimeGranularity() {
+        try
+        {
+            Path p = Files.createTempFile(Util.class.getSimpleName(), "dummy-file");
+            FileTime ft = Files.getLastModifiedTime(p);
+            Files.deleteIfExists(p);
+            Field f = FileTime.class.getDeclaredField("unit");
+            f.setAccessible(true);
+            return (TimeUnit) f.get(ft);
+        }
+        catch (IOException |  NoSuchFieldException | IllegalAccessException e)
+        {
+            throw new AssertionError("Failed to read supported file modification time granularity");
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
@@ -1,31 +1,42 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.cassandra.utils;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.text.NumberFormat;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
@@ -36,14 +47,17 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.IFilter.FilterKey;
 import org.apache.cassandra.utils.KeyGenerator.RandomStringGenerator;
 import org.apache.cassandra.utils.obs.IBitSet;
+import org.apache.cassandra.utils.obs.MemoryLimiter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class BloomFilterTest
 {
     public IFilter bfInvHashes;
-
-
+    public MemoryLimiter memoryLimiter;
 
     public static IFilter testSerialize(IFilter f, boolean oldBfFormat) throws IOException
     {
@@ -55,11 +69,11 @@ public class BloomFilterTest
         }
         else
         {
-            BloomFilterSerializer.serialize((BloomFilter) f, out);
+            BloomFilter.serializer.serialize((BloomFilter) f, out);
         }
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.getData(), 0, out.getLength());
-        IFilter f2 = BloomFilterSerializer.deserialize(new DataInputStream(in), oldBfFormat);
+        IFilter f2 = BloomFilter.serializer.deserialize(new DataInputStream(in), oldBfFormat);
 
         assert f2.isPresent(FilterTestHelper.bytes("a"));
         assert !f2.isPresent(FilterTestHelper.bytes("b"));
@@ -74,8 +88,12 @@ public class BloomFilterTest
     }
 
     @Before
-    public void setup()
+    public void setupClass()
     {
+        // Set a high limit so that normal tests won't reach it, but we don't want Long.MAX_VALUE because
+        // we want to test what happens when we reach it
+        System.setProperty("cassandra.max_bf_memory_mb", Long.toString(128 << 10));
+        memoryLimiter = new MemoryLimiter(128L << 30, "Allocating %s for bloom filter would reach max of %s (current %s)");
         bfInvHashes = FilterFactory.getFilter(10000L, FilterTestHelper.MAX_FAILURE_RATE);
     }
 
@@ -83,6 +101,7 @@ public class BloomFilterTest
     public void destroy()
     {
         bfInvHashes.close();
+        assertEquals(0, memoryLimiter.memoryAllocated());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -164,13 +183,13 @@ public class BloomFilterTest
             collisions += (MAX_HASH_COUNT - hashes.size());
             bf.close();
         }
-        Assert.assertTrue("collisions=" + collisions, collisions <= 100);
+        assertTrue("collisions=" + collisions, collisions <= 100);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testOffHeapException()
     {
-        long numKeys = ((long)Integer.MAX_VALUE) * 64L + 1L; // approx 128 Billion
+        long numKeys = ((long) Integer.MAX_VALUE) * 64L + 1L; // approx 128 Billion
         FilterFactory.getFilter(numKeys, 0.01d).close();
     }
 
@@ -202,22 +221,21 @@ public class BloomFilterTest
     }
 
     @Test
-    @Ignore
-    public void testHugeBFSerialization() throws IOException
+    public void testHugeBFSerialization() throws Exception
     {
-        ByteBuffer test = ByteBuffer.wrap(new byte[] {0, 1});
+        ByteBuffer test = ByteBuffer.wrap(new byte[]{ 0, 1 });
 
         File file = FileUtils.createDeletableTempFile("bloomFilterTest-", ".dat");
         BloomFilter filter = (BloomFilter) FilterFactory.getFilter(((long) Integer.MAX_VALUE / 8) + 1, 0.01d);
         filter.add(FilterTestHelper.wrap(test));
         DataOutputStreamPlus out = new BufferedDataOutputStreamPlus(new FileOutputStream(file));
-        BloomFilterSerializer.serialize(filter, out);
+        BloomFilter.serializer.serialize(filter, out);
         out.close();
         filter.close();
 
         DataInputStream in = new DataInputStream(new FileInputStream(file));
-        BloomFilter filter2 = BloomFilterSerializer.deserialize(in, false);
-        Assert.assertTrue(filter2.isPresent(FilterTestHelper.wrap(test)));
+        IFilter filter2 = BloomFilter.serializer.deserialize(in, false);
+        assertTrue(filter2.isPresent(FilterTestHelper.wrap(test)));
         FileUtils.closeQuietly(in);
         filter2.close();
     }
@@ -241,6 +259,98 @@ public class BloomFilterTest
             actualKey.filterHash(actual);
             expectedKey.filterHash(expected);
             Assert.assertArrayEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testMaxMemoryExceeded()
+    {
+        long allocSize = 2L * (1 << 20);
+        double fpChance = 0.01;
+        long size;
+
+        try (IFilter filter = FilterFactory.getFilter(allocSize, fpChance, memoryLimiter))
+        {
+            size = filter.offHeapSize();
+        }
+        assertNotEquals(0, size);
+
+        memoryLimiter = new MemoryLimiter(3 * size / 2, "Allocating %s for bloom filter would reach max of %s (current %s)");
+
+        try (IFilter filter = FilterFactory.getFilter(allocSize, fpChance, memoryLimiter))
+        {
+            assertNotNull(filter);
+            assertTrue(filter instanceof BloomFilter);
+
+            long memBefore = memoryLimiter.memoryAllocated();
+
+            try (IFilter blankFilter = FilterFactory.getFilter(allocSize, fpChance, memoryLimiter))
+            {
+                assertNotNull(blankFilter);
+                assertTrue(blankFilter instanceof AlwaysPresentFilter);
+
+                assertEquals(memBefore, memoryLimiter.memoryAllocated());
+            }
+        }
+    }
+
+    @Test
+    public void testMaxMemoryExceededOnDeserialize() throws IOException
+    {
+        long allocSize = 2L * (1 << 20);
+        double fpChance = 0.01;
+        long size;
+
+        DataOutputBuffer out = new DataOutputBuffer();
+        try (IFilter filter = FilterFactory.getFilter(allocSize, fpChance, memoryLimiter))
+        {
+            size = filter.offHeapSize();
+            BloomFilter.serializer.serialize((BloomFilter) filter, out);
+        }
+        assertNotEquals(0, size);
+
+        memoryLimiter = new MemoryLimiter(3 * size / 2, "Allocating %s for bloom filter would reach max of %s (current %s)");
+
+        try (IFilter filter = FilterFactory.getFilter(allocSize, fpChance, memoryLimiter))
+        {
+            assertNotNull(filter);
+            assertTrue(filter instanceof BloomFilter);
+
+            long memBefore = memoryLimiter.memoryAllocated();
+
+            ByteArrayInputStream in = new ByteArrayInputStream(out.getData(), 0, out.getLength());
+            try (IFilter blankFilter = new BloomFilterSerializer(memoryLimiter).deserialize(new DataInputStream(in), false))
+            {
+                assertNotNull(blankFilter);
+                assertTrue(blankFilter instanceof AlwaysPresentFilter);
+                assertEquals(memBefore, memoryLimiter.memoryAllocated());
+            }
+        }
+    }
+
+    @Test
+    @Ignore // this is a test that can be used to print out the sizes of BFs
+    public void testBloomFilterSize()
+    {
+        int[] nks = new int[]{
+        100_000, 500_000,
+        1_000_000, 5_000_000,
+        10_000_000, 50_000_000,
+        100_000_000, 500_000_000 };
+
+        //double[] fps = new double[] { 0.01, 0.05, 0.1, 0.2, 0.25 };
+        double[] fps = new double[]{ 0.01, 0.1 };
+
+        for (int nk : nks)
+        {
+            for (double fp : fps)
+            {
+                IFilter filter = FilterFactory.getFilter(nk, fp);
+                System.out.println(String.format("%s keys %s FP chance => %s",
+                                                 NumberFormat.getNumberInstance(Locale.US).format(nk),
+                                                 NumberFormat.getNumberInstance(Locale.US).format(fp),
+                                                 FBUtilities.prettyPrintMemory(filter.serializedSize())));
+            }
         }
     }
 }

--- a/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
@@ -88,11 +88,11 @@ public class BloomFilterTest
     }
 
     @Before
-    public void setupClass()
+    public void setup()
     {
         // Set a high limit so that normal tests won't reach it, but we don't want Long.MAX_VALUE because
         // we want to test what happens when we reach it
-        System.setProperty("cassandra.max_bf_memory_mb", Long.toString(128 << 10));
+        System.setProperty(BloomFilter.MAX_MEMORY_MB_PROP, Long.toString(128 << 10));
         memoryLimiter = new MemoryLimiter(128L << 30, "Allocating %s for bloom filter would reach max of %s (current %s)");
         bfInvHashes = FilterFactory.getFilter(10000L, FilterTestHelper.MAX_FAILURE_RATE);
     }

--- a/test/unit/org/apache/cassandra/utils/SerializationsTest.java
+++ b/test/unit/org/apache/cassandra/utils/SerializationsTest.java
@@ -66,7 +66,7 @@ public class SerializationsTest extends AbstractSerializationsTester
                 if (oldBfFormat)
                     serializeOldBfFormat((BloomFilter) bf, out);
                 else
-                    BloomFilterSerializer.serialize((BloomFilter) bf, out);
+                    BloomFilter.serializer.serialize((BloomFilter) bf, out);
             }
         }
     }
@@ -81,7 +81,7 @@ public class SerializationsTest extends AbstractSerializationsTester
         }
 
         try (DataInputStream in = getInput("4.0", "utils.BloomFilter1000.bin");
-             IFilter filter = BloomFilterSerializer.deserialize(in, false))
+             IFilter filter = BloomFilter.serializer.deserialize(in, false))
         {
             boolean present;
             for (int i = 0 ; i < 1000 ; i++)
@@ -97,7 +97,7 @@ public class SerializationsTest extends AbstractSerializationsTester
         }
 
         try (DataInputStream in = getInput("3.0", "utils.BloomFilter1000.bin");
-             IFilter filter = BloomFilterSerializer.deserialize(in, true))
+             IFilter filter = BloomFilter.serializer.deserialize(in, true))
         {
             boolean present;
             for (int i = 0 ; i < 1000 ; i++)
@@ -124,7 +124,7 @@ public class SerializationsTest extends AbstractSerializationsTester
         Murmur3Partitioner partitioner = new Murmur3Partitioner();
 
         try (DataInputStream in = new DataInputStream(new FileInputStream(new File(file)));
-             IFilter filter = BloomFilterSerializer.deserialize(in, oldBfFormat))
+             IFilter filter = BloomFilter.serializer.deserialize(in, oldBfFormat))
         {
             for (int i = 1; i <= 10; i++)
             {


### PR DESCRIPTION
In this PR it was a global memory limit added for all Bloom filters. It is configurable via a system property. 

Also, the FP chance is considered to change if the change is greater than the defined (also via system property) tolerance.

Optionally, the Bloom filters can be recreated when SSTable is being loaded (for example on startup) and FP chance changed since the last compaction - this behaviour is controlled also by a system property - by default we do not do that (the OSS way - see [CASSANDRA-11163](https://issues.apache.org/jira/browse/CASSANDRA-11163)), but in DSE we do (see [DSP-21344](https://datastax.jira.com/browse/DSP-21344)).

The implementation is a bit different to what we have in DSE, partially because to limit the amount of changes but also because my preference to limit static stuff and make it a bit more testable. 

Perhaps there is a bug fixed there as well - OSS could recreate a filter and it saved the created one, but it didn't update validation metadata with the new information - this is now fixed as we pulled the fix from DSE.
