### PR TITLE
Simplify background compaction check initiation logic

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -195,9 +195,9 @@ public class CompactionManager implements CompactionManagerMBean
         return backgroundCompactionRunner.requestCompaction(cfs);
     }
 
-    public int getOngoingBackgroundCompactionsCount(ColumnFamilyStore cfs)
+    public int getOngoingBackgroundCompactionsCount()
     {
-        return backgroundCompactionRunner.getOngoingCompactionsCount(cfs);
+        return backgroundCompactionRunner.getOngoingCompactionsCount();
     }
 
     public boolean isCompacting(Iterable<ColumnFamilyStore> cfses, Predicate<SSTableReader> sstablePredicate)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsBytemanTest.java
@@ -141,11 +141,11 @@ public class CompactionsBytemanTest extends CQLTester
         cfs.enableAutoCompaction();
 
         execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", 0, 1, 1);
-        assertEquals(0, CompactionManager.instance.getOngoingBackgroundCompactionsCount(cfs));
+        assertEquals(0, CompactionManager.instance.getOngoingBackgroundCompactionsCount());
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
 
         FBUtilities.waitOnFuture(CompactionManager.instance.submitBackground(cfs));
-        assertEquals(0, CompactionManager.instance.getOngoingBackgroundCompactionsCount(cfs));
+        assertEquals(0, CompactionManager.instance.getOngoingBackgroundCompactionsCount());
     }
 
     private void createPossiblyExpiredSSTable(final ColumnFamilyStore cfs, final boolean expired) throws Throwable


### PR DESCRIPTION
Since we now have a global trigger that visits all marked CFSs, it no longer makes sense to have special treatment for CFSs that don't have running compactions (the check will be triggered for all once a thread frees up). Thus we can simplify the processing:
- we can simply abort the `run` method whenever we have enough scheduled compactions
- it makes better sense to trigger a run after individual compaction tasks complete

This patch also makes sure that the futures we return cannot be cancelled by the caller.