### PR TITLE
STAR-96: OR and IN support for SAI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -654,7 +654,8 @@
           <dependency groupId="org.hamcrest" artifactId="hamcrest" version="2.2" scope="test"/>
           <dependency groupId="org.agrona" artifactId="agrona" version="0.9.26" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="7.5.0" />
-          <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2">
+          <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
+          <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">
               <exclusion groupId="junit" artifactId="junit"/>
           </dependency>
         </dependencyManagement>
@@ -739,6 +740,7 @@
         <dependency groupId="org.jboss.byteman" artifactId="byteman-bmunit" scope="test"/>
 
         <dependency groupId="org.apache.lucene" artifactId="lucene-core"/>
+        <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
         <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" scope="test"/>
       </artifact:pom>
 
@@ -825,6 +827,7 @@
         <dependency groupId="org.hdrhistogram" artifactId="HdrHistogram"/>
         <dependency groupId="org.agrona" artifactId="agrona"/>
         <dependency groupId="org.apache.lucene" artifactId="lucene-core"/>
+        <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.23" scope="test"/>
         <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" scope="test"/>
         <dependency groupId="org.hamcrest" artifactId="hamcrest" scope="test"/>
         <dependency groupId="com.esri.geometry" artifactId="esri-geometry-api"/>

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -150,7 +150,7 @@ public final class SingleColumnRelation extends Relation
             entityAsString = String.format("%s[%s]", entityAsString, mapKey);
 
         if (isIN())
-            return String.format("%s IN %s", entityAsString, Tuples.tupleToString(inValues));
+            return String.format("%s IN %s", entityAsString, inValues == null ? value : Tuples.tupleToString(inValues));
 
         return String.format("%s %s %s", entityAsString, relationType, value);
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -127,7 +127,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
     }
 
     @Override
-    public void addToRowFilter(RowFilter filter,
+    public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
                                QueryOptions options) throws InvalidRequestException
     {
@@ -181,6 +181,11 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
 
         public ClusteringColumnRestrictions.Builder addRestriction(Restriction restriction)
         {
+            return addRestriction(restriction, false);
+        }
+
+        public ClusteringColumnRestrictions.Builder addRestriction(Restriction restriction, boolean isDisjunction)
+        {
             SingleRestriction newRestriction = (SingleRestriction) restriction;
             boolean isEmpty = restrictions.isEmpty();
 
@@ -189,7 +194,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
                 SingleRestriction lastRestriction = restrictions.lastRestriction();
                 ColumnMetadata lastRestrictionStart = lastRestriction.getFirstColumn();
                 ColumnMetadata newRestrictionStart = newRestriction.getFirstColumn();
-                restrictions.addRestriction(newRestriction);
+                restrictions.addRestriction(newRestriction, isDisjunction);
 
                 checkFalse(lastRestriction.isSlice() && newRestrictionStart.position() > lastRestrictionStart.position(),
                            "Clustering column \"%s\" cannot be restricted (preceding column \"%s\" is restricted by a non-EQ relation)",
@@ -203,7 +208,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             }
             else
             {
-                restrictions.addRestriction(newRestriction);
+                restrictions.addRestriction(newRestriction, isDisjunction);
             }
 
             return this;

--- a/src/java/org/apache/cassandra/cql3/restrictions/CustomIndexExpression.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/CustomIndexExpression.java
@@ -47,7 +47,7 @@ public class CustomIndexExpression
         value.collectMarkerSpecification(boundNames);
     }
 
-    public void addToRowFilter(RowFilter filter, TableMetadata table, QueryOptions options)
+    public void addToRowFilter(RowFilter.Builder filter, TableMetadata table, QueryOptions options)
     {
         filter.addCustomIndexExpression(table,
                                         table.indexes

--- a/src/java/org/apache/cassandra/cql3/restrictions/ExpressionTree.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ExpressionTree.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.restrictions;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.Relation;
+
+/**
+ * This is a representation of a complex query as a tree of expression elements. An element in the
+ * tree can have one or more relations or custom index expressions associated with it and
+ * one or more child expression elements.
+ *
+ *
+ */
+public class ExpressionTree
+{
+    public static final ExpressionTree EMPTY = new ExpressionTree(ExpressionElement.EMPTY);
+
+    private final ExpressionElement root;
+
+    private ExpressionTree(ExpressionElement root)
+    {
+        this.root = root;
+    }
+
+    public boolean isEmpty()
+    {
+        return root == null;
+    }
+
+    public ExpressionElement root()
+    {
+        return root;
+    }
+
+    public ExpressionTree rename(ColumnIdentifier from, ColumnIdentifier to)
+    {
+        return new ExpressionTree(root.rename(from, to));
+    }
+
+    @Override
+    public String toString()
+    {
+        return root.toString();
+    }
+
+    /**
+     * This receives fragments from the parse operation and builds them into the final <code>ExpressionTree</code>.
+     *
+     * The received fragments are:
+     * <ul>
+     *     <li><code>add(Relation)</code> - adds a new relation to the current <code>ParseState</code></li>
+     *     <li><code>add(CustomIndexExpression)</code> - adds a new custom index expression to the current <code>ParseState</code></li>
+     *     <li><code>startEnclosure</code> - responds to a '(' and pushes the current <code>ParseState</code> onto the precedence stack</li>
+     *     <li><code>endEnclosure</code> - responds to a ')' and pulls the <code>ParseState</code> associated with the
+     *     matching <code>startEnclosure</code>. It will pull any intermediate precedence states off the stack until it
+     *     reaches the matching enclosure state</li>
+     *     <li><code>setCurrentOperator</code> - changes the operator in the <code>ParseState</code>. If this new operator is
+     *     of a higher precedence than the current operator, the last expression is popped from the <code>ParseState</code> and
+     *     the state is pushed onto the precedence stack</li>
+     *     <li><code>build</code> - always the last call. This builds the resultant <code>ExpressionTree</code> from the
+     *     precedence stack and the current <code>ParseState</code></li>
+     * </ul>
+     */
+    public static class Builder
+    {
+        private final Deque<ParseState> precedenceStack = new ArrayDeque<>();
+        private ParseState parseState = new ParseState();
+
+        public void add(Relation relation)
+        {
+            parseState.push(new RelationElement(relation));
+        }
+
+        public void add(CustomIndexExpression customIndexExpression)
+        {
+            parseState.push(new CustomIndexExpressionElement(customIndexExpression));
+        }
+
+        public void startEnclosure()
+        {
+            pushStack(PushState.ENCLOSURE);
+        }
+
+        public void endEnclosure()
+        {
+            do
+            {
+                ExpressionElement expression = generate();
+                parseState = precedenceStack.pop();
+                parseState.push(expression);
+            }
+            while (parseState.enclosure == PushState.PRECEDENCE);
+        }
+
+        public void setCurrentOperator(String value)
+        {
+            Operator operator = Operator.valueOf(value.toUpperCase());
+            if (parseState.isChangeOfOperator(operator))
+            {
+                if (parseState.higherPrecedence(operator))
+                {
+                    // Where we have a = 1 OR b = 1 AND c = 1. When the operator changes to AND
+                    // we need to pop b = 1 from the parseState, push the parseState containing
+                    // a = 1 OR and then add b = 1 to the new parseState
+                    ExpressionElement last = parseState.pop();
+                    pushStack(PushState.PRECEDENCE);
+                    parseState.push(last);
+                }
+                else
+                {
+                    ExpressionElement element = generate();
+                    if (!precedenceStack.isEmpty() && precedenceStack.peek().enclosure == PushState.PRECEDENCE)
+                        parseState = precedenceStack.pop();
+                    else
+                        parseState.clear();
+                    parseState.push(element);
+                }
+            }
+            parseState.operator = operator;
+        }
+
+        public ExpressionTree build()
+        {
+            while (!precedenceStack.isEmpty())
+            {
+                ExpressionElement expression = generate();
+                parseState = precedenceStack.pop();
+                parseState.push(expression);
+            }
+            return new ExpressionTree(generate());
+        }
+
+        private void pushStack(PushState enclosure)
+        {
+            parseState.enclosure = enclosure;
+            precedenceStack.push(parseState);
+            parseState = new ParseState();
+        }
+
+        private ExpressionElement generate()
+        {
+            if (parseState.size() == 1)
+                return parseState.pop();
+            return parseState.asContainer();
+        }
+    }
+
+    /**
+     * Represents the state of the parsing operation at a point of enclosure or precedence change.
+     */
+    public static class ParseState
+    {
+        Operator operator = Operator.NONE;
+        PushState enclosure = PushState.NONE;
+        Deque<ExpressionElement> expressionElements = new ArrayDeque<>();
+
+        void push(ExpressionElement element)
+        {
+            expressionElements.add(element);
+        }
+
+        ExpressionElement pop()
+        {
+            return expressionElements.removeLast();
+        }
+
+        int size()
+        {
+            return expressionElements.size();
+        }
+
+        ParseState clear()
+        {
+            expressionElements.clear();
+            return this;
+        }
+
+        boolean isChangeOfOperator(Operator operator)
+        {
+            return this.operator != operator && expressionElements.size() > 1;
+        }
+
+        boolean higherPrecedence(Operator operator)
+        {
+            return operator.compareTo(this.operator) > 0;
+        }
+
+        ContainerElement asContainer()
+        {
+            return operator == Operator.OR ? new OrElement().add(expressionElements) : new AndElement().add(expressionElements);
+        }
+    }
+
+    enum Operator
+    {
+        NONE, OR, AND;
+
+        public String joinValue()
+        {
+            return " " + name() + " ";
+        }
+    }
+
+    /**
+     * This is the reason why the <code>ParseState</code> was pushed onto the precedence stack.
+     */
+    enum PushState
+    {
+        NONE, PRECEDENCE, ENCLOSURE
+    }
+
+    public static abstract class ExpressionElement
+    {
+        private static final ExpressionElement EMPTY = new EmptyElement();
+
+        public List<ContainerElement> operations()
+        {
+            return Collections.emptyList();
+        }
+
+        public boolean isDisjunction()
+        {
+            return false;
+        }
+
+        public List<Relation> relations()
+        {
+            return Collections.emptyList();
+        }
+
+        public List<CustomIndexExpression> expressions()
+        {
+            return Collections.emptyList();
+        }
+
+        public boolean containsCustomExpressions()
+        {
+            return false;
+        }
+
+        public abstract String toEncapsulatedString();
+
+        public ExpressionElement rename(ColumnIdentifier from, ColumnIdentifier to)
+        {
+            return this;
+        }
+    }
+
+    public static abstract class VariableElement extends ExpressionElement
+    {
+        @Override
+        public String toEncapsulatedString()
+        {
+            return toString();
+        }
+    }
+
+    public static class EmptyElement extends VariableElement
+    {
+    }
+
+    public static class RelationElement extends VariableElement
+    {
+        private final Relation relation;
+
+        public RelationElement(Relation relation)
+        {
+            this.relation = relation;
+        }
+
+        @Override
+        public List<Relation> relations()
+        {
+            return Lists.newArrayList(relation);
+        }
+
+        @Override
+        public ExpressionElement rename(ColumnIdentifier from, ColumnIdentifier to)
+        {
+            return new RelationElement(relation.renameIdentifier(from, to));
+        }
+
+        @Override
+        public String toString()
+        {
+            return relation.toString();
+        }
+    }
+
+    public static class CustomIndexExpressionElement extends VariableElement
+    {
+        private final CustomIndexExpression customIndexExpression;
+
+        public CustomIndexExpressionElement(CustomIndexExpression customIndexExpression)
+        {
+            this.customIndexExpression = customIndexExpression;
+        }
+
+        @Override
+        public List<CustomIndexExpression> expressions()
+        {
+            return Lists.newArrayList(customIndexExpression);
+        }
+
+        @Override
+        public boolean containsCustomExpressions()
+        {
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return customIndexExpression.toString();
+        }
+    }
+
+    public static abstract class ContainerElement extends ExpressionElement
+    {
+        protected final List<ExpressionElement> children = new ArrayList<>();
+
+        @Override
+        public List<ContainerElement> operations()
+        {
+            return children.stream()
+                           .filter(c -> (c instanceof ContainerElement))
+                           .map(r -> ((ContainerElement)r))
+                           .collect(Collectors.toList());
+        }
+
+        public ContainerElement add(Deque<ExpressionElement> children)
+        {
+            this.children.addAll(children);
+            return this;
+        }
+
+        protected abstract Operator operator();
+
+        @Override
+        public List<Relation> relations()
+        {
+            return children.stream()
+                           .filter(c -> (c instanceof RelationElement))
+                           .map(r -> (((RelationElement)r).relation))
+                           .collect(Collectors.toList());
+        }
+
+        @Override
+        public List<CustomIndexExpression> expressions()
+        {
+            return children.stream()
+                           .filter(c -> (c instanceof CustomIndexExpressionElement))
+                           .map(r -> (((CustomIndexExpressionElement)r).customIndexExpression))
+                           .collect(Collectors.toList());
+        }
+
+        @Override
+        public boolean containsCustomExpressions()
+        {
+            return children.stream().anyMatch(ExpressionElement::containsCustomExpressions);
+        }
+
+        @Override
+        public ExpressionElement rename(ColumnIdentifier from, ColumnIdentifier to)
+        {
+            AndElement element = new AndElement();
+            children.stream().map(c -> c.rename(from, to)).forEach(c -> element.children.add(c));
+            return element;
+        }
+
+        @Override
+        public String toString()
+        {
+            return children.stream().map(ExpressionElement::toEncapsulatedString).collect(Collectors.joining(operator().joinValue()));
+        }
+
+        @Override
+        public String toEncapsulatedString()
+        {
+            return children.stream().map(ExpressionElement::toEncapsulatedString).collect(Collectors.joining(operator().joinValue(), "(", ")"));
+        }
+
+    }
+
+    public static class AndElement extends ContainerElement
+    {
+        @Override
+        protected Operator operator()
+        {
+            return Operator.AND;
+        }
+    }
+
+    public static class OrElement extends ContainerElement
+    {
+        @Override
+        protected Operator operator()
+        {
+            return Operator.OR;
+        }
+
+        @Override
+        public boolean isDisjunction()
+        {
+            return true;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/restrictions/IndexRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/IndexRestrictions.java
@@ -151,6 +151,19 @@ public final class IndexRestrictions
         return false;
     }
 
+    public boolean indexBeingUsed(Index.Group indexGroup)
+    {
+        for (Restrictions restrictions : regularRestrictions)
+            if (!restrictions.needsFiltering(indexGroup))
+                return true;
+
+        for (CustomIndexExpression restriction : externalRestrictions)
+            if (!restriction.needsFiltering(indexGroup))
+                return true;
+
+        return false;
+    }
+
     static InvalidRequestException invalidIndex(QualifiedName indexName, TableMetadata table)
     {
         return new InvalidRequestException(String.format(INVALID_INDEX, indexName.getName(), table));

--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -211,7 +211,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+        public final void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
         {
             Tuples.Value t = ((Tuples.Value) value.bind(options));
             List<ByteBuffer> values = t.getElements();
@@ -265,7 +265,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter filter,
+        public final void addToRowFilter(RowFilter.Builder filter,
                                          IndexRegistry indexRegistry,
                                          QueryOptions options)
         {
@@ -491,7 +491,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter filter,
+        public final void addToRowFilter(RowFilter.Builder filter,
                                          IndexRegistry indexRegistry,
                                          QueryOptions options)
         {
@@ -577,7 +577,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+        public final void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
         {
             throw new UnsupportedOperationException("Secondary indexes do not support IS NOT NULL restrictions");
         }

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
@@ -123,7 +123,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     }
 
     @Override
-    public void addToRowFilter(RowFilter filter,
+    public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
                                QueryOptions options)
     {
@@ -166,12 +166,19 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             this.clusteringComparator = clusteringComparator;
         }
 
-        public Builder addRestriction(Restriction restriction) {
+        public Builder addRestriction(Restriction restriction)
+        {
             restrictions.add(restriction);
             return this;
         }
 
-        public PartitionKeyRestrictions build() {
+        public PartitionKeyRestrictions build()
+        {
+            return build(false);
+        }
+
+        public PartitionKeyRestrictions build(boolean isDisjunction)
+        {
             RestrictionSet.Builder restrictionSet = RestrictionSet.builder();
 
             for (int i = 0; i < restrictions.size(); i++) {
@@ -181,13 +188,14 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
                 if (restriction.isOnToken())
                     return buildWithTokens(restrictionSet, i);
 
-                restrictionSet.addRestriction((SingleRestriction) restriction);
+                restrictionSet.addRestriction((SingleRestriction) restriction, isDisjunction);
             }
 
             return buildPartitionKeyRestrictions(restrictionSet);
         }
 
-        private PartitionKeyRestrictions buildWithTokens(RestrictionSet.Builder restrictionSet, int i) {
+        private PartitionKeyRestrictions buildWithTokens(RestrictionSet.Builder restrictionSet, int i)
+        {
             PartitionKeyRestrictions merged = buildPartitionKeyRestrictions(restrictionSet);
 
             for (; i < restrictions.size(); i++) {
@@ -199,7 +207,8 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             return merged;
         }
 
-        private PartitionKeySingleRestrictionSet buildPartitionKeyRestrictions(RestrictionSet.Builder restrictionSet) {
+        private PartitionKeySingleRestrictionSet buildPartitionKeyRestrictions(RestrictionSet.Builder restrictionSet)
+        {
             return new PartitionKeySingleRestrictionSet(restrictionSet.build(), clusteringComparator);
         }
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.cql3.restrictions;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -89,7 +88,7 @@ public interface Restriction
      * @param indexRegistry the index registry
      * @param options the query options
      */
-    public void addToRowFilter(RowFilter filter,
+    public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
                                QueryOptions options);
 }

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -18,7 +18,10 @@
 package org.apache.cassandra.cql3.restrictions;
 
 import java.util.*;
-import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.functions.Function;
@@ -50,7 +53,7 @@ public abstract class RestrictionSet implements Restrictions
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options) throws InvalidRequestException
+        public void addToRowFilter(RowFilter.Builder rowFilter, IndexRegistry indexRegistry, QueryOptions options) throws InvalidRequestException
         {
         }
 
@@ -149,7 +152,7 @@ public abstract class RestrictionSet implements Restrictions
          * The values as returned from {@link #restrictions()}.
          */
         private final List<SingleRestriction> restrictionsValues;
-        private final Map<ColumnMetadata, SingleRestriction> restrictionsHashMap;
+        private final Multimap<ColumnMetadata, SingleRestriction> restrictionsMap;
         private final int hasBitmap;
         private final int restrictionForKindBitmap;
         private static final int maskHasContains = 1;
@@ -159,7 +162,7 @@ public abstract class RestrictionSet implements Restrictions
         private static final int maskHasMultiColumnSlice = 16;
         private static final int maskHasMultipleContains = 32;
 
-        private DefaultRestrictionSet(Map<ColumnMetadata, SingleRestriction> restrictions,
+        private DefaultRestrictionSet(Multimap<ColumnMetadata, SingleRestriction> restrictions,
                                       boolean hasMultiColumnRestrictions)
         {
             this.restrictionsKeys = new ArrayList<>(restrictions.keySet());
@@ -175,52 +178,55 @@ public abstract class RestrictionSet implements Restrictions
             for (int i = 0; i < restrictionsKeys.size(); i++)
             {
                 ColumnMetadata col = restrictionsKeys.get(i);
-                SingleRestriction singleRestriction = restrictions.get(col);
+                Collection<SingleRestriction> columnRestrictions = restrictions.get(col);
 
-                if (singleRestriction.isContains())
+                for (SingleRestriction singleRestriction : columnRestrictions)
                 {
-                    bitmap |= maskHasContains;
-                    ContainsRestriction contains = (ContainsRestriction) singleRestriction;
-                    numberOfContains += (contains.numberOfValues() + contains.numberOfKeys() + contains.numberOfEntries());
+                    if (singleRestriction.isContains())
+                    {
+                        bitmap |= maskHasContains;
+                        ContainsRestriction contains = (ContainsRestriction) singleRestriction;
+                        numberOfContains += (contains.numberOfValues() + contains.numberOfKeys() + contains.numberOfEntries());
+                    }
+
+                    if (hasMultiColumnRestrictions)
+                    {
+                        if (singleRestriction.equals(previous))
+                            continue;
+                        previous = singleRestriction;
+                    }
+
+                    restrictionForBitmap |= 1 << col.kind.ordinal();
+
+                    sortedRestrictions.add(singleRestriction);
+
+                    if (singleRestriction.isSlice())
+                    {
+                        bitmap |= maskHasSlice;
+                        if (singleRestriction.isMultiColumn())
+                            bitmap |= maskHasMultiColumnSlice;
+                    }
+
+                    if (singleRestriction.isIN())
+                        bitmap |= maskHasIN;
+                    else if (!singleRestriction.isEQ())
+                        bitmap &= ~maskHasOnlyEqualityRestrictions;
                 }
-
-                if (hasMultiColumnRestrictions)
-                {
-                    if (singleRestriction.equals(previous))
-                        continue;
-                    previous = singleRestriction;
-                }
-
-                restrictionForBitmap |= 1 << col.kind.ordinal();
-
-                sortedRestrictions.add(singleRestriction);
-
-                if (singleRestriction.isSlice())
-                {
-                    bitmap |= maskHasSlice;
-                    if (singleRestriction.isMultiColumn())
-                        bitmap |= maskHasMultiColumnSlice;
-                }
-
-                if (singleRestriction.isIN())
-                    bitmap |= maskHasIN;
-                else if (!singleRestriction.isEQ())
-                    bitmap &= ~maskHasOnlyEqualityRestrictions;
             }
             this.hasBitmap = bitmap | (numberOfContains > 1 ? maskHasMultipleContains : 0);
             this.restrictionForKindBitmap = restrictionForBitmap;
 
             this.restrictionsValues = Collections.unmodifiableList(sortedRestrictions);
-            this.restrictionsHashMap = restrictions;
+            this.restrictionsMap = restrictions;
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter,
+        public void addToRowFilter(RowFilter.Builder rowFilter,
                                    IndexRegistry indexRegistry,
                                    QueryOptions options) throws InvalidRequestException
         {
-            for (SingleRestriction restriction : restrictionsHashMap.values())
-                restriction.addToRowFilter(filter, indexRegistry, options);
+            for (SingleRestriction restriction : restrictionsMap.values())
+                restriction.addToRowFilter(rowFilter, indexRegistry, options);
         }
 
         @Override
@@ -257,14 +263,13 @@ public abstract class RestrictionSet implements Restrictions
         @Override
         public Set<Restriction> getRestrictions(ColumnMetadata columnDef)
         {
-            Restriction existing = restrictionsHashMap.get(columnDef);
-            return existing == null ? Collections.emptySet() : Collections.singleton(existing);
+            return restrictionsMap.get(columnDef).stream().map(r -> ((Restriction)r)).collect(Collectors.toSet());
         }
 
         @Override
         public boolean hasSupportingIndex(IndexRegistry indexRegistry)
         {
-            for (SingleRestriction restriction : restrictionsHashMap.values())
+            for (SingleRestriction restriction : restrictionsMap.values())
                 if (restriction.hasSupportingIndex(indexRegistry))
                     return true;
             return false;
@@ -273,7 +278,7 @@ public abstract class RestrictionSet implements Restrictions
         @Override
         public boolean needsFiltering(Index.Group indexGroup)
         {
-            for (SingleRestriction restriction : restrictionsHashMap.values())
+            for (SingleRestriction restriction : restrictionsMap.values())
                 if (restriction.needsFiltering(indexGroup))
                     return true;
 
@@ -378,7 +383,7 @@ public abstract class RestrictionSet implements Restrictions
 
     public static final class Builder
     {
-        private final Map<ColumnMetadata, SingleRestriction> newRestrictions = new HashMap<>();
+        private final Multimap<ColumnMetadata, SingleRestriction> newRestrictions = ArrayListMultimap.create();
         private boolean multiColumn = false;
 
         private ColumnMetadata lastRestrictionColumn;
@@ -388,27 +393,35 @@ public abstract class RestrictionSet implements Restrictions
         {
         }
 
-        public void addRestriction(SingleRestriction restriction)
+        public void addRestriction(SingleRestriction restriction, boolean isDisjunction)
         {
             List<ColumnMetadata> columnDefs = restriction.getColumnDefs();
-            Set<SingleRestriction> existingRestrictions = getRestrictions(newRestrictions, columnDefs);
 
-            if (existingRestrictions.isEmpty())
+            if (isDisjunction)
             {
-                addRestrictionForColumns(columnDefs, restriction);
+                addRestrictionForColumns(columnDefs, restriction, false);
             }
             else
             {
-                for (SingleRestriction existing : existingRestrictions)
-                {
-                    SingleRestriction newRestriction = existing.mergeWith(restriction);
+                Set<SingleRestriction> existingRestrictions = getRestrictions(newRestrictions, columnDefs);
 
-                    addRestrictionForColumns(columnDefs, newRestriction);
+                if (existingRestrictions.isEmpty())
+                {
+                    addRestrictionForColumns(columnDefs, restriction, false);
+                }
+                else
+                {
+                    for (SingleRestriction existing : existingRestrictions)
+                    {
+                        SingleRestriction newRestriction = existing.mergeWith(restriction);
+
+                        addRestrictionForColumns(columnDefs, newRestriction, true);
+                    }
                 }
             }
         }
 
-        private void addRestrictionForColumns(List<ColumnMetadata> columnDefs, SingleRestriction restriction)
+        private void addRestrictionForColumns(List<ColumnMetadata> columnDefs, SingleRestriction restriction, boolean clear)
         {
             for (int i = 0; i < columnDefs.size(); i++)
             {
@@ -418,21 +431,23 @@ public abstract class RestrictionSet implements Restrictions
                     lastRestrictionColumn = column;
                     lastRestriction = restriction;
                 }
+                if (clear)
+                    newRestrictions.removeAll(column);
                 newRestrictions.put(column, restriction);
             }
 
             multiColumn |= restriction.isMultiColumn();
         }
 
-        private static Set<SingleRestriction> getRestrictions(Map<ColumnMetadata, SingleRestriction> restrictions,
+        private static Set<SingleRestriction> getRestrictions(Multimap<ColumnMetadata, SingleRestriction> restrictions,
                                                               List<ColumnMetadata> columnDefs)
         {
             Set<SingleRestriction> set = new HashSet<>();
             for (int i = 0; i < columnDefs.size(); i++)
             {
-                SingleRestriction existing = restrictions.get(columnDefs.get(i));
-                if (existing != null)
-                    set.add(existing);
+                Collection<SingleRestriction> existing = restrictions.get(columnDefs.get(i));
+                if (!existing.isEmpty())
+                    set.addAll(existing);
             }
             return set;
         }

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.cql3.restrictions;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -45,11 +44,11 @@ class RestrictionSetWrapper implements Restrictions
     }
 
     @Override
-    public void addToRowFilter(RowFilter filter,
+    public void addToRowFilter(RowFilter.Builder rowFilter,
                                IndexRegistry indexRegistry,
                                QueryOptions options)
     {
-        restrictions.addToRowFilter(filter, indexRegistry, options);
+        restrictions.addToRowFilter(rowFilter, indexRegistry, options);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -21,15 +21,14 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
+import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.Term.Terminal;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.Bound;
 import org.apache.cassandra.db.MultiCBuilder;
-import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.serializers.ListSerializer;
@@ -163,7 +162,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter,
+        public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
                                    QueryOptions options)
         {
@@ -227,7 +226,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter,
+        public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
                                    QueryOptions options)
         {
@@ -405,7 +404,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
         {
             for (Bound b : Bound.values())
                 if (hasBound(b))
@@ -495,7 +494,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
         {
             for (ByteBuffer value : bindAndGet(values, options))
                 filter.add(columnDef, Operator.CONTAINS, value);
@@ -634,7 +633,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter,
+        public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
                                    QueryOptions options)
         {
@@ -710,7 +709,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter filter,
+        public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
                                    QueryOptions options)
         {

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.cql3.restrictions;
 
 import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.function.Consumer;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -42,7 +41,9 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.utils.btree.BTreeSet;
 
-import static org.apache.cassandra.cql3.statements.RequestValidations.*;
+import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
+import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
+import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
 /**
  * The restrictions corresponding to the relations specified on the where-clause of CQL query.
@@ -50,9 +51,9 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.*;
 public class StatementRestrictions
 {
     public static final String REQUIRES_ALLOW_FILTERING_MESSAGE =
-            "Cannot execute this query as it might involve data filtering and " +
-            "thus may have unpredictable performance. If you want to execute " +
-            "this query despite the performance unpredictability, use ALLOW FILTERING";
+    "Cannot execute this query as it might involve data filtering and " +
+    "thus may have unpredictable performance. If you want to execute " +
+    "this query despite the performance unpredictability, use ALLOW FILTERING";
 
     public static final String HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE =
     "Column '%s' has an index but does not support the operators specified in the query. " +
@@ -64,10 +65,8 @@ public class StatementRestrictions
 
     public static final String INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE = "Index on column %s does not support LIKE restrictions.";
 
-    /**
-     * The type of statement
-     */
-    private final StatementType type;
+    public static final String INDEX_DOES_NOT_SUPPORT_DISJUNCTION =
+    "An index involved in this query does not support disjunctive queries using the OR operator";
 
     /**
      * The Column Family meta data
@@ -97,6 +96,11 @@ public class StatementRestrictions
     private final IndexRestrictions filterRestrictions;
 
     /**
+     * <code>true</code> if these restrictions form part of an OR query, <code>false</code> otherwise
+     */
+    private boolean isDisjunction;
+
+    /**
      * <code>true</code> if the secondary index need to be queried, <code>false</code> otherwise
      */
     protected boolean usesSecondaryIndexing;
@@ -112,48 +116,28 @@ public class StatementRestrictions
      */
     private boolean hasRegularColumnsRestrictions;
 
+    private final List<StatementRestrictions> children;
+
     /**
      * Creates a new empty <code>StatementRestrictions</code>.
      *
-     * @param type the type of statement
      * @param table the column family meta data
      * @return a new empty <code>StatementRestrictions</code>.
      */
-    public static StatementRestrictions empty(StatementType type, TableMetadata table)
+    public static StatementRestrictions empty(TableMetadata table)
     {
-        return new StatementRestrictions(type, table, false);
+        return new StatementRestrictions(table, false);
     }
 
-    private StatementRestrictions(StatementType type, TableMetadata table, boolean allowFiltering)
+    private StatementRestrictions(TableMetadata table, boolean allowFiltering)
     {
-        this.type = type;
         this.table = table;
         this.partitionKeyRestrictions = PartitionKeySingleRestrictionSet.builder(table.partitionKeyAsClusteringComparator()).build();
         this.clusteringColumnsRestrictions = ClusteringColumnRestrictions.builder(table, allowFiltering).build();
         this.nonPrimaryKeyRestrictions = RestrictionSet.builder().build();
         this.notNullColumns = ImmutableSet.of();
         this.filterRestrictions = IndexRestrictions.of();
-    }
-
-    private StatementRestrictions(StatementType type,
-                                  TableMetadata table,
-                                  PartitionKeyRestrictions partitionKeyRestrictions,
-                                  ClusteringColumnRestrictions clusteringColumnsRestrictions,
-                                  RestrictionSet nonPrimaryKeyRestrictions,
-                                  ImmutableSet<ColumnMetadata> notNullColumns,
-                                  boolean usesSecondaryIndexing,
-                                  boolean isKeyRange,
-                                  IndexRestrictions filterRestrictions)
-    {
-        this.type = type;
-        this.table = table;
-        this.partitionKeyRestrictions = partitionKeyRestrictions;
-        this.clusteringColumnsRestrictions = clusteringColumnsRestrictions;
-        this.nonPrimaryKeyRestrictions = nonPrimaryKeyRestrictions;
-        this.notNullColumns = notNullColumns;
-        this.usesSecondaryIndexing = usesSecondaryIndexing;
-        this.isKeyRange = isKeyRange;
-        this.filterRestrictions = filterRestrictions;
+        this.children = Collections.emptyList();
     }
 
     /**
@@ -169,15 +153,17 @@ public class StatementRestrictions
                                                                   .add(restrictions)
                                                                   .build();
 
-        return new StatementRestrictions(type,
-                                         table,
+        return new StatementRestrictions(table,
                                          partitionKeyRestrictions,
                                          clusteringColumnsRestrictions,
                                          nonPrimaryKeyRestrictions,
                                          notNullColumns,
+                                         isDisjunction,
                                          usesSecondaryIndexing,
                                          isKeyRange,
-                                         newIndexRestrictions);
+                                         hasRegularColumnsRestrictions,
+                                         newIndexRestrictions,
+                                         children);
     }
 
     /**
@@ -194,196 +180,470 @@ public class StatementRestrictions
         for (CustomIndexExpression restriction : restrictions)
             newIndexRestrictions.add(restriction);
 
-        return new StatementRestrictions(type,
-                                         table,
+        return new StatementRestrictions(table,
                                          partitionKeyRestrictions,
                                          clusteringColumnsRestrictions,
                                          nonPrimaryKeyRestrictions,
                                          notNullColumns,
+                                         isDisjunction,
                                          usesSecondaryIndexing,
                                          isKeyRange,
-                                         newIndexRestrictions.build());
+                                         hasRegularColumnsRestrictions,
+                                         newIndexRestrictions.build(),
+                                         children);
     }
 
-    public StatementRestrictions(StatementType type,
-                                 TableMetadata table,
-                                 WhereClause whereClause,
-                                 VariableSpecifications boundNames,
-                                 boolean selectsOnlyStaticColumns,
-                                 boolean allowFiltering,
-                                 boolean forView)
+    private StatementRestrictions(TableMetadata table,
+                                  PartitionKeyRestrictions partitionKeyRestrictions,
+                                  ClusteringColumnRestrictions clusteringColumnsRestrictions,
+                                  RestrictionSet nonPrimaryKeyRestrictions,
+                                  ImmutableSet<ColumnMetadata> notNullColumns,
+                                  boolean isDisjunction,
+                                  boolean usesSecondaryIndexing,
+                                  boolean isKeyRange,
+                                  boolean hasRegularColumnsRestrictions,
+                                  IndexRestrictions filterRestrictions,
+                                  List<StatementRestrictions> children)
     {
-        this(type, table, whereClause, boundNames, selectsOnlyStaticColumns, type.allowUseOfSecondaryIndices(), allowFiltering, forView);
-    }
-
-    /*
-     * We want to override allowUseOfSecondaryIndices flag from the StatementType for MV statements
-     * to avoid initing the Keyspace and SecondaryIndexManager.
-     */
-    public StatementRestrictions(StatementType type,
-                                 TableMetadata table,
-                                 WhereClause whereClause,
-                                 VariableSpecifications boundNames,
-                                 boolean selectsOnlyStaticColumns,
-                                 boolean allowUseOfSecondaryIndices,
-                                 boolean allowFiltering,
-                                 boolean forView)
-    {
-        this.type = type;
         this.table = table;
+        this.partitionKeyRestrictions = partitionKeyRestrictions;
+        this.clusteringColumnsRestrictions = clusteringColumnsRestrictions;
+        this.nonPrimaryKeyRestrictions = nonPrimaryKeyRestrictions;
+        this.notNullColumns = notNullColumns;
+        this.filterRestrictions = filterRestrictions;
+        this.isDisjunction = isDisjunction;
+        this.usesSecondaryIndexing = usesSecondaryIndexing;
+        this.isKeyRange = isKeyRange;
+        this.hasRegularColumnsRestrictions = hasRegularColumnsRestrictions;
+        this.children = children;
+    }
 
-        IndexRegistry indexRegistry = null;
+    public static StatementRestrictions.Builder builder(StatementType type,
+                                                        TableMetadata table,
+                                                        WhereClause whereClause,
+                                                        VariableSpecifications boundNames,
+                                                        boolean selectsOnlyStaticColumns,
+                                                        boolean allowFiltering,
+                                                        boolean forView)
+    {
+        return new StatementRestrictions.Builder(type, table, whereClause, boundNames, selectsOnlyStaticColumns, type.allowUseOfSecondaryIndices(), allowFiltering, forView);
+    }
 
-        // We want to avoid opening the keyspace during view construction
-        // since we're parsing these for restore and the base table or keyspace might not exist in the current schema.
-        if (allowUseOfSecondaryIndices && type.allowUseOfSecondaryIndices())
-            indexRegistry = IndexRegistry.obtain(table);
+    public static StatementRestrictions.Builder builder(StatementType type,
+                                                        TableMetadata table,
+                                                        WhereClause whereClause,
+                                                        VariableSpecifications boundNames,
+                                                        boolean selectsOnlyStaticColumns,
+                                                        boolean allowUseOfSecondaryIndices,
+                                                        boolean allowFiltering,
+                                                        boolean forView)
+    {
+        return new StatementRestrictions.Builder(type, table, whereClause, boundNames, selectsOnlyStaticColumns, allowUseOfSecondaryIndices, allowFiltering, forView);
+    }
 
-        PartitionKeySingleRestrictionSet.Builder partitionKeyRestrictionSet = PartitionKeySingleRestrictionSet.builder(table.partitionKeyAsClusteringComparator());
-        ClusteringColumnRestrictions.Builder clusteringColumnsRestrictionSet = ClusteringColumnRestrictions.builder(table, allowFiltering, indexRegistry);
-        RestrictionSet.Builder nonPrimaryKeyRestrictionSet = RestrictionSet.builder();
+    public static class Builder
+    {
+        private final StatementType type;
+        private final TableMetadata table;
+        private final WhereClause whereClause;
+        private final VariableSpecifications boundNames;
+        private final boolean selectsOnlyStaticColumns;
+        private final boolean allowUseOfSecondaryIndices;
+        private final boolean allowFiltering;
+        private final boolean forView;
 
-        ImmutableSet.Builder<ColumnMetadata> notNullColumnsBuilder = ImmutableSet.builder();
-
-        /*
-         * WHERE clause. For a given entity, rules are:
-         *   - EQ relation conflicts with anything else (including a 2nd EQ)
-         *   - Can't have more than one LT(E) relation (resp. GT(E) relation)
-         *   - IN relation are restricted to row keys (for now) and conflicts with anything else (we could
-         *     allow two IN for the same entity but that doesn't seem very useful)
-         *   - The value_alias cannot be restricted in any way (we don't support wide rows with indexed value
-         *     in CQL so far)
-         */
-        for (Relation relation : whereClause.relations)
+        public Builder(StatementType type,
+                       TableMetadata table,
+                       WhereClause whereClause,
+                       VariableSpecifications boundNames,
+                       boolean selectsOnlyStaticColumns,
+                       boolean allowUseOfSecondaryIndices,
+                       boolean allowFiltering,
+                       boolean forView)
         {
-            if (relation.operator() == Operator.IS_NOT)
+            this.type = type;
+            this.table = table;
+            this.whereClause = whereClause;
+            this.boundNames = boundNames;
+            this.selectsOnlyStaticColumns = selectsOnlyStaticColumns;
+            this.allowUseOfSecondaryIndices = allowUseOfSecondaryIndices;
+            this.allowFiltering = allowFiltering;
+            this.forView = forView;
+        }
+
+        public StatementRestrictions build()
+        {
+            IndexRegistry indexRegistry = null;
+
+            // We want to avoid opening the keyspace during view construction
+            // since we're parsing these for restore and the base table or keyspace might not exist in the current schema.
+            if (allowUseOfSecondaryIndices && type.allowUseOfSecondaryIndices())
+                indexRegistry = IndexRegistry.obtain(table);
+
+            return doBuild(whereClause.root(), indexRegistry);
+        }
+
+        StatementRestrictions doBuild(ExpressionTree.ExpressionElement element, IndexRegistry indexRegistry)
+        {
+            PartitionKeySingleRestrictionSet.Builder partitionKeyRestrictionSet = PartitionKeySingleRestrictionSet.builder(table.partitionKeyAsClusteringComparator());
+            ClusteringColumnRestrictions.Builder clusteringColumnsRestrictionSet = ClusteringColumnRestrictions.builder(table, allowFiltering, indexRegistry);
+            RestrictionSet.Builder nonPrimaryKeyRestrictionSet = RestrictionSet.builder();
+            ImmutableSet.Builder<ColumnMetadata> notNullColumnsBuilder = ImmutableSet.builder();
+
+            /*
+             * WHERE clause. For a given entity, rules are:
+             *   - EQ relation conflicts with anything else (including a 2nd EQ)
+             *   - Can't have more than one LT(E) relation (resp. GT(E) relation)
+             *   - IN relation are restricted to row keys (for now) and conflicts with anything else (we could
+             *     allow two IN for the same entity but that doesn't seem very useful)
+             *   - The value_alias cannot be restricted in any way (we don't support wide rows with indexed value
+             *     in CQL so far)
+             */
+            for (Relation relation : element.relations())
             {
-                if (!forView)
-                    throw invalidRequest("Unsupported restriction: %s", relation);
-
-                notNullColumnsBuilder.addAll(relation.toRestriction(table, boundNames).getColumnDefs());
-            }
-            else
-            {
-                Restriction restriction = relation.toRestriction(table, boundNames);
-
-                if (relation.isLIKE() && (!type.allowUseOfSecondaryIndices() || !restriction.hasSupportingIndex(indexRegistry)))
+                if (relation.operator() == Operator.IS_NOT)
                 {
-                    if (getColumnsWithUnsupportedIndexRestrictions(table, ImmutableList.of(restriction)).isEmpty())
-                    {
-                        throw invalidRequest("LIKE restriction is only supported on properly indexed columns. %s is not valid.", relation.toString());
-                    }
-                    else
-                    {
-                        throw invalidRequest(INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, restriction.getFirstColumn());
-                    }
-                }
+                    if (!forView)
+                        throw invalidRequest("Unsupported restriction: %s", relation);
 
-                ColumnMetadata def = restriction.getFirstColumn();
-                if (def.isPartitionKey())
-                {
-                    partitionKeyRestrictionSet.addRestriction(restriction);
-                }
-                else if (def.isClusteringColumn())
-                {
-                    clusteringColumnsRestrictionSet.addRestriction(restriction);
+                    notNullColumnsBuilder.addAll(relation.toRestriction(table, boundNames).getColumnDefs());
                 }
                 else
                 {
-                    nonPrimaryKeyRestrictionSet.addRestriction((SingleRestriction) restriction);
+                    Restriction restriction = relation.toRestriction(table, boundNames);
+
+                    if (relation.isLIKE() && (!type.allowUseOfSecondaryIndices() || !restriction.hasSupportingIndex(indexRegistry)))
+                    {
+                        if (getColumnsWithUnsupportedIndexRestrictions(table, ImmutableList.of(restriction)).isEmpty())
+                        {
+                            throw invalidRequest("LIKE restriction is only supported on properly indexed columns. %s is not valid.", relation.toString());
+                        }
+                        else
+                        {
+                            throw invalidRequest(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, restriction.getFirstColumn());
+                        }
+                    }
+
+                    ColumnMetadata def = restriction.getFirstColumn();
+                    if (def.isPartitionKey())
+                    {
+                        partitionKeyRestrictionSet.addRestriction(restriction);
+                    }
+                    else if (def.isClusteringColumn())
+                    {
+                        clusteringColumnsRestrictionSet.addRestriction(restriction, element.isDisjunction());
+                    }
+                    else
+                    {
+                        nonPrimaryKeyRestrictionSet.addRestriction((SingleRestriction) restriction, element.isDisjunction());
+                    }
                 }
             }
-        }
 
-        this.partitionKeyRestrictions = partitionKeyRestrictionSet.build();
-        this.clusteringColumnsRestrictions = clusteringColumnsRestrictionSet.build();
-        this.nonPrimaryKeyRestrictions = nonPrimaryKeyRestrictionSet.build();
-        this.notNullColumns = notNullColumnsBuilder.build();
-        this.hasRegularColumnsRestrictions = nonPrimaryKeyRestrictions.hasRestrictionFor(ColumnMetadata.Kind.REGULAR);
+            PartitionKeyRestrictions partitionKeyRestrictions = partitionKeyRestrictionSet.build();
+            ClusteringColumnRestrictions clusteringColumnsRestrictions = clusteringColumnsRestrictionSet.build();
+            RestrictionSet nonPrimaryKeyRestrictions = nonPrimaryKeyRestrictionSet.build();
+            ImmutableSet<ColumnMetadata> notNullColumns = notNullColumnsBuilder.build();
+            boolean hasRegularColumnsRestrictions = nonPrimaryKeyRestrictions.hasRestrictionFor(ColumnMetadata.Kind.REGULAR);
+            boolean usesSecondaryIndexing = false;
+            boolean isKeyRange = false;
 
-        boolean hasQueriableClusteringColumnIndex = false;
-        boolean hasQueriableIndex = false;
+            boolean hasQueriableClusteringColumnIndex = false;
+            boolean hasQueriableIndex = false;
 
-        IndexRestrictions.Builder filterRestrictionsBuilder = IndexRestrictions.builder();
+            IndexRestrictions.Builder filterRestrictionsBuilder = IndexRestrictions.builder();
 
-        if (allowUseOfSecondaryIndices)
-        {
-            if (whereClause.containsCustomExpressions())
+            if (allowUseOfSecondaryIndices)
             {
-                CustomIndexExpression customExpression = prepareCustomIndexExpression(whereClause.expressions,
-                                                                                      boundNames,
-                                                                                      indexRegistry);
-                filterRestrictionsBuilder.add(customExpression);
+                if (element.containsCustomExpressions())
+                {
+                    CustomIndexExpression customExpression = prepareCustomIndexExpression(element.expressions(),
+                                                                                          boundNames,
+                                                                                          indexRegistry);
+                    filterRestrictionsBuilder.add(customExpression);
+                }
+
+                hasQueriableClusteringColumnIndex = clusteringColumnsRestrictions.hasSupportingIndex(indexRegistry);
+                hasQueriableIndex = element.containsCustomExpressions()
+                                    || hasQueriableClusteringColumnIndex
+                                    || partitionKeyRestrictions.hasSupportingIndex(indexRegistry)
+                                    || nonPrimaryKeyRestrictions.hasSupportingIndex(indexRegistry);
             }
 
-            hasQueriableClusteringColumnIndex = clusteringColumnsRestrictions.hasSupportingIndex(indexRegistry);
-            hasQueriableIndex = whereClause.containsCustomExpressions()
-                    || hasQueriableClusteringColumnIndex
-                    || partitionKeyRestrictions.hasSupportingIndex(indexRegistry)
-                    || nonPrimaryKeyRestrictions.hasSupportingIndex(indexRegistry);
-        }
-
-        // At this point, the select statement if fully constructed, but we still have a few things to validate
-        processPartitionKeyRestrictions(hasQueriableIndex, allowFiltering, forView);
-
-        // Some but not all of the partition key columns have been specified;
-        // hence we need turn these restrictions into a row filter.
-        if (usesSecondaryIndexing || partitionKeyRestrictions.needFiltering(table))
-            filterRestrictionsBuilder.add(partitionKeyRestrictions);
-
-        if (selectsOnlyStaticColumns && hasClusteringColumnsRestrictions())
-        {
-            // If the only updated/deleted columns are static, then we don't need clustering columns.
-            // And in fact, unless it is an INSERT, we reject if clustering colums are provided as that
-            // suggest something unintended. For instance, given:
-            //   CREATE TABLE t (k int, v int, s int static, PRIMARY KEY (k, v))
-            // it can make sense to do:
-            //   INSERT INTO t(k, v, s) VALUES (0, 1, 2)
-            // but both
-            //   UPDATE t SET s = 3 WHERE k = 0 AND v = 1
-            //   DELETE v FROM t WHERE k = 0 AND v = 1
-            // sounds like you don't really understand what your are doing.
-            if (type.isDelete() || type.isUpdate())
-                throw invalidRequest("Invalid restrictions on clustering columns since the %s statement modifies only static columns",
-                                     type);
-        }
-
-        processClusteringColumnsRestrictions(hasQueriableIndex,
-                                             selectsOnlyStaticColumns,
-                                             forView,
-                                             allowFiltering);
-
-        // Covers indexes on the first clustering column (among others).
-        if (isKeyRange && hasQueriableClusteringColumnIndex)
-            usesSecondaryIndexing = true;
-
-        if (usesSecondaryIndexing || clusteringColumnsRestrictions.needFiltering())
-            filterRestrictionsBuilder.add(clusteringColumnsRestrictions);
-
-        // Even if usesSecondaryIndexing is false at this point, we'll still have to use one if
-        // there is restrictions not covered by the PK.
-        if (!nonPrimaryKeyRestrictions.isEmpty())
-        {
-            if (!type.allowNonPrimaryKeyInWhereClause())
+            // At this point, the select statement if fully constructed, but we still have a few things to validate
+            if (!type.allowPartitionKeyRanges())
             {
-                Collection<ColumnIdentifier> nonPrimaryKeyColumns =
-                        ColumnMetadata.toIdentifiers(nonPrimaryKeyRestrictions.getColumnDefs());
+                checkFalse(partitionKeyRestrictions.isOnToken(),
+                           "The token function cannot be used in WHERE clauses for %s statements", type);
 
-                throw invalidRequest("Non PRIMARY KEY columns found in where clause: %s ",
-                                     Joiner.on(", ").join(nonPrimaryKeyColumns));
+                if (partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table))
+                    throw invalidRequest("Some partition key parts are missing: %s",
+                                         Joiner.on(", ").join(getPartitionKeyUnrestrictedComponents(partitionKeyRestrictions)));
+
+                // slice query
+                checkFalse(partitionKeyRestrictions.hasSlice(),
+                           "Only EQ and IN relation are supported on the partition key (unless you use the token() function)"
+                           + " for %s statements", type);
             }
-            if (hasQueriableIndex)
+            else
+            {
+                // If there are no partition restrictions or there's only token restriction, we have to set a key range
+                if (partitionKeyRestrictions.isOnToken())
+                    isKeyRange = true;
+
+                if (partitionKeyRestrictions.isEmpty() && partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table))
+                {
+                    isKeyRange = true;
+                    usesSecondaryIndexing = hasQueriableIndex;
+                }
+
+                // If there is a queriable index, no special condition is required on the other restrictions.
+                // But we still need to know 2 things:
+                // - If we don't have a queriable index, is the query ok
+                // - Is it queriable without 2ndary index, which is always more efficient
+                // If a component of the partition key is restricted by a relation, all preceding
+                // components must have a EQ. Only the last partition key component can be in IN relation.
+                // If partition key restrictions exist and this is a disjunction then we may need filtering
+                if (partitionKeyRestrictions.needFiltering(table) || (!partitionKeyRestrictions.isEmpty() && element.isDisjunction()))
+                {
+                    if (!allowFiltering && !forView && !hasQueriableIndex)
+                        throw new InvalidRequestException(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+
+                    isKeyRange = true;
+                    usesSecondaryIndexing = hasQueriableIndex;
+                }
+            }
+
+            // Some but not all of the partition key columns have been specified or they form part of a disjunction;
+            // hence we need turn these restrictions into a row filter.
+            if (usesSecondaryIndexing || partitionKeyRestrictions.needFiltering(table) || element.isDisjunction())
+                filterRestrictionsBuilder.add(partitionKeyRestrictions);
+
+            if (selectsOnlyStaticColumns && !clusteringColumnsRestrictions.isEmpty())
+            {
+                // If the only updated/deleted columns are static, then we don't need clustering columns.
+                // And in fact, unless it is an INSERT, we reject if clustering colums are provided as that
+                // suggest something unintended. For instance, given:
+                //   CREATE TABLE t (k int, v int, s int static, PRIMARY KEY (k, v))
+                // it can make sense to do:
+                //   INSERT INTO t(k, v, s) VALUES (0, 1, 2)
+                // but both
+                //   UPDATE t SET s = 3 WHERE k = 0 AND v = 1
+                //   DELETE v FROM t WHERE k = 0 AND v = 1
+                // sounds like you don't really understand what your are doing.
+                if (type.isDelete() || type.isUpdate())
+                    throw invalidRequest("Invalid restrictions on clustering columns since the %s statement modifies only static columns",
+                                         type);
+            }
+
+            // Now process and validate the clustering column restrictions
+            checkFalse(!type.allowClusteringColumnSlices() && clusteringColumnsRestrictions.hasSlice(),
+                       "Slice restrictions are not supported on the clustering columns in %s statements", type);
+
+            if (!type.allowClusteringColumnSlices()
+                && (!table.isCompactTable() || (table.isCompactTable() && clusteringColumnsRestrictions.isEmpty())))
+            {
+                if (!selectsOnlyStaticColumns && (table.clusteringColumns().size() != clusteringColumnsRestrictions.size()))
+                    throw invalidRequest("Some clustering keys are missing: %s",
+                                         Joiner.on(", ").join(getUnrestrictedClusteringColumns(clusteringColumnsRestrictions)));
+            }
+            else
+            {
+                checkFalse(clusteringColumnsRestrictions.hasContains() && !hasQueriableIndex && !allowFiltering,
+                           "Clustering columns can only be restricted with CONTAINS with a secondary index or filtering");
+
+                if (!clusteringColumnsRestrictions.isEmpty() && clusteringColumnsRestrictions.needFiltering())
+                {
+                    if (hasQueriableIndex || forView)
+                    {
+                        usesSecondaryIndexing = true;
+                    }
+                    else if (!allowFiltering)
+                    {
+                        List<ColumnMetadata> clusteringColumns = table.clusteringColumns();
+                        List<ColumnMetadata> restrictedColumns = clusteringColumnsRestrictions.getColumnDefs();
+
+                        for (int i = 0, m = restrictedColumns.size(); i < m; i++)
+                        {
+                            ColumnMetadata clusteringColumn = clusteringColumns.get(i);
+                            ColumnMetadata restrictedColumn = restrictedColumns.get(i);
+
+                            if (!clusteringColumn.equals(restrictedColumn))
+                            {
+                                throw invalidRequest("PRIMARY KEY column \"%s\" cannot be restricted as preceding column \"%s\" is not restricted",
+                                                     restrictedColumn.name,
+                                                     clusteringColumn.name);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Covers indexes on the first clustering column (among others).
+            if (isKeyRange && hasQueriableClusteringColumnIndex)
                 usesSecondaryIndexing = true;
-            else if (!allowFiltering)
-                throwRequiresAllowFilteringError(table);
 
-            filterRestrictionsBuilder.add(nonPrimaryKeyRestrictions);
+            if (usesSecondaryIndexing || clusteringColumnsRestrictions.needFiltering())
+                filterRestrictionsBuilder.add(clusteringColumnsRestrictions);
+
+            // Even if usesSecondaryIndexing is false at this point, we'll still have to use one if
+            // there is restrictions not covered by the PK.
+            if (!nonPrimaryKeyRestrictions.isEmpty())
+            {
+                if (!type.allowNonPrimaryKeyInWhereClause())
+                {
+                    Collection<ColumnIdentifier> nonPrimaryKeyColumns =
+                    ColumnMetadata.toIdentifiers(nonPrimaryKeyRestrictions.getColumnDefs());
+
+                    throw invalidRequest("Non PRIMARY KEY columns found in where clause: %s ",
+                                         Joiner.on(", ").join(nonPrimaryKeyColumns));
+                }
+                if (hasQueriableIndex)
+                    usesSecondaryIndexing = true;
+                else if (!allowFiltering)
+                    throwRequiresAllowFilteringError(table, clusteringColumnsRestrictions, nonPrimaryKeyRestrictions);
+
+                filterRestrictionsBuilder.add(nonPrimaryKeyRestrictions);
+            }
+
+            if (usesSecondaryIndexing)
+                checkFalse(partitionKeyRestrictions.hasIN(),
+                           "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported");
+
+            ImmutableList.Builder<StatementRestrictions> children = ImmutableList.builder();
+
+            for (ExpressionTree.ContainerElement container : element.operations())
+                children.add(doBuild(container, indexRegistry));
+
+            return new StatementRestrictions(table,
+                                             partitionKeyRestrictions,
+                                             clusteringColumnsRestrictions,
+                                             nonPrimaryKeyRestrictions,
+                                             notNullColumns,
+                                             element.isDisjunction(),
+                                             usesSecondaryIndexing,
+                                             isKeyRange,
+                                             hasRegularColumnsRestrictions,
+                                             filterRestrictionsBuilder.build(),
+                                             children.build());
         }
 
-        filterRestrictions = filterRestrictionsBuilder.build();
+        private Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table,
+                                                                               ClusteringColumnRestrictions clusteringColumnsRestrictions,
+                                                                               RestrictionSet nonPrimaryKeyRestrictions)
+        {
+            return getColumnsWithUnsupportedIndexRestrictions(table, Iterables.concat(clusteringColumnsRestrictions.restrictions(), nonPrimaryKeyRestrictions.restrictions()));
+        }
 
-        if (usesSecondaryIndexing)
-            validateSecondaryIndexSelections();
+        private Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table, Iterable<Restriction> restrictions)
+        {
+            IndexRegistry indexRegistry = IndexRegistry.obtain(table);
+            if (indexRegistry.listIndexes().isEmpty())
+                return Collections.emptySet();
+
+            ImmutableSet.Builder<ColumnMetadata> builder = ImmutableSet.builder();
+
+            for (Restriction restriction : restrictions)
+            {
+                if (!restriction.hasSupportingIndex(indexRegistry))
+                {
+                    for (Index index : indexRegistry.listIndexes())
+                    {
+                        // If a column restriction has an index which was not picked up by hasSupportingIndex, it means it's an unsupported restriction
+                        for (ColumnMetadata column : restriction.getColumnDefs())
+                        {
+                            if (index.dependsOn(column))
+                                builder.add(column);
+                        }
+                    }
+                }
+            }
+
+            return builder.build();
+        }
+
+        private void throwRequiresAllowFilteringError(TableMetadata table,
+                                                      ClusteringColumnRestrictions clusteringColumnsRestrictions,
+                                                      RestrictionSet nonPrimaryKeyRestrictions)
+        {
+            Set<ColumnMetadata> unsupported = getColumnsWithUnsupportedIndexRestrictions(table,
+                                                                                         clusteringColumnsRestrictions,
+                                                                                         nonPrimaryKeyRestrictions);
+            if (unsupported.isEmpty())
+            {
+                throw invalidRequest(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+            }
+            else
+            {
+                // If there's an index on these columns but the restriction is not supported on this index, throw a more specific error message
+                if (unsupported.size() == 1)
+                    throw invalidRequest(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, unsupported.iterator().next()));
+                else
+                    throw invalidRequest(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_MULTI, unsupported));
+            }
+        }
+
+
+        private CustomIndexExpression prepareCustomIndexExpression(List<CustomIndexExpression> expressions,
+                                                                   VariableSpecifications boundNames,
+                                                                   IndexRegistry indexRegistry)
+        {
+            if (expressions.size() > 1)
+                throw new InvalidRequestException(IndexRestrictions.MULTIPLE_EXPRESSIONS);
+
+            CustomIndexExpression expression = expressions.get(0);
+
+            QualifiedName name = expression.targetIndex;
+
+            if (name.hasKeyspace() && !name.getKeyspace().equals(table.keyspace))
+                throw IndexRestrictions.invalidIndex(expression.targetIndex, table);
+
+            if (!table.indexes.has(expression.targetIndex.getName()))
+                throw IndexRestrictions.indexNotFound(expression.targetIndex, table);
+
+            Index index = indexRegistry.getIndex(table.indexes.get(expression.targetIndex.getName()).get());
+            if (!index.getIndexMetadata().isCustom())
+                throw IndexRestrictions.nonCustomIndexInExpression(expression.targetIndex);
+
+            AbstractType<?> expressionType = index.customExpressionValueType();
+            if (expressionType == null)
+                throw IndexRestrictions.customExpressionNotSupported(expression.targetIndex);
+
+            expression.prepareValue(table, expressionType, boundNames);
+            return expression;
+        }
+
+        /**
+         * Returns the partition key components that are not restricted.
+         * @return the partition key components that are not restricted.
+         */
+        private Collection<ColumnIdentifier> getPartitionKeyUnrestrictedComponents(PartitionKeyRestrictions partitionKeyRestrictions)
+        {
+            List<ColumnMetadata> list = new ArrayList<>(table.partitionKeyColumns());
+            list.removeAll(partitionKeyRestrictions.getColumnDefs());
+            return ColumnMetadata.toIdentifiers(list);
+        }
+
+        /**
+         * Returns the clustering columns that are not restricted.
+         * @return the clustering columns that are not restricted.
+         */
+        private Collection<ColumnIdentifier> getUnrestrictedClusteringColumns(ClusteringColumnRestrictions clusteringColumnsRestrictions)
+        {
+            List<ColumnMetadata> missingClusteringColumns = new ArrayList<>(table.clusteringColumns());
+            missingClusteringColumns.removeAll(clusteringColumnsRestrictions.getColumnDefs());
+            return ColumnMetadata.toIdentifiers(missingClusteringColumns);
+        }
+    }
+
+    public IndexRestrictions filterRestrictions()
+    {
+        return filterRestrictions;
+    }
+
+    public List<StatementRestrictions> children()
+    {
+        return children;
     }
 
     public void throwRequiresAllowFilteringError(TableMetadata table)
@@ -403,11 +663,19 @@ public class StatementRestrictions
         }
     }
 
+    public void throwsRequiresIndexSupportingDisjunctionError(TableMetadata table)
+    {
+        throw invalidRequest(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION);
+    }
+
     public void addFunctionsTo(List<Function> functions)
     {
         partitionKeyRestrictions.addFunctionsTo(functions);
         clusteringColumnsRestrictions.addFunctionsTo(functions);
         nonPrimaryKeyRestrictions.addFunctionsTo(functions);
+
+        for (StatementRestrictions child : children)
+            child.addFunctionsTo(functions);
     }
 
     // may be used by QueryHandler implementations
@@ -433,12 +701,15 @@ public class StatementRestrictions
 
         if (includeNotNullRestrictions)
         {
-            for (ColumnMetadata def : notNullColumns)
+            for (ColumnMetadata def : notNullColumns())
             {
                 if (!def.isPrimaryKeyColumn())
                     columns.add(def);
             }
         }
+
+        for (StatementRestrictions child : children)
+            columns.addAll(child.nonPKRestrictedColumns(includeNotNullRestrictions));
 
         return columns;
     }
@@ -456,10 +727,17 @@ public class StatementRestrictions
      */
     public boolean isRestricted(ColumnMetadata column)
     {
-        if (notNullColumns.contains(column))
+        if (notNullColumns().contains(column))
             return true;
 
-        return getRestrictions(column.kind).getColumnDefs().contains(column);
+        if (getRestrictions(column.kind).getColumnDefs().contains(column))
+            return true;
+
+        for (StatementRestrictions child : children)
+            if (child.isRestricted(column))
+                return true;
+
+        return false;
     }
 
     /**
@@ -480,7 +758,7 @@ public class StatementRestrictions
      */
     public boolean isKeyRange()
     {
-        return this.isKeyRange;
+        return isKeyRange;
     }
 
     /**
@@ -521,52 +799,14 @@ public class StatementRestrictions
      */
     public boolean usesSecondaryIndexing()
     {
-        return this.usesSecondaryIndexing;
-    }
+        if (usesSecondaryIndexing)
+            return true;
 
-    protected void processPartitionKeyRestrictions(boolean hasQueriableIndex, boolean allowFiltering, boolean forView)
-    {
-        if (!type.allowPartitionKeyRanges())
-        {
-            checkFalse(partitionKeyRestrictions.isOnToken(),
-                       "The token function cannot be used in WHERE clauses for %s statements", type);
+        for (StatementRestrictions child: children)
+            if (child.usesSecondaryIndexing)
+                return true;
 
-            if (partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table))
-                throw invalidRequest("Some partition key parts are missing: %s",
-                                     Joiner.on(", ").join(getPartitionKeyUnrestrictedComponents()));
-
-            // slice query
-            checkFalse(partitionKeyRestrictions.hasSlice(),
-                    "Only EQ and IN relation are supported on the partition key (unless you use the token() function)"
-                            + " for %s statements", type);
-        }
-        else
-        {
-            // If there are no partition restrictions or there's only token restriction, we have to set a key range
-            if (partitionKeyRestrictions.isOnToken())
-                isKeyRange = true;
-
-            if (partitionKeyRestrictions.isEmpty() && partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table))
-            {
-                isKeyRange = true;
-                usesSecondaryIndexing = hasQueriableIndex;
-            }
-
-            // If there is a queriable index, no special condition is required on the other restrictions.
-            // But we still need to know 2 things:
-            // - If we don't have a queriable index, is the query ok
-            // - Is it queriable without 2ndary index, which is always more efficient
-            // If a component of the partition key is restricted by a relation, all preceding
-            // components must have a EQ. Only the last partition key component can be in IN relation.
-            if (partitionKeyRestrictions.needFiltering(table))
-            {
-                if (!allowFiltering && !forView && !hasQueriableIndex)
-                    throw new InvalidRequestException(REQUIRES_ALLOW_FILTERING_MESSAGE);
-
-                isKeyRange = true;
-                usesSecondaryIndexing = hasQueriableIndex;
-            }
-        }
+        return false;
     }
 
     public boolean hasPartitionKeyRestrictions()
@@ -581,17 +821,6 @@ public class StatementRestrictions
     public boolean hasNonPrimaryKeyRestrictions()
     {
         return !nonPrimaryKeyRestrictions.isEmpty();
-    }
-
-    /**
-     * Returns the partition key components that are not restricted.
-     * @return the partition key components that are not restricted.
-     */
-    private Collection<ColumnIdentifier> getPartitionKeyUnrestrictedComponents()
-    {
-        List<ColumnMetadata> list = new ArrayList<>(table.partitionKeyColumns());
-        list.removeAll(partitionKeyRestrictions.getColumnDefs());
-        return ColumnMetadata.toIdentifiers(list);
     }
 
     /**
@@ -617,74 +846,6 @@ public class StatementRestrictions
     }
 
     /**
-     * Processes the clustering column restrictions.
-     *
-     * @param hasQueriableIndex <code>true</code> if some of the queried data are indexed, <code>false</code> otherwise
-     * @param selectsOnlyStaticColumns <code>true</code> if the selected or modified columns are all statics,
-     * <code>false</code> otherwise.
-     */
-    private void processClusteringColumnsRestrictions(boolean hasQueriableIndex,
-                                                      boolean selectsOnlyStaticColumns,
-                                                      boolean forView,
-                                                      boolean allowFiltering)
-    {
-        checkFalse(!type.allowClusteringColumnSlices() && clusteringColumnsRestrictions.hasSlice(),
-                   "Slice restrictions are not supported on the clustering columns in %s statements", type);
-
-        if (!type.allowClusteringColumnSlices()
-            && (!table.isCompactTable() || (table.isCompactTable() && !hasClusteringColumnsRestrictions())))
-        {
-            if (!selectsOnlyStaticColumns && hasUnrestrictedClusteringColumns())
-                throw invalidRequest("Some clustering keys are missing: %s",
-                                     Joiner.on(", ").join(getUnrestrictedClusteringColumns()));
-        }
-        else
-        {
-            checkFalse(clusteringColumnsRestrictions.hasContains() && !hasQueriableIndex && !allowFiltering,
-                       "Clustering columns can only be restricted with CONTAINS with a secondary index or filtering");
-
-            if (hasClusteringColumnsRestrictions() && clusteringColumnsRestrictions.needFiltering())
-            {
-                if (hasQueriableIndex || forView)
-                {
-                    usesSecondaryIndexing = true;
-                }
-                else if (!allowFiltering)
-                {
-                    List<ColumnMetadata> clusteringColumns = table.clusteringColumns();
-                    List<ColumnMetadata> restrictedColumns = clusteringColumnsRestrictions.getColumnDefs();
-
-                    for (int i = 0, m = restrictedColumns.size(); i < m; i++)
-                    {
-                        ColumnMetadata clusteringColumn = clusteringColumns.get(i);
-                        ColumnMetadata restrictedColumn = restrictedColumns.get(i);
-
-                        if (!clusteringColumn.equals(restrictedColumn))
-                        {
-                            throw invalidRequest("PRIMARY KEY column \"%s\" cannot be restricted as preceding column \"%s\" is not restricted",
-                                                 restrictedColumn.name,
-                                                 clusteringColumn.name);
-                        }
-                    }
-                }
-            }
-
-        }
-
-    }
-
-    /**
-     * Returns the clustering columns that are not restricted.
-     * @return the clustering columns that are not restricted.
-     */
-    private Collection<ColumnIdentifier> getUnrestrictedClusteringColumns()
-    {
-        List<ColumnMetadata> missingClusteringColumns = new ArrayList<>(table.clusteringColumns());
-        missingClusteringColumns.removeAll(clusteringColumnsRestrictions.getColumnDefs());
-        return ColumnMetadata.toIdentifiers(missingClusteringColumns);
-    }
-
-    /**
      * Checks if some clustering columns are not restricted.
      * @return <code>true</code> if some clustering columns are not restricted, <code>false</code> otherwise.
      */
@@ -693,48 +854,12 @@ public class StatementRestrictions
         return table.clusteringColumns().size() != clusteringColumnsRestrictions.size();
     }
 
-    private CustomIndexExpression prepareCustomIndexExpression(List<CustomIndexExpression> expressions,
-                                                               VariableSpecifications boundNames,
-                                                               IndexRegistry indexRegistry)
-    {
-        if (expressions.size() > 1)
-            throw new InvalidRequestException(IndexRestrictions.MULTIPLE_EXPRESSIONS);
-
-        CustomIndexExpression expression = expressions.get(0);
-
-        QualifiedName name = expression.targetIndex;
-
-        if (name.hasKeyspace() && !name.getKeyspace().equals(table.keyspace))
-            throw IndexRestrictions.invalidIndex(expression.targetIndex, table);
-
-        if (!table.indexes.has(expression.targetIndex.getName()))
-            throw IndexRestrictions.indexNotFound(expression.targetIndex, table);
-
-        Index index = indexRegistry.getIndex(table.indexes.get(expression.targetIndex.getName()).get());
-        if (!index.getIndexMetadata().isCustom())
-            throw IndexRestrictions.nonCustomIndexInExpression(expression.targetIndex);
-
-        AbstractType<?> expressionType = index.customExpressionValueType();
-        if (expressionType == null)
-            throw IndexRestrictions.customExpressionNotSupported(expression.targetIndex);
-
-        expression.prepareValue(table, expressionType, boundNames);
-        return expression;
-    }
-
     public RowFilter getRowFilter(IndexRegistry indexManager, QueryOptions options)
     {
-        if (filterRestrictions.isEmpty())
+        if (filterRestrictions.isEmpty() && children.isEmpty())
             return RowFilter.NONE;
 
-        RowFilter filter = RowFilter.create();
-        for (Restrictions restrictions : filterRestrictions.getRestrictions())
-            restrictions.addToRowFilter(filter, indexManager, options);
-
-        for (CustomIndexExpression expression : filterRestrictions.getExternalExpressions())
-            expression.addToRowFilter(filter, table, options);
-
-        return filter;
+        return RowFilter.builder().buildFromRestrictions(this, indexManager, table, options);
     }
 
     /**
@@ -785,7 +910,7 @@ public class StatementRestrictions
     {
         // Deal with unrestricted partition key components (special-casing is required to deal with 2i queries on the
         // first component of a composite partition key) queries that filter on the partition key.
-        if (partitionKeyRestrictions.needFiltering(table))
+        if (partitionKeyRestrictions.needFiltering(table) || isDisjunction)
             return new Range<>(p.getMinimumToken().minKeyBound(), p.getMinimumToken().maxKeyBound());
 
         ByteBuffer startKeyBytes = getPartitionKeyBound(Bound.START, options);
@@ -800,13 +925,13 @@ public class StatementRestrictions
         if (partitionKeyRestrictions.isInclusive(Bound.START))
         {
             return partitionKeyRestrictions.isInclusive(Bound.END)
-                    ? new Bounds<>(startKey, finishKey)
-                    : new IncludingExcludingBounds<>(startKey, finishKey);
+                   ? new Bounds<>(startKey, finishKey)
+                   : new IncludingExcludingBounds<>(startKey, finishKey);
         }
 
         return partitionKeyRestrictions.isInclusive(Bound.END)
-                ? new Range<>(startKey, finishKey)
-                : new ExcludingBounds<>(startKey, finishKey);
+               ? new Range<>(startKey, finishKey)
+               : new ExcludingBounds<>(startKey, finishKey);
     }
 
     private AbstractBounds<PartitionPosition> getPartitionKeyBoundsForTokenRestrictions(IPartitioner p,
@@ -830,7 +955,7 @@ public class StatementRestrictions
          */
         int cmp = startToken.compareTo(endToken);
         if (!startToken.isMinimum() && !endToken.isMinimum()
-                && (cmp > 0 || (cmp == 0 && (!includeStart || !includeEnd))))
+            && (cmp > 0 || (cmp == 0 && (!includeStart || !includeEnd))))
             return null;
 
         PartitionPosition start = includeStart ? startToken.minKeyBound() : startToken.maxKeyBound();
@@ -890,6 +1015,11 @@ public class StatementRestrictions
         return clusteringColumnsRestrictions.boundsAsClustering(b, options);
     }
 
+    public boolean isDisjunction()
+    {
+        return isDisjunction;
+    }
+
     /**
      * Checks if the query returns a range of columns.
      *
@@ -903,7 +1033,7 @@ public class StatementRestrictions
         int numberOfClusteringColumns = table.isStaticCompactTable() ? 0 : table.clusteringColumns().size();
         // it is a range query if it has at least one the column alias for which no relation is defined or is not EQ or IN.
         return clusteringColumnsRestrictions.size() < numberOfClusteringColumns
-            || !clusteringColumnsRestrictions.hasOnlyEqualityRestrictions();
+               || !clusteringColumnsRestrictions.hasOnlyEqualityRestrictions();
     }
 
     /**
@@ -916,15 +1046,43 @@ public class StatementRestrictions
         IndexRegistry indexRegistry = IndexRegistry.obtain(table);
         boolean hasClusteringColumnRestrictions = !clusteringColumnsRestrictions.isEmpty();
         boolean hasMultipleContains = nonPrimaryKeyRestrictions.hasMultipleContains();
-        return filterRestrictions.needFiltering(indexRegistry, hasClusteringColumnRestrictions, hasMultipleContains);
+        if (filterRestrictions.needFiltering(indexRegistry, hasClusteringColumnRestrictions, hasMultipleContains))
+            return true;
+
+        for (StatementRestrictions child : children)
+            if (child.needFiltering(table))
+                return true;
+
+        return false;
     }
 
-    public Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table)
+    public boolean needsDisjunctionSupport(TableMetadata table)
     {
-        return getColumnsWithUnsupportedIndexRestrictions(table, Iterables.concat(clusteringColumnsRestrictions.restrictions(), nonPrimaryKeyRestrictions.restrictions()));
+        boolean containsDisjunction = isDisjunction || !children.isEmpty();
+
+        if (!containsDisjunction)
+            return false;
+
+        IndexRegistry indexRegistry = IndexRegistry.obtain(table);
+
+        for (Index.Group group : indexRegistry.listIndexGroups())
+            if (filterRestrictions.indexBeingUsed(group) && !group.supportsDisjunction())
+                return true;
+
+        for (StatementRestrictions child : children)
+            if (child.needsDisjunctionSupport(table))
+                return true;
+
+        return false;
     }
 
-    public Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table, Iterable<Restriction> restrictions)
+    private Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table)
+    {
+        return getColumnsWithUnsupportedIndexRestrictions(table, Iterables.concat(clusteringColumnsRestrictions.restrictions(),
+                                                                                  nonPrimaryKeyRestrictions.restrictions()));
+    }
+
+    private Set<ColumnMetadata> getColumnsWithUnsupportedIndexRestrictions(TableMetadata table, Iterable<Restriction> restrictions)
     {
         IndexRegistry indexRegistry = IndexRegistry.obtain(table);
         if (indexRegistry.listIndexes().isEmpty())
@@ -951,12 +1109,6 @@ public class StatementRestrictions
         return builder.build();
     }
 
-    protected void validateSecondaryIndexSelections()
-    {
-        checkFalse(keyIsInRelation(),
-                   "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported");
-    }
-
     /**
      * Checks that all the primary key columns (partition key and clustering columns) are restricted by an equality
      * relation ('=' or 'IN').
@@ -966,10 +1118,10 @@ public class StatementRestrictions
     public boolean hasAllPKColumnsRestrictedByEqualities()
     {
         return !isPartitionKeyRestrictionsOnToken()
-                && !partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table)
-                && (partitionKeyRestrictions.hasOnlyEqualityRestrictions())
-                && !hasUnrestrictedClusteringColumns()
-                && (clusteringColumnsRestrictions.hasOnlyEqualityRestrictions());
+               && !partitionKeyRestrictions.hasUnrestrictedPartitionKeyComponents(table)
+               && (partitionKeyRestrictions.hasOnlyEqualityRestrictions())
+               && !hasUnrestrictedClusteringColumns()
+               && (clusteringColumnsRestrictions.hasOnlyEqualityRestrictions());
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableRangeSet;
@@ -338,7 +337,7 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
-    public void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
     {
         restrictions.addToRowFilter(filter, indexRegistry, options);
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -130,7 +130,7 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
-    public void addToRowFilter(RowFilter filter, IndexRegistry indexRegistry, QueryOptions options)
+    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
     {
         throw new UnsupportedOperationException("Index expression cannot be created for token restriction");
     }

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -1008,7 +1008,7 @@ public abstract class ModificationStatement implements CQLStatement
                 throw new InvalidRequestException(CUSTOM_EXPRESSIONS_NOT_ALLOWED);
 
             boolean applyOnlyToStaticColumns = appliesOnlyToStaticColumns(operations, conditions);
-            return new StatementRestrictions(type, metadata, where, boundNames, applyOnlyToStaticColumns, false, false);
+            return StatementRestrictions.builder(type, metadata, where, boundNames, applyOnlyToStaticColumns, false, false).build();
         }
 
         public List<Pair<ColumnIdentifier, ColumnCondition.Raw>> getConditions()

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -194,7 +194,7 @@ public class SelectStatement implements CQLStatement
                                    VariableSpecifications.empty(),
                                    defaultParameters,
                                    selection,
-                                   StatementRestrictions.empty(StatementType.SELECT, table),
+                                   StatementRestrictions.empty(table),
                                    false,
                                    null,
                                    null,
@@ -285,7 +285,7 @@ public class SelectStatement implements CQLStatement
                               int perPartitionLimit,
                               int pageSize)
     {
-        boolean isPartitionRangeQuery = restrictions.isKeyRange() || restrictions.usesSecondaryIndexing();
+        boolean isPartitionRangeQuery = restrictions.isKeyRange() || restrictions.usesSecondaryIndexing() || restrictions.isDisjunction();
 
         DataLimits limit = getDataLimits(userLimit, perPartitionLimit, pageSize);
 
@@ -619,6 +619,11 @@ public class SelectStatement implements CQLStatement
             // so that it's hard to really optimize properly internally. So to keep it simple, we simply query
             // for the first row of the partition and hence uses Slices.ALL. We'll limit it to the first live
             // row however in getLimit().
+            return new ClusteringIndexSliceFilter(Slices.ALL, false);
+        }
+
+        if (restrictions.isDisjunction())
+        {
             return new ClusteringIndexSliceFilter(Slices.ALL, false);
         }
 
@@ -1012,6 +1017,8 @@ public class SelectStatement implements CQLStatement
                     orderingComparator = Collections.reverseOrder(orderingComparator);
             }
 
+            checkDisjunctionIsSupported(table, restrictions);
+
             checkNeedsFiltering(table, restrictions);
 
             return new SelectStatement(table,
@@ -1100,13 +1107,13 @@ public class SelectStatement implements CQLStatement
                                                           boolean selectsOnlyStaticColumns,
                                                           boolean forView) throws InvalidRequestException
         {
-            return new StatementRestrictions(StatementType.SELECT,
-                                             metadata,
-                                             whereClause,
-                                             boundNames,
-                                             selectsOnlyStaticColumns,
-                                             parameters.allowFiltering,
-                                             forView);
+            return StatementRestrictions.builder(StatementType.SELECT,
+                                                 metadata,
+                                                 whereClause,
+                                                 boundNames,
+                                                 selectsOnlyStaticColumns,
+                                                 parameters.allowFiltering,
+                                                 forView).build();
         }
 
         /** Returns a Term for the limit or null if no limit is set */
@@ -1267,6 +1274,17 @@ public class SelectStatement implements CQLStatement
             }
             assert isReversed != null;
             return isReversed;
+        }
+
+        /**
+         * This verifies that if the expression contains a disjunction - "value = 1 or value = 2" or "value in (1, 2)"
+         * the indexes involved in the query support disjunction.
+         */
+        private void checkDisjunctionIsSupported(TableMetadata table, StatementRestrictions restrictions) throws InvalidRequestException
+        {
+            if (restrictions.usesSecondaryIndexing())
+                if (restrictions.needsDisjunctionSupport(table))
+                    restrictions.throwsRequiresIndexSupportingDisjunctionError(table);
         }
 
         /** If ALLOW FILTERING was not specified, this verifies that it is not needed */

--- a/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
@@ -176,13 +176,13 @@ public class UpdateStatement extends ModificationStatement
 
             boolean applyOnlyToStaticColumns = !hasClusteringColumnsSet && appliesOnlyToStaticColumns(operations, conditions);
 
-            StatementRestrictions restrictions = new StatementRestrictions(type,
-                                                                           metadata,
-                                                                           whereClause.build(),
-                                                                           bindVariables,
-                                                                           applyOnlyToStaticColumns,
-                                                                           false,
-                                                                           false);
+            StatementRestrictions restrictions = StatementRestrictions.builder(type,
+                                                                               metadata,
+                                                                               whereClause.build(),
+                                                                               bindVariables,
+                                                                               applyOnlyToStaticColumns,
+                                                                               false,
+                                                                               false).build();
 
             return new UpdateStatement(type,
                                        bindVariables,
@@ -244,13 +244,13 @@ public class UpdateStatement extends ModificationStatement
 
             boolean applyOnlyToStaticColumns = !hasClusteringColumnsSet && appliesOnlyToStaticColumns(operations, conditions);
 
-            StatementRestrictions restrictions = new StatementRestrictions(type,
-                                                                           metadata,
-                                                                           whereClause.build(),
-                                                                           bindVariables,
-                                                                           applyOnlyToStaticColumns,
-                                                                           false,
-                                                                           false);
+            StatementRestrictions restrictions = StatementRestrictions.builder(type,
+                                                                               metadata,
+                                                                               whereClause.build(),
+                                                                               bindVariables,
+                                                                               applyOnlyToStaticColumns,
+                                                                               false,
+                                                                               false).build();
 
             return new UpdateStatement(type,
                                        bindVariables,

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -272,15 +272,14 @@ public final class CreateViewStatement extends AlterSchemaStatement
         if (whereClause.containsCustomExpressions())
             throw ire("WHERE clause for materialized view '%s' cannot contain custom index expressions", viewName);
 
-        StatementRestrictions restrictions =
-            new StatementRestrictions(StatementType.SELECT,
-                                      table,
-                                      whereClause,
-                                      VariableSpecifications.empty(),
-                                      false,
-                                      false,
-                                      true,
-                                      true);
+        StatementRestrictions restrictions = StatementRestrictions.builder(StatementType.SELECT,
+                                                                           table,
+                                                                           whereClause,
+                                                                           VariableSpecifications.empty(),
+                                                                           false,
+                                                                           false,
+                                                                           true,
+                                                                           true).build();
 
         List<ColumnIdentifier> nonRestrictedPrimaryKeyColumns =
             Lists.newArrayList(filter(primaryKeyColumns, name -> !restrictions.isRestricted(table.getColumn(name))));

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -769,6 +769,14 @@ public interface Index
         {
             return false;
         }
+
+        /**
+         * @return true is this index group supports disjunction queries of "a = 1 OR a = 2" or "a IN (1, 2)"
+         */
+        default boolean supportsDisjunction()
+        {
+            return false;
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/ColumnContext.java
+++ b/src/java/org/apache/cassandra/index/sai/ColumnContext.java
@@ -390,6 +390,9 @@ public class ColumnContext
 
         AbstractType<?> validator = getValidator();
 
+        if (operator == Expression.Op.IN)
+            return true;
+
         if (operator != Expression.Op.EQ && EQ_ONLY_TYPES.contains(validator)) return false;
 
         // RANGE only applicable to non-literal indexes

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -149,6 +149,12 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     }
 
     @Override
+    public boolean supportsDisjunction()
+    {
+        return true;
+    }
+
+    @Override
     public boolean containsIndex(Index index)
     {
         return index instanceof StorageAttachedIndex && indices.contains(index);

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -48,7 +48,7 @@ public class Expression
 
     public enum Op
     {
-        EQ, MATCH, PREFIX, NOT_EQ, RANGE, CONTAINS_KEY, CONTAINS_VALUE;
+        EQ, MATCH, PREFIX, NOT_EQ, RANGE, CONTAINS_KEY, CONTAINS_VALUE, IN;
 
         public static Op valueOf(Operator operator)
         {
@@ -77,6 +77,9 @@ public class Expression
 
                 case LIKE_MATCHES:
                     return MATCH;
+
+                case IN:
+                    return IN;
 
                 default:
                     return null;

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -24,10 +24,8 @@
 
 package org.apache.cassandra.index.sai.plan;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,21 +34,19 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 
-import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.rows.Row;
-import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.index.sai.ColumnContext;
-import org.apache.cassandra.index.sai.SSTableIndex;
-import org.apache.cassandra.index.sai.Token;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
-import org.apache.cassandra.index.sai.utils.RangeIntersectionIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
-import org.apache.cassandra.index.sai.utils.RangeUnionIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.serializers.ListSerializer;
+import org.apache.cassandra.transport.ProtocolVersion;
 
-public class Operation extends RangeIterator
+public class Operation
 {
     public enum OperationType
     {
@@ -70,24 +66,6 @@ public class Operation extends RangeIterator
                     throw new AssertionError();
             }
         }
-    }
-
-    final FilterTree filterTree;
-    final RangeIterator range;
-
-    final QueryController controller;
-
-    private Operation(RangeIterator range, FilterTree filterTree, QueryController controller)
-    {
-        super(range);
-        this.filterTree = filterTree;
-        this.range = range;
-        this.controller = controller;
-    }
-
-    public boolean satisfiedBy(DecoratedKey key, Unfiltered currentCluster, Row staticRow)
-    {
-        return filterTree.satisfiedBy(key, currentCluster, staticRow);
     }
 
     @VisibleForTesting
@@ -210,269 +188,216 @@ public class Operation extends RangeIterator
         }
     }
 
-    @Override
-    protected Token computeNext()
+    static RangeIterator buildIterator(QueryController controller)
     {
-        return range != null && range.hasNext() ? range.next() : endOfData();
+        return Node.buildTree(controller.filterOperation()).analyzeTree(controller).rangeIterator(controller);
     }
 
-    @Override
-    protected void performSkipTo(Long nextToken)
+    static FilterTree buildFilter(QueryController controller)
     {
-        if (range != null)
-            range.skipTo(nextToken);
+        return Node.buildTree(controller.filterOperation()).buildFilter(controller);
     }
 
-    @Override
-    public void close() throws IOException
+    public static abstract class Node
     {
-        if (range != null)
-            range.close();
+        ListMultimap<ColumnMetadata, Expression> expressionMap;
 
-        controller.releaseIndexes(filterTree.expressions);
-    }
-
-    /**
-     * @param controller current query controller
-     * @return tree builder with query expressions added from query controller.
-     */
-    static TreeBuilder initTreeBuilder(QueryController controller)
-    {
-        TreeBuilder tree = new TreeBuilder(controller);
-        tree.add(controller.getExpressions());
-        return tree;
-    }
-
-    /**
-     * A builder on which like expressions are built as subtrees using {@link OperationType} OR to
-     * keep their correct semantics. Remaining expressions are added into the root AND OperationType.
-     *
-     *  Example:
-     *
-     *   3 Like expressions:
-     *
-     *                    AND (expressions)
-     *                  /   \
-     *                AND   OR (like)
-     *               /   \
-     *      (like) OR   OR (like)
-     *
-     **/
-    public static class TreeBuilder
-    {
-        private final QueryController controller;
-        final Builder root;
-        Builder subtree;
-
-        TreeBuilder(QueryController controller)
+        ListMultimap<ColumnMetadata, Expression> expressionMap()
         {
-            this.controller = controller;
-            this.root = new Builder(OperationType.AND, controller);
-            this.subtree = root;
+            return expressionMap;
         }
 
-        public TreeBuilder add(Collection<RowFilter.Expression> expressions)
+        boolean canFilter()
         {
-            if (expressions != null)
-                expressions.forEach(this::add);
-            return this;
+            return (expressionMap != null && !expressionMap.isEmpty()) || !children().isEmpty() ;
         }
 
-        public TreeBuilder add(RowFilter.Expression exp)
+        List<Node> children()
         {
-            if (exp.operator().isLike())
-                addToSubTree(exp);
-            else
-                root.add(exp);
-
-            return this;
+            return Collections.emptyList();
         }
 
-        private void addToSubTree(RowFilter.Expression exp)
+        void add(Node child)
         {
-            Builder likeOperation = new Builder(OperationType.OR, controller);
-            likeOperation.add(exp);
-            if (subtree.right == null)
+            throw new UnsupportedOperationException();
+        }
+
+        RowFilter.Expression expression()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        abstract void analyze(List<RowFilter.Expression> expressionList, QueryController controller);
+
+        abstract FilterTree filterTree();
+
+        abstract RangeIterator rangeIterator(QueryController controller);
+
+        static Node buildTree(RowFilter.FilterElement filterOperation)
+        {
+            OperatorNode node = filterOperation.isDisjunction() ? new OrNode() : new AndNode();
+            for (RowFilter.Expression expression : filterOperation.expressions())
+                node.add(buildExpression(expression));
+            for (RowFilter.FilterElement child : filterOperation.children())
+                node.add(buildTree(child));
+            return node;
+        }
+
+        static Node buildExpression(RowFilter.Expression expression)
+        {
+            if (expression.operator() == Operator.IN)
             {
-                subtree.setRight(likeOperation);
-            }
-            else if (subtree.left == null)
-            {
-                Builder newSubtree = new Builder(OperationType.AND, controller);
-                subtree.setLeft(newSubtree);
-                newSubtree.setRight(likeOperation);
-                subtree = newSubtree;
+                OperatorNode node = new OrNode();
+                int size = ListSerializer.readCollectionSize(expression.getIndexValue(), ByteBufferAccessor.instance, ProtocolVersion.V3);
+                int offset = ListSerializer.sizeOfCollectionSize(size, ProtocolVersion.V3);
+                for (int index = 0; index < size; index++)
+                {
+                    node.add(new ExpressionNode(new RowFilter.SimpleExpression(expression.column(),
+                                                                               Operator.EQ,
+                                                                               ListSerializer.readValue(expression.getIndexValue(),
+                                                                                                        ByteBufferAccessor.instance,
+                                                                                                        offset,
+                                                                                                        ProtocolVersion.V3))));
+                    offset += TypeSizes.INT_SIZE + ByteBufferAccessor.instance.getInt(expression.getIndexValue(), offset);
+                }
+                return node;
             }
             else
+                return new ExpressionNode(expression);
+        }
+
+        Node analyzeTree(QueryController controller)
+        {
+            List<RowFilter.Expression> expressionList = new ArrayList<>();
+            doTreeAnalysis(this, expressionList, controller);
+            if (!expressionList.isEmpty())
+                this.analyze(expressionList, controller);
+            return this;
+        }
+
+        void doTreeAnalysis(Node node, List<RowFilter.Expression> expressions, QueryController controller)
+        {
+            if (node.children().isEmpty())
+                expressions.add(node.expression());
+            else
             {
-                throw new IllegalStateException("Both trees are full");
+                List<RowFilter.Expression> expressionList = new ArrayList<>();
+                for (Node child : node.children())
+                    doTreeAnalysis(child, expressionList, controller);
+                node.analyze(expressionList, controller);
             }
         }
 
-        public Operation complete()
+        FilterTree buildFilter(QueryController controller)
         {
-            return root.complete();
-        }
-
-        FilterTree completeFilter()
-        {
-            return root.completeFilter();
+            analyzeTree(controller);
+            FilterTree tree = filterTree();
+            for (Node child : children())
+                if (child.canFilter())
+                    tree.addChild(child.buildFilter(controller));
+            return tree;
         }
     }
 
-    public static class Builder
+    public static abstract class OperatorNode extends Node
     {
-        private final QueryController controller;
+        List<Node> children = new ArrayList<>();
 
-        protected final OperationType op;
-        private final List<RowFilter.Expression> expressions;
-
-        protected Builder left, right;
-
-        public Builder(OperationType operation, QueryController controller, RowFilter.Expression... columns)
+        @Override
+        public List<Node> children()
         {
-            this.op = operation;
-            this.controller = controller;
-            this.expressions = new ArrayList<>();
-            Collections.addAll(expressions, columns);
+            return children;
         }
 
-        public Builder setRight(Builder operation)
+        @Override
+        public void add(Node child)
         {
-            this.right = operation;
-            return this;
+            children.add(child);
+        }
+    }
+
+    public static class AndNode extends OperatorNode
+    {
+        @Override
+        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        {
+            expressionMap = analyzeGroup(controller, OperationType.AND, expressionList);
         }
 
-        public Builder setLeft(Builder operation)
+        @Override
+        FilterTree filterTree()
         {
-            this.left = operation;
-            return this;
+            return new FilterTree(OperationType.AND, expressionMap);
         }
 
-        public void add(RowFilter.Expression e)
+        @Override
+        RangeIterator rangeIterator(QueryController controller)
         {
-            expressions.add(e);
+            RangeIterator.Builder builder = controller.getIndexes(OperationType.AND, expressionMap.values());
+            for (Node child : children)
+                if (child.canFilter())
+                    builder.add(child.rangeIterator(controller));
+            return builder.build();
+        }
+    }
+
+    public static class OrNode extends OperatorNode
+    {
+        @Override
+        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        {
+            expressionMap = analyzeGroup(controller, OperationType.OR, expressionList);
         }
 
-        public void add(Collection<RowFilter.Expression> newExpressions)
+        @Override
+        FilterTree filterTree()
         {
-            if (expressions != null)
-                expressions.addAll(newExpressions);
+            return new FilterTree(OperationType.OR, expressionMap);
         }
 
-        @SuppressWarnings("resource")
-        public Operation complete()
+        @Override
+        RangeIterator rangeIterator(QueryController controller)
         {
-            if (!expressions.isEmpty())
-            {
-                ListMultimap<ColumnMetadata, Expression> analyzedExpressions = analyzeGroup(controller, op, expressions);
-                RangeIterator.Builder range = controller.getIndexes(op, analyzedExpressions.values());
+            RangeIterator.Builder builder = controller.getIndexes(OperationType.OR, expressionMap.values());
+            for (Node child : children)
+                if (child.canFilter())
+                    builder.add(child.rangeIterator(controller));
+            return builder.build();
+        }
+    }
 
-                Operation rightOp = null;
-                if (right != null)
-                {
-                    rightOp = right.complete();
-                    range.add(rightOp);
-                }
+    public static class ExpressionNode extends Node
+    {
+        RowFilter.Expression expression;
 
-                FilterTree filterTree  = new FilterTree(op, analyzedExpressions, null, rightOp != null ? rightOp.filterTree : null);
-                return new Operation(range.build(), filterTree, controller);
-            }
-            else // when OR is used
-            {
-                Operation leftOp = null, rightOp = null;
-                boolean leftIndexes = false, rightIndexes = false;
-
-                if (left != null)
-                {
-                    leftOp = left.complete();
-                    leftIndexes = leftOp != null && leftOp.range != null;
-                }
-
-                if (right != null)
-                {
-                    rightOp = right.complete();
-                    rightIndexes = rightOp != null && rightOp.range != null;
-                }
-
-                RangeIterator join;
-                /**
-                 * Operation should allow one of it's sub-trees to wrap no indexes, that is related  to the fact that we
-                 * have to accept defined-but-not-indexed columns as well as key range as IndexExpressions.
-                 *
-                 * Two cases are possible:
-                 *
-                 * only left child produced indexed iterators, that could happen when there are two columns
-                 * or key range on the right:
-                 *
-                 *                AND
-                 *              /     \
-                 *            OR       \
-                 *           /   \     AND
-                 *          a     b   /   \
-                 *                  key   key
-                 *
-                 * only right child produced indexed iterators:
-                 *
-                 *               AND
-                 *              /    \
-                 *            AND     a
-                 *           /   \
-                 *         key  key
-                 */
-                if (leftIndexes && !rightIndexes)
-                    join = leftOp;
-                else if (!leftIndexes && rightIndexes)
-                    join = rightOp;
-                else if (leftIndexes)
-                {
-                    RangeIterator.Builder builder = op == OperationType.OR
-                                                                 ? RangeUnionIterator.builder()
-                                                                 : RangeIntersectionIterator.selectiveBuilder();
-
-                    join = builder.add(leftOp).add(rightOp).build();
-                }
-                else
-                    throw new AssertionError("both sub-trees have 0 indexes.");
-
-                return new Operation(join,
-                                     new FilterTree(op, null,
-                                                    leftOp == null ? null : leftOp.filterTree,
-                                                    leftOp == null ? null : leftOp.filterTree),
-                                     controller);
-            }
+        @Override
+        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        {
+            expressionMap = analyzeGroup(controller, OperationType.AND, expressionList);
         }
 
-        /**
-         * To build a filter tree used to filter data using indexed expressions and non-user-defined expressions.
-         *
-         * Similar to {@link #complete()}, except that this method won't reference {@link SSTableIndex} and avoids
-         * complexity of RangeIterator.
-         *
-         * @return the filter tree
-         */
-        FilterTree completeFilter()
+        @Override
+        FilterTree filterTree()
         {
-            if (!expressions.isEmpty())
-            {
-                ListMultimap<ColumnMetadata, Expression> analyzedExpressions = analyzeGroup(controller, op, expressions);
-                if (right != null)
-                {
-                    FilterTree ro = right.completeFilter();
-                    return new FilterTree(op, analyzedExpressions, null, ro);
-                }
-                return new FilterTree(op, analyzedExpressions, null, null);
-            }
-            else
-            {
-                FilterTree leftOperation = left != null ? left.completeFilter() : null;
-                FilterTree rightOperation = right != null ? right.completeFilter() : null;
+            return new FilterTree(OperationType.AND, expressionMap);
+        }
 
-                if (leftOperation == null && rightOperation == null)
-                    throw new AssertionError("both sub-trees have 0 indexes.");
+        public ExpressionNode(RowFilter.Expression expression)
+        {
+            this.expression = expression;
+        }
 
-                return new FilterTree(op, null, leftOperation, rightOperation);
-            }
+        @Override
+        public RowFilter.Expression expression()
+        {
+            return expression;
+        }
+
+        @Override
+        RangeIterator rangeIterator(QueryController controller)
+        {
+            assert canFilter();
+            return controller.getIndexes(OperationType.AND, expressionMap.values()).build();
         }
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/restrictions/ExpressionTreeTest.java
+++ b/test/unit/org/apache/cassandra/cql3/restrictions/ExpressionTreeTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.restrictions;
+
+import org.junit.Test;
+
+import com.bpodgursky.jbool_expressions.parsers.ExprParser;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.WhereClause;
+import org.apache.cassandra.exceptions.SyntaxException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExpressionTreeTest
+{
+    @Test(expected = SyntaxException.class)
+    public void cannotHaveEmptyWhereClause() throws Throwable
+    {
+        cqlParse("");
+    }
+
+    @Test
+    public void singleRelationWithoutEnclosure() throws Throwable
+    {
+        testExpression("a = 1");
+    }
+
+    @Test
+    public void singleRelationWithEnclosure() throws Throwable
+    {
+        testExpression("(a = 1)");
+    }
+
+    @Test
+    public void simpleAndExpressionWithRelationsWithoutEnclosure() throws Throwable
+    {
+        testExpression("a = 1 AND b = 1");
+    }
+
+    @Test
+    public void simpleAndExpressionWithRelationsWithEnclosure() throws Throwable
+    {
+        testExpression("(a = 1 AND b = 1)");
+    }
+
+    @Test
+    public void multipleAndExpressionWithRelations() throws Throwable
+    {
+        testExpression("a = 1 AND b = 1 AND c = 1");
+    }
+
+    @Test
+    public void disjunctionExpression() throws Throwable
+    {
+        testExpression("a = 1 AND b = 1 OR c = 1");
+    }
+
+    @Test
+    public void test() throws Throwable
+    {
+        System.out.println(cqlParse("a = 1 OR b = 1 AND c = 1"));
+    }
+
+    @Test
+    public void precedenceIsMaintainedWithoutParentheses() throws Throwable
+    {
+        testExpression("a = 1 AND b = 1 OR c = 1");
+
+        testExpression("a = 1 OR b = 1 AND c = 1");
+
+        testExpression("a = 1 OR b = 1 OR c = 1 AND d = 1 OR e = 1");
+
+        testExpression("a = 1 AND b = 1 AND c = 1 OR d = 1 AND e = 1");
+    }
+
+    @Test
+    public void multipleDisjunctionExpression() throws Throwable
+    {
+        testExpression("(a = 1 AND b = 1) OR (c = 1 AND d = 1)");
+    }
+
+    @Test
+    public void disjunctionExpressionWithPrecedence() throws Throwable
+    {
+        testExpression("a = 1 AND (b = 1 OR (c = 1 AND d = 1 AND e = 1))");
+    }
+
+    @Test
+    public void randomTest() throws Throwable
+    {
+        for (int count = 0; count < CQLTester.getRandom().nextIntBetween(100, 1000); count++)
+            testExpression(randomExpression());
+    }
+
+    private void testExpression(String expression) throws Throwable
+    {
+        assertEquals("Failed to correctly parse: [" + expression + "]", jboolParse(expression), jboolParse(cqlParse(expression)));
+    }
+
+   private static String alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+   private String randomExpression()
+   {
+       StringBuilder builder = new StringBuilder();
+
+       boolean applyPrecedence = CQLTester.getRandom().nextBoolean();
+
+       int numberOfElements = CQLTester.getRandom().nextIntBetween(1, 26);
+       int precedenceLevel = 0;
+       for (int element = 0; element < numberOfElements - 1; element++)
+       {
+           if (applyPrecedence && CQLTester.getRandom().nextIntBetween(0, 2) == 0)
+           {
+               builder.append("(");
+               precedenceLevel++;
+           }
+           builder.append(alphabet, element, element + 1);
+           builder.append(" = 1");
+           if (applyPrecedence && CQLTester.getRandom().nextIntBetween(0, 2) == 2 && precedenceLevel > 0)
+           {
+               builder.append(")");
+               precedenceLevel--;
+           }
+           builder.append(CQLTester.getRandom().nextBoolean() ? " AND " : " OR ");
+       }
+       builder.append(alphabet, numberOfElements - 1, numberOfElements);
+       builder.append(" = 1");
+       if (applyPrecedence)
+           while (precedenceLevel-- > 0)
+               builder.append(")");
+
+       return builder.toString();
+   }
+
+   private String cqlParse(String expression) throws Throwable
+   {
+       return WhereClause.parse(expression).root().toString();
+   }
+
+   private String jboolParse(String expression)
+   {
+       return ExprParser.parse(toJbool(expression)).toString();
+   }
+
+   private String toJbool(String cqlExpression)
+   {
+       return cqlExpression.replaceAll("AND", "&").replaceAll("OR", "|").replaceAll(" = 1", "");
+   }
+}

--- a/test/unit/org/apache/cassandra/db/AbstractReadCommandBuilder.java
+++ b/test/unit/org/apache/cassandra/db/AbstractReadCommandBuilder.java
@@ -43,7 +43,7 @@ public abstract class AbstractReadCommandBuilder
     protected boolean reversed = false;
 
     protected Set<ColumnIdentifier> columns;
-    protected final RowFilter filter = RowFilter.create();
+    protected final RowFilter.Builder filter = RowFilter.builder();
 
     private ClusteringBound<?> lowerClusteringBound;
     private ClusteringBound<?> upperClusteringBound;
@@ -233,7 +233,7 @@ public abstract class AbstractReadCommandBuilder
         @Override
         public ReadCommand build()
         {
-            return SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, makeColumnFilter(), filter, makeLimits(), partitionKey, makeFilter());
+            return SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, makeColumnFilter(), filter.build(), makeLimits(), partitionKey, makeFilter());
         }
     }
 
@@ -307,7 +307,7 @@ public abstract class AbstractReadCommandBuilder
             else
                 bounds = new ExcludingBounds<>(start, end);
 
-            return PartitionRangeReadCommand.create(cfs.metadata(), nowInSeconds, makeColumnFilter(), filter, makeLimits(), new DataRange(bounds, makeFilter()));
+            return PartitionRangeReadCommand.create(cfs.metadata(), nowInSeconds, makeColumnFilter(), filter.build(), makeLimits(), new DataRange(bounds, makeFilter()));
         }
 
         static DecoratedKey makeKey(TableMetadata metadata, Object... partitionKey)

--- a/test/unit/org/apache/cassandra/db/CleanupTest.java
+++ b/test/unit/org/apache/cassandra/db/CleanupTest.java
@@ -159,7 +159,7 @@ public class CleanupTest
         while (!cfs.getBuiltIndexes().contains(indexName) && System.nanoTime() - start < TimeUnit.SECONDS.toNanos(10))
             Thread.sleep(10);
 
-        RowFilter cf = RowFilter.create();
+        RowFilter.Builder cf = RowFilter.builder();
         cf.add(cdef, Operator.EQ, VALUE);
         assertEquals(LOOPS, Util.getAll(Util.cmd(cfs).filterOn("birthdate", Operator.EQ, VALUE).build()).size());
 

--- a/test/unit/org/apache/cassandra/db/ReadCommandTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandTest.java
@@ -330,7 +330,7 @@ public class ReadCommandTest
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
         ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
-        RowFilter rowFilter = RowFilter.create();
+        RowFilter.Builder rowFilter = RowFilter.builder();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(Slices.with(cfs.metadata().comparator, slice), false);
 
@@ -354,7 +354,7 @@ public class ReadCommandTest
                 {
                     RowUpdateBuilder.deleteRow(cfs.metadata(), FBUtilities.timestampMicros(), ByteBufferUtil.bytes(data[1]), data[2]).apply();
                 }
-                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter, DataLimits.NONE, Util.dk(data[1]), sliceFilter));
+                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter.build(), DataLimits.NONE, Util.dk(data[1]), sliceFilter));
             }
 
             cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
@@ -497,7 +497,7 @@ public class ReadCommandTest
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
         ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
-        RowFilter rowFilter = RowFilter.create();
+        RowFilter.Builder rowFilter = RowFilter.builder();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(
                 Slices.with(cfs.metadata().comparator, slice), false);
@@ -523,7 +523,7 @@ public class ReadCommandTest
                     RowUpdateBuilder.deleteRow(cfs.metadata(), FBUtilities.timestampMicros(),
                             ByteBufferUtil.bytes(data[1]), data[2]).apply();
                 }
-                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter,
+                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter.build(),
                         DataLimits.NONE, Util.dk(data[1]), sliceFilter));
             }
 
@@ -573,7 +573,7 @@ public class ReadCommandTest
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
         ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
-        RowFilter rowFilter = RowFilter.create();
+        RowFilter.Builder rowFilter = RowFilter.builder();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(
                 Slices.with(cfs.metadata().comparator, slice), false);
@@ -599,7 +599,7 @@ public class ReadCommandTest
                     RowUpdateBuilder.deleteRow(cfs.metadata(), FBUtilities.timestampMicros(),
                             ByteBufferUtil.bytes(data[1]), data[2]).apply();
                 }
-                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter,
+                commands.add(SinglePartitionReadCommand.create(cfs.metadata(), nowInSeconds, columnFilter, rowFilter.build(),
                         DataLimits.NONE, Util.dk(data[1]), sliceFilter));
             }
 

--- a/test/unit/org/apache/cassandra/db/filter/RowFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/RowFilterTest.java
@@ -63,10 +63,10 @@ public class RowFilterTest
         ColumnMetadata r = metadata.getColumn(new ColumnIdentifier("r", true));
 
         ByteBuffer one = Int32Type.instance.decompose(1);
-        RowFilter filter = RowFilter.NONE.withNewExpressions(new ArrayList<>());
+        RowFilter.Builder filter = RowFilter.builder();
         filter.add(s, Operator.NEQ, one);
         AtomicBoolean closed = new AtomicBoolean();
-        UnfilteredPartitionIterator iter = filter.filter(new SingletonUnfilteredPartitionIterator(new UnfilteredRowIterator()
+        UnfilteredPartitionIterator iter = filter.build().filter(new SingletonUnfilteredPartitionIterator(new UnfilteredRowIterator()
         {
             public DeletionTime partitionLevelDeletion() { return null; }
             public EncodingStats stats() { return null; }
@@ -91,10 +91,10 @@ public class RowFilterTest
         Assert.assertFalse(iter.hasNext());
         Assert.assertTrue(closed.get());
 
-        filter = RowFilter.NONE.withNewExpressions(new ArrayList<>());
+        filter = RowFilter.builder();
         filter.add(r, Operator.NEQ, one);
         closed.set(false);
-        iter = filter.filter(new SingletonUnfilteredPartitionIterator(new UnfilteredRowIterator()
+        iter = filter.build().filter(new SingletonUnfilteredPartitionIterator(new UnfilteredRowIterator()
         {
             boolean hasNext = true;
             public DeletionTime partitionLevelDeletion() { return null; }

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -381,11 +381,6 @@ public class AllowFilteringTest extends SAITester
         assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_MULTI, "[b, c]"), "SELECT * FROM %s WHERE c > 'Test' AND b < 'Test3'");
         assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_MULTI, "[b, d]"), "SELECT * FROM %s WHERE d > 'Test' AND b < 'Test3'");
 
-        // IN restriction
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "b"), "SELECT * FROM %s WHERE b IN ('Test1', 'Test2')");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"), "SELECT * FROM %s WHERE c IN ('Test1', 'Test2')");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "d"), "SELECT * FROM %s WHERE d IN ('Test1', 'Test2')");
-
         // The same queries with ALLOW FILTERING should work
 
         // Single restriction
@@ -411,14 +406,6 @@ public class AllowFilteringTest extends SAITester
                                                                                                                     row("Test2", "Test2", "Test2", "Test2"));
         assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE d > 'Test' AND b < 'Test3' ALLOW FILTERING"), row("Test1", "Test1", "Test1", "Test1"),
                                                                                                                     row("Test2", "Test2", "Test2", "Test2"));
-
-        // IN restriction
-        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE b IN ('Test1', 'Test2') ALLOW FILTERING"), row("Test1", "Test1", "Test1", "Test1"),
-                                                                                                                 row("Test2", "Test2", "Test2", "Test2"));
-        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE c IN ('Test1', 'Test2') ALLOW FILTERING"), row("Test1", "Test1", "Test1", "Test1"),
-                                                                                                                 row("Test2", "Test2", "Test2", "Test2"));
-        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE d IN ('Test1', 'Test2') ALLOW FILTERING"), row("Test1", "Test1", "Test1", "Test1"),
-                                                                                                                 row("Test2", "Test2", "Test2", "Test2"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.sai.SAITester;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+
+public class ComplexQueryTest extends SAITester
+{
+    @Test
+    public void basicOrTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 3, 3);
+
+        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE a = 1 or a = 3");
+
+        assertRowsIgnoringOrder(resultSet, row(1), row(3) );
+    }
+
+    @Test
+    public void basicInTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 3, 3);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 4, 4);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 5, 5);
+
+        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE a in (1, 3, 5)");
+
+        assertRowsIgnoringOrder(resultSet, row(1), row(3), row(5));
+    }
+
+    @Test
+    public void complexQueryTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, a int, b int, c int, d int, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 1, 1, 1, 1, 1);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 2, 2, 1, 1, 1);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 3, 3, 2, 1, 1);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 4, 4, 2, 2, 1);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 5, 5, 3, 2, 1);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 6, 6, 3, 2, 2);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 7, 7, 4, 3, 2);
+        execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 8, 8, 4, 3, 3);
+
+
+        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE (a = 1 AND c = 1) OR (b IN (3, 4) AND d = 2)");
+
+        assertRowsIgnoringOrder(resultSet, row(1), row(6), row(7) );
+    }
+
+    @Test
+    public void disjunctionWithIndexOnClusteringKey() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, a int, PRIMARY KEY(pk, ck))");
+        createIndex("CREATE CUSTOM INDEX ON %s(ck) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, ck, a) VALUES (?, ?, ?)", 1, 1, 1);
+        execute("INSERT INTO %s (pk, ck, a) VALUES (?, ?, ?)", 2, 2, 2);
+
+        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE a = 1 or ck = 2");
+
+        assertRowsIgnoringOrder(resultSet, row(1), row(2));
+    }
+
+    @Test
+    public void complexQueryWithMultipleClusterings() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck0 int, ck1 int, a int, b int, c int, d int, e int, PRIMARY KEY(pk, ck0, ck1))");
+        createIndex("CREATE CUSTOM INDEX ON %s(ck0) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(ck1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(e) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 1, 1, 1, 1, 1, 1, 1, 1);
+        execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 2, 2, 2, 2, 2, 2, 2, 2);
+        execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 3, 3, 3, 3, 3, 3, 3, 3);
+        execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 4, 4, 4, 4, 4, 4, 4, 4);
+        execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 5, 5, 5, 5, 5, 5, 5, 5);
+
+        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE b = 6 AND d = 6 OR (a = 6 OR (c = 3 OR ck0 = 5))");
+
+        assertRowsIgnoringOrder(resultSet, row(3), row(5));
+
+        resultSet = execute("SELECT pk FROM %s WHERE ck0 = 1 AND (b = 6 AND c = 6 OR (d = 6 OR e = 6))");
+
+        assertEquals(0 , resultSet.size());
+
+        resultSet = execute("SELECT pk FROM %s WHERE b = 4 OR a = 3 OR c = 5");
+
+        assertRowsIgnoringOrder(resultSet, row(3), row(4), row(5));
+
+    }
+
+    @Test
+    public void complexQueryWithPartitionKeyRestriction() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY(pk, ck))");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 1, 1, 5);
+        execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 2, 2, 6);
+        execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 2, 1, 3, 7);
+        execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 2, 2, 4, 8);
+
+        UntypedResultSet resultSet = execute("SELECT pk, ck FROM %s WHERE pk = 1 AND (a = 2 OR b = 7)");
+
+        assertRowsIgnoringOrder(resultSet, row(1, 2));
+
+        assertThatThrownBy(() -> execute("SELECT pk, ck FROM %s WHERE pk = 1 OR a = 2 OR b = 7")).isInstanceOf(InvalidRequestException.class)
+                                                                                                 .hasMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+
+        resultSet = execute("SELECT pk, ck FROM %s WHERE pk = 1 OR a = 2 OR b = 7 ALLOW FILTERING");
+
+        assertRowsIgnoringOrder(resultSet, row(1, 1), row(1, 2), row(2, 1));
+    }
+
+    @Test
+    public void indexNotSupportingDisjunctionTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'org.apache.cassandra.index.sasi.SASIIndex'");
+
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
+        execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
+
+        assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE a = 1 or a = 2")).isInstanceOf(InvalidRequestException.class)
+                                                                                   .hasMessage(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION);
+
+        assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE a = 1 or a = 2 ALLOW FILTERING")).isInstanceOf(InvalidRequestException.class)
+                                                                                                   .hasMessage(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Streams;
+import com.google.common.collect.TreeMultimap;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.Constants;
+import org.apache.cassandra.cql3.Relation;
+import org.apache.cassandra.cql3.SingleColumnRelation;
+import org.apache.cassandra.cql3.WhereClause;
+import org.apache.cassandra.cql3.restrictions.ExpressionTree;
+import org.apache.cassandra.index.sai.SAITester;
+import org.assertj.core.util.Lists;
+
+/**
+ * This test produces a random schema, loads it with random data and then runs a series of
+ * random queries against it.
+ *
+ * The purpose of the test is to test that the <code>RowFilter</code> and <code>Operation</code>
+ * classes correctly support complex queries.
+ *
+ * At present the test only supports ascii and int datatypes and only supports EQ expressions.
+ * It is intended that this can be extended in the future to support more functionality.
+ */
+public class RandomisedComplexQueryTest extends SAITester
+{
+    private static final List<TypeInfo> types = Lists.list(TypeInfo.create(CQL3Type.Native.ASCII, () -> CQLTester.getRandom().nextAsciiString(4, 30), true),
+                                                           TypeInfo.create(CQL3Type.Native.INT, () -> CQLTester.getRandom().nextIntBetween(0, 1000), false));
+
+    @Test
+    public void test() throws Throwable
+    {
+        for (int test = 0; test < getRandom().nextIntBetween(10, 50); test++)
+            runRandomTest();
+    }
+
+    private void runRandomTest() throws Throwable
+    {
+        RandomSchema schema = new RandomSchema();
+
+        createTable(schema.toTableDefinition());
+
+        schema.generateIndexStrings().stream().forEach(index -> createIndex(index));
+
+        waitForIndexQueryable();
+
+        List<RandomRow> data = schema.generateDataset();
+
+        String insert = schema.toInsert();
+
+        for (RandomRow row : data)
+            execute(insert, row.toArray());
+
+        for (int query = 0; query < getRandom().nextIntBetween(100, 1000); query++)
+            schema.generateQuery().test(this, data);
+    }
+
+    public static class RandomSchema
+    {
+        private final Map<String, RandomColumn> columnMap = new HashMap<>();
+        private final TreeMultimap<String, Object> values = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
+
+        private final List<RandomColumn> partitionKeys;
+        private final List<RandomColumn> clusteringKeys;
+        private final List<RandomColumn> normalColumns;
+
+        RandomSchema()
+        {
+            int bindPosition = 0;
+            partitionKeys = generateColumns("pk", CQLTester.getRandom().nextIntBetween(1, 3), bindPosition);
+            bindPosition += partitionKeys.size();
+            clusteringKeys = generateColumns("ck", CQLTester.getRandom().nextIntBetween(0, 4), bindPosition);
+            bindPosition += clusteringKeys.size();
+            normalColumns = generateColumns("nc", CQLTester.getRandom().nextIntBetween(1, 10), bindPosition);
+        }
+
+        public String toTableDefinition()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            builder.append("CREATE TABLE %s (");
+            builder.append(Streams.concat(partitionKeys.stream(), clusteringKeys.stream(), normalColumns.stream())
+                                  .map(RandomColumn::toColumnDefinition)
+                                  .collect(Collectors.joining(", ")));
+            builder.append(", PRIMARY KEY (");
+            String partitionKeyString = partitionKeys.stream().map(RandomColumn::name).collect(Collectors.joining(", ", "(", ")"));
+            if (clusteringKeys.isEmpty())
+                builder.append(partitionKeyString);
+            else
+                builder.append(Stream.of(partitionKeyString,
+                                         clusteringKeys.stream().map(RandomColumn::name).collect(Collectors.joining(", ")))
+                                     .collect(Collectors.joining(", ")));
+            builder.append("))");
+            return builder.toString();
+        }
+
+        public String toInsert()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            builder.append("INSERT INTO %s (");
+            builder.append(Streams.concat(partitionKeys.stream(), clusteringKeys.stream(), normalColumns.stream())
+                                  .map(RandomColumn::name)
+                                  .collect(Collectors.joining(", ")));
+            builder.append(") VALUES (");
+            builder.append(Streams.concat(partitionKeys.stream(), clusteringKeys.stream(), normalColumns.stream())
+                                  .map(RandomColumn::bindMarker)
+                                  .collect(Collectors.joining(", ")));
+            builder.append(")");
+
+            return builder.toString();
+        }
+
+        public List<String> generateIndexStrings()
+        {
+            List<String> indexes = new ArrayList<>();
+            clusteringKeys.stream().map(RandomColumn::toIndexDefinition).forEach(indexes::add);
+            normalColumns.stream().map(RandomColumn::toIndexDefinition).forEach(indexes::add);
+            return indexes;
+        }
+
+        public List<RandomRow> generateDataset()
+        {
+            List<RandomRow> data = new ArrayList<>();
+
+            for (int row = 0; row < CQLTester.getRandom().nextIntBetween(100, 1000); row++)
+            {
+                RandomRow newRow = generateRow();
+                // Remove any duplicate rows - makes it easier to build result set
+                // It may be possible to handle duplicates in the filtering but for the
+                // time being we just get rid of them
+                List<RandomRow> duplicates = data.stream()
+                                                 .filter(r -> {
+                                                    for (int pk = 0; pk < partitionKeys.size(); pk++)
+                                                        if (!r.values.get(pk).equals(newRow.values.get(pk)))
+                                                            return true;
+                                                    return false;
+                                                 })
+                                                 .collect(Collectors.toList());
+                duplicates.stream().forEach(data::remove);
+                data.add(newRow);
+            }
+
+            return data;
+        }
+
+        public RandomQuery generateQuery() throws Throwable
+        {
+            StringBuilder builder = new StringBuilder();
+
+            boolean applyPrecedence = CQLTester.getRandom().nextBoolean();
+
+            List<RandomColumn> allColumns = Lists.newArrayList(clusteringKeys);
+            allColumns.addAll(normalColumns);
+            int numberOfElements = CQLTester.getRandom().nextIntBetween(1, allColumns.size());
+            Set<RandomColumn> columns = new HashSet<>();
+            while (columns.size() < numberOfElements)
+                columns.add(allColumns.get(CQLTester.getRandom().nextIntBetween(0, allColumns.size() - 1)));
+
+            RandomColumn[] columnArray = columns.toArray(new RandomColumn[] {});
+            int precedenceLevel = 0;
+            for (int element = 0; element < numberOfElements - 1; element++)
+            {
+                if (applyPrecedence && CQLTester.getRandom().nextIntBetween(0, 2) == 0)
+                {
+                    builder.append("(");
+                    precedenceLevel++;
+                }
+                builder.append(columnArray[element].name);
+                builder.append(" = ");
+                builder.append(columnArray[element].randomQueryValue());
+
+                if (applyPrecedence && CQLTester.getRandom().nextIntBetween(0, 2) == 2 && precedenceLevel > 0)
+                {
+                    builder.append(")");
+                    precedenceLevel--;
+                }
+                builder.append(CQLTester.getRandom().nextBoolean() ? " AND " : " OR ");
+            }
+            builder.append(columnArray[columnArray.length - 1].name);
+            builder.append(" = ");
+            builder.append(columnArray[columnArray.length - 1].randomQueryValue());
+            if (applyPrecedence)
+                while (precedenceLevel-- > 0)
+                    builder.append(")");
+
+            return new RandomQuery(this, builder.toString());
+        }
+
+        private RandomRow generateRow()
+        {
+            RandomRow row = new RandomRow();
+            Streams.concat(partitionKeys.stream(), clusteringKeys.stream(), normalColumns.stream())
+                   .map(RandomColumn::nextValue).forEach(row::add);
+            return row;
+        }
+
+        private List<RandomColumn> generateColumns(String prefix, int count, int bindPosition)
+        {
+            List<RandomColumn> columns = new ArrayList<>(count);
+            for (int index = 0; index < count; index++)
+            {
+                RandomColumn column = new RandomColumn(this, prefix + index, getRandomType(), bindPosition++);
+                columns.add(column);
+                columnMap.put(column.name, column);
+            }
+            return columns;
+        }
+
+        private static TypeInfo getRandomType()
+        {
+            return types.get(CQLTester.getRandom().nextIntBetween(0, types.size() - 1));
+        }
+    }
+
+    public static class RandomQuery
+    {
+        private final RandomSchema schema;
+        private final String query;
+        private final Filter filter;
+
+        RandomQuery(RandomSchema schema, String query) throws Throwable
+        {
+            this.schema = schema;
+            this.query = query;
+            filter = buildFilter(WhereClause.parse(query).root());
+        }
+
+        void test(SAITester tester, List<RandomRow> data) throws Throwable
+        {
+            CQLTester.assertRowsIgnoringOrder(tester.execute("SELECT * FROM %s WHERE " + query), expectedRows(data));
+        }
+
+        Object[][] expectedRows(List<RandomRow> data)
+        {
+            List<Object[]> expected = new ArrayList<>();
+
+            for (RandomRow row : data)
+            {
+                if (filter.isSatisfiedBy(row))
+                    expected.add(row.toArray());
+            }
+
+            return expected.toArray(new Object[][]{});
+        }
+
+        Filter buildFilter(ExpressionTree.ExpressionElement element)
+        {
+            Filter filter = new Filter();
+            filter.isDisjunction = element.isDisjunction();
+            for (Relation relation : element.relations())
+            {
+                filter.expressions.add(new Expression(schema, relation));
+            }
+            for (ExpressionTree.ExpressionElement child : element.operations())
+                filter.children.add(buildFilter(child));
+            return filter;
+        }
+
+        static class Filter
+        {
+            boolean isDisjunction;
+
+            List<Expression> expressions = new ArrayList<>();
+
+            List<Filter> children = new ArrayList<>();
+
+            boolean isSatisfiedBy(RandomRow row)
+            {
+                if (isDisjunction)
+                {
+                    for (Expression e : expressions)
+                        if (e.isSatisfiedBy(row))
+                            return true;
+                    for (Filter child : children)
+                        if (child.isSatisfiedBy(row))
+                            return true;
+                    return false;
+                }
+                else
+                {
+                    for (Expression e : expressions)
+                        if (!e.isSatisfiedBy(row))
+                            return false;
+                    for (Filter child : children)
+                        if (!child.isSatisfiedBy(row))
+                            return false;
+                    return true;
+                }
+            }
+        }
+
+        static class Expression
+        {
+            ColumnIdentifier column;
+            String value;
+            int bindPosition;
+
+            Expression(RandomSchema schema, Relation relation)
+            {
+                assert relation instanceof SingleColumnRelation;
+                SingleColumnRelation singleColumnRelation = (SingleColumnRelation)relation;
+                column = singleColumnRelation.getEntity();
+                value = ((Constants.Literal)singleColumnRelation.getValue()).getRawText();
+                bindPosition = schema.columnMap.get(column.toString()).bindPosition;
+            }
+
+            boolean isSatisfiedBy(RandomRow row)
+            {
+                Object rowValue = row.values.get(bindPosition);
+                return rowValue.toString().equals(value);
+            }
+        }
+    }
+
+    public static class RandomColumn
+    {
+        private final RandomSchema schema;
+        private final String name;
+        private final TypeInfo type;
+        private final int bindPosition;
+
+        RandomColumn(RandomSchema schema, String name, TypeInfo type, int bindPosition)
+        {
+            this.schema = schema;
+            this.name = name;
+            this.type = type;
+            this.bindPosition = bindPosition;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        public String toColumnDefinition()
+        {
+            return name + " " + type.type.toString();
+        }
+
+        public String bindMarker()
+        {
+            return "?";
+        }
+
+        public String randomQueryValue()
+        {
+            Object[] columnValues = schema.values.get(name).toArray();
+            Object randomValue = columnValues[CQLTester.getRandom().nextIntBetween(0, columnValues.length - 1)];
+            return type.toCqlString(randomValue);
+        }
+
+        public String toIndexDefinition()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.append("CREATE CUSTOM INDEX ON %s(");
+            builder.append(name);
+            builder.append(") USING 'StorageAttachedIndex'");
+            return builder.toString();
+        }
+
+        public Object nextValue()
+        {
+            Object value = type.nextValue();
+            schema.values.put(name, value);
+            return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+
+    public static class RandomRow
+    {
+        List<Object> values = new ArrayList<>();
+
+        public void add(Object value)
+        {
+            values.add(value);
+        }
+
+        public Object[] toArray()
+        {
+            return values.toArray();
+        }
+    }
+
+    public static class TypeInfo
+    {
+        private final CQL3Type.Native type;
+        private final Supplier<?> supplier;
+        private final boolean quoted;
+
+        TypeInfo(CQL3Type.Native type, Supplier<?> supplier, boolean quoted)
+        {
+            this.type = type;
+            this.supplier = supplier;
+            this.quoted = quoted;
+        }
+
+        static TypeInfo create(CQL3Type.Native type, Supplier<?> supplier, boolean quoted)
+        {
+            return new TypeInfo(type, supplier, quoted);
+        }
+
+        public Object nextValue()
+        {
+            return supplier.get();
+        }
+
+        public String toCqlString(Object value)
+        {
+            return quoted ? "'" + value + "'" : value.toString();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -1369,14 +1369,14 @@ public class SASIIndexTest
 
         ColumnFamilyStore store = loadData(data1, true);
 
-        RowFilter filter = RowFilter.create();
+        RowFilter.Builder filter = RowFilter.builder();
         filter.add(store.metadata().getColumn(firstName), Operator.LIKE_CONTAINS, AsciiType.instance.fromString("a"));
 
         ReadCommand command =
             PartitionRangeReadCommand.create(store.metadata(),
                                              FBUtilities.nowInSeconds(),
                                              ColumnFilter.all(store.metadata()),
-                                             filter,
+                                             filter.build(),
                                              DataLimits.NONE,
                                              DataRange.allData(store.metadata().partitioner));
         try
@@ -2563,7 +2563,7 @@ public class SASIIndexTest
                             ? DataRange.allData(PARTITIONER)
                             : DataRange.forKeyRange(new Range<>(startKey, PARTITIONER.getMinimumToken().maxKeyBound()));
 
-        RowFilter filter = RowFilter.create();
+        RowFilter.Builder filter = RowFilter.builder();
         for (Expression e : expressions)
             filter.add(store.metadata().getColumn(e.name), e.op, e.value);
 
@@ -2571,7 +2571,7 @@ public class SASIIndexTest
             PartitionRangeReadCommand.create(store.metadata(),
                                              FBUtilities.nowInSeconds(),
                                              columnFilter,
-                                             filter,
+                                             filter.build(),
                                              DataLimits.cqlLimits(maxResults),
                                              range);
 


### PR DESCRIPTION
These changes can be broken into the following sections:

- The parsing of complex expressions which is done in the antlr grammar and handled by the `WhereClause` and `ExpressionTree`
- The building of the `StatementRestrictions` from the `ExpressionTree`. This is a significant change because it changes the `StatementRestrictions` from being a single layer of restrictions to an unbounded tree containing child `StatementRestrictions`.
- The building of the `RowFilter` and the `RowFilter` filtering. Like the `StatementRestrictions` the `RowFilter` becomes an unbounded tree with a parent filter and child filters. This impacts the building of the `RowFilter` and how filtering is handled.
- The SAI `Operation` and `FilterTree`. The `Operation` has changed to a builder class that provides the search `RangeIterator` and `FilterTree`. The `FilterTree` changes to an unbounded tree of parent `FilterTree` and child `FilterTree`s.

It should be noted that a lot of javadoc has been removed from the SAI code because it was incorrect. I haven't replaced it, letting the code and tests speak for themselves. If you think anywhere needs commenting, let me know and I'll add what I can.

There are 3 new tests added to cover these changes.

- `ExpressionTreeTest` - tests the basic parsing functionality and includes a random expression tester.
- `ComplexQueryTest` - is a functional CQL test for complex, multi-layer, expressions. 
- `RandomComplexQueryTest` - this is randomised tester of different schemas and queries and has fed tests into `ComplexQueryTest` when it has highlighted errors.