### PR TITLE
STAR-865 Refactor and port metrics code from cndb

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -665,6 +665,7 @@
           </dependency>
             
           <dependency groupId="io.micrometer" artifactId="micrometer-core" version="1.5.5"/>
+          <dependency groupId="org.latencyutils" artifactId="LatencyUtils" version="2.0.3"/>
         </dependencyManagement>
         <developer id="adelapena" name="Andres de la Peña"/>
         <developer id="alakshman" name="Avinash Lakshman"/>
@@ -849,6 +850,7 @@
         <dependency groupId="org.jboss.byteman" artifactId="byteman-bmunit"/>
 
         <dependency groupId="io.micrometer" artifactId="micrometer-core"/>
+        <dependency groupId="org.latencyutils" artifactId="LatencyUtils"/>
       </artifact:pom>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -663,6 +663,8 @@
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">
             <exclusion groupId="junit" artifactId="junit"/>
           </dependency>
+            
+          <dependency groupId="io.micrometer" artifactId="micrometer-core" version="1.5.5"/>
         </dependencyManagement>
         <developer id="adelapena" name="Andres de la Peña"/>
         <developer id="alakshman" name="Avinash Lakshman"/>
@@ -845,6 +847,8 @@
         <dependency groupId="org.jboss.byteman" artifactId="byteman"/>
         <dependency groupId="org.jboss.byteman" artifactId="byteman-submit"/>
         <dependency groupId="org.jboss.byteman" artifactId="byteman-bmunit"/>
+
+        <dependency groupId="io.micrometer" artifactId="micrometer-core"/>
       </artifact:pom>
     </target>
 

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -145,7 +145,7 @@ public class ChunkCache
     private ChunkCache(BufferPool pool)
     {
         bufferPool = pool;
-        metrics = new ChunkCacheMetrics(this);
+        metrics = ChunkCacheMetrics.create(this);
         cache = Caffeine.newBuilder()
                         .maximumWeight(cacheSize)
                         .executor(MoreExecutors.directExecutor())

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -181,7 +181,13 @@ public enum CassandraRelevantProperties
     MBEAN_REGISTRATION_CLASS("org.apache.cassandra.mbean_registration_class"),
 
     /** Which class to use for failure detection */
-    CUSTOM_FAILURE_DETECTOR_PROPERTY("cassandra.custom_failure_detector_class");
+    CUSTOM_FAILURE_DETECTOR_PROPERTY("cassandra.custom_failure_detector_class"),
+
+    /** Set this property to true in order to switch to micrometer metrics */
+    USE_MICROMETER("cassandra.use_micrometer_metrics", "false"),
+
+    /** Which class to use for coordinator client request metrics */
+    CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY("cassandra.custom_client_request_metrics_provider_class");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
@@ -48,7 +48,7 @@ class RealEnvironment implements Environment
     @Override
     public double cacheMissRatio()
     {
-        double hitRate = ChunkCache.instance.metrics.hitRate.getValue();
+        double hitRate = ChunkCache.instance.metrics.hitRate();
         if (Double.isNaN(hitRate))
             return 1; // if the cache is not yet initialized then assume all requests are a cache miss
 

--- a/src/java/org/apache/cassandra/db/virtual/CachesTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CachesTable.java
@@ -21,6 +21,7 @@ import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.marshal.*;
 import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.metrics.CacheMetrics;
+import org.apache.cassandra.metrics.ChunkCacheMetrics;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.CacheService;
 
@@ -65,6 +66,19 @@ final class CachesTable extends AbstractVirtualTable
               .column(HIT_RATIO, metrics.hitRate.getValue())
               .column(RECENT_REQUEST_RATE_PER_SECOND, (long) metrics.requests.getFifteenMinuteRate())
               .column(RECENT_HIT_RATE_PER_SECOND, (long) metrics.hits.getFifteenMinuteRate());
+    }
+
+    private void addRow(SimpleDataSet result, String name, ChunkCacheMetrics metrics)
+    {
+        result.row(name)
+              .column(CAPACITY_BYTES, metrics.capacity())
+              .column(SIZE_BYTES, metrics.size())
+              .column(ENTRY_COUNT, metrics.entries())
+              .column(REQUEST_COUNT, metrics.requests())
+              .column(HIT_COUNT, metrics.hits())
+              .column(HIT_RATIO, metrics.hitRate())
+              .column(RECENT_REQUEST_RATE_PER_SECOND, metrics.requestsFifteenMinuteRate())
+              .column(RECENT_HIT_RATE_PER_SECOND, metrics.hitsFifteenMinuteRate());
     }
 
     public DataSet data()

--- a/src/java/org/apache/cassandra/metrics/CASClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CASClientRequestMetrics.java
@@ -30,19 +30,20 @@ public class CASClientRequestMetrics extends ClientRequestMetrics
     public final Counter unfinishedCommit;
     public final Meter unknownResult;
 
-    public CASClientRequestMetrics(String scope)
+    public CASClientRequestMetrics(String scope, String namePrefix)
     {
-        super(scope);
-        contention = Metrics.histogram(factory.createMetricName("ContentionHistogram"), false);
-        unfinishedCommit = Metrics.counter(factory.createMetricName("UnfinishedCommit"));
-        unknownResult = Metrics.meter(factory.createMetricName("UnknownResult"));
+        super(scope, namePrefix);
+
+        contention = Metrics.histogram(factory.createMetricName(namePrefix + "ContentionHistogram"), false);
+        unfinishedCommit = Metrics.counter(factory.createMetricName(namePrefix + "UnfinishedCommit"));
+        unknownResult = Metrics.meter(factory.createMetricName(namePrefix + "UnknownResult"));
     }
 
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("ContentionHistogram"));
-        Metrics.remove(factory.createMetricName("UnfinishedCommit"));
-        Metrics.remove(factory.createMetricName("UnknownResult"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ContentionHistogram"));
+        Metrics.remove(factory.createMetricName(namePrefix + "UnfinishedCommit"));
+        Metrics.remove(factory.createMetricName(namePrefix + "UnknownResult"));
     }
 }

--- a/src/java/org/apache/cassandra/metrics/CASClientWriteRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CASClientWriteRequestMetrics.java
@@ -36,20 +36,27 @@ public class CASClientWriteRequestMetrics extends CASClientRequestMetrics
 
     public final Counter conditionNotMet;
 
-    public CASClientWriteRequestMetrics(String scope)
+    /**
+     * Metric for tracking the number of CAS write (aka LWT) requests, rejected due to the threshold of maximum active LWTs being reached.
+     */
+    public final Counter overMaxPendingThreshold;
+
+    public CASClientWriteRequestMetrics(String scope, String namePrefix)
     {
-        super(scope);
-        mutationSize = Metrics.histogram(factory.createMetricName("MutationSizeHistogram"), false);
+        super(scope, namePrefix);
+        mutationSize = Metrics.histogram(factory.createMetricName(namePrefix + "MutationSizeHistogram"), false);
         // scope for this metric was changed in 4.0; adding backward compatibility
-        conditionNotMet = Metrics.counter(factory.createMetricName("ConditionNotMet"),
-                                          DefaultNameFactory.createMetricName("ClientRequest", "ConditionNotMet", "CASRead"));
+        conditionNotMet = Metrics.counter(factory.createMetricName(namePrefix + "ConditionNotMet"),
+                                          DefaultNameFactory.createMetricName("ClientRequest", namePrefix + "ConditionNotMet", "CASRead"));
+        overMaxPendingThreshold = Metrics.counter(factory.createMetricName(namePrefix + "OverMaxPendingThreshold"));
     }
 
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("ConditionNotMet"),
-                       DefaultNameFactory.createMetricName("ClientRequest", "ConditionNotMet", "CASRead"));
-        Metrics.remove(factory.createMetricName("MutationSizeHistogram"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ConditionNotMet"),
+                       DefaultNameFactory.createMetricName("ClientRequest", namePrefix + "ConditionNotMet", "CASRead"));
+        Metrics.remove(factory.createMetricName(namePrefix + "MutationSizeHistogram"));
+        Metrics.remove(factory.createMetricName(namePrefix + "OverMaxPendingThreshold"));
     }
 }

--- a/src/java/org/apache/cassandra/metrics/CacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CacheMetrics.java
@@ -66,26 +66,34 @@ public class CacheMetrics
     {
         factory = new DefaultNameFactory("Cache", type);
 
-        capacity = Metrics.register(factory.createMetricName("Capacity"), cache::capacity);
-        size = Metrics.register(factory.createMetricName("Size"), cache::weightedSize);
-        entries = Metrics.register(factory.createMetricName("Entries"), cache::size);
+        capacity = registerGauge("Capacity", cache::capacity);
+        size = registerGauge("Size", cache::weightedSize);
+        entries = registerGauge("Entries", cache::size);
 
-        hits = Metrics.meter(factory.createMetricName("Hits"));
-        misses = Metrics.meter(factory.createMetricName("Misses"));
-        requests = Metrics.meter(factory.createMetricName("Requests"));
+        requests = registerMeter("Requests");
 
-        hitRate =
-            Metrics.register(factory.createMetricName("HitRate"),
-                             ratioGauge(hits::getCount, requests::getCount));
-        oneMinuteHitRate =
-            Metrics.register(factory.createMetricName("OneMinuteHitRate"),
-                             ratioGauge(hits::getOneMinuteRate, requests::getOneMinuteRate));
-        fiveMinuteHitRate =
-            Metrics.register(factory.createMetricName("FiveMinuteHitRate"),
-                             ratioGauge(hits::getFiveMinuteRate, requests::getFiveMinuteRate));
-        fifteenMinuteHitRate =
-            Metrics.register(factory.createMetricName("FifteenMinuteHitRate"),
-                             ratioGauge(hits::getFifteenMinuteRate, requests::getFifteenMinuteRate));
+        hits = registerMeter("Hits");
+        misses = registerMeter("Misses");
+
+        hitRate = registerGauge("HitRate", ratioGauge(hits::getCount, requests::getCount));
+        oneMinuteHitRate = registerGauge("OneMinuteHitRate", ratioGauge(hits::getOneMinuteRate, requests::getOneMinuteRate));
+        fiveMinuteHitRate = registerGauge("FiveMinuteHitRate", ratioGauge(hits::getFiveMinuteRate, requests::getFiveMinuteRate));
+        fifteenMinuteHitRate = registerGauge("FifteenMinuteHitRate", ratioGauge(hits::getFifteenMinuteRate, requests::getFifteenMinuteRate));
+    }
+
+    protected final <T> Gauge<T> registerGauge(String name, Gauge<T> gauge)
+    {
+        return Metrics.register(factory.createMetricName(name), gauge);
+    }
+
+    protected final Meter registerMeter(String name)
+    {
+        return Metrics.meter(factory.createMetricName(name));
+    }
+
+    protected final Timer registerTimer(String name)
+    {
+        return Metrics.timer(factory.createMetricName(name));
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
@@ -28,14 +28,13 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import org.apache.cassandra.cache.ChunkCache;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.USE_MICROMETER;
+
 public interface ChunkCacheMetrics extends StatsCounter
 {
-    /** Set this property to true in order to switch to micrometer metrics */
-    boolean USE_MICROMETER = Boolean.getBoolean(System.getProperty("cassandra.use_micrometer_metrics", "false"));
-
     static ChunkCacheMetrics create(ChunkCache cache)
     {
-        return USE_MICROMETER ? new MicrometerChunkCacheMetrics(cache) : new CodahaleChunkCacheMetrics(cache);
+        return USE_MICROMETER.getBoolean() ? new MicrometerChunkCacheMetrics(cache) : new CodahaleChunkCacheMetrics(cache);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,79 +8,75 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.apache.cassandra.metrics;
 
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
-import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import org.apache.cassandra.cache.ChunkCache;
 
-import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
-
-/**
- * Metrics for {@code ICache}.
- */
-public class ChunkCacheMetrics extends CacheMetrics implements StatsCounter
+public interface ChunkCacheMetrics extends StatsCounter
 {
-    /** Latency of misses */
-    public final Timer missLatency;
+    /** Set this property to true in order to switch to micrometer metrics */
+    boolean USE_MICROMETER = Boolean.getBoolean(System.getProperty("cassandra.use_micrometer_metrics", "false"));
 
-    /**
-     * Create metrics for the provided chunk cache.
-     *
-     * @param cache Chunk cache to measure metrics
-     */
-    public ChunkCacheMetrics(ChunkCache cache)
+    static ChunkCacheMetrics create(ChunkCache cache)
     {
-        super("ChunkCache", cache);
-        missLatency = Metrics.timer(factory.createMetricName("MissLatency"));
+        return USE_MICROMETER ? new MicrometerChunkCacheMetrics(cache) : new CodahaleChunkCacheMetrics(cache);
     }
 
     @Override
-    public void recordHits(int count)
-    {
-        requests.mark(count);
-        hits.mark(count);
-    }
+    void recordHits(int count);
 
     @Override
-    public void recordMisses(int count)
-    {
-        requests.mark(count);
-        misses.mark(count);
-    }
+    void recordMisses(int count);
 
     @Override
-    public void recordLoadSuccess(long loadTime)
-    {
-        missLatency.update(loadTime, TimeUnit.NANOSECONDS);
-    }
+    void recordLoadSuccess(long loadTime);
 
     @Override
-    public void recordLoadFailure(long loadTime)
-    {
-    }
+    void recordLoadFailure(long loadTime);
 
     @Override
-    public void recordEviction()
-    {
-    }
+    void recordEviction();
+
+    double hitRate();
+
+    long requests();
+
+    long misses();
+
+    long hits();
+
+    double missLatency();
+
+    long capacity();
+
+    long size();
+    
+    long entries();
+
+    long requestsFifteenMinuteRate();
+
+    long hitsFifteenMinuteRate();
 
     @Nonnull
     @Override
-    public CacheStats snapshot()
-    {
-        return new CacheStats(hits.getCount(), misses.getCount(), missLatency.getCount(), 0L, missLatency.getCount(), 0L, 0L);
-    }
+    CacheStats snapshot();
+
+    @VisibleForTesting
+    void reset();
 }

--- a/src/java/org/apache/cassandra/metrics/ClientRangeRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRangeRequestMetrics.java
@@ -33,15 +33,15 @@ public class ClientRangeRequestMetrics extends ClientRequestMetrics
      */
     public final Histogram roundTrips;
 
-    public ClientRangeRequestMetrics(String scope)
+    public ClientRangeRequestMetrics(String scope, String namePrefix)
     {
-        super(scope);
-        roundTrips = Metrics.histogram(factory.createMetricName("RoundTripsPerReadHistogram"), false);
+        super(scope, namePrefix);
+        roundTrips = Metrics.histogram(factory.createMetricName(namePrefix + "RoundTripsPerReadHistogram"), false);
     }
 
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("RoundTripsPerReadHistogram"));
+        Metrics.remove(factory.createMetricName(namePrefix + "RoundTripsPerReadHistogram"));
     }
 }

--- a/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
@@ -32,20 +32,20 @@ public class ClientRequestMetrics extends LatencyMetrics
     public final Meter unavailables;
     public final Meter failures;
 
-    public ClientRequestMetrics(String scope)
+    public ClientRequestMetrics(String scope, String namePrefix)
     {
-        super("ClientRequest", scope);
+        super("ClientRequest", namePrefix, scope);
 
-        timeouts = Metrics.meter(factory.createMetricName("Timeouts"));
-        unavailables = Metrics.meter(factory.createMetricName("Unavailables"));
-        failures = Metrics.meter(factory.createMetricName("Failures"));
+        timeouts = Metrics.meter(factory.createMetricName(namePrefix + "Timeouts"));
+        unavailables = Metrics.meter(factory.createMetricName(namePrefix + "Unavailables"));
+        failures = Metrics.meter(factory.createMetricName(namePrefix + "Failures"));
     }
 
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("Timeouts"));
-        Metrics.remove(factory.createMetricName("Unavailables"));
-        Metrics.remove(factory.createMetricName("Failures"));
+        Metrics.remove(factory.createMetricName(namePrefix + "Timeouts"));
+        Metrics.remove(factory.createMetricName(namePrefix + "Unavailables"));
+        Metrics.remove(factory.createMetricName(namePrefix + "Failures"));
     }
 }

--- a/src/java/org/apache/cassandra/metrics/ClientWriteRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientWriteRequestMetrics.java
@@ -33,15 +33,15 @@ public class ClientWriteRequestMetrics extends ClientRequestMetrics
      */
     public final Histogram mutationSize;
 
-    public ClientWriteRequestMetrics(String scope)
+    public ClientWriteRequestMetrics(String scope, String namePrefix)
     {
-        super(scope);
-        mutationSize = Metrics.histogram(factory.createMetricName("MutationSizeHistogram"), false);
+        super(scope, namePrefix);
+        mutationSize = Metrics.histogram(factory.createMetricName(namePrefix + "MutationSizeHistogram"), false);
     }
 
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("MutationSizeHistogram"));
+        Metrics.remove(factory.createMetricName(namePrefix + "MutationSizeHistogram"));
     }
 }

--- a/src/java/org/apache/cassandra/metrics/CodahaleChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodahaleChunkCacheMetrics.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.codahale.metrics.Timer;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.utils.FBUtilities;
 
 /**
  * Codahale implementation for the chunk cache metrics.
@@ -51,12 +52,14 @@ public class CodahaleChunkCacheMetrics implements ChunkCacheMetrics
     @Override
     public void recordHits(int count)
     {
+        metrics.requests.mark(count);
         metrics.hits.mark(count);
     }
 
     @Override
     public void recordMisses(int count)
     {
+        metrics.requests.mark(count);
         metrics.misses.mark(count);
     }
 
@@ -91,7 +94,7 @@ public class CodahaleChunkCacheMetrics implements ChunkCacheMetrics
     @Override
     public long misses()
     {
-        return missLatency.getCount();
+        return metrics.misses.getCount();
     }
 
     @Override
@@ -145,7 +148,20 @@ public class CodahaleChunkCacheMetrics implements ChunkCacheMetrics
     @VisibleForTesting
     public void reset()
     {
-        metrics.hits.mark(-metrics.hits.getCount());
-        metrics.misses.mark(-metrics.misses.getCount());
+        metrics.reset();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Chunk cache metrics: " + System.lineSeparator() +
+               "Miss latency in seconds: " + missLatency() + System.lineSeparator() +
+               "Misses count: " + misses() + System.lineSeparator() +
+               "Hits count: " + hits() + System.lineSeparator() +
+               "Cache requests count: " + requests() + System.lineSeparator() +
+               "Moving hit rate: " + hitRate() + System.lineSeparator() +
+               "Num entries: " + entries() + System.lineSeparator() +
+               "Size in memory: " + FBUtilities.prettyPrintMemory(size()) + System.lineSeparator() +
+               "Capacity: " + FBUtilities.prettyPrintMemory(capacity());
     }
 }

--- a/src/java/org/apache/cassandra/metrics/CodahaleChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodahaleChunkCacheMetrics.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.codahale.metrics.Timer;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.apache.cassandra.cache.ChunkCache;
+
+/**
+ * Codahale implementation for the chunk cache metrics.
+ */
+public class CodahaleChunkCacheMetrics implements ChunkCacheMetrics
+{
+    /** Metrics in common with ICache implementations */
+    private final CacheMetrics metrics;
+
+    /** Latency of misses */
+    public final Timer missLatency;
+
+    /**
+     * Create metrics for the provided chunk cache.
+     *
+     * @param cache Chunk cache to measure metrics
+     */
+    CodahaleChunkCacheMetrics(ChunkCache cache)
+    {
+        metrics = new CacheMetrics("ChunkCache", cache);
+        missLatency = metrics.registerTimer("MissLatency");
+    }
+
+    @Override
+    public void recordHits(int count)
+    {
+        metrics.hits.mark(count);
+    }
+
+    @Override
+    public void recordMisses(int count)
+    {
+        metrics.misses.mark(count);
+    }
+
+    @Override
+    public void recordLoadSuccess(long loadTime)
+    {
+        missLatency.update(loadTime, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void recordLoadFailure(long loadTime)
+    {
+    }
+
+    @Override
+    public void recordEviction()
+    {
+    }
+
+    @Override
+    public double hitRate()
+    {
+        return metrics.hitRate.getValue();
+    }
+
+    @Override
+    public long requests()
+    {
+        return metrics.requests.getCount();
+    }
+
+    @Override
+    public long misses()
+    {
+        return missLatency.getCount();
+    }
+
+    @Override
+    public long hits()
+    {
+        return metrics.hits.getCount();
+    }
+
+    @Override
+    public double missLatency()
+    {
+        return missLatency.getOneMinuteRate();
+    }
+
+    @Override
+    public long capacity()
+    {
+        return metrics.capacity.getValue();
+    }
+
+    @Override
+    public long size()
+    {
+        return metrics.size.getValue();
+    }
+
+    @Override
+    public long entries()
+    {
+        return metrics.entries.getValue();
+    }
+
+    public long requestsFifteenMinuteRate()
+    {
+        return (long) metrics.requests.getFifteenMinuteRate();
+    }
+
+    public long hitsFifteenMinuteRate()
+    {
+        return (long) metrics.hits.getFifteenMinuteRate();
+    }
+
+    @Nonnull
+    @Override
+    public CacheStats snapshot()
+    {
+        return new CacheStats(metrics.hits.getCount(), metrics.misses.getCount(), missLatency.getCount(), 0L, missLatency.getCount(), 0L, 0L);
+    }
+
+    @Override
+    @VisibleForTesting
+    public void reset()
+    {
+        metrics.hits.mark(-metrics.hits.getCount());
+        metrics.misses.mark(-metrics.misses.getCount());
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetrics.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+
+public class CoordinatorClientRequestMetrics
+{
+    public final ClientRequestMetrics readMetrics;
+    public final ClientRangeRequestMetrics rangeMetrics;
+    public final ClientWriteRequestMetrics writeMetrics;
+    public final CASClientWriteRequestMetrics casWriteMetrics;
+    public final CASClientRequestMetrics casReadMetrics;
+    public final ViewWriteMetrics viewWriteMetrics;
+    public final Map<ConsistencyLevel, ClientRequestMetrics> readMetricsMap;
+    public final Map<ConsistencyLevel, ClientWriteRequestMetrics> writeMetricsMap;
+
+    public CoordinatorClientRequestMetrics()
+    {
+        this("");
+    }
+
+    /**
+     * CassandraMetricsRegistry requires unique metrics name, otherwise it returns previous metrics.
+     * CNDB will create coordinator metrics with unique name prefix for each tenant
+     */
+    public CoordinatorClientRequestMetrics(String namePrefix)
+    {
+        readMetrics = new ClientRequestMetrics("Read", namePrefix);
+        rangeMetrics = new ClientRangeRequestMetrics("RangeSlice", namePrefix);
+        writeMetrics = new ClientWriteRequestMetrics("Write", namePrefix);
+        casWriteMetrics = new CASClientWriteRequestMetrics("CASWrite", namePrefix);
+        casReadMetrics = new CASClientRequestMetrics("CASRead", namePrefix);
+        viewWriteMetrics = new ViewWriteMetrics("ViewWrite", namePrefix);
+        readMetricsMap = new EnumMap<>(ConsistencyLevel.class);
+        writeMetricsMap = new EnumMap<>(ConsistencyLevel.class);
+
+        for (ConsistencyLevel level : ConsistencyLevel.values())
+        {
+            readMetricsMap.put(level, new ClientRequestMetrics("Read-" + level.name(), namePrefix));
+            writeMetricsMap.put(level, new ClientWriteRequestMetrics("Write-" + level.name(), namePrefix));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetricsProvider.java
+++ b/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetricsProvider.java
@@ -19,16 +19,17 @@
 package org.apache.cassandra.metrics;
 
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY;
+
 /**
  * Provides access to the {@link CoordinatorClientRequestMetrics} instance used by this node
  * and provides per-tenant metrics in CNDB.
  */
 public interface CoordinatorClientRequestMetricsProvider
 {
-    String CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY = "cassandra.custom_client_request_metrics_provider_class";
-    CoordinatorClientRequestMetricsProvider instance = System.getProperty(CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY) == null ?
+    CoordinatorClientRequestMetricsProvider instance = CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY.getString() == null ?
                                                        new DefaultCoordinatorMetricsProvider() :
-                                                       make(System.getProperty(CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY));
+                                                       make(CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY.getString());
 
     CoordinatorClientRequestMetrics metrics(String keyspace);
 

--- a/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetricsProvider.java
+++ b/src/java/org/apache/cassandra/metrics/CoordinatorClientRequestMetricsProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+
+/**
+ * Provides access to the {@link CoordinatorClientRequestMetrics} instance used by this node
+ * and provides per-tenant metrics in CNDB.
+ */
+public interface CoordinatorClientRequestMetricsProvider
+{
+    String CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY = "cassandra.custom_client_request_metrics_provider_class";
+    CoordinatorClientRequestMetricsProvider instance = System.getProperty(CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY) == null ?
+                                                       new DefaultCoordinatorMetricsProvider() :
+                                                       make(System.getProperty(CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY));
+
+    CoordinatorClientRequestMetrics metrics(String keyspace);
+
+    static CoordinatorClientRequestMetricsProvider make(String customImpl)
+    {
+        try
+        {
+            return (CoordinatorClientRequestMetricsProvider) Class.forName(customImpl).newInstance();
+        }
+        catch (Throwable ex)
+        {
+            throw new IllegalStateException("Unknown client request metrics provider: " + customImpl);
+        }
+    }
+
+    class DefaultCoordinatorMetricsProvider implements CoordinatorClientRequestMetricsProvider
+    {
+        private final CoordinatorClientRequestMetrics metrics = new CoordinatorClientRequestMetrics();
+
+        @Override
+        public CoordinatorClientRequestMetrics metrics(String keyspace)
+        {
+            return metrics;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
@@ -47,9 +47,9 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
     public static final String CHUNK_CACHE_SIZE = "chunk_cache_size";
     public static final String CHUNK_CACHE_NUM_ENTRIES = "chunk_cache_num_entries";
     public static final String CHUNK_CACHE_HIT_RATE = "chunk_cache_hit_rate";
-    public static final String CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS = "chunk_cache_not_in_cache_exceptions";
 
-    private final static long hitRateUpdateInterval = TimeUnit.MILLISECONDS.toNanos(100);
+    @VisibleForTesting
+    protected final static long hitRateUpdateInterval = TimeUnit.MILLISECONDS.toNanos(100);
 
     private final CacheSize cache;
     private final MovingAverage hitRate;
@@ -60,7 +60,6 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
     private volatile Counter hits;
     private volatile Counter requests;
     private volatile Counter evictions;
-    private volatile Counter notInCacheExceptions;
 
     MicrometerChunkCacheMetrics(CacheSize cache)
     {
@@ -73,7 +72,6 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
         this.hits = counter(CHUNK_CACHE_HITS);
         this.requests = counter(CHUNK_CACHE_REQUESTS);
         this.evictions = counter(CHUNK_CACHE_EVICTIONS);
-        this.notInCacheExceptions = counter(CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS);
     }
 
     @Override
@@ -91,7 +89,6 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
         this.hits = counter(CHUNK_CACHE_HITS);
         this.requests = counter(CHUNK_CACHE_REQUESTS);
         this.evictions = counter(CHUNK_CACHE_EVICTIONS);
-        this.notInCacheExceptions = counter(CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS);
     }
 
     @Override
@@ -224,17 +221,14 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
     @Override
     public String toString()
     {
-        String ret = "Chunk cache metrics: " + System.lineSeparator() +
-                "Miss latency in seconds: " + missLatency.mean(TimeUnit.SECONDS) + System.lineSeparator() +
-                "Misses count: " + misses.count() + System.lineSeparator() +
-                "Hits count: " + hits.count() + System.lineSeparator() +
-                "Cache requests count: " + requests.count() + System.lineSeparator() +
-                "Moving hit rate: " + hitRate.get() + System.lineSeparator() +
-                "NotInCacheExceptions: " + notInCacheExceptions.count() + System.lineSeparator() +
-                "Num entries: " + cache.size() + System.lineSeparator() +
-                "Size in memory: " + FBUtilities.prettyPrintMemory(cache.weightedSize()) + System.lineSeparator() +
-                "Capacity: " + FBUtilities.prettyPrintMemory(cache.capacity());
-
-        return ret;
+        return "Chunk cache metrics: " + System.lineSeparator() +
+               "Miss latency in seconds: " + missLatency() + System.lineSeparator() +
+               "Misses count: " + misses() + System.lineSeparator() +
+               "Hits count: " + hits() + System.lineSeparator() +
+               "Cache requests count: " + requests() + System.lineSeparator() +
+               "Moving hit rate: " + hitRate() + System.lineSeparator() +
+               "Num entries: " + entries() + System.lineSeparator() +
+               "Size in memory: " + FBUtilities.prettyPrintMemory(size()) + System.lineSeparator() +
+               "Capacity: " + FBUtilities.prettyPrintMemory(capacity());
     }
 }

--- a/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.cassandra.cache.CacheSize;
+import org.apache.cassandra.utils.ExpMovingAverage;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.MovingAverage;
+
+/**
+ * Micrometer implementation for the chunk cache metrics.
+ */
+public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements ChunkCacheMetrics
+{
+    public static final String CHUNK_CACHE_MISS_LATENCY = "chunk_cache_miss_latency_seconds";
+    public static final String CHUNK_CACHE_MISSES = "chunk_cache_misses";
+    public static final String CHUNK_CACHE_HITS = "chunk_cache_hits";
+    public static final String CHUNK_CACHE_REQUESTS = "chunk_cache_requests";
+    public static final String CHUNK_CACHE_EVICTIONS = "chunk_cache_evictions";
+    public static final String CHUNK_CACHE_CAPACITY = "chunk_cache_capacity";
+    public static final String CHUNK_CACHE_SIZE = "chunk_cache_size";
+    public static final String CHUNK_CACHE_NUM_ENTRIES = "chunk_cache_num_entries";
+    public static final String CHUNK_CACHE_HIT_RATE = "chunk_cache_hit_rate";
+    public static final String CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS = "chunk_cache_not_in_cache_exceptions";
+
+    private final static long hitRateUpdateInterval = TimeUnit.MILLISECONDS.toNanos(100);
+
+    private final CacheSize cache;
+    private final MovingAverage hitRate;
+    private final AtomicLong hitRateUpdateTime;
+
+    private volatile Timer missLatency;
+    private volatile Counter misses;
+    private volatile Counter hits;
+    private volatile Counter requests;
+    private volatile Counter evictions;
+    private volatile Counter notInCacheExceptions;
+
+    MicrometerChunkCacheMetrics(CacheSize cache)
+    {
+        this.cache = cache;
+        this.hitRate = ExpMovingAverage.decayBy1000();
+        this.hitRateUpdateTime = new AtomicLong(System.nanoTime());
+
+        this.missLatency = timer(CHUNK_CACHE_MISS_LATENCY);
+        this.misses = counter(CHUNK_CACHE_MISSES);
+        this.hits = counter(CHUNK_CACHE_HITS);
+        this.requests = counter(CHUNK_CACHE_REQUESTS);
+        this.evictions = counter(CHUNK_CACHE_EVICTIONS);
+        this.notInCacheExceptions = counter(CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS);
+    }
+
+    @Override
+    public synchronized void register(MeterRegistry newRegistry, Tags newTags)
+    {
+        super.register(newRegistry, newTags);
+
+        gauge(CHUNK_CACHE_CAPACITY, cache, CacheSize::capacity);
+        gauge(CHUNK_CACHE_SIZE, cache, CacheSize::weightedSize);
+        gauge(CHUNK_CACHE_NUM_ENTRIES, cache, CacheSize::size);
+        gauge(CHUNK_CACHE_HIT_RATE, hitRate, MovingAverage::get);
+
+        this.missLatency = timer(CHUNK_CACHE_MISS_LATENCY);
+        this.misses = counter(CHUNK_CACHE_MISSES);
+        this.hits = counter(CHUNK_CACHE_HITS);
+        this.requests = counter(CHUNK_CACHE_REQUESTS);
+        this.evictions = counter(CHUNK_CACHE_EVICTIONS);
+        this.notInCacheExceptions = counter(CHUNK_CACHE_NOT_IN_CACHE_EXCEPTIONS);
+    }
+
+    @Override
+    public void recordMisses(int count)
+    {
+        misses.increment(count);
+        requests.increment(count);
+        updateHitRate();
+    }
+
+    private void updateHitRate()
+    {
+        long lastUpdate = hitRateUpdateTime.get();
+        if ((System.nanoTime() - lastUpdate) >= hitRateUpdateInterval)
+        {
+            if (hitRateUpdateTime.compareAndSet(lastUpdate, System.nanoTime()))
+            {
+                double numRequests = requests.count();
+                if (numRequests > 0)
+                    hitRate.update(hits.count() / numRequests);
+                else
+                    hitRate.update(0);
+            }
+        }
+    }
+
+    @Override
+    public void recordLoadSuccess(long val)
+    {
+        missLatency.record(val, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void recordLoadFailure(long val)
+    {
+    }
+
+    @Override
+    public void recordEviction()
+    {
+        evictions.increment();
+    }
+
+    @Override
+    public void recordEviction(int weight)
+    {
+    }
+
+    @Override
+    public void recordHits(int count)
+    {
+        hits.increment(count);
+        requests.increment(count);
+        updateHitRate();
+    }
+
+    @Override
+    public double hitRate()
+    {
+        return hitRate.get();
+    }
+
+    @Override
+    public long requests()
+    {
+        return (long) requests.count();
+    }
+
+    @Override
+    public long misses()
+    {
+        return (long) misses.count();
+    }
+
+    @Override
+    public long hits()
+    {
+        return (long) hits.count();
+    }
+
+    @Override
+    public double missLatency()
+    {
+        return missLatency.mean(TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public long capacity()
+    {
+        return cache.capacity();
+    }
+
+    @Override
+    public long size()
+    {
+        return cache.weightedSize();
+    }
+
+    public long entries()
+    {
+        return cache.size();
+    }
+
+    public long requestsFifteenMinuteRate()
+    {
+        return 0;
+    }
+
+    public long hitsFifteenMinuteRate()
+    {
+        return 0;
+    }
+
+    @Override
+    @VisibleForTesting
+    public void reset()
+    {
+        // This method is only used for unit tests, and unit tests only use the codahale implementation
+        throw new UnsupportedOperationException("This was not expected to be called and should be implemented if required");
+    }
+
+    @Nonnull
+    @Override
+    public CacheStats snapshot()
+    {
+        return new CacheStats((long) hits.count(), (long) misses.count(), missLatency.count(),
+                0L, (long) missLatency.totalTime(TimeUnit.NANOSECONDS), (long) evictions.count(), 0L);
+    }
+
+    @Override
+    public String toString()
+    {
+        String ret = "Chunk cache metrics: " + System.lineSeparator() +
+                "Miss latency in seconds: " + missLatency.mean(TimeUnit.SECONDS) + System.lineSeparator() +
+                "Misses count: " + misses.count() + System.lineSeparator() +
+                "Hits count: " + hits.count() + System.lineSeparator() +
+                "Cache requests count: " + requests.count() + System.lineSeparator() +
+                "Moving hit rate: " + hitRate.get() + System.lineSeparator() +
+                "NotInCacheExceptions: " + notInCacheExceptions.count() + System.lineSeparator() +
+                "Num entries: " + cache.size() + System.lineSeparator() +
+                "Size in memory: " + FBUtilities.prettyPrintMemory(cache.weightedSize()) + System.lineSeparator() +
+                "Capacity: " + FBUtilities.prettyPrintMemory(cache.capacity());
+
+        return ret;
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/MicrometerMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import java.util.function.ToDoubleFunction;
+
+import com.google.common.base.Preconditions;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.cassandra.utils.Pair;
+
+public abstract class MicrometerMetrics
+{
+    private volatile Pair<MeterRegistry, Tags> registryWithTags;
+
+    protected MicrometerMetrics()
+    {
+        this.registryWithTags = Pair.create(new SimpleMeterRegistry(), Tags.empty());
+    }
+
+    public Counter counter(String name)
+    {
+        Pair<MeterRegistry, Tags> current = registryWithTags;
+        return current.left.counter(name, current.right);
+    }
+
+    public Counter counter(String name, Tags tags)
+    {
+        Pair<MeterRegistry, Tags> current = registryWithTags;
+        return current.left.counter(name, current.right.and(tags));
+    }
+
+    public Timer timer(String name)
+    {
+        Pair<MeterRegistry, Tags> current = registryWithTags;
+        return current.left.timer(name, current.right);
+    }
+
+    public <T> T gauge(String name, T obj, ToDoubleFunction<T> fcn)
+    {
+        Pair<MeterRegistry, Tags> current = registryWithTags;
+        return current.left.gauge(name, current.right, obj, fcn);
+    }
+
+    public synchronized void register(MeterRegistry newRegistry, Tags newTags)
+    {
+        Preconditions.checkArgument(!this.registryWithTags.left.equals(newRegistry), "Cannot set the same registry twice!");
+        this.registryWithTags = Pair.create(newRegistry, newTags);
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/ViewWriteMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ViewWriteMetrics.java
@@ -30,14 +30,15 @@ public class ViewWriteMetrics extends ClientRequestMetrics
     public final Counter viewReplicasSuccess;
     // time between when mutation is applied to local memtable to when CL.ONE is achieved on MV
     public final Timer viewWriteLatency;
+    public final Gauge<Long> viewPendingMutations;
 
-    public ViewWriteMetrics(String scope)
+    public ViewWriteMetrics(String scope, String namePrefix)
     {
-        super(scope);
-        viewReplicasAttempted = Metrics.counter(factory.createMetricName("ViewReplicasAttempted"));
-        viewReplicasSuccess = Metrics.counter(factory.createMetricName("ViewReplicasSuccess"));
-        viewWriteLatency = Metrics.timer(factory.createMetricName("ViewWriteLatency"));
-        Metrics.register(factory.createMetricName("ViewPendingMutations"), new Gauge<Long>()
+        super(scope, namePrefix);
+        viewReplicasAttempted = Metrics.counter(factory.createMetricName(namePrefix + "ViewReplicasAttempted"));
+        viewReplicasSuccess = Metrics.counter(factory.createMetricName(namePrefix + "ViewReplicasSuccess"));
+        viewWriteLatency = Metrics.timer(factory.createMetricName(namePrefix + "ViewWriteLatency"));
+        viewPendingMutations = Metrics.register(factory.createMetricName(namePrefix + "ViewPendingMutations"), new Gauge<Long>()
                 {
                     public Long getValue()
                     {
@@ -49,9 +50,9 @@ public class ViewWriteMetrics extends ClientRequestMetrics
     public void release()
     {
         super.release();
-        Metrics.remove(factory.createMetricName("ViewReplicasAttempted"));
-        Metrics.remove(factory.createMetricName("ViewReplicasSuccess"));
-        Metrics.remove(factory.createMetricName("ViewWriteLatency"));
-        Metrics.remove(factory.createMetricName("ViewPendingMutations"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ViewReplicasAttempted"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ViewReplicasSuccess"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ViewWriteLatency"));
+        Metrics.remove(factory.createMetricName(namePrefix + "ViewPendingMutations"));
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommandIterator.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRangeRequestMetrics;
+import org.apache.cassandra.metrics.CoordinatorClientRequestMetricsProvider;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -46,7 +47,7 @@ public abstract class RangeCommandIterator extends AbstractIterator<RowIterator>
     private static final Logger logger = LoggerFactory.getLogger(RangeCommandIterator.class);
 
     @VisibleForTesting
-    public static final ClientRangeRequestMetrics rangeMetrics = new ClientRangeRequestMetrics("RangeSlice");
+    public final ClientRangeRequestMetrics rangeMetrics;
 
     protected final CloseableIterator<ReplicaPlan.ForRangeRead> replicaPlans;
     private final int totalRangeCount;
@@ -95,6 +96,7 @@ public abstract class RangeCommandIterator extends AbstractIterator<RowIterator>
                          int totalRangeCount,
                          long queryStartNanoTime)
     {
+        this.rangeMetrics = CoordinatorClientRequestMetricsProvider.instance.metrics(command.metadata().keyspace).rangeMetrics;
         this.replicaPlans = replicaPlans;
         this.command = command;
         this.concurrencyFactor = concurrencyFactor;

--- a/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
+++ b/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
@@ -35,6 +35,8 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.metrics.CoordinatorClientRequestMetrics;
+import org.apache.cassandra.metrics.CoordinatorClientRequestMetricsProvider;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.WrappedRunnable;
@@ -118,7 +120,8 @@ public class TraceStateImpl extends TraceState
     {
         try
         {
-            StorageProxy.mutate(Collections.singletonList(mutation), ConsistencyLevel.ANY, System.nanoTime());
+            CoordinatorClientRequestMetrics metrics = CoordinatorClientRequestMetricsProvider.instance.metrics(mutation.getKeyspaceName());
+            StorageProxy.mutate(Collections.singletonList(mutation), ConsistencyLevel.ANY, System.nanoTime(), metrics);
         }
         catch (OverloadedException e)
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/ConcurrencyFactorTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/ConcurrencyFactorTest.java
@@ -28,7 +28,8 @@ import org.junit.Test;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
-import org.apache.cassandra.service.reads.range.RangeCommandIterator;
+import org.apache.cassandra.metrics.ClientRangeRequestMetrics;
+import org.apache.cassandra.metrics.CoordinatorClientRequestMetricsProvider;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
@@ -41,6 +42,8 @@ public class ConcurrencyFactorTest extends TestBaseImpl
     private static final int nodes = 3;
 
     private org.apache.cassandra.distributed.Cluster cluster;
+
+    ClientRangeRequestMetrics rangeMetrics = CoordinatorClientRequestMetricsProvider.instance.metrics(KEYSPACE).rangeMetrics;
 
     @Before
     public void init() throws IOException
@@ -126,11 +129,11 @@ public class ConcurrencyFactorTest extends TestBaseImpl
 
     private int getRangeReadCount()
     {
-        return cluster.get(1).callOnInstance(() -> Math.toIntExact(RangeCommandIterator.rangeMetrics.roundTrips.getCount()));
+        return cluster.get(1).callOnInstance(() -> Math.toIntExact(rangeMetrics.roundTrips.getCount()));
     }
 
     private int getMaxRoundTrips()
     {
-        return cluster.get(1).callOnInstance(() -> Math.toIntExact(RangeCommandIterator.rangeMetrics.roundTrips.getSnapshot().getMax()));
+        return cluster.get(1).callOnInstance(() -> Math.toIntExact(rangeMetrics.roundTrips.getSnapshot().getMax()));
     }
 }

--- a/test/long/org/apache/cassandra/cql3/CachingBench.java
+++ b/test/long/org/apache/cassandra/cql3/CachingBench.java
@@ -237,18 +237,18 @@ public class CachingBench extends CQLTester
         System.out.println("Reader " + cfs.getLiveSSTables().iterator().next().getFileDataInput(0).toString());
         if (cacheEnabled)
             System.out.format("Cache size %s requests %,d hit ratio %f\n",
-                FileUtils.stringifyFileSize(ChunkCache.instance.metrics.size.getValue()),
-                ChunkCache.instance.metrics.requests.getCount(),
-                ChunkCache.instance.metrics.hitRate.getValue());
+                FileUtils.stringifyFileSize(ChunkCache.instance.metrics.size()),
+                ChunkCache.instance.metrics.requests(),
+                ChunkCache.instance.metrics.hitRate());
         else
         {
-            assertThat(ChunkCache.instance.metrics.requests.getCount()).as("Chunk cache had requests: %s",
-                                                                           ChunkCache.instance.metrics.requests.getCount())
+            assertThat(ChunkCache.instance.metrics.requests()).as("Chunk cache had requests: %s",
+                                                                           ChunkCache.instance.metrics.requests())
                                                                        .isLessThan(COUNT);
             System.out.println("Cache disabled");
         }
 
-        assertThat(ChunkCache.instance.metrics.missLatency.getCount()).isGreaterThan(0);
+        assertThat(ChunkCache.instance.metrics.missLatency()).isGreaterThan(0);
 
         System.out.println(String.format("Operations completed in %.3fs", (onEndTime - onStartTime) * 1e-3));
         if (!CONCURRENT_COMPACTIONS)

--- a/test/unit/org/apache/cassandra/db/virtual/CachesTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/CachesTableTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.junit.Assert.assertFalse;
+
+public class CachesTableTest
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        CQLTester.setUpClass();
+    }
+
+    @Test
+    public void test() throws Throwable
+    {
+        CachesTable cachesTable = new CachesTable("test");
+        AbstractVirtualTable.DataSet dataSet = cachesTable.data();
+        assertFalse(dataSet.isEmpty());
+    }
+}

--- a/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
@@ -94,7 +94,8 @@ public class CodahaleChunkCacheMetricsTest
 
         assertEquals(0.0, chunkCacheMetrics.missLatency(), 0.0);
 
-        assertEquals(503316480, chunkCacheMetrics.capacity());
+        // Cache size was statically initialized 
+        assertEquals(ChunkCache.cacheSize, chunkCacheMetrics.capacity());
 
         assertEquals(0, chunkCacheMetrics.size());
 

--- a/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.assertj.core.api.Assertions;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CodahaleChunkCacheMetricsTest
+{
+    private ChunkCache mockChunkCache;
+
+    private ChunkCacheMetrics chunkCacheMetrics;
+
+    @BeforeClass
+    public static void init()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Before
+    public void before()
+    {
+        mockChunkCache = Mockito.mock(ChunkCache.class);
+
+        // Make sure to not use micrometer metrics
+        System.setProperty("cassandra.use_micrometer_metrics", "false");
+
+        chunkCacheMetrics = ChunkCacheMetrics.create(mockChunkCache);
+        assertTrue(chunkCacheMetrics instanceof CodahaleChunkCacheMetrics);
+    }
+
+    @After
+    public void after()
+    {
+        chunkCacheMetrics.reset();
+    }
+
+    @Test
+    public void testHitRate()
+    {
+        chunkCacheMetrics.recordHits(90);
+        assertEquals(90, chunkCacheMetrics.hits());
+
+        chunkCacheMetrics.recordMisses(10);
+        assertEquals(10, chunkCacheMetrics.misses());
+
+        // Verify requests = hits + misses
+        assertEquals(100, chunkCacheMetrics.requests());
+
+        // Verify hitrate
+        assertEquals(0.9, chunkCacheMetrics.hitRate(), 0.0);
+    }
+
+    @Test
+    public void testCommonChunkCacheMetrics()
+    {
+        // No-op
+        chunkCacheMetrics.recordEviction();
+
+        // No-op
+        chunkCacheMetrics.recordLoadFailure(25);
+
+        chunkCacheMetrics.recordLoadSuccess(TimeUnit.MILLISECONDS.toNanos(15));
+
+        assertEquals(0.0, chunkCacheMetrics.missLatency(), 0.0);
+
+        assertEquals(503316480, chunkCacheMetrics.capacity());
+
+        assertEquals(0, chunkCacheMetrics.size());
+
+        assertEquals(0, chunkCacheMetrics.entries());
+
+        assertEquals(0, chunkCacheMetrics.requestsFifteenMinuteRate());
+
+        assertEquals(0, chunkCacheMetrics.hitsFifteenMinuteRate());
+
+        CacheStats snapshot = chunkCacheMetrics.snapshot();
+        assertNotNull(snapshot);
+        assertEquals(chunkCacheMetrics.hits(), snapshot.hitCount());
+        assertEquals(chunkCacheMetrics.misses(), snapshot.missCount());
+
+        String toString = chunkCacheMetrics.toString();
+        assertNotNull(toString);
+        Assertions.assertThat(toString).contains("Capacity:");
+    }
+
+    @Test
+    public void testReset()
+    {
+        chunkCacheMetrics.recordHits(90);
+        assertEquals(90, chunkCacheMetrics.hits());
+        chunkCacheMetrics.recordMisses(10);
+        assertEquals(10, chunkCacheMetrics.misses());
+
+        chunkCacheMetrics.reset();
+
+        assertEquals(0, chunkCacheMetrics.hits());
+        assertEquals(0, chunkCacheMetrics.misses());
+        assertEquals(0, chunkCacheMetrics.requests());
+    }
+}

--- a/test/unit/org/apache/cassandra/metrics/CoordinatorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CoordinatorMetricsTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ConsistencyLevel;
+
+import static org.junit.Assert.assertEquals;
+
+public class CoordinatorMetricsTest
+{
+    private static CoordinatorClientRequestMetrics c1;
+    private static CoordinatorClientRequestMetrics c2;
+
+    @BeforeClass
+    public static void init()
+    {
+        DatabaseDescriptor.daemonInitialization();
+
+        c1 = new CoordinatorClientRequestMetrics("tenant1");
+        c2 = new CoordinatorClientRequestMetrics("tenant2");
+    }
+
+    @Test
+    public void testReadMetrics()
+    {
+        // update tenant1 read metrics, tenant2 metrics remain 0
+        updateClientRequestMetrics(c1.readMetrics);
+        verifyClientRequestMetrics(c1.readMetrics, 1);
+        verifyClientRequestMetrics(c2.readMetrics, 0);
+
+        // update tenant2 read metrics, tenant1 metrics remain 1
+        updateClientRequestMetrics(c2.readMetrics);
+        verifyClientRequestMetrics(c1.readMetrics, 1);
+        verifyClientRequestMetrics(c2.readMetrics, 1);
+    }
+
+    @Test
+    public void testRangeMetrics()
+    {
+        // update tenant1 range metrics, tenant2 metrics remain 0
+        updateClientRangeRequestMetrics(c1.rangeMetrics);
+        verifyClientRangeRequestMetrics(c1.rangeMetrics, 1);
+        verifyClientRangeRequestMetrics(c2.rangeMetrics, 0);
+
+        // update tenant2 range metrics, tenant1 metrics remain 1
+        updateClientRangeRequestMetrics(c2.rangeMetrics);
+        verifyClientRangeRequestMetrics(c1.rangeMetrics, 1);
+        verifyClientRangeRequestMetrics(c2.rangeMetrics, 1);
+    }
+
+    @Test
+    public void testWriteMetrics()
+    {
+        // update tenant1 write metrics, tenant2 metrics remain 0
+        updateClientWriteRequestMetrics(c1.writeMetrics);
+        verifyClientWriteRequestMetrics(c1.writeMetrics, 1);
+        verifyClientWriteRequestMetrics(c2.writeMetrics, 0);
+
+        // update tenant2 write metrics, tenant1 metrics remain 1
+        updateClientWriteRequestMetrics(c2.writeMetrics);
+        verifyClientWriteRequestMetrics(c1.writeMetrics, 1);
+        verifyClientWriteRequestMetrics(c2.writeMetrics, 1);
+    }
+
+    @Test
+    public void testCasReadMetrics()
+    {
+        // update tenant1 cas metrics, tenant2 metrics remain 0
+        updateCASClientRequestMetrics(c1.casReadMetrics);
+        verifyCASClientRequestMetrics(c1.casReadMetrics, 1);
+        verifyCASClientRequestMetrics(c2.casReadMetrics, 0);
+
+        // update tenant2 cas metrics, tenant1 metrics remain 1
+        updateCASClientRequestMetrics(c2.casReadMetrics);
+        verifyCASClientRequestMetrics(c1.casReadMetrics, 1);
+        verifyCASClientRequestMetrics(c2.casReadMetrics, 1);
+    }
+
+    @Test
+    public void testViewWriteMetrics()
+    {
+        // update tenant1 view metrics, tenant2 metrics remain 0
+        updateViewWriteMetrics(c1.viewWriteMetrics);
+        verifyViewWriteMetrics(c1.viewWriteMetrics, 1);
+        verifyViewWriteMetrics(c2.viewWriteMetrics, 0);
+
+        // update tenant2 view metrics, tenant1 metrics remain 1
+        updateViewWriteMetrics(c2.viewWriteMetrics);
+        verifyViewWriteMetrics(c1.viewWriteMetrics, 1);
+        verifyViewWriteMetrics(c2.viewWriteMetrics, 1);
+    }
+
+    @Test
+    public void testCasWriteMetrics()
+    {
+        // update tenant1 cas write metrics, tenant2 metrics remain 0
+        updateCASClientWriteRequestMetrics(c1.casWriteMetrics);
+        verifyCASClientWriteRequestMetrics(c1.casWriteMetrics, 1);
+        verifyCASClientWriteRequestMetrics(c2.casWriteMetrics, 0);
+
+        // update tenant2 cas write metrics, tenant1 metrics remain 1
+        updateCASClientWriteRequestMetrics(c2.casWriteMetrics);
+        verifyCASClientWriteRequestMetrics(c1.casWriteMetrics, 1);
+        verifyCASClientWriteRequestMetrics(c2.casWriteMetrics, 1);
+    }
+
+    @Test
+    public void testReadMetricsMap()
+    {
+        for (ConsistencyLevel level : ConsistencyLevel.values())
+        {
+            // update tenant1 view metrics, tenant2 metrics remain 0
+            updateClientRequestMetrics(c1.readMetricsMap.get(level));
+            verifyClientRequestMetrics(c1.readMetricsMap.get(level), 1);
+            verifyClientRequestMetrics(c2.readMetricsMap.get(level), 0);
+
+            // update tenant2 view metrics, tenant1 metrics remain 1
+            updateClientRequestMetrics(c2.readMetricsMap.get(level));
+            verifyClientRequestMetrics(c1.readMetricsMap.get(level), 1);
+            verifyClientRequestMetrics(c2.readMetricsMap.get(level), 1);
+        }
+    }
+
+    @Test
+    public void testWriteMetricsMap()
+    {
+        for (ConsistencyLevel level : ConsistencyLevel.values())
+        {
+            // update tenant1 view metrics, tenant2 metrics remain 0
+            updateClientWriteRequestMetrics(c1.writeMetricsMap.get(level));
+            verifyClientWriteRequestMetrics(c1.writeMetricsMap.get(level), 1);
+            verifyClientWriteRequestMetrics(c2.writeMetricsMap.get(level), 0);
+
+            // update tenant2 view metrics, tenant1 metrics remain 1
+            updateClientWriteRequestMetrics(c2.writeMetricsMap.get(level));
+            verifyClientWriteRequestMetrics(c1.writeMetricsMap.get(level), 1);
+            verifyClientWriteRequestMetrics(c2.writeMetricsMap.get(level), 1);
+        }
+    }
+
+    private void updateViewWriteMetrics(ViewWriteMetrics metrics)
+    {
+        metrics.viewWriteLatency.update(1, TimeUnit.MILLISECONDS);
+        metrics.viewReplicasSuccess.inc();
+        metrics.viewReplicasAttempted.inc(2);
+        updateClientRequestMetrics(metrics);
+    }
+
+    private void updateCASClientWriteRequestMetrics(CASClientWriteRequestMetrics metrics)
+    {
+        metrics.overMaxPendingThreshold.inc();
+        metrics.conditionNotMet.inc();
+        metrics.mutationSize.update(1);
+        updateCASClientRequestMetrics(metrics);
+    }
+
+    private void updateCASClientRequestMetrics(CASClientRequestMetrics metrics)
+    {
+        metrics.unfinishedCommit.inc();
+        metrics.contention.update(1);
+        updateClientRequestMetrics(metrics);
+    }
+
+    private void updateClientRangeRequestMetrics(ClientRangeRequestMetrics metrics)
+    {
+        metrics.roundTrips.update(1);
+        updateClientRequestMetrics(metrics);
+    }
+
+    private void updateClientWriteRequestMetrics(ClientWriteRequestMetrics metrics)
+    {
+        metrics.mutationSize.update(1);
+        updateClientRequestMetrics(metrics);
+    }
+
+    private void updateClientRequestMetrics(ClientRequestMetrics metrics)
+    {
+        metrics.timeouts.mark();
+        metrics.failures.mark();
+        metrics.unavailables.mark();
+        updateLatencyMetrics(metrics);
+    }
+
+    private void updateLatencyMetrics(LatencyMetrics metrics)
+    {
+        metrics.latency.update(1, TimeUnit.MILLISECONDS);
+        metrics.totalLatency.inc();
+    }
+
+    private void verifyViewWriteMetrics(ViewWriteMetrics metrics, int value)
+    {
+        assertEquals(value == 0 ? 0 : value + 1, metrics.viewReplicasAttempted.getCount());
+        assertEquals(value, metrics.viewReplicasSuccess.getCount());
+        assertEquals(value == 0 ? 0 : 1, metrics.viewPendingMutations.getValue().intValue());
+        assertEquals(value, metrics.viewWriteLatency.getCount());
+        verifyClientRequestMetrics(metrics, value);
+    }
+
+    private void verifyCASClientWriteRequestMetrics(CASClientWriteRequestMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.mutationSize.getCount());
+        assertEquals(value, metrics.conditionNotMet.getCount());
+        assertEquals(value, metrics.overMaxPendingThreshold.getCount());
+        verifyCASClientRequestMetrics(metrics, value);
+    }
+
+    private void verifyCASClientRequestMetrics(CASClientRequestMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.unfinishedCommit.getCount());
+        assertEquals(value, metrics.contention.getCount());
+        verifyClientRequestMetrics(metrics, value);
+    }
+
+    private void verifyClientRangeRequestMetrics(ClientRangeRequestMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.roundTrips.getCount());
+        verifyClientRequestMetrics(metrics, value);
+    }
+
+    private void verifyClientWriteRequestMetrics(ClientWriteRequestMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.mutationSize.getCount());
+        verifyClientRequestMetrics(metrics, value);
+    }
+
+    private void verifyClientRequestMetrics(ClientRequestMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.timeouts.getCount());
+        assertEquals(value, metrics.failures.getCount());
+        assertEquals(value, metrics.unavailables.getCount());
+        verifyLatencyMetrics(metrics, value);
+    }
+
+    private void verifyLatencyMetrics(LatencyMetrics metrics, int value)
+    {
+        assertEquals(value, metrics.latency.getCount());
+        assertEquals(value, metrics.totalLatency.getCount());
+    }
+}

--- a/test/unit/org/apache/cassandra/metrics/CustomCoordinatorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CustomCoordinatorMetricsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomCoordinatorMetricsTest
+{
+    @BeforeClass
+    public static void beforeClass()
+    {
+        // Sets custom client provider class used in {@code CoordinatorClientRequestMetricsProvider#instance}
+        CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY.setString(CoordinatorClientRequestMetricsProvider.DefaultCoordinatorMetricsProvider.class.getName());
+    }
+
+    @AfterClass
+    public static void teardown()
+    {
+        CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY.setString("");
+    }
+
+    @Test
+    public void testStaticInstanceWithCustomProviderClassName()
+    {
+        // Custom client provider class name set in {@link beforeClass()}
+        CoordinatorClientRequestMetricsProvider customClientRequestMetricsProvider = CoordinatorClientRequestMetricsProvider.instance;
+        assertThat(customClientRequestMetricsProvider).isInstanceOf(CoordinatorClientRequestMetricsProvider.DefaultCoordinatorMetricsProvider.class);
+        CoordinatorClientRequestMetrics metrics = customClientRequestMetricsProvider.metrics("");
+    }
+
+    @Test
+    public void testMakeProviderWithClassThatExists()
+    {
+        CoordinatorClientRequestMetricsProvider.make(CoordinatorClientRequestMetricsProvider.DefaultCoordinatorMetricsProvider.class.getName());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMakeProviderWithClassThatDoesNotExist()
+    {
+        CoordinatorClientRequestMetricsProvider.make("SomeOtherCLass");
+    }
+}

--- a/test/unit/org/apache/cassandra/metrics/MicrometerChunkCacheMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/MicrometerChunkCacheMetricsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.assertj.core.api.Assertions;
+import org.mockito.Mockito;
+
+import static org.apache.cassandra.metrics.MicrometerChunkCacheMetrics.hitRateUpdateInterval;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MicrometerChunkCacheMetricsTest
+{
+    private ChunkCache mockChunkCache;
+
+    private ChunkCacheMetrics chunkCacheMetrics;
+
+    @BeforeClass
+    public static void init()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Before
+    public void before()
+    {
+        mockChunkCache = Mockito.mock(ChunkCache.class);
+
+        // Use micrometer metrics
+        System.setProperty("cassandra.use_micrometer_metrics", "true");
+
+        chunkCacheMetrics = ChunkCacheMetrics.create(mockChunkCache);
+        assertTrue(chunkCacheMetrics instanceof MicrometerChunkCacheMetrics);
+    }
+
+    @After
+    public void after()
+    {
+        // Reset to not use micrometer metrics
+        System.setProperty("cassandra.use_micrometer_metrics", "false");
+    }
+
+    @Test
+    public void testHitRate() throws InterruptedException
+    {
+        chunkCacheMetrics.recordHits(90);
+        assertEquals(90, chunkCacheMetrics.hits());
+
+        // Added delay to increase code coverage updating hit rate when calling recordMisses
+        Thread.sleep(2 * TimeUnit.NANOSECONDS.toMillis(hitRateUpdateInterval));
+
+        chunkCacheMetrics.recordMisses(10);
+        assertEquals(10, chunkCacheMetrics.misses());
+
+        // Verify requests = hits + misses
+        assertEquals(100, chunkCacheMetrics.requests());
+
+        // Verify hitrate
+        assertEquals(0.9, chunkCacheMetrics.hitRate(), 0.0);
+    }
+
+    @Test
+    public void testCommonChunkCacheMetrics()
+    {
+
+        // No-op
+        chunkCacheMetrics.recordEviction();
+
+        // No-op
+        chunkCacheMetrics.recordLoadFailure(25);
+
+        chunkCacheMetrics.recordLoadSuccess(15);
+
+        // missLatency based on recordLoadSuccess
+        assertEquals(15.0, chunkCacheMetrics.missLatency(), 0.0);
+
+        assertEquals(0, chunkCacheMetrics.capacity());
+
+        assertEquals(0, chunkCacheMetrics.size());
+
+        assertEquals(0, chunkCacheMetrics.entries());
+
+        assertEquals(0, chunkCacheMetrics.requestsFifteenMinuteRate());
+
+        assertEquals(0, chunkCacheMetrics.hitsFifteenMinuteRate());
+
+        CacheStats snapshot = chunkCacheMetrics.snapshot();
+        assertNotNull(snapshot);
+        System.out.println(snapshot);
+
+        String toString = chunkCacheMetrics.toString();
+        assertNotNull(toString);
+        Assertions.assertThat(toString).contains("Capacity:");
+    }
+
+    @Test
+    public void testRegister()
+    {
+        ((MicrometerChunkCacheMetrics) chunkCacheMetrics).register(new SimpleMeterRegistry(), Tags.of("tagKey", "tagValue"));
+    }
+
+    @Test
+    public void testCounter()
+    {
+        ((MicrometerChunkCacheMetrics) chunkCacheMetrics).counter("counter", Tags.of("tagKey", "tagValue"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReset()
+    {
+        chunkCacheMetrics.reset();
+    }
+}


### PR DESCRIPTION
Changes are mainly around:
* First commit: `ClientRequestMetrics` and subclasses from [cndb-884](https://github.com/riptano/bdp/commit/03b23db6a5697baaf71d46d661c0ac1c908bc33e) and riptano/bdp#19515
and
* Second commit: Porting `MicrometerChunkCacheMetrics` from [CNDB-780 - Add Micrometer metrics for the chunk cache
](https://github.com/riptano/bdp/commit/378a7a6dbafe6b71cb7820abe9fe2700c9218748)

Some differences from bdp/cndb are mention in code comments.
