### PR TITLE
STAR-563: Fix SIGSEGVs on aborted flush

### DIFF
--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -384,6 +384,13 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
         return txnProxy.commit(accumulate);
     }
 
+    /**
+     * Stop the operation after errors, i.e. close and release all held resources.
+     *
+     * Do not use this to interrupt a write operation running in another thread.
+     * This is thread-unsafe, releasing and cleaning the buffer while it is being written can have disastrous
+     * consequences (e.g. SIGSEGV).
+     */
     public final Throwable abort(Throwable accumulate)
     {
         return txnProxy.abort(accumulate);

--- a/test/unit/org/apache/cassandra/db/MemtableTest.java
+++ b/test/unit/org/apache/cassandra/db/MemtableTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.SSTableMultiWriter;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(BMUnitRunner.class)
+@BMUnitConfig(debug = true)
+public class MemtableTest extends CQLTester
+{
+    List<PartitionPosition> ranges;
+    List<Directories.DataDirectory> locations;
+    ColumnFamilyStore cfs;
+    Memtable memtable;
+    ExecutorService executor;
+    int nThreads;
+
+    @Before
+    public void setup() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value int)");
+
+        for (int i = 0; i < 10000; i++)
+            execute("INSERT INTO %s (pk, value) VALUES (?, ?)", i, i);
+
+        cfs = getCurrentColumnFamilyStore();
+        memtable = cfs.getTracker().getView().getCurrentMemtable();
+
+        OpOrder.Barrier barrier = cfs.keyspace.writeOrder.newBarrier();
+        memtable.setDiscarding(barrier, new AtomicReference<>(CommitLog.instance.getCurrentPosition()));
+        barrier.issue();
+
+        ranges = new ArrayList<>();
+        locations = new ArrayList<>();
+        // this determines the number of flush writers created, the FlushRunnable will convert a null location into an sstable location for us
+        int rangeCount = 24;
+        for (int i = 0; i < rangeCount; ++i)
+        {
+            // split the range to ensure there are partitions to write
+            ranges.add(cfs.getPartitioner().split(cfs.getPartitioner().getMinimumToken(),
+                                                  cfs.getPartitioner().getMaximumToken(),
+                                                  (i+1) * 1.0 / rangeCount).minKeyBound());
+            locations.add(null);
+        }
+        nThreads = locations.size() / 2;
+        executor = Executors.newFixedThreadPool(nThreads);
+    }
+
+    @Test
+    public void testAbortingFlushRunnablesWithoutStarting() throws Throwable
+    {
+        // abort without starting
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.FLUSH))
+        {
+            List<Memtable.FlushRunnable> flushRunnables = memtable.createFlushRunnables(ranges, locations, txn);
+            assertNotNull(flushRunnables);
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertEquals(Memtable.FlushRunnableWriterState.IDLE, flushRunnable.state());
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertNull(flushRunnable.abort(null));
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertEquals(Memtable.FlushRunnableWriterState.ABORTED, flushRunnable.state());
+        }
+    }
+
+    static Semaphore stopSignal = null;
+    static Semaphore continueSignal;
+
+    public static void stopAndWait() throws InterruptedException
+    {
+        if (stopSignal != null)
+        {
+            stopSignal.release();
+            continueSignal.acquire();
+        }
+    }
+
+    @Test
+    @BMRule(name = "Wait before loop",
+    targetClass = "Memtable$FlushRunnable",
+    targetMethod = "writeSortedContents",
+    targetLocation = "AT INVOKE Logger.isTraceEnabled()",
+    action = "org.apache.cassandra.db.MemtableTest.stopAndWait()")
+    public void testAbortingFlushRunnablesAfterStarting() throws Throwable
+    {
+        // abort after starting
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.FLUSH))
+        {
+            List<Memtable.FlushRunnable> flushRunnables = memtable.createFlushRunnables(ranges, locations, txn);
+
+            stopSignal = new Semaphore(0);
+            continueSignal = new Semaphore(0);
+
+            List<Future<SSTableMultiWriter>> futures = flushRunnables.stream().map(executor::submit).collect(Collectors.toList());
+
+            stopSignal.acquire(nThreads);
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertNull(flushRunnable.abort(null));
+            continueSignal.release(flushRunnables.size());  // release all, including the ones that have not started yet
+
+            FBUtilities.waitOnFutures(futures);
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertEquals(Memtable.FlushRunnableWriterState.ABORTED, flushRunnable.state());
+        }
+    }
+
+    @Test
+    public void testAbortingFlushRunnablesBeforeStarting() throws Throwable
+    {
+        // abort before starting
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.FLUSH))
+        {
+            List<Memtable.FlushRunnable> flushRunnables = memtable.createFlushRunnables(ranges, locations, txn);
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertNull(flushRunnable.abort(null));
+
+            List<Future<SSTableMultiWriter>> futures = flushRunnables.stream().map(executor::submit).collect(Collectors.toList());
+
+            FBUtilities.waitOnFutures(futures);
+
+            for (Memtable.FlushRunnable flushRunnable : flushRunnables)
+                assertEquals(Memtable.FlushRunnableWriterState.ABORTED, flushRunnable.state());
+        }
+    }
+}


### PR DESCRIPTION
If a flush is aborted, e.g. by exception thrown by `flushAllNonCFSBackedIndexesBlocking()`, this was done by closing the flush writer, potentially concurrent with operations on it. The latter is unsafe and may cause writes to released memory.

Fixed by adding an abort mechanism to the flush runnables.

Port of ac3f0d38d130891d3f75d87295601de4be12a40b and 3a88a826891776468ffc49e252eec443b9424609 (DB-962).

patch by Stefania Alborghetti, ported by Branimir Lambov