### PR TITLE
STAR-708: Port bug: DB-3162 - DSE fails to start with ERROR "Attempte…

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
@@ -126,7 +126,17 @@ public class CommitLogReader
         for (File file: filteredLogs)
         {
             i++;
-            readCommitLogSegment(handler, file, minPosition, ALL_MUTATIONS, i == filteredLogs.size());
+            try
+            {
+                readCommitLogSegment(handler, file, minPosition, ALL_MUTATIONS, i == filteredLogs.size());
+            }
+            catch (Throwable t)
+            {
+                logger.error("Error encountered reading commit log {}, which may indicate corruption. You may need to (re)move " +
+                             "this file and then restart the server followed by a repair operation to restore potentially corrupted " +
+                             "data from other replicas.", file.getName());
+                throw t;
+            }
         }
     }
 


### PR DESCRIPTION
…d serializing to buffer exceeded maximum of 65535 bytes"

Porting patch DB-3162 riptano/bdp#15599

Co-authored-by: Brandon Williams <driftx@gmail.com>