### PR TITLE
STAR-867 Fix resource management errors related to PrimaryKeyMap

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/IndexSearcher.java
@@ -134,7 +134,7 @@ public abstract class IndexSearcher implements Closeable
         {
             this.context = context;
             this.postingList = postingList;
-            this.primaryKeyMap = IndexSearcher.this.primaryKeyMap.copyOf();
+            this.primaryKeyMap = IndexSearcher.this.primaryKeyMap;
 
             minimumKey = this.primaryKeyMap.primaryKeyFromRowId(postingList.peek());
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/BKDReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/BKDReader.java
@@ -437,7 +437,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
         }
         finally
         {
-            FileUtils.closeQuietly(postingsFile);
+            FileUtils.closeQuietly(postingsFile, primaryKeyMap);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PostingsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PostingsReader.java
@@ -189,7 +189,7 @@ public class PostingsReader implements OrdinalPostingList
     public void close() throws IOException
     {
         listener.postingDecoded(postingsDecoded);
-        FileUtils.closeQuietly(input);
+        FileUtils.closeQuietly(input, primaryKeyMap);
         summary.close();
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
@@ -67,6 +67,11 @@ public class TermsReader implements Closeable
     private final long termDictionaryRoot;
     private final PrimaryKeyMap primaryKeyMap;
 
+    /**
+     * Creates a new TermsReader.
+     * The primaryKeyMap, termsData and postingLists passed to this constructor
+     * will become owned by this object and released by close().
+     */
     public TermsReader(IndexComponents components,
                        PrimaryKeyMap primaryKeyMap,
                        FileHandle termsData,
@@ -109,14 +114,7 @@ public class TermsReader implements Closeable
     @Override
     public void close()
     {
-        try
-        {
-            termDictionaryFile.close();
-        }
-        finally
-        {
-            postingsFile.close();
-        }
+        FileUtils.closeQuietly(termDictionaryFile, postingsFile, primaryKeyMap);
     }
 
     public TermsIterator allTerms(long segmentOffset, QueryEventListener.TrieIndexEventListener listener)

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -434,7 +434,7 @@ public final class FileUtils
         maybeFail(e, IOException.class);
     }
 
-    public static void closeQuietly(Closeable... cs)
+    public static void closeQuietly(AutoCloseable... cs)
     {
         closeQuietly(Arrays.asList(cs));
     }


### PR DESCRIPTION
Fixed FileHandle leaks caused by lack of proper closing of PrimaryKeyMap
in various places. Removed sharing of primaryKeyOffsets
between copies of PrimaryKeyMap.