### PR TITLE
STAR-687: materialized views' WHERE clauses stored in the schema should reference quoted functions when necessary

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/FunctionCall.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FunctionCall.java
@@ -227,7 +227,9 @@ public class FunctionCall extends Term.NonTerminal
 
         public String getText()
         {
-            return name + terms.stream().map(Term.Raw::getText).collect(Collectors.joining(", ", "(", ")"));
+            CqlBuilder cqlNameBuilder = new CqlBuilder();
+            name.appendCqlTo(cqlNameBuilder);
+            return cqlNameBuilder + terms.stream().map(Term.Raw::getText).collect(Collectors.joining(", ", "(", ")"));
         }
     }
 }


### PR DESCRIPTION
Co-authored-by: Andrés de la Peña <a.penya.garcia@gmail.com>