### PR TITLE
STAR-580 replace polymorphic calls with a switch

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -556,8 +556,8 @@
           <dependency groupId="net.bytebuddy" artifactId="byte-buddy" version="${bytebuddy.version}" />
           <dependency groupId="net.bytebuddy" artifactId="byte-buddy-agent" version="${bytebuddy.version}" />
 
-          <dependency groupId="org.openjdk.jmh" artifactId="jmh-core" version="1.21" scope="test"/>
-          <dependency groupId="org.openjdk.jmh" artifactId="jmh-generator-annprocess" version="1.21" scope="test"/>
+          <dependency groupId="org.openjdk.jmh" artifactId="jmh-core" version="1.32" scope="test"/>
+          <dependency groupId="org.openjdk.jmh" artifactId="jmh-generator-annprocess" version="1.32" scope="test"/>
 
           <dependency groupId="org.apache.cassandra" artifactId="cassandra-all" version="${version}" />
           <dependency groupId="io.dropwizard.metrics" artifactId="metrics-core" version="3.1.5" />

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -40,14 +40,12 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
 {
     protected AbstractCompositeType()
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, VARIABLE_LENGTH);
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         boolean isStaticL = readIsStatic(left, accessorL);
         boolean isStaticR = readIsStatic(right, accessorR);
         if (isStaticL != isStaticR)

--- a/src/java/org/apache/cassandra/db/marshal/AsciiType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AsciiType.java
@@ -39,7 +39,7 @@ public class AsciiType extends AbstractType<String>
 {
     public static final AsciiType instance = new AsciiType();
 
-    AsciiType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    AsciiType() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     private final FastThreadLocal<CharsetEncoder> encoder = new FastThreadLocal<CharsetEncoder>()
     {

--- a/src/java/org/apache/cassandra/db/marshal/BooleanType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BooleanType.java
@@ -36,18 +36,15 @@ public class BooleanType extends AbstractType<Boolean>
 
     public static final BooleanType instance = new BooleanType();
 
-    BooleanType() {super(ComparisonType.CUSTOM);} // singleton
+    BooleanType() {super(ComparisonType.PRIMITIVE_COMPARE, 1, PrimitiveType.BOOLEAN, 0);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
         return true;
     }
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         // False is 0, True is anything else, makes False sort before True.
         int v1 = accessorL.getByte(left, 0) == 0 ? 0 : 1;
         int v2 = accessorR.getByte(right, 0) == 0 ? 0 : 1;
@@ -92,11 +89,5 @@ public class BooleanType extends AbstractType<Boolean>
     public TypeSerializer<Boolean> getSerializer()
     {
         return BooleanSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 1;
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/ByteType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteType.java
@@ -34,10 +34,11 @@ public class ByteType extends NumberType<Byte>
 
     ByteType()
     {
-        super(ComparisonType.CUSTOM);
+        // VAR_LENGTH due to compatibility reasons, should be 1
+        super(ComparisonType.PRIMITIVE_COMPARE, VARIABLE_LENGTH, PrimitiveType.BYTE);
     } // singleton
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return accessorL.getByte(left, 0) - accessorR.getByte(right, 0);
     }

--- a/src/java/org/apache/cassandra/db/marshal/BytesType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BytesType.java
@@ -33,7 +33,7 @@ public class BytesType extends AbstractType<ByteBuffer>
 {
     public static final BytesType instance = new BytesType();
 
-    BytesType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    BytesType() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     public ByteBuffer fromString(String source)
     {

--- a/src/java/org/apache/cassandra/db/marshal/CollectionType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CollectionType.java
@@ -77,7 +77,7 @@ public abstract class CollectionType<T> extends AbstractType<T>
 
     protected CollectionType(ComparisonType comparisonType, Kind kind)
     {
-        super(comparisonType);
+        super(comparisonType, VARIABLE_LENGTH);
         this.kind = kind;
     }
 

--- a/src/java/org/apache/cassandra/db/marshal/CounterColumnType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CounterColumnType.java
@@ -32,7 +32,7 @@ public class CounterColumnType extends NumberType<Long>
 {
     public static final CounterColumnType instance = new CounterColumnType();
 
-    CounterColumnType() {super(ComparisonType.NOT_COMPARABLE);} // singleton
+    CounterColumnType() {super(ComparisonType.NOT_COMPARABLE, VARIABLE_LENGTH);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {

--- a/src/java/org/apache/cassandra/db/marshal/DateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DateType.java
@@ -43,7 +43,7 @@ public class DateType extends AbstractType<Date>
 
     public static final DateType instance = new DateType();
 
-    DateType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    DateType() {super(ComparisonType.BYTE_ORDER, 8);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
@@ -116,11 +116,5 @@ public class DateType extends AbstractType<Date>
     public TypeSerializer<Date> getSerializer()
     {
         return TimestampSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 8;
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/DecimalType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DecimalType.java
@@ -41,7 +41,7 @@ public class DecimalType extends NumberType<BigDecimal>
     private static final int MAX_SCALE = 1000;
     private static final MathContext MAX_PRECISION = new MathContext(10000);
 
-    DecimalType() {super(ComparisonType.CUSTOM);} // singleton
+    DecimalType() {super(ComparisonType.CUSTOM, VARIABLE_LENGTH);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
@@ -54,6 +54,7 @@ public class DecimalType extends NumberType<BigDecimal>
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return compareComposed(left, accessorL, right, accessorR, this);

--- a/src/java/org/apache/cassandra/db/marshal/DoubleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DoubleType.java
@@ -32,7 +32,7 @@ public class DoubleType extends NumberType<Double>
 {
     public static final DoubleType instance = new DoubleType();
 
-    DoubleType() {super(ComparisonType.CUSTOM);} // singleton
+    DoubleType() {super(ComparisonType.PRIMITIVE_COMPARE, 8, PrimitiveType.DOUBLE);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
@@ -45,9 +45,9 @@ public class DoubleType extends NumberType<Double>
         return true;
     }
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        return compareComposed(left, accessorL, right, accessorR, this);
+        return Double.compare(accessorL.toDouble(left), accessorR.toDouble(right));
     }
 
     public ByteBuffer fromString(String source) throws MarshalException
@@ -103,12 +103,6 @@ public class DoubleType extends NumberType<Double>
     public TypeSerializer<Double> getSerializer()
     {
         return DoubleSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 8;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/DurationType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DurationType.java
@@ -39,7 +39,7 @@ public class DurationType extends AbstractType<Duration>
 
     DurationType()
     {
-        super(ComparisonType.BYTE_ORDER);
+        super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);
     } // singleton
 
     public ByteBuffer fromString(String source) throws MarshalException

--- a/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DynamicCompositeType.java
@@ -383,17 +383,10 @@ public class DynamicCompositeType extends AbstractCompositeType
         public static final FixedValueComparator alwaysLesserThan = new FixedValueComparator(-1);
         public static final FixedValueComparator alwaysGreaterThan = new FixedValueComparator(1);
 
-        private final int cmp;
-
         public FixedValueComparator(int cmp)
         {
-            super(ComparisonType.CUSTOM);
-            this.cmp = cmp;
-        }
-
-        public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
-        {
-            return cmp;
+            // VAR_LENGTH due to compatibility reasons, should be 0
+            super(ComparisonType.FIXED_COMPARE, VARIABLE_LENGTH, PrimitiveType.NONE, cmp);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/marshal/EmptyType.java
+++ b/src/java/org/apache/cassandra/db/marshal/EmptyType.java
@@ -66,12 +66,7 @@ public class EmptyType extends AbstractType<Void>
 
     public static final EmptyType instance = new EmptyType();
 
-    private EmptyType() {super(ComparisonType.CUSTOM);} // singleton
-
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
-    {
-        return 0;
-    }
+    private EmptyType() {super(ComparisonType.FIXED_COMPARE, 0, PrimitiveType.NONE, 0);} // singleton
 
     public <V> String getString(V value, ValueAccessor<V> accessor)
     {
@@ -112,31 +107,6 @@ public class EmptyType extends AbstractType<Void>
     public TypeSerializer<Void> getSerializer()
     {
         return EmptySerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 0;
-    }
-
-    @Override
-    public <V> long writtenLength(V value, ValueAccessor<V> accessor)
-    {
-        // default implemenation requires non-empty bytes but this always requires empty bytes, so special case
-        validate(value, accessor);
-        return 0;
-    }
-
-    public ByteBuffer readBuffer(DataInputPlus in)
-    {
-        return ByteBufferUtil.EMPTY_BYTE_BUFFER;
-    }
-
-    @Override
-    public ByteBuffer readBuffer(DataInputPlus in, int maxValueSize)
-    {
-        return ByteBufferUtil.EMPTY_BYTE_BUFFER;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/FloatType.java
+++ b/src/java/org/apache/cassandra/db/marshal/FloatType.java
@@ -33,7 +33,7 @@ public class FloatType extends NumberType<Float>
 {
     public static final FloatType instance = new FloatType();
 
-    FloatType() {super(ComparisonType.CUSTOM);} // singleton
+    FloatType() {super(ComparisonType.PRIMITIVE_COMPARE, 4, PrimitiveType.FLOAT);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
@@ -46,9 +46,9 @@ public class FloatType extends NumberType<Float>
         return true;
     }
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        return compareComposed(left, accessorL, right, accessorR, this);
+        return Float.compare(accessorL.toFloat(left), accessorR.toFloat(right));
     }
 
     public ByteBuffer fromString(String source) throws MarshalException
@@ -104,12 +104,6 @@ public class FloatType extends NumberType<Float>
     public TypeSerializer<Float> getSerializer()
     {
         return FloatSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 4;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/FrozenType.java
+++ b/src/java/org/apache/cassandra/db/marshal/FrozenType.java
@@ -34,7 +34,7 @@ public class FrozenType extends AbstractType<Void>
 {
     protected FrozenType()
     {
-        super(ComparisonType.NOT_COMPARABLE);
+        super(ComparisonType.NOT_COMPARABLE, VARIABLE_LENGTH);
     }
 
     public static AbstractType<?> getInstance(TypeParser parser) throws ConfigurationException, SyntaxException

--- a/src/java/org/apache/cassandra/db/marshal/InetAddressType.java
+++ b/src/java/org/apache/cassandra/db/marshal/InetAddressType.java
@@ -33,7 +33,7 @@ public class InetAddressType extends AbstractType<InetAddress>
 {
     public static final InetAddressType instance = new InetAddressType();
 
-    InetAddressType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    InetAddressType() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {

--- a/src/java/org/apache/cassandra/db/marshal/Int32Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/Int32Type.java
@@ -35,7 +35,7 @@ public class Int32Type extends NumberType<Integer>
 
     Int32Type()
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.PRIMITIVE_COMPARE, 4, PrimitiveType.INT32);
     } // singleton
 
     public boolean isEmptyValueMeaningless()
@@ -43,11 +43,8 @@ public class Int32Type extends NumberType<Integer>
         return true;
     }
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         int diff = accessorL.getByte(left, 0) - accessorR.getByte(right, 0);
         if (diff != 0)
             return diff;
@@ -110,12 +107,6 @@ public class Int32Type extends NumberType<Integer>
     public TypeSerializer<Integer> getSerializer()
     {
         return Int32Serializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 4;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/IntegerType.java
+++ b/src/java/org/apache/cassandra/db/marshal/IntegerType.java
@@ -61,13 +61,14 @@ public final class IntegerType extends NumberType<BigInteger>
         return i;
     }
 
-    IntegerType() {super(ComparisonType.CUSTOM);}/* singleton */
+    IntegerType() {super(ComparisonType.CUSTOM, VARIABLE_LENGTH);}/* singleton */
 
     public boolean isEmptyValueMeaningless()
     {
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return IntegerType.compareIntegers(left, accessorL, right, accessorR);

--- a/src/java/org/apache/cassandra/db/marshal/LexicalUUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LexicalUUIDType.java
@@ -33,7 +33,7 @@ public class LexicalUUIDType extends AbstractType<UUID>
 
     LexicalUUIDType()
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, 16);
     } // singleton
 
     public boolean isEmptyValueMeaningless()
@@ -43,8 +43,6 @@ public class LexicalUUIDType extends AbstractType<UUID>
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
         return accessorL.toUUID(left).compareTo(accessorR.toUUID(right));
     }
 
@@ -81,11 +79,5 @@ public class LexicalUUIDType extends AbstractType<UUID>
     public TypeSerializer<UUID> getSerializer()
     {
         return UUIDSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 16;
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -172,10 +172,6 @@ public class ListType<T> extends CollectionType<List<T>>
 
     static <VL, VR> int compareListOrSet(AbstractType<?> elementsComparator, VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        // Note that this is only used if the collection is frozen
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         int sizeL = CollectionSerializer.readCollectionSize(left, accessorL, ProtocolVersion.V3);
         int offsetL = CollectionSerializer.sizeOfCollectionSize(sizeL, ProtocolVersion.V3);
         int sizeR = CollectionSerializer.readCollectionSize(right, accessorR, ProtocolVersion.V3);

--- a/src/java/org/apache/cassandra/db/marshal/LongType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LongType.java
@@ -33,23 +33,20 @@ public class LongType extends NumberType<Long>
 {
     public static final LongType instance = new LongType();
 
-    LongType() {super(ComparisonType.CUSTOM);} // singleton
+    LongType() {super(ComparisonType.PRIMITIVE_COMPARE, 8, PrimitiveType.LONG);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
         return true;
     }
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return compareLongs(left, accessorL, right, accessorR);
     }
 
     public static <VL, VR> int compareLongs(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left)|| accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         int diff = accessorL.getByte(left, 0) - accessorR.getByte(right, 0);
         if (diff != 0)
             return diff;
@@ -118,12 +115,6 @@ public class LongType extends NumberType<Long>
     public TypeSerializer<Long> getSerializer()
     {
         return LongSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 8;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -185,10 +185,6 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
 
     public static <TL, TR> int compareMaps(AbstractType<?> keysComparator, AbstractType<?> valuesComparator, TL left, ValueAccessor<TL> accessorL, TR right, ValueAccessor<TR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
-
         ProtocolVersion protocolVersion = ProtocolVersion.V3;
         int sizeL = CollectionSerializer.readCollectionSize(left, accessorL, protocolVersion);
         int sizeR = CollectionSerializer.readCollectionSize(right, accessorR, protocolVersion);

--- a/src/java/org/apache/cassandra/db/marshal/NumberType.java
+++ b/src/java/org/apache/cassandra/db/marshal/NumberType.java
@@ -26,9 +26,14 @@ import java.nio.ByteBuffer;
  */
 public abstract class NumberType<T extends Number> extends AbstractType<T>
 {
-    protected NumberType(ComparisonType comparisonType)
+    protected NumberType(ComparisonType comparisonType, int valueLength)
     {
-        super(comparisonType);
+        super(comparisonType, valueLength);
+    }
+
+    public NumberType(ComparisonType comparisonType, int valueLength, PrimitiveType primitiveType)
+    {
+        super(comparisonType, valueLength, primitiveType, 0);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
+++ b/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
@@ -37,7 +37,7 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
 
     public PartitionerDefinedOrder(IPartitioner partitioner)
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, VARIABLE_LENGTH);
         this.partitioner = partitioner;
     }
 
@@ -87,6 +87,7 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         // o1 and o2 can be empty so we need to use PartitionPosition, not DecoratedKey

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -54,18 +54,13 @@ public class ReversedType<T> extends AbstractType<T>
 
     private ReversedType(AbstractType<T> baseType)
     {
-        super(ComparisonType.CUSTOM);
+        super(baseType.comparisonType, baseType.valueLengthIfFixed(), baseType.primitiveType, baseType.fixedCompareReturns, true);
         this.baseType = baseType;
     }
 
     public boolean isEmptyValueMeaningless()
     {
         return baseType.isEmptyValueMeaningless();
-    }
-
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
-    {
-        return baseType.compare(right, accessorR, left, accessorL);
     }
 
     @Override
@@ -143,18 +138,6 @@ public class ReversedType<T> extends AbstractType<T>
         instances.remove(baseType);
 
         return getInstance(baseType.withUpdatedUserType(udt));
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return baseType.valueLengthIfFixed();
-    }
-
-    @Override
-    public boolean isReversed()
-    {
-        return true;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/ShortType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ShortType.java
@@ -35,10 +35,11 @@ public class ShortType extends NumberType<Short>
 
     ShortType()
     {
-        super(ComparisonType.CUSTOM);
+        // VAR_LENGTH due to compatibility reasons, should be 2
+        super(ComparisonType.PRIMITIVE_COMPARE, VARIABLE_LENGTH, PrimitiveType.SHORT);
     } // singleton
 
-    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    public static <VL, VR> int compareType(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         int diff = accessorL.getByte(left, 0) - accessorR.getByte(right, 0);
         if (diff != 0)

--- a/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SimpleDateType.java
@@ -36,7 +36,7 @@ public class SimpleDateType extends TemporalType<Integer>
 {
     public static final SimpleDateType instance = new SimpleDateType();
 
-    SimpleDateType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    SimpleDateType() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     public ByteBuffer fromString(String source) throws MarshalException
     {

--- a/src/java/org/apache/cassandra/db/marshal/TemporalType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TemporalType.java
@@ -27,9 +27,9 @@ import org.apache.cassandra.cql3.Duration;
  */
 public abstract class TemporalType<T> extends AbstractType<T>
 {
-    protected TemporalType(ComparisonType comparisonType)
+    public TemporalType(ComparisonType comparisonType, int fixedValueLength)
     {
-        super(comparisonType);
+        super(comparisonType, fixedValueLength);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/TimeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimeType.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.transport.ProtocolVersion;
 public class TimeType extends TemporalType<Long>
 {
     public static final TimeType instance = new TimeType();
-    private TimeType() {super(ComparisonType.BYTE_ORDER);} // singleton
+    private TimeType() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     public ByteBuffer fromString(String source) throws MarshalException
     {

--- a/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java
@@ -35,7 +35,7 @@ public class TimeUUIDType extends TemporalType<UUID>
 
     TimeUUIDType()
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, 16);
     } // singleton
 
     public boolean isEmptyValueMeaningless()
@@ -43,6 +43,7 @@ public class TimeUUIDType extends TemporalType<UUID>
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         // Compare for length
@@ -126,12 +127,6 @@ public class TimeUUIDType extends TemporalType<UUID>
     public TypeSerializer<UUID> getSerializer()
     {
         return TimeUUIDSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 16;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/TimestampType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimestampType.java
@@ -49,13 +49,14 @@ public class TimestampType extends TemporalType<Date>
 
     public static final TimestampType instance = new TimestampType();
 
-    private TimestampType() {super(ComparisonType.CUSTOM);} // singleton
+    private TimestampType() {super(ComparisonType.CUSTOM, 8);} // singleton
 
     public boolean isEmptyValueMeaningless()
     {
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return LongType.compareLongs(left, accessorL, right, accessorR);
@@ -142,12 +143,6 @@ public class TimestampType extends TemporalType<Date>
     public TypeSerializer<Date> getSerializer()
     {
         return TimestampSerializer.instance;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 8;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -65,7 +65,7 @@ public class TupleType extends AbstractType<ByteBuffer>
 
     protected TupleType(List<AbstractType<?>> types, boolean freezeInner)
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, VARIABLE_LENGTH);
 
         if (freezeInner)
             this.types = Lists.newArrayList(transform(types, AbstractType::freeze));
@@ -143,11 +143,9 @@ public class TupleType extends AbstractType<ByteBuffer>
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
-            return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
-
         int offsetL = 0;
         int offsetR = 0;
 

--- a/src/java/org/apache/cassandra/db/marshal/UTF8Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/UTF8Type.java
@@ -21,14 +21,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.cassandra.cql3.Constants;
-import org.apache.cassandra.cql3.Json;
-
-import org.apache.cassandra.cql3.CQL3Type;
-import org.apache.cassandra.cql3.Term;
-import org.apache.cassandra.serializers.MarshalException;
-import org.apache.cassandra.serializers.TypeSerializer;
-import org.apache.cassandra.serializers.UTF8Serializer;
+import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.serializers.*;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -36,7 +30,7 @@ public class UTF8Type extends AbstractType<String>
 {
     public static final UTF8Type instance = new UTF8Type();
 
-    UTF8Type() {super(ComparisonType.BYTE_ORDER);} // singleton
+    UTF8Type() {super(ComparisonType.BYTE_ORDER, VARIABLE_LENGTH);} // singleton
 
     public ByteBuffer fromString(String source)
     {

--- a/src/java/org/apache/cassandra/db/marshal/UUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UUIDType.java
@@ -48,7 +48,7 @@ public class UUIDType extends AbstractType<UUID>
 
     UUIDType()
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, 16);
     }
 
     public boolean isEmptyValueMeaningless()
@@ -56,6 +56,7 @@ public class UUIDType extends AbstractType<UUID>
         return true;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
 
@@ -166,11 +167,5 @@ public class UUIDType extends AbstractType<UUID>
     static int version(ByteBuffer uuid)
     {
         return (uuid.get(6) & 0xf0) >> 4;
-    }
-
-    @Override
-    public int valueLengthIfFixed()
-    {
-        return 16;
     }
 }

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -476,7 +476,7 @@ public class ByteBufferUtil
     }
 
     /**
-     * Convert a byte buffer to a short.
+     * Convert a byte buffer to a byte.
      * Does not change the byte buffer position.
      *
      * @param bytes byte buffer to convert to byte

--- a/test/unit/org/apache/cassandra/db/marshal/EmptyTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/EmptyTypeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.marshal;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.junit.Test;
@@ -60,7 +61,7 @@ public class EmptyTypeTest
     }
 
     @Test
-    public void read()
+    public void read() throws IOException
     {
         DataInputPlus input = Mockito.mock(DataInputPlus.class);
 

--- a/test/unit/org/apache/cassandra/db/marshal/TypeReadWriteValueTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TypeReadWriteValueTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import org.junit.Test;
+
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * This is a guard against breaking the unversioned and under documented serialization properties of the AbstractType
+ * properties. This is documenting current behaviour as standard until we have time to invest in sorting out the mess.
+ */
+public class TypeReadWriteValueTest
+{
+    @Test
+    public void testByte() throws IOException
+    {
+        testVariableLengthType(ByteType.instance, (byte) 1, 1);
+    }
+
+    @Test
+    public void testShort() throws IOException
+    {
+        testVariableLengthType(ShortType.instance, (short) 1, 2);
+    }
+
+    @Test
+    public void testInteger2() throws IOException
+    {
+        testVariableLengthType(IntegerType.instance, new BigInteger(new byte[]{127,1}), 2);
+    }
+
+    @Test
+    public void testInteger8() throws IOException
+    {
+        testVariableLengthType(IntegerType.instance, new BigInteger(new byte[]{127,0,0,0,0,0,0,1}), 8);
+    }
+
+    @Test
+    public void testInteger16() throws IOException
+    {
+        testVariableLengthType(IntegerType.instance, new BigInteger(new byte[]{127,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1}), 16);
+    }
+
+    @Test
+    public void testCompositeType() throws IOException
+    {
+        CompositeType type = CompositeType.getInstance(Int32Type.instance);
+        testVariableLengthType(type, ByteBuffer.allocate(4).putInt(1).clear(), 4);
+    }
+
+    @Test
+    public void testDecimalType() throws IOException
+    {
+        testVariableLengthType(DecimalType.instance, new BigDecimal("1234"), 6);
+    }
+
+    @Test
+    public void testAsciiType() throws IOException
+    {
+        testVariableLengthType(AsciiType.instance, "bugger", 6);
+    }
+
+    @Test
+    public void testWTF8Type() throws IOException
+    {
+        testVariableLengthType(UTF8Type.instance, "bugger", 6);
+    }
+
+    @Test
+    public void testListType() throws IOException
+    {
+        ListType<Integer> type = ListType.getInstance(Int32Type.instance, false);
+        testVariableLengthType(type, Arrays.asList(1, 2, 3, 4), 36);
+    }
+
+    @Test
+    public void testMapType() throws IOException
+    {
+        MapType<Integer, Integer> type = MapType.getInstance(Int32Type.instance, Int32Type.instance, false);
+        Map<Integer,Integer> map = new HashMap<>();
+        map.put(1,2);
+        map.put(3,4);
+        testVariableLengthType(type, map, 36);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testEmpty() throws IOException
+    {
+        testFixedLengthType(EmptyType.instance, null);
+    }
+
+    @Test
+    public void testBoolean() throws IOException
+    {
+        testFixedLengthType(BooleanType.instance, true);
+    }
+
+    @Test
+    public void testInt32() throws IOException
+    {
+        testFixedLengthType(Int32Type.instance, 1);
+    }
+
+    @Test
+    public void testFloat() throws IOException
+    {
+        testFixedLengthType(FloatType.instance, (float) 1);
+    }
+
+    @Test
+    public void testLong() throws IOException
+    {
+        testFixedLengthType(LongType.instance, (long) 1);
+    }
+
+    @Test
+    public void testTimestamp() throws IOException
+    {
+        testFixedLengthType(TimestampType.instance, new Date());
+    }
+
+    @Test
+    public void testDate() throws IOException
+    {
+        testFixedLengthType(DateType.instance, new Date());
+    }
+
+    @Test
+    public void testDouble() throws IOException
+    {
+        testFixedLengthType(DoubleType.instance, (double) 1);
+    }
+
+    @Test
+    public void testUUID() throws IOException
+    {
+        testFixedLengthType(UUIDType.instance, new UUID(1234L,1234L));
+    }
+
+    @Test
+    public void testLexUUID() throws IOException
+    {
+        testFixedLengthType(LexicalUUIDType.instance, new UUID(1234L,1234L));
+    }
+
+    @Test
+    public void testTimeUUID() throws IOException
+    {
+        testFixedLengthType(TimeUUIDType.instance, new UUID(1234L,1234L));
+    }
+
+    private void testFixedLengthType(AbstractType type, Object value) throws IOException
+    {
+        DataOutputPlus out = mock(DataOutputPlus.class);
+
+        final ByteBuffer valueWrite = type.decompose(value);
+
+        type.writeValue(valueWrite, out);
+        verify(out).write(valueWrite);
+        Mockito.verifyNoMoreInteractions(out);
+
+        DataInputPlus in = mock(DataInputPlus.class);
+        doAnswer(copyAnswer(valueWrite)).when(in).readFully(any(byte[].class));
+
+        ByteBuffer valueRead = type.readValue(in);
+
+        verify(in).readFully(any(byte[].class));
+        assertEquals(valueWrite.clear(), valueRead.clear());
+    }
+
+    private Answer copyAnswer(ByteBuffer valueWrite)
+    {
+        return invocationOnMock ->
+                 {
+                     byte[] bytes = (byte[])invocationOnMock.getArguments()[0];
+                     valueWrite.position(0);
+                     valueWrite.get(bytes);
+                     return null;
+                 };
+    }
+
+    protected void testVariableLengthType(AbstractType type, Object value, long length) throws IOException
+    {
+
+        DataOutputPlus out = mock(DataOutputPlus.class);
+        ByteBuffer valueWrite = type.decompose(value);
+
+        type.writeValue(valueWrite, out);
+
+        InOrder inOrder = inOrder(out);
+        inOrder.verify(out).writeUnsignedVInt(Mockito.eq(length));
+        inOrder.verify(out).write(valueWrite);
+        Mockito.verifyNoMoreInteractions(out);
+
+
+        DataInputPlus in = mock(DataInputPlus.class);
+        when(in.readUnsignedVInt()).thenReturn(length);
+        doAnswer(copyAnswer(valueWrite)).when(in).readFully(any(byte[].class));
+
+        ByteBuffer valueRead = type.readValue(in);
+
+        verify(in).readUnsignedVInt();
+        verify(in).readFully(any(byte[].class));
+        assertEquals(valueWrite.clear(), valueRead.clear());
+        Mockito.verifyNoMoreInteractions(in);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/TypeReadWriteValueTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TypeReadWriteValueTest.java
@@ -192,7 +192,7 @@ public class TypeReadWriteValueTest
         DataInputPlus in = mock(DataInputPlus.class);
         doAnswer(copyAnswer(valueWrite)).when(in).readFully(any(byte[].class));
 
-        ByteBuffer valueRead = type.readValue(in);
+        ByteBuffer valueRead = type.readBuffer(in);
 
         verify(in).readFully(any(byte[].class));
         assertEquals(valueWrite.clear(), valueRead.clear());
@@ -227,7 +227,7 @@ public class TypeReadWriteValueTest
         when(in.readUnsignedVInt()).thenReturn(length);
         doAnswer(copyAnswer(valueWrite)).when(in).readFully(any(byte[].class));
 
-        ByteBuffer valueRead = type.readValue(in);
+        ByteBuffer valueRead = type.readBuffer(in);
 
         verify(in).readUnsignedVInt();
         verify(in).readFully(any(byte[].class));

--- a/test/unit/org/apache/cassandra/db/marshal/TypeValueLengthTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TypeValueLengthTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.marshal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a guard against breaking the unversioned and under documented serialization properties of the AbstractType
+ * properties. This is documenting current behaviour as standard until we have time to invest in sorting out the mess.
+ */
+public class TypeValueLengthTest
+{
+    static final int VARIABLE_LENGTH = -1;
+
+    @Test
+    public void testVariableLength()
+    {
+        assertEquals(VARIABLE_LENGTH, ByteType.instance.valueLengthIfFixed());// Gaaaaah!!!! I know
+        assertEquals(VARIABLE_LENGTH, ShortType.instance.valueLengthIfFixed());// Gaaaaah!!!! I know
+        assertEquals(VARIABLE_LENGTH, IntegerType.instance.valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, CompositeType.getInstance(Int32Type.instance).valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, DecimalType.instance.valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, AsciiType.instance.valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, UTF8Type.instance.valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, ListType.getInstance(Int32Type.instance, true).valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, MapType.getInstance(Int32Type.instance,Int32Type.instance, true).valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, ListType.getInstance(Int32Type.instance, false).valueLengthIfFixed());
+        assertEquals(VARIABLE_LENGTH, MapType.getInstance(Int32Type.instance,Int32Type.instance, false).valueLengthIfFixed());
+
+        assertEquals(VARIABLE_LENGTH, ReversedType.getInstance(IntegerType.instance).valueLengthIfFixed());
+    }
+
+    @Test
+    public void testFixedLength()
+    {
+        assertEquals(1, BooleanType.instance.valueLengthIfFixed());
+        assertEquals(8, DateType.instance.valueLengthIfFixed());
+        assertEquals(8, DoubleType.instance.valueLengthIfFixed());
+        assertEquals(0, EmptyType.instance.valueLengthIfFixed());
+        assertEquals(4, FloatType.instance.valueLengthIfFixed());
+        assertEquals(4, Int32Type.instance.valueLengthIfFixed());
+        assertEquals(16, LexicalUUIDType.instance.valueLengthIfFixed());
+        assertEquals(8, LongType.instance.valueLengthIfFixed());
+        assertEquals(8, TimestampType.instance.valueLengthIfFixed());
+        assertEquals(16, TimeUUIDType.instance.valueLengthIfFixed());
+        assertEquals(16, UUIDType.instance.valueLengthIfFixed());
+        assertEquals(16, ReversedType.getInstance(UUIDType.instance).valueLengthIfFixed());
+    }
+}


### PR DESCRIPTION
The original description:

In profiling JMH workload ReadWide a bottleneck has been identified
in the compareTo call made for AbstractType subclasses. The
comparison code seem overtly generic. For the numerical types in
particular, it is better to specialize.

This ported commit replaces polymorphic 'compare' calls with a
switch. A single entry point for comparison has been created -
AbstractType.compare.
Primitive types were extracted to a separate subgroup with
static calls.