### PR TITLE
STAR-571 fix *SnichTests

### DIFF
--- a/test/unit/org/apache/cassandra/locator/AlibabaCloudSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/AlibabaCloudSnitchTest.java
@@ -25,6 +25,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
@@ -47,9 +48,7 @@ public class AlibabaCloudSnitchTest
     {
         System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
         DatabaseDescriptor.daemonInitialization();
-        CommitLog.instance.start();
-        mkdirs();
-        cleanup();
+        ServerTestUtils.cleanupAndLeaveDirs();
         Keyspace.setInitialized();
         StorageService.instance.initServer(0);
     }

--- a/test/unit/org/apache/cassandra/locator/CloudstackSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/CloudstackSnitchTest.java
@@ -26,6 +26,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
@@ -48,9 +49,7 @@ public class CloudstackSnitchTest
     {
         System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
         DatabaseDescriptor.daemonInitialization();
-        CommitLog.instance.start();
-        mkdirs();
-        cleanup();
+        ServerTestUtils.cleanupAndLeaveDirs();
         Keyspace.setInitialized();
         StorageService.instance.initServer(0);
     }

--- a/test/unit/org/apache/cassandra/locator/EC2SnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/EC2SnitchTest.java
@@ -31,6 +31,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
@@ -62,9 +63,7 @@ public class EC2SnitchTest
     {
         System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
         DatabaseDescriptor.daemonInitialization();
-        CommitLog.instance.start();
-        mkdirs();
-        cleanup();
+        ServerTestUtils.cleanupAndLeaveDirs();
         Keyspace.setInitialized();
         StorageService.instance.initServer(0);
     }

--- a/test/unit/org/apache/cassandra/locator/GoogleCloudSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/GoogleCloudSnitchTest.java
@@ -27,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
@@ -49,9 +50,7 @@ public class GoogleCloudSnitchTest
     {
         System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
         DatabaseDescriptor.daemonInitialization();
-        CommitLog.instance.start();
-        mkdirs();
-        cleanup();
+        ServerTestUtils.cleanupAndLeaveDirs();
         Keyspace.setInitialized();
         StorageService.instance.initServer(0);
     }


### PR DESCRIPTION
Migrate to commit log initialization implemented by
ServerTestUtils that is race free. Files were removed by
the cleanup that followed CL init.