### PR TITLE
STAR-815: MultiRangeReadCommand on by default and remove info log in query path

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.schema.TableMetadata;
 
 public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
 {
-    private static final boolean USE_MULTI_RANGE_READ_COMMAND = Boolean.parseBoolean(System.getProperty("cassandra.sai.use_multi_range_read_command", "false"));
     private final ColumnFamilyStore cfs;
     private final TableQueryMetrics queryMetrics;
     private final RowFilter postIndexFilter;
@@ -137,6 +136,6 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     @Override
     public boolean supportsMultiRangeReadCommand()
     {
-        return USE_MULTI_RANGE_READ_COMMAND;
+        return true;
     }
 }


### PR DESCRIPTION
This patch also sets the `rangeFetched` flag in the `ShortReadPartitionsProtection.applyToPartition` method. The `rangeFetched` flag is used by the `EndpointGroupingCoordinator.EndpointShortReadResponseProtection.rangeExhausted` method to check if the range was fetched by short read protection or by the original read command. This should have been set in the `applyToPartition` method, indicating that the range was read by the original read command but was missed out in the original PR for STAR-184.