### PR TITLE
STAR-844 Read/Write hooks

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -449,7 +449,7 @@ public class BatchStatement implements CQLStatement
         updatePartitionsPerBatchMetrics(mutations.size());
 
         boolean mutateAtomic = (isLogged() && mutations.size() > 1);
-        StorageProxy.mutateWithTriggers(mutations, cl, mutateAtomic, queryStartNanoTime);
+        StorageProxy.mutateWithTriggers(mutations, cl, mutateAtomic, queryStartNanoTime, queryState.getClientState());
     }
 
     private void updatePartitionsPerBatchMetrics(int updatedPartitions)

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -389,6 +389,7 @@ public abstract class ModificationStatement implements CQLStatement
 
     private Map<DecoratedKey, Partition> readRequiredLists(Collection<ByteBuffer> partitionKeys,
                                                            ClusteringIndexFilter filter,
+                                                           QueryState state,
                                                            DataLimits limits,
                                                            boolean local,
                                                            ConsistencyLevel cl,
@@ -428,7 +429,7 @@ public abstract class ModificationStatement implements CQLStatement
             }
         }
 
-        try (PartitionIterator iter = group.execute(cl, null, queryStartNanoTime))
+        try (PartitionIterator iter = group.execute(cl, state, queryStartNanoTime))
         {
             return asMaterializedMap(iter);
         }
@@ -487,7 +488,7 @@ public abstract class ModificationStatement implements CQLStatement
             options.getTimestamp(queryState),
             options.getNowInSeconds(queryState), queryStartNanoTime);
         if (!mutations.isEmpty())
-            StorageProxy.mutateWithTriggers(mutations, cl, false, queryStartNanoTime);
+            StorageProxy.mutateWithTriggers(mutations, cl, false, queryStartNanoTime, queryState.getClientState());
 
         return null;
     }
@@ -850,6 +851,7 @@ public abstract class ModificationStatement implements CQLStatement
         Map<DecoratedKey, Partition> lists =
             readRequiredLists(keys,
                               filter,
+                              state,
                               limits,
                               local,
                               options.getConsistency(),

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -265,7 +265,7 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
 
     public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
-        return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime);
+        return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime, queryState.getClientState());
     }
 
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -387,7 +387,14 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         if (clusteringIndexFilter.isEmpty(metadata().comparator))
             return EmptyIterators.partition();
 
-        return StorageProxy.read(Group.one(this), consistency, queryState, queryStartNanoTime);
+        Group group = Group.one(this);
+        QueryInfoTracker.ReadTracker readTracker = StorageProxy.queryTracker().onRead(queryState.getClientState(),
+                                                                                      group.metadata(),
+                                                                                      group.queries,
+                                                                                      consistency);
+
+        PartitionIterator partitions = StorageProxy.read(group, consistency, queryState, queryStartNanoTime, readTracker);
+        return PartitionIterators.doOnClose(partitions, readTracker::onDone);
     }
 
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)
@@ -1137,7 +1144,12 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
 
         public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
         {
-            return StorageProxy.read(this, consistency, queryState, queryStartNanoTime);
+            QueryInfoTracker.ReadTracker readTracker = StorageProxy.queryTracker().onRead(queryState.getClientState(),
+                                                                                          this.metadata(),
+                                                                                          this.queries,
+                                                                                          consistency);
+            PartitionIterator partitions = StorageProxy.read(this, consistency, queryState, queryStartNanoTime, readTracker);
+            return PartitionIterators.doOnClose(partitions, readTracker::onDone);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -387,14 +387,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         if (clusteringIndexFilter.isEmpty(metadata().comparator))
             return EmptyIterators.partition();
 
-        Group group = Group.one(this);
-        QueryInfoTracker.ReadTracker readTracker = StorageProxy.queryTracker().onRead(queryState.getClientState(),
-                                                                                      group.metadata(),
-                                                                                      group.queries,
-                                                                                      consistency);
-
-        PartitionIterator partitions = StorageProxy.read(group, consistency, queryState, queryStartNanoTime, readTracker);
-        return PartitionIterators.doOnClose(partitions, readTracker::onDone);
+        return StorageProxy.read(Group.one(this), consistency, queryState, queryStartNanoTime);
     }
 
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)
@@ -1144,12 +1137,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
 
         public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
         {
-            QueryInfoTracker.ReadTracker readTracker = StorageProxy.queryTracker().onRead(queryState.getClientState(),
-                                                                                          this.metadata(),
-                                                                                          this.queries,
-                                                                                          consistency);
-            PartitionIterator partitions = StorageProxy.read(this, consistency, queryState, queryStartNanoTime, readTracker);
-            return PartitionIterators.doOnClose(partitions, readTracker::onDone);
+            return StorageProxy.read(this, consistency, queryState, queryStartNanoTime);
         }
     }
 

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -430,6 +430,15 @@ public class Message<T>
         {
             return (TraceType) params.getOrDefault(ParamType.TRACE_TYPE, TraceType.QUERY);
         }
+
+        /**
+         * Keyspace that is beeing traced by the trace session attached to this message (if any).
+         */
+        @Nullable
+        public String traceKeyspace()
+        {
+            return (String) params.get(ParamType.TRACE_KEYSPACE);
+        }
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.StringSerializer;
 import org.apache.cassandra.utils.UUIDSerializer;
 
 import static java.lang.Math.max;
@@ -54,7 +55,12 @@ public enum ParamType
     TRACE_TYPE          (6, "TraceType",     Tracing.traceTypeSerializer),
 
     @Deprecated
-    TRACK_REPAIRED_DATA (7, "TrackRepaired", LegacyFlag.serializer);
+    TRACK_REPAIRED_DATA (7, "TrackRepaired", LegacyFlag.serializer),
+
+    /**
+     * Messages with tracing sessions are decorated with the traced keyspace.
+     */
+    TRACE_KEYSPACE      (8, "TraceKeyspace", StringSerializer.serializer);
 
     final int id;
     @Deprecated final String legacyAlias; // pre-4.0 we used to serialize entire param name string

--- a/src/java/org/apache/cassandra/repair/RepairRunnable.java
+++ b/src/java/org/apache/cassandra/repair/RepairRunnable.java
@@ -291,7 +291,7 @@ public class RepairRunnable implements Runnable, ProgressEventNotifier
         for (ColumnFamilyStore cfs : columnFamilyStores)
             cfsb.append(", ").append(cfs.keyspace.getName()).append(".").append(cfs.name);
 
-        UUID sessionId = Tracing.instance.newSession(Tracing.TraceType.REPAIR);
+        UUID sessionId = Tracing.instance.newSession(ClientState.forInternalCalls(), Tracing.TraceType.REPAIR);
         TraceState traceState = Tracing.instance.begin("repair", ImmutableMap.of("keyspace", keyspace, "columnFamilies",
                                                                                  cfsb.substring(2)));
         traceState.enableActivityNotification(tag);

--- a/src/java/org/apache/cassandra/service/QueryInfoTracker.java
+++ b/src/java/org/apache/cassandra/service/QueryInfoTracker.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.util.Collection;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.IMutation;
+
+/**
+ * A tracker objects that can be registered against {@link StorageProxy} to be called back with information on executed
+ * queries.
+ *
+ * <p>The goal of this interface is to provide to implementations enough information for it to accurately estimate how
+ * much "work" a query has performed. So while for write this mostly just mean passing the generated mutations, for
+ * reads this mean passing the unfiltered result of the query.
+ *
+ * <p>The methods of this tracker are called from {@link StorageProxy} and are thus "coordinator level". As such, all
+ * user writes or reads will trigger the call of one of these methods, as will internal distributed system table
+ * queries, but internal local system table queries will not.
+ *
+ * <p>For writes, the {@link #onWrite} method is only called for the "user write", but if that write trigger either
+ * secondary index or materialized views updates, those additional update do not trigger additional calls.
+ *
+ * <p>The methods of this tracker are called on hot path, so none of them should be blocking, and they should be as
+ * lightweight as possible.
+ */
+public interface QueryInfoTracker
+{
+    /** A tracker that does nothing. */
+    QueryInfoTracker NOOP = new QueryInfoTracker() {
+        @Override
+        public WriteTracker onWrite(ClientState state,
+                                    boolean isLogged,
+                                    Collection<? extends IMutation> mutations,
+                                    ConsistencyLevel consistencyLevel)
+        {
+            return WriteTracker.NOOP;
+        }
+    };
+
+    /**
+     * Called before every (non-LWT) write coordinated on the local node.
+     *
+     * @param state the state of the client that performed the write
+     * @param isLogged whether this is a logged batch write.
+     * @param mutations the mutations written by the write.
+     * @param consistencyLevel the consistency level of the write.
+     * @return a tracker that should be notified when either the read error out or completes successfully.
+     */
+    WriteTracker onWrite(ClientState state,
+                         boolean isLogged,
+                         Collection<? extends IMutation> mutations,
+                         ConsistencyLevel consistencyLevel);
+
+    /**
+     * A tracker for a specific query.
+     *
+     * <p>For the tracked query, exactly one of its method should be called.
+     */
+    interface Tracker
+    {
+        /** Called when the tracked query completes successfully. */
+        void onDone();
+
+        /** Called when the tracked query completes with an error. */
+        void onError(Throwable exception);
+    }
+
+    /**
+     * Tracker for a write query.
+     */
+    interface WriteTracker extends Tracker
+    {
+        WriteTracker NOOP = new WriteTracker() {
+            @Override
+            public void onDone()
+            {
+            }
+
+            @Override
+            public void onError(Throwable exception)
+            {
+            }
+        };
+    }
+}

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -359,40 +359,35 @@ public class StorageProxy implements StorageProxyMBean
         catch (CasWriteUnknownResultException e)
         {
             metrics.casWriteMetrics.unknownResult.mark();
-            if (lwtTracker != null)
-                lwtTracker.onError(e);
+            lwtTracker.onError(e);
             throw e;
         }
         catch (CasWriteTimeoutException wte)
         {
             metrics.casWriteMetrics.timeouts.mark();
             metrics.writeMetricsMap.get(consistencyForPaxos).timeouts.mark();
-            if (lwtTracker != null)
-                lwtTracker.onError(wte);
+            lwtTracker.onError(wte);
             throw new CasWriteTimeoutException(wte.writeType, wte.consistency, wte.received, wte.blockFor, wte.contentions);
         }
         catch (ReadTimeoutException e)
         {
             metrics.casWriteMetrics.timeouts.mark();
             metrics.writeMetricsMap.get(consistencyForPaxos).timeouts.mark();
-            if (lwtTracker != null)
-                lwtTracker.onError(e);
+            lwtTracker.onError(e);
             throw e;
         }
         catch (WriteFailureException | ReadFailureException e)
         {
             metrics.casWriteMetrics.failures.mark();
             metrics.writeMetricsMap.get(consistencyForPaxos).failures.mark();
-            if (lwtTracker != null)
-                lwtTracker.onError(e);
+            lwtTracker.onError(e);
             throw e;
         }
         catch (UnavailableException e)
         {
             metrics.casWriteMetrics.unavailables.mark();
             metrics.writeMetricsMap.get(consistencyForPaxos).unavailables.mark();
-            if (lwtTracker != null)
-                lwtTracker.onError(e);
+            lwtTracker.onError(e);
             throw e;
         }
         finally

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1757,7 +1757,21 @@ public class StorageProxy implements StorageProxyMBean
                                                       consistencyLevel,
                                                       queryState,
                                                       queryStartNanoTime,
-                                                      readTracker), command);
+                                                      readTracker),
+                                                 command);
+    }
+
+    public static PartitionIterator read(SinglePartitionReadCommand.Group group,
+                                         ConsistencyLevel consistencyLevel,
+                                         QueryState queryState,
+                                         long queryStartNanoTime)
+    {
+        QueryInfoTracker.ReadTracker readTracker = StorageProxy.queryTracker().onRead(queryState.getClientState(),
+                                                                                      group.metadata(),
+                                                                                      group.queries,
+                                                                                      consistencyLevel);
+        PartitionIterator partitions = read(group, consistencyLevel, queryState, queryStartNanoTime, readTracker);
+        return PartitionIterators.doOnClose(partitions, readTracker::onDone);
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -227,7 +227,7 @@ public class StorageProxy implements StorageProxyMBean
      *
      * @param tracker the tracker to register.
      */
-    public void register(QueryInfoTracker tracker) {
+    public void registerQueryTracker(QueryInfoTracker tracker) {
         Objects.requireNonNull(tracker);
         queryInfoTracker = tracker;
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -164,6 +164,8 @@ public class StorageProxy implements StorageProxyMBean
         }
     };
 
+    private static volatile QueryInfoTracker queryInfoTracker = QueryInfoTracker.NOOP;
+
     private static final String DISABLE_SERIAL_READ_LINEARIZABILITY_KEY = "cassandra.unsafe.disable-serial-reads-linearizability";
     private static final boolean disableSerialReadLinearizability =
         Boolean.parseBoolean(System.getProperty(DISABLE_SERIAL_READ_LINEARIZABILITY_KEY, "false"));
@@ -215,6 +217,23 @@ public class StorageProxy implements StorageProxyMBean
                         "the restricted case of upgrading from a pre-CASSANDRA-12126 version, and only if you " +
                         "understand the tradeoff.", DISABLE_SERIAL_READ_LINEARIZABILITY_KEY);
         }
+    }
+
+    /**
+     * Registers the provided query info tracker
+     *
+     * <p>Note that only 1 query tracker can be registered at a time, so the provided tracker will unconditionally
+     * replace the currently registered tracker.
+     *
+     * @param tracker the tracker to register.
+     */
+    public void register(QueryInfoTracker tracker) {
+        Objects.requireNonNull(tracker);
+        queryInfoTracker = tracker;
+    }
+
+    public QueryInfoTracker queryTracker() {
+        return queryInfoTracker;
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/TracingClientState.java
+++ b/src/java/org/apache/cassandra/service/TracingClientState.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.service;
+
+import javax.annotation.Nullable;
+
+/**
+ * As tracing can happen at both coordinator and replicas, at replica side, CNDB needs to knows the traced keyspace for billing
+ */
+public class TracingClientState extends ClientState
+{
+    private final @Nullable String tracedKeyspace;
+
+    protected TracingClientState(String tracedKeyspace, ClientState state)
+    {
+        super(state);
+        this.tracedKeyspace = tracedKeyspace;
+    }
+
+    /**
+     * @return the keyspace being traced
+     */
+    @Nullable
+    public String tracedKeyspace()
+    {
+        return tracedKeyspace;
+    }
+
+    /**
+     * @return a ClientState object for internal C* calls (not limited by any kind of auth) with traced keyspace
+     */
+    public static TracingClientState withTracedKeyspace(@Nullable String tracedKeyspace)
+    {
+        return new TracingClientState(tracedKeyspace, ClientState.forInternalCalls());
+    }
+}

--- a/src/java/org/apache/cassandra/service/TracingClientState.java
+++ b/src/java/org/apache/cassandra/service/TracingClientState.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.service;
 import javax.annotation.Nullable;
 
 /**
- * As tracing can happen at both coordinator and replicas, at replica side, CNDB needs to knows the traced keyspace for billing
+ * As tracing can happen at both coordinator and replicas, at replica side, CNDB needs to know the traced keyspace for billing
  */
 public class TracingClientState extends ClientState
 {

--- a/src/java/org/apache/cassandra/service/TracingClientState.java
+++ b/src/java/org/apache/cassandra/service/TracingClientState.java
@@ -32,6 +32,14 @@ public class TracingClientState extends ClientState
         this.tracedKeyspace = tracedKeyspace;
     }
 
+    @Override
+    public ClientState cloneWithKeyspaceIfSet(String keyspace)
+    {
+        if (keyspace == null)
+            return this;
+        return new TracingClientState(tracedKeyspace, super.cloneWithKeyspaceIfSet(keyspace));
+    }
+
     /**
      * @return the keyspace being traced
      */

--- a/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.locator.ReplicaPlans;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.service.StorageProxy.LocalReadRunnable;
 import org.apache.cassandra.service.reads.repair.ReadRepair;
 import org.apache.cassandra.tracing.TraceState;
@@ -71,19 +72,26 @@ public abstract class AbstractReadExecutor
     protected final long queryStartNanoTime;
     private   final int initialDataRequestCount;
     protected volatile PartitionIterator result = null;
+    protected final QueryInfoTracker.ReadTracker readTracker;
 
-    AbstractReadExecutor(ColumnFamilyStore cfs, ReadCommand command, ReplicaPlan.ForTokenRead replicaPlan, int initialDataRequestCount, long queryStartNanoTime)
+    AbstractReadExecutor(ColumnFamilyStore cfs,
+                         ReadCommand command,
+                         ReplicaPlan.ForTokenRead replicaPlan,
+                         int initialDataRequestCount,
+                         long queryStartNanoTime,
+                         QueryInfoTracker.ReadTracker readTracker)
     {
         this.command = command;
         this.replicaPlan = ReplicaPlan.shared(replicaPlan);
         this.initialDataRequestCount = initialDataRequestCount;
         // the ReadRepair and DigestResolver both need to see our updated
         this.readRepair = ReadRepair.create(command, this.replicaPlan, queryStartNanoTime);
-        this.digestResolver = new DigestResolver<>(command, this.replicaPlan, queryStartNanoTime);
+        this.digestResolver = new DigestResolver<>(command, this.replicaPlan, queryStartNanoTime, readTracker);
         this.handler = new ReadCallback<>(digestResolver, command, this.replicaPlan, queryStartNanoTime);
         this.cfs = cfs;
         this.traceState = Tracing.instance.get();
         this.queryStartNanoTime = queryStartNanoTime;
+        this.readTracker = readTracker;
 
 
         // Set the digest version (if we request some digests). This is the smallest version amongst all our target replicas since new nodes
@@ -180,7 +188,10 @@ public abstract class AbstractReadExecutor
     /**
      * @return an executor appropriate for the configured speculative read policy
      */
-    public static AbstractReadExecutor getReadExecutor(SinglePartitionReadCommand command, ConsistencyLevel consistencyLevel, long queryStartNanoTime) throws UnavailableException
+    public static AbstractReadExecutor getReadExecutor(SinglePartitionReadCommand command,
+                                                       ConsistencyLevel consistencyLevel,
+                                                       long queryStartNanoTime,
+                                                       QueryInfoTracker.ReadTracker readTracker) throws UnavailableException
     {
         Keyspace keyspace = Keyspace.open(command.metadata().keyspace);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(command.metadata().id);
@@ -191,20 +202,20 @@ public abstract class AbstractReadExecutor
         // Speculative retry is disabled *OR*
         // 11980: Disable speculative retry if using EACH_QUORUM in order to prevent miscounting DC responses
         if (retry.equals(NeverSpeculativeRetryPolicy.INSTANCE) || consistencyLevel == ConsistencyLevel.EACH_QUORUM)
-            return new NeverSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, false);
+            return new NeverSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, false, readTracker);
 
         // There are simply no extra replicas to speculate.
         // Handle this separately so it can record failed attempts to speculate due to lack of replicas
         if (replicaPlan.contacts().size() == replicaPlan.candidates().size())
         {
             boolean recordFailedSpeculation = consistencyLevel != ConsistencyLevel.ALL;
-            return new NeverSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, recordFailedSpeculation);
+            return new NeverSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, recordFailedSpeculation, readTracker);
         }
 
         if (retry.equals(AlwaysSpeculativeRetryPolicy.INSTANCE))
-            return new AlwaysSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime);
+            return new AlwaysSpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, readTracker);
         else // PERCENTILE or CUSTOM.
-            return new SpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime);
+            return new SpeculatingReadExecutor(cfs, command, replicaPlan, queryStartNanoTime, readTracker);
     }
 
     /**
@@ -236,9 +247,9 @@ public abstract class AbstractReadExecutor
          */
         private final boolean logFailedSpeculation;
 
-        public NeverSpeculatingReadExecutor(ColumnFamilyStore cfs, ReadCommand command, ReplicaPlan.ForTokenRead replicaPlan, long queryStartNanoTime, boolean logFailedSpeculation)
+        public NeverSpeculatingReadExecutor(ColumnFamilyStore cfs, ReadCommand command, ReplicaPlan.ForTokenRead replicaPlan, long queryStartNanoTime, boolean logFailedSpeculation, QueryInfoTracker.ReadTracker readTracker)
         {
-            super(cfs, command, replicaPlan, 1, queryStartNanoTime);
+            super(cfs, command, replicaPlan, 1, queryStartNanoTime, readTracker);
             this.logFailedSpeculation = logFailedSpeculation;
         }
 
@@ -258,12 +269,13 @@ public abstract class AbstractReadExecutor
         public SpeculatingReadExecutor(ColumnFamilyStore cfs,
                                        ReadCommand command,
                                        ReplicaPlan.ForTokenRead replicaPlan,
-                                       long queryStartNanoTime)
+                                       long queryStartNanoTime,
+                                       QueryInfoTracker.ReadTracker readTracker)
         {
             // We're hitting additional targets for read repair (??).  Since our "extra" replica is the least-
             // preferred by the snitch, we do an extra data read to start with against a replica more
             // likely to respond; better to let RR fail than the entire query.
-            super(cfs, command, replicaPlan, replicaPlan.blockFor() < replicaPlan.contacts().size() ? 2 : 1, queryStartNanoTime);
+            super(cfs, command, replicaPlan, replicaPlan.blockFor() < replicaPlan.contacts().size() ? 2 : 1, queryStartNanoTime, readTracker);
         }
 
         public void maybeTryAdditionalReplicas()
@@ -328,11 +340,12 @@ public abstract class AbstractReadExecutor
         public AlwaysSpeculatingReadExecutor(ColumnFamilyStore cfs,
                                              ReadCommand command,
                                              ReplicaPlan.ForTokenRead replicaPlan,
-                                             long queryStartNanoTime)
+                                             long queryStartNanoTime,
+                                             QueryInfoTracker.ReadTracker readTracker)
         {
             // presumably, we speculate an extra data request here in case it is our data request that fails to respond,
             // and there are no more nodes to consult
-            super(cfs, command, replicaPlan, replicaPlan.contacts().size() > 1 ? 2 : 1, queryStartNanoTime);
+            super(cfs, command, replicaPlan, replicaPlan.contacts().size() > 1 ? 2 : 1, queryStartNanoTime, readTracker);
         }
 
         public void maybeTryAdditionalReplicas()

--- a/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
@@ -102,6 +102,8 @@ public abstract class AbstractReadExecutor
         for (Replica replica : replicaPlan.contacts())
             digestVersion = Math.min(digestVersion, MessagingService.instance().versions.get(replica.endpoint()));
         command.setDigestVersion(digestVersion);
+
+        readTracker.onReplicaPlan(replicaPlan);
     }
 
     public DecoratedKey getKey()

--- a/src/java/org/apache/cassandra/service/reads/DigestResolver.java
+++ b/src/java/org/apache/cassandra/service/reads/DigestResolver.java
@@ -28,12 +28,15 @@ import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadResponse;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
+import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.locator.Endpoints;
-import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.net.Message;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.service.reads.repair.NoopReadRepair;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -42,12 +45,17 @@ import static com.google.common.collect.Iterables.any;
 public class DigestResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<E>> extends ResponseResolver<E, P>
 {
     private volatile Message<ReadResponse> dataResponse;
+    private final QueryInfoTracker.ReadTracker readTracker;
 
-    public DigestResolver(ReadCommand command, ReplicaPlan.Shared<E, P> replicaPlan, long queryStartNanoTime)
+    public DigestResolver(ReadCommand command,
+                          ReplicaPlan.Shared<E, P> replicaPlan,
+                          long queryStartNanoTime,
+                          QueryInfoTracker.ReadTracker readTracker)
     {
         super(command, replicaPlan, queryStartNanoTime);
         Preconditions.checkArgument(command instanceof SinglePartitionReadCommand,
                                     "DigestResolver can only be used with SinglePartitionReadCommand commands");
+        this.readTracker = readTracker;
     }
 
     @Override
@@ -78,14 +86,17 @@ public class DigestResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRea
 
         if (!hasTransientResponse(responses))
         {
-            return UnfilteredPartitionIterators.filter(dataResponse.payload.makeIterator(command), command.nowInSec());
+            UnfilteredPartitionIterator unfilteredPartitionIterator = dataResponse.payload.makeIterator(command);
+            UnfilteredPartitionIterator trackedPartitionIterator = Transformation.apply(unfilteredPartitionIterator,
+                                                                                        new ReadTrackingTransformation(readTracker));
+            return UnfilteredPartitionIterators.filter(trackedPartitionIterator, command.nowInSec());
         }
         else
         {
             // This path can be triggered only if we've got responses from full replicas and they match, but
             // transient replica response still contains data, which needs to be reconciled.
             DataResolver<E, P> dataResolver
-                    = new DataResolver<>(command, replicaPlan, NoopReadRepair.instance, queryStartNanoTime);
+                    = new DataResolver<>(command, replicaPlan, NoopReadRepair.instance, queryStartNanoTime, readTracker);
 
             dataResolver.preprocess(dataResponse);
             // Reconcile with transient replicas
@@ -147,6 +158,11 @@ public class DigestResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRea
             ret[i] = new DigestResolverDebugResult(message.from(), digestHex, message.payload.isDigestResponse());
         }
         return ret;
+    }
+
+    public QueryInfoTracker.ReadTracker getReadTracker()
+    {
+        return readTracker;
     }
 
     public static class DigestResolverDebugResult

--- a/src/java/org/apache/cassandra/service/reads/DigestResolver.java
+++ b/src/java/org/apache/cassandra/service/reads/DigestResolver.java
@@ -87,9 +87,12 @@ public class DigestResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRea
         if (!hasTransientResponse(responses))
         {
             UnfilteredPartitionIterator unfilteredPartitionIterator = dataResponse.payload.makeIterator(command);
-            UnfilteredPartitionIterator trackedPartitionIterator = Transformation.apply(unfilteredPartitionIterator,
-                                                                                        new ReadTrackingTransformation(readTracker));
-            return UnfilteredPartitionIterators.filter(trackedPartitionIterator, command.nowInSec());
+            if (!QueryInfoTracker.ReadTracker.NOOP.equals(readTracker) && !QueryInfoTracker.LWTWriteTracker.NOOP.equals(readTracker))
+            {
+                unfilteredPartitionIterator = Transformation.apply(unfilteredPartitionIterator,
+                                                                  new ReadTrackingTransformation(readTracker));
+            }
+            return UnfilteredPartitionIterators.filter(unfilteredPartitionIterator, command.nowInSec());
         }
         else
         {

--- a/src/java/org/apache/cassandra/service/reads/ReadTrackingTransformation.java
+++ b/src/java/org/apache/cassandra/service/reads/ReadTrackingTransformation.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.reads;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.db.transform.Transformation;
+import org.apache.cassandra.service.QueryInfoTracker;
+import org.apache.cassandra.utils.NoSpamLogger;
+
+/**
+ * {@code UnfilteredRowIterator} transformation that callbacks {@link QueryInfoTracker.ReadTracker} on
+ * each row and partition. The transformation may be extended with other callback methods (like
+ * {@code applyToStatic} or {@code applyToDeletion} if necessary.
+ *
+ * Do not move closing the tracker here (to @{code onClose} method). One read may include more than
+ * one row iterator, closing the tracker here may result in multiple close callbacks.
+ */
+class ReadTrackingTransformation extends Transformation<UnfilteredRowIterator>
+{
+    private final QueryInfoTracker.ReadTracker readTracker;
+    private static final Logger logger = LoggerFactory.getLogger(ReadTrackingTransformation.class);
+
+    public ReadTrackingTransformation(QueryInfoTracker.ReadTracker readTracker)
+    {
+        this.readTracker = readTracker;
+    }
+
+    @Override
+    protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
+    {
+        return Transformation.apply(partition, this);
+    }
+
+    @Override
+    protected Row applyToRow(Row row)
+    {
+        try
+        {
+            readTracker.onRow(row);
+        }
+        catch (Exception exc)
+        {
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 60, TimeUnit.SECONDS,
+                             "Tracking callback for read rows failed", exc);
+        }
+        return super.applyToRow(row);
+    }
+
+    @Override
+    protected DecoratedKey applyToPartitionKey(DecoratedKey key)
+    {
+        try
+        {
+            readTracker.onPartition(key);
+        }
+        catch (Exception exc)
+        {
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 60, TimeUnit.SECONDS,
+                             "Tracking callback for read partitions failed", exc);
+        }
+        return super.applyToPartitionKey(key);
+    }
+}

--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -68,6 +68,7 @@ import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ClientWarn;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.reads.repair.NoopReadRepair;
 import org.apache.cassandra.tracing.Tracing;
@@ -144,7 +145,11 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
     {
         @SuppressWarnings("unchecked")
         DataResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver =
-            new DataResolver<>(cmd, replicaPlan, (NoopReadRepair<EndpointsForToken, ReplicaPlan.ForTokenRead>) NoopReadRepair.instance, queryStartNanoTime);
+            new DataResolver<>(cmd,
+                               replicaPlan,
+                               (NoopReadRepair<EndpointsForToken, ReplicaPlan.ForTokenRead>) NoopReadRepair.instance,
+                               queryStartNanoTime,
+                               QueryInfoTracker.ReadTracker.NOOP);
 
         ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime);
 

--- a/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.dht.ExcludingBounds;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.service.reads.repair.NoopReadRepair;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.tracing.Tracing;
@@ -192,7 +193,11 @@ public class ShortReadPartitionsProtection extends Transformation<UnfilteredRowI
     private <E extends Endpoints<E>, P extends ReplicaPlan.ForRead<E>>
     UnfilteredPartitionIterator executeReadCommand(ReadCommand cmd, ReplicaPlan.Shared<E, P> replicaPlan)
     {
-        DataResolver<E, P> resolver = new DataResolver<>(cmd, replicaPlan, (NoopReadRepair<E, P>)NoopReadRepair.instance, queryStartNanoTime);
+        DataResolver<E, P> resolver = new DataResolver<>(cmd,
+                                                         replicaPlan,
+                                                         (NoopReadRepair<E, P>)NoopReadRepair.instance,
+                                                         queryStartNanoTime,
+                                                         QueryInfoTracker.ReadTracker.NOOP);
         ReadCallback<E, P> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime);
 
         if (source.isSelf())

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
@@ -48,6 +48,8 @@ import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.QueryInfoTracker;
+import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.reads.DataResolver;
 import org.apache.cassandra.service.reads.ReadCallback;
 import org.apache.cassandra.service.reads.ShortReadPartitionsProtection;
@@ -82,6 +84,7 @@ public class EndpointGroupingCoordinator
     private final List<PartitionIterator> concurrentQueries;
 
     private final long queryStartNanoTime;
+    private QueryInfoTracker.ReadTracker readTracker;
     private final int vnodeRanges;
 
     /**
@@ -90,16 +93,18 @@ public class EndpointGroupingCoordinator
      * @param replicaPlans to be queried
      * @param concurrencyFactor number of vnode ranges to query at once
      * @param queryStartNanoTime the start time of the query
+     * @param readTracker
      */
     public EndpointGroupingCoordinator(PartitionRangeReadCommand command,
                                        DataLimits.Counter counter,
                                        Iterator<ReplicaPlan.ForRangeRead> replicaPlans,
                                        int concurrencyFactor,
-                                       long queryStartNanoTime)
+                                       long queryStartNanoTime, QueryInfoTracker.ReadTracker readTracker)
     {
         this.command = command;
         this.counter = counter;
         this.queryStartNanoTime = queryStartNanoTime;
+        this.readTracker = readTracker;
         this.endpointContexts = new HashMap<>();
 
         // Read callbacks in token order
@@ -161,8 +166,11 @@ public class EndpointGroupingCoordinator
 
         ReplicaPlan.SharedForRangeRead sharedReplicaPlan = ReplicaPlan.shared(replicaPlan);
 
-        DataResolver<EndpointsForRange, ReplicaPlan.ForRangeRead> resolver =
-                new EndpointDataResolver(subrangeCommand, sharedReplicaPlan, NoopReadRepair.instance, queryStartNanoTime);
+        DataResolver<EndpointsForRange, ReplicaPlan.ForRangeRead> resolver = new EndpointDataResolver(subrangeCommand,
+                                                                                                      sharedReplicaPlan,
+                                                                                                      NoopReadRepair.instance,
+                                                                                                      queryStartNanoTime,
+                                                                                                      readTracker);
 
         // Create a handler for the range and add it, by replica, to the endpoint contexts.
         ReadCallback<EndpointsForRange, ReplicaPlan.ForRangeRead> handler =
@@ -285,9 +293,9 @@ public class EndpointGroupingCoordinator
      */
     private class EndpointDataResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<E>> extends DataResolver<E, P>
     {
-        public EndpointDataResolver(ReadCommand command, ReplicaPlan.Shared replicaPlan, ReadRepair readRepair, long queryStartNanoTime)
+        public EndpointDataResolver(ReadCommand command, ReplicaPlan.Shared replicaPlan, ReadRepair readRepair, long queryStartNanoTime, QueryInfoTracker.ReadTracker readTracker)
         {
-            super(command, replicaPlan, readRepair, queryStartNanoTime);
+            super(command, replicaPlan, readRepair, queryStartNanoTime, readTracker);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
@@ -99,7 +99,8 @@ public class EndpointGroupingCoordinator
                                        DataLimits.Counter counter,
                                        Iterator<ReplicaPlan.ForRangeRead> replicaPlans,
                                        int concurrencyFactor,
-                                       long queryStartNanoTime, QueryInfoTracker.ReadTracker readTracker)
+                                       long queryStartNanoTime,
+                                       QueryInfoTracker.ReadTracker readTracker)
     {
         this.command = command;
         this.counter = counter;

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
@@ -117,6 +117,7 @@ public class EndpointGroupingCoordinator
         while (replicaPlans.hasNext() && vnodeRanges < concurrencyFactor)
         {
             ReplicaPlan.ForRangeRead replicaPlan = replicaPlans.next();
+            readTracker.onReplicaPlan(replicaPlan);
 
             boolean isFirst = vnodeRanges == 0;
             vnodeRanges += replicaPlan.vnodeCount();

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingRangeCommandIterator.java
@@ -41,8 +41,6 @@ import org.apache.cassandra.utils.CloseableIterator;
  */
 public class EndpointGroupingRangeCommandIterator extends RangeCommandIterator
 {
-    private QueryInfoTracker.ReadTracker readTracker;
-
     EndpointGroupingRangeCommandIterator(CloseableIterator<ReplicaPlan.ForRangeRead> replicaPlans,
                                          PartitionRangeReadCommand command,
                                          int concurrencyFactor,

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingRangeCommandIterator.java
@@ -19,9 +19,9 @@
 package org.apache.cassandra.service.reads.range;
 
 import org.apache.cassandra.db.PartitionRangeReadCommand;
-import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
 
@@ -41,14 +41,17 @@ import org.apache.cassandra.utils.CloseableIterator;
  */
 public class EndpointGroupingRangeCommandIterator extends RangeCommandIterator
 {
+    private QueryInfoTracker.ReadTracker readTracker;
+
     EndpointGroupingRangeCommandIterator(CloseableIterator<ReplicaPlan.ForRangeRead> replicaPlans,
                                          PartitionRangeReadCommand command,
                                          int concurrencyFactor,
                                          int maxConcurrencyFactor,
                                          int totalRangeCount,
-                                         long queryStartNanoTime)
+                                         long queryStartNanoTime,
+                                         QueryInfoTracker.ReadTracker readTracker)
     {
-        super(replicaPlans, command, concurrencyFactor, maxConcurrencyFactor, totalRangeCount, queryStartNanoTime);
+        super(replicaPlans, command, concurrencyFactor, maxConcurrencyFactor, totalRangeCount, queryStartNanoTime, readTracker);
     }
 
     @Override
@@ -60,7 +63,8 @@ public class EndpointGroupingRangeCommandIterator extends RangeCommandIterator
                                                                                   counter,
                                                                                   replicaPlans,
                                                                                   concurrencyFactor(),
-                                                                                  queryStartNanoTime);
+                                                                                  queryStartNanoTime,
+                                                                                  readTracker);
         PartitionIterator partitions = coordinator.execute();
 
         rangesQueried += coordinator.vnodeRanges();

--- a/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
@@ -46,7 +46,8 @@ public class NonGroupingRangeCommandIterator extends RangeCommandIterator
                                     int concurrencyFactor,
                                     int maxConcurrencyFactor,
                                     int totalRangeCount,
-                                    long queryStartNanoTime, QueryInfoTracker.ReadTracker readTracker)
+                                    long queryStartNanoTime,
+                                    QueryInfoTracker.ReadTracker readTracker)
     {
         super(replicaPlans, command, concurrencyFactor, maxConcurrencyFactor, totalRangeCount, queryStartNanoTime, readTracker);
     }

--- a/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
@@ -62,6 +62,7 @@ public class NonGroupingRangeCommandIterator extends RangeCommandIterator
             for (int i = 0; i < concurrencyFactor() && replicaPlans.hasNext(); )
             {
                 ReplicaPlan.ForRangeRead replicaPlan = replicaPlans.next();
+                readTracker.onReplicaPlan(replicaPlan);
 
                 @SuppressWarnings("resource") // response will be closed by concatAndBlockOnRepair, or in the catch block below
                 SingleRangeResponse response = query(replicaPlan, i == 0);

--- a/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
@@ -25,13 +25,13 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
 import org.apache.cassandra.db.ReadCommand;
-import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.locator.EndpointsForRange;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.reads.DataResolver;
 import org.apache.cassandra.service.reads.ReadCallback;
@@ -46,9 +46,9 @@ public class NonGroupingRangeCommandIterator extends RangeCommandIterator
                                     int concurrencyFactor,
                                     int maxConcurrencyFactor,
                                     int totalRangeCount,
-                                    long queryStartNanoTime)
+                                    long queryStartNanoTime, QueryInfoTracker.ReadTracker readTracker)
     {
-        super(replicaPlans, command, concurrencyFactor, maxConcurrencyFactor, totalRangeCount, queryStartNanoTime);
+        super(replicaPlans, command, concurrencyFactor, maxConcurrencyFactor, totalRangeCount, queryStartNanoTime, readTracker);
     }
 
     protected PartitionIterator sendNextRequests()
@@ -112,7 +112,7 @@ public class NonGroupingRangeCommandIterator extends RangeCommandIterator
         ReadRepair<EndpointsForRange, ReplicaPlan.ForRangeRead> readRepair =
         ReadRepair.create(command, sharedReplicaPlan, queryStartNanoTime);
         DataResolver<EndpointsForRange, ReplicaPlan.ForRangeRead> resolver =
-        new DataResolver<>(rangeCommand, sharedReplicaPlan, readRepair, queryStartNanoTime);
+        new DataResolver<>(rangeCommand, sharedReplicaPlan, readRepair, queryStartNanoTime, readTracker);
         ReadCallback<EndpointsForRange, ReplicaPlan.ForRangeRead> handler =
         new ReadCallback<>(resolver, rangeCommand, sharedReplicaPlan, queryStartNanoTime);
 

--- a/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
@@ -125,7 +125,7 @@ public abstract class AbstractReadRepair<E extends Endpoints<E>, P extends Repli
         getRepairMeter().mark();
 
         // Do a full data read to resolve the correct response (and repair node that need be)
-        DataResolver<E, P> resolver = new DataResolver<>(command, replicaPlan, this, queryStartNanoTime);
+        DataResolver<E, P> resolver = new DataResolver<>(command, replicaPlan, this, queryStartNanoTime, digestResolver.getReadTracker());
         ReadCallback<E, P> readCallback = new ReadCallback<>(resolver, command, replicaPlan, queryStartNanoTime);
 
         digestRepair = new DigestRepair(resolver, readCallback, resultConsumer);

--- a/src/java/org/apache/cassandra/tracing/ExpiredTraceState.java
+++ b/src/java/org/apache/cassandra/tracing/ExpiredTraceState.java
@@ -29,7 +29,7 @@ class ExpiredTraceState extends TraceState
 
     ExpiredTraceState(TraceState delegate)
     {
-        super(FBUtilities.getBroadcastAddressAndPort(), delegate.sessionId, delegate.traceType);
+        super(delegate.clientState, FBUtilities.getBroadcastAddressAndPort(), delegate.sessionId, delegate.traceType);
         this.delegate = delegate;
     }
 

--- a/src/java/org/apache/cassandra/tracing/TraceState.java
+++ b/src/java/org/apache/cassandra/tracing/TraceState.java
@@ -28,6 +28,7 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.helpers.MessageFormatter;
 
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.progress.ProgressEvent;
 import org.apache.cassandra.utils.progress.ProgressEventNotifier;
@@ -45,6 +46,7 @@ public abstract class TraceState implements ProgressEventNotifier
     public final ByteBuffer sessionIdBytes;
     public final Tracing.TraceType traceType;
     public final int ttl;
+    public final ClientState clientState;
 
     private boolean notify;
     private final List<ProgressListener> listeners = new CopyOnWriteArrayList<>();
@@ -63,11 +65,12 @@ public abstract class TraceState implements ProgressEventNotifier
     // See CASSANDRA-7626 for more details.
     private final AtomicInteger references = new AtomicInteger(1);
 
-    protected TraceState(InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType)
+    protected TraceState(ClientState clientState, InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType)
     {
         assert coordinator != null;
         assert sessionId != null;
 
+        this.clientState = clientState;
         this.coordinator = coordinator;
         this.sessionId = sessionId;
         sessionIdBytes = ByteBufferUtil.bytes(sessionId);

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -157,7 +157,11 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
     public String getKeyspace()
     {
         assert isTracing();
-        return state.get().clientState.getKeyspace();
+
+        if (state.get().clientState instanceof TracingClientState)
+            return ((TracingClientState) state.get().clientState).tracedKeyspace();
+
+        return null;
     }
 
     /**
@@ -327,7 +331,11 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
 
         addToMutable.put(ParamType.TRACE_SESSION, Tracing.instance.getSessionId());
         addToMutable.put(ParamType.TRACE_TYPE, Tracing.instance.getTraceType());
-        addToMutable.put(ParamType.TRACE_KEYSPACE, Tracing.instance.getKeyspace());
+        String keyspace = Tracing.instance.getKeyspace();
+        if (keyspace != null)
+        {
+            addToMutable.put(ParamType.TRACE_KEYSPACE, keyspace);
+        }
         return addToMutable;
     }
 

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -28,6 +28,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,8 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.ParamType;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.TracingClientState;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.UUIDGen;
@@ -149,6 +153,13 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
         return state.get().ttl;
     }
 
+    @Nullable
+    public String getKeyspace()
+    {
+        assert isTracing();
+        return state.get().clientState.getKeyspace();
+    }
+
     /**
      * Indicates if the current thread's execution is being traced.
      */
@@ -157,33 +168,35 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
         return instance.get() != null;
     }
 
-    public UUID newSession(Map<String,ByteBuffer> customPayload)
+    public UUID newSession(ClientState state, Map<String,ByteBuffer> customPayload)
     {
         return newSession(
+                state,
                 TimeUUIDType.instance.compose(ByteBuffer.wrap(UUIDGen.getTimeUUIDBytes())),
                 TraceType.QUERY,
                 customPayload);
     }
 
-    public UUID newSession(TraceType traceType)
+    public UUID newSession(ClientState state, TraceType traceType)
     {
         return newSession(
+                state,
                 TimeUUIDType.instance.compose(ByteBuffer.wrap(UUIDGen.getTimeUUIDBytes())),
                 traceType,
                 Collections.EMPTY_MAP);
     }
 
-    public UUID newSession(UUID sessionId, Map<String,ByteBuffer> customPayload)
+    public UUID newSession(ClientState state, UUID sessionId, Map<String,ByteBuffer> customPayload)
     {
-        return newSession(sessionId, TraceType.QUERY, customPayload);
+        return newSession(state, sessionId, TraceType.QUERY, customPayload);
     }
 
     /** This method is intended to be overridden in tracing implementations that need access to the customPayload */
-    protected UUID newSession(UUID sessionId, TraceType traceType, Map<String,ByteBuffer> customPayload)
+    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, Map<String,ByteBuffer> customPayload)
     {
         assert get() == null;
 
-        TraceState ts = newTraceState(localAddress, sessionId, traceType);
+        TraceState ts = newTraceState(state, localAddress, sessionId, traceType);
         set(ts);
         sessions.put(sessionId, ts);
 
@@ -258,14 +271,16 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
 
         TraceType traceType = header.traceType();
 
+        ClientState clientState = TracingClientState.withTracedKeyspace(header.traceKeyspace());
+        ts = newTraceState(clientState, header.from, sessionId, traceType);
+
         if (header.verb.isResponse())
         {
             // received a message for a session we've already closed out.  see CASSANDRA-5668
-            return new ExpiredTraceState(newTraceState(header.from, sessionId, traceType));
+            return new ExpiredTraceState(ts);
         }
         else
         {
-            ts = newTraceState(header.from, sessionId, traceType);
             sessions.put(sessionId, ts);
             return ts;
         }
@@ -289,7 +304,9 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
             if (state == null) // session may have already finished; see CASSANDRA-5668
             {
                 TraceType traceType = message.traceType();
-                trace(ByteBuffer.wrap(UUIDGen.decompose(sessionId)), logMessage, traceType.getTTL());
+                String traceKeyspace = message.header.traceKeyspace();
+                ClientState clientState = TracingClientState.withTracedKeyspace(traceKeyspace);
+                trace(clientState, ByteBuffer.wrap(UUIDGen.decompose(sessionId)), logMessage, traceType.getTTL());
             }
             else
             {
@@ -310,10 +327,15 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
 
         addToMutable.put(ParamType.TRACE_SESSION, Tracing.instance.getSessionId());
         addToMutable.put(ParamType.TRACE_TYPE, Tracing.instance.getTraceType());
+        addToMutable.put(ParamType.TRACE_KEYSPACE, Tracing.instance.getKeyspace());
         return addToMutable;
     }
 
-    protected abstract TraceState newTraceState(InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType);
+    protected abstract TraceState newTraceState(
+        ClientState state,
+        InetAddressAndPort coordinator,
+        UUID sessionId,
+        Tracing.TraceType traceType);
 
     // repair just gets a varargs method since it's so heavyweight anyway
     public static void traceRepair(String format, Object... args)
@@ -365,5 +387,5 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
     /**
      * Called for non-local traces (traces that are not initiated by local node == coordinator).
      */
-    public abstract void trace(ByteBuffer sessionId, String message, int ttl);
+    public abstract void trace(ClientState clientState, ByteBuffer sessionId, String message, int ttl);
 }

--- a/src/java/org/apache/cassandra/tracing/TracingImpl.java
+++ b/src/java/org/apache/cassandra/tracing/TracingImpl.java
@@ -25,7 +25,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.utils.WrappedRunnable;
 
 
@@ -93,15 +95,15 @@ class TracingImpl extends Tracing
     }
 
     @Override
-    protected TraceState newTraceState(InetAddressAndPort coordinator, UUID sessionId, TraceType traceType)
+    protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType)
     {
-        return new TraceStateImpl(coordinator, sessionId, traceType);
+        return new TraceStateImpl(state, coordinator, sessionId, traceType);
     }
 
     /**
      * Called for non-local traces (traces that are not initiated by local node == coordinator).
      */
-    public void trace(final ByteBuffer sessionId, final String message, final int ttl)
+    public void trace(ClientState clientState, final ByteBuffer sessionId, final String message, final int ttl)
     {
         final String threadName = Thread.currentThread().getName();
 
@@ -109,7 +111,8 @@ class TracingImpl extends Tracing
         {
             public void runMayThrow()
             {
-                TraceStateImpl.mutateWithCatch(TraceKeyspace.makeEventMutation(sessionId, message, -1, threadName, ttl));
+                Mutation mutation = TraceKeyspace.makeEventMutation(sessionId, message, -1, threadName, ttl);
+                TraceStateImpl.mutateWithCatch(clientState, mutation);
             }
         });
     }

--- a/src/java/org/apache/cassandra/transport/Message.java
+++ b/src/java/org/apache/cassandra/transport/Message.java
@@ -227,12 +227,12 @@ public abstract class Message
                 {
                     shouldTrace = true;
                     tracingSessionId = UUIDGen.getTimeUUID();
-                    Tracing.instance.newSession(tracingSessionId, getCustomPayload());
+                    Tracing.instance.newSession(queryState.getClientState(), tracingSessionId, getCustomPayload());
                 }
                 else if (StorageService.instance.shouldTraceProbablistically())
                 {
                     shouldTrace = true;
-                    Tracing.instance.newSession(getCustomPayload());
+                    Tracing.instance.newSession(queryState.getClientState(), getCustomPayload());
                 }
             }
 

--- a/src/java/org/apache/cassandra/utils/StringSerializer.java
+++ b/src/java/org/apache/cassandra/utils/StringSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils;
+
+import java.io.IOException;
+
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.io.IVersionedSerializer;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+
+public class StringSerializer implements IVersionedSerializer<String>
+{
+    public static StringSerializer serializer = new StringSerializer();
+
+    @Override
+    public void serialize(String value, DataOutputPlus out, int version) throws IOException
+    {
+        out.writeUTF(value);
+    }
+
+    @Override
+    public String deserialize(DataInputPlus in, int version) throws IOException
+    {
+        return in.readUTF();
+    }
+
+    @Override
+    public long serializedSize(String value, int version)
+    {
+        return TypeSizes.sizeof(value);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/impl/Coordinator.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Coordinator.java
@@ -63,12 +63,13 @@ public class Coordinator implements ICoordinator
         return instance().sync(() -> executeInternal(query, consistencyLevel, boundValues)).call();
     }
 
+    @Override
     public Future<SimpleQueryResult> asyncExecuteWithTracingWithResult(UUID sessionId, String query, ConsistencyLevel consistencyLevelOrigin, Object... boundValues)
     {
         return instance.async(() -> {
             try
             {
-                Tracing.instance.newSession(sessionId, Collections.emptyMap());
+                Tracing.instance.newSession(ClientState.forInternalCalls(), sessionId, Collections.emptyMap());
                 return executeInternal(query, consistencyLevelOrigin, boundValues);
             }
             finally

--- a/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
@@ -74,7 +74,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
         tester.mutate(2, "INSERT INTO %s (pk, ck, v) VALUES (1, 1, 2)");
 
         cluster.get(tester.coordinator).runOnInstance(() -> {
-            StorageProxy.instance.register(new QueryInfoTrackerTest.TestQueryInfoTracker(keyspace));
+            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(keyspace));
         });
 
         tester.assertRowsDistributed("SELECT * FROM %s WHERE pk=1 AND ck=1",
@@ -97,7 +97,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
         cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
 
         cluster.get(1).runOnInstance(() -> {
-            StorageProxy.instance.register(new QueryInfoTrackerTest.TestQueryInfoTracker(KEYSPACE));
+            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(KEYSPACE));
         });
 
         cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1) IF NOT EXISTS",

--- a/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
@@ -88,6 +88,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
             Assert.assertEquals(1, tracker.reads.get());
             Assert.assertEquals(1, tracker.readPartitions.get());
             Assert.assertEquals(1, tracker.readRows.get());
+            Assert.assertEquals(1, tracker.replicaPlans.get());
         });
     }
 
@@ -100,7 +101,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
             StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(KEYSPACE));
         });
 
-        cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1) IF NOT EXISTS",
+        cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1)",
                                        ConsistencyLevel.QUORUM);
         assertRows(cluster.coordinator(1).execute("SELECT * FROM " + KEYSPACE + ".tbl WHERE pk = 1",
                                                   ConsistencyLevel.QUORUM),
@@ -114,6 +115,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
             Assert.assertEquals(1, tracker.reads.get());
             Assert.assertEquals(1, tracker.readPartitions.get());
             Assert.assertEquals(1, tracker.readRows.get());
+            Assert.assertEquals(1, tracker.replicaPlans.get());
         });
     }
 
@@ -150,6 +152,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
             Assert.assertEquals(1, tracker.rangeReads.get());
             Assert.assertEquals(rowsCount, tracker.readPartitions.get());
             Assert.assertEquals(rowsCount, tracker.readRows.get());
+            Assert.assertEquals(4, tracker.replicaPlans.get());
         });
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.service.QueryInfoTrackerTest;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.reads.repair.ReadRepairStrategy;
+
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+public class QueryInfoTrackerDistributedTest extends TestBaseImpl
+{
+    private static Cluster cluster;
+    private final static String rfOneKs = "rfoneks";
+
+    @BeforeClass
+    public static void setupCluster() throws Throwable
+    {
+        cluster = init(Cluster.build().withNodes(3).start());
+
+        cluster.schemaChange("CREATE KEYSPACE " + rfOneKs +
+                             " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
+    }
+
+    @AfterClass
+    public static void close() throws Exception
+    {
+        cluster.close();
+        cluster = null;
+    }
+
+    @Test
+    public void testTrackingInDataResolverResolve()
+    {
+        ReadRepairTester tester = new ReadRepairTester(cluster, ReadRepairStrategy.BLOCKING, 1, false, false, false)
+        {
+            @Override
+            ReadRepairTester self()
+            {
+                return this;
+            }
+        };
+
+        String keyspace = tester.qualifiedTableName.split("\\.")[0];
+
+        tester.createTable("CREATE TABLE %s (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        cluster.coordinator(1).execute("INSERT INTO " + tester.qualifiedTableName + " (pk, ck, v) VALUES (1, 1, 1)",
+                                       ConsistencyLevel.QUORUM);
+
+        tester.mutate(2, "INSERT INTO %s (pk, ck, v) VALUES (1, 1, 2)");
+
+        cluster.get(tester.coordinator).runOnInstance(() -> {
+            StorageProxy.instance.register(new QueryInfoTrackerTest.TestQueryInfoTracker(keyspace));
+        });
+
+        tester.assertRowsDistributed("SELECT * FROM %s WHERE pk=1 AND ck=1",
+                                     2,
+                                     row(1, 1, 2));
+
+        cluster.get(tester.coordinator).runOnInstance(() -> {
+            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
+            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
+
+            Assert.assertEquals(1, tracker.reads.get());
+            Assert.assertEquals(1, tracker.readPartitions.get());
+            Assert.assertEquals(1, tracker.readRows.get());
+        });
+    }
+
+    @Test
+    public void testTrackingInDigestResolverGetData()
+    {
+        cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+
+        cluster.get(1).runOnInstance(() -> {
+            StorageProxy.instance.register(new QueryInfoTrackerTest.TestQueryInfoTracker(KEYSPACE));
+        });
+
+        cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1) IF NOT EXISTS",
+                                       ConsistencyLevel.QUORUM);
+        assertRows(cluster.coordinator(1).execute("SELECT * FROM " + KEYSPACE + ".tbl WHERE pk = 1",
+                                                  ConsistencyLevel.QUORUM),
+                   row(1, 1, 1));
+
+
+        cluster.get(1).runOnInstance(() -> {
+            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
+            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
+
+            Assert.assertEquals(1, tracker.reads.get());
+            Assert.assertEquals(1, tracker.readPartitions.get());
+            Assert.assertEquals(1, tracker.readRows.get());
+        });
+    }
+
+    @Test
+    public void testTrackingReadsWithEndpointGrouping() throws Throwable
+    {
+        String table = rfOneKs + ".saiTbl";
+        cluster.schemaChange("CREATE TABLE " + table + " (id1 TEXT PRIMARY KEY, v1 INT, v2 TEXT)");
+        cluster.schemaChange("CREATE CUSTOM INDEX IF NOT EXISTS test_idx ON " + table + " (v1) USING 'StorageAttachedIndex'");
+
+        int rowsCount = 1000;
+
+        for (int i = 0; i < rowsCount; ++i)
+        {
+            cluster.coordinator(1).execute("INSERT INTO " + table + " (id1, v1, v2) VALUES (?, ?, ?);",
+                                           ConsistencyLevel.QUORUM,
+                                           String.valueOf(i),
+                                           i,
+                                           String.valueOf(i));
+        }
+
+
+        cluster.get(1).runOnInstance(() -> {
+            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(rfOneKs));
+        });
+
+        cluster.coordinator(1).execute(String.format("SELECT id1 FROM %s WHERE v1>=0", table),
+                                       ConsistencyLevel.QUORUM);
+
+        cluster.get(1).runOnInstance(() -> {
+            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
+            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
+
+            Assert.assertEquals(1, tracker.rangeReads.get());
+            Assert.assertEquals(rowsCount, tracker.readPartitions.get());
+            Assert.assertEquals(rowsCount, tracker.readRows.get());
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/concurrent/DebuggableThreadPoolExecutorTest.java
+++ b/test/unit/org/apache/cassandra/concurrent/DebuggableThreadPoolExecutorTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.TraceStateImpl;
 import org.apache.cassandra.tracing.Tracing;
@@ -157,7 +158,7 @@ public class DebuggableThreadPoolExecutorTest
     {
         TraceState state = Tracing.instance.get();
         try {
-            Tracing.instance.set(new TraceStateImpl(InetAddressAndPort.getByAddress(InetAddresses.forString("127.0.0.1")), UUID.randomUUID(), Tracing.TraceType.NONE));
+            Tracing.instance.set(new TraceStateImpl(ClientState.forInternalCalls(), InetAddressAndPort.getByAddress(InetAddresses.forString("127.0.0.1")), UUID.randomUUID(), Tracing.TraceType.NONE));
             fn.run();
         }
         finally

--- a/test/unit/org/apache/cassandra/db/ReadCommandTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandTest.java
@@ -77,6 +77,7 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableParams;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -440,7 +441,7 @@ public class ReadCommandTest
         ReadCommand readCommand = Util.cmd(cfs, Util.dk("key")).includeRow("dd").build();
         int messagingVersion = MessagingService.current_version;
         FakeOutputStream out = new FakeOutputStream();
-        Tracing.instance.newSession(Tracing.TraceType.QUERY);
+        Tracing.instance.newSession(ClientState.forInternalCalls(), Tracing.TraceType.QUERY);
         Message<ReadCommand> messageOut = Message.out(Verb.READ_REQ, readCommand);
         long size = messageOut.serializedSize(messagingVersion);
         Message.serializer.serialize(messageOut, new WrappedDataOutputStreamPlus(out), messagingVersion);

--- a/test/unit/org/apache/cassandra/net/MessageTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageTest.java
@@ -35,10 +35,10 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.tracing.Tracing.TraceType;
 import org.apache.cassandra.utils.FBUtilities;
-import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.net.Message.serializer;
 import static org.apache.cassandra.net.MessagingService.VERSION_3014;
@@ -215,7 +215,7 @@ public class MessageTest
     {
         try
         {
-            UUID sessionId = Tracing.instance.newSession(traceType);
+            UUID sessionId = Tracing.instance.newSession(ClientState.forInternalCalls(), traceType);
             Message<NoPayload> msg = Message.builder(Verb._TEST_1, noPayload).withTracingParams().build();
             assertEquals(sessionId, msg.header.traceSession());
             assertEquals(traceType, msg.header.traceType());

--- a/test/unit/org/apache/cassandra/service/QueryInfoTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/QueryInfoTrackerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.collect.Iterables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that the methods of the {@link QueryInfoTracker} interface are correctly called.
+ *
+ * <p>The tests below use "drivers" sessions so as to ensure that queries go through {@link StorageProxy}, where
+ * {@link QueryInfoTracker} is setup.
+ */
+public class QueryInfoTrackerTest extends CQLTester
+{
+    private static final String KEYSPACE = "test_ks";
+    private volatile TestQueryInfoTracker tracker;
+    private volatile Session session;
+
+    @Before
+    public void setupTest()
+    {
+        tracker = new TestQueryInfoTracker();
+        StorageProxy.instance.register(tracker);
+        requireNetwork();
+        session = sessionNet();
+        // Just in case the teardown didn't run for some reason.
+        session.execute("DROP KEYSPACE IF EXISTS " + KEYSPACE);
+        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE +
+                        " WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+    }
+
+    @After
+    public void teardownTest()
+    {
+        session.execute("DROP KEYSPACE IF EXISTS " + KEYSPACE);
+    }
+
+    @Test
+    public void testSimpleQueryTracing()
+    {
+        int KEYS = 4;
+        int CLUSTERING = 4;
+        String TABLE = KEYSPACE + ".simple";
+        session.execute("CREATE TABLE " + TABLE + "(k int, c int, v int, PRIMARY KEY (k, c))");
+        for (int k = 0; k < KEYS; k++)
+        {
+            for (int v = 0; v < CLUSTERING; v++)
+            {
+                session.execute("INSERT INTO " + TABLE + "(k, c) values (?, ?)", k, v);
+            }
+        }
+
+        int expectedWrites = KEYS * CLUSTERING;
+        int expectedRows = KEYS * CLUSTERING;
+        assertEquals(expectedWrites, tracker.writes.get());
+        assertEquals(expectedRows, tracker.writtenRows.get());
+        assertEquals(0, tracker.loggedWrites.get());
+
+        session.execute("SELECT * FROM " + TABLE + " WHERE k = ?", 0);
+
+        session.execute("UPDATE " + TABLE + " SET v = ? WHERE k = ? AND c IN ?", 42, 0, Arrays.asList(0, 2, 3));
+        expectedWrites += 1; // We only did one more write ...
+        expectedRows += 3;   // ... but it updates 3 rows.
+        assertEquals(expectedWrites, tracker.writes.get());
+        assertEquals(expectedRows, tracker.writtenRows.get());
+        assertEquals(0, tracker.loggedWrites.get());
+    }
+
+    @Test
+    public void testLoggedBatchQueryTracing()
+    {
+        String TABLE = KEYSPACE + ".logged_batch";
+        session.execute("CREATE TABLE " + TABLE + "(k int, c int, v int, PRIMARY KEY (k, c))");
+
+        session.execute("BEGIN BATCH "
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (0, 0, 0);"
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (1, 1, 1);"
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (2, 2, 2);"
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (3, 3, 3);"
+                        + "APPLY BATCH");
+
+        assertEquals(1, tracker.writes.get());
+        assertEquals(1, tracker.loggedWrites.get());
+        assertEquals(4, tracker.writtenRows.get());
+
+        session.execute("BEGIN BATCH "
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (4, 4, 4);"
+                        + "INSERT INTO " + TABLE + "(k, c, v) VALUES (5, 5, 5);"
+                        + "APPLY BATCH");
+
+        assertEquals(2, tracker.writes.get());
+        assertEquals(2, tracker.loggedWrites.get());
+        assertEquals(6, tracker.writtenRows.get());
+    }
+
+    private static class TestQueryInfoTracker implements QueryInfoTracker
+    {
+        public final AtomicInteger writes = new AtomicInteger();
+        public final AtomicInteger loggedWrites = new AtomicInteger();
+        public final AtomicInteger writtenRows = new AtomicInteger();
+        public final AtomicInteger errorWrites = new AtomicInteger();
+
+        private boolean shouldIgnore(TableMetadata table)
+        {
+            // We exclude anything that isn't on our test keyspace to be sure no "system" query interferes.
+            return !table.keyspace.equals(KEYSPACE);
+        }
+
+        private TableMetadata extractTable(Collection<? extends IMutation> mutations)
+        {
+            return Iterables.getLast(mutations).getPartitionUpdates().iterator().next().metadata();
+        }
+
+        @Override
+        public WriteTracker onWrite(ClientState state,
+                                    boolean isLogged,
+                                    Collection<? extends IMutation> mutations,
+                                    ConsistencyLevel consistencyLevel)
+        {
+            if (shouldIgnore(extractTable(mutations)))
+                return WriteTracker.NOOP;
+
+            return new WriteTracker() {
+                @Override
+                public void onDone()
+                {
+                    writes.incrementAndGet();
+                    if (isLogged)
+                        loggedWrites.incrementAndGet();
+                    for (IMutation mutation : mutations)
+                    {
+                        for (PartitionUpdate update : mutation.getPartitionUpdates())
+                        {
+                            writtenRows.addAndGet(update.rowCount());
+                        }
+                    }
+                }
+
+                @Override
+                public void onError(Throwable exception)
+                {
+                    errorWrites.incrementAndGet();
+                }
+            };
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/reads/AbstractReadResponseTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/AbstractReadResponseTest.java
@@ -72,6 +72,7 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -343,5 +344,10 @@ public abstract class AbstractReadResponseTest
             }
         };
         return new SingletonUnfilteredPartitionIterator(rowIter);
+    }
+
+    public QueryInfoTracker.ReadTracker noopReadTracker()
+    {
+        return QueryInfoTracker.ReadTracker.NOOP;
     }
 }

--- a/test/unit/org/apache/cassandra/service/reads/DataResolverTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/DataResolverTest.java
@@ -132,7 +132,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveNewerSingleRow()
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, iter(new RowUpdateBuilder(cfm, nowInSec, 0L, dk).clustering("1")
                                                                                                      .add("c1", "v1")
@@ -164,7 +164,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveDisjointSingleRow()
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, iter(new RowUpdateBuilder(cfm, nowInSec, 0L, dk).clustering("1")
                                                                                                      .add("c1", "v1")
@@ -201,7 +201,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveDisjointMultipleRows() throws UnknownHostException
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, iter(new RowUpdateBuilder(cfm, nowInSec, 0L, dk).clustering("1")
                                                                                                      .add("c1", "v1")
@@ -248,7 +248,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveDisjointMultipleRowsWithRangeTombstones()
     {
         EndpointsForRange replicas = makeReplicas(4);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
 
         RangeTombstone tombstone1 = tombstone("1", "11", 1, nowInSec);
         RangeTombstone tombstone2 = tombstone("3", "31", 1, nowInSec);
@@ -329,7 +329,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveWithOneEmpty()
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, iter(new RowUpdateBuilder(cfm, nowInSec, 1L, dk).clustering("1")
                                                                                                      .add("c2", "v2")
@@ -360,7 +360,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     {
         EndpointsForRange replicas = makeReplicas(2);
         TestableReadRepair readRepair = new TestableReadRepair(command);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         resolver.preprocess(response(command, replicas.get(0).endpoint(), EmptyIterators.unfilteredPartition(cfm)));
         resolver.preprocess(response(command, replicas.get(1).endpoint(), EmptyIterators.unfilteredPartition(cfm)));
 
@@ -376,7 +376,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveDeleted()
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         // one response with columns timestamped before a delete in another response
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, iter(new RowUpdateBuilder(cfm, nowInSec, 0L, dk).clustering("1")
@@ -402,7 +402,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testResolveMultipleDeleted()
     {
         EndpointsForRange replicas = makeReplicas(4);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         // deletes and columns with interleaved timestamp, with out of order return sequence
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         resolver.preprocess(response(command, peer1, fullPartitionDelete(cfm, dk, 0, nowInSec)));
@@ -487,7 +487,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     private void resolveRangeTombstonesOnBoundary(long timestamp1, long timestamp2)
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         InetAddressAndPort peer2 = replicas.get(1).endpoint();
 
@@ -561,7 +561,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     private void testRepairRangeTombstoneBoundary(int timestamp1, int timestamp2, int timestamp3) throws UnknownHostException
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         InetAddressAndPort peer2 = replicas.get(1).endpoint();
 
@@ -614,7 +614,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     {
         EndpointsForRange replicas = makeReplicas(2);
 
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         InetAddressAndPort peer2 = replicas.get(1).endpoint();
 
@@ -653,7 +653,7 @@ public class DataResolverTest extends AbstractReadResponseTest
     public void testRepairRangeTombstoneWithPartitionDeletion2()
     {
         EndpointsForRange replicas = makeReplicas(2);
-        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(command, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
         InetAddressAndPort peer1 = replicas.get(0).endpoint();
         InetAddressAndPort peer2 = replicas.get(1).endpoint();
 
@@ -737,7 +737,7 @@ public class DataResolverTest extends AbstractReadResponseTest
         EndpointsForRange replicas = makeReplicas(2);
         ReadCommand cmd = Util.cmd(cfs2, dk).withNowInSeconds(nowInSec).build();
         TestableReadRepair readRepair = new TestableReadRepair(cmd);
-        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
 
         long[] ts = {100, 200};
 
@@ -789,7 +789,7 @@ public class DataResolverTest extends AbstractReadResponseTest
         EndpointsForRange replicas = makeReplicas(2);
         ReadCommand cmd = Util.cmd(cfs2, dk).withNowInSeconds(nowInSec).build();
         TestableReadRepair readRepair = new TestableReadRepair(cmd);
-        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
 
         long[] ts = {100, 200};
 
@@ -833,7 +833,7 @@ public class DataResolverTest extends AbstractReadResponseTest
         EndpointsForRange replicas = makeReplicas(2);
         ReadCommand cmd = Util.cmd(cfs2, dk).withNowInSeconds(nowInSec).build();
         TestableReadRepair readRepair = new TestableReadRepair(cmd);
-        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
 
         long[] ts = {100, 200};
 
@@ -883,7 +883,7 @@ public class DataResolverTest extends AbstractReadResponseTest
         EndpointsForRange replicas = makeReplicas(2);
         ReadCommand cmd = Util.cmd(cfs2, dk).withNowInSeconds(nowInSec).build();
         TestableReadRepair readRepair = new TestableReadRepair(cmd);
-        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime());
+        DataResolver resolver = new DataResolver(cmd, plan(replicas, ConsistencyLevel.ALL), readRepair, System.nanoTime(), noopReadTracker());
 
         long[] ts = {100, 200};
 
@@ -1255,7 +1255,7 @@ public class DataResolverTest extends AbstractReadResponseTest
 
             public TestableDataResolver(ReadCommand command, ReplicaPlan.SharedForRangeRead plan, ReadRepair readRepair, long queryStartNanoTime)
             {
-                super(command, plan, readRepair, queryStartNanoTime);
+                super(command, plan, readRepair, queryStartNanoTime, noopReadTracker());
             }
 
             protected RepairedDataVerifier getRepairedDataVerifier(ReadCommand command)

--- a/test/unit/org/apache/cassandra/service/reads/DigestResolverTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/DigestResolverTest.java
@@ -67,7 +67,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
     {
         SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
         EndpointsForToken targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), full(EP2));
-        DigestResolver resolver = new DigestResolver(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0);
+        DigestResolver resolver = new DigestResolver(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0, noopReadTracker());
 
         PartitionUpdate response = update(row(1000, 4, 4), row(1000, 5, 5)).build();
 
@@ -99,7 +99,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
             while (System.nanoTime() < endTime)
             {
                 final long startNanos = System.nanoTime();
-                final DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = new DigestResolver<>(command, plan, startNanos);
+                final DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = new DigestResolver<>(command, plan, startNanos, noopReadTracker());
                 final ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = new ReadCallback<>(resolver, command, plan, startNanos);
                 
                 final CountDownLatch startlatch = new CountDownLatch(2);
@@ -134,7 +134,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
     {
         SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
         EndpointsForToken targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), full(EP2));
-        DigestResolver resolver = new DigestResolver(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0);
+        DigestResolver resolver = new DigestResolver(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0, noopReadTracker());
 
         PartitionUpdate response1 = update(row(1000, 4, 4), row(1000, 5, 5)).build();
         PartitionUpdate response2 = update(row(2000, 4, 5)).build();
@@ -155,7 +155,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
     {
         SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
         EndpointsForToken targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), trans(EP2));
-        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0);
+        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0, noopReadTracker());
 
         PartitionUpdate response1 = update(row(1000, 4, 4), row(1000, 5, 5)).build();
         PartitionUpdate response2 = update(row(1000, 5, 5)).build();
@@ -176,7 +176,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
     {
         SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
         EndpointsForToken targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), trans(EP2));
-        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0);
+        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0, noopReadTracker());
 
         PartitionUpdate response2 = update(row(1000, 5, 5)).build();
         Assert.assertFalse(resolver.isDataPresent());
@@ -191,7 +191,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
     {
         SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
         EndpointsForToken targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), full(EP2), trans(EP3));
-        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0);
+        DigestResolver<?, ?> resolver = new DigestResolver<>(command, plan(ConsistencyLevel.QUORUM, targetReplicas), 0, noopReadTracker());
 
         PartitionUpdate fullResponse = update(row(1000, 1, 1)).build();
         PartitionUpdate digestResponse = update(row(1000, 1, 1)).build();

--- a/test/unit/org/apache/cassandra/service/reads/ReadTrackingTransformationTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/ReadTrackingTransformationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.reads;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.service.QueryInfoTracker;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class ReadTrackingTransformationTest
+{
+    @Test
+    public void testOnRowHandling() throws Throwable
+    {
+        QueryInfoTracker.ReadTracker readTracker = mock(QueryInfoTracker.ReadTracker.class);
+        Row row = mock(Row.class);
+
+        ReadTrackingTransformation transformation = new ReadTrackingTransformation(readTracker);
+        transformation.applyToRow(row);
+        Mockito.verify(readTracker).onRow(Mockito.eq(row));
+
+        doThrow(RuntimeException.class).when(readTracker).onRow(any(Row.class));
+        transformation.applyToRow(row); // swallows exception
+    }
+
+    @Test
+    public void testOnPartitionHandling() throws Throwable
+    {
+        QueryInfoTracker.ReadTracker readTracker = mock(QueryInfoTracker.ReadTracker.class);
+        DecoratedKey key = mock(DecoratedKey.class);
+
+        ReadTrackingTransformation transformation = new ReadTrackingTransformation(readTracker);
+        transformation.applyToPartitionKey(key);
+        Mockito.verify(readTracker).onPartition(Mockito.eq(key));
+
+        doThrow(RuntimeException.class).when(readTracker).onPartition(any(DecoratedKey.class));
+        transformation.applyToPartitionKey(key); // swallows exception
+    }
+}

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandIteratorTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandIteratorTest.java
@@ -40,8 +40,10 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.locator.ReplicaPlans;
 import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.service.QueryInfoTracker;
 import org.apache.cassandra.utils.CloseableIterator;
 
+import static org.apache.cassandra.service.QueryInfoTracker.*;
 import static org.junit.Assert.assertEquals;
 
 public class RangeCommandIteratorTest
@@ -104,27 +106,27 @@ public class RangeCommandIteratorTest
 
         // without range merger, there will be 2 batches requested: 1st batch with 1 range and 2nd batch with remaining ranges
         CloseableIterator<ReplicaPlan.ForRangeRead> replicaPlans = replicaPlanIterator(keyRange, keyspace, false);
-        RangeCommandIterator data = RangeCommandIterator.create(replicaPlans, command, 1, 1000, vnodeCount, System.nanoTime());
+        RangeCommandIterator data = RangeCommandIterator.create(replicaPlans, command, 1, 1000, vnodeCount, System.nanoTime(), ReadTracker.NOOP);
         verifyRangeCommandIterator(data, rows, 2, vnodeCount);
 
         // without range merger and initial cf=5, there will be 1 batches requested: 5 vnode ranges for 1st batch
         replicaPlans = replicaPlanIterator(keyRange, keyspace, false);
-        data = RangeCommandIterator.create(replicaPlans, command, vnodeCount, 1000, vnodeCount, System.nanoTime());
+        data = RangeCommandIterator.create(replicaPlans, command, vnodeCount, 1000, vnodeCount, System.nanoTime(), ReadTracker.NOOP);
         verifyRangeCommandIterator(data, rows, 1, vnodeCount);
 
         // without range merger and max cf=1, there will be 5 batches requested: 1 vnode range per batch
         replicaPlans = replicaPlanIterator(keyRange, keyspace, false);
-        data = RangeCommandIterator.create(replicaPlans, command, 1, 1, vnodeCount, System.nanoTime());
+        data = RangeCommandIterator.create(replicaPlans, command, 1, 1, vnodeCount, System.nanoTime(), ReadTracker.NOOP);
         verifyRangeCommandIterator(data, rows, vnodeCount, vnodeCount);
 
         // with range merger, there will be only 1 batch requested, as all ranges share the same replica - localhost
         replicaPlans = replicaPlanIterator(keyRange, keyspace, true);
-        data = RangeCommandIterator.create(replicaPlans, command, 1, 1000, vnodeCount, System.nanoTime());
+        data = RangeCommandIterator.create(replicaPlans, command, 1, 1000, vnodeCount, System.nanoTime(), ReadTracker.NOOP);
         verifyRangeCommandIterator(data, rows, 1, vnodeCount);
 
         // with range merger and max cf=1, there will be only 1 batch requested, as all ranges share the same replica - localhost
         replicaPlans = replicaPlanIterator(keyRange, keyspace, true);
-        data = RangeCommandIterator.create(replicaPlans, command, 1, 1, vnodeCount, System.nanoTime());
+        data = RangeCommandIterator.create(replicaPlans, command, 1, 1, vnodeCount, System.nanoTime(), ReadTracker.NOOP);
         verifyRangeCommandIterator(data, rows, 1, vnodeCount);
     }
 

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -38,8 +38,10 @@ import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.index.StubIndex;
 import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.service.QueryInfoTracker;
 
 import static org.apache.cassandra.db.ConsistencyLevel.ONE;
+import static org.apache.cassandra.service.QueryInfoTracker.*;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -74,7 +76,7 @@ public class RangeCommandsTest extends CQLTester
 
         // verify that a low concurrency factor is not capped by the max concurrency factor
         PartitionRangeReadCommand command = command(cfs, 50, 50);
-        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime());
+        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime(), ReadTracker.NOOP);
              ReplicaPlanIterator ranges = new ReplicaPlanIterator(command.dataRange().keyRange(), command.indexQueryPlan(), keyspace, ONE))
         {
             assertEquals(2, partitions.concurrencyFactor());
@@ -84,7 +86,7 @@ public class RangeCommandsTest extends CQLTester
 
         // verify that a high concurrency factor is capped by the max concurrency factor
         command = command(cfs, 1000, 50);
-        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime());
+        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime(), ReadTracker.NOOP);
              ReplicaPlanIterator ranges = new ReplicaPlanIterator(command.dataRange().keyRange(), command.indexQueryPlan(), keyspace, ONE))
         {
             assertEquals(MAX_CONCURRENCY_FACTOR, partitions.concurrencyFactor());
@@ -94,7 +96,7 @@ public class RangeCommandsTest extends CQLTester
 
         // with 0 estimated results per range the concurrency factor should be 1
         command = command(cfs, 1000, 0);
-        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime());
+        try (RangeCommandIterator partitions = RangeCommands.rangeCommandIterator(command, ONE, System.nanoTime(), ReadTracker.NOOP);
              ReplicaPlanIterator ranges = new ReplicaPlanIterator(command.dataRange().keyRange(), command.indexQueryPlan(), keyspace, ONE))
         {
             assertEquals(1, partitions.concurrencyFactor());

--- a/test/unit/org/apache/cassandra/service/reads/repair/AbstractReadRepairTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/repair/AbstractReadRepairTest.java
@@ -75,11 +75,13 @@ import org.apache.cassandra.schema.MigrationManager;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.Tables;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.reads.DigestResolver;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static org.apache.cassandra.locator.Replica.fullReplica;
 import static org.apache.cassandra.locator.ReplicaUtils.FULL_RANGE;
 import static org.apache.cassandra.net.Verb.INTERNAL_RSP;
+import static org.mockito.Mockito.mock;
 
 @Ignore
 public abstract  class AbstractReadRepairTest
@@ -335,7 +337,7 @@ public abstract  class AbstractReadRepairTest
         ResultConsumer consumer = new ResultConsumer();
 
         Assert.assertEquals(epSet(), repair.getReadRecipients());
-        repair.startRepair(null, consumer);
+        repair.startRepair(mock(DigestResolver.class), consumer);
 
         Assert.assertEquals(epSet(target1, target2), repair.getReadRecipients());
         repair.maybeSendAdditionalReads();
@@ -354,7 +356,7 @@ public abstract  class AbstractReadRepairTest
         ResultConsumer consumer = new ResultConsumer();
 
         Assert.assertEquals(epSet(), repair.getReadRecipients());
-        repair.startRepair(null, consumer);
+        repair.startRepair(mock(DigestResolver.class), consumer);
 
         Assert.assertEquals(epSet(target1, target2), repair.getReadRecipients());
         repair.getReadCallback().onResponse(msg(target1, cell1));

--- a/test/unit/org/apache/cassandra/tracing/TracingTest.java
+++ b/test/unit/org/apache/cassandra/tracing/TracingTest.java
@@ -23,8 +23,10 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.UUID;
 
 import org.junit.BeforeClass;
@@ -32,6 +34,11 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.ParamType;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.TracingClientState;
 import org.apache.cassandra.utils.progress.ProgressEvent;
 import org.apache.commons.lang3.StringUtils;
 
@@ -48,7 +55,7 @@ public final class TracingTest
     {
         List<String> traces = new ArrayList<>();
         Tracing tracing = new TracingImpl(traces);
-        tracing.newSession(Tracing.TraceType.NONE);
+        tracing.newSession(ClientState.forInternalCalls(), Tracing.TraceType.NONE);
         TraceState state = tracing.begin("test-request", Collections.<String,String>emptyMap());
         state.trace("test-1");
         state.trace("test-2");
@@ -68,7 +75,7 @@ public final class TracingTest
     {
         List<String> traces = new ArrayList<>();
         Tracing tracing = new TracingImpl(traces);
-        tracing.newSession(Tracing.TraceType.NONE);
+        tracing.newSession(ClientState.forInternalCalls(), Tracing.TraceType.NONE);
         tracing.begin("test-request", Collections.<String,String>emptyMap());
         tracing.get().trace("test-1");
         tracing.get().trace("test-2");
@@ -88,7 +95,7 @@ public final class TracingTest
     {
         List<String> traces = new ArrayList<>();
         Tracing tracing = new TracingImpl(traces);
-        UUID uuid = tracing.newSession(Tracing.TraceType.NONE);
+        UUID uuid = tracing.newSession(ClientState.forInternalCalls(), Tracing.TraceType.NONE);
         tracing.begin("test-request", Collections.<String,String>emptyMap());
         tracing.get(uuid).trace("test-1");
         tracing.get(uuid).trace("test-2");
@@ -112,7 +119,7 @@ public final class TracingTest
         Map<String,ByteBuffer> customPayload = Collections.singletonMap("test-key", customPayloadValue);
 
         TracingImpl tracing = new TracingImpl(traces);
-        tracing.newSession(customPayload);
+        tracing.newSession(ClientState.forInternalCalls(), customPayload);
         TraceState state = tracing.begin("test-custom_payload", Collections.<String,String>emptyMap());
         state.trace("test-1");
         state.trace("test-2");
@@ -134,7 +141,7 @@ public final class TracingTest
     {
         List<String> traces = new ArrayList<>();
         Tracing tracing = new TracingImpl(traces);
-        tracing.newSession(Tracing.TraceType.REPAIR);
+        tracing.newSession(ClientState.forInternalCalls(), Tracing.TraceType.REPAIR);
         tracing.begin("test-request", Collections.<String,String>emptyMap());
         tracing.get().enableActivityNotification("test-tag");
         assert TraceState.Status.IDLE == tracing.get().waitActivity(1);
@@ -151,7 +158,7 @@ public final class TracingTest
     {
         List<String> traces = new ArrayList<>();
         Tracing tracing = new TracingImpl(traces);
-        tracing.newSession(Tracing.TraceType.REPAIR);
+        tracing.newSession(ClientState.forInternalCalls(), Tracing.TraceType.REPAIR);
         tracing.begin("test-request", Collections.<String,String>emptyMap());
         tracing.get().enableActivityNotification("test-tag");
 
@@ -163,6 +170,112 @@ public final class TracingTest
         tracing.get().trace("test-trace");
         tracing.stopSession();
         assert null == tracing.get();
+    }
+
+    @Test
+    public void test_adding_keyspace_to_trace_state()
+    {
+        Tracing tracing = Tracing.instance;
+        String keyspace = "someKeyspace";
+        UUID sessionId = tracing.newSession(ClientState.forInternalCalls(keyspace), Tracing.TraceType.QUERY);
+
+        assert keyspace.equals(tracing.get().clientState.getKeyspace());
+        assert keyspace.equals(tracing.get(sessionId).clientState.getKeyspace());
+
+        Map<ParamType, Object> headers = tracing.addTraceHeaders(new HashMap<>());
+        assert keyspace.equals(headers.get(ParamType.TRACE_KEYSPACE));
+        tracing.stopSession();
+    }
+
+    @Test
+    public void test_initializing_from_message_with_keyspace()
+    {
+        ClientStateAccumulatingTracing tracing = new ClientStateAccumulatingTracing();
+
+        Message<Object> message = Message.builder(Verb._TEST_1, new Object())
+                                         .withParam(ParamType.TRACE_KEYSPACE, "testKeyspace")
+                                         .withParam(ParamType.TRACE_SESSION, UUID.randomUUID())
+                                         .build();
+
+        TraceState traceState = tracing.initializeFromMessage(message.header);
+
+        assert traceState.clientState instanceof TracingClientState;
+        assert "testKeyspace".equals(((TracingClientState) traceState.clientState).tracedKeyspace());
+    }
+
+    @Test
+    public void test_initializing_from_message_without_keyspace()
+    {
+        ClientStateAccumulatingTracing tracing = new ClientStateAccumulatingTracing();
+
+        Message<Object> message = Message.builder(Verb._TEST_1, new Object())
+                                         .withParam(ParamType.TRACE_SESSION, UUID.randomUUID())
+                                         .build();
+
+        TraceState traceState = tracing.initializeFromMessage(message.header);
+
+        assert traceState.clientState instanceof TracingClientState;
+        assert ((TracingClientState) traceState.clientState).tracedKeyspace() == null;
+    }
+
+    @Test
+    public void test_tracing_outgoing_message_with_keyspace()
+    {
+        ClientStateAccumulatingTracing tracing = new ClientStateAccumulatingTracing();
+
+        Message<Object> message = Message.builder(Verb._TEST_1, new Object())
+                                         .withParam(ParamType.TRACE_KEYSPACE, "testKeyspace")
+                                         .withParam(ParamType.TRACE_SESSION, UUID.randomUUID())
+                                         .build();
+
+        tracing.traceOutgoingMessage(message, 999, InetAddressAndPort.getLocalHost());
+
+        assert tracing.states.size() == 1;
+        assert tracing.states.peek() instanceof TracingClientState;
+        assert "testKeyspace".equals(((TracingClientState) tracing.states.peek()).tracedKeyspace());
+    }
+
+    @Test
+    public void test_tracing_outgoing_message_without_keyspace()
+    {
+        ClientStateAccumulatingTracing tracing = new ClientStateAccumulatingTracing();
+
+        Message<Object> message = Message.builder(Verb._TEST_1, new Object())
+                                         .withParam(ParamType.TRACE_SESSION, UUID.randomUUID())
+                                         .build();
+
+        tracing.traceOutgoingMessage(message, 999, InetAddressAndPort.getLocalHost());
+
+        assert tracing.states.size() == 1;
+        assert tracing.states.peek() instanceof TracingClientState;
+        assert ((TracingClientState) tracing.states.peek()).tracedKeyspace() == null;
+    }
+
+    private static final class ClientStateAccumulatingTracing extends Tracing
+    {
+        Queue<ClientState> states = new LinkedList<>();
+
+        @Override
+        protected void stopSessionImpl()
+        {}
+
+        @Override
+        public TraceState begin(String request, InetAddress client, Map<String, String> parameters)
+        {
+            return null;
+        }
+
+        @Override
+        protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType)
+        {
+            return new TraceStateImpl(state, coordinator, sessionId, traceType);
+        }
+
+        @Override
+        public void trace(ClientState clientState, ByteBuffer sessionId, String message, int ttl)
+        {
+            states.add(clientState);
+        }
     }
 
     private static final class TracingImpl extends Tracing
@@ -189,18 +302,20 @@ public final class TracingTest
             return get();
         }
 
-        protected UUID newSession(UUID sessionId, TraceType traceType, Map<String,ByteBuffer> customPayload)
+        @Override
+        protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, Map<String,ByteBuffer> customPayload)
         {
             if (!customPayload.isEmpty())
                 logger.info("adding custom payload items {}", StringUtils.join(customPayload.keySet(), ','));
 
             payloads.putAll(customPayload);
-            return super.newSession(sessionId, traceType, customPayload);
+            return super.newSession(state, sessionId, traceType, customPayload);
         }
 
-        protected TraceState newTraceState(InetAddressAndPort ia, UUID uuid, Tracing.TraceType tt)
+        @Override
+        protected TraceState newTraceState(ClientState state, InetAddressAndPort ia, UUID uuid, Tracing.TraceType tt)
         {
-            return new TraceState(ia, uuid, tt)
+            return new TraceState(state, ia, uuid, tt)
             {
                 protected void traceImpl(String string)
                 {
@@ -213,7 +328,8 @@ public final class TracingTest
             };
         }
 
-        public void trace(ByteBuffer bb, String string, int i)
+        @Override
+        public void trace(ClientState state, ByteBuffer bb, String string, int i)
         {
             throw new UnsupportedOperationException("Not supported yet.");
         }

--- a/test/unit/org/apache/cassandra/utils/StringSerializerTest.java
+++ b/test/unit/org/apache/cassandra/utils/StringSerializerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputBufferFixed;
+import org.apache.cassandra.io.util.DataOutputPlus;
+
+public class StringSerializerTest
+{
+    @Test
+    public void testStringSerialization() throws IOException
+    {
+        serializationRoundTrip("");
+        serializationRoundTrip(" ");
+        serializationRoundTrip("zxc");
+        serializationRoundTrip("óążćź");
+    }
+
+    private void serializationRoundTrip(String value) throws IOException
+    {
+        int protocolVersion = 1;
+        StringSerializer serializer = StringSerializer.serializer;
+        long size = serializer.serializedSize(value, protocolVersion);
+
+        ByteBuffer buf = ByteBuffer.allocate((int)size);
+        DataOutputPlus out = new DataOutputBufferFixed(buf);
+        serializer.serialize(value, out, protocolVersion);
+        Assert.assertEquals(size, buf.position());
+
+        buf.flip();
+        DataInputPlus in = new DataInputBuffer(buf, false);
+        String deserialized = serializer.deserialize(in, protocolVersion);
+        Assert.assertEquals(value, deserialized);
+        Assert.assertEquals(value.hashCode(), deserialized.hashCode());
+    }
+}


### PR DESCRIPTION
This is a port of 
- https://github.com/riptano/bdp/commit/b6f0a18cb832c62f05cdcbd9cdcc2923f2fa727f
- https://github.com/riptano/bdp/pull/19468
The first change set introduces `QueryInfoTracker` (QIT) interface and hooks it to `StorageProxy`. The second adds `ClientState` to the interface.

The original QIT utilizes `ReadReconciliationObserver` in the `ReadTracker` paths. Only `onRow`, `onPartition` and `queried` callbacks are utilized by CNDB and thus only these methods are ported to Converged Cassandra (CC). The callbacks are a bit different tho:
- The callback methods are added directly to `ReadTracker` as CC doesn't have `ReadReconciliationObserver`. The class was added as a part of NodeSync effort and it is rather superfluous. Porting the whole class would add unnecessary complexity. Adding the required methods directly to the `ReadTracker` makes the interface cleaner and easier to understand.
- CC operates on `ReplicaPlans` instead of plain host lists, that is why `queried` was changed to `onReplicaPlan`.

The PR adds empty QIT (with write callback only) + `ClientState` and then step by step extends it with more callback methods. It is advisable to review commit by commit although some of the code parts were slightly refactored along the way.  