### PR TITLE
STAR-847 Close client to prevent driver queries after dropping user

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1129,7 +1129,7 @@ public abstract class CQLTester
                                         userProto -> initClientCluster(user, protocolVersion));
     }
 
-    private static Cluster initClientCluster(User user, ProtocolVersion version)
+    private Cluster initClientCluster(User user, ProtocolVersion version)
     {
         Pair<User, ProtocolVersion> key = Pair.create(user, version);
         Cluster cluster = clusters.get(key);
@@ -1141,9 +1141,37 @@ public abstract class CQLTester
             builder.withCredentials(user.username, user.password);
         cluster = builder.build();
 
-        logger.info("Started Java Driver instance for protocol version {}", version);
+        logger.info("Started Java Driver session for {} with protocol version {}", user, version);
 
         return cluster;
+    }
+
+    protected void closeClientCluster(String username, String password)
+    {
+        // Close driver cluster belonging to user
+        User user = new User(username, password);
+        for (ProtocolVersion protocolVersion : PROTOCOL_VERSIONS)
+        {
+            closeClientCluster(user, protocolVersion);
+        }
+    }
+
+    private void closeClientCluster(User user, ProtocolVersion protocolVersion)
+    {
+        Pair<User, ProtocolVersion> key = Pair.create(user, protocolVersion);
+        Session session = sessions.remove(key);
+        if (session != null)
+        {
+            session.close();
+        }
+        
+        Cluster cluster = clusters.remove(key);
+        if (cluster != null)
+        {
+            cluster.close();
+        }
+
+        logger.info("Closed Java Driver session for {} with protocol version {}", user, protocolVersion);
     }
 
     public static Cluster.Builder clusterBuilder(ProtocolVersion version)
@@ -2278,6 +2306,11 @@ public abstract class CQLTester
 
             return Objects.equal(username, u.username)
                    && Objects.equal(password, u.password);
+        }
+
+        public String toString()
+        {
+            return username;
         }
     }
 }

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailTester.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.guardrails;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
@@ -32,7 +31,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -40,7 +38,6 @@ import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
-import org.awaitility.Awaitility;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -83,13 +80,6 @@ public abstract class GuardrailTester extends CQLTester
         executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USERNAME, PASSWORD));
         executeNet(format("GRANT ALL ON KEYSPACE %s TO %s", KEYSPACE, USERNAME));
 
-        // Make sure keyspace permissions have been applied
-        Awaitility.await()
-                  .atMost(10, TimeUnit.SECONDS)
-                  .with()
-                  .pollInterval(500, TimeUnit.MILLISECONDS)
-                  .until(() -> !executeNet(new SimpleStatement("LIST ALL OF " + USERNAME)).all().isEmpty());
-        
         useUser(USERNAME, PASSWORD);
 
         listener = new TestListener(null);
@@ -103,6 +93,8 @@ public abstract class GuardrailTester extends CQLTester
     public void afterGuardrailTest() throws Throwable
     {
         Guardrails.unregister(listener);
+
+        closeClientCluster(USERNAME, PASSWORD);
 
         useSuperUser();
         executeNet("DROP USER " + USERNAME);


### PR DESCRIPTION
STAR-847 guardrail unit tests sometimes fail with `User guardrail_user has no SELECT permission on <table cql_test_keyspace.table_01> or any of its parents`

The `GuardrailTester. afterGuardrailTest` method drops the test user after each test, however the java driver cluster/session remains open. If the timing is right, the driver control connection will issue queries as the test user *after* the user has been dropped, and this can result in an empty entry in the Roles cache. If that entry does not expire before the next test starts and the test user is created again, the empty entry will result in no permissions being recognized for the user.

A previous attempt to fix the issue - issuing a LIST ROLES query and waiting for results - didn't actually go through the Roles cache, so wasn't effective and is removed here.

This fix closes the driver cluster/session belonging to the test user when the test user is dropped, preventing bad entries from getting into the Roles cache.
