### PR TITLE
STAR-590 invalidate caches

### DIFF
--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -18,12 +18,20 @@
 
 package org.apache.cassandra.auth;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,6 +133,13 @@ public class AuthCache<K, V> implements AuthCacheMBean
         return cache.get(k);
     }
 
+    @Nullable
+    @VisibleForTesting
+    protected V getIfPresent(K k)
+    {
+        return cache == null ? null : cache.getIfPresent(k);
+    }
+
     /**
      * Invalidate the entire cache.
      */
@@ -141,6 +156,19 @@ public class AuthCache<K, V> implements AuthCacheMBean
     {
         if (cache != null)
             cache.invalidate(k);
+    }
+
+    public void maybeInvalidateByFilter(Predicate<? super Map.Entry<K,V>> filter)
+    {
+        if (cache != null)
+        {
+            Collection<K> iterable = cache.asMap().entrySet()
+                                          .stream()
+                                          .filter(filter)
+                                          .map(entry -> entry.getKey())
+                                          .collect(Collectors.toSet());
+            cache.invalidateAll(iterable);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -165,7 +165,7 @@ public class AuthCache<K, V> implements AuthCacheMBean
             Collection<K> iterable = cache.asMap().entrySet()
                                           .stream()
                                           .filter(filter)
-                                          .map(entry -> entry.getKey())
+                                          .map(Map.Entry::getKey)
                                           .collect(Collectors.toSet());
             cache.invalidateAll(iterable);
         }

--- a/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
+++ b/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
@@ -119,24 +119,6 @@ public class AuthenticatedUser
         return permissionsCache.getPermissions(this, resource);
     }
     
-    @VisibleForTesting
-    public static void clearCache()
-    {
-        permissionsCache.invalidate();
-    }
-
-    public static void invalidate(Collection<RoleResource> roles, IResource resource)
-    {
-        for (RoleResource role : roles)
-            permissionsCache.invalidate(new AuthenticatedUser(role.getRoleName()), resource);
-    }
-
-    public static void invalidate(Collection<RoleResource> roles)
-    {
-        for (RoleResource role : roles)
-            permissionsCache.invalidateByAuthenticatedUser(new AuthenticatedUser(role.getRoleName()));
-    }
-    
     /**
      * Check whether this user has login privileges.
      * LOGIN is not inherited from granted roles, so must be directly granted to the primary role for this user

--- a/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
+++ b/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
@@ -127,11 +127,14 @@ public class AuthenticatedUser
 
     public static void invalidate(Collection<RoleResource> roles, IResource resource)
     {
-        if (roles == null || roles.isEmpty())
-            permissionsCache.invalidate();
-        else
-            for (RoleResource role: roles)
-                permissionsCache.invalidate(new AuthenticatedUser(role.getRoleName()), resource);
+        for (RoleResource role : roles)
+            permissionsCache.invalidate(new AuthenticatedUser(role.getRoleName()), resource);
+    }
+
+    public static void invalidate(Collection<RoleResource> roles)
+    {
+        for (RoleResource role : roles)
+            permissionsCache.invalidateByAuthenticatedUser(new AuthenticatedUser(role.getRoleName()));
     }
     
     /**

--- a/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
@@ -93,20 +93,16 @@ public class CassandraAuthorizer implements IAuthorizer
 
     private void invalidateRolesAndPermissions(Collection<RoleResource> roles, IResource resource)
     {
-        if (!roles.isEmpty())
-        {
-            Roles.invalidate(roles);
-            AuthenticatedUser.invalidate(roles, resource);
-        }
+        Roles.cache.invalidate(roles);
+        // All permission entries associated with the resource need to be cleared as they may be
+        // transitively applied to user/roles besides those directly affected by the grant/revoke/drop operation 
+        AuthenticatedUser.permissionsCache.invalidate(resource);
     }
 
     private void invalidateRolesAndPermissions(Collection<RoleResource> roles)
     {
-        if (!roles.isEmpty())
-        {
-            Roles.invalidate(roles);
-            AuthenticatedUser.invalidate(roles);
-        }
+        Roles.cache.invalidate(roles);
+        AuthenticatedUser.permissionsCache.invalidate(roles);
     }
 
     public void revoke(AuthenticatedUser performer, Set<Permission> permissions, IResource resource, RoleResource revokee)

--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -187,8 +187,8 @@ public class CassandraRoleManager implements IRoleManager
 
     private void invalidateRolesAndPermissions(Collection<RoleResource> roles)
     {
-        Roles.invalidate(roles);
-        AuthenticatedUser.invalidate(roles);
+        Roles.cache.invalidate(roles);
+        AuthenticatedUser.permissionsCache.invalidate(roles);
     }
     
     public void alterRole(AuthenticatedUser performer, RoleResource role, RoleOptions options)

--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -185,10 +185,10 @@ public class CassandraRoleManager implements IRoleManager
         removeAllMembers(role);
     }
 
-    private void invalidateRoles(Collection<RoleResource> roles)
+    private void invalidateRolesAndPermissions(Collection<RoleResource> roles)
     {
         Roles.invalidate(roles);
-        AuthenticatedUser.invalidate(roles, null);
+        AuthenticatedUser.invalidate(roles);
     }
     
     public void alterRole(AuthenticatedUser performer, RoleResource role, RoleOptions options)
@@ -226,7 +226,7 @@ public class CassandraRoleManager implements IRoleManager
                               escape(role.getRoleName()),
                               escape(grantee.getRoleName())),
                 consistencyForRole(role.getRoleName()));
-        invalidateRoles(Collections.singleton(grantee));
+        invalidateRolesAndPermissions(Collections.singleton(grantee));
     }
 
     public void revokeRole(AuthenticatedUser performer, RoleResource role, RoleResource revokee)
@@ -244,7 +244,7 @@ public class CassandraRoleManager implements IRoleManager
                               escape(role.getRoleName()),
                               escape(revokee.getRoleName())),
                 consistencyForRole(role.getRoleName()));
-        invalidateRoles(Collections.singleton(revokee));
+        invalidateRolesAndPermissions(Collections.singleton(revokee));
     }
 
     public Set<RoleResource> getRoles(RoleResource grantee, boolean includeInherited)
@@ -478,7 +478,7 @@ public class CassandraRoleManager implements IRoleManager
                               escape(role.getRoleName())),
                 consistencyForRole(role.getRoleName()));
         
-        invalidateRoles(roles);
+        invalidateRolesAndPermissions(roles);
     }
 
     /*

--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -182,9 +182,15 @@ public class CassandraRoleManager implements IRoleManager
                               AuthKeyspace.ROLES,
                               escape(role.getRoleName())),
                 consistencyForRole(role.getRoleName()));
-        removeAllMembers(role.getRoleName());
+        removeAllMembers(role);
     }
 
+    private void invalidateRoles(Collection<RoleResource> roles)
+    {
+        Roles.invalidate(roles);
+        AuthenticatedUser.invalidate(roles, null);
+    }
+    
     public void alterRole(AuthenticatedUser performer, RoleResource role, RoleOptions options)
     {
         // Unlike most of the other data access methods here, this does not use a
@@ -220,6 +226,7 @@ public class CassandraRoleManager implements IRoleManager
                               escape(role.getRoleName()),
                               escape(grantee.getRoleName())),
                 consistencyForRole(role.getRoleName()));
+        invalidateRoles(Collections.singleton(grantee));
     }
 
     public void revokeRole(AuthenticatedUser performer, RoleResource role, RoleResource revokee)
@@ -237,6 +244,7 @@ public class CassandraRoleManager implements IRoleManager
                               escape(role.getRoleName()),
                               escape(revokee.getRoleName())),
                 consistencyForRole(role.getRoleName()));
+        invalidateRoles(Collections.singleton(revokee));
     }
 
     public Set<RoleResource> getRoles(RoleResource grantee, boolean includeInherited)
@@ -441,27 +449,36 @@ public class CassandraRoleManager implements IRoleManager
     /*
      * Clear the membership list of the given role
      */
-    private void removeAllMembers(String role) throws RequestValidationException, RequestExecutionException
+    private void removeAllMembers(RoleResource role) throws RequestValidationException, RequestExecutionException
     {
+        Set<RoleResource> roles = new HashSet<>();
+        roles.add(role);
+
         // Get the membership list of the the given role
         UntypedResultSet rows = process(String.format("SELECT member FROM %s.%s WHERE role = '%s'",
                                                       SchemaConstants.AUTH_KEYSPACE_NAME,
                                                       AuthKeyspace.ROLE_MEMBERS,
-                                                      escape(role)),
-                                        consistencyForRole(role));
+                                                      escape(role.getRoleName())),
+                                        consistencyForRole(role.getRoleName()));
         if (rows.isEmpty())
             return;
 
         // Update each member in the list, removing this role from its own list of granted roles
         for (UntypedResultSet.Row row : rows)
-            modifyRoleMembership(row.getString("member"), role, "-");
+        {
+            String member = row.getString("member");
+            modifyRoleMembership(member, role.getRoleName(), "-");
+            roles.add(RoleResource.role(member));
+        }
 
         // Finally, remove the membership list for the dropped role
         process(String.format("DELETE FROM %s.%s WHERE role = '%s'",
                               SchemaConstants.AUTH_KEYSPACE_NAME,
                               AuthKeyspace.ROLE_MEMBERS,
-                              escape(role)),
-                consistencyForRole(role));
+                              escape(role.getRoleName())),
+                consistencyForRole(role.getRoleName()));
+        
+        invalidateRoles(roles);
     }
 
     /*

--- a/src/java/org/apache/cassandra/auth/PermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.auth;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 
@@ -42,16 +43,17 @@ public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResourc
     {
         return get(Pair.create(user, resource));
     }
-    
-    public void invalidate(AuthenticatedUser user, IResource resource)
+
+    public void invalidate(IResource resource)
     {
         // Invalidate all entries associated with the resource part of the cache key
         maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().right, resource));
     }
 
-    public void invalidateByAuthenticatedUser(AuthenticatedUser user)
+    public void invalidate(Collection<RoleResource> roles)
     {
-        // Invalidate all entries associated with the user part of the cache key
-        maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().left, user));
+        for (RoleResource role : roles)
+            // Invalidate all entries associated with the user part of the cache key
+            maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().left, new AuthenticatedUser(role.getRoleName())));
     }
 }

--- a/src/java/org/apache/cassandra/auth/PermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.auth;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -40,5 +41,14 @@ public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResourc
     public Set<Permission> getPermissions(AuthenticatedUser user, IResource resource)
     {
         return get(Pair.create(user, resource));
+    }
+    
+    public void invalidate(AuthenticatedUser user, IResource resource)
+    {
+        if (resource != null)
+            invalidate(Pair.create(user, resource));
+        else
+            // Invalidate all entries associated with the user
+            maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().left, user));
     }
 }

--- a/src/java/org/apache/cassandra/auth/PermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCache.java
@@ -45,10 +45,13 @@ public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResourc
     
     public void invalidate(AuthenticatedUser user, IResource resource)
     {
-        if (resource != null)
-            invalidate(Pair.create(user, resource));
-        else
-            // Invalidate all entries associated with the user
-            maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().left, user));
+        // Invalidate all entries associated with the resource part of the cache key
+        maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().right, resource));
+    }
+
+    public void invalidateByAuthenticatedUser(AuthenticatedUser user)
+    {
+        // Invalidate all entries associated with the user part of the cache key
+        maybeInvalidateByFilter((entry) -> Objects.equals(entry.getKey().left, user));
     }
 }

--- a/src/java/org/apache/cassandra/auth/Roles.java
+++ b/src/java/org/apache/cassandra/auth/Roles.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.auth;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +39,8 @@ public class Roles
 
     private static final Role NO_ROLE = new Role("", false, false, Collections.emptyMap(), Collections.emptySet());
 
-    private static RolesCache cache;
+    @VisibleForTesting
+    static RolesCache cache;
     static
     {
         initRolesCache(DatabaseDescriptor.getRoleManager(),
@@ -57,6 +59,17 @@ public class Roles
     public static void clearCache()
     {
         cache.invalidate();
+    }
+    
+    public static void invalidate(Collection<RoleResource> roles)
+    {
+        if (roles == null || roles.isEmpty())
+        {
+            cache.invalidate();
+        }
+        else
+            for (RoleResource role: roles)
+                cache.invalidate(role);
     }
 
     /**

--- a/src/java/org/apache/cassandra/auth/Roles.java
+++ b/src/java/org/apache/cassandra/auth/Roles.java
@@ -55,23 +55,6 @@ public class Roles
         cache = new RolesCache(roleManager, enableCache);
     }
 
-    @VisibleForTesting
-    public static void clearCache()
-    {
-        cache.invalidate();
-    }
-    
-    public static void invalidate(Collection<RoleResource> roles)
-    {
-        if (roles == null || roles.isEmpty())
-        {
-            cache.invalidate();
-        }
-        else
-            for (RoleResource role: roles)
-                cache.invalidate(role);
-    }
-
     /**
      * Identify all roles granted to the supplied Role, including both directly granted
      * and inherited roles.

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.auth;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
@@ -61,5 +62,14 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>>
     Set<Role> getRoles(RoleResource primaryRole)
     {
         return get(primaryRole);
+    }
+    
+    public void invalidate(RoleResource primaryRole)
+    {
+        super.invalidate(primaryRole);
+        // Invalidate entries with role resources containing this role
+        super.maybeInvalidateByFilter((entry) -> entry.getValue().stream()
+                                                      .anyMatch(role -> Objects.equals(role.resource, primaryRole))
+        );
     }
 }

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.auth;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
@@ -63,7 +64,22 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>>
     {
         return get(primaryRole);
     }
-    
+
+    /**
+     * Invalidate all RoleResource entries in the given collection. If the collection is null, then
+     * the entire cache is invalidated.
+     *
+     * @param roles collection of Roles to be invalidated 
+     */
+    public void invalidate(Collection<RoleResource> roles)
+    {
+        if (roles == null)
+            invalidate();
+        else
+            for (RoleResource role: roles)
+                invalidate(role);
+    }
+
     public void invalidate(RoleResource primaryRole)
     {
         // Invalidate the primary role

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -66,8 +66,10 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>>
     
     public void invalidate(RoleResource primaryRole)
     {
+        // Invalidate the primary role
         super.invalidate(primaryRole);
-        // Invalidate entries with role resources containing this role
+        
+        // Invalidate roles containing this role
         super.maybeInvalidateByFilter((entry) -> entry.getValue().stream()
                                                       .anyMatch(role -> Objects.equals(role.resource, primaryRole))
         );

--- a/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
+++ b/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
@@ -96,8 +96,8 @@ public class AuthCacheInvalidationTest extends CQLTester
         executeNet("GRANT MODIFY ON TABLE " + ks + '.' + tab + " TO " + role1.getRoleName());
         executeNet("GRANT MODIFY ON KEYSPACE " + ks + " TO " + role2.getRoleName());
 
-        Roles.clearCache();
-        AuthenticatedUser.clearCache();
+        Roles.cache.invalidate();
+        AuthenticatedUser.permissionsCache.invalidate();
     }
 
     private void createRole(RoleResource role) throws Throwable

--- a/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
+++ b/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
@@ -1,0 +1,712 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.auth;
+
+import java.util.*;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.exceptions.UnauthorizedException;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.utils.MapsFactory;
+import org.apache.cassandra.utils.Pair;
+
+import static java.util.Collections.emptyMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import static org.apache.cassandra.auth.permission.CorePermission.EXECUTE;
+import static org.apache.cassandra.auth.permission.CorePermission.UPDATE;
+import static org.apache.cassandra.auth.permission.CorePermission.SELECT;
+
+public class AuthCacheInvalidationTest extends CQLTester
+{
+    private static final String ks = "acinv_ks";
+    private static final String tab = "acinv_tab";
+    private static final String tab2 = "acinv_tab2";
+    private static final String func = "acinv_func";
+    private static final String aggr = "acinv_aggr";
+    private static final RoleResource user1 = RoleResource.role("acinv_user1");
+    private static final String userPw = "12345";
+    private static final RoleResource role1 = RoleResource.role("acinv_role1");
+    private static final RoleResource role2 = RoleResource.role("acinv_role2");
+    private static final RoleResource role3 = RoleResource.role("acinv_role3");
+
+    @BeforeClass
+    public static void setup()
+    {
+        requireAuthentication();
+        DatabaseDescriptor.setPermissionsValidity(9999);
+        DatabaseDescriptor.setPermissionsUpdateInterval(9999);
+        requireNetwork();
+    }
+
+    @Before
+    public void prepare() throws Throwable
+    {
+        useSuperUser();
+
+        executeNet("DROP ROLE IF EXISTS " + user1.getRoleName());
+        executeNet("DROP ROLE IF EXISTS " + role1.getRoleName());
+        executeNet("DROP ROLE IF EXISTS " + role2.getRoleName());
+        executeNet("DROP ROLE IF EXISTS " + role3.getRoleName());
+        executeNet("DROP KEYSPACE IF EXISTS " + ks);
+
+        executeNet("CREATE USER " + user1.getRoleName() + " WITH PASSWORD '" + userPw + '\'');
+        executeNet("CREATE ROLE " + role1.getRoleName());
+        executeNet("CREATE ROLE " + role2.getRoleName());
+        executeNet("GRANT " + role1.getRoleName() + " TO " + user1.getRoleName());
+        executeNet("GRANT " + role2.getRoleName() + " TO " + role1.getRoleName());
+
+        execute("CREATE KEYSPACE " + ks + " WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        execute("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
+        execute("CREATE TABLE " + ks + '.' + tab2 + " (id int PRIMARY KEY)");
+
+        executeNet("GRANT SELECT, UPDATE ON TABLE " + ks + '.' + tab + " TO " + role1.getRoleName());
+        executeNet("GRANT UPDATE ON KEYSPACE " + ks + " TO " + role2.getRoleName());
+
+        DatabaseDescriptor.getAuthManager().invalidateCaches();
+    }
+
+    @Test
+    public void testInvalidationOnGrant() throws Throwable
+    {
+        // Checks that the user has no SELECT permissions on tab2
+
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks that the caches have been populated by the query.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Allow the user to execute SELECT on tab2
+        useSuperUser();
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role2.getRoleName());
+
+        // Checks that only the role2 data have been removed from the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(role2);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheDoesNotContains(role2);
+
+        // Checks that the user is now allowed to execute SELECT queries on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        executeNet("SELECT * FROM " + ks + '.' + tab2);
+
+        // Checks that role2 data been re-populated by the query.
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), SELECT, UPDATE));
+    }
+
+    @Test
+    public void testInvalidationOnRevoke() throws Throwable
+    {
+        // Checks that the user has SELECT permissions on tab
+        useUser(user1.getRoleName(), userPw);
+
+        executeNet("SELECT * FROM " + ks + '.' + tab);
+
+        // Checks that the caches have been populated by the query.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Revoke SELECT on tab
+        useSuperUser();
+
+        executeNet("REVOKE SELECT ON TABLE " + ks + '.' + tab + " FROM " + role1.getRoleName());
+
+        // Checks that only the role1 data have been removed from the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Checks that the user has no SELECT permissions on tab
+        useUser(user1.getRoleName(), userPw);
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
+
+        // Checks that the cache content is the expected one
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Revoke SELECT on tab
+        useSuperUser();
+
+        executeNet("REVOKE ALL ON TABLE " + ks + '.' + tab + " FROM " + role1.getRoleName());
+
+        // Checks that only the role1 data have been removed from the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+    }
+
+    @Test
+    public void testInvalidationOnDropRole() throws Throwable
+    {
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks that the caches have been populated by the query.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Create new ROLE with SELECT permission on tab2 and grant it to the user
+        useSuperUser();
+
+        executeNet("CREATE ROLE " + role3.getRoleName());
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
+        executeNet("GRANT " + role3.getRoleName() + " TO " + user1.getRoleName());
+
+        // Checks that only the user1 has been removed from the caches
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheDoesNotContains(user1);
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(role3);
+
+        // Checks the the user is now allowed to perform the query
+        useUser(user1.getRoleName(), userPw);
+        executeNet("SELECT * FROM " + ks + '.' + tab2);
+
+        // Checks that the caches have been populated by the query correctly.
+        assertRolesCacheContains(user1, setOf(role1, role3));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheContains(role3, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
+
+        // Drop the role3
+        useSuperUser();
+        executeNet("DROP ROLE " + role3.getRoleName());
+
+        // Checks that role3 and its children have been removed from the cache correctly.
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheDoesNotContains(user1);
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(role3);
+
+        // Re-create role3 without granting it to the user
+        executeNet("CREATE ROLE " + role3.getRoleName());
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
+
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks the cache
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(role3);
+    }
+
+    @Test
+    public void testInvalidationOnRevokeRole() throws Throwable
+    {
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks that the caches have been populated by the query.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Create new ROLE with SELECT permission on tab2 and grant it to the user
+        useSuperUser();
+
+        executeNet("CREATE ROLE " + role3.getRoleName());
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
+        executeNet("GRANT " + role3.getRoleName() + " TO " + user1.getRoleName());
+
+        // Checks that only the user1 has been removed from the caches
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheDoesNotContains(user1);
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(role3);
+
+        // Checks the the user is now allowed to perform the query
+        useUser(user1.getRoleName(), userPw);
+        executeNet("SELECT * FROM " + ks + '.' + tab2);
+
+        // Checks that the caches have been populated by the query correctly.
+        assertRolesCacheContains(user1, setOf(role1, role3));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheContains(role3, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
+
+        // Revoke the role3
+        useSuperUser();
+        executeNet("REVOKE " + role3.getRoleName() + " FROM " + user1.getRoleName());
+
+        // Checks that the user has been removed from the cache correctly.
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheContains(role3, setOf());
+
+        assertPermissionsCacheDoesNotContains(user1);
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
+
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+    }
+
+    @Test
+    public void testInvalidationOnDropRoleWithNonDirectChildren() throws Throwable
+    {
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks that the caches have been populated by the query.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Create new ROLE with SELECT permission on tab2 and grant it to the user
+        useSuperUser();
+
+        executeNet("CREATE ROLE " + role3.getRoleName());
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
+        executeNet("GRANT " + role3.getRoleName() + " TO " + role2.getRoleName());
+
+        // Checks that only the user1 has been removed from the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(role2);
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheDoesNotContains(role2);
+        assertPermissionsCacheDoesNotContains(role3);
+
+        // Checks the the user is now allowed to perform the query
+        useUser(user1.getRoleName(), userPw);
+        executeNet("SELECT * FROM " + ks + '.' + tab2);
+
+        // Checks that the caches have been populated by the query correctly.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf(role3));
+        assertRolesCacheContains(role3, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
+
+        // Drop the role3
+        useSuperUser();
+        executeNet("DROP ROLE " + role3.getRoleName());
+
+        // Checks that role3 and its direct children have been removed from the cache correctly.
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(role2);
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheDoesNotContains(role2);
+        assertPermissionsCacheDoesNotContains(role3);
+
+        // Re-create role3 without granting it to role2
+        executeNet("CREATE ROLE " + role3.getRoleName());
+        executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
+
+        // Checks that the user has no SELECT permissions on tab2
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+
+        // Checks the cache
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role3);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(role3);
+    }
+
+    private void populateAndCheckCaches() throws Throwable
+    {
+        populateCaches();
+
+        // roles cache should be populated for user1 + assigned roles role1 + role2
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        // permissions are checked against all roles
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+    }
+
+    private void populateCaches() throws Throwable
+    {
+        useUser(user1.getRoleName(), userPw);
+
+        // perform a query to populate the permissions cache for user1 and all assigned roles
+        executeNet("SELECT * FROM " + ks + '.' + tab);
+    }
+
+    @Test
+    public void testInvalidationOnDropTable() throws Throwable
+    {
+        populateAndCheckCaches();
+
+        useSuperUser();
+
+        executeNet("DROP TABLE " + ks + '.' + tab);
+
+        // permissions were only granted to role1 - so only role1 needs to be invalidated
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+
+        // Re-create the dropped table
+        execute("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
+
+        // Checks that the user has no SELECT permissions on tab
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
+
+        // checks the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, emptyMap());
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+    }
+
+    @Test
+    public void testInvalidationOnDropKeyspace() throws Throwable
+    {
+        populateAndCheckCaches();
+
+        useSuperUser();
+
+        executeNet("DROP KEYSPACE " + ks);
+
+        // permissions were only granted to role1 - so only role1 needs to be invalidated
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheDoesNotContains(role2);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheDoesNotContains(role2);
+
+        // Re-create keyspace and table
+        executeNet("CREATE KEYSPACE " + ks + " WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        executeNet("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
+
+        // Checks that the user has no SELECT permissions on tab
+        useUser(user1.getRoleName(), userPw);
+
+        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
+                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
+
+        // checks the caches
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, emptyMap());
+        assertPermissionsCacheContains(role2, emptyMap());
+    }
+
+    @Test
+    public void testInvalidationOnDropAggregateAndFunction() throws Throwable
+    {
+        execute("CREATE FUNCTION " + ks + '.' + func + " ( input1 int, input2 int ) " +
+                "CALLED ON NULL INPUT " +
+                "RETURNS int " +
+                "LANGUAGE java AS 'return input1 + input2;'");
+
+        execute("CREATE AGGREGATE " + ks + '.' + aggr + "(int)" +
+                "SFUNC " + func + ' ' +
+                "STYPE int " +
+                "INITCOND 0");
+
+        executeNet("GRANT EXECUTE ON FUNCTION " + ks + '.' + func + "(int,int) TO " + role2.getRoleName());
+        executeNet("GRANT EXECUTE ON FUNCTION " + ks + '.' + aggr + "(int) TO " + role1.getRoleName());
+
+        IResource functionResource = FunctionResource.function(ks, func, Arrays.asList(Int32Type.instance, Int32Type.instance));
+        IResource aggregateResource = FunctionResource.function(ks, aggr, Arrays.asList(Int32Type.instance));
+
+        Map<IResource, PermissionSets> role1Permissions = MapsFactory.newMap();
+        role1Permissions.put(DataResource.table(ks, tab), permissionSet(SELECT, UPDATE));
+        role1Permissions.put(aggregateResource, permissionSet(EXECUTE));
+
+        Map<IResource, PermissionSets> role2Permissions = MapsFactory.newMap();
+        role2Permissions.put(DataResource.keyspace(ks), permissionSet(UPDATE));
+        role2Permissions.put(functionResource, permissionSet(EXECUTE));
+
+        populateCaches();
+
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheContains(role2, role2Permissions);
+
+        useSuperUser();
+
+        executeNet("DROP AGGREGATE " + ks + '.' + aggr + "(int)");
+
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheContains(role2, role2Permissions);
+
+        populateCaches();
+
+        role1Permissions.remove(aggregateResource);
+
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheContains(role2, role2Permissions);
+
+        useSuperUser();
+
+        executeNet("DROP FUNCTION " + ks + '.' + func + "(int,int)");
+
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(role2);
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheDoesNotContains(role2);
+
+        populateCaches();
+
+        role2Permissions.remove(functionResource);
+
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheContains(role2, setOf());
+
+        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheContains(role2, role2Permissions);
+    }
+
+    private void assertUnauthorized(String query, String errorMessage) throws Throwable
+    {
+        try
+        {
+            executeNet(query);
+        }
+        catch (UnauthorizedException e)
+        {
+            assertEquals(errorMessage, e.getMessage());
+        }
+    }
+
+    private static void assertRolesCacheContains(RoleResource resource, Set<RoleResource> memberOf)
+    {
+        tryWithBackoff(() -> {
+            Role role = DatabaseDescriptor.getAuthManager().rolesCache.getIfPresent(Pair.create(resource, null));
+            assertNotNull("The role " + resource + " should be in the role cache but is not.", role);
+            assertEquals("The role " + resource + " is not a member of the expected roles.", memberOf, role.memberOf);
+        });
+    }
+
+    private static void assertRolesCacheDoesNotContains(RoleResource resource)
+    {
+        tryWithBackoff(() -> {
+            Role role = DatabaseDescriptor.getAuthManager().rolesCache.getIfPresent(Pair.create(resource, null));
+            assertNull("The role " + resource + " is in the role cache but should not.", role);
+        });
+    }
+
+    private void assertPermissionsCacheContains(RoleResource resource, Map<IResource, PermissionSets> expectedPermissions)
+    {
+        tryWithBackoff(() -> {
+            Map<IResource, PermissionSets> actual = DatabaseDescriptor.getAuthManager().permissionsCache.getIfPresent(Pair.create(resource, null));
+            assertNotNull("The resource " + resource + " is not in the permissions cache.", actual);
+            assertEquals("The expected permissions for the role " + resource + " do not match the ones of the permissions cache.", expectedPermissions, actual);
+        });
+    }
+
+    private void assertPermissionsCacheDoesNotContains(RoleResource resource)
+    {
+        tryWithBackoff(() -> {
+            Map<IResource, PermissionSets> permissions = DatabaseDescriptor.getAuthManager().permissionsCache.getIfPresent(Pair.create(resource, null));
+            assertNull("The role " + resource + " has some permissions int the cache.", permissions);
+        });
+    }
+
+    /**
+     * Try the assertion in the given function a few times.
+     * Reason for this retry functionality is that the caches might not be updated immediately or there are
+     * some "visibility issues" in the cache. For production code, that is usually fine.
+     * But the test code relies on "immediate-ish" cache updates.
+     *
+     * See DB-2740
+     */
+    private static void tryWithBackoff(Runnable f)
+    {
+        AssertionError err = null;
+        for (int i = 0; i < 10; i++)
+        {
+            try
+            {
+                f.run();
+                break;
+            }
+            catch (AssertionError e)
+            {
+                logger.warn("An assertion failed in try #{}: {}", i + 1, e.toString());
+                err = e;
+            }
+
+            Thread.yield();
+        }
+        if (err != null)
+            throw err;
+    }
+
+    private static <T> Set<T> setOf(T... elem)
+    {
+        return new HashSet<>(Arrays.asList(elem));
+    }
+
+    private static Map<IResource, PermissionSets> permissionPerResource(IResource resource, Permission... granted)
+    {
+        return Collections.singletonMap(resource, permissionSet(granted));
+    }
+
+    private static PermissionSets permissionSet(Permission... granted)
+    {
+        PermissionSets.Builder builder = PermissionSets.builder();
+        for (Permission permission : granted)
+        {
+            builder.addGranted(permission);
+        }
+        return builder.build();
+    }
+}

--- a/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
+++ b/test/unit/org/apache/cassandra/auth/AuthCacheInvalidationTest.java
@@ -1,33 +1,53 @@
 /*
- * Copyright DataStax, Inc.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Please see the included license file for details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.cassandra.auth;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.datastax.driver.core.exceptions.UnauthorizedException;
-
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.utils.MapsFactory;
 import org.apache.cassandra.utils.Pair;
 
-import static java.util.Collections.emptyMap;
-
+import static java.lang.String.format;
+import static org.apache.cassandra.auth.Permission.EXECUTE;
+import static org.apache.cassandra.auth.Permission.MODIFY;
+import static org.apache.cassandra.auth.Permission.SELECT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
-import static org.apache.cassandra.auth.permission.CorePermission.EXECUTE;
-import static org.apache.cassandra.auth.permission.CorePermission.UPDATE;
-import static org.apache.cassandra.auth.permission.CorePermission.SELECT;
+import static org.junit.Assert.assertTrue;
 
 public class AuthCacheInvalidationTest extends CQLTester
 {
@@ -63,8 +83,8 @@ public class AuthCacheInvalidationTest extends CQLTester
         executeNet("DROP KEYSPACE IF EXISTS " + ks);
 
         executeNet("CREATE USER " + user1.getRoleName() + " WITH PASSWORD '" + userPw + '\'');
-        executeNet("CREATE ROLE " + role1.getRoleName());
-        executeNet("CREATE ROLE " + role2.getRoleName());
+        createRole(role1);
+        createRole(role2);
         executeNet("GRANT " + role1.getRoleName() + " TO " + user1.getRoleName());
         executeNet("GRANT " + role2.getRoleName() + " TO " + role1.getRoleName());
 
@@ -72,71 +92,85 @@ public class AuthCacheInvalidationTest extends CQLTester
         execute("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
         execute("CREATE TABLE " + ks + '.' + tab2 + " (id int PRIMARY KEY)");
 
-        executeNet("GRANT SELECT, UPDATE ON TABLE " + ks + '.' + tab + " TO " + role1.getRoleName());
-        executeNet("GRANT UPDATE ON KEYSPACE " + ks + " TO " + role2.getRoleName());
+        executeNet("GRANT SELECT ON TABLE " + ks + '.' + tab + " TO " + role1.getRoleName());
+        executeNet("GRANT MODIFY ON TABLE " + ks + '.' + tab + " TO " + role1.getRoleName());
+        executeNet("GRANT MODIFY ON KEYSPACE " + ks + " TO " + role2.getRoleName());
 
-        DatabaseDescriptor.getAuthManager().invalidateCaches();
+        Roles.clearCache();
+        AuthenticatedUser.clearCache();
+    }
+
+    private void createRole(RoleResource role) throws Throwable
+    {
+        executeNet(format("CREATE ROLE %s WITH LOGIN = true AND password = '%s'", role.getRoleName(), userPw));
     }
 
     @Test
     public void testInvalidationOnGrant() throws Throwable
     {
+        populateAndCheckCaches();
+        
         // Checks that the user has no SELECT permissions on tab2
-
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
+        assertSelectNotAllowed(role1, ks, tab2);
+        assertSelectNotAllowed(role2, ks, tab2);
 
         // Checks that the caches have been populated by the query.
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(user1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Allow the user to execute SELECT on tab2
         useSuperUser();
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role2.getRoleName());
 
-        // Checks that only the role2 data have been removed from the caches
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
+        // Checks that all role data have been removed from the caches
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
         assertRolesCacheDoesNotContains(role2);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheDoesNotContains(user1, DataResource.keyspace(ks));
+        assertPermissionsCacheDoesNotContains(user1, DataResource.table(ks, tab2));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
         assertPermissionsCacheDoesNotContains(role2);
 
         // Checks that the user is now allowed to execute SELECT queries on tab2
-        useUser(user1.getRoleName(), userPw);
-
-        executeNet("SELECT * FROM " + ks + '.' + tab2);
+        assertSelectAllowed(user1, ks, tab2);
+        assertSelectAllowed(role1, ks, tab2);
+        assertSelectAllowed(role2, ks, tab2);
 
         // Checks that role2 data been re-populated by the query.
         assertRolesCacheContains(role2, setOf());
+        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheContains(role1, setOf(role2));
 
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), SELECT, UPDATE));
+        assertPermissionsCacheContains(user1, permissionPerResource(DataResource.keyspace(ks), SELECT, MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.keyspace(ks), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), SELECT, MODIFY));
     }
 
     @Test
     public void testInvalidationOnRevoke() throws Throwable
     {
+        populateAndCheckCaches();
+        
         // Checks that the user has SELECT permissions on tab
-        useUser(user1.getRoleName(), userPw);
-
-        executeNet("SELECT * FROM " + ks + '.' + tab);
+        assertSelectAllowed(user1, ks, tab);
 
         // Checks that the caches have been populated by the query.
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Revoke SELECT on tab
         useSuperUser();
@@ -144,65 +178,66 @@ public class AuthCacheInvalidationTest extends CQLTester
         executeNet("REVOKE SELECT ON TABLE " + ks + '.' + tab + " FROM " + role1.getRoleName());
 
         // Checks that only the role1 data have been removed from the caches
-        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(user1);
         assertRolesCacheDoesNotContains(role1);
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(user1);
         assertPermissionsCacheDoesNotContains(role1);
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Checks that the user has no SELECT permissions on tab
-        useUser(user1.getRoleName(), userPw);
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
-
+        assertSelectNotAllowed(user1, ks, tab);
+        assertSelectNotAllowed(role1, ks, tab);
+        assertSelectNotAllowed(role2, ks, tab);
+        
         // Checks that the cache content is the expected one
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, permissionPerResource(DataResource.table(ks, tab), MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Revoke SELECT on tab
         useSuperUser();
 
         executeNet("REVOKE ALL ON TABLE " + ks + '.' + tab + " FROM " + role1.getRoleName());
 
-        // Checks that only the role1 data have been removed from the caches
-        assertRolesCacheContains(user1, setOf(role1));
+        // Checks that only the user1 and role1 data have been removed from the caches
+        assertRolesCacheDoesNotContains(user1);
         assertRolesCacheDoesNotContains(role1);
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheDoesNotContains(role1);
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(user1, DataResource.table(ks, tab));
+        assertPermissionsCacheDoesNotContains(role1, DataResource.table(ks, tab));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
     }
 
     @Test
     public void testInvalidationOnDropRole() throws Throwable
     {
-        // Checks that the user has no SELECT permissions on tab2
-        useUser(user1.getRoleName(), userPw);
+        populateAndCheckCaches();
 
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        // Checks that the user has no SELECT permissions on tab2
+        assertSelectNotAllowed(user1, ks, tab2);
+        assertSelectNotAllowed(role1, ks, tab2);
+        assertSelectNotAllowed(role2, ks, tab2);
 
         // Checks that the caches have been populated by the query.
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Create new ROLE with SELECT permission on tab2 and grant it to the user
         useSuperUser();
 
-        executeNet("CREATE ROLE " + role3.getRoleName());
+        createRole(role3);
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
         executeNet("GRANT " + role3.getRoleName() + " TO " + user1.getRoleName());
 
@@ -213,13 +248,14 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheDoesNotContains(role3);
 
         assertPermissionsCacheDoesNotContains(user1);
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheDoesNotContains(role2, DataResource.keyspace(ks));
         assertPermissionsCacheDoesNotContains(role3);
 
         // Checks the the user is now allowed to perform the query
-        useUser(user1.getRoleName(), userPw);
-        executeNet("SELECT * FROM " + ks + '.' + tab2);
+        assertSelectAllowed(user1, ks, tab2);
+        assertSelectNotAllowed(role2, ks, tab2);
+        assertSelectAllowed(role3, ks, tab2);
 
         // Checks that the caches have been populated by the query correctly.
         assertRolesCacheContains(user1, setOf(role1, role3));
@@ -227,9 +263,9 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheContains(role2, setOf());
         assertRolesCacheContains(role3, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
         assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
 
         // Drop the role3
@@ -243,19 +279,18 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheDoesNotContains(role3);
 
         assertPermissionsCacheDoesNotContains(user1);
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
         assertPermissionsCacheDoesNotContains(role3);
 
         // Re-create role3 without granting it to the user
-        executeNet("CREATE ROLE " + role3.getRoleName());
+        createRole(role3);
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
 
         // Checks that the user has no SELECT permissions on tab2
         useUser(user1.getRoleName(), userPw);
 
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
 
         // Checks the cache
         assertRolesCacheContains(user1, setOf(role1));
@@ -263,34 +298,33 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheContains(role2, setOf());
         assertRolesCacheDoesNotContains(role3);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheDoesNotContains(role2);
         assertPermissionsCacheDoesNotContains(role3);
     }
 
     @Test
     public void testInvalidationOnRevokeRole() throws Throwable
     {
+        populateAndCheckCaches();
+        
         // Checks that the user has no SELECT permissions on tab2
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
 
         // Checks that the caches have been populated by the query.
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Create new ROLE with SELECT permission on tab2 and grant it to the user
         useSuperUser();
 
-        executeNet("CREATE ROLE " + role3.getRoleName());
+        createRole(role3);
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
         executeNet("GRANT " + role3.getRoleName() + " TO " + user1.getRoleName());
 
@@ -301,13 +335,14 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheDoesNotContains(role3);
 
         assertPermissionsCacheDoesNotContains(user1);
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheDoesNotContains(role2);
         assertPermissionsCacheDoesNotContains(role3);
 
         // Checks the the user is now allowed to perform the query
-        useUser(user1.getRoleName(), userPw);
-        executeNet("SELECT * FROM " + ks + '.' + tab2);
+        assertSelectAllowed(user1, ks, tab2);
+        assertSelectNotAllowed(role2, ks, tab);
+        assertSelectAllowed(role3, ks, tab2);
 
         // Checks that the caches have been populated by the query correctly.
         assertRolesCacheContains(user1, setOf(role1, role3));
@@ -315,9 +350,9 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheContains(role2, setOf());
         assertRolesCacheContains(role3, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
         assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
 
         // Revoke the role3
@@ -331,102 +366,94 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheContains(role3, setOf());
 
         assertPermissionsCacheDoesNotContains(user1);
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
         assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
 
         // Checks that the user has no SELECT permissions on tab2
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
     }
 
     @Test
     public void testInvalidationOnDropRoleWithNonDirectChildren() throws Throwable
     {
+        populateAndCheckCaches();
+        
         // Checks that the user has no SELECT permissions on tab2
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
 
         // Checks that the caches have been populated by the query.
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Create new ROLE with SELECT permission on tab2 and grant it to the user
         useSuperUser();
 
-        executeNet("CREATE ROLE " + role3.getRoleName());
+        createRole(role3);
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
         executeNet("GRANT " + role3.getRoleName() + " TO " + role2.getRoleName());
 
-        // Checks that only the user1 has been removed from the caches
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
+        // Checks that all roles have been removed from the caches
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
         assertRolesCacheDoesNotContains(role2);
         assertRolesCacheDoesNotContains(role3);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
         assertPermissionsCacheDoesNotContains(role2);
         assertPermissionsCacheDoesNotContains(role3);
 
         // Checks the the user is now allowed to perform the query
-        useUser(user1.getRoleName(), userPw);
-        executeNet("SELECT * FROM " + ks + '.' + tab2);
+        assertSelectAllowed(user1, ks, tab2);
 
         // Checks that the caches have been populated by the query correctly.
         assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
-        assertRolesCacheContains(role2, setOf(role3));
-        assertRolesCacheContains(role3, setOf());
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheDoesNotContains(role2);
+        assertRolesCacheDoesNotContains(role3);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
-        assertPermissionsCacheContains(role3, permissionPerResource(DataResource.keyspace(ks), SELECT));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheDoesNotContains(role2);
+        assertPermissionsCacheDoesNotContains(role3);
 
         // Drop the role3
         useSuperUser();
         executeNet("DROP ROLE " + role3.getRoleName());
 
         // Checks that role3 and its direct children have been removed from the cache correctly.
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
         assertRolesCacheDoesNotContains(role2);
         assertRolesCacheDoesNotContains(role3);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
         assertPermissionsCacheDoesNotContains(role2);
         assertPermissionsCacheDoesNotContains(role3);
 
         // Re-create role3 without granting it to role2
-        executeNet("CREATE ROLE " + role3.getRoleName());
+        createRole(role3);
         executeNet("GRANT SELECT ON KEYSPACE " + ks + " TO " + role3.getRoleName());
 
         // Checks that the user has no SELECT permissions on tab2
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab2,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab2 + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab2);
 
         // Checks the cache
         assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
-        assertRolesCacheContains(role2, setOf());
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheDoesNotContains(role2);
         assertRolesCacheDoesNotContains(role3);
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, emptyPermissionPerResource(DataResource.table(ks, tab2)));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheDoesNotContains(role2);
         assertPermissionsCacheDoesNotContains(role3);
     }
 
@@ -440,17 +467,17 @@ public class AuthCacheInvalidationTest extends CQLTester
         assertRolesCacheContains(role2, setOf());
 
         // permissions are checked against all roles
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, UPDATE));
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(user1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role1, permissionPerResource(DataResource.table(ks, tab), SELECT, MODIFY));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
     }
 
     private void populateCaches() throws Throwable
     {
-        useUser(user1.getRoleName(), userPw);
-
-        // perform a query to populate the permissions cache for user1 and all assigned roles
-        executeNet("SELECT * FROM " + ks + '.' + tab);
+        String query = format("SELECT * FROM %s.%s", ks, tab);
+        executeIgnoreError(role1, query);
+        executeIgnoreError(role2, query);
+        executeIgnoreError(user1, query);
     }
 
     @Test
@@ -462,32 +489,31 @@ public class AuthCacheInvalidationTest extends CQLTester
 
         executeNet("DROP TABLE " + ks + '.' + tab);
 
-        // permissions were only granted to role1 - so only role1 needs to be invalidated
-        assertRolesCacheContains(user1, setOf(role1));
+        // permissions were only granted to role1 - so only role1 and user1 are invalidated
+        assertRolesCacheDoesNotContains(user1);
         assertRolesCacheDoesNotContains(role1);
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(user1);
         assertPermissionsCacheDoesNotContains(role1);
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
 
         // Re-create the dropped table
         execute("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
 
         // Checks that the user has no SELECT permissions on tab
-        useUser(user1.getRoleName(), userPw);
-
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
+        assertSelectNotAllowed(user1, ks, tab);
+        assertSelectNotAllowed(role1, ks, tab);
+        assertSelectNotAllowed(role2, ks, tab);
 
         // checks the caches
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, emptyMap());
-        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), UPDATE));
+        assertPermissionsCacheDoesNotContains(user1, DataResource.table(ks, tab));
+        assertPermissionsCacheDoesNotContains(role1, DataResource.table(ks, tab));
+        assertPermissionsCacheContains(role2, permissionPerResource(DataResource.keyspace(ks), MODIFY));
     }
 
     @Test
@@ -499,12 +525,12 @@ public class AuthCacheInvalidationTest extends CQLTester
 
         executeNet("DROP KEYSPACE " + ks);
 
-        // permissions were only granted to role1 - so only role1 needs to be invalidated
-        assertRolesCacheContains(user1, setOf(role1));
+        // permissions were only granted to role1 - so only role1 and user1 are invalidated
+        assertRolesCacheDoesNotContains(user1);
         assertRolesCacheDoesNotContains(role1);
         assertRolesCacheDoesNotContains(role2);
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheDoesNotContains(user1);
         assertPermissionsCacheDoesNotContains(role1);
         assertPermissionsCacheDoesNotContains(role2);
 
@@ -512,20 +538,20 @@ public class AuthCacheInvalidationTest extends CQLTester
         executeNet("CREATE KEYSPACE " + ks + " WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}");
         executeNet("CREATE TABLE " + ks + '.' + tab + " (id int PRIMARY KEY)");
 
-        // Checks that the user has no SELECT permissions on tab
-        useUser(user1.getRoleName(), userPw);
+        // Re-populate caches
+        populateCaches();
 
-        assertUnauthorized("SELECT * FROM " + ks + '.' + tab,
-                           "User " + user1.getRoleName() + " has no SELECT permission on <table " + ks + '.' + tab + "> or any of its parents");
+        // Checks that the user has no SELECT permissions on tab
+        assertSelectNotAllowed(user1, ks, tab);
 
         // checks the caches
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheContains(role1, emptyMap());
-        assertPermissionsCacheContains(role2, emptyMap());
+        assertPermissionsCacheDoesNotContains(user1);
+        assertPermissionsCacheDoesNotContains(role1);
+        assertPermissionsCacheDoesNotContains(role2);
     }
 
     @Test
@@ -547,21 +573,37 @@ public class AuthCacheInvalidationTest extends CQLTester
         IResource functionResource = FunctionResource.function(ks, func, Arrays.asList(Int32Type.instance, Int32Type.instance));
         IResource aggregateResource = FunctionResource.function(ks, aggr, Arrays.asList(Int32Type.instance));
 
-        Map<IResource, PermissionSets> role1Permissions = MapsFactory.newMap();
-        role1Permissions.put(DataResource.table(ks, tab), permissionSet(SELECT, UPDATE));
+        Map<IResource, Set<Permission>> role1Permissions = new HashMap<>();
+        role1Permissions.put(DataResource.table(ks, tab), permissionSet(SELECT, MODIFY));
         role1Permissions.put(aggregateResource, permissionSet(EXECUTE));
 
-        Map<IResource, PermissionSets> role2Permissions = MapsFactory.newMap();
-        role2Permissions.put(DataResource.keyspace(ks), permissionSet(UPDATE));
+        Map<IResource, Set<Permission>> role2Permissions = new HashMap<>();
+        role2Permissions.put(DataResource.keyspace(ks), permissionSet(MODIFY));
         role2Permissions.put(functionResource, permissionSet(EXECUTE));
 
+        Map<IResource, Set<Permission>> user1Permissions = new HashMap<>();
+        user1Permissions.put(DataResource.table(ks, tab), permissionSet(SELECT, MODIFY));
+        user1Permissions.put(aggregateResource, permissionSet(EXECUTE));
+        user1Permissions.put(functionResource, permissionSet(EXECUTE));
+
         populateCaches();
+        
+        String funcQuery = format("SELECT %s.%s(listen_port, listen_port) FROM system.local", ks, func);
+        assertQueryAllowed(user1, funcQuery);
+        assertQueryAllowed(role1, funcQuery);
+        assertQueryAllowed(role2, funcQuery);
+
+        String aggrQuery = format("SELECT %s.%s(listen_port) FROM system.local", ks, aggr);
+        assertQueryAllowed(user1, aggrQuery);
+        assertQueryAllowed(role1, aggrQuery);
+        String expected = format("User %s has no EXECUTE permission on <function %s.%s(int)> or any of its parents", role2.getRoleName(), ks, aggr);
+        assertQueryNotAllowed(role2, aggrQuery, expected);
 
         assertRolesCacheContains(user1, setOf(role1));
         assertRolesCacheContains(role1, setOf(role2));
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(user1, user1Permissions);
         assertPermissionsCacheContains(role1, role1Permissions);
         assertPermissionsCacheContains(role2, role2Permissions);
 
@@ -569,94 +611,164 @@ public class AuthCacheInvalidationTest extends CQLTester
 
         executeNet("DROP AGGREGATE " + ks + '.' + aggr + "(int)");
 
-        assertRolesCacheContains(user1, setOf(role1));
+        assertRolesCacheDoesNotContains(user1);
         assertRolesCacheDoesNotContains(role1);
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
-        assertPermissionsCacheDoesNotContains(role1);
+        role1Permissions.remove(aggregateResource);
+        user1Permissions.remove(aggregateResource);
+
+        assertPermissionsCacheContains(user1, user1Permissions);
+        assertPermissionsCacheDoesNotContains(user1, aggregateResource);
+        assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheDoesNotContains(role1, aggregateResource);
         assertPermissionsCacheContains(role2, role2Permissions);
 
         populateCaches();
 
-        role1Permissions.remove(aggregateResource);
-
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
         assertRolesCacheContains(role2, setOf());
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(user1, user1Permissions);
+        assertPermissionsCacheDoesNotContains(user1, aggregateResource);
         assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheDoesNotContains(role1, aggregateResource);
         assertPermissionsCacheContains(role2, role2Permissions);
 
         useSuperUser();
 
         executeNet("DROP FUNCTION " + ks + '.' + func + "(int,int)");
 
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
         assertRolesCacheDoesNotContains(role2);
 
-        assertPermissionsCacheContains(user1, emptyMap());
+        role2Permissions.remove(functionResource);
+        user1Permissions.remove(functionResource);
+
+        assertPermissionsCacheContains(user1, user1Permissions);
+        assertPermissionsCacheDoesNotContains(user1, functionResource);
         assertPermissionsCacheContains(role1, role1Permissions);
-        assertPermissionsCacheDoesNotContains(role2);
+        assertPermissionsCacheDoesNotContains(role1, functionResource);
+        assertPermissionsCacheDoesNotContains(role2, FunctionResource.function(ks, func, Arrays.asList(Int32Type.instance, Int32Type.instance)));
 
         populateCaches();
 
-        role2Permissions.remove(functionResource);
+        assertRolesCacheDoesNotContains(user1);
+        assertRolesCacheDoesNotContains(role1);
+        assertRolesCacheDoesNotContains(role2);
 
-        assertRolesCacheContains(user1, setOf(role1));
-        assertRolesCacheContains(role1, setOf(role2));
-        assertRolesCacheContains(role2, setOf());
-
-        assertPermissionsCacheContains(user1, emptyMap());
+        assertPermissionsCacheContains(user1, user1Permissions);
+        assertPermissionsCacheDoesNotContains(user1, functionResource);
         assertPermissionsCacheContains(role1, role1Permissions);
+        assertPermissionsCacheDoesNotContains(role1, functionResource);
         assertPermissionsCacheContains(role2, role2Permissions);
     }
 
-    private void assertUnauthorized(String query, String errorMessage) throws Throwable
+    private void assertSelectAllowed(RoleResource role, String ks, String table) throws Throwable
     {
+        assertQueryAllowed(role, format("SELECT * FROM %s.%s", ks, table));
+    }
+    
+    private void assertQueryAllowed(RoleResource role, String query) throws Throwable
+    {
+        useUser(role.getRoleName(), userPw);
+        executeNet(query);
+    }
+    
+    private void assertSelectNotAllowed(RoleResource role, String ks, String table) throws Throwable
+    {
+        String query = format("SELECT * FROM %s.%s", ks, table);
+        String expected = format("User %s has no SELECT permission on <table %s.%s> or any of its parents", role.getRoleName(), ks, table);
+        assertQueryNotAllowed(role, query, expected);
+    }
+
+    private void assertQueryNotAllowed(RoleResource role, String query, String expected) throws Throwable
+    {
+        useUser(role.getRoleName(), userPw);
         try
         {
             executeNet(query);
         }
         catch (UnauthorizedException e)
         {
-            assertEquals(errorMessage, e.getMessage());
+            assertEquals(expected, e.getMessage());
+        }
+    }
+    
+    private void executeIgnoreError(RoleResource role, String query) throws Throwable
+    {
+        useUser(role.getRoleName(), userPw);
+        try
+        {
+            executeNet(query);
+        }
+        catch (Exception e)
+        {
+            // ignore
         }
     }
 
     private static void assertRolesCacheContains(RoleResource resource, Set<RoleResource> memberOf)
     {
         tryWithBackoff(() -> {
-            Role role = DatabaseDescriptor.getAuthManager().rolesCache.getIfPresent(Pair.create(resource, null));
+            Set<Role> roles = Roles.cache.getIfPresent(resource);
+            assertNotNull("The role " + resource + " should be in the role cache but is not.", roles);
+
+            Role role = roles.stream().filter(r -> r.resource.equals(resource)).findFirst().orElse(null);
             assertNotNull("The role " + resource + " should be in the role cache but is not.", role);
-            assertEquals("The role " + resource + " is not a member of the expected roles.", memberOf, role.memberOf);
+
+            Set<String> memberOfStr = memberOf.stream().map(roleResource -> roleResource.getRoleName()).collect(Collectors.toSet());
+            assertEquals("The role " + resource + " is not a member of the expected roles.", memberOfStr, role.memberOf);
         });
     }
 
     private static void assertRolesCacheDoesNotContains(RoleResource resource)
     {
         tryWithBackoff(() -> {
-            Role role = DatabaseDescriptor.getAuthManager().rolesCache.getIfPresent(Pair.create(resource, null));
-            assertNull("The role " + resource + " is in the role cache but should not.", role);
+            Set<Role> roles = Roles.cache.getIfPresent(resource);
+            assertNull(format("The role %s is in the role cache but should not.", resource), roles);
         });
     }
 
-    private void assertPermissionsCacheContains(RoleResource resource, Map<IResource, PermissionSets> expectedPermissions)
+    private void assertPermissionsCacheContains(RoleResource roleResource, Map<IResource, Set<Permission>> expectedPermissions)
+    {
+        assertFalse("Pass emptyPermissionPerResource or use assertPermissionsCacheNotContains", expectedPermissions.isEmpty());
+        AuthenticatedUser authUser = new AuthenticatedUser(roleResource.getRoleName());
+        for (Map.Entry<IResource, Set<Permission>> entry : expectedPermissions.entrySet())
+        {
+            assertPermissionsCacheContains(authUser, entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void assertPermissionsCacheContains(AuthenticatedUser user, IResource resource, Set<Permission> expectedPermissions)
     {
         tryWithBackoff(() -> {
-            Map<IResource, PermissionSets> actual = DatabaseDescriptor.getAuthManager().permissionsCache.getIfPresent(Pair.create(resource, null));
-            assertNotNull("The resource " + resource + " is not in the permissions cache.", actual);
-            assertEquals("The expected permissions for the role " + resource + " do not match the ones of the permissions cache.", expectedPermissions, actual);
+            Set<Permission> actual = AuthenticatedUser.permissionsCache.getIfPresent(Pair.create(user, resource));
+            assertNotNull("AuthUser " + user + " resource " + resource + " is not in the permissions cache.", actual);
+            assertEquals("The expected permissions for user " + user + " resource " + resource + " do not match the ones of the permissions cache.", expectedPermissions, actual);
         });
     }
 
     private void assertPermissionsCacheDoesNotContains(RoleResource resource)
     {
+        assertPermissionsCacheDoesNotContains(resource, null);
+    }
+    
+    private void assertPermissionsCacheDoesNotContains(RoleResource roleResource, IResource resource)
+    {
         tryWithBackoff(() -> {
-            Map<IResource, PermissionSets> permissions = DatabaseDescriptor.getAuthManager().permissionsCache.getIfPresent(Pair.create(resource, null));
-            assertNull("The role " + resource + " has some permissions int the cache.", permissions);
+            AuthenticatedUser user = new AuthenticatedUser(roleResource.getRoleName());
+            Set<Map.Entry<Pair<AuthenticatedUser, IResource>, Set<Permission>>> entries = 
+            AuthenticatedUser.permissionsCache.cache.asMap().entrySet().stream().filter(entry -> {
+                boolean userMatches = Objects.equals(entry.getKey().left(), user);
+                boolean resourceMatches = resource == null || Objects.equals(entry.getKey().right, resource);
+                boolean permissionsNotEmpty = !entry.getValue().isEmpty();
+                return userMatches && resourceMatches && permissionsNotEmpty;
+            }).collect(Collectors.toSet());
+            String message = format("The role %s has %s permissions in the cache: %s", roleResource, resource == null ? "" : resource, entries);
+            assertFalse(message, !entries.isEmpty());
         });
     }
 
@@ -695,18 +807,21 @@ public class AuthCacheInvalidationTest extends CQLTester
         return new HashSet<>(Arrays.asList(elem));
     }
 
-    private static Map<IResource, PermissionSets> permissionPerResource(IResource resource, Permission... granted)
+    private static Map<IResource, Set<Permission>> emptyPermissionPerResource(IResource resource)
     {
+        return Collections.singletonMap(resource, ImmutableSet.of());
+    }
+
+    private static Map<IResource, Set<Permission>> permissionPerResource(IResource resource, Permission... granted)
+    {
+        assertTrue("Use emptyPermissionPerResource", granted.length > 0);
         return Collections.singletonMap(resource, permissionSet(granted));
     }
 
-    private static PermissionSets permissionSet(Permission... granted)
+    private static Set<Permission> permissionSet(Permission... granted)
     {
-        PermissionSets.Builder builder = PermissionSets.builder();
-        for (Permission permission : granted)
-        {
-            builder.addGranted(permission);
-        }
-        return builder.build();
+        Set<Permission> permissions = new HashSet<>();
+        Collections.addAll(permissions, granted);
+        return permissions;
     }
 }

--- a/test/unit/org/apache/cassandra/auth/CassandraNetworkAuthorizerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraNetworkAuthorizerTest.java
@@ -160,7 +160,7 @@ public class CassandraNetworkAuthorizerTest
         AuthenticationStatement authStmt = (AuthenticationStatement) statement;
 
         // invalidate roles cache so that any changes to the underlying roles are picked up
-        Roles.clearCache();
+        Roles.cache.invalidate();
         authStmt.execute(getClientState());
     }
 
@@ -231,7 +231,7 @@ public class CassandraNetworkAuthorizerTest
         assertDcPermRow(username, "dc1");
 
         // clear the roles cache to lose the (non-)superuser status for the user
-        Roles.clearCache();
+        Roles.cache.invalidate();
         auth("ALTER ROLE %s WITH superuser = true", username);
         Assert.assertEquals(DCPermissions.all(), dcPerms(username));
     }

--- a/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
@@ -58,7 +58,7 @@ public class PreparedStatementsTest extends CQLTester
     @Test
     public void testInvalidatePreparedStatementsOnDrop()
     {
-        Session session = sessions.get(ProtocolVersion.V5);
+        Session session = sessionNet(ProtocolVersion.V5);
         session.execute(dropKsStatement);
         session.execute(createKsStatement);
 
@@ -102,7 +102,7 @@ public class PreparedStatementsTest extends CQLTester
 
     private void testInvalidatePreparedStatementOnAlter(ProtocolVersion version, boolean supportsMetadataChange)
     {
-        Session session = sessions.get(version);
+        Session session = sessionNet(version);
         String createTableStatement = "CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".qp_cleanup (a int PRIMARY KEY, b int, c int);";
         String alterTableStatement = "ALTER TABLE " + KEYSPACE + ".qp_cleanup ADD d int;";
 
@@ -162,7 +162,7 @@ public class PreparedStatementsTest extends CQLTester
 
     private void testInvalidatePreparedStatementOnAlterUnchangedMetadata(ProtocolVersion version)
     {
-        Session session = sessions.get(version);
+        Session session = sessionNet(version);
         String createTableStatement = "CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".qp_cleanup (a int PRIMARY KEY, b int, c int);";
         String alterTableStatement = "ALTER TABLE " + KEYSPACE + ".qp_cleanup ADD d int;";
 
@@ -200,7 +200,7 @@ public class PreparedStatementsTest extends CQLTester
     @Test
     public void testStatementRePreparationOnReconnect()
     {
-        Session session = sessions.get(ProtocolVersion.V5);
+        Session session = sessionNet(ProtocolVersion.V5);
         session.execute("USE " + keyspace());
 
         session.execute(dropKsStatement);
@@ -241,7 +241,7 @@ public class PreparedStatementsTest extends CQLTester
     @Test
     public void prepareAndExecuteWithCustomExpressions() throws Throwable
     {
-        Session session = sessions.get(ProtocolVersion.V5);
+        Session session = sessionNet(ProtocolVersion.V5);
 
         session.execute(dropKsStatement);
         session.execute(createKsStatement);

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestSizeMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestSizeMetricsTest.java
@@ -70,6 +70,9 @@ public class ClientRequestSizeMetricsTest extends CQLTester
         try
         {
             reinitializeNetwork(builder -> builder.withQueryOptions(new QueryOptions().setMetadataEnabled(false)));
+            // Establish session before executing queries
+            sessionNet(version);
+            
             // We want to ignore all the messages sent by the driver upon connection as well as
             // the event sent upon schema updates
             clearMetrics();


### PR DESCRIPTION
STAR-590 port of DB-1716

Note that in the first commit `AuthCacheInvalidationTest` was ported as is. Then in [commit cf440c4](https://github.com/datastax/cassandra/pull/207/commits/cf440c4e455b55416c4be3742b4a760182764c71) I made changes making it possible to see changes made during porting.
