### PR TITLE
STAR-543 Port remaining guardrails and sync with cndb

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1263,9 +1263,6 @@ replica_filtering_protection:
     cached_rows_warn_threshold: 2000
     cached_rows_fail_threshold: 32000
 
-# Log a warning when compacting partitions larger than this value
-compaction_large_partition_warning_threshold_mb: 100
-
 # GC Pauses greater than 200 ms will be logged at INFO level
 # This threshold can be adjusted to minimize logging if necessary
 # gc_log_threshold_in_ms: 200

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1243,18 +1243,6 @@ transparent_data_encryption_options:
 # SAFETY THRESHOLDS #
 #####################
 
-# When executing a scan, within or across a partition, we need to keep the
-# tombstones seen in memory so we can return them to the coordinator, which
-# will use them to make sure other replicas also know about the deleted rows.
-# With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
-# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
-# Adjust the thresholds here if you understand the dangers and want to
-# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
-# using the StorageService mbean.
-tombstone_warn_threshold: 1000
-tombstone_failure_threshold: 100000
-
 # Filtering and secondary index queries at read consistency levels above ONE/LOCAL_ONE use a
 # mechanism called replica filtering protection to ensure that results from stale replicas do
 # not violate consistency. (See CASSANDRA-8272 and CASSANDRA-15907 for more details.) This
@@ -1274,16 +1262,6 @@ replica_filtering_protection:
     # is too large or one or more replicas is severely out-of-sync and in need of repair.
     cached_rows_warn_threshold: 2000
     cached_rows_fail_threshold: 32000
-
-# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
-# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
-batch_size_warn_threshold_in_kb: 5
-
-# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
-batch_size_fail_threshold_in_kb: 50
-
-# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
-unlogged_batch_across_partitions_warn_threshold: 10
 
 # Log a warning when compacting partitions larger than this value
 compaction_large_partition_warning_threshold_mb: 100
@@ -1435,16 +1413,20 @@ enable_sasi_indexes: false
 # Transient replication is experimental and is not recommended for production use.
 enable_transient_replication: false
 
-# Apply database-as-a-service defaults.
-#
-# When enabled, some guardrails defaults are modified to values that are appropriate for cloud environments.
-# This includes (but is not limited to) stricter guardrails defaults.
-#
-# This can be used as an convenience to develop and test applications meant to run in a cloud environment.
-# apply_dbaas_defaults: false
+  # Emulates DataStax Constellation database-as-a-service defaults.
+  #
+  # When enabled, some defaults are modified to match those used by DataStax Constellation (DataStax cloud data
+  # platform). This includes (but is not limited to) stricter guardrails defaults.
+  #
+  # This can be used as an convenience to develop and test applications meant to run on DataStax Constellation.
+  #
+  # Warning: when enabled, the updated defaults reflect those of DataStax Constellation _at the time_ of the currently
+  #                 used DSE release. This is a best-effort emulation of said defaults. Further, all nodes must use the same
+  #                 config value.
+  # emulate_dbaas_defaults: false
 
-# Guardrails settings.
-# guardrails:
+  # Guardrails settings.
+  # guardrails:
   # When executing a scan, within or across a partition, we need to keep the
   # tombstones seen in memory so we can return them to the coordinator, which
   # will use them to make sure other replicas also know about the deleted rows.
@@ -1455,93 +1437,113 @@ enable_transient_replication: false
   # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
   # using the StorageService mbean.
   #
-  # Default: tombstone_warn_threshold is 1000, may differ if apply_dbaas_defaults is enabled
-  # Default: tombstone_failure_threshold is 100000, may differ if apply_dbaas_defaults is enabled
+  # Default tombstone_warn_threshold is 1000, may differ if emulate_dbaas_defaults is enabled
+  # Default tombstone_failure_threshold is 100000, may differ if emulate_dbaas_defaults is enabled
   # tombstone_warn_threshold: 1000
   # tombstone_failure_threshold: 100000
 
-  # Failure threshold to prevent writing large a column value into Cassandra.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
+  # Log a warning when compacting partitions larger than this value.
+  # Default value is 100mb, may differ if emulate_dbaas_defaults is enabled
+  # partition_size_warn_threshold_in_mb: 100
+
+  # Log WARN on any multiple-partition batch size that exceeds this value. 64kb per batch by default.
+  # Use caution when increasing the size of this threshold as it can lead to node instability.
+  # Default value is 64kb, may differ if emulate_dbaas_defaults is enabled
+  # batch_size_warn_threshold_in_kb: 64
+
+  # Fail any multiple-partition batch that exceeds this value. The calculated default is 640kb (10x warn threshold).
+  # Default value is 640kb, may differ if emulate_dbaas_defaults is enabled
+  # batch_size_fail_threshold_in_kb: 640
+
+  # Log WARN on any batches not of type LOGGED than span across more partitions than this limit.
+  # Default value is 10, may differ if emulate_dbaas_defaults is enabled
+  # unlogged_batch_across_partitions_warn_threshold: 10
+
+  # Failure threshold to prevent writing large column value into Cassandra.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # column_value_size_failure_threshold_in_kb: -1
 
   # Failure threshold to prevent creating more columns per table than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # columns_per_table_failure_threshold: -1
 
-  # Failure threshold to prevent creating more secondary indexes per table than threshold (does not apply to CUSTOM INDEX StorageAttachedIndex)
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # secondary_index_per_table_failure_threshold: -1
-
-  # Failure threshold for number of StorageAttachedIndex per table (only applies to CUSTOM INDEX StorageAttachedIndex)
-  # Default is 10 (same when apply_dbaas_defaults is enabled)
-  # sai_indexes_per_table_failure_threshold: 10
-  #
-  # Failure threshold for total number of StorageAttachedIndex across all keyspaces (only applies to CUSTOM INDEX StorageAttachedIndex)
-  # Default is 10 (same when apply_dbaas_defaults is enabled)
-  # sai_indexes_total_failure_threshold: 100
-
-  # Failure threshold to prevent creating more materialized views per table than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # materialized_view_per_table_failure_threshold: -1
-
-  # Warn threshold to warn creating more tables than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # tables_warn_threshold: -1
-
-  # Failure threshold to prevent creating more tables than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # tables_failure_threshold: -1
-
-  # Prevents creating tables with provided configurations.
-  # Default: all properties are allowed, may differ if apply_dbaas_defaults is enabled
-  # table_properties_disallowed:
-
-  # Whether to allow user-provided timestamps in write requests
-  # Default: true to allow user-provided timestamps, may differ if apply_dbaas_defaults is enabled
-  # user_timestamps_enabled: true
-
-  # Preventing a query with provided consistency levels
-  # Default: all consistency levels are allowed.
-  # write_consistency_levels_disallowed:
-
-  # Log a warning when compacting partitions larger than this value.
-  # Default: 100mb, may differ if apply_dbaas_defaults is enabled
-  # partition_size_warn_threshold_in_mb: 100
-
-  # Failure threshold to prevent IN query containing more partition keys than threshold
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # partition_keys_in_select_failure_threshold: -1
-
-  # Warning threshold to warn when local disk usage exceeding threshold. Valid values: (1, 100]
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # disk_usage_percentage_warn_threshold: -1
-
-  # Failure threshold to reject write requests if replica disk usage exceeding threshold. Valid values: (1, 100]
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # disk_usage_percentage_failure_threshold: -1
-
-  # Failure threshold to prevent IN query creating size of cartesian product exceeding threshold, eg.
-  # "a IN (1,2,...10) AND b IN (1,2...10)" results in cartesian product of 100.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
-  # in_select_cartesian_product_failure_threshold: -1
-
-  # Whether to allow user-provided timestamps in write request (USING TIMESTAMP ...)
-  # Default: true to allow user-provided timestamp, may differ if apply_dbaas_defaults is enabled
-  # user_timestamps_enabled: true
-
-  # Whether read-before-write operation is allowed on lists, eg. setting list element by index, removing list element
-  # by index. Note: LWT is always allowed.
-  # Default: true to allow read before write operation on lists, may differ if apply_dbaas_defaults is enabled
-  # read_before_write_list_operations_enabled: true
-
   # Failure threshold to prevent creating more fields in user-defined-type than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # fields_per_udt_failure_threshold: -1
 
   # Warning threshold to warn when encountering larger size of collection data than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # collection_size_warn_threshold_in_kb: -1
 
   # Warning threshold to warn when encountering more elements in collection than threshold.
-  # Default: -1 to disable, may differ if apply_dbaas_defaults is enabled
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # items_per_collection_warn_threshold: -1
+
+  # Whether read-before-write operation is allowed, eg. setting list element by index, removing list element
+  # by index. Note: LWT is always allowed.
+  # Default true to allow read before write operation, may differ if emulate_dbaas_defaults is enabled
+  # read_before_write_list_operations_enabled: true
+
+  # Failure threshold to prevent creating more secondary index per table than threshold (does not apply to CUSTOM INDEX StorageAttachedIndex)
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # secondary_index_per_table_failure_threshold: -1
+
+  # Failure threshold for number of StorageAttachedIndex per table (only applies to CUSTOM INDEX StorageAttachedIndex)
+  # Default is 10 (same when emulate_dbaas_defaults is enabled)
+  # sai_indexes_per_table_failure_threshold: 10
+  #
+  # Failure threshold for total number of StorageAttachedIndex across all keyspaces (only applies to CUSTOM INDEX StorageAttachedIndex)
+  # Default is 10 (same when emulate_dbaas_defaults is enabled)
+  # sai_indexes_total_failure_threshold: 100
+
+  # Failure threshold to prevent creating more materialized views per table than threshold.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # materialized_view_per_table_failure_threshold: -1
+
+  # Warn threshold to warn creating more tables than threshold.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # tables_warn_threshold: -1
+
+  # Failure threshold to prevent creating more tables than threshold.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # tables_failure_threshold: -1
+
+  # Preventing creating tables with provided configurations.
+  # Default all properties are allowed, may differ if emulate_dbaas_defaults is enabled
+  # table_properties_disallowed:
+
+  # Whether to allow user-provided timestamp in write request
+  # Default true to allow user-provided timestamp, may differ if emulate_dbaas_defaults is enabled
+  # user_timestamps_enabled: true
+
+  # Preventing query with provided consistency levels
+  # Default all consistency levels are allowed.
+  # write_consistency_levels_disallowed:
+
+  # Failure threshold to prevent providing larger paging by bytes than threshold, also served as a hard paging limit
+  # when paging by rows is used.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # page_size_failure_threshold_in_kb: -1
+
+  # Failure threshold to prevent IN query creating size of cartesian product exceeding threshold, eg.
+  # "a in (1,2,...10) and b in (1,2...10)" results in cartesian product of 100.
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # in_select_cartesian_product_failure_threshold: -1
+
+  # Failure threshold to prevent IN query containing more partition keys than threshold
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # partition_keys_in_select_failure_threshold: -1
+
+  # Warning threshold to warn when local disk usage exceeding threshold. Valid values: (1, 100]
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # disk_usage_percentage_warn_threshold: -1
+
+  # Failure threshold to reject write requests if replica disk usage exceeding threshold. Valid values: (1, 100]
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # disk_usage_percentage_failure_threshold: -1
+
+  # Allows configuring max disk size of data directories when calculating thresholds for disk_usage_percentage_warn_threshold
+  # and disk_usage_percentage_failure_threshold. Valid values: (1, max available disk size of all data directories]
+  # Default -1 to disable and use the physically available disk size of data directories during calculations.
+  # may differ if emulate_dbaas_defaults is enabled
+# disk_usage_max_disk_size_in_gb: -1

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1543,4 +1543,4 @@ enable_transient_replication: false
   # and disk_usage_percentage_failure_threshold. Valid values: (1, max available disk size of all data directories]
   # Default -1 to disable and use the physically available disk size of data directories during calculations.
   # may differ if emulate_dbaas_defaults is enabled
-# disk_usage_max_disk_size_in_gb: -1
+  # disk_usage_max_disk_size_in_gb: -1

--- a/doc/source/configuration/cass_yaml_file.rst
+++ b/doc/source/configuration/cass_yaml_file.rst
@@ -1861,6 +1861,14 @@ Log WARN on any batches not of type LOGGED than span across more partitions than
 
 *Default Value:* 10
 
+``partition_size_warn_threshold_in_mb``
+---------------------------------------------------
+
+Log a warning when compacting partitions larger than this value
+
+*Default Value:* 100
+
+`
 ``gc_log_threshold_in_ms``
 --------------------------
 *This option is commented out by default.*

--- a/doc/source/configuration/cass_yaml_file.rst
+++ b/doc/source/configuration/cass_yaml_file.rst
@@ -1861,13 +1861,6 @@ Log WARN on any batches not of type LOGGED than span across more partitions than
 
 *Default Value:* 10
 
-``compaction_large_partition_warning_threshold_mb``
----------------------------------------------------
-
-Log a warning when compacting partitions larger than this value
-
-*Default Value:* 100
-
 ``gc_log_threshold_in_ms``
 --------------------------
 *This option is commented out by default.*

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -214,12 +214,20 @@ public class Config
     /* if the size of columns or super-columns are more than this, indexing will kick in */
     public int column_index_size_in_kb = 64;
     public volatile int column_index_cache_size_in_kb = 2;
-    public volatile int batch_size_warn_threshold_in_kb = 5;
-    public volatile int batch_size_fail_threshold_in_kb = 50;
-    public Integer unlogged_batch_across_partitions_warn_threshold = 10;
+    @Deprecated
+//    @HiddenInformation
+    public int batch_size_warn_threshold_in_kb = 0;
+    @Deprecated
+//    @HiddenInformation
+    public int batch_size_fail_threshold_in_kb = 0;
+    @Deprecated
+//    @HiddenInformation
+    public Integer unlogged_batch_across_partitions_warn_threshold = 0;
     public volatile Integer concurrent_compactors;
     public volatile int compaction_throughput_mb_per_sec = 16;
-    public volatile int compaction_large_partition_warning_threshold_mb = 100;
+    @Deprecated
+//    @HiddenInformation
+    public int compaction_large_partition_warning_threshold_mb = 0;
     public int min_free_space_per_drive_in_mb = 50;
 
     public volatile int concurrent_materialized_view_builders = 1;
@@ -344,8 +352,12 @@ public class Config
 
     public MemtableAllocationType memtable_allocation_type = MemtableAllocationType.offheap_objects;
 
-    public volatile int tombstone_warn_threshold = 1000;
-    public volatile int tombstone_failure_threshold = 100000;
+    @Deprecated
+//    @HiddenInformation
+    public int tombstone_warn_threshold = 0;
+    @Deprecated
+//    @HiddenInformation
+    public int tombstone_failure_threshold = 0;
 
     public final ReplicaFilteringProtectionOptions replica_filtering_protection = new ReplicaFilteringProtectionOptions();
 
@@ -506,7 +518,8 @@ public class Config
      */
     public volatile int validation_preview_purge_head_start_in_sec = 60 * 60;
 
-    public boolean apply_dbaas_defaults = false;
+    public boolean emulate_dbaas_defaults = false;
+    
     public GuardrailsConfig guardrails = new GuardrailsConfig();
 
     /**

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -215,18 +215,14 @@ public class Config
     public int column_index_size_in_kb = 64;
     public volatile int column_index_cache_size_in_kb = 2;
     @Deprecated
-//    @HiddenInformation
     public int batch_size_warn_threshold_in_kb = 0;
     @Deprecated
-//    @HiddenInformation
     public int batch_size_fail_threshold_in_kb = 0;
     @Deprecated
-//    @HiddenInformation
     public Integer unlogged_batch_across_partitions_warn_threshold = 0;
     public volatile Integer concurrent_compactors;
     public volatile int compaction_throughput_mb_per_sec = 16;
     @Deprecated
-//    @HiddenInformation
     public int compaction_large_partition_warning_threshold_mb = 0;
     public int min_free_space_per_drive_in_mb = 50;
 
@@ -353,10 +349,8 @@ public class Config
     public MemtableAllocationType memtable_allocation_type = MemtableAllocationType.offheap_objects;
 
     @Deprecated
-//    @HiddenInformation
     public int tombstone_warn_threshold = 0;
     @Deprecated
-//    @HiddenInformation
     public int tombstone_failure_threshold = 0;
 
     public final ReplicaFilteringProtectionOptions replica_filtering_protection = new ReplicaFilteringProtectionOptions();

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -214,14 +214,26 @@ public class Config
     /* if the size of columns or super-columns are more than this, indexing will kick in */
     public int column_index_size_in_kb = 64;
     public volatile int column_index_cache_size_in_kb = 2;
+    /**
+     * @deprecated Migrated to 'guardrails.batch_size_warn_threshold_in_kb'
+     */
     @Deprecated
     public int batch_size_warn_threshold_in_kb = 0;
+    /**
+     * @deprecated Migrated to 'guardrails.batch_size_fail_threshold_in_kb'
+     */
     @Deprecated
     public int batch_size_fail_threshold_in_kb = 0;
+    /**
+     * @deprecated Migrated to 'guardrails.unlogged_batch_across_partitions_warn_threshold'
+     */
     @Deprecated
     public Integer unlogged_batch_across_partitions_warn_threshold = 0;
     public volatile Integer concurrent_compactors;
     public volatile int compaction_throughput_mb_per_sec = 16;
+    /**
+     * @deprecated Migrated to 'guardrails.compaction_large_partition_warning_threshold_mb'
+     */
     @Deprecated
     public int compaction_large_partition_warning_threshold_mb = 0;
     public int min_free_space_per_drive_in_mb = 50;
@@ -348,8 +360,14 @@ public class Config
 
     public MemtableAllocationType memtable_allocation_type = MemtableAllocationType.offheap_objects;
 
+    /**
+     * @deprecated Migrated to 'guardrails.tombstone_warn_threshold'
+     */
     @Deprecated
     public int tombstone_warn_threshold = 0;
+    /**
+     * @deprecated Migrated to 'guardrails.tombstone_failure_threshold'
+     */
     @Deprecated
     public int tombstone_failure_threshold = 0;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -177,6 +177,11 @@ public class DatabaseDescriptor
 
         setConfig(config.get());
         applyAll();
+
+        createAllDirectories();
+        applyGuardrails(); // requires created directories
+        applyAfterDataDirectoriesAreCreated(); // requires setup Guardrails
+
         AuthConfig.applyAuth();
     }
 
@@ -363,11 +368,9 @@ public class DatabaseDescriptor
         applyEncryptionContext();
 
         applySslContext();
-
-        applyGuardrailsConfig();
     }
 
-    private static void applyGuardrailsConfig()
+    private static void applyGuardrails()
     {
         conf.guardrails.applyConfig();
         conf.guardrails.validate();
@@ -763,6 +766,48 @@ public class DatabaseDescriptor
 
         if (conf.user_defined_function_fail_timeout < conf.user_defined_function_warn_timeout)
             throw new ConfigurationException("user_defined_function_warn_timeout must less than user_defined_function_fail_timeout", false);
+
+        if (conf.compaction_large_partition_warning_threshold_mb != 0)
+        {
+            logger.warn("Found deprecated property 'compaction_large_partition_warning_threshold_mb' in config - migrate to `guardrails.partition_size_warn_threshold_in_mb`. " +
+                        "The value of 'guardrails.partition_size_warn_threshold_in_mb' is overwritten by 'compaction_large_partition_warning_threshold_mb'.");
+            getGuardrailsConfig().partition_size_warn_threshold_in_mb = conf.compaction_large_partition_warning_threshold_mb;
+        }
+
+        if (conf.tombstone_failure_threshold != 0)
+        {
+            logger.warn("Found deprecated property 'tombstone_failure_threshold' in config - migrate to 'guardrails.tombstone_failure_threshold'. " +
+                        "The value of 'guardrails.tombstone_failure_threshold' is overwritten by 'tombstone_failure_threshold'.");
+            getGuardrailsConfig().tombstone_failure_threshold = conf.tombstone_failure_threshold;
+        }
+
+        if (conf.tombstone_warn_threshold != 0)
+        {
+            logger.warn("Found deprecated property 'tombstone_warn_threshold' in config - migrate to 'guardrails.tombstone_warn_threshold'. " +
+                        "The value of 'guardrails.tombstone_warn_threshold' is overwritten by 'tombstone_warn_threshold'.");
+            getGuardrailsConfig().tombstone_warn_threshold = conf.tombstone_warn_threshold;
+        }
+
+        if (conf.batch_size_fail_threshold_in_kb != 0)
+        {
+            logger.warn("Found deprecated property 'batch_size_fail_threshold_in_kb' in config - migrate to 'guardrails.batch_size_fail_threshold_in_kb'. " +
+                        "The value of 'guardrails.batch_size_fail_threshold_in_kb' is overwritten by 'batch_size_fail_threshold_in_kb'.");
+            getGuardrailsConfig().batch_size_fail_threshold_in_kb = conf.batch_size_fail_threshold_in_kb;
+        }
+
+        if (conf.batch_size_warn_threshold_in_kb != 0)
+        {
+            logger.warn("Found deprecated property 'batch_size_warn_threshold_in_kb' in config - migrate to 'guardrails.batch_size_warn_threshold_in_kb'. " +
+                        "The value of 'guardrails.batch_size_warn_threshold_in_kb' is overwritten by 'batch_size_warn_threshold_in_kb'.");
+            getGuardrailsConfig().batch_size_warn_threshold_in_kb = conf.batch_size_warn_threshold_in_kb;
+        }
+
+        if (conf.unlogged_batch_across_partitions_warn_threshold != 0)
+        {
+            logger.warn("Found deprecated property 'unlogged_batch_across_partitions_warn_threshold' in config - migrate to 'guardrails.unlogged_batch_across_partitions_warn_threshold'. " +
+                        "The value of 'guardrails.unlogged_batch_across_partitions_warn_threshold' is overwritten by 'unlogged_batch_across_partitions_warn_threshold'.");
+            getGuardrailsConfig().unlogged_batch_across_partitions_warn_threshold = conf.unlogged_batch_across_partitions_warn_threshold;
+        }
 
         if (conf.commitlog_segment_size_in_mb <= 0)
             throw new ConfigurationException("commitlog_segment_size_in_mb must be positive, but was "
@@ -1492,42 +1537,6 @@ public class DatabaseDescriptor
         conf.column_index_cache_size_in_kb = val;
     }
 
-    public static int getBatchSizeWarnThreshold()
-    {
-        return (int) ByteUnit.KIBI_BYTES.toBytes(conf.batch_size_warn_threshold_in_kb);
-    }
-
-    public static int getBatchSizeWarnThresholdInKB()
-    {
-        return conf.batch_size_warn_threshold_in_kb;
-    }
-
-    public static long getBatchSizeFailThreshold()
-    {
-        return ByteUnit.KIBI_BYTES.toBytes(conf.batch_size_fail_threshold_in_kb);
-    }
-
-    public static int getBatchSizeFailThresholdInKB()
-    {
-        return conf.batch_size_fail_threshold_in_kb;
-    }
-
-    public static int getUnloggedBatchAcrossPartitionsWarnThreshold()
-    {
-        return conf.unlogged_batch_across_partitions_warn_threshold;
-    }
-
-    public static void setBatchSizeWarnThresholdInKB(int threshold)
-    {
-        checkValidForByteConversion(threshold, "batch_size_warn_threshold_in_kb", ByteUnit.KIBI_BYTES);
-        conf.batch_size_warn_threshold_in_kb = threshold;
-    }
-
-    public static void setBatchSizeFailThresholdInKB(int threshold)
-    {
-        conf.batch_size_fail_threshold_in_kb = threshold;
-    }
-
     public static Collection<String> getInitialTokens()
     {
         return tokensFromString(System.getProperty(Config.PROPERTY_PREFIX + "initial_token", conf.initial_token));
@@ -1966,26 +1975,6 @@ public class DatabaseDescriptor
     public static int getMaxMutationSize()
     {
         return (int) ByteUnit.KIBI_BYTES.toBytes(conf.max_mutation_size_in_kb);
-    }
-
-    public static int getTombstoneWarnThreshold()
-    {
-        return conf.tombstone_warn_threshold;
-    }
-
-    public static void setTombstoneWarnThreshold(int threshold)
-    {
-        conf.tombstone_warn_threshold = threshold;
-    }
-
-    public static int getTombstoneFailureThreshold()
-    {
-        return conf.tombstone_failure_threshold;
-    }
-
-    public static void setTombstoneFailureThreshold(int threshold)
-    {
-        conf.tombstone_failure_threshold = threshold;
     }
 
     public static int getCachedReplicaRowsWarnThreshold()
@@ -3406,13 +3395,22 @@ public class DatabaseDescriptor
     }
 
     @VisibleForTesting
-    public static boolean setApplyDbaasDefaults(boolean dbaasDefaults)
+    public static boolean setEmulateDbaasDefaults(boolean dbaasDefaults)
     {
-        return conf.apply_dbaas_defaults = dbaasDefaults;
+        return conf.emulate_dbaas_defaults = dbaasDefaults;
     }
 
-    public static boolean isApplyDbaasDefaults()
+    public static boolean isEmulateDbaasDefaults()
     {
-        return conf.apply_dbaas_defaults;
+        return conf.emulate_dbaas_defaults;
+    }
+
+    /**
+     * This should be called after {@link DatabaseDescriptor#createAllDirectories()} is being called as some validation
+     * can only happen after those data directories actually exist
+     */
+    public static void applyAfterDataDirectoriesAreCreated()
+    {
+        getGuardrailsConfig().validateAfterDataDirectoriesExist();
     }
 }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1817,8 +1817,6 @@ public class DatabaseDescriptor
         conf.compaction_throughput_mb_per_sec = value;
     }
 
-    public static long getCompactionLargePartitionWarningThreshold() { return ByteUnit.MEBI_BYTES.toBytes(conf.compaction_large_partition_warning_threshold_mb); }
-
     public static int getConcurrentValidations()
     {
         return conf.concurrent_validations;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -180,7 +180,6 @@ public class DatabaseDescriptor
 
         createAllDirectories();
         applyGuardrails(); // requires created directories
-        applyAfterDataDirectoriesAreCreated(); // requires setup Guardrails
 
         AuthConfig.applyAuth();
     }
@@ -374,6 +373,7 @@ public class DatabaseDescriptor
     {
         conf.guardrails.applyConfig();
         conf.guardrails.validate();
+        getGuardrailsConfig().validateAfterDataDirectoriesExist();
     }
 
     private static void applySimpleConfig()
@@ -3401,14 +3401,5 @@ public class DatabaseDescriptor
     public static boolean isEmulateDbaasDefaults()
     {
         return conf.emulate_dbaas_defaults;
-    }
-
-    /**
-     * This should be called after {@link DatabaseDescriptor#createAllDirectories()} is being called as some validation
-     * can only happen after those data directories actually exist
-     */
-    public static void applyAfterDataDirectoriesAreCreated()
-    {
-        getGuardrailsConfig().validateAfterDataDirectoriesExist();
     }
 }

--- a/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
@@ -69,7 +69,6 @@ public abstract class BatchQueryOptions
         return wrapped.getKeyspace();
     }
 
-    // TODO Note DB-3681
     public ConsistencyLevel getSerialConsistency(QueryState state)
     {
         return wrapped.getSerialConsistency(state);

--- a/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
@@ -69,9 +69,10 @@ public abstract class BatchQueryOptions
         return wrapped.getKeyspace();
     }
 
-    public ConsistencyLevel getSerialConsistency()
+    // TODO Note DB-3681
+    public ConsistencyLevel getSerialConsistency(QueryState state)
     {
-        return wrapped.getSerialConsistency();
+        return wrapped.getSerialConsistency(state);
     }
 
     public List<Object> getQueryOrIdList()

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -398,7 +398,7 @@ public abstract class QueryOptions
         {
             this.pageSize = pageSize;
             this.state = state;
-            this.serialConsistency = serialConsistency; // == null ? ConsistencyLevel.SERIAL : serialConsistency;
+            this.serialConsistency = serialConsistency;
             this.timestamp = timestamp;
             this.keyspace = keyspace;
             this.nowInSeconds = nowInSeconds;

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -192,8 +192,6 @@ public abstract class QueryOptions
     /**  Serial consistency for conditional updates. */
     public ConsistencyLevel getSerialConsistency(@Nullable QueryState state)
     {
-        // TODO Note DB-3681
-//        return getSpecificOptions().serialConsistency;
         ConsistencyLevel cl = getSpecificOptions().serialConsistency;
         return cl != null ? cl : ConsistencyLevel.defaultSerialConsistency(state);
     }

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -38,6 +38,8 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import javax.annotation.Nullable;
+
 /**
  * Options for a query.
  */
@@ -188,9 +190,12 @@ public abstract class QueryOptions
     }
 
     /**  Serial consistency for conditional updates. */
-    public ConsistencyLevel getSerialConsistency()
+    public ConsistencyLevel getSerialConsistency(@Nullable QueryState state)
     {
-        return getSpecificOptions().serialConsistency;
+        // TODO Note DB-3681
+//        return getSpecificOptions().serialConsistency;
+        ConsistencyLevel cl = getSpecificOptions().serialConsistency;
+        return cl != null ? cl : ConsistencyLevel.defaultSerialConsistency(state);
     }
 
     public long getTimestamp(QueryState state)
@@ -395,7 +400,7 @@ public abstract class QueryOptions
         {
             this.pageSize = pageSize;
             this.state = state;
-            this.serialConsistency = serialConsistency == null ? ConsistencyLevel.SERIAL : serialConsistency;
+            this.serialConsistency = serialConsistency; // == null ? ConsistencyLevel.SERIAL : serialConsistency;
             this.timestamp = timestamp;
             this.keyspace = keyspace;
             this.nowInSeconds = nowInSeconds;
@@ -471,7 +476,7 @@ public abstract class QueryOptions
             {
                 int pageSize = flags.contains(Flag.PAGE_SIZE) ? body.readInt() : -1;
                 PagingState pagingState = flags.contains(Flag.PAGING_STATE) ? PagingState.deserialize(CBUtil.readValueNoCopy(body), version) : null;
-                ConsistencyLevel serialConsistency = flags.contains(Flag.SERIAL_CONSISTENCY) ? CBUtil.readConsistencyLevel(body) : ConsistencyLevel.SERIAL;
+                ConsistencyLevel serialConsistency = flags.contains(Flag.SERIAL_CONSISTENCY) ? CBUtil.readConsistencyLevel(body) : null;
                 long timestamp = Long.MIN_VALUE;
                 if (flags.contains(Flag.TIMESTAMP))
                 {
@@ -506,7 +511,7 @@ public abstract class QueryOptions
             if (flags.contains(Flag.PAGING_STATE))
                 CBUtil.writeValue(options.getPagingState().serialize(version), dest);
             if (flags.contains(Flag.SERIAL_CONSISTENCY))
-                CBUtil.writeConsistencyLevel(options.getSerialConsistency(), dest);
+                CBUtil.writeConsistencyLevel(options.getSerialConsistency(null), dest);
             if (flags.contains(Flag.TIMESTAMP))
                 dest.writeLong(options.getSpecificOptions().timestamp);
             if (flags.contains(Flag.KEYSPACE))
@@ -535,7 +540,7 @@ public abstract class QueryOptions
             if (flags.contains(Flag.PAGING_STATE))
                 size += CBUtil.sizeOfValue(options.getPagingState().serializedSize(version));
             if (flags.contains(Flag.SERIAL_CONSISTENCY))
-                size += CBUtil.sizeOfConsistencyLevel(options.getSerialConsistency());
+                size += CBUtil.sizeOfConsistencyLevel(options.getSerialConsistency(null));
             if (flags.contains(Flag.TIMESTAMP))
                 size += 8;
             if (flags.contains(Flag.KEYSPACE))
@@ -557,7 +562,7 @@ public abstract class QueryOptions
                 flags.add(Flag.PAGE_SIZE);
             if (options.getPagingState() != null)
                 flags.add(Flag.PAGING_STATE);
-            if (options.getSerialConsistency() != ConsistencyLevel.SERIAL)
+            if (options.getSpecificOptions().serialConsistency != null)
                 flags.add(Flag.SERIAL_CONSISTENCY);
             if (options.getSpecificOptions().timestamp != Long.MIN_VALUE)
                 flags.add(Flag.TIMESTAMP);

--- a/src/java/org/apache/cassandra/cql3/UpdateParameters.java
+++ b/src/java/org/apache/cassandra/cql3/UpdateParameters.java
@@ -144,7 +144,7 @@ public class UpdateParameters
     public void addTombstone(ColumnMetadata column, CellPath path) throws InvalidRequestException
     {
         if (path != null && column.type.isMultiCell())
-            Guardrails.columnValueSize.guard(path.dataSize(), column.name.toString(), state);
+            Guardrails.columnValueSize.guard(path.dataSize(), column.name.toString(), false, state);
 
         builder.addCell(BufferCell.tombstone(column, timestamp, nowInSec, path));
     }
@@ -156,10 +156,10 @@ public class UpdateParameters
 
     public Cell addCell(ColumnMetadata column, CellPath path, ByteBuffer value) throws InvalidRequestException
     {
-        Guardrails.columnValueSize.guard(value.remaining(), column.name.toString(), state);
+        Guardrails.columnValueSize.guard(value.remaining(), column.name.toString(), false, state);
 
         if (path != null && column.type.isMultiCell())
-            Guardrails.columnValueSize.guard(path.dataSize(), column.name.toString(), state);
+            Guardrails.columnValueSize.guard(path.dataSize(), column.name.toString(), false, state);
 
         Cell<?> cell = ttl == LivenessInfo.NO_TTL
                        ? BufferCell.live(column, timestamp, value, path)

--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -60,11 +60,11 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             SingleRestriction r = restrictions.get(i);
             r.appendTo(builder, options);
 
+            if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(queryState))
+                Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "IN Select", false, queryState);
+
             if (builder.hasMissingElements())
                 break;
-
-            if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(queryState))
-                Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "IN Select", queryState);
         }
         return builder.build();
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
@@ -82,11 +82,11 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             SingleRestriction r = restrictions.get(i);
             r.appendTo(builder, options);
 
+            if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(queryState))
+                Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "IN Select", false, queryState);
+
             if (builder.hasMissingElements())
                 break;
-
-            if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(queryState))
-                Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "IN Select", queryState);
         }
         return builder.buildSerializedPartitionKeys();
     }

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -277,7 +277,6 @@ public class BatchStatement implements CQLStatement
     @Override
     public void validate(QueryState state) throws InvalidRequestException
     {
-        // TODO: Note cndb-338
         if (isLogged())
             Guardrails.loggedBatchEnabled.ensureEnabled(state);
 
@@ -369,7 +368,6 @@ public class BatchStatement implements CQLStatement
                     tableNames.add(update.metadata().toString());
             }
 
-            //TODO: Note from DB-3611
             Guardrails.batchSize.guard(size, tableNames.toString(), false, queryState);
         }
     }

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -18,7 +18,15 @@
 package org.apache.cassandra.cql3.statements;
 
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -32,16 +40,35 @@ import org.slf4j.helpers.MessageFormatter;
 import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.*;
-import org.apache.cassandra.db.*;
+import org.apache.cassandra.cql3.Attributes;
+import org.apache.cassandra.cql3.BatchQueryOptions;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.VariableSpecifications;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.Slice;
+import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.RowIterator;
-import org.apache.cassandra.exceptions.*;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.metrics.BatchMetrics;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.service.*;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.ClientWarn;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.FBUtilities;
@@ -77,10 +104,6 @@ public class BatchStatement implements CQLStatement
     private final boolean updatesVirtualTables;
 
     private static final Logger logger = LoggerFactory.getLogger(BatchStatement.class);
-
-    private static final String UNLOGGED_BATCH_WARNING = "Unlogged batch covering {} partitions detected " +
-                                                         "against table{} {}. You should use a logged batch for " +
-                                                         "atomicity, or asynchronous writes for performance.";
 
     private static final String LOGGED_BATCH_LOW_GCGS_WARNING = "Executing a LOGGED BATCH on table{} {}, configured with a " +
                                                                 "gc_grace_seconds of 0. The gc_grace_seconds is used to TTL " +
@@ -254,6 +277,10 @@ public class BatchStatement implements CQLStatement
     @Override
     public void validate(QueryState state) throws InvalidRequestException
     {
+        // TODO: Note cndb-338
+        if (isLogged())
+            Guardrails.loggedBatchEnabled.ensureEnabled(state);
+
         for (ModificationStatement statement : statements)
             statement.validate(state);
     }
@@ -325,16 +352,15 @@ public class BatchStatement implements CQLStatement
      *
      * @param mutations - the batch mutations.
      */
-    private static void verifyBatchSize(Collection<? extends IMutation> mutations) throws InvalidRequestException
+    private static void verifyBatchSize(Collection<? extends IMutation> mutations, QueryState queryState) throws InvalidRequestException
     {
         // We only warn for batch spanning multiple mutations (#10876)
         if (mutations.size() <= 1)
             return;
 
-        long warnThreshold = DatabaseDescriptor.getBatchSizeWarnThreshold();
         long size = IMutation.dataSize(mutations);
 
-        if (size > warnThreshold)
+        if (Guardrails.batchSize.triggersOn(size, queryState))
         {
             Set<String> tableNames = new HashSet<>();
             for (IMutation mutation : mutations)
@@ -343,27 +369,12 @@ public class BatchStatement implements CQLStatement
                     tableNames.add(update.metadata().toString());
             }
 
-            long failThreshold = DatabaseDescriptor.getBatchSizeFailThreshold();
-
-            String format = "Batch for {} is of size {}, exceeding specified threshold of {} by {}.{}";
-            if (size > failThreshold)
-            {
-                Tracing.trace(format, tableNames, FBUtilities.prettyPrintMemory(size), FBUtilities.prettyPrintMemory(failThreshold),
-                              FBUtilities.prettyPrintMemory(size - failThreshold), " (see batch_size_fail_threshold_in_kb)");
-                logger.error(format, tableNames, FBUtilities.prettyPrintMemory(size), FBUtilities.prettyPrintMemory(failThreshold),
-                             FBUtilities.prettyPrintMemory(size - failThreshold), " (see batch_size_fail_threshold_in_kb)");
-                throw new InvalidRequestException("Batch too large");
-            }
-            else if (logger.isWarnEnabled())
-            {
-                logger.warn(format, tableNames, FBUtilities.prettyPrintMemory(size), FBUtilities.prettyPrintMemory(warnThreshold),
-                            FBUtilities.prettyPrintMemory(size - warnThreshold), "");
-            }
-            ClientWarn.instance.warn(MessageFormatter.arrayFormat(format, new Object[] {tableNames, size, warnThreshold, size - warnThreshold, ""}).getMessage());
+            //TODO: Note from DB-3611
+            Guardrails.batchSize.guard(size, tableNames.toString(), false, queryState);
         }
     }
 
-    private void verifyBatchType(Collection<? extends IMutation> mutations)
+    private void verifyBatchType(Collection<? extends IMutation> mutations, QueryState queryState)
     {
         if (!isLogged() && mutations.size() > 1)
         {
@@ -382,13 +393,9 @@ public class BatchStatement implements CQLStatement
 
             // CASSANDRA-11529: log only if we have more than a threshold of keys, this was also suggested in the
             // original ticket that introduced this warning, CASSANDRA-9282
-            if (keySet.size() > DatabaseDescriptor.getUnloggedBatchAcrossPartitionsWarnThreshold())
+            if (Guardrails.unloggedBatchAcrossPartitions.triggersOn(keySet.size(), queryState))
             {
-                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES, UNLOGGED_BATCH_WARNING,
-                                 keySet.size(), tableNames.size() == 1 ? "" : "s", tableNames);
-
-                ClientWarn.instance.warn(MessageFormatter.arrayFormat(UNLOGGED_BATCH_WARNING, new Object[]{keySet.size(),
-                                                    tableNames.size() == 1 ? "" : "s", tableNames}).getMessage());
+                Guardrails.unloggedBatchAcrossPartitions.guard(keySet.size(), tableNames.toString(), false, queryState);
             }
         }
     }
@@ -415,7 +422,7 @@ public class BatchStatement implements CQLStatement
             statement.validateDiskUsage(queryState, options.forStatement(i));
         }
 
-        if (options.getSerialConsistency() == null)
+        if (options.getSerialConsistency(queryState) == null)
             throw new InvalidRequestException("Invalid empty serial consistency level");
 
         if (hasConditions)
@@ -424,18 +431,22 @@ public class BatchStatement implements CQLStatement
         if (updatesVirtualTables)
             executeInternalWithoutCondition(queryState, options, queryStartNanoTime);
         else    
-            executeWithoutConditions(getMutations(queryState, options, false, timestamp, nowInSeconds, queryStartNanoTime), cl, queryStartNanoTime);
+            executeWithoutConditions(getMutations(queryState, options, false, timestamp, nowInSeconds, queryStartNanoTime), 
+                                     queryState, cl, queryStartNanoTime);
 
         return new ResultMessage.Void();
     }
 
-    private void executeWithoutConditions(List<? extends IMutation> mutations, ConsistencyLevel cl, long queryStartNanoTime) throws RequestExecutionException, RequestValidationException
+    private void executeWithoutConditions(List<? extends IMutation> mutations,
+                                          QueryState queryState,
+                                          ConsistencyLevel cl,
+                                          long queryStartNanoTime) throws RequestExecutionException, RequestValidationException
     {
         if (mutations.isEmpty())
             return;
 
-        verifyBatchSize(mutations);
-        verifyBatchType(mutations);
+        verifyBatchSize(mutations, queryState);
+        verifyBatchType(mutations, queryState);
 
         updatePartitionsPerBatchMetrics(mutations.size());
 
@@ -467,7 +478,7 @@ public class BatchStatement implements CQLStatement
                                                    tableName,
                                                    casRequest.key,
                                                    casRequest,
-                                                   options.getSerialConsistency(),
+                                                   options.getSerialConsistency(state),
                                                    options.getConsistency(),
                                                    state,
                                                    options.getNowInSeconds(state),

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -518,7 +518,7 @@ public abstract class ModificationStatement implements CQLStatement
                                                    columnFamily(),
                                                    request.key,
                                                    request,
-                                                   options.getSerialConsistency(),
+                                                   options.getSerialConsistency(queryState),
                                                    options.getConsistency(),
                                                    queryState,
                                                    options.getNowInSeconds(queryState),

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -522,7 +522,7 @@ public class SelectStatement implements CQLStatement
         if (keys.isEmpty())
             return ReadQuery.empty(table);
 
-        Guardrails.partitionKeysInSelectQuery.guard(keys.size(), "Select query", queryState);
+        Guardrails.partitionKeysInSelectQuery.guard(keys.size(), "Select query", false, queryState);
 
         ClusteringIndexFilter filter = makeClusteringIndexFilter(options, columnFilter, queryState);
         if (filter == null || filter.isEmpty(table.comparator))

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -198,7 +198,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             TableMetadata tableMetadata = tableBuilder.build();
             tableMetadata.validate();
 
-            Guardrails.columnsPerTable.guard(tableBuilder.numColumns(), tableName, queryState);
+            Guardrails.columnsPerTable.guard(tableBuilder.numColumns(), tableName, false, queryState);
 
             return keyspace.withSwapped(keyspace.tables.withSwapped(tableMetadata))
                            .withSwapped(viewsBuilder.build());

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -138,7 +138,7 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
             List<AbstractType<?>> fieldTypes = new ArrayList<>(userType.fieldTypes()); fieldTypes.add(fieldType);
 
             int newSize = userType.size() + 1;
-            Guardrails.fieldsPerUDT.guard(newSize, userType.getNameAsString(), state);
+            Guardrails.fieldsPerUDT.guard(newSize, userType.getNameAsString(), false, state);
 
             return new UserType(keyspaceName, userType.name, fieldNames, fieldTypes, true);
         }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -112,7 +112,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
                 Guardrails.counterEnabled.ensureEnabled(state);
 
             // Guardrail on columns per table
-            Guardrails.columnsPerTable.guard(rawColumns.size(), tableName, state);
+            Guardrails.columnsPerTable.guard(rawColumns.size(), tableName, false, state);
 
             if (Guardrails.tablesLimit.enabled(state))
             {
@@ -120,7 +120,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
                 int totalUserTables = Schema.instance.getNonInternalKeyspaces().stream().map(Keyspace::open)
                                                      .mapToInt(keyspace -> keyspace.getColumnFamilyStores().size())
                                                      .sum();
-                Guardrails.tablesLimit.guard(totalUserTables + 1, tableName, state);
+                Guardrails.tablesLimit.guard(totalUserTables + 1, tableName, false, state);
             }
         }
     }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTypeStatement.java
@@ -70,7 +70,7 @@ public final class CreateTypeStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        Guardrails.fieldsPerUDT.guard(fieldNames.size(), typeName, state);
+        Guardrails.fieldsPerUDT.guard(fieldNames.size(), typeName, false, state);
     }
 
     public Keyspaces apply(Keyspaces schema)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -160,6 +160,7 @@ public final class CreateViewStatement extends AlterSchemaStatement
                                                         .collect(Collectors.toCollection(HashSet::new));
         Guardrails.materializedViewsPerTable.guard(baseTableViews.size() + 1,
                                                    String.format("%s on table %s", viewName, table.name),
+                                                   false,
                                                    state);
 
         if (table.params.gcGraceSeconds == 0)

--- a/src/java/org/apache/cassandra/db/ConsistencyLevel.java
+++ b/src/java/org/apache/cassandra/db/ConsistencyLevel.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.locator.Endpoints;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -261,7 +260,6 @@ public enum ConsistencyLevel
 
     public void validateCounterForWrite(TableMetadata metadata, QueryState queryState) throws InvalidRequestException
     {
-        // TODO Note from DB-2258
         Guardrails.disallowedWriteConsistencies.ensureAllowed(this, queryState);
 
         if (this == ConsistencyLevel.ANY)
@@ -278,7 +276,6 @@ public enum ConsistencyLevel
                                                             this, replicationStrategy.getClass().getName()));
     }
 
-    // TODO Note DB-3681
     /**
      * Returns the strictest consistency level allowed by Guardrails.
      *

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.*;
 import org.apache.cassandra.db.filter.*;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.guardrails.Guardrail;
@@ -64,7 +63,6 @@ import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.SchemaProvider;
 import org.apache.cassandra.service.ActiveRepairService;
-import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -568,14 +566,9 @@ public abstract class ReadCommand extends AbstractReadQuery
     {
         class MetricRecording extends Transformation<UnfilteredRowIterator>
         {
-//            private final int failureThreshold = DatabaseDescriptor.getTombstoneFailureThreshold();
-//            private final int warningThreshold = DatabaseDescriptor.getTombstoneWarnThreshold();
-
-//            private final boolean respectTombstoneThresholds = !SchemaConstants.isLocalSystemKeyspace(ReadCommand.this.metadata().keyspace);
             private final boolean enforceStrictLiveness = metadata().enforceStrictLiveness();
 
             private int liveRows = 0;
-//            private int tombstones = 0;
             private final Guardrail.Threshold.GuardedCounter tombstones = createTombstoneCounter();
 
             private DecoratedKey currentKey;

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -36,6 +36,9 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.*;
 import org.apache.cassandra.db.filter.*;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.guardrails.Guardrail;
+import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.net.MessageFlag;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.db.partitions.*;
@@ -547,6 +550,17 @@ public abstract class ReadCommand extends AbstractReadQuery
     }
 
     /**
+     * Whether tombstone guardrail ({@link Guardrails#scannedTombstones} should be respected for this query.
+     *
+     * @return {@code true} if the tombstone thresholds should be respected for the query. If {@code false}, no
+     * tombstone warning will ever be logged, and the query will never fail due to tombstones.
+     */
+    protected boolean shouldRespectTombstoneThresholds()
+    {
+        return !SchemaConstants.isLocalSystemKeyspace(ReadCommand.this.metadata().keyspace);
+    }
+
+    /**
      * Wraps the provided iterator so that metrics on what is scanned by the command are recorded.
      * This also log warning/trow TombstoneOverwhelmingException if appropriate.
      */
@@ -554,16 +568,25 @@ public abstract class ReadCommand extends AbstractReadQuery
     {
         class MetricRecording extends Transformation<UnfilteredRowIterator>
         {
-            private final int failureThreshold = DatabaseDescriptor.getTombstoneFailureThreshold();
-            private final int warningThreshold = DatabaseDescriptor.getTombstoneWarnThreshold();
+//            private final int failureThreshold = DatabaseDescriptor.getTombstoneFailureThreshold();
+//            private final int warningThreshold = DatabaseDescriptor.getTombstoneWarnThreshold();
 
-            private final boolean respectTombstoneThresholds = !SchemaConstants.isLocalSystemKeyspace(ReadCommand.this.metadata().keyspace);
+//            private final boolean respectTombstoneThresholds = !SchemaConstants.isLocalSystemKeyspace(ReadCommand.this.metadata().keyspace);
             private final boolean enforceStrictLiveness = metadata().enforceStrictLiveness();
 
             private int liveRows = 0;
-            private int tombstones = 0;
+//            private int tombstones = 0;
+            private final Guardrail.Threshold.GuardedCounter tombstones = createTombstoneCounter();
 
             private DecoratedKey currentKey;
+
+            private Guardrail.Threshold.GuardedCounter createTombstoneCounter()
+            {
+                Guardrail.Threshold guardrail = shouldRespectTombstoneThresholds()
+                                                ? Guardrails.scannedTombstones
+                                                : Guardrail.Threshold.NEVER_TRIGGERED;
+                return guardrail.newCounter(ReadCommand.this::toCQLString, true, null);
+            }
 
             @Override
             public UnfilteredRowIterator applyToPartition(UnfilteredRowIterator iter)
@@ -613,13 +636,18 @@ public abstract class ReadCommand extends AbstractReadQuery
 
             private void countTombstone(ClusteringPrefix<?> clustering)
             {
-                ++tombstones;
-                if (tombstones > failureThreshold && respectTombstoneThresholds)
+                try
                 {
-                    String query = ReadCommand.this.toCQLString();
-                    Tracing.trace("Scanned over {} tombstones for query {}; query aborted (see tombstone_failure_threshold)", failureThreshold, query);
+                    tombstones.add(1);
+                }
+                catch (InvalidRequestException e)
+                {
                     metric.tombstoneFailures.inc();
-                    throw new TombstoneOverwhelmingException(tombstones, query, ReadCommand.this.metadata(), currentKey, clustering);
+                    throw new TombstoneOverwhelmingException(tombstones.get(),
+                                                             ReadCommand.this.toCQLString(),
+                                                             ReadCommand.this.metadata(),
+                                                             currentKey,
+                                                             clustering);
                 }
             }
 
@@ -628,27 +656,13 @@ public abstract class ReadCommand extends AbstractReadQuery
             {
                 recordLatency(metric, System.nanoTime() - startTimeNanos);
 
-                metric.tombstoneScannedHistogram.update(tombstones);
+                metric.tombstoneScannedHistogram.update(tombstones.get());
                 metric.liveScannedHistogram.update(liveRows);
 
-                boolean warnTombstones = tombstones > warningThreshold && respectTombstoneThresholds;
-                if (warnTombstones)
-                {
-                    String msg = String.format(
-                            "Read %d live rows and %d tombstone cells for query %1.512s; token %s (see tombstone_warn_threshold)",
-                            liveRows, tombstones, ReadCommand.this.toCQLString(), currentKey.getToken());
-                    ClientWarn.instance.warn(msg);
-                    if (tombstones < failureThreshold)
-                    {
-                        metric.tombstoneWarnings.inc();
-                    }
+                if (tombstones.checkAndTriggerWarning())
+                    metric.tombstoneWarnings.inc();
 
-                    logger.warn(msg);
-                }
-
-                Tracing.trace("Read {} live rows and {} tombstone cells{}",
-                        liveRows, tombstones,
-                        (warnTombstones ? " (see tombstone_warn_threshold)" : ""));
+                Tracing.trace("Read {} live rows and {} tombstone ones", liveRows, tombstones.get());
             }
         }
 

--- a/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
+++ b/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
@@ -26,7 +26,7 @@ import org.apache.cassandra.db.marshal.*;
 
 public class TombstoneOverwhelmingException extends RuntimeException
 {
-    public TombstoneOverwhelmingException(int numTombstones, String query, TableMetadata metadata, DecoratedKey lastPartitionKey, ClusteringPrefix<?> lastClustering)
+    public TombstoneOverwhelmingException(long numTombstones, String query, TableMetadata metadata, DecoratedKey lastPartitionKey, ClusteringPrefix<?> lastClustering)
     {
         super(String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partion key was (%s)); query aborted",
                             numTombstones, query, lastPartitionKey.getToken(), makePKString(metadata, lastPartitionKey.getKey(), lastClustering)));

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -166,7 +166,7 @@ public abstract class Guardrails
                   (x, what, v, t) -> format("Tables cannot have more than %s materialized views, failed to create materialized view %s",
                                             t, what));
 
-    // TODO STAR-543: Unused until STAR-762 implements paging by bytes and can port pagesize related DB-3208 guardrails
+    // TODO Unused until STAR-762 implements paging by bytes and can port pagesize related DB-3208 guardrails
     public static final Threshold pageSize =
     new SizeThreshold("page_size",
                       () -> -1L,
@@ -286,9 +286,8 @@ public abstract class Guardrails
      *
      * <p>Listeners should be registered through the {@link #register} method to take effect.
      *
-     * <p>Note: this is primarily target at Insights, to generate events when guardrails are triggered.
+     * <p>Note: this provides a mechanism to generate events when guardrails are triggered.
      */
-    //TODO STAR-543 Only used by Insights in DSE - should it be kept?
     public interface Listener
     {
         /**

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -166,6 +166,7 @@ public abstract class Guardrails
                   (x, what, v, t) -> format("Tables cannot have more than %s materialized views, failed to create materialized view %s",
                                             t, what));
 
+    // TODO STAR-543: Unused until STAR-762 implements paging by bytes and can port pagesize related DB-3208 guardrails
     public static final Threshold pageSize =
     new SizeThreshold("page_size",
                       () -> -1L,

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -43,117 +43,46 @@ public abstract class Guardrails
 {
     private static final GuardrailsConfig config = DatabaseDescriptor.getGuardrailsConfig();
 
-    public static final Threshold columnValueSize = new SizeThreshold("column_value_size",
-                                                                      () -> -1L, // not needed so far
-                                                                      () -> config.column_value_size_failure_threshold_in_kb * 1024L,
-                                                                      (x, what, v, t) -> format("Value of %s of size %s is greater than the maximum allowed (%s)",
-                                                                                                what, v, t));
+    public static final Threshold tablesLimit =
+    new Threshold("number_of_tables",
+                  () -> config.tables_warn_threshold,
+                  () -> config.tables_failure_threshold,
+                  (isWarning, what, v, t) -> isWarning
+                                             ? format("Creating table %s, current number of tables %s exceeds warning threshold of %s.",
+                                                      what, v, t)
+                                             : format("Cannot have more than %s tables, failed to create table %s",
+                                                      t, what));
 
-    public static final Threshold columnsPerTable = new Threshold("columns_per_table",
-                                                                  () -> -1L, // not needed so far
-                                                                  () -> config.columns_per_table_failure_threshold,
-                                                                  (x, what, v, t) -> format("Tables cannot have more than %s columns, but %s provided for table %s",
-                                                                                            t, v, what));
+    public static final DisallowedValues<String> disallowedTableProperties =
+    new DisallowedValues<>("disallowed_table_properties",
+                           () -> config.table_properties_disallowed,
+                           String::toLowerCase,
+                           "Table Properties");
 
-    public static final DisableFlag userTimestampsEnabled = new DisableFlag("user_provided_timestamps",
-                                                                            () -> !config.user_timestamps_enabled,
-                                                                            "User provided timestamps (USING TIMESTAMP)");
+    public static final IgnoredValues<String> ignoredTableProperties =
+    new IgnoredValues<>("ignored_table_properties",
+                        () -> config.table_properties_ignored,
+                        String::toLowerCase,
+                        "Table Properties");
 
-    public static final DisableFlag truncateTableEnabled = new DisableFlag("truncate_table",
-                                                                           () -> !config.truncate_table_enabled,
-                                                                           "TRUNCATE table");
+    public static final DisableFlag counterEnabled =
+    new DisableFlag("counter",
+                    () -> !config.counter_enabled,
+                    "Counter");
 
-    public static final DisallowedValues<ConsistencyLevel> disallowedWriteConsistencies = new DisallowedValues<>("disallowed_write_consistency_levels",
-                                                                                                                 () -> config.write_consistency_levels_disallowed,
-                                                                                                                 ConsistencyLevel::fromString,
-                                                                                                                 "Consistency Level");
-
-    public static final Threshold secondaryIndexesPerTable = new Threshold("secondary_indexes_per_table",
-                                                                           () -> -1,
-                                                                           () -> config.secondary_index_per_table_failure_threshold,
-                                                                           (x, what, v, t) -> format("Tables cannot have more than %s secondary indexes, failed to create secondary index %s",
-                                                                                                     t, what));
-
-    public static final Threshold indexesPerTableSasi = new Threshold("sasi_indexes_per_table_failure_threshold",
-                                                                      () -> -1,
-                                                                      () -> config.sasi_indexes_per_table_failure_threshold,
-                                                                      (x, what, v, t) -> format("Tables cannot have more than %s SASI indexes, failed to create SASI index %s",
-                                                                                                t, what));
-
-    public static final Threshold indexesPerTableSai = new Threshold("sai_indexes_per_table_failure_threshold",
-                                                                     () -> -1,
-                                                                     () -> config.sai_indexes_per_table_failure_threshold,
-                                                                     (x, what, v, t) -> format("Tables cannot have more than %s StorageAttachedIndex secondary indexes, failed to create secondary index %s",
-                                                                                               t, what));
-
-    public static final Threshold indexesTotalSai = new Threshold("sai_indexes_total_failure_threshold",
-                                                                  () -> -1,
-                                                                  () -> config.sai_indexes_total_failure_threshold,
-                                                                  (x, what, v, t) -> format("Cannot have more than %s StorageAttachedIndex secondary indexes across all keyspaces, failed to create secondary index %s",
-                                                                                            t, what));
-
-    public static final Threshold materializedViewsPerTable = new Threshold("materialized_views_per_table",
-                                                                            () -> -1,
-                                                                            () -> config.materialized_view_per_table_failure_threshold,
-                                                                            (x, what, v, t) -> format("Tables cannot have more than %s materialized views, failed to create materialized view %s",
-                                                                                                      t, what));
-
-    public static final Threshold tablesLimit = new Threshold("number_of_tables",
-                                                              () -> config.tables_warn_threshold,
-                                                              () -> config.tables_failure_threshold,
-                                                              (isWarning, what, v, t) -> isWarning
-                                                                                         ? format("Creating table %s, current number of tables %s exceeds warning threshold of %s.",
-                                                                                                  what, v, t)
-                                                                                         : format("Cannot have more than %s tables, failed to create table %s",
-                                                                                                  t, what));
-
-    public static final DisallowedValues<String> disallowedTableProperties = new DisallowedValues<>("disallowed_table_properties",
-                                                                                                    () -> config.table_properties_disallowed,
-                                                                                                    String::toLowerCase,
-                                                                                                    "Table Properties");
-
-    public static final IgnoredValues<String> ignoredTableProperties = new IgnoredValues<>("ignored_table_properties", 
-                                                                                           () -> config.table_properties_ignored, 
-                                                                                           String::toLowerCase, 
-                                                                                           "Table Properties");
-    
-    public static final DisableFlag counterEnabled = new DisableFlag("counter",
-                                                                     () -> !config.counter_enabled,
-                                                                     "Counter");
-
-    @SuppressWarnings("unchecked")
-    public static final Predicates<InetAddressAndPort> replicaDiskUsage =
-    (Predicates<InetAddressAndPort>) new Predicates<>("replica_disk_usage",
-                                                      DiskUsageBroadcaster.instance::isStuffed,
-                                                      DiskUsageBroadcaster.instance::isFull,
-                                                      // not using `what` because it represents replica address which should be hidden from client.
-                                                      (isWarning, what) -> isWarning
-                                                                           ? "Replica disk usage exceeds warn threshold"
-                                                                           : "Write request failed because disk usage exceeds failure threshold")
-                                     .minNotifyIntervalInMs(TimeUnit.MINUTES.toMillis(30));
-
-    public static final PercentageThreshold localDiskUsage =
-    (PercentageThreshold) new PercentageThreshold("local_disk_usage",
-                                                  () -> config.disk_usage_percentage_warn_threshold,
-                                                  () -> config.disk_usage_percentage_failure_threshold,
-                                                  (isWarning, what, v, t) -> isWarning
-                                                                             ? format("Local disk usage %s(%s) exceeds warn threshold of %s", v, what, t)
-                                                                             : format("Local disk usage %s(%s) exceeds failure threshold of %s, will stop accepting writes", v, what, t))
-                          .noExceptionOnFailure()
-                          .minNotifyIntervalInMs(TimeUnit.MINUTES.toMillis(30));
-
-    public static final Threshold partitionSize =
-    new SizeThreshold("partition_size",
-                      () -> config.partition_size_warn_threshold_in_mb * 1024L * 1024L,
-                      () -> -1L,
-                      (x, what, v, t) -> format("Detected partition %s of size %s is greater than the maximum recommended size (%s)",
+    public static final Threshold columnValueSize =
+    new SizeThreshold("column_value_size",
+                      () -> -1L, // not needed so far
+                      () -> config.column_value_size_failure_threshold_in_kb * 1024L,
+                      (x, what, v, t) -> format("Value of %s of size %s is greater than the maximum allowed (%s)",
                                                 what, v, t));
 
-    public static final Threshold partitionKeysInSelectQuery =
-    new Threshold("partition_keys_in_select_query",
-                  () -> -1L,
-                  () -> config.partition_keys_in_select_failure_threshold,
-                  (x, what, v, t) -> format("%s cannot be completed because it selects %s partitions keys - more than the maximum allowed %s", what, v, t));
+    public static final Threshold columnsPerTable =
+    new Threshold("columns_per_table",
+                  () -> -1L, // not needed so far
+                  () -> config.columns_per_table_failure_threshold,
+                  (x, what, v, t) -> format("Tables cannot have more than %s columns, but %s provided for table %s",
+                                            t, v, what));
 
     public static final Threshold fieldsPerUDT =
     new Threshold("fields_per_udt",
@@ -176,33 +105,144 @@ public abstract class Guardrails
                   (x, what, v, t) -> format("Detected collection %s with %s items, greater than the maximum recommended (%s)",
                                             what, v, t));
 
+    public static final DisableFlag readBeforeWriteListOperationsEnabled =
+    new DisableFlag("read_before_write_list_operations",
+                    () -> !config.read_before_write_list_operations_enabled,
+                    "List operation requiring read before write");
+
+    public static final DisableFlag userTimestampsEnabled =
+    new DisableFlag("user_provided_timestamps",
+                    () -> !config.user_timestamps_enabled,
+                    "User provided timestamps (USING TIMESTAMP)");
+
+    public static final DisableFlag loggedBatchEnabled =
+    new DisableFlag("logged_batch",
+                    () -> !config.logged_batch_enabled,
+                    "LOGGED batch");
+
+    public static final DisableFlag truncateTableEnabled =
+    new DisableFlag("truncate_table",
+                    () -> !config.truncate_table_enabled,
+                    "TRUNCATE table");
+
+    public static final DisallowedValues<ConsistencyLevel> disallowedWriteConsistencies =
+    new DisallowedValues<>("disallowed_write_consistency_levels",
+                           () -> config.write_consistency_levels_disallowed,
+                           ConsistencyLevel::fromString,
+                           "Write Consistency Level");
+
+    public static final Threshold secondaryIndexesPerTable =
+    new Threshold("secondary_indexes_per_table",
+                  () -> -1,
+                  () -> config.secondary_index_per_table_failure_threshold,
+                  (x, what, v, t) -> format("Tables cannot have more than %s secondary indexes, failed to create secondary index %s",
+                                            t, what));
+
+    public static final Threshold indexesPerTableSasi =
+    new Threshold("sasi_indexes_per_table_failure_threshold",
+                  () -> -1,
+                  () -> config.sasi_indexes_per_table_failure_threshold,
+                  (x, what, v, t) -> format("Tables cannot have more than %s SASI indexes, failed to create SASI index %s",
+                                            t, what));
+
+    public static final Threshold indexesPerTableSai =
+    new Threshold("sai_indexes_per_table_failure_threshold",
+                  () -> -1,
+                  () -> config.sai_indexes_per_table_failure_threshold,
+                  (x, what, v, t) -> format("Tables cannot have more than %s StorageAttachedIndex secondary indexes, failed to create secondary index %s",
+                                            t, what));
+
+    public static final Threshold indexesTotalSai =
+    new Threshold("sai_indexes_total_failure_threshold",
+                  () -> -1,
+                  () -> config.sai_indexes_total_failure_threshold,
+                  (x, what, v, t) -> format("Cannot have more than %s StorageAttachedIndex secondary indexes across all keyspaces, failed to create secondary index %s",
+                                            t, what));
+
+    public static final Threshold materializedViewsPerTable =
+    new Threshold("materialized_views_per_table",
+                  () -> -1,
+                  () -> config.materialized_view_per_table_failure_threshold,
+                  (x, what, v, t) -> format("Tables cannot have more than %s materialized views, failed to create materialized view %s",
+                                            t, what));
+
+    public static final Threshold pageSize =
+    new SizeThreshold("page_size",
+                      () -> -1L,
+                      () -> config.page_size_failure_threshold_in_kb * 1024L,
+                      (x, what, v, t) -> format("Page size %s - %s is greater than the maximum allowed (%s)",
+                                                what, v, t));
+
+    public static final Threshold partitionSize =
+    new SizeThreshold("partition_size",
+                      () -> config.partition_size_warn_threshold_in_mb * 1024L * 1024L,
+                      () -> -1L,
+                      (x, what, v, t) -> format("Detected partition %s of size %s is greater than the maximum recommended size (%s)",
+                                                what, v, t));
+
+    public static final Threshold partitionKeysInSelectQuery =
+    new Threshold("partition_keys_in_select_query",
+                  () -> -1L,
+                  () -> config.partition_keys_in_select_failure_threshold,
+                  (x, what, v, t) -> format("%s cannot be completed because it selects %s partitions keys - more than the maximum allowed %s", what, v, t));
+
     public static final Threshold inSelectCartesianProduct =
     new Threshold("in_select_cartesian_product",
                   () -> -1L,
                   () -> config.in_select_cartesian_product_failure_threshold,
                   (x, what, v, t) -> format("The query cannot be completed because cartesian product of all values in IN conditions is greater than %s", t));
 
-    public static final DisableFlag readBeforeWriteListOperationsEnabled =
-    new DisableFlag("read_before_write_list_operations",
-                    () -> !config.read_before_write_list_operations_enabled,
-                    "List operation requiring read before write");
+    @SuppressWarnings("unchecked")
+    public static final Predicates<InetAddressAndPort> replicaDiskUsage =
+    (Predicates<InetAddressAndPort>) new Predicates<>("replica_disk_usage",
+                                               DiskUsageBroadcaster.instance::isStuffed,
+                                               DiskUsageBroadcaster.instance::isFull,
+                                               // not using `what` because it represents replica address which should be hidden from client.
+                                               (isWarning, what) -> isWarning
+                                                                    ? "Replica disk usage exceeds warn threshold"
+                                                                    : "Write request failed because disk usage exceeds failure threshold")
+                              .minNotifyIntervalInMs(TimeUnit.MINUTES.toMillis(30));
+
+    public static final PercentageThreshold localDiskUsage =
+    (PercentageThreshold) new PercentageThreshold("local_disk_usage",
+                                                  () -> config.disk_usage_percentage_warn_threshold,
+                                                  () -> config.disk_usage_percentage_failure_threshold,
+                                                  (isWarning, what, v, t) -> isWarning
+                                                                             ? format("Local disk usage %s(%s) exceeds warn threshold of %s", v, what, t)
+                                                                             : format("Local disk usage %s(%s) exceeds failure threshold of %s, will stop accepting writes", v, what, t))
+                          .noExceptionOnFailure()
+                          .minNotifyIntervalInMs(TimeUnit.MINUTES.toMillis(30));
+
+    public static final Threshold scannedTombstones =
+    new Threshold("scanned_tombstones",
+                  () -> config.tombstone_warn_threshold,
+                  () -> config.tombstone_failure_threshold,
+                  (isWarning, what, v, t) -> isWarning ?
+                                             format("Scanned over %s tombstone rows for query %1.512s - more than the warning threshold %s", v, what, t) :
+                                             format("Scanned over %s tombstone rows during query %1.512s - more than the maximum allowed %s; query aborted", v, what, t));
+
+
+    public static final Threshold batchSize =
+    new SizeThreshold("batch_size",
+                      config::getBatchSizeWarnThreshold,
+                      config::getBatchSizeFailThreshold,
+                      (isWarning, what, v, t) -> isWarning
+                                                 ? format("Batch for %s is of size %s, exceeding specified warning threshold %s", what, v, t)
+                                                 : format("Batch for %s is of size %s, exceeding specified failure threshold %s", what, v, t));
+
+    public static final Threshold unloggedBatchAcrossPartitions =
+    new Threshold("unlogged_batch_across_partitions",
+                  () -> config.unlogged_batch_across_partitions_warn_threshold,
+                  () -> -1L,
+                  (x, what, v, t) -> format("Unlogged batch covering %s partitions detected " +
+                                            "against table%s %s. You should use a logged batch for " +
+                                            "atomicity, or asynchronous writes for performance.",
+                                            v, what.contains(", ") ? "s" : "", what));
 
     static final List<Listener> listeners = new CopyOnWriteArrayList<>();
 
     private Guardrails()
-    {
-    }
-
-    /**
-     * Whether guardrails are enabled globally or not.
-     *
-     * @return {@code true} if guardrails are enabled (applies based on their individual setting), {@code false}
-     * otherwise (in which case no guardrail will trigger).
-     */
-    public static boolean enabled()
-    {
-        return config.enabled;
-    }
+    {}
 
     /**
      * Whether guardrails are ready.
@@ -222,7 +262,7 @@ public abstract class Guardrails
      * is triggered.
      *
      * @param listener the listener to register. If the same listener is registered twice (or more), its method will be
-     *                 called twice (or more) for every trigger.
+     * called twice (or more) for every trigger.
      */
     public static void register(Listener listener)
     {
@@ -233,7 +273,7 @@ public abstract class Guardrails
      * Unregister a previously registered listener.
      *
      * @param listener the listener to unregister. If it was not registered before, this is a no-op. If it was
-     *                 registered more than once, only one of the instance is unregistered.
+     * registered more than once, only one of the instance is unregistered.
      */
     public static void unregister(Listener listener)
     {
@@ -241,25 +281,36 @@ public abstract class Guardrails
     }
 
     /**
-     * Interface for external listeners interested in being notified when a guardrail is triggered.
+     * Interface for external listener interested in being notified when a guardrail is triggered.
      *
      * <p>Listeners should be registered through the {@link #register} method to take effect.
+     *
+     * <p>Note: this is primarily target at Insights, to generate events when guardrails are triggered.
      */
+    //TODO STAR-543 Only used by Insights in DSE - should it be kept?
     public interface Listener
     {
         /**
          * Called when a guardrail triggers a warning.
          *
+         * <p>This method is called on the thread on which the guardrail is triggered.
+         * Overall, if any blocking work is to be done, the method should submit it asynchronously on a
+         * separate dedicated thread.
+         *
          * @param guardrailName a name describing the guardrail.
-         * @param message       the message corresponding to the guardrail trigger.
+         * @param message the message corresponding to the guardrail trigger.
          */
         public void onWarningTriggered(String guardrailName, String message);
 
         /**
          * Called when a guardrail triggers a failure.
          *
+         * <p>This method is called on the thread on which the guardrail is triggered.
+         * Overall, if any blocking work is to be done, the method should submit it asynchronously on a
+         * separate dedicated thread.
+         *
          * @param guardrailName a name describing the guardrail.
-         * @param message       the message corresponding to the guardrail trigger.
+         * @param message the message corresponding to the guardrail trigger.
          */
         public void onFailureTriggered(String guardrailName, String message);
     }

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -28,10 +28,8 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 
-import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.statements.schema.TableAttributes;
-import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -290,7 +288,6 @@ public class GuardrailsConfig
     public void validateDiskUsageMaxSize()
     {
         long totalDiskSizeInGb = 0L;
-//        for (Directories.DataDirectory directory : ColumnFamilyStore.getInitialDirectories())
         for (Directories.DataDirectory directory : Directories.dataDirectories.getAllDirectories())
         {
             totalDiskSizeInGb += SizeUnit.BYTES.toGigaBytes(directory.getTotalSpace());

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -31,8 +31,11 @@ import com.google.common.collect.Sets;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.statements.schema.TableAttributes;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.utils.units.SizeUnit;
 
 import static java.lang.String.format;
 
@@ -43,17 +46,14 @@ import static java.lang.String.format;
  * checking each guarded constraint (which, again, should use the higher level abstractions defined in
  * {@link Guardrails}).
  *
- * <p>This contains a main setting, {@code enabled}, controlling if guardrails are globally active or not, and
- * individual setting to control each guardrail. We have 2 variants of guardrails, soft (warn) and hard (fail) limits,
- * each guardrail having either one of the variant or both (note in particular that hard limits only make sense for
- * guardrails triggering during query execution. For other guardrails, say one triggering during compaction, failing
- * does not make sense).
+ * <p>We have 2 variants of guardrails, soft (warn) and hard (fail) limits, each guardrail having either one of the
+ * variant or both (note in particular that hard limits only make sense for guardrails triggering during query
+ * execution. For other guardrails, say one triggering during compaction, failing does not make sense).
  *
- * <p>If {@code enabled == false}, no limits should be enforced, be it soft or hard. Additionally, each individual
- * setting should have a specific value (typically -1 for numeric settings), that allows to disable the corresponding
- * guardrail.
+ * <p>Additionally, each individual setting should have a specific value (typically -1 for numeric settings),
+ * that allows to disable the corresponding guardrail.
  *
- * <p>The default values for each guardrail settings should reflect what is mandated for C* aaS environment.
+ * <p>The default values for each guardrail settings should reflect what is mandated for DCaaS.
  *
  * <p>For consistency, guardrails based on a simple numeric threshold should use the naming scheme
  * {@code <what_is_guarded>_warn_threshold} for soft limits and {@code <what_is_guarded>_failure_threshold} for hard
@@ -64,124 +64,128 @@ import static java.lang.String.format;
  */
 public class GuardrailsConfig
 {
-    public static final String INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD = Config.PROPERTY_PREFIX + "index.guardrails.table_failure_threshold";
-    public static final String INDEX_GUARDRAILS_TOTAL_FAILURE_THRESHOLD = Config.PROPERTY_PREFIX + "index.guardrails.total_failure_threshold";
+    public static final String INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD = "index.guardrails.table_failure_threshold";
+    public static final String INDEX_GUARDRAILS_TOTAL_FAILURE_THRESHOLD = "index.guardrails.total_failure_threshold";
 
     public static final int NO_LIMIT = -1;
     public static final int UNSET = -2;
     public static final int DEFAULT_INDEXES_PER_TABLE_THRESHOLD = 10;
     public static final int DEFAULT_INDEXES_TOTAL_THRESHOLD = 100;
 
-    public Boolean enabled = false;
-
-    public Long column_value_size_failure_threshold_in_kb;
-    public Long columns_per_table_failure_threshold;
-
-    public Long tables_warn_threshold;
-    public Long tables_failure_threshold;
-    public Set<String> table_properties_disallowed;
-    public Set<String> table_properties_ignored;
-
-    public Boolean user_timestamps_enabled;
-
-    public Boolean counter_enabled;
+    public volatile Long column_value_size_failure_threshold_in_kb;
+    public volatile Long columns_per_table_failure_threshold;
+    public volatile Long fields_per_udt_failure_threshold;
+    public volatile Long collection_size_warn_threshold_in_kb;
+    public volatile Long items_per_collection_warn_threshold;
+    public volatile Boolean read_before_write_list_operations_enabled;
 
     // Legacy 2i guardrail
-    public Integer secondary_index_per_table_failure_threshold;
-    public Integer sasi_indexes_per_table_failure_threshold;
+    public volatile Integer secondary_index_per_table_failure_threshold;
+    public volatile Integer sasi_indexes_per_table_failure_threshold;
     // SAI indexes guardrail
-    public Integer sai_indexes_per_table_failure_threshold;
-    public Integer sai_indexes_total_failure_threshold;
-    public Integer materialized_view_per_table_failure_threshold;
+    public volatile Integer sai_indexes_per_table_failure_threshold;
+    public volatile Integer sai_indexes_total_failure_threshold;
+    public volatile Integer materialized_view_per_table_failure_threshold;
 
-    public Set<String> write_consistency_levels_disallowed;
+    public volatile Long tables_warn_threshold;
+    public volatile Long tables_failure_threshold;
+    public volatile Set<String> table_properties_disallowed;
+    public volatile Set<String> table_properties_ignored;
 
-    public Integer partition_size_warn_threshold_in_mb;
-    public Integer partition_keys_in_select_failure_threshold;
+    public volatile Boolean user_timestamps_enabled;
+
+    public volatile Boolean logged_batch_enabled;
+
+    public volatile Boolean truncate_table_enabled;
+
+    public volatile Boolean counter_enabled;
+
+    public volatile Set<String> write_consistency_levels_disallowed;
+
+    // For paging by bytes having a page bigger than this threshold will result in a failure
+    // For paging by rows the result will be silently cut short if it is bigger than the threshold
+    public volatile Integer page_size_failure_threshold_in_kb;
 
     // Limit number of terms and their cartesian product in IN query
-    public Integer in_select_cartesian_product_failure_threshold;
+    public volatile Integer in_select_cartesian_product_failure_threshold;
+    public volatile Integer partition_keys_in_select_failure_threshold;
 
-    public Long fields_per_udt_failure_threshold;
-    public Long collection_size_warn_threshold_in_kb;
-    public Long items_per_collection_warn_threshold;
+    // represent percentage of disk space, -1 means disabled
+    public volatile Integer disk_usage_percentage_warn_threshold;
+    public volatile Integer disk_usage_percentage_failure_threshold;
+    public volatile Long disk_usage_max_disk_size_in_gb;
 
-    public Integer disk_usage_percentage_warn_threshold;
-    public Integer disk_usage_percentage_failure_threshold;
+    // When executing a scan, within or across a partition, we need to keep the
+    // tombstones seen in memory so we can return them to the coordinator, which
+    // will use them to make sure other replicas also know about the deleted rows.
+    // With workloads that generate a lot of tombstones, this can cause performance
+    // problems and even exaust the server heap.
+    // (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+    // Adjust the thresholds here if you understand the dangers and want to
+    // scan more tombstones anyway. These thresholds may also be adjusted at runtime
+    // using the StorageService mbean.
+    public volatile Integer tombstone_warn_threshold;
+    public volatile Integer tombstone_failure_threshold;
 
-    public Boolean read_before_write_list_operations_enabled;
+    // Log WARN on any multiple-partition batch size that exceeds this value. 5kb per batch by default.
+    // Use caution when increasing the size of this threshold as it can lead to node instability.
+    public volatile Integer batch_size_warn_threshold_in_kb;
+    // Fail any multiple-partition batch that exceeds this value. The calculated default is 50kb (10x warn threshold).
+    public volatile Integer batch_size_fail_threshold_in_kb;
+    // Log WARN on any batches not of type LOGGED than span across more partitions than this limit.
+    public volatile Integer unlogged_batch_across_partitions_warn_threshold;
 
-    public Boolean truncate_table_enabled;
-
-    /**
-     * Validate that the value provided for each guardrail setting is valid.
-     *
-     * @throws ConfigurationException if any of the settings has an invalid setting.
-     */
-    public void validate()
-    {
-        validateStrictlyPositiveInteger(column_value_size_failure_threshold_in_kb,
-                                        "column_value_size_failure_threshold_in_kb");
-
-        validateStrictlyPositiveInteger(columns_per_table_failure_threshold,
-                                        "columns_per_table_failure_threshold");
-
-        validateStrictlyPositiveInteger(tables_warn_threshold, "tables_warn_threshold");
-        validateStrictlyPositiveInteger(tables_failure_threshold, "tables_failure_threshold");
-        validateWarnLowerThanFail(tables_warn_threshold, tables_failure_threshold, "tables");
-        validateStrictlyPositiveInteger(partition_size_warn_threshold_in_mb, "partition_size_warn_threshold_in_mb");
-        validateStrictlyPositiveInteger(partition_keys_in_select_failure_threshold, "partition_keys_in_select_failure_threshold");
-
-        validateStrictlyPositiveInteger(fields_per_udt_failure_threshold, "fields_per_udt_failure_threshold");
-        validateStrictlyPositiveInteger(collection_size_warn_threshold_in_kb, "collection_size_warn_threshold_in_kb");
-        validateStrictlyPositiveInteger(items_per_collection_warn_threshold, "items_per_collection_warn_threshold");
-
-        validateStrictlyPositiveInteger(in_select_cartesian_product_failure_threshold, "in_select_cartesian_product_failure_threshold");
-
-        validateDisallowedTableProperties();
-        validateIgnoredTableProperties();
-
-        validateDiskUsageThreshold();
-
-        for (String rawCL : write_consistency_levels_disallowed)
-        {
-            try
-            {
-                ConsistencyLevel.fromString(rawCL);
-            }
-            catch (Exception e)
-            {
-                throw new ConfigurationException(format("Invalid value for write_consistency_level_disallowed guardrail: "
-                                                        + "'%s' does not parse as a Consistency Level", rawCL));
-            }
-        }
-    }
+    public volatile Integer partition_size_warn_threshold_in_mb;
 
     /**
-     * If {@link DatabaseDescriptor#isApplyDbaasDefaults()} is true, apply cloud defaults to guardrails settings that
+     * If {@link DatabaseDescriptor#isEmulateDbaasDefaults()} is true, apply cloud defaults to guardrails settings that
      * are not specified in yaml; otherwise, apply on-prem defaults to guardrails settings that are not specified in yaml;
      */
     @VisibleForTesting
     public void applyConfig()
     {
+        // for read requests
+        enforceDefault(page_size_failure_threshold_in_kb, v -> page_size_failure_threshold_in_kb = v, NO_LIMIT, 512);
+
+        enforceDefault(in_select_cartesian_product_failure_threshold, v -> in_select_cartesian_product_failure_threshold = v, NO_LIMIT, 25);
+        enforceDefault(partition_keys_in_select_failure_threshold, v -> partition_keys_in_select_failure_threshold = v, NO_LIMIT, 20);
+
+        enforceDefault(tombstone_warn_threshold, v -> tombstone_warn_threshold = v, 1000, 1000);
+        enforceDefault(tombstone_failure_threshold, v -> tombstone_failure_threshold = v, 100000, 100000);
+
+        // for write requests
+        enforceDefault(logged_batch_enabled, v -> logged_batch_enabled = v, true, true);
+        enforceDefault(batch_size_warn_threshold_in_kb, v -> batch_size_warn_threshold_in_kb = v, 64, 64);
+        enforceDefault(batch_size_fail_threshold_in_kb, v -> batch_size_fail_threshold_in_kb = v, 640, 640);
+        enforceDefault(unlogged_batch_across_partitions_warn_threshold, v -> unlogged_batch_across_partitions_warn_threshold = v, 10, 10);
+
         enforceDefault(truncate_table_enabled, v -> truncate_table_enabled = v, true, true);
 
         enforceDefault(user_timestamps_enabled, v -> user_timestamps_enabled = v, true, true);
 
         enforceDefault(column_value_size_failure_threshold_in_kb, v -> column_value_size_failure_threshold_in_kb = v, -1L, 5 * 1024L);
 
-        enforceDefault(columns_per_table_failure_threshold, v -> columns_per_table_failure_threshold = v, -1L, 20L);
-        enforceDefault(secondary_index_per_table_failure_threshold, v -> secondary_index_per_table_failure_threshold = v, NO_LIMIT, 1);
-        enforceDefault(sasi_indexes_per_table_failure_threshold, v -> sasi_indexes_per_table_failure_threshold = v, NO_LIMIT, 0);
-        enforceDefault(materialized_view_per_table_failure_threshold, v -> materialized_view_per_table_failure_threshold = v, NO_LIMIT, 2);
-        enforceDefault(tables_warn_threshold, v -> tables_warn_threshold = v, -1L, 100L);
-        enforceDefault(tables_failure_threshold, v -> tables_failure_threshold = v, -1L, 200L);
+        enforceDefault(read_before_write_list_operations_enabled, v -> read_before_write_list_operations_enabled = v, true, false);
 
         // We use a LinkedHashSet just for the sake of preserving the ordering in error messages
         enforceDefault(write_consistency_levels_disallowed,
                        v -> write_consistency_levels_disallowed = v,
                        Collections.<String>emptySet(),
                        new LinkedHashSet<>(Arrays.asList("ANY", "ONE", "LOCAL_ONE")));
+
+        // for schema
+        enforceDefault(counter_enabled, v -> counter_enabled = v, true, true);
+
+        enforceDefault(fields_per_udt_failure_threshold, v -> fields_per_udt_failure_threshold = v, -1L, 10L);
+        enforceDefault(collection_size_warn_threshold_in_kb, v -> collection_size_warn_threshold_in_kb = v, -1L, 5 * 1024L);
+        enforceDefault(items_per_collection_warn_threshold, v -> items_per_collection_warn_threshold = v, -1L, 20L);
+
+        enforceDefault(columns_per_table_failure_threshold, v -> columns_per_table_failure_threshold = v, -1L, 50L);
+        enforceDefault(secondary_index_per_table_failure_threshold, v -> secondary_index_per_table_failure_threshold = v, NO_LIMIT, 1);
+        enforceDefault(sasi_indexes_per_table_failure_threshold, v -> sasi_indexes_per_table_failure_threshold = v, NO_LIMIT, 0);
+        enforceDefault(materialized_view_per_table_failure_threshold, v -> materialized_view_per_table_failure_threshold = v, NO_LIMIT, 2);
+        enforceDefault(tables_warn_threshold, v -> tables_warn_threshold = v, -1L, 100L);
+        enforceDefault(tables_failure_threshold, v -> tables_failure_threshold = v, -1L, 200L);
 
         enforceDefault(table_properties_disallowed,
                        v -> table_properties_disallowed = v,
@@ -196,21 +200,12 @@ public class GuardrailsConfig
                                                           .filter(p -> !p.equals("default_time_to_live"))
                                                           .collect(Collectors.toList())));
 
-        enforceDefault(partition_size_warn_threshold_in_mb, v -> partition_size_warn_threshold_in_mb = v, 100, 100);
-        enforceDefault(partition_keys_in_select_failure_threshold, v -> partition_keys_in_select_failure_threshold = v, NO_LIMIT, 20);
-
-        enforceDefault(counter_enabled, v -> counter_enabled = v, true, true);
-
-        enforceDefault(fields_per_udt_failure_threshold, v -> fields_per_udt_failure_threshold = v, -1L, 10L);
-        enforceDefault(collection_size_warn_threshold_in_kb, v -> collection_size_warn_threshold_in_kb = v, -1L, 5 * 1024L);
-        enforceDefault(items_per_collection_warn_threshold, v -> items_per_collection_warn_threshold = v, -1L, 20L);
-
         // for node status
         enforceDefault(disk_usage_percentage_warn_threshold, v -> disk_usage_percentage_warn_threshold = v, NO_LIMIT, 70);
         enforceDefault(disk_usage_percentage_failure_threshold, v -> disk_usage_percentage_failure_threshold = v, NO_LIMIT, 80);
+        enforceDefault(disk_usage_max_disk_size_in_gb, v -> disk_usage_max_disk_size_in_gb = v, (long) NO_LIMIT, (long) NO_LIMIT);
 
-        enforceDefault(in_select_cartesian_product_failure_threshold, v -> in_select_cartesian_product_failure_threshold = v, NO_LIMIT, 25);
-        enforceDefault(read_before_write_list_operations_enabled, v -> read_before_write_list_operations_enabled = v, true, false);
+        enforceDefault(partition_size_warn_threshold_in_mb, v -> partition_size_warn_threshold_in_mb = v, 100, 100);
 
         // SAI Table Failure threshold (maye be overridden via system property)
         Integer overrideTableFailureThreshold = Integer.getInteger(INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD, UNSET);
@@ -223,6 +218,135 @@ public class GuardrailsConfig
         if (overrideTotalFailureThreshold != UNSET)
             sai_indexes_total_failure_threshold = overrideTotalFailureThreshold;
         enforceDefault(sai_indexes_total_failure_threshold, v -> sai_indexes_total_failure_threshold = v, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD);
+    }
+
+    /**
+     * Validate that the value provided for each guardrail setting is valid.
+     *
+     * @throws ConfigurationException if any of the settings has an invalid setting.
+     */
+    public void validate()
+    {
+        validateStrictlyPositiveInteger(column_value_size_failure_threshold_in_kb,
+                                        "column_value_size_failure_threshold_in_kb");
+
+        validateStrictlyPositiveInteger(columns_per_table_failure_threshold,
+                                        "columns_per_table_failure_threshold");
+
+        validateStrictlyPositiveInteger(fields_per_udt_failure_threshold,
+                                        "fields_per_udt_failure_threshold");
+
+        validateStrictlyPositiveInteger(collection_size_warn_threshold_in_kb,
+                                        "collection_size_warn_threshold_in_kb");
+
+        validateStrictlyPositiveInteger(items_per_collection_warn_threshold,
+                                        "items_per_collection_warn_threshold");
+
+        validateStrictlyPositiveInteger(tables_warn_threshold, "tables_warn_threshold");
+        validateStrictlyPositiveInteger(tables_failure_threshold, "tables_failure_threshold");
+        validateWarnLowerThanFail(tables_warn_threshold, tables_failure_threshold, "tables");
+
+        validateDisallowedTableProperties();
+        validateIgnoredTableProperties();
+
+        validateStrictlyPositiveInteger(page_size_failure_threshold_in_kb, "page_size_failure_threshold_in_kb");
+
+        validateStrictlyPositiveInteger(partition_size_warn_threshold_in_mb, "partition_size_warn_threshold_in_mb");
+
+        validateStrictlyPositiveInteger(partition_keys_in_select_failure_threshold, "partition_keys_in_select_failure_threshold");
+
+        validateStrictlyPositiveInteger(in_select_cartesian_product_failure_threshold, "in_select_cartesian_product_failure_threshold");
+
+        validateDiskUsageThreshold();
+
+        validateTombstoneThreshold(tombstone_warn_threshold, tombstone_failure_threshold);
+
+        validateBatchSizeThreshold(batch_size_warn_threshold_in_kb, batch_size_fail_threshold_in_kb);
+        validateStrictlyPositiveInteger(unlogged_batch_across_partitions_warn_threshold, "unlogged_batch_across_partitions_warn_threshold");
+
+        for (String rawCL : write_consistency_levels_disallowed)
+        {
+            try
+            {
+                ConsistencyLevel.fromString(rawCL);
+            }
+            catch (Exception e)
+            {
+                throw new ConfigurationException(format("Invalid value for write_consistency_levels_disallowed guardrail: "
+                                                        + "'%s' does not parse as a Consistency Level", rawCL));
+            }
+        }
+    }
+
+    /**
+     * This validation method should only be called after {@link DatabaseDescriptor#createAllDirectories()} has been called.
+     */
+    public void validateAfterDataDirectoriesExist()
+    {
+        validateDiskUsageMaxSize();
+    }
+
+    @VisibleForTesting
+    public void validateDiskUsageMaxSize()
+    {
+        long totalDiskSizeInGb = 0L;
+//        for (Directories.DataDirectory directory : ColumnFamilyStore.getInitialDirectories())
+        for (Directories.DataDirectory directory : Directories.dataDirectories.getAllDirectories())
+        {
+            totalDiskSizeInGb += SizeUnit.BYTES.toGigaBytes(directory.getTotalSpace());
+        }
+
+        if (totalDiskSizeInGb == 0L)
+        {
+            totalDiskSizeInGb = Long.MAX_VALUE;
+        }
+        validatePositiveNumeric(disk_usage_max_disk_size_in_gb, totalDiskSizeInGb, false, "disk_usage_max_disk_size_in_gb");
+    }
+
+    /**
+     * Enforce default value based on {@link DatabaseDescriptor#isEmulateDbaasDefaults()} if
+     * it's not specified in yaml
+     *
+     * @param current current config value defined in yaml
+     * @param optionSetter setter to updated given config
+     * @param onPremDefault default value for on-prem
+     * @param dbaasDefault default value for constellation DB-as-a-service
+     * @param <T>
+     */
+    private static <T> void enforceDefault(T current, Consumer<T> optionSetter, T onPremDefault, T dbaasDefault)
+    {
+        if (current != null)
+            return;
+
+        optionSetter.accept(DatabaseDescriptor.isEmulateDbaasDefaults() ? dbaasDefault : onPremDefault);
+    }
+
+    /**
+     * @return true if given disk usage threshold disables disk usage guardrail
+     */
+    public static boolean diskUsageGuardrailDisabled(double value)
+    {
+        return value < 0;
+    }
+
+    /**
+     * Validate that the values provided for disk usage are valid.
+     *
+     * @throws ConfigurationException if any of the settings has an invalid setting.
+     */
+    @VisibleForTesting
+    public void validateDiskUsageThreshold()
+    {
+        validatePositiveNumeric(disk_usage_percentage_warn_threshold, 100, false, "disk_usage_percentage_warn_threshold");
+        validatePositiveNumeric(disk_usage_percentage_failure_threshold, 100, false, "disk_usage_percentage_failure_threshold");
+        validateWarnLowerThanFail(disk_usage_percentage_warn_threshold, disk_usage_percentage_failure_threshold, "disk_usage_percentage");
+    }
+
+    public void validateTombstoneThreshold(long warnThreshold, long failureThreshold)
+    {
+        validateStrictlyPositiveInteger(warnThreshold, "tombstone_warn_threshold");
+        validateStrictlyPositiveInteger(failureThreshold, "tombstone_failure_threshold");
+        validateWarnLowerThanFail(warnThreshold, failureThreshold, "tombstone_threshold");
     }
 
     private void validateDisallowedTableProperties()
@@ -247,7 +371,7 @@ public class GuardrailsConfig
 
     private void validateStrictlyPositiveInteger(long value, String name)
     {
-        // We use 'long' for generality, but most numeric guardrails cannot effectively be more than an 'int' for various
+        // We use 'long' for generality, but most numeric guardrail cannot effectively be more than a 'int' for various
         // internal reasons. Not that any should ever come close in practice ...
         // Also, in most cases, zero does not make sense (allowing 0 tables or columns is not exactly useful).
         validatePositiveNumeric(value, Integer.MAX_VALUE, false, name);
@@ -280,42 +404,45 @@ public class GuardrailsConfig
                                                     warnValue, guardName, failValue));
     }
 
-    /**
-     * Enforce default value based on {@link DatabaseDescriptor#isApplyDbaasDefaults()} if
-     * it's not specified in yaml
-     *
-     * @param current       current config value defined in yaml
-     * @param optionSetter  setter to updated given config
-     * @param onPremDefault default value for on-prem
-     * @param dbaasDefault  default value for constellation DB-as-a-service
-     * @param <T>
-     */
-    private static <T> void enforceDefault(T current, Consumer<T> optionSetter, T onPremDefault, T dbaasDefault)
+    public void setTombstoneFailureThreshold(int threshold)
     {
-        if (current != null)
-            return;
-
-        optionSetter.accept(DatabaseDescriptor.isApplyDbaasDefaults() ? dbaasDefault : onPremDefault);
+        validateTombstoneThreshold(tombstone_warn_threshold, threshold);
+        tombstone_failure_threshold = threshold;
     }
 
-    /**
-     * @return true if given disk usage threshold disables disk usage guardrail
-     */
-    public static boolean diskUsageGuardrailDisabled(double value)
+    public void setTombstoneWarnThreshold(int threshold)
     {
-        return value < 0;
+        validateTombstoneThreshold(threshold, tombstone_failure_threshold);
+        tombstone_warn_threshold = threshold;
     }
 
-    /**
-     * Validate that the values provided for disk usage are valid.
-     *
-     * @throws ConfigurationException if any of the settings has an invalid setting.
-     */
-    @VisibleForTesting
-    public void validateDiskUsageThreshold()
+
+    public void validateBatchSizeThreshold(long warnThreshold, long failureThreshold)
     {
-        validatePositiveNumeric(disk_usage_percentage_warn_threshold, 100, false, "disk_usage_percentage_warn_threshold");
-        validatePositiveNumeric(disk_usage_percentage_failure_threshold, 100, false, "disk_usage_percentage_failure_threshold");
-        validateWarnLowerThanFail(disk_usage_percentage_warn_threshold, disk_usage_percentage_failure_threshold, "disk_usage_percentage");
+        validateStrictlyPositiveInteger(warnThreshold, "batch_size_warn_threshold_in_kb");
+        validateStrictlyPositiveInteger(failureThreshold, "batch_size_fail_threshold_in_kb");
+        validateWarnLowerThanFail(warnThreshold, failureThreshold, "batch_size_threshold");
+    }
+
+    public int getBatchSizeWarnThreshold()
+    {
+        return batch_size_warn_threshold_in_kb * 1024;
+    }
+
+    public int getBatchSizeFailThreshold()
+    {
+        return batch_size_fail_threshold_in_kb * 1024;
+    }
+
+    public void setBatchSizeWarnThresholdInKB(int threshold)
+    {
+        validateBatchSizeThreshold(threshold, batch_size_fail_threshold_in_kb);
+        batch_size_warn_threshold_in_kb = threshold;
+    }
+
+    public void setBatchSizeFailThresholdInKB(int threshold)
+    {
+        validateBatchSizeThreshold(batch_size_warn_threshold_in_kb, threshold);
+        batch_size_fail_threshold_in_kb = threshold;
     }
 }

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -89,8 +89,8 @@ public class GuardrailsConfig
 
     public volatile Long tables_warn_threshold;
     public volatile Long tables_failure_threshold;
-    public volatile ImmutableSet<String> table_properties_disallowed;
-    public volatile ImmutableSet<String> table_properties_ignored;
+    public volatile Set<String> table_properties_disallowed;
+    public volatile Set<String> table_properties_ignored;
 
     public volatile Boolean user_timestamps_enabled;
 
@@ -100,7 +100,7 @@ public class GuardrailsConfig
 
     public volatile Boolean counter_enabled;
 
-    public volatile ImmutableSet<String> write_consistency_levels_disallowed;
+    public volatile Set<String> write_consistency_levels_disallowed;
 
     // For paging by bytes having a page bigger than this threshold will result in a failure
     // For paging by rows the result will be silently cut short if it is bigger than the threshold

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -87,8 +88,8 @@ public class GuardrailsConfig
 
     public volatile Long tables_warn_threshold;
     public volatile Long tables_failure_threshold;
-    public volatile Set<String> table_properties_disallowed;
-    public volatile Set<String> table_properties_ignored;
+    public volatile ImmutableSet<String> table_properties_disallowed;
+    public volatile ImmutableSet<String> table_properties_ignored;
 
     public volatile Boolean user_timestamps_enabled;
 
@@ -98,7 +99,7 @@ public class GuardrailsConfig
 
     public volatile Boolean counter_enabled;
 
-    public volatile Set<String> write_consistency_levels_disallowed;
+    public volatile ImmutableSet<String> write_consistency_levels_disallowed;
 
     // For paging by bytes having a page bigger than this threshold will result in a failure
     // For paging by rows the result will be silently cut short if it is bigger than the threshold
@@ -167,7 +168,7 @@ public class GuardrailsConfig
 
         // We use a LinkedHashSet just for the sake of preserving the ordering in error messages
         enforceDefault(write_consistency_levels_disallowed,
-                       v -> write_consistency_levels_disallowed = v,
+                       v -> write_consistency_levels_disallowed = ImmutableSet.copyOf(v),
                        Collections.<String>emptySet(),
                        new LinkedHashSet<>(Arrays.asList("ANY", "ONE", "LOCAL_ONE")));
 
@@ -186,12 +187,12 @@ public class GuardrailsConfig
         enforceDefault(tables_failure_threshold, v -> tables_failure_threshold = v, -1L, 200L);
 
         enforceDefault(table_properties_disallowed,
-                       v -> table_properties_disallowed = v,
+                       v -> table_properties_disallowed = ImmutableSet.copyOf(v),
                        Collections.<String>emptySet(),
                        Collections.<String>emptySet());
 
         enforceDefault(table_properties_ignored,
-                       v -> table_properties_ignored = v,
+                       v -> table_properties_ignored = ImmutableSet.copyOf(v),
                        Collections.<String>emptySet(),
                        new LinkedHashSet<>(TableAttributes.allKeywords().stream()
                                                           .sorted()

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.statements.schema.TableAttributes;
 import org.apache.cassandra.db.ConsistencyLevel;
@@ -63,8 +64,8 @@ import static java.lang.String.format;
  */
 public class GuardrailsConfig
 {
-    public static final String INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD = "index.guardrails.table_failure_threshold";
-    public static final String INDEX_GUARDRAILS_TOTAL_FAILURE_THRESHOLD = "index.guardrails.total_failure_threshold";
+    public static final String INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD = Config.PROPERTY_PREFIX + "index.guardrails.table_failure_threshold";
+    public static final String INDEX_GUARDRAILS_TOTAL_FAILURE_THRESHOLD = Config.PROPERTY_PREFIX + "index.guardrails.total_failure_threshold";
 
     public static final int NO_LIMIT = -1;
     public static final int UNSET = -2;

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -89,6 +89,7 @@ public class GuardrailsConfig
 
     public volatile Long tables_warn_threshold;
     public volatile Long tables_failure_threshold;
+    // N.B. Not safe for concurrent modification
     public volatile Set<String> table_properties_disallowed;
     public volatile Set<String> table_properties_ignored;
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -436,7 +436,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         if (!unfiltered.isRow() || SchemaConstants.isInternalKeyspace(partition.metadata().keyspace))
             return;
 
-        if (!Guardrails.collectionSize.enabled() && !Guardrails.itemsPerCollection.enabled())
+        if (!Guardrails.collectionSize.enabled(null) && !Guardrails.itemsPerCollection.enabled(null))
             return;
 
         Row row = (Row) unfiltered;
@@ -456,8 +456,8 @@ public abstract class SSTableWriter extends SSTable implements Transactional
             int cellsSize = liveCells.dataSize();
             int cellsCount = liveCells.cellsCount();
 
-            if (!Guardrails.collectionSize.triggersOn(cellsSize) &&
-                !Guardrails.itemsPerCollection.triggersOn(cellsCount))
+            if (!Guardrails.collectionSize.triggersOn(cellsSize, null) &&
+                !Guardrails.itemsPerCollection.triggersOn(cellsCount, null))
                 continue;
 
             TableMetadata metadata = partition.metadata();
@@ -467,8 +467,8 @@ public abstract class SSTableWriter extends SSTable implements Transactional
                                        column.name.toString(),
                                        keyString,
                                        metadata);
-            Guardrails.collectionSize.guard(cellsSize, msg, true);
-            Guardrails.itemsPerCollection.guard(cellsCount, msg, true);
+            Guardrails.collectionSize.guard(cellsSize, msg, true, null);
+            Guardrails.itemsPerCollection.guard(cellsCount, msg, true, null);
         }
     }
 
@@ -494,10 +494,10 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         if (SchemaConstants.isInternalKeyspace(metadata().keyspace))
             return;
 
-        if (Guardrails.partitionSize.triggersOn(rowSize))
+        if (Guardrails.partitionSize.triggersOn(rowSize, null))
         {
             String keyString = metadata().partitionKeyAsCQLLiteral(key.getKey());
-            Guardrails.partitionSize.guard(rowSize, String.format("%s in %s", keyString, metadata), true);
+            Guardrails.partitionSize.guard(rowSize, String.format("%s in %s", keyString, metadata), true, null);
         }
 
         if (rowSize > DatabaseDescriptor.getCompactionLargePartitionWarningThreshold())

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -499,11 +499,5 @@ public abstract class SSTableWriter extends SSTable implements Transactional
             String keyString = metadata().partitionKeyAsCQLLiteral(key.getKey());
             Guardrails.partitionSize.guard(rowSize, String.format("%s in %s", keyString, metadata), true, null);
         }
-
-        if (rowSize > DatabaseDescriptor.getCompactionLargePartitionWarningThreshold())
-        {
-            String keyString = metadata().partitionKeyType.getString(key.getKey());
-            logger.warn("Writing large partition {}/{}:{} ({}) to sstable {}", metadata.keyspace, metadata.name, keyString, FBUtilities.prettyPrintMemory(rowSize), getFilename());
-        }
     }
 }

--- a/src/java/org/apache/cassandra/service/QueryState.java
+++ b/src/java/org/apache/cassandra/service/QueryState.java
@@ -123,7 +123,7 @@ public class QueryState
      */
     public boolean isOrdinaryUser()
     {
-        AuthenticatedUser user = this.getClientState().getUser();
-        return null != user && !user.isSystem() && !user.isSuper();
+        AuthenticatedUser user = getClientState().getUser();
+        return !getClientState().isInternal && null != user && !user.isSystem() && !user.isSuper();
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5641,23 +5641,23 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public int getTombstoneWarnThreshold()
     {
-        return DatabaseDescriptor.getTombstoneWarnThreshold();
+        return DatabaseDescriptor.getGuardrailsConfig().tombstone_warn_threshold;
     }
 
     public void setTombstoneWarnThreshold(int threshold)
     {
-        DatabaseDescriptor.setTombstoneWarnThreshold(threshold);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneWarnThreshold(threshold);
         logger.info("updated tombstone_warn_threshold to {}", threshold);
     }
 
     public int getTombstoneFailureThreshold()
     {
-        return DatabaseDescriptor.getTombstoneFailureThreshold();
+        return DatabaseDescriptor.getGuardrailsConfig().tombstone_failure_threshold;
     }
 
     public void setTombstoneFailureThreshold(int threshold)
     {
-        DatabaseDescriptor.setTombstoneFailureThreshold(threshold);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneFailureThreshold(threshold);
         logger.info("updated tombstone_failure_threshold to {}", threshold);
     }
 
@@ -5696,23 +5696,23 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public int getBatchSizeFailureThreshold()
     {
-        return DatabaseDescriptor.getBatchSizeFailThresholdInKB();
+        return DatabaseDescriptor.getGuardrailsConfig().batch_size_fail_threshold_in_kb;
     }
 
     public void setBatchSizeFailureThreshold(int threshold)
     {
-        DatabaseDescriptor.setBatchSizeFailThresholdInKB(threshold);
+        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB(threshold);
         logger.info("updated batch_size_fail_threshold_in_kb to {}", threshold);
     }
 
     public int getBatchSizeWarnThreshold()
     {
-        return DatabaseDescriptor.getBatchSizeWarnThresholdInKB();
+        return DatabaseDescriptor.getGuardrailsConfig().batch_size_warn_threshold_in_kb;
     }
 
     public void setBatchSizeWarnThreshold(int threshold)
     {
-        DatabaseDescriptor.setBatchSizeWarnThresholdInKB(threshold);
+        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(threshold);
         logger.info("Updated batch_size_warn_threshold_in_kb to {}", threshold);
     }
 

--- a/src/java/org/apache/cassandra/service/disk/usage/DiskUsageMonitor.java
+++ b/src/java/org/apache/cassandra/service/disk/usage/DiskUsageMonitor.java
@@ -75,7 +75,7 @@ public class DiskUsageMonitor
         // start the scheduler regardless guardrail is enabled, so we can enable it later without a restart
         ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
 
-            if (!Guardrails.localDiskUsage.enabled())
+            if (!Guardrails.localDiskUsage.enabled(null))
                 return;
 
             updateLocalState(getDiskUsage(), notifier);
@@ -90,7 +90,7 @@ public class DiskUsageMonitor
 
         DiskUsageState state = getState(percentageCeiling);
 
-        Guardrails.localDiskUsage.guard(percentageCeiling, state.toString(), false);
+        Guardrails.localDiskUsage.guard(percentageCeiling, state.toString(), false, null);
 
         // if state remains unchanged, no need to notify peers
         if (state == localState)

--- a/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
@@ -236,8 +236,8 @@ public class BatchMessage extends Message.Request
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         if (options.getConsistency() != null)
             builder.put("consistency_level", options.getConsistency().name());
-        if (options.getSerialConsistency() != null)
-            builder.put("serial_consistency_level", options.getSerialConsistency().name());
+        if (options.getSerialConsistency(state) != null)
+            builder.put("serial_consistency_level", options.getSerialConsistency(state).name());
 
         // TODO we don't have [typed] access to CQL bind variables here.  CASSANDRA-4560 is open to add support.
         Tracing.instance.begin("Execute batch of CQL3 queries", state.getClientAddress(), builder.build());

--- a/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
@@ -186,7 +186,6 @@ public class ExecuteMessage extends Message.Request
             builder.put("page_size", Integer.toString(options.getPageSize()));
         if (options.getConsistency() != null)
             builder.put("consistency_level", options.getConsistency().name());
-        // TODO Note DB-3681
         if (options.getSerialConsistency(state) != null)
             builder.put("serial_consistency_level", options.getSerialConsistency(state).name());
 

--- a/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
@@ -186,8 +186,9 @@ public class ExecuteMessage extends Message.Request
             builder.put("page_size", Integer.toString(options.getPageSize()));
         if (options.getConsistency() != null)
             builder.put("consistency_level", options.getConsistency().name());
-        if (options.getSerialConsistency() != null)
-            builder.put("serial_consistency_level", options.getSerialConsistency().name());
+        // TODO Note DB-3681
+        if (options.getSerialConsistency(state) != null)
+            builder.put("serial_consistency_level", options.getSerialConsistency(state).name());
 
         builder.put("query", prepared.rawCQLStatement);
 

--- a/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
@@ -18,12 +18,14 @@
 package org.apache.cassandra.transport.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Compressor;
@@ -73,6 +75,7 @@ public class OptionsMessage extends Message.Request
         supported.put(StartupMessage.CQL_VERSION, cqlVersions);
         supported.put(StartupMessage.COMPRESSION, compressions);
         supported.put(StartupMessage.PROTOCOL_VERSIONS, ProtocolVersion.supportedVersions());
+        supported.put(StartupMessage.EMULATE_DBAAS_DEFAULTS, Collections.singletonList(String.valueOf(DatabaseDescriptor.isEmulateDbaasDefaults())));
 
         return new SupportedMessage(supported);
     }

--- a/src/java/org/apache/cassandra/transport/messages/QueryMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/QueryMessage.java
@@ -131,8 +131,8 @@ public class QueryMessage extends Message.Request
             builder.put("page_size", Integer.toString(options.getPageSize()));
         if (options.getConsistency() != null)
             builder.put("consistency_level", options.getConsistency().name());
-        if (options.getSerialConsistency() != null)
-            builder.put("serial_consistency_level", options.getSerialConsistency().name());
+        if (options.getSerialConsistency(state) != null)
+            builder.put("serial_consistency_level", options.getSerialConsistency(state).name());
 
         Tracing.instance.begin("Execute CQL3 query", state.getClientAddress(), builder.build());
     }

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -40,6 +40,7 @@ public class StartupMessage extends Message.Request
     public static final String DRIVER_NAME = "DRIVER_NAME";
     public static final String DRIVER_VERSION = "DRIVER_VERSION";
     public static final String THROW_ON_OVERLOAD = "THROW_ON_OVERLOAD";
+    public static final String EMULATE_DBAAS_DEFAULTS = "EMULATE_DBAAS_DEFAULTS";
 
     public static final Message.Codec<StartupMessage> codec = new Message.Codec<StartupMessage>()
     {

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -313,15 +313,15 @@ public class DatabaseDescriptorTest
 
         try
         {
-            DatabaseDescriptor.setBatchSizeWarnThresholdInKB(-1);
-            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = -1");
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(-2);
+            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = -2");
         }
         catch (ConfigurationException ignored) { }
-        Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+        Assert.assertEquals(65536, DatabaseDescriptor.getGuardrailsConfig().getBatchSizeWarnThreshold());
 
         try
         {
-            DatabaseDescriptor.setBatchSizeWarnThresholdInKB(2 * 1024 * 1024);
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(2 * 1024 * 1024);
             fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = 2GiB");
         }
         catch (ConfigurationException ignored) { }

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
@@ -668,17 +668,17 @@ public class SecondaryIndexTest extends CQLTester
         // (the non-conditional batch doesn't hit this because
         // BatchStatement::executeLocally skips the size check but CAS
         // path does not)
-        long batchSizeThreshold = DatabaseDescriptor.getBatchSizeFailThreshold();
+        int batchSizeThreshold = DatabaseDescriptor.getGuardrailsConfig().batch_size_fail_threshold_in_kb;
         try
         {
-            DatabaseDescriptor.setBatchSizeFailThresholdInKB( (TOO_BIG / 1024) * 2);
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB((TOO_BIG / 1024) * 2);
             succeedInsert("BEGIN BATCH\n" +
                           "INSERT INTO %s (a, b, c) VALUES (1, 1, ?) IF NOT EXISTS;\n" +
                           "APPLY BATCH", ByteBuffer.allocate(TOO_BIG));
         }
         finally
         {
-            DatabaseDescriptor.setBatchSizeFailThresholdInKB((int) (batchSizeThreshold / 1024));
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB(batchSizeThreshold);
         }
     }
 
@@ -721,17 +721,20 @@ public class SecondaryIndexTest extends CQLTester
         // (the non-conditional batch doesn't hit this because
         // BatchStatement::executeLocally skips the size check but CAS
         // path does not)
-        long batchSizeThreshold = DatabaseDescriptor.getBatchSizeFailThreshold();
+        int batchSizeThreshold = DatabaseDescriptor.getGuardrailsConfig().batch_size_fail_threshold_in_kb;
+        int diskUsageThreshold = DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold;
         try
         {
-            DatabaseDescriptor.setBatchSizeFailThresholdInKB( (TOO_BIG / 1024) * 2);
+            DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold = -1;
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB( (TOO_BIG / 1024) * 2);
             succeedInsert("BEGIN BATCH\n" +
                           "INSERT INTO %s (a, b, c) VALUES (1, 1, ?) IF NOT EXISTS;\n" +
                           "APPLY BATCH", ByteBuffer.allocate(TOO_BIG));
         }
         finally
         {
-            DatabaseDescriptor.setBatchSizeFailThresholdInKB((int)(batchSizeThreshold / 1024));
+            DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB(batchSizeThreshold);
+            DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold = diskUsageThreshold;
         }
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/TombstonesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/TombstonesTest.java
@@ -72,13 +72,13 @@ public class TombstonesTest extends CQLTester
 
         // insert exactly the amount of tombstones that shouldn't trigger an exception
         for (int i = 0; i < FAILURE_THRESHOLD; i++)
-            execute("INSERT INTO %s (a, b, c) VALUES ('key', 'column" + i + "', null);");
+            execute("DELETE FROM %s WHERE a = 'key' and b = '" + i + "'");
 
         try
         {
             execute("SELECT * FROM %s WHERE a = 'key';");
             assertEquals(oldFailures, cfs.metric.tombstoneFailures.getCount());
-            assertEquals(oldWarnings, cfs.metric.tombstoneWarnings.getCount());
+            assertEquals(oldWarnings + 1, cfs.metric.tombstoneWarnings.getCount());
         }
         catch (Throwable e)
         {
@@ -96,7 +96,7 @@ public class TombstonesTest extends CQLTester
 
         // insert exactly the amount of tombstones that *SHOULD* trigger an exception
         for (int i = 0; i < FAILURE_THRESHOLD + 1; i++)
-            execute("INSERT INTO %s (a, b, c) VALUES ('key', 'column" + i + "', null);");
+            execute("DELETE FROM %s WHERE a = 'key' and b = '" + i + "'");
 
         try
         {
@@ -218,7 +218,7 @@ public class TombstonesTest extends CQLTester
 
         // insert the number of tombstones that *SHOULD* trigger an Warning
         for (int i = 0; i < WARN_THRESHOLD + 1; i++)
-            execute("INSERT INTO %s (a, b, c ) VALUES ('key', 'cc" + i + "',  null);");
+            execute("DELETE FROM %s WHERE a = 'key' and b = '" + i + "'");
         try
         {
             execute("SELECT * FROM %s WHERE a = 'key';");

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/TombstonesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/TombstonesTest.java
@@ -40,25 +40,25 @@ import static junit.framework.Assert.fail;
  */
 public class TombstonesTest extends CQLTester
 {
-    static final int ORIGINAL_FAILURE_THRESHOLD = DatabaseDescriptor.getTombstoneFailureThreshold();
+    static final int ORIGINAL_FAILURE_THRESHOLD = DatabaseDescriptor.getGuardrailsConfig().tombstone_failure_threshold;
     static final int FAILURE_THRESHOLD = 100;
 
-    static final int ORIGINAL_WARN_THRESHOLD = DatabaseDescriptor.getTombstoneFailureThreshold();
+    static final int ORIGINAL_WARN_THRESHOLD = DatabaseDescriptor.getGuardrailsConfig().tombstone_warn_threshold;
     static final int WARN_THRESHOLD = 50;
 
     @BeforeClass
     public static void setUp() throws Throwable
     {
         DatabaseDescriptor.daemonInitialization();
-        DatabaseDescriptor.setTombstoneFailureThreshold(FAILURE_THRESHOLD);
-        DatabaseDescriptor.setTombstoneWarnThreshold(WARN_THRESHOLD);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneWarnThreshold(WARN_THRESHOLD);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneFailureThreshold(FAILURE_THRESHOLD);
     }
 
     @AfterClass
     public static void tearDown()
     {
-        DatabaseDescriptor.setTombstoneFailureThreshold(ORIGINAL_FAILURE_THRESHOLD);
-        DatabaseDescriptor.setTombstoneWarnThreshold(ORIGINAL_WARN_THRESHOLD);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneFailureThreshold(ORIGINAL_FAILURE_THRESHOLD);
+        DatabaseDescriptor.getGuardrailsConfig().setTombstoneWarnThreshold(ORIGINAL_WARN_THRESHOLD);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
+++ b/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
@@ -678,7 +678,7 @@ public class FullQueryLoggerTest extends CQLTester
         assertEquals(a.getConsistency(), b.getConsistency());
         assertEquals(a.getPagingState(), b.getPagingState());
         assertEquals(a.getValues(), b.getValues());
-        assertEquals(a.getSerialConsistency(), b.getSerialConsistency());
+        assertEquals(a.getSerialConsistency(null), b.getSerialConsistency(null));
     }
 
     private void configureFQL() throws Exception

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -38,11 +39,9 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.ProtocolVersion;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 public class GuardrailConsistencyTest extends GuardrailTester
 {
-    private static final Set<String> DISALLOWED_WRITE_CLS = new LinkedHashSet<>(Arrays.asList(
+    private static Set<String> disallowedConsistencyLevels = new LinkedHashSet<>(Arrays.asList(
     ConsistencyLevel.ANY.toString(),
     ConsistencyLevel.ONE.toString(),
     ConsistencyLevel.TWO.toString(),
@@ -50,14 +49,12 @@ public class GuardrailConsistencyTest extends GuardrailTester
     ConsistencyLevel.QUORUM.toString(),
     ConsistencyLevel.ALL.toString(),
     ConsistencyLevel.EACH_QUORUM.toString(),
-    ConsistencyLevel.LOCAL_ONE.toString()));
-
-    private static final Set<String> SERIAL_CLS = new LinkedHashSet<>(Arrays.asList(
+    ConsistencyLevel.LOCAL_ONE.toString()
+    ));
+    private static Set<String> serialConsistencyLevels = new LinkedHashSet<>(Arrays.asList(
     ConsistencyLevel.SERIAL.toString(),
     ConsistencyLevel.LOCAL_SERIAL.toString()
     ));
-    private static final Set<String> SERIAL_ONLY = new LinkedHashSet<>(Collections.singletonList(ConsistencyLevel.SERIAL.toString()));
-    private static final LinkedHashSet<String> LOCAL_SERIAL_ONLY = new LinkedHashSet<>(Collections.singletonList(ConsistencyLevel.LOCAL_SERIAL.toString()));
 
     private static Set<String> defaultDisallowedWriteConsistencyLevels;
     private Supplier<QueryState> queryState;
@@ -79,12 +76,31 @@ public class GuardrailConsistencyTest extends GuardrailTester
     {
         createTable("CREATE TABLE IF NOT EXISTS %s (k INT, c INT, v TEXT, PRIMARY KEY(k, c))");
         queryState = this::userQueryState;
-        disableConsistencyLevels(DISALLOWED_WRITE_CLS);
+        disableConsistencyLevels(disallowedConsistencyLevels);
     }
 
     private void disableConsistencyLevels(Set<String> consistencyLevels)
     {
         DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = consistencyLevels;
+    }
+
+    private QueryOptions queryOptions(ConsistencyLevel cl, ConsistencyLevel serialCl)
+    {
+        return QueryOptions.create(cl,
+                                   Collections.emptyList(),
+                                   false,
+                                   1,
+                                   null,
+//                                   new QueryOptions.PagingOptions(new PageSize(1,
+//                                                                               PageSize.PageUnit.ROWS),
+//                                                                  QueryOptions.PagingOptions.Mechanism.CONTINUOUS,
+//                                                                  null,
+//                                                                  10,
+//                                                                  1,
+//                                                                  1),
+                                   serialCl,
+                                   ProtocolVersion.CURRENT,
+                                   KEYSPACE);
     }
 
     private void executeWithConsistency(String query, ConsistencyLevel cl, ConsistencyLevel serialCl)
@@ -105,30 +121,24 @@ public class GuardrailConsistencyTest extends GuardrailTester
         executeWithConsistency("INSERT INTO %s (k, c, v) VALUES (1, 2, 'val') IF NOT EXISTS", cl, serialCl);
     }
 
-    @Test
+    @Test(expected = InvalidRequestException.class)
     public void testInsertWithDisallowedConsistency()
     {
-        assertThatThrownBy(() -> insert(ConsistencyLevel.ONE))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value ONE is not allowed for Consistency Level (disallowed values are: [ANY, ONE, TWO, THREE, QUORUM, ALL, EACH_QUORUM, LOCAL_ONE])");
+        insert(ConsistencyLevel.ONE);
     }
 
-    @Test
+    @Test(expected = InvalidRequestException.class)
     public void testLWTInsertWithDisallowedConsistency1()
     {
-        disableConsistencyLevels(SERIAL_ONLY);
-        assertThatThrownBy(() -> lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL])");
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
     }
 
-    @Test
+    @Test(expected = InvalidRequestException.class)
     public void testLWTInsertWithDisallowedConsistency2()
     {
-        disableConsistencyLevels(SERIAL_CLS);
-        assertThatThrownBy(() -> lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL, LOCAL_SERIAL])");
+        disableConsistencyLevels(serialConsistencyLevels);
+        lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null);
     }
 
     @Test
@@ -137,149 +147,13 @@ public class GuardrailConsistencyTest extends GuardrailTester
         // test that it does not throw
         insert(ConsistencyLevel.LOCAL_QUORUM);
 
-        disableConsistencyLevels(SERIAL_ONLY);
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
+        lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null);
 
-        disableConsistencyLevels(LOCAL_SERIAL_ONLY);
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
-    }
-
-    @Test
-    public void testLWTUpdateWithDisallowedConsistency()
-    {
-        disableConsistencyLevels(SERIAL_ONLY);
-        assertThatThrownBy(() -> lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL])");
-    }
-
-    @Test
-    public void testLWTUpdateWithDisallowedConsistency1()
-    {
-        disableConsistencyLevels(SERIAL_ONLY);
-        assertThatThrownBy(() -> lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL])");
-    }
-
-    @Test
-    public void testLWTUpdateWithDisallowedConsistency2()
-    {
-        disableConsistencyLevels(SERIAL_CLS);
-        assertThatThrownBy(() -> lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL, LOCAL_SERIAL])");
-    }
-
-    @Test
-    public void testUpdateWithAllowedConsistency()
-    {
-        // test that it does not throw
-        update(ConsistencyLevel.LOCAL_QUORUM);
-
-        disableConsistencyLevels(SERIAL_ONLY);
-        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
-
-        disableConsistencyLevels(LOCAL_SERIAL_ONLY);
-        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
-    }
-
-    @Test
-    public void testUpdateWithDisallowedConsistency()
-    {
-        assertThatThrownBy(() -> update(ConsistencyLevel.ONE))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value ONE is not allowed for Consistency Level (disallowed values are: [ANY, ONE, TWO, THREE, QUORUM, ALL, EACH_QUORUM, LOCAL_ONE])");
-    }
-
-    @Test
-    public void testDeleteWithDisallowedConsistency()
-    {
-        assertThatThrownBy(() -> delete(ConsistencyLevel.ONE))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value ONE is not allowed for Consistency Level (disallowed values are: [ANY, ONE, TWO, THREE, QUORUM, ALL, EACH_QUORUM, LOCAL_ONE])");
-    }
-
-    @Test
-    public void testLWTDeleteWithAllowedConsistency1()
-    {
-        disableConsistencyLevels(SERIAL_ONLY);
-        assertThatThrownBy(() -> lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL])");
-    }
-
-    @Test
-    public void testLWTDeleteWithAllowedConsistency2()
-    {
-        disableConsistencyLevels(SERIAL_CLS);
-        assertThatThrownBy(() -> lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL, LOCAL_SERIAL])");
-    }
-
-    @Test
-    public void testDeleteWithAllowedConsistency()
-    {
-        // test that it does not throw
-        delete(ConsistencyLevel.LOCAL_QUORUM);
-
-        disableConsistencyLevels(SERIAL_ONLY);
-        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
-
-        disableConsistencyLevels(LOCAL_SERIAL_ONLY);
-        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
-    }
-
-    @Test
-    public void testLWTBatchWithDisallowedConsistency1()
-    {
-        disableConsistencyLevels(SERIAL_ONLY);
-        assertThatThrownBy(() -> lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL])");
-    }
-
-    @Test
-    public void testLWTBatchWithDisallowedConsistency2()
-    {
-        disableConsistencyLevels(SERIAL_CLS);
-        assertThatThrownBy(() -> lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value SERIAL is not allowed for Consistency Level (disallowed values are: [SERIAL, LOCAL_SERIAL])");
-    }
-
-    @Test
-    public void testBatchWithAllowedConsistency()
-    {
-        // test that it does not throw
-        batch(ConsistencyLevel.LOCAL_QUORUM);
-
-        disableConsistencyLevels(SERIAL_ONLY);
-        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
-
-        disableConsistencyLevels(LOCAL_SERIAL_ONLY);
-        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
-    }
-
-    @Test
-    public void testBatchWithDisallowedConsistency()
-    {
-        assertThatThrownBy(() -> batch(ConsistencyLevel.ONE))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Provided value ONE is not allowed for Consistency Level (disallowed values are: [ANY, ONE, TWO, THREE, QUORUM, ALL, EACH_QUORUM, LOCAL_ONE])");
-    }
-
-    private QueryOptions queryOptions(ConsistencyLevel cl, ConsistencyLevel serialCl)
-    {
-        return QueryOptions.create(cl,
-                                   Collections.emptyList(),
-                                   false,
-                                   1,
-                                   null,
-                                   serialCl,
-                                   ProtocolVersion.CURRENT,
-                                   KEYSPACE);
+        lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null);
     }
 
     private void update(ConsistencyLevel cl)
@@ -292,6 +166,41 @@ public class GuardrailConsistencyTest extends GuardrailTester
         executeWithConsistency("UPDATE %s SET v = 'val2' WHERE k = 1 and c = 2 IF EXISTS", cl, serialCl);
     }
 
+    @Test(expected = InvalidRequestException.class)
+    public void testUpdateWithDisallowedConsistency()
+    {
+        update(ConsistencyLevel.ONE);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTUpdateWithDisallowedConsistency1()
+    {
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTUpdateWithDisallowedConsistency2()
+    {
+        disableConsistencyLevels(serialConsistencyLevels);
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null);
+    }
+
+    @Test
+    public void testUpdateWithAllowedConsistency()
+    {
+        // test that it does not throw
+        update(ConsistencyLevel.LOCAL_QUORUM);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+        lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null);
+    }
+
     private void delete(ConsistencyLevel cl)
     {
         executeWithConsistency("DELETE FROM %s WHERE k=1", cl, null);
@@ -300,6 +209,41 @@ public class GuardrailConsistencyTest extends GuardrailTester
     private void lwtDelete(ConsistencyLevel cl, ConsistencyLevel serialCl)
     {
         executeWithConsistency("DELETE FROM %s WHERE k=1 AND c=2 IF EXISTS", cl, serialCl);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testDeleteWithDisallowedConsistency()
+    {
+        delete(ConsistencyLevel.ONE);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTDeleteWithAllowedConsistency1()
+    {
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTDeleteWithAllowedConsistency2()
+    {
+        disableConsistencyLevels(serialConsistencyLevels);
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null);
+    }
+
+    @Test
+    public void testDeleteWithAllowedConsistency()
+    {
+        // test that it does not throw
+        delete(ConsistencyLevel.LOCAL_QUORUM);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+        lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null);
     }
 
     private void batch(ConsistencyLevel cl)
@@ -314,6 +258,40 @@ public class GuardrailConsistencyTest extends GuardrailTester
         executeWithConsistency("BEGIN BATCH " +
                                "INSERT INTO %s (k, c, v) VALUES (1, 2, 'val') IF NOT EXISTS " +
                                "APPLY BATCH", cl, serialCl);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testBatchWithDisallowedConsistency()
+    {
+        batch(ConsistencyLevel.ONE);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTBatchWithDisallowedConsistency1()
+    {
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testLWTBatchWithDisallowedConsistency2()
+    {
+        disableConsistencyLevels(serialConsistencyLevels);
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null);
+    }
+    @Test
+    public void testBatchWithAllowedConsistency()
+    {
+        // test that it does not throw
+        batch(ConsistencyLevel.LOCAL_QUORUM);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null);
+
+        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
+        lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null);
     }
 
     @Test
@@ -332,6 +310,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
 
     private void testExcludedUser()
     {
+        disableConsistencyLevels(Sets.union(defaultDisallowedWriteConsistencyLevels, serialConsistencyLevels));
         insert(ConsistencyLevel.ONE);
         insert(ConsistencyLevel.LOCAL_QUORUM);
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
@@ -353,4 +332,3 @@ public class GuardrailConsistencyTest extends GuardrailTester
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
     }
 }
-

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
@@ -57,7 +57,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     ConsistencyLevel.LOCAL_SERIAL.toString()
     ));
 
-    private static ImmutableSet<String> defaultDisallowedWriteConsistencyLevels;
+    private static Set<String> defaultDisallowedWriteConsistencyLevels;
     private Supplier<QueryState> queryState;
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
@@ -18,9 +18,7 @@
 
 package org.apache.cassandra.guardrails;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -42,7 +40,7 @@ import org.apache.cassandra.transport.ProtocolVersion;
 
 public class GuardrailConsistencyTest extends GuardrailTester
 {
-    private static Set<String> disallowedConsistencyLevels = new LinkedHashSet<>(Arrays.asList(
+    private static Set<String> disallowedConsistencyLevels = ImmutableSet.of(
     ConsistencyLevel.ANY.toString(),
     ConsistencyLevel.ONE.toString(),
     ConsistencyLevel.TWO.toString(),
@@ -51,11 +49,11 @@ public class GuardrailConsistencyTest extends GuardrailTester
     ConsistencyLevel.ALL.toString(),
     ConsistencyLevel.EACH_QUORUM.toString(),
     ConsistencyLevel.LOCAL_ONE.toString()
-    ));
-    private static Set<String> serialConsistencyLevels = new LinkedHashSet<>(Arrays.asList(
+    );
+    private static Set<String> serialConsistencyLevels = ImmutableSet.of(
     ConsistencyLevel.SERIAL.toString(),
     ConsistencyLevel.LOCAL_SERIAL.toString()
-    ));
+    );
 
     private static Set<String> defaultDisallowedWriteConsistencyLevels;
     private Supplier<QueryState> queryState;
@@ -124,7 +122,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     @Test(expected = InvalidRequestException.class)
     public void testLWTInsertWithDisallowedConsistency1()
     {
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
     }
 
@@ -141,11 +139,11 @@ public class GuardrailConsistencyTest extends GuardrailTester
         // test that it does not throw
         insert(ConsistencyLevel.LOCAL_QUORUM);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.LOCAL_SERIAL.toString()));
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
         lwtInsert(ConsistencyLevel.LOCAL_QUORUM, null);
     }
@@ -169,7 +167,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     @Test(expected = InvalidRequestException.class)
     public void testLWTUpdateWithDisallowedConsistency1()
     {
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
     }
 
@@ -186,11 +184,11 @@ public class GuardrailConsistencyTest extends GuardrailTester
         // test that it does not throw
         update(ConsistencyLevel.LOCAL_QUORUM);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
         lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.LOCAL_SERIAL.toString()));
         lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
         lwtUpdate(ConsistencyLevel.LOCAL_QUORUM, null);
     }
@@ -214,7 +212,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     @Test(expected = InvalidRequestException.class)
     public void testLWTDeleteWithAllowedConsistency1()
     {
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
     }
 
@@ -231,11 +229,11 @@ public class GuardrailConsistencyTest extends GuardrailTester
         // test that it does not throw
         delete(ConsistencyLevel.LOCAL_QUORUM);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
         lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.LOCAL_SERIAL.toString()));
         lwtDelete(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
         lwtDelete(ConsistencyLevel.LOCAL_QUORUM, null);
     }
@@ -263,7 +261,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     @Test(expected = InvalidRequestException.class)
     public void testLWTBatchWithDisallowedConsistency1()
     {
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
     }
 
@@ -279,11 +277,11 @@ public class GuardrailConsistencyTest extends GuardrailTester
         // test that it does not throw
         batch(ConsistencyLevel.LOCAL_QUORUM);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.SERIAL.toString()));
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_SERIAL);
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null);
 
-        disableConsistencyLevels(new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())));
+        disableConsistencyLevels(ImmutableSet.of(ConsistencyLevel.LOCAL_SERIAL.toString()));
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.SERIAL);
         lwtBatch(ConsistencyLevel.LOCAL_QUORUM, null);
     }

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -56,7 +57,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
     ConsistencyLevel.LOCAL_SERIAL.toString()
     ));
 
-    private static Set<String> defaultDisallowedWriteConsistencyLevels;
+    private static ImmutableSet<String> defaultDisallowedWriteConsistencyLevels;
     private Supplier<QueryState> queryState;
 
     @BeforeClass
@@ -81,7 +82,7 @@ public class GuardrailConsistencyTest extends GuardrailTester
 
     private void disableConsistencyLevels(Set<String> consistencyLevels)
     {
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = consistencyLevels;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.copyOf(consistencyLevels);
     }
 
     private QueryOptions queryOptions(ConsistencyLevel cl, ConsistencyLevel serialCl)

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailConsistencyTest.java
@@ -91,13 +91,6 @@ public class GuardrailConsistencyTest extends GuardrailTester
                                    false,
                                    1,
                                    null,
-//                                   new QueryOptions.PagingOptions(new PageSize(1,
-//                                                                               PageSize.PageUnit.ROWS),
-//                                                                  QueryOptions.PagingOptions.Mechanism.CONTINUOUS,
-//                                                                  null,
-//                                                                  10,
-//                                                                  1,
-//                                                                  1),
                                    serialCl,
                                    ProtocolVersion.CURRENT,
                                    KEYSPACE);

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailDiskUsageTest.java
@@ -336,9 +336,14 @@ public class GuardrailDiskUsageTest extends GuardrailTester
             executeNet(batchStatement);
         };
 
+        // STAR-654 Short delay after grant permissions
+        Thread.sleep(1000);
+
         // default state, write request works fine
-        assertTrue(Guardrails.enabled());
+        assertTrue(Guardrails.ready());
+//        logger.info("danj diskusagetest before select");
         assertValid(select);
+//        logger.info("danj diskusagetest after select");
         assertValid(insert);
         assertValid(batch);
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailDiskUsageTest.java
@@ -336,14 +336,12 @@ public class GuardrailDiskUsageTest extends GuardrailTester
             executeNet(batchStatement);
         };
 
-        // STAR-654 Short delay after grant permissions
+        // delay needed after grant permissions
         Thread.sleep(1000);
 
         // default state, write request works fine
         assertTrue(Guardrails.ready());
-//        logger.info("danj diskusagetest before select");
         assertValid(select);
-//        logger.info("danj diskusagetest after select");
         assertValid(insert);
         assertValid(batch);
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
@@ -1,8 +1,21 @@
 /*
- * Copyright DataStax, Inc.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Please see the included license file for details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.cassandra.guardrails;
 
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.guardrails;
+
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.BatchStatement;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+public class GuardrailLoggedBatchTest extends GuardrailTester
+{
+    private static boolean loggedBatchEnabled;
+
+    @BeforeClass
+    public static void setup()
+    {
+        loggedBatchEnabled = DatabaseDescriptor.getGuardrailsConfig().logged_batch_enabled;
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        DatabaseDescriptor.getGuardrailsConfig().logged_batch_enabled = loggedBatchEnabled;
+    }
+
+    @Before
+    public void setupTest()
+    {
+        createTable("CREATE TABLE IF NOT EXISTS %s (k INT, c INT, v TEXT, PRIMARY KEY(k, c))");
+    }
+
+    private void setGuardrails(boolean logged_batch_enabled)
+    {
+        DatabaseDescriptor.getGuardrailsConfig().logged_batch_enabled = logged_batch_enabled;
+    }
+
+    private void insertBatch(boolean loggedBatchEnabled, boolean logged) throws Throwable
+    {
+        setGuardrails(loggedBatchEnabled);
+
+        BatchStatement batch = new BatchStatement(logged ? BatchStatement.Type.LOGGED : BatchStatement.Type.UNLOGGED);
+        batch.add(new SimpleStatement(String.format("INSERT INTO %s.%s (k, c, v) VALUES (1, 2, 'val')", keyspace(), currentTable())));
+        batch.add(new SimpleStatement(String.format("INSERT INTO %s.%s (k, c, v) VALUES (3, 4, 'val')", keyspace(), currentTable())));
+
+        assertValid(batch);
+    }
+
+    @Test
+    public void testInsertUnloggedBatch() throws Throwable
+    {
+        insertBatch(false, false);
+        insertBatch(true, false);
+    }
+
+    @Test(expected = InvalidQueryException.class)
+    public void testDisabledLoggedBatch() throws Throwable
+    {
+        insertBatch(false, true);
+    }
+
+    @Test
+    public void testEnabledLoggedBatch() throws Throwable
+    {
+        insertBatch(true, true);
+    }
+}

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailLoggedBatchTest.java
@@ -56,7 +56,7 @@ public class GuardrailLoggedBatchTest extends GuardrailTester
         DatabaseDescriptor.getGuardrailsConfig().logged_batch_enabled = logged_batch_enabled;
     }
 
-    private void insertBatch(boolean loggedBatchEnabled, boolean logged) throws Throwable
+    private void insertBatchAndAssertValid(boolean loggedBatchEnabled, boolean logged) throws Throwable
     {
         setGuardrails(loggedBatchEnabled);
 
@@ -70,19 +70,19 @@ public class GuardrailLoggedBatchTest extends GuardrailTester
     @Test
     public void testInsertUnloggedBatch() throws Throwable
     {
-        insertBatch(false, false);
-        insertBatch(true, false);
+        insertBatchAndAssertValid(false, false);
+        insertBatchAndAssertValid(true, false);
     }
 
     @Test(expected = InvalidQueryException.class)
     public void testDisabledLoggedBatch() throws Throwable
     {
-        insertBatch(false, true);
+        insertBatchAndAssertValid(false, true);
     }
 
     @Test
     public void testEnabledLoggedBatch() throws Throwable
     {
-        insertBatch(true, true);
+        insertBatchAndAssertValid(true, true);
     }
 }

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailSAIIndexesTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailSAIIndexesTest.java
@@ -67,10 +67,10 @@ public class GuardrailSAIIndexesTest extends GuardrailTester
 
     public void testDefaults(boolean dbaas)
     {
-        boolean previous = DatabaseDescriptor.isApplyDbaasDefaults();
+        boolean previous = DatabaseDescriptor.isEmulateDbaasDefaults();
         try
         {
-            DatabaseDescriptor.setApplyDbaasDefaults(dbaas);
+            DatabaseDescriptor.setEmulateDbaasDefaults(dbaas);
 
             GuardrailsConfig config = new GuardrailsConfig();
             config.applyConfig();
@@ -80,7 +80,7 @@ public class GuardrailSAIIndexesTest extends GuardrailTester
         }
         finally
         {
-            DatabaseDescriptor.setApplyDbaasDefaults(previous);
+            DatabaseDescriptor.setEmulateDbaasDefaults(previous);
         }
     }
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -31,6 +31,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -52,7 +53,6 @@ public abstract class GuardrailTester extends CQLTester
     static final String USERNAME = "guardrail_user";
     static final String PASSWORD = "guardrail_password";
 
-    private static boolean guardRailsEnabled;
     private static Set<String> tablePropertiesDisallowed;
 
     protected TestListener listener;
@@ -60,9 +60,6 @@ public abstract class GuardrailTester extends CQLTester
     @BeforeClass
     public static void setupGuardrailTester()
     {
-        guardRailsEnabled = DatabaseDescriptor.getGuardrailsConfig().enabled;
-        DatabaseDescriptor.getGuardrailsConfig().enabled = true;
-
         tablePropertiesDisallowed = DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed;
         DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = Collections.emptySet();
 
@@ -73,7 +70,6 @@ public abstract class GuardrailTester extends CQLTester
     @AfterClass
     public static void tearDownGuardrailTester()
     {
-        DatabaseDescriptor.getGuardrailsConfig().enabled = guardRailsEnabled;
         DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = tablePropertiesDisallowed;
     }
 
@@ -86,6 +82,10 @@ public abstract class GuardrailTester extends CQLTester
         useSuperUser();
         executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USERNAME, PASSWORD));
         executeNet(format("GRANT ALL ON KEYSPACE %s TO %s", KEYSPACE, USERNAME));
+
+        // STAR-654 Short delay after grant permissions
+//        Thread.sleep(1000);
+        
         useUser(USERNAME, PASSWORD);
 
         listener = new TestListener(null);
@@ -236,6 +236,11 @@ public abstract class GuardrailTester extends CQLTester
     protected void assertValid(String query, Object... args) throws Throwable
     {
         assertValid(() -> executeNet(query, args));
+    }
+
+    protected void assertValid(Statement query) throws Throwable
+    {
+        assertValid(() -> executeNet(query));
     }
 
     protected void assertWarns(CheckedFunction function, String... messages) throws Throwable

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.guardrails;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
@@ -49,7 +50,7 @@ public abstract class GuardrailTester extends CQLTester
     static final String USERNAME = "guardrail_user";
     static final String PASSWORD = "guardrail_password";
 
-    private static ImmutableSet<String> tablePropertiesDisallowed;
+    private static Set<String> tablePropertiesDisallowed;
 
     protected TestListener listener;
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -18,9 +18,7 @@
 
 package org.apache.cassandra.guardrails;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
@@ -81,9 +79,6 @@ public abstract class GuardrailTester extends CQLTester
         executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USERNAME, PASSWORD));
         executeNet(format("GRANT ALL ON KEYSPACE %s TO %s", KEYSPACE, USERNAME));
 
-        // STAR-654 Short delay after grant permissions
-//        Thread.sleep(1000);
-        
         useUser(USERNAME, PASSWORD);
 
         listener = new TestListener(null);

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -50,7 +51,7 @@ public abstract class GuardrailTester extends CQLTester
     static final String USERNAME = "guardrail_user";
     static final String PASSWORD = "guardrail_password";
 
-    private static Set<String> tablePropertiesDisallowed;
+    private static ImmutableSet<String> tablePropertiesDisallowed;
 
     protected TestListener listener;
 
@@ -58,7 +59,7 @@ public abstract class GuardrailTester extends CQLTester
     public static void setupGuardrailTester()
     {
         tablePropertiesDisallowed = DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed;
-        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = Collections.emptySet();
+        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = ImmutableSet.of();
 
         requireAuthentication();
         requireNetwork();

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import org.junit.After;
@@ -38,11 +37,9 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.ClientState;
-import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.After;
@@ -67,7 +66,7 @@ public class GuardrailsOnTableTest extends GuardrailTester
                                      .map(String::toUpperCase)
                                      .collect(ImmutableSet.toImmutableSet());
         // but actually ignore "comment"
-        DatabaseDescriptor.getGuardrailsConfig().table_properties_ignored = ImmutableSet.copyOf(Arrays.asList("comment"));
+        DatabaseDescriptor.getGuardrailsConfig().table_properties_ignored = ImmutableSet.of("comment");
     }
 
     @After
@@ -207,10 +206,10 @@ public class GuardrailsOnTableTest extends GuardrailTester
     {
         GuardrailsConfig config = DatabaseDescriptor.getGuardrailsConfig();
 
-        config.table_properties_disallowed = ImmutableSet.copyOf(Arrays.asList("ID1", "gc_grace_seconds"));
+        config.table_properties_disallowed = ImmutableSet.of("ID1", "gc_grace_seconds");
         assertConfigFails(config::validate, "[id1]");
 
-        config.table_properties_disallowed = ImmutableSet.copyOf(Arrays.asList("ID", "Gc_Grace_Seconds"));
+        config.table_properties_disallowed = ImmutableSet.of("ID", "Gc_Grace_Seconds");
         config.validate();
     }
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
@@ -46,8 +46,8 @@ public class GuardrailsOnTableTest extends GuardrailTester
     private static long defaultTablesSoftLimit;
     private static long defaultTableHardLimit;
     private static int defaultMVPerTableFailureThreshold;
-    private static ImmutableSet<String> defaultTablePropertiesDisallowed;
-    private static ImmutableSet<String> defaultTablePropertiesIgnored;
+    private static Set<String> defaultTablePropertiesDisallowed;
+    private static Set<String> defaultTablePropertiesIgnored;
 
     @Before
     public void before()

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,8 +46,8 @@ public class GuardrailsOnTableTest extends GuardrailTester
     private static long defaultTablesSoftLimit;
     private static long defaultTableHardLimit;
     private static int defaultMVPerTableFailureThreshold;
-    private static Set<String> defaultTablePropertiesDisallowed;
-    private static Set<String> defaultTablePropertiesIgnored;
+    private static ImmutableSet<String> defaultTablePropertiesDisallowed;
+    private static ImmutableSet<String> defaultTablePropertiesIgnored;
 
     @Before
     public void before()
@@ -64,9 +65,9 @@ public class GuardrailsOnTableTest extends GuardrailTester
         TableAttributes.validKeywords.stream()
                                      .filter(p -> !allowed.contains(p))
                                      .map(String::toUpperCase)
-                                     .collect(Collectors.toSet());
+                                     .collect(ImmutableSet.toImmutableSet());
         // but actually ignore "comment"
-        DatabaseDescriptor.getGuardrailsConfig().table_properties_ignored = new HashSet<>(Arrays.asList("comment"));
+        DatabaseDescriptor.getGuardrailsConfig().table_properties_ignored = ImmutableSet.copyOf(Arrays.asList("comment"));
     }
 
     @After
@@ -206,10 +207,10 @@ public class GuardrailsOnTableTest extends GuardrailTester
     {
         GuardrailsConfig config = DatabaseDescriptor.getGuardrailsConfig();
 
-        config.table_properties_disallowed = new HashSet<>(Arrays.asList("ID1", "gc_grace_seconds"));
+        config.table_properties_disallowed = ImmutableSet.copyOf(Arrays.asList("ID1", "gc_grace_seconds"));
         assertConfigFails(config::validate, "[id1]");
 
-        config.table_properties_disallowed = new HashSet<>(Arrays.asList("ID", "Gc_Grace_Seconds"));
+        config.table_properties_disallowed = ImmutableSet.copyOf(Arrays.asList("ID", "Gc_Grace_Seconds"));
         config.validate();
     }
 

--- a/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.service;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 

--- a/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
@@ -18,6 +18,8 @@
 package org.apache.cassandra.service;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +62,10 @@ public class ClientWarningsTest extends CQLTester
     public static void setUp()
     {
         requireNetwork();
-        DatabaseDescriptor.setBatchSizeWarnThresholdInKB(1);
+        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(1);
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = new HashSet<>();
+        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = new HashSet<>();
+        DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold = -1;
     }
 
     @Test
@@ -77,7 +82,7 @@ public class ClientWarningsTest extends CQLTester
             Message.Response resp = client.execute(query);
             assertNull(resp.getWarnings());
 
-            query = new QueryMessage(createBatchStatement2(DatabaseDescriptor.getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
+            query = new QueryMessage(createBatchStatement2(DatabaseDescriptor.getGuardrailsConfig().getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
             resp = client.execute(query);
             assertEquals(1, resp.getWarnings().size());
         }
@@ -93,11 +98,11 @@ public class ClientWarningsTest extends CQLTester
         {
             client.connect(false);
 
-            QueryMessage query = new QueryMessage(createBatchStatement2(DatabaseDescriptor.getBatchSizeWarnThreshold() / 2 + 1), QueryOptions.DEFAULT);
+            QueryMessage query = new QueryMessage(createBatchStatement2(DatabaseDescriptor.getGuardrailsConfig().getBatchSizeWarnThreshold() / 2 + 1), QueryOptions.DEFAULT);
             Message.Response resp = client.execute(query);
             assertEquals(1, resp.getWarnings().size());
 
-            query = new QueryMessage(createBatchStatement(DatabaseDescriptor.getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
+            query = new QueryMessage(createBatchStatement(DatabaseDescriptor.getGuardrailsConfig().getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
             resp = client.execute(query);
             assertNull(resp.getWarnings());
         }
@@ -153,7 +158,7 @@ public class ClientWarningsTest extends CQLTester
         {
             client.connect(false);
 
-            QueryMessage query = new QueryMessage(createBatchStatement(DatabaseDescriptor.getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
+            QueryMessage query = new QueryMessage(createBatchStatement(DatabaseDescriptor.getGuardrailsConfig().getBatchSizeWarnThreshold()), QueryOptions.DEFAULT);
             Message.Response resp = client.execute(query);
             assertNull(resp.getWarnings());
         }

--- a/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 
 import org.junit.BeforeClass;
@@ -62,8 +63,8 @@ public class ClientWarningsTest extends CQLTester
     {
         requireNetwork();
         DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(1);
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = new HashSet<>();
-        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = new HashSet<>();
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.of();
+        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = ImmutableSet.of();
         DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold = -1;
     }
 

--- a/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
@@ -18,12 +18,13 @@
 package org.apache.cassandra.service;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.guardrails.GuardrailsConfig;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.SimpleClient;
@@ -46,6 +48,11 @@ import static org.junit.Assert.assertNull;
 @RunWith(Parameterized.class)
 public class ClientWarningsTest extends CQLTester
 {
+    private static int defaultBatchSizeWarnThreshold;
+    private static Set<String> defaultWriteConsistencyLevelsDisallowed;
+    private static Set<String> defaultTable_properties_disallowed;
+    private static Integer defaultDisk_usage_percentage_failure_threshold;
+
     @Parameterized.Parameter
     public ProtocolVersion version;
 
@@ -62,12 +69,32 @@ public class ClientWarningsTest extends CQLTester
     public static void setUp()
     {
         requireNetwork();
-        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(1);
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.of();
-        DatabaseDescriptor.getGuardrailsConfig().table_properties_disallowed = ImmutableSet.of();
-        DatabaseDescriptor.getGuardrailsConfig().disk_usage_percentage_failure_threshold = -1;
+
+        GuardrailsConfig guardrailsConfig = DatabaseDescriptor.getGuardrailsConfig();
+        
+        // Save current settings
+        defaultBatchSizeWarnThreshold = guardrailsConfig.batch_size_warn_threshold_in_kb;
+        defaultWriteConsistencyLevelsDisallowed = guardrailsConfig.write_consistency_levels_disallowed;
+        defaultTable_properties_disallowed = guardrailsConfig.table_properties_disallowed;
+        defaultDisk_usage_percentage_failure_threshold = guardrailsConfig.disk_usage_percentage_failure_threshold;
+
+        guardrailsConfig.setBatchSizeWarnThresholdInKB(1);
+        guardrailsConfig.write_consistency_levels_disallowed = ImmutableSet.of();
+        guardrailsConfig.table_properties_disallowed = ImmutableSet.of();
+        guardrailsConfig.disk_usage_percentage_failure_threshold = -1;
     }
 
+    @AfterClass 
+    public static void teardown()
+    {
+        // Restore previous settings
+        GuardrailsConfig guardrailsConfig = DatabaseDescriptor.getGuardrailsConfig();
+        guardrailsConfig.setBatchSizeWarnThresholdInKB(defaultBatchSizeWarnThreshold);
+        guardrailsConfig.write_consistency_levels_disallowed = defaultWriteConsistencyLevelsDisallowed;
+        guardrailsConfig.table_properties_disallowed = defaultTable_properties_disallowed;
+        guardrailsConfig.disk_usage_percentage_failure_threshold = defaultDisk_usage_percentage_failure_threshold;
+    }
+    
     @Test
     public void testUnloggedBatch() throws Exception
     {

--- a/test/unit/org/apache/cassandra/service/ProtocolBetaVersionTest.java
+++ b/test/unit/org/apache/cassandra/service/ProtocolBetaVersionTest.java
@@ -35,7 +35,6 @@ public class ProtocolBetaVersionTest extends CQLTester
     public static void setUp()
     {
         requireNetwork();
-        DatabaseDescriptor.setBatchSizeWarnThresholdInKB(1);
     }
 
     private ProtocolVersion getBetaVersion()

--- a/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
@@ -63,7 +63,7 @@ public class ClientResourceLimitsTest extends CQLTester
         QueryOptions.DEFAULT.skipMetadata(),
         QueryOptions.DEFAULT.getPageSize(),
         QueryOptions.DEFAULT.getPagingState(),
-        QueryOptions.DEFAULT.getSerialConsistency(),
+        QueryOptions.DEFAULT.getSerialConsistency(null),
         ProtocolVersion.V5,
         KEYSPACE);
 

--- a/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
@@ -140,7 +140,7 @@ public class MessagePayloadTest extends CQLTester
                   QueryOptions.DEFAULT.skipMetadata(),
                   QueryOptions.DEFAULT.getPageSize(),
                   QueryOptions.DEFAULT.getPagingState(),
-                  QueryOptions.DEFAULT.getSerialConsistency(),
+                  QueryOptions.DEFAULT.getSerialConsistency(null),
                   ProtocolVersion.V5,
                   KEYSPACE);
                 QueryMessage queryMessage = new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)",

--- a/test/unit/org/apache/cassandra/transport/SerDeserTest.java
+++ b/test/unit/org/apache/cassandra/transport/SerDeserTest.java
@@ -400,7 +400,6 @@ public class SerDeserTest
         assertEquals(options.getNowInSeconds(state), decodedOptions.getNowInSeconds(state));
     }
 
-    // TODO Note DB-3681
     @Test
     public void defaultSerialCLGuardrailsTest()
     {

--- a/test/unit/org/apache/cassandra/transport/SerDeserTest.java
+++ b/test/unit/org/apache/cassandra/transport/SerDeserTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.transport;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import io.netty.buffer.Unpooled;
@@ -424,7 +425,7 @@ public class SerDeserTest
                                                ConsistencyLevel expectedDecodedSerialConsistency)
     {
         Set<String> previousConsistencyLevels =  DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed;
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = writeConsistencyLevelsDisallowed;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.copyOf(writeConsistencyLevelsDisallowed);
 
         QueryOptions queryOptions = QueryOptions.create(ConsistencyLevel.ALL,
                                                         Collections.singletonList(ByteBuffer.wrap(new byte[] { 0x00, 0x01, 0x02 })),
@@ -455,7 +456,7 @@ public class SerDeserTest
             }
         }
 
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = previousConsistencyLevels;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.copyOf(previousConsistencyLevels);
     }
 
     @Test
@@ -481,7 +482,7 @@ public class SerDeserTest
                                                  ConsistencyLevel expectedDecodedSerialConsistency)
     {
         Set<String> previousConsistencyLevels =  DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed;
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = writeConsistencyLevelsDisallowed;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.copyOf(writeConsistencyLevelsDisallowed);
 
         QueryOptions queryOptions = QueryOptions.create(ConsistencyLevel.ALL,
                                                         Collections.singletonList(ByteBuffer.wrap(new byte[] { 0x00, 0x01, 0x02 })),
@@ -496,7 +497,7 @@ public class SerDeserTest
         QueryOptions decodedOptions = QueryOptions.codec.decode(buf, version);
         assertEquals(expectedDecodedSerialConsistency, decodedOptions.getSerialConsistency(null));
 
-        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = previousConsistencyLevels;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = ImmutableSet.copyOf(previousConsistencyLevels);
     }
 
     // return utf8 string that contains no ascii chars

--- a/test/unit/org/apache/cassandra/transport/SerDeserTest.java
+++ b/test/unit/org/apache/cassandra/transport/SerDeserTest.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.serializers.CollectionSerializer;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -388,7 +389,7 @@ public class SerDeserTest
 
         assertNotNull(decodedOptions);
         assertEquals(options.getConsistency(), decodedOptions.getConsistency());
-        assertEquals(options.getSerialConsistency(), decodedOptions.getSerialConsistency());
+        assertEquals(options.getSerialConsistency(null), decodedOptions.getSerialConsistency(null));
         assertEquals(options.getPageSize(), decodedOptions.getPageSize());
         assertEquals(options.getProtocolVersion(), decodedOptions.getProtocolVersion());
         assertEquals(options.getValues(), decodedOptions.getValues());
@@ -397,6 +398,106 @@ public class SerDeserTest
         assertEquals(options.getKeyspace(), decodedOptions.getKeyspace());
         assertEquals(options.getTimestamp(state), decodedOptions.getTimestamp(state));
         assertEquals(options.getNowInSeconds(state), decodedOptions.getNowInSeconds(state));
+    }
+
+    // TODO Note DB-3681
+    @Test
+    public void defaultSerialCLGuardrailsTest()
+    {
+        for(ProtocolVersion version : ProtocolVersion.SUPPORTED)
+        {
+            defaultSerialCLGuardrailsTest(version, new LinkedHashSet<>(), ConsistencyLevel.SERIAL);
+            defaultSerialCLGuardrailsTest(version,
+                                          new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString())),
+                                          ConsistencyLevel.SERIAL);
+            defaultSerialCLGuardrailsTest(version,
+                                          new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString())),
+                                          ConsistencyLevel.LOCAL_SERIAL);
+            defaultSerialCLGuardrailsTest(version,
+                                          new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.SERIAL.toString(),
+                                                                   ConsistencyLevel.LOCAL_SERIAL.toString())),
+                                          null);
+        }
+    }
+
+    private void defaultSerialCLGuardrailsTest(ProtocolVersion version,
+                                               Set<String> writeConsistencyLevelsDisallowed,
+                                               ConsistencyLevel expectedDecodedSerialConsistency)
+    {
+        Set<String> previousConsistencyLevels =  DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = writeConsistencyLevelsDisallowed;
+
+        QueryOptions queryOptions = QueryOptions.create(ConsistencyLevel.ALL,
+                                                        Collections.singletonList(ByteBuffer.wrap(new byte[] { 0x00, 0x01, 0x02 })),
+                                                        false,
+                                                        5000,
+                                                        Util.makeSomePagingState(version),
+                                                        null,
+                                                        version,
+                                                        null);
+        ByteBuf buf = Unpooled.buffer(QueryOptions.codec.encodedSize(queryOptions, version));
+        QueryOptions.codec.encode(queryOptions, buf, version);
+        QueryOptions decodedOptions = QueryOptions.codec.decode(buf, version);
+        if (expectedDecodedSerialConsistency != null)
+        {
+            assertEquals(expectedDecodedSerialConsistency, decodedOptions.getSerialConsistency(null));
+        }
+        else
+        {
+            try
+            {
+                decodedOptions.getSerialConsistency(null);
+                throw new AssertionError("Decoding should have failed with InvalidRequestException");
+            }
+            catch (InvalidRequestException e)
+            {
+                assertEquals("Serial consistency levels are disallowed by disallowedWriteConsistencies Guardrail",
+                             e.getMessage());
+            }
+        }
+
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = previousConsistencyLevels;
+    }
+
+    @Test
+    public void specifiedSerialCLGuardrailsTest()
+    {
+        // write consistency level guardrail check happens before query execution. Here we validate only that if
+        // QueryOptions has explicitly set serial consistency, the same consistency level remains after encoding/decoding
+        // even if that level is forbidden by the guardrail.
+
+        Set<String> serialCLs = new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.LOCAL_SERIAL.toString(), ConsistencyLevel.SERIAL.toString()));
+        for(ProtocolVersion version : ProtocolVersion.SUPPORTED)
+        {
+            specifiedSerialCLGuardrailsTest(version, ConsistencyLevel.SERIAL, new LinkedHashSet<>(), ConsistencyLevel.SERIAL);
+            specifiedSerialCLGuardrailsTest(version, ConsistencyLevel.SERIAL, serialCLs, ConsistencyLevel.SERIAL);
+            specifiedSerialCLGuardrailsTest(version, ConsistencyLevel.LOCAL_SERIAL, new LinkedHashSet<>(), ConsistencyLevel.LOCAL_SERIAL);
+            specifiedSerialCLGuardrailsTest(version, ConsistencyLevel.LOCAL_SERIAL, serialCLs, ConsistencyLevel.LOCAL_SERIAL);
+        }
+    }
+
+    private void specifiedSerialCLGuardrailsTest(ProtocolVersion version,
+                                                 ConsistencyLevel specifiedSerialConsistency,
+                                                 Set<String> writeConsistencyLevelsDisallowed,
+                                                 ConsistencyLevel expectedDecodedSerialConsistency)
+    {
+        Set<String> previousConsistencyLevels =  DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed;
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = writeConsistencyLevelsDisallowed;
+
+        QueryOptions queryOptions = QueryOptions.create(ConsistencyLevel.ALL,
+                                                        Collections.singletonList(ByteBuffer.wrap(new byte[] { 0x00, 0x01, 0x02 })),
+                                                        false,
+                                                        5000,
+                                                        Util.makeSomePagingState(version),
+                                                        specifiedSerialConsistency,
+                                                        version,
+                                                        null);
+        ByteBuf buf = Unpooled.buffer(QueryOptions.codec.encodedSize(queryOptions, version));
+        QueryOptions.codec.encode(queryOptions, buf, version);
+        QueryOptions decodedOptions = QueryOptions.codec.decode(buf, version);
+        assertEquals(expectedDecodedSerialConsistency, decodedOptions.getSerialConsistency(null));
+
+        DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed = previousConsistencyLevels;
     }
 
     // return utf8 string that contains no ascii chars


### PR DESCRIPTION
STAR-543

To complete the porting of guardrails, the approach taken here was to sync (copy) the latest DSE 6.8 cndb guardrails code and tests contained `org.apache.cassandra.guardrails` and fix any broken code or tests that resulted. Doing this identified more clearly guardrail tickets not yet ported (some from cndb), and more importantly guardrail tickets that were either not fully ported or had been subsequently updated some other ticket.

The classes directly updated/synced with the latest from the DSE bdp repo `6.8-cndb` branch include:
`Guardrail`
`Guardrails`
`GuardrailsConfig`
`GuardrailTester`
all `Guardrail*Test` test classes

List of changes (approx.) by ticket:
### DB-2258 
* SelectStatement, AlterTableStatement, AlterTypeStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement
* ConsistencyLevel
* DiskUsageMonitor

### DB-2831
* ReadCommand

### DB-2426 (`tombstone_warn/fail_threshold`, `partition_size_warn_threshold`)
* cassandra.yaml
* Config
* ReadCommand
* TombstoneOverwhelmingException
* StorageService

### DB-3361 (`compaction_large_partition_warning_threshold_mb` replaced with `partition_size_warn_threshold_in_mb`)
* DatabaseDescriptor

### DB-3561 (`emulate_dbaas_defaults`)
* cassandra.yaml
* DatabaseDescriptor
* OptionsMessage
* StartupMessage

### DB-3611 (`batch_size_warn_threshold`, `batch_size_fail_threshold`, `unlogged_batch_across_partitions_warn_threshold`)
* cassandra.yaml 
* Config
* DatabaseDescriptor
* BatchStatement 

### DB-3654 (use of `QueryState`)
* SelectStatement, AlterTableStatement, AlterTypeStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement
* ConsistencyLevel
* SSTableWriter

### DB-3681 (Use `LOCAL_SERIAL CL` by default if `SERIAL` is disallowed)
* BatchQueryOptions
* QueryOptions
* ConsistencyLevel
* BatchMessage
* ExecuteMessage
* QueryMessage

### DB-3803
* UpdateParameters
* PartitionKeySingleRestrictionSet

### DB-4380
* DatabaseDescriptor (`applyAfterDataDirectoriesCreated`)

### DSP-19348 (`setEmulateDbaasDefaults`)
* DatabaseDescriptor

### cndb-63
* DatabaseDescriptor (`createAllDirectories`, `applyGuardrails`, `afterApplyDataDirectoriesCreated`)

### cndb-338 (`loggedBatchEnabled`)
* BatchStatement
