### PR TITLE
STAR-845: Port MessagingService implementation from DSE

### DIFF
--- a/src/java/org/apache/cassandra/metrics/DroppedMessageMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/DroppedMessageMetrics.java
@@ -18,6 +18,8 @@
 package org.apache.cassandra.metrics;
 
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -42,7 +44,7 @@ public class DroppedMessageMetrics
 
     static
     {
-        EnumMap<Verb, String> aliases = new EnumMap<>(Verb.class);
+        Map<Verb, String> aliases = new HashMap<>();
         aliases.put(Verb.BATCH_REMOVE_REQ, "BATCH_REMOVE");
         aliases.put(Verb.BATCH_STORE_REQ, "BATCH_STORE");
         aliases.put(Verb.COUNTER_MUTATION_REQ, "COUNTER_MUTATION");
@@ -53,7 +55,7 @@ public class DroppedMessageMetrics
         aliases.put(Verb.READ_REPAIR_REQ, "READ_REPAIR");
         aliases.put(Verb.REQUEST_RSP, "REQUEST_RESPONSE");
 
-        REQUEST_VERB_ALIAS = Maps.immutableEnumMap(aliases);
+        REQUEST_VERB_ALIAS = ImmutableMap.copyOf(aliases);
     }
 
     /** Number of dropped messages */

--- a/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
@@ -94,20 +94,20 @@ public class MessagingMetrics implements InboundMessageHandlers.GlobalMetricCall
 
     private final Timer allLatency;
     public final ConcurrentHashMap<String, DCLatencyRecorder> dcLatency;
-    public final EnumMap<Verb, Timer> internalLatency;
+    public final Map<Verb, Timer> internalLatency = new HashMap<>();
 
     // total dropped message counts for server lifetime
-    private final Map<Verb, DroppedForVerb> droppedMessages = new EnumMap<>(Verb.class);
+    private final Map<Verb, DroppedForVerb> droppedMessages = new HashMap<>();
 
     public MessagingMetrics()
     {
         allLatency = Metrics.timer(factory.createMetricName("CrossNodeLatency"));
         dcLatency = new ConcurrentHashMap<>();
-        internalLatency = new EnumMap<>(Verb.class);
-        for (Verb verb : Verb.VERBS)
+        for (Verb verb : Verb.getValues())
+        {
             internalLatency.put(verb, Metrics.timer(factory.createMetricName(verb + "-WaitLatency")));
-        for (Verb verb : Verb.values())
             droppedMessages.put(verb, new DroppedForVerb(verb));
+        }
     }
 
     public DCLatencyRecorder internodeLatencyRecorder(InetAddressAndPort from)

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -385,8 +385,8 @@ public class Verb
     private static final int MAX_CUSTOM_VERB_ID = 1000;
 
     private static final Verb[] idToVerbMap;
-    private static Verb[] idToCustomVerbMap;
-    private static int minCustomId;
+    private static volatile Verb[] idToCustomVerbMap;
+    private static volatile int minCustomId;
 
     static
     {
@@ -511,6 +511,7 @@ public class Verb
         return verb;
     }
 
+    // Callers must take care of synchronizing to protect against concurrent updates to verbs.
     private static void assertNameIsUnused(String name)
     {
         if (verbs.stream().map(v -> v.name).collect(Collectors.toList()).contains(name))
@@ -525,7 +526,7 @@ public class Verb
      * @param verbs the list of verbs whose handlers should be wrapped by {@code decoratorFn}.
      * @param decoratorFn the method that decorates the handlers in verbs.
      */
-    public static void decorateHandler(List<Verb> verbs, Function<IVerbHandler<?>, IVerbHandler<?>> decoratorFn)
+    public static synchronized void decorateHandler(List<Verb> verbs, Function<IVerbHandler<?>, IVerbHandler<?>> decoratorFn)
     {
         for (Verb v : verbs)
         {

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -19,10 +19,14 @@ package org.apache.cassandra.net;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -99,104 +103,8 @@ import static org.apache.cassandra.schema.MigrationManager.MigrationsSerializer;
 /**
  * Note that priorities except P0 are presently unused.  P0 corresponds to urgent, i.e. what used to be the "Gossip" connection.
  */
-public enum Verb
+public class Verb
 {
-    MUTATION_RSP           (60,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    MUTATION_REQ           (0,   P3, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> MutationVerbHandler.instance,        MUTATION_RSP        ),
-    HINT_RSP               (61,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    HINT_REQ               (1,   P4, writeTimeout,    MUTATION,          () -> HintMessage.serializer,               () -> HintVerbHandler.instance,            HINT_RSP            ),
-    READ_REPAIR_RSP        (62,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    READ_REPAIR_REQ        (2,   P1, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> ReadRepairVerbHandler.instance,      READ_REPAIR_RSP     ),
-    BATCH_STORE_RSP        (65,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    BATCH_STORE_REQ        (5,   P3, writeTimeout,    MUTATION,          () -> Batch.serializer,                     () -> BatchStoreVerbHandler.instance,      BATCH_STORE_RSP     ),
-    BATCH_REMOVE_RSP       (66,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    BATCH_REMOVE_REQ       (6,   P3, writeTimeout,    MUTATION,          () -> UUIDSerializer.serializer,            () -> BatchRemoveVerbHandler.instance,     BATCH_REMOVE_RSP    ),
-
-    PAXOS_PREPARE_RSP      (93,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> PrepareResponse.serializer,           () -> ResponseVerbHandler.instance                             ),
-    PAXOS_PREPARE_REQ      (33,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> PrepareVerbHandler.instance,         PAXOS_PREPARE_RSP   ),
-    PAXOS_PROPOSE_RSP      (94,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> BooleanSerializer.serializer,         () -> ResponseVerbHandler.instance                             ),
-    PAXOS_PROPOSE_REQ      (34,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> ProposeVerbHandler.instance,         PAXOS_PROPOSE_RSP   ),
-    PAXOS_COMMIT_RSP       (95,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    PAXOS_COMMIT_REQ       (35,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> CommitVerbHandler.instance,          PAXOS_COMMIT_RSP    ),
-
-    TRUNCATE_RSP           (79,  P0, truncateTimeout, REQUEST_RESPONSE,  () -> TruncateResponse.serializer,          () -> ResponseVerbHandler.instance                             ),
-    TRUNCATE_REQ           (19,  P0, truncateTimeout, MUTATION,          () -> TruncateRequest.serializer,           () -> TruncateVerbHandler.instance,        TRUNCATE_RSP        ),
-
-    COUNTER_MUTATION_RSP   (84,  P1, counterTimeout,  REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    COUNTER_MUTATION_REQ   (24,  P2, counterTimeout,  COUNTER_MUTATION,  () -> CounterMutation.serializer,           () -> CounterMutationVerbHandler.instance, COUNTER_MUTATION_RSP),
-
-    READ_RSP               (63,  P2, readTimeout,     REQUEST_RESPONSE,  () -> ReadResponse.serializer,              () -> ResponseVerbHandler.instance                             ),
-    READ_REQ               (3,   P3, readTimeout,     READ,              () -> ReadCommand.serializer,               () -> ReadCommandVerbHandler.instance,     READ_RSP            ),
-    RANGE_RSP              (69,  P2, rangeTimeout,    REQUEST_RESPONSE,  () -> ReadResponse.serializer,              () -> ResponseVerbHandler.instance                             ),
-    RANGE_REQ              (9,   P3, rangeTimeout,    READ,              () -> ReadCommand.serializer,               () -> ReadCommandVerbHandler.instance,     RANGE_RSP           ),
-    MULTI_RANGE_RSP        (67,  P2, rangeTimeout,    REQUEST_RESPONSE,  () -> MultiRangeReadResponse.serializer,    () -> ResponseVerbHandler.instance                             ),
-    MULTI_RANGE_REQ        (7,   P3, rangeTimeout,    READ,              () -> MultiRangeReadCommand.serializer,     () -> ReadCommandVerbHandler.instance,     MULTI_RANGE_RSP     ),
-
-    GOSSIP_DIGEST_SYN      (14,  P0, longTimeout,     GOSSIP,            () -> GossipDigestSyn.serializer,           () -> GossipDigestSynVerbHandler.instance                      ),
-    GOSSIP_DIGEST_ACK      (15,  P0, longTimeout,     GOSSIP,            () -> GossipDigestAck.serializer,           () -> GossipDigestAckVerbHandler.instance                      ),
-    GOSSIP_DIGEST_ACK2     (16,  P0, longTimeout,     GOSSIP,            () -> GossipDigestAck2.serializer,          () -> GossipDigestAck2VerbHandler.instance                     ),
-    GOSSIP_SHUTDOWN        (29,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> GossipShutdownVerbHandler.instance                       ),
-
-    ECHO_RSP               (91,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    ECHO_REQ               (31,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> EchoVerbHandler.instance,            ECHO_RSP            ),
-    PING_RSP               (97,  P1, pingTimeout,     GOSSIP,            () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    PING_REQ               (37,  P1, pingTimeout,     GOSSIP,            () -> PingRequest.serializer,               () -> PingVerbHandler.instance,            PING_RSP            ),
-
-    // P1 because messages can be arbitrarily large or aren't crucial
-    SCHEMA_PUSH_RSP        (98,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    SCHEMA_PUSH_REQ        (18,  P1, rpcTimeout,      MIGRATION,         () -> MigrationsSerializer.instance,        () -> SchemaPushVerbHandler.instance,      SCHEMA_PUSH_RSP     ),
-    SCHEMA_PULL_RSP        (88,  P1, rpcTimeout,      MIGRATION,         () -> MigrationsSerializer.instance,        () -> ResponseVerbHandler.instance                             ),
-    SCHEMA_PULL_REQ        (28,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> SchemaPullVerbHandler.instance,      SCHEMA_PULL_RSP     ),
-    SCHEMA_VERSION_RSP     (80,  P1, rpcTimeout,      MIGRATION,         () -> UUIDSerializer.serializer,            () -> ResponseVerbHandler.instance                             ),
-    SCHEMA_VERSION_REQ     (20,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> SchemaVersionVerbHandler.instance,   SCHEMA_VERSION_RSP  ),
-
-    // repair; mostly doesn't use callbacks and sends responses as their own request messages, with matching sessions by uuid; should eventually harmonize and make idiomatic
-    REPAIR_RSP             (100, P1, rpcTimeout,      REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    VALIDATION_RSP         (102, P1, rpcTimeout,      ANTI_ENTROPY,      () -> ValidationResponse.serializer,        () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    VALIDATION_REQ         (101, P1, rpcTimeout,      ANTI_ENTROPY,      () -> ValidationRequest.serializer,         () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    SYNC_RSP               (104, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SyncResponse.serializer,              () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    SYNC_REQ               (103, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SyncRequest.serializer,               () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    PREPARE_MSG            (105, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareMessage.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    SNAPSHOT_MSG           (106, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SnapshotMessage.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    CLEANUP_MSG            (107, P1, rpcTimeout,      ANTI_ENTROPY,      () -> CleanupMessage.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    PREPARE_CONSISTENT_RSP (109, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareConsistentResponse.serializer, () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    PREPARE_CONSISTENT_REQ (108, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareConsistentRequest.serializer,  () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    FINALIZE_PROPOSE_MSG   (110, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizePropose.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    FINALIZE_PROMISE_MSG   (111, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizePromise.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    FINALIZE_COMMIT_MSG    (112, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizeCommit.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    FAILED_SESSION_MSG     (113, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FailSession.serializer,               () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    STATUS_RSP             (115, P1, rpcTimeout,      ANTI_ENTROPY,      () -> StatusResponse.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-    STATUS_REQ             (114, P1, rpcTimeout,      ANTI_ENTROPY,      () -> StatusRequest.serializer,             () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          ),
-
-    REPLICATION_DONE_RSP   (82,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    REPLICATION_DONE_REQ   (22,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ReplicationDoneVerbHandler.instance, REPLICATION_DONE_RSP),
-    SNAPSHOT_RSP           (87,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             ),
-    SNAPSHOT_REQ           (27,  P0, rpcTimeout,      MISC,              () -> SnapshotCommand.serializer,           () -> SnapshotVerbHandler.instance,        SNAPSHOT_RSP        ),
-
-    // generic failure response
-    FAILURE_RSP            (99,  P0, noTimeout,       REQUEST_RESPONSE,  () -> RequestFailureReason.serializer,      () -> ResponseVerbHandler.instance                             ),
-
-    // dummy verbs
-    _TRACE                 (30,  P1, rpcTimeout,      TRACING,           () -> NoPayload.serializer,                 () -> null                                                     ),
-    _SAMPLE                (42,  P1, rpcTimeout,      INTERNAL_RESPONSE, () -> NoPayload.serializer,                 () -> null                                                     ),
-    _TEST_1                (10,  P0, writeTimeout,    IMMEDIATE,         () -> NoPayload.serializer,                 () -> null                                                     ),
-    _TEST_2                (11,  P1, rpcTimeout,      IMMEDIATE,         () -> NoPayload.serializer,                 () -> null                                                     ),
-
-    @Deprecated
-    REQUEST_RSP            (4,   P1, rpcTimeout,      REQUEST_RESPONSE,  () -> null,                                 () -> ResponseVerbHandler.instance                             ),
-    @Deprecated
-    INTERNAL_RSP           (23,  P1, rpcTimeout,      INTERNAL_RESPONSE, () -> null,                                 () -> ResponseVerbHandler.instance                             ),
-
-    // largest used ID: 116
-
-    // CUSTOM VERBS
-    UNUSED_CUSTOM_VERB     (CUSTOM,
-                            0,   P1, rpcTimeout,      INTERNAL_RESPONSE, () -> null,                                 () -> null                                                     ),
-
-    ;
-
-    public static final List<Verb> VERBS = ImmutableList.copyOf(Verb.values());
-
     public enum Priority
     {
         P0,  // sends on the urgent connection (i.e. for Gossip, Echo)
@@ -206,12 +114,111 @@ public enum Verb
         P4
     }
 
+    private static final List<Verb> verbs = new ArrayList<>();
+
+    public static List<Verb> getValues()
+    {
+        return ImmutableList.copyOf(verbs);
+    }
+
+    public static Verb MUTATION_RSP           = new Verb("MUTATION_RSP",           60,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance);
+    public static Verb MUTATION_REQ           = new Verb("MUTATION_REQ",           0,   P3, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> MutationVerbHandler.instance,        MUTATION_RSP);
+    public static Verb HINT_RSP               = new Verb("HINT_RSP",               61,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb HINT_REQ               = new Verb("HINT_REQ",               1,   P4, writeTimeout,    MUTATION,          () -> HintMessage.serializer,               () -> HintVerbHandler.instance,            HINT_RSP            );
+    public static Verb READ_REPAIR_RSP        = new Verb("READ_REPAIR_RSP",        62,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb READ_REPAIR_REQ        = new Verb("READ_REPAIR_REP",        2,   P1, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> ReadRepairVerbHandler.instance,      READ_REPAIR_RSP     );
+    public static Verb BATCH_STORE_RSP        = new Verb("BATCH_STORE_RSP",        65,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb BATCH_STORE_REQ        = new Verb("BATCH_STORE_REQ",        5,   P3, writeTimeout,    MUTATION,          () -> Batch.serializer,                     () -> BatchStoreVerbHandler.instance,      BATCH_STORE_RSP     );
+    public static Verb BATCH_REMOVE_RSP       = new Verb("BATCH_REMOVE_RSP",       66,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb BATCH_REMOVE_REQ       = new Verb("BATCH_REMOVE_REQ",       6,   P3, writeTimeout,    MUTATION,          () -> UUIDSerializer.serializer,            () -> BatchRemoveVerbHandler.instance,     BATCH_REMOVE_RSP    );
+
+    public static Verb PAXOS_PREPARE_RSP      = new Verb("PAXOS_PREPARE_RSP",      93,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> PrepareResponse.serializer,           () -> ResponseVerbHandler.instance                             );
+    public static Verb PAXOS_PREPARE_REQ      = new Verb("PAXOS_PREPARE_REQ",      33,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> PrepareVerbHandler.instance,         PAXOS_PREPARE_RSP   );
+    public static Verb PAXOS_PROPOSE_RSP      = new Verb("PAXOS_PROPOSE_RSP",      94,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> BooleanSerializer.serializer,         () -> ResponseVerbHandler.instance                             );
+    public static Verb PAXOS_PROPOSE_REQ      = new Verb("PAXOS_PROPOSE_REQ",      34,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> ProposeVerbHandler.instance,         PAXOS_PROPOSE_RSP   );
+    public static Verb PAXOS_COMMIT_RSP       = new Verb("PAXOS_COMMIT_RSP",       95,  P2, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb PAXOS_COMMIT_REQ       = new Verb("PAXOS_COMMIT_REQ",       35,  P2, writeTimeout,    MUTATION,          () -> Commit.serializer,                    () -> CommitVerbHandler.instance,          PAXOS_COMMIT_RSP    );
+
+    public static Verb TRUNCATE_RSP           = new Verb("TRUNCATE_RSP",           79,  P0, truncateTimeout, REQUEST_RESPONSE,  () -> TruncateResponse.serializer,          () -> ResponseVerbHandler.instance                             );
+    public static Verb TRUNCATE_REQ           = new Verb("TRUNCATE_REQ",           19,  P0, truncateTimeout, MUTATION,          () -> TruncateRequest.serializer,           () -> TruncateVerbHandler.instance,        TRUNCATE_RSP        );
+
+    public static Verb COUNTER_MUTATION_RSP   = new Verb("COUNTER_MUTATION_RSP",   84,  P1, counterTimeout,  REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb COUNTER_MUTATION_REQ   = new Verb("COUNTER_MUTATION_REQ",   24,  P2, counterTimeout,  COUNTER_MUTATION,  () -> CounterMutation.serializer,           () -> CounterMutationVerbHandler.instance, COUNTER_MUTATION_RSP);
+
+    public static Verb READ_RSP               = new Verb("READ_RSP",               63,  P2, readTimeout,     REQUEST_RESPONSE,  () -> ReadResponse.serializer,              () -> ResponseVerbHandler.instance                             );
+    public static Verb READ_REQ               = new Verb("READ_REQ",               3,   P3, readTimeout,     READ,              () -> ReadCommand.serializer,               () -> ReadCommandVerbHandler.instance,     READ_RSP            );
+    public static Verb RANGE_RSP              = new Verb("RANGE_RSP",              69,  P2, rangeTimeout,    REQUEST_RESPONSE,  () -> ReadResponse.serializer,              () -> ResponseVerbHandler.instance                             );
+    public static Verb RANGE_REQ              = new Verb("RANGE_REQ",              9,   P3, rangeTimeout,    READ,              () -> ReadCommand.serializer,               () -> ReadCommandVerbHandler.instance,     RANGE_RSP           );
+    public static Verb MULTI_RANGE_RSP        = new Verb("MULTI_RANGE_RSP",        67,  P2, rangeTimeout,    REQUEST_RESPONSE,  () -> MultiRangeReadResponse.serializer,    () -> ResponseVerbHandler.instance                             );
+    public static Verb MULTI_RANGE_REQ        = new Verb("MULTI_RANGE_REQ",        7,   P3, rangeTimeout,    READ,              () -> MultiRangeReadCommand.serializer,     () -> ReadCommandVerbHandler.instance,     MULTI_RANGE_RSP     );
+
+    public static Verb GOSSIP_DIGEST_SYN      = new Verb("GOSSIP_DIGEST_SYN",      14,  P0, longTimeout,     GOSSIP,            () -> GossipDigestSyn.serializer,           () -> GossipDigestSynVerbHandler.instance                      );
+    public static Verb GOSSIP_DIGEST_ACK      = new Verb("GOSSIP_DIGEST_ACK",      15,  P0, longTimeout,     GOSSIP,            () -> GossipDigestAck.serializer,           () -> GossipDigestAckVerbHandler.instance                      );
+    public static Verb GOSSIP_DIGEST_ACK2     = new Verb("GOSSIP_DIGEST_ACK2",     16,  P0, longTimeout,     GOSSIP,            () -> GossipDigestAck2.serializer,          () -> GossipDigestAck2VerbHandler.instance                     );
+    public static Verb GOSSIP_SHUTDOWN        = new Verb("GOSSIP_SHUTDOWN",        29,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> GossipShutdownVerbHandler.instance                       );
+
+    public static Verb ECHO_RSP               = new Verb("ECHO_RSP",               91,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb ECHO_REQ               = new Verb("ECHO_REQ",               31,  P0, rpcTimeout,      GOSSIP,            () -> NoPayload.serializer,                 () -> EchoVerbHandler.instance,            ECHO_RSP            );
+    public static Verb PING_RSP               = new Verb("PING_RSP",               97,  P1, pingTimeout,     GOSSIP,            () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb PING_REQ               = new Verb("PING_REQ",               37,  P1, pingTimeout,     GOSSIP,            () -> PingRequest.serializer,               () -> PingVerbHandler.instance,            PING_RSP            );
+
+    // public static Verb P1 because messages can be arbitrarily large or aren't crucial
+    public static Verb SCHEMA_PUSH_RSP        = new Verb("SCHEMA_PUSH_RSP",        98,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb SCHEMA_PUSH_REQ        = new Verb("SCHEMA_PUSH_REQ",        18,  P1, rpcTimeout,      MIGRATION,         () -> MigrationsSerializer.instance,        () -> SchemaPushVerbHandler.instance,      SCHEMA_PUSH_RSP     );
+    public static Verb SCHEMA_PULL_RSP        = new Verb("SCHEMA_PULL_RSP",        88,  P1, rpcTimeout,      MIGRATION,         () -> MigrationsSerializer.instance,        () -> ResponseVerbHandler.instance                             );
+    public static Verb SCHEMA_PULL_REQ        = new Verb("SCHEMA_PULL_REQ",        28,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> SchemaPullVerbHandler.instance,      SCHEMA_PULL_RSP     );
+    public static Verb SCHEMA_VERSION_RSP     = new Verb("SCHEMA_VERSION_RSP",     80,  P1, rpcTimeout,      MIGRATION,         () -> UUIDSerializer.serializer,            () -> ResponseVerbHandler.instance                             );
+    public static Verb SCHEMA_VERSION_REQ     = new Verb("SCHEMA_VERSION_REQ",     20,  P1, rpcTimeout,      MIGRATION,         () -> NoPayload.serializer,                 () -> SchemaVersionVerbHandler.instance,   SCHEMA_VERSION_RSP  );
+
+    // repair; mostly doesn't use callbacks and sends responses as their own request messages, with matching sessions by uuid; should eventually harmonize and make idiomatic
+    public static Verb REPAIR_RSP             = new Verb("REPAIR_RSP",             100, P1, rpcTimeout,      REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb VALIDATION_RSP         = new Verb("VALIDATION_RSP",         102, P1, rpcTimeout,      ANTI_ENTROPY,      () -> ValidationResponse.serializer,        () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb VALIDATION_REQ         = new Verb("VALIDATION_REQ",         101, P1, rpcTimeout,      ANTI_ENTROPY,      () -> ValidationRequest.serializer,         () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb SYNC_RSP               = new Verb("SYNC_RSP",               104, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SyncResponse.serializer,              () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb SYNC_REQ               = new Verb("SYNC_REQ",               103, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SyncRequest.serializer,               () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb PREPARE_MSG            = new Verb("PREPARE_MSG",            105, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareMessage.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb SNAPSHOT_MSG           = new Verb("SNAPSHOT_MSG",           106, P1, rpcTimeout,      ANTI_ENTROPY,      () -> SnapshotMessage.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb CLEANUP_MSG            = new Verb("CLEANUP_MSG",            107, P1, rpcTimeout,      ANTI_ENTROPY,      () -> CleanupMessage.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb PREPARE_CONSISTENT_RSP = new Verb("PREPARE_CONSISTENT_RSP", 109, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareConsistentResponse.serializer, () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb PREPARE_CONSISTENT_REQ = new Verb("PREPARE_CONSISTENT_REQ", 108, P1, rpcTimeout,      ANTI_ENTROPY,      () -> PrepareConsistentRequest.serializer,  () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb FINALIZE_PROPOSE_MSG   = new Verb("FINALIZE_PROPOSE_MSG",   110, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizePropose.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb FINALIZE_PROMISE_MSG   = new Verb("FINALIZE_PROMISE_MSG",   111, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizePromise.serializer,           () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb FINALIZE_COMMIT_MSG    = new Verb("FINALIZE_COMMIT_MSG",    112, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FinalizeCommit.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb FAILED_SESSION_MSG     = new Verb("FAILED_SESSION_MSG",     113, P1, rpcTimeout,      ANTI_ENTROPY,      () -> FailSession.serializer,               () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb STATUS_RSP             = new Verb("STATUS_RSP",             115, P1, rpcTimeout,      ANTI_ENTROPY,      () -> StatusResponse.serializer,            () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+    public static Verb STATUS_REQ             = new Verb("STATUS_REQ",             114, P1, rpcTimeout,      ANTI_ENTROPY,      () -> StatusRequest.serializer,             () -> RepairMessageVerbHandler.instance,   REPAIR_RSP          );
+
+    public static Verb REPLICATION_DONE_RSP   = new Verb("REPLICATION_DONE_RSP",   82,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb REPLICATION_DONE_REQ   = new Verb("REPLICATION_DONE_REQ",   22,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ReplicationDoneVerbHandler.instance, REPLICATION_DONE_RSP);
+    public static Verb SNAPSHOT_RSP           = new Verb("SNAPSHOT_RSP",           87,  P0, rpcTimeout,      MISC,              () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
+    public static Verb SNAPSHOT_REQ           = new Verb("SNAPSHOT_REQ",           27,  P0, rpcTimeout,      MISC,              () -> SnapshotCommand.serializer,           () -> SnapshotVerbHandler.instance,        SNAPSHOT_RSP        );
+
+    // generic failure response
+    public static Verb FAILURE_RSP            = new Verb("FAILURE_RSP",            99,  P0, noTimeout,       REQUEST_RESPONSE,  () -> RequestFailureReason.serializer,      () -> ResponseVerbHandler.instance                             );
+
+    // dummy verbs
+    public static Verb _TRACE                 = new Verb("_TRACE",                 30,  P1, rpcTimeout,      TRACING,           () -> NoPayload.serializer,                 () -> null                                                     );
+    public static Verb _SAMPLE                = new Verb("_SAMPLE",                42,  P1, rpcTimeout,      INTERNAL_RESPONSE, () -> NoPayload.serializer,                 () -> null                                                     );
+    public static Verb _TEST_1                = new Verb("_TEST_1",                10,  P0, writeTimeout,    IMMEDIATE,         () -> NoPayload.serializer,                 () -> null                                                     );
+    public static Verb _TEST_2                = new Verb("_TEST_2",                11,  P1, rpcTimeout,      IMMEDIATE,         () -> NoPayload.serializer,                 () -> null                                                     );
+
+    @Deprecated
+    public static Verb REQUEST_RSP            = new Verb("REQUEST_RSP",            4,   P1, rpcTimeout,      REQUEST_RESPONSE,  () -> null,                                 () -> ResponseVerbHandler.instance                             );
+    @Deprecated
+    public static Verb INTERNAL_RSP           = new Verb("INTERNAL_RSP",           23,  P1, rpcTimeout,      INTERNAL_RESPONSE, () -> null,                                 () -> ResponseVerbHandler.instance                             );
+
+    // largest used public static Verb ID: 116
+
+    // CUSTOM VERBS
+    public static Verb UNUSED_CUSTOM_VERB     = new Verb("CUSTOM", CUSTOM,         0,   P1, rpcTimeout,      INTERNAL_RESPONSE, null,                                 () -> null                                                     );
+
     public enum Kind
     {
         NORMAL,
         CUSTOM
     }
 
+    public final String name;
     public final int id;
     public final Priority priority;
     public final Stage stage;
@@ -229,38 +236,37 @@ public enum Verb
      * NOTE: we use a Supplier to avoid loading the dependent classes until necessary.
      */
     private final Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer;
-    private final Supplier<? extends IVerbHandler<?>> handler;
+    private Supplier<? extends IVerbHandler<?>> handler;
 
     final Verb responseVerb;
 
     private final ToLongFunction<TimeUnit> expiration;
-
 
     /**
      * Verbs it's okay to drop if the request has been queued longer than the request timeout.  These
      * all correspond to client requests or something triggered by them; we don't want to
      * drop internal messages like bootstrap or repair notifications.
      */
-    Verb(int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler)
+    Verb(String name, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler)
     {
-        this(id, priority, expiration, stage, serializer, handler, null);
+        this(name, id, priority, expiration, stage, serializer, handler, null);
     }
 
-    Verb(int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler, Verb responseVerb)
+    Verb(String name, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler, Verb responseVerb)
     {
-        this(NORMAL, id, priority, expiration, stage, serializer, handler, responseVerb);
+        this(name, NORMAL, id, priority, expiration, stage, serializer, handler, responseVerb);
     }
 
-    Verb(Kind kind, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler)
+    Verb(String name, Kind kind, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler)
     {
-        this(kind, id, priority, expiration, stage, serializer, handler, null);
+        this(name, kind, id, priority, expiration, stage, serializer, handler, null);
     }
 
-    Verb(Kind kind, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler, Verb responseVerb)
+    Verb(String name, Kind kind, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler, Verb responseVerb)
     {
         this.stage = stage;
         if (id < 0)
-            throw new IllegalArgumentException("Verb id must be non-negative, got " + id + " for verb " + name());
+            throw new IllegalArgumentException("Verb id must be non-negative, got " + id + " for verb " + name);
 
         if (kind == CUSTOM)
         {
@@ -274,12 +280,15 @@ public enum Verb
                 throw new AssertionError("Invalid verb id " + id + " - we only allow ids between 0 and " + (CUSTOM_VERB_START - MAX_CUSTOM_VERB_ID));
             this.id = id;
         }
+        this.name = name;
         this.priority = priority;
         this.serializer = serializer;
         this.handler = handler;
         this.responseVerb = responseVerb;
         this.expiration = expiration;
         this.kind = kind;
+
+         verbs.add(this);
     }
 
     public <In, Out> IVersionedAsymmetricSerializer<In, Out> serializer()
@@ -356,6 +365,12 @@ public enum Verb
         return original;
     }
 
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+
     // This is the largest number we can store in 2 bytes using VIntCoding (1 bit per byte is used to indicate if there is more data coming).
     // When generating ids we count *down* from this number
     private static final int CUSTOM_VERB_START = (1 << (7 * 2)) - 1;
@@ -365,12 +380,12 @@ public enum Verb
     private static final int MAX_CUSTOM_VERB_ID = 1000;
 
     private static final Verb[] idToVerbMap;
-    private static final Verb[] idToCustomVerbMap;
-    private static final int minCustomId;
+    private static Verb[] idToCustomVerbMap;
+    private static int minCustomId;
 
     static
     {
-        Verb[] verbs = values();
+        List<Verb> verbs = getValues();
         int max = -1;
         int minCustom = Integer.MAX_VALUE;
         for (Verb v : verbs)
@@ -406,8 +421,7 @@ public enum Verb
                     break;
                 case CUSTOM:
                     int relativeId = idForCustomVerb(v.id);
-                    if (customIdMap[relativeId] != null)
-                        throw new IllegalArgumentException("cannot have two custom verbs that map to the same id: " + v + " and " + customIdMap[relativeId]);
+                    assertCustomIdIsUnused(customIdMap, relativeId, v.name);
                     customIdMap[relativeId] = v;
                     break;
                 default:
@@ -417,6 +431,12 @@ public enum Verb
 
         idToVerbMap = idMap;
         idToCustomVerbMap = customIdMap;
+    }
+
+    private static void assertCustomIdIsUnused(Verb[] customIdMap, int id, String name)
+    {
+        if (id < customIdMap.length && customIdMap[id] != null)
+            throw new IllegalArgumentException("cannot have two custom verbs that map to the same id: " + name + " and " + customIdMap[id]);
     }
 
     public static Verb fromId(int id)
@@ -439,6 +459,63 @@ public enum Verb
     private static int idForCustomVerb(int id)
     {
         return CUSTOM_VERB_START - id;
+    }
+
+    /**
+     * Add a new custom verb to the list of verbs.
+     *
+     * While we could dynamically generate an {code}id{/code} for callers, it's safer to have users
+     * explicitly control the ID space since it prevents nodes with different versions disagreeing on which
+     * verb has which ID, e.g. during upgrade.
+     *
+     * @param name the name of the new verb.
+     * @param id the identifier for this custom verb (must be >= 0 and <= MAX_CUSTOM_VERB_ID).
+     * @param priority the priority of the new verb.
+     * @param expiration an optional timeout for this verb. @see VerbTimeouts.
+     * @param stage The stage this verb should execute in.
+     * @param serializer A method to serialize this verb
+     * @param handler A method to handle this verb when received by the network
+     * @param responseVerb The verb to respond with (optional)
+     * @return A Verb for the newly added verb.
+     */
+    public static synchronized Verb addCustomVerb(String name, int id, Priority priority, ToLongFunction<TimeUnit> expiration, Stage stage, Supplier<? extends IVersionedAsymmetricSerializer<?, ?>> serializer, Supplier<? extends IVerbHandler<?>> handler, Verb responseVerb)
+    {
+        assertNameIsUnused(name);
+        assertCustomIdIsUnused(idToCustomVerbMap, id, name);
+        Verb verb =  new Verb(name, CUSTOM, id, priority, expiration, stage, serializer, handler, responseVerb);
+
+        int absoluteId = idForCustomVerb(id);
+        minCustomId = Math.min(absoluteId, minCustomId);
+
+        Verb[] newMap = Arrays.copyOf(idToCustomVerbMap, CUSTOM_VERB_START - minCustomId + 1);
+        System.arraycopy(idToCustomVerbMap, 0, newMap, 0, idToCustomVerbMap.length);
+        newMap[id] = verb;
+        idToCustomVerbMap = newMap;
+
+        return verb;
+    }
+
+    private static void assertNameIsUnused(String name)
+    {
+        if (verbs.stream().map(v -> v.name).collect(Collectors.toList()).contains(name))
+            throw new IllegalArgumentException("Verb name '" + name + "' already exists");
+    }
+
+    /**
+     * Decorates the specified verb handler with the provided method.
+     *
+     * An example use case is to run a custom method after every write request.
+     *
+     * @param verbs the list of verbs whose handlers should be wrapped by method.
+     * @param decoratorFn the method that decorates the handlers in verbs.
+     */
+    public static void decorateHandler(List<Verb> verbs, Function<IVerbHandler<?>, IVerbHandler<?>> decoratorFn)
+    {
+        for (Verb v : verbs)
+        {
+            IVerbHandler<?> handler = v.handler();
+            v.handler = () -> decoratorFn.apply(handler);
+        }
     }
 }
 

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -117,7 +117,7 @@ public class Verb
     public static Verb HINT_RSP               = new Verb("HINT_RSP",               61,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
     public static Verb HINT_REQ               = new Verb("HINT_REQ",               1,   P4, writeTimeout,    MUTATION,          () -> HintMessage.serializer,               () -> HintVerbHandler.instance,            HINT_RSP            );
     public static Verb READ_REPAIR_RSP        = new Verb("READ_REPAIR_RSP",        62,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
-    public static Verb READ_REPAIR_REQ        = new Verb("READ_REPAIR_REP",        2,   P1, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> ReadRepairVerbHandler.instance,      READ_REPAIR_RSP     );
+    public static Verb READ_REPAIR_REQ        = new Verb("READ_REPAIR_REQ",        2,   P1, writeTimeout,    MUTATION,          () -> Mutation.serializer,                  () -> ReadRepairVerbHandler.instance,      READ_REPAIR_RSP     );
     public static Verb BATCH_STORE_RSP        = new Verb("BATCH_STORE_RSP",        65,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
     public static Verb BATCH_STORE_REQ        = new Verb("BATCH_STORE_REQ",        5,   P3, writeTimeout,    MUTATION,          () -> Batch.serializer,                     () -> BatchStoreVerbHandler.instance,      BATCH_STORE_RSP     );
     public static Verb BATCH_REMOVE_RSP       = new Verb("BATCH_REMOVE_RSP",       66,  P1, writeTimeout,    REQUEST_RESPONSE,  () -> NoPayload.serializer,                 () -> ResponseVerbHandler.instance                             );
@@ -201,7 +201,7 @@ public class Verb
     // largest used public static Verb ID: 116
 
     // CUSTOM VERBS
-    public static Verb UNUSED_CUSTOM_VERB     = new Verb("CUSTOM", CUSTOM,         0,   P1, rpcTimeout,      INTERNAL_RESPONSE, null,                                 () -> null                                                     );
+    public static Verb UNUSED_CUSTOM_VERB     = new Verb("UNUSED_CUSTOM_VERB", CUSTOM,         0,   P1, rpcTimeout,      INTERNAL_RESPONSE, null,                                 () -> null                                                     );
 
     public enum Priority
     {

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -498,7 +498,7 @@ public class Verb
     {
         assertNameIsUnused(name);
         assertCustomIdIsUnused(idToCustomVerbMap, id, name);
-        Verb verb =  new Verb(name, CUSTOM, id, priority, expiration, stage, serializer, handler, responseVerb);
+        Verb verb = new Verb(name, CUSTOM, id, priority, expiration, stage, serializer, handler, responseVerb);
 
         int absoluteId = idForCustomVerb(id);
         minCustomId = Math.min(absoluteId, minCustomId);

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -218,7 +218,7 @@ public class Verb
         CUSTOM
     }
 
-    public final String name;
+    private final String name;
     public final int id;
     public final Priority priority;
     public final Stage stage;
@@ -368,7 +368,7 @@ public class Verb
     @Override
     public String toString()
     {
-        return name;
+        return name();
     }
 
     public String name()
@@ -459,7 +459,18 @@ public class Verb
     }
 
     /**
-     * calculate an id for a custom verb
+     * Convert to/from relative and absolute id for a custom verb.
+     *
+     * <pre>{@code
+     *          relId = idForCustomVerb(absId)
+     *          absId = idForCustomVerb(relId).
+     * }</pre>
+     *
+     * <p>Relative ids can be used for indexing idToCustomVerbMap. Absolute ids exist to distinguish
+     * regular verbs from custom verbs in the id space.</p>
+     *
+     * @param id the relative or absolute id.
+     * @return a relative id if {@code id} is absolute, or absolute id if {@code id} is relative.
      */
     private static int idForCustomVerb(int id)
     {
@@ -470,8 +481,8 @@ public class Verb
      * Add a new custom verb to the list of verbs.
      *
      * <p>While we could dynamically generate an {@code id} for callers, it's safer to have users
-     * explicitly control the ID space since it prevents nodes with different versions disagreeing on which
-     * verb has which ID, e.g. during upgrade.</p>
+     * explicitly control the id space since it prevents nodes with different versions disagreeing on which
+     * verb has which id, e.g. during upgrade.</p>
      *
      * @param name the name of the new verb.
      * @param id the identifier for this custom verb (must be >= 0 and <= MAX_CUSTOM_VERB_ID).

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -371,6 +371,11 @@ public class Verb
         return name;
     }
 
+    public String name()
+    {
+        return name;
+    }
+
     // This is the largest number we can store in 2 bytes using VIntCoding (1 bit per byte is used to indicate if there is more data coming).
     // When generating ids we count *down* from this number
     private static final int CUSTOM_VERB_START = (1 << (7 * 2)) - 1;

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -105,15 +105,6 @@ import static org.apache.cassandra.schema.MigrationManager.MigrationsSerializer;
  */
 public class Verb
 {
-    public enum Priority
-    {
-        P0,  // sends on the urgent connection (i.e. for Gossip, Echo)
-        P1,  // small or empty responses
-        P2,  // larger messages that can be dropped but who have a larger impact on system stability (e.g. READ_REPAIR, READ_RSP)
-        P3,
-        P4
-    }
-
     private static final List<Verb> verbs = new ArrayList<>();
 
     public static List<Verb> getValues()
@@ -211,6 +202,15 @@ public class Verb
 
     // CUSTOM VERBS
     public static Verb UNUSED_CUSTOM_VERB     = new Verb("CUSTOM", CUSTOM,         0,   P1, rpcTimeout,      INTERNAL_RESPONSE, null,                                 () -> null                                                     );
+
+    public enum Priority
+    {
+        P0,  // sends on the urgent connection (i.e. for Gossip, Echo)
+        P1,  // small or empty responses
+        P2,  // larger messages that can be dropped but who have a larger impact on system stability (e.g. READ_REPAIR, READ_RSP)
+        P3,
+        P4
+    }
 
     public enum Kind
     {
@@ -469,9 +469,9 @@ public class Verb
     /**
      * Add a new custom verb to the list of verbs.
      *
-     * While we could dynamically generate an {code}id{/code} for callers, it's safer to have users
+     * <p>While we could dynamically generate an {@code id} for callers, it's safer to have users
      * explicitly control the ID space since it prevents nodes with different versions disagreeing on which
-     * verb has which ID, e.g. during upgrade.
+     * verb has which ID, e.g. during upgrade.</p>
      *
      * @param name the name of the new verb.
      * @param id the identifier for this custom verb (must be >= 0 and <= MAX_CUSTOM_VERB_ID).
@@ -509,9 +509,9 @@ public class Verb
     /**
      * Decorates the specified verb handler with the provided method.
      *
-     * An example use case is to run a custom method after every write request.
+     * <p>An example use case is to run a custom method after every write request.</p>
      *
-     * @param verbs the list of verbs whose handlers should be wrapped by method.
+     * @param verbs the list of verbs whose handlers should be wrapped by {@code decoratorFn}.
      * @param decoratorFn the method that decorates the handlers in verbs.
      */
     public static void decorateHandler(List<Verb> verbs, Function<IVerbHandler<?>, IVerbHandler<?>> decoratorFn)

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -485,7 +485,7 @@ public class Verb
      * verb has which id, e.g. during upgrade.</p>
      *
      * @param name the name of the new verb.
-     * @param id the identifier for this custom verb (must be >= 0 and <= MAX_CUSTOM_VERB_ID).
+     * @param id the identifier for this custom verb (must be relative id and >= 0 && <= MAX_CUSTOM_VERB_ID).
      * @param priority the priority of the new verb.
      * @param expiration an optional timeout for this verb. @see VerbTimeouts.
      * @param stage The stage this verb should execute in.

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -32,6 +32,19 @@ import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.streaming.PreviewKind;
 
+import static org.apache.cassandra.net.Verb.CLEANUP_MSG;
+import static org.apache.cassandra.net.Verb.FAILED_SESSION_MSG;
+import static org.apache.cassandra.net.Verb.FINALIZE_COMMIT_MSG;
+import static org.apache.cassandra.net.Verb.FINALIZE_PROMISE_MSG;
+import static org.apache.cassandra.net.Verb.FINALIZE_PROPOSE_MSG;
+import static org.apache.cassandra.net.Verb.PREPARE_CONSISTENT_REQ;
+import static org.apache.cassandra.net.Verb.PREPARE_CONSISTENT_RSP;
+import static org.apache.cassandra.net.Verb.PREPARE_MSG;
+import static org.apache.cassandra.net.Verb.SNAPSHOT_MSG;
+import static org.apache.cassandra.net.Verb.STATUS_REQ;
+import static org.apache.cassandra.net.Verb.STATUS_RSP;
+import static org.apache.cassandra.net.Verb.SYNC_REQ;
+import static org.apache.cassandra.net.Verb.VALIDATION_REQ;
 import static org.apache.cassandra.net.Verb.VALIDATION_RSP;
 
 /**
@@ -62,144 +75,142 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
         RepairJobDesc desc = message.payload.desc;
         try
         {
-            switch (message.verb())
+            if (message.verb() == PREPARE_MSG)
             {
-                case PREPARE_MSG:
-                    PrepareMessage prepareMessage = (PrepareMessage) message.payload;
-                    logger.debug("Preparing, {}", prepareMessage);
+                PrepareMessage prepareMessage = (PrepareMessage) message.payload;
+                logger.debug("Preparing, {}", prepareMessage);
 
-                    if (!ActiveRepairService.verifyCompactionsPendingThreshold(prepareMessage.parentRepairSession, prepareMessage.previewKind))
+                if (!ActiveRepairService.verifyCompactionsPendingThreshold(prepareMessage.parentRepairSession, prepareMessage.previewKind))
+                {
+                    // error is logged in verifyCompactionsPendingThreshold
+                    sendFailureResponse(message);
+                    return;
+                }
+
+                List<ColumnFamilyStore> columnFamilyStores = new ArrayList<>(prepareMessage.tableIds.size());
+                for (TableId tableId : prepareMessage.tableIds)
+                {
+                    ColumnFamilyStore columnFamilyStore = ColumnFamilyStore.getIfExists(tableId);
+                    if (columnFamilyStore == null)
                     {
-                        // error is logged in verifyCompactionsPendingThreshold
-                        sendFailureResponse(message);
+                        logErrorAndSendFailureResponse(String.format("Table with id %s was dropped during prepare phase of repair",
+                                                                     tableId), message);
                         return;
                     }
+                    columnFamilyStores.add(columnFamilyStore);
+                }
+                ActiveRepairService.instance.registerParentRepairSession(prepareMessage.parentRepairSession,
+                                                                         message.from(),
+                                                                         columnFamilyStores,
+                                                                         prepareMessage.ranges,
+                                                                         prepareMessage.isIncremental,
+                                                                         prepareMessage.timestamp,
+                                                                         prepareMessage.isGlobal,
+                                                                         prepareMessage.previewKind);
+                MessagingService.instance().send(message.emptyResponse(), message.from());
+            }
+            else if (message.verb() == SNAPSHOT_MSG)
+            {
+                logger.debug("Snapshotting {}", desc);
+                final ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
+                if (cfs == null)
+                {
+                    logErrorAndSendFailureResponse(String.format("Table %s.%s was dropped during snapshot phase of repair %s",
+                                                                 desc.keyspace, desc.columnFamily, desc.parentSessionId), message);
+                    return;
+                }
 
-                    List<ColumnFamilyStore> columnFamilyStores = new ArrayList<>(prepareMessage.tableIds.size());
-                    for (TableId tableId : prepareMessage.tableIds)
-                    {
-                        ColumnFamilyStore columnFamilyStore = ColumnFamilyStore.getIfExists(tableId);
-                        if (columnFamilyStore == null)
-                        {
-                            logErrorAndSendFailureResponse(String.format("Table with id %s was dropped during prepare phase of repair",
-                                                                         tableId), message);
-                            return;
-                        }
-                        columnFamilyStores.add(columnFamilyStore);
-                    }
-                    ActiveRepairService.instance.registerParentRepairSession(prepareMessage.parentRepairSession,
-                                                                             message.from(),
-                                                                             columnFamilyStores,
-                                                                             prepareMessage.ranges,
-                                                                             prepareMessage.isIncremental,
-                                                                             prepareMessage.timestamp,
-                                                                             prepareMessage.isGlobal,
-                                                                             prepareMessage.previewKind);
-                    MessagingService.instance().send(message.emptyResponse(), message.from());
-                    break;
+                ActiveRepairService.ParentRepairSession prs = ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId);
+                TableRepairManager repairManager = cfs.getRepairManager();
+                if (prs.isGlobal)
+                {
+                    repairManager.snapshot(desc.parentSessionId.toString(), prs.getRanges(), false);
+                }
+                else
+                {
+                    repairManager.snapshot(desc.parentSessionId.toString(), desc.ranges, true);
+                }
+                logger.debug("Enqueuing response to snapshot request {} to {}", desc.sessionId, message.from());
+                MessagingService.instance().send(message.emptyResponse(), message.from());
+            }
+            else if (message.verb() == VALIDATION_REQ)
+            {
+                ValidationRequest validationRequest = (ValidationRequest) message.payload;
+                logger.debug("Validating {}", validationRequest);
+                // trigger read-only compaction
+                ColumnFamilyStore store = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
+                if (store == null)
+                {
+                    logger.error("Table {}.{} was dropped during snapshot phase of repair {}",
+                                 desc.keyspace, desc.columnFamily, desc.parentSessionId);
+                    MessagingService.instance().send(Message.out(VALIDATION_RSP, new ValidationResponse(desc)), message.from());
+                    return;
+                }
 
-                case SNAPSHOT_MSG:
-                    logger.debug("Snapshotting {}", desc);
-                    final ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
-                    if (cfs == null)
-                    {
-                        logErrorAndSendFailureResponse(String.format("Table %s.%s was dropped during snapshot phase of repair %s",
-                                                                     desc.keyspace, desc.columnFamily, desc.parentSessionId), message);
-                        return;
-                    }
-
-                    ActiveRepairService.ParentRepairSession prs = ActiveRepairService.instance.getParentRepairSession(desc.parentSessionId);
-                    TableRepairManager repairManager = cfs.getRepairManager();
-                    if (prs.isGlobal)
-                    {
-                        repairManager.snapshot(desc.parentSessionId.toString(), prs.getRanges(), false);
-                    }
-                    else
-                    {
-                        repairManager.snapshot(desc.parentSessionId.toString(), desc.ranges, true);
-                    }
-                    logger.debug("Enqueuing response to snapshot request {} to {}", desc.sessionId, message.from());
-                    MessagingService.instance().send(message.emptyResponse(), message.from());
-                    break;
-
-                case VALIDATION_REQ:
-                    ValidationRequest validationRequest = (ValidationRequest) message.payload;
-                    logger.debug("Validating {}", validationRequest);
-                    // trigger read-only compaction
-                    ColumnFamilyStore store = ColumnFamilyStore.getIfExists(desc.keyspace, desc.columnFamily);
-                    if (store == null)
-                    {
-                        logger.error("Table {}.{} was dropped during snapshot phase of repair {}",
-                                     desc.keyspace, desc.columnFamily, desc.parentSessionId);
-                        MessagingService.instance().send(Message.out(VALIDATION_RSP, new ValidationResponse(desc)), message.from());
-                        return;
-                    }
-
-                    ActiveRepairService.instance.consistent.local.maybeSetRepairing(desc.parentSessionId);
-                    Validator validator = new Validator(desc, message.from(), validationRequest.nowInSec,
-                                                        isIncremental(desc.parentSessionId), previewKind(desc.parentSessionId));
-                    ValidationManager.instance.submitValidation(store, validator);
-                    break;
-
-                case SYNC_REQ:
-                    // forwarded sync request
-                    SyncRequest request = (SyncRequest) message.payload;
-                    logger.debug("Syncing {}", request);
-                    StreamingRepairTask task = new StreamingRepairTask(desc,
-                                                                       request.initiator,
-                                                                       request.src,
-                                                                       request.dst,
-                                                                       request.ranges,
-                                                                       isIncremental(desc.parentSessionId) ? desc.parentSessionId : null,
-                                                                       request.previewKind,
-                                                                       request.asymmetric);
-                    task.run();
-                    break;
-
-                case CLEANUP_MSG:
-                    logger.debug("cleaning up repair");
-                    CleanupMessage cleanup = (CleanupMessage) message.payload;
-                    ActiveRepairService.instance.removeParentRepairSession(cleanup.parentRepairSession);
-                    MessagingService.instance().send(message.emptyResponse(), message.from());
-                    break;
-
-                case PREPARE_CONSISTENT_REQ:
-                    ActiveRepairService.instance.consistent.local.handlePrepareMessage(message.from(), (PrepareConsistentRequest) message.payload);
-                    break;
-
-                case PREPARE_CONSISTENT_RSP:
-                    ActiveRepairService.instance.consistent.coordinated.handlePrepareResponse((PrepareConsistentResponse) message.payload);
-                    break;
-
-                case FINALIZE_PROPOSE_MSG:
-                    ActiveRepairService.instance.consistent.local.handleFinalizeProposeMessage(message.from(), (FinalizePropose) message.payload);
-                    break;
-
-                case FINALIZE_PROMISE_MSG:
-                    ActiveRepairService.instance.consistent.coordinated.handleFinalizePromiseMessage((FinalizePromise) message.payload);
-                    break;
-
-                case FINALIZE_COMMIT_MSG:
-                    ActiveRepairService.instance.consistent.local.handleFinalizeCommitMessage(message.from(), (FinalizeCommit) message.payload);
-                    break;
-
-                case FAILED_SESSION_MSG:
-                    FailSession failure = (FailSession) message.payload;
-                    ActiveRepairService.instance.consistent.coordinated.handleFailSessionMessage(failure);
-                    ActiveRepairService.instance.consistent.local.handleFailSessionMessage(message.from(), failure);
-                    break;
-
-                case STATUS_REQ:
-                    ActiveRepairService.instance.consistent.local.handleStatusRequest(message.from(), (StatusRequest) message.payload);
-                    break;
-
-                case STATUS_RSP:
-                    ActiveRepairService.instance.consistent.local.handleStatusResponse(message.from(), (StatusResponse) message.payload);
-                    break;
-
-                default:
-                    ActiveRepairService.instance.handleMessage(message);
-                    break;
+                ActiveRepairService.instance.consistent.local.maybeSetRepairing(desc.parentSessionId);
+                Validator validator = new Validator(desc, message.from(), validationRequest.nowInSec,
+                                                    isIncremental(desc.parentSessionId), previewKind(desc.parentSessionId));
+                ValidationManager.instance.submitValidation(store, validator);
+            }
+            else if (message.verb() == SYNC_REQ)
+            {
+                // forwarded sync request
+                SyncRequest request = (SyncRequest) message.payload;
+                logger.debug("Syncing {}", request);
+                StreamingRepairTask task = new StreamingRepairTask(desc,
+                                                                   request.initiator,
+                                                                   request.src,
+                                                                   request.dst,
+                                                                   request.ranges,
+                                                                   isIncremental(desc.parentSessionId) ? desc.parentSessionId : null,
+                                                                   request.previewKind,
+                                                                   request.asymmetric);
+                task.run();
+            }
+            else if (message.verb() == CLEANUP_MSG)
+            {
+                logger.debug("cleaning up repair");
+                CleanupMessage cleanup = (CleanupMessage) message.payload;
+                ActiveRepairService.instance.removeParentRepairSession(cleanup.parentRepairSession);
+                MessagingService.instance().send(message.emptyResponse(), message.from());
+            }
+            else if (message.verb() == PREPARE_CONSISTENT_REQ)
+            {
+                ActiveRepairService.instance.consistent.local.handlePrepareMessage(message.from(), (PrepareConsistentRequest) message.payload);
+            }
+            else if (message.verb() == PREPARE_CONSISTENT_RSP)
+            {
+                ActiveRepairService.instance.consistent.coordinated.handlePrepareResponse((PrepareConsistentResponse) message.payload);
+            }
+            else if (message.verb() ==  FINALIZE_PROPOSE_MSG)
+            {
+                ActiveRepairService.instance.consistent.local.handleFinalizeProposeMessage(message.from(), (FinalizePropose) message.payload);
+            }
+            else if (message.verb() == FINALIZE_PROMISE_MSG)
+            {
+                ActiveRepairService.instance.consistent.coordinated.handleFinalizePromiseMessage((FinalizePromise) message.payload);
+            }
+            else if (message.verb() == FINALIZE_COMMIT_MSG)
+            {
+                ActiveRepairService.instance.consistent.local.handleFinalizeCommitMessage(message.from(), (FinalizeCommit) message.payload);
+            }
+            else if (message.verb() ==  FAILED_SESSION_MSG)
+            {
+                FailSession failure = (FailSession) message.payload;
+                ActiveRepairService.instance.consistent.coordinated.handleFailSessionMessage(failure);
+                ActiveRepairService.instance.consistent.local.handleFailSessionMessage(message.from(), failure);
+            }
+            else if (message.verb() == STATUS_REQ)
+            {
+                ActiveRepairService.instance.consistent.local.handleStatusRequest(message.from(), (StatusRequest) message.payload);
+            }
+            else if (message.verb() == STATUS_RSP)
+            {
+                ActiveRepairService.instance.consistent.local.handleStatusResponse(message.from(), (StatusResponse) message.payload);
+            }
+            else
+            {
+                ActiveRepairService.instance.handleMessage(message);
             }
         }
         catch (Exception e)

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -93,6 +93,8 @@ import org.apache.cassandra.utils.UUIDGen;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.transform;
 import static org.apache.cassandra.net.Verb.PREPARE_MSG;
+import static org.apache.cassandra.net.Verb.SYNC_RSP;
+import static org.apache.cassandra.net.Verb.VALIDATION_RSP;
 
 /**
  * ActiveRepairService is the starting point for manual "active" repairs.
@@ -712,19 +714,17 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         RepairSession session = sessions.get(desc.sessionId);
         if (session == null)
             return;
-        switch (message.verb())
+
+        if (message.verb() == VALIDATION_RSP)
         {
-            case VALIDATION_RSP:
-                ValidationResponse validation = (ValidationResponse) message.payload;
-                session.validationComplete(desc, message.from(), validation.trees);
-                break;
-            case SYNC_RSP:
-                // one of replica is synced.
-                SyncResponse sync = (SyncResponse) message.payload;
-                session.syncComplete(desc, sync.nodes, sync.success, sync.summaries);
-                break;
-            default:
-                break;
+            ValidationResponse validation = (ValidationResponse) message.payload;
+            session.validationComplete(desc, message.from(), validation.trees);
+        }
+        else if (message.verb() == SYNC_RSP)
+        {
+            // one of replica is synced.
+            SyncResponse sync = (SyncResponse) message.payload;
+            session.syncComplete(desc, sync.nodes, sync.success, sync.summaries);
         }
     }
 

--- a/test/unit/org/apache/cassandra/net/VerbTest.java
+++ b/test/unit/org/apache/cassandra/net/VerbTest.java
@@ -18,16 +18,135 @@
 
 package org.apache.cassandra.net;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.MutationVerbHandler;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class VerbTest
 {
     @Test
     public void idsMatch()
     {
-        for (Verb v : Verb.values())
+        for (Verb v : Verb.getValues())
             assertEquals(v, Verb.fromId(v.id));
+    }
+
+    @Test
+    public void verbName()
+    {
+        // MUTATION_RSP is the first
+        Verb v = Verb.getValues().get(0);
+        assertEquals("MUTATION_RSP", v.toString());
+    }
+
+    @Test
+    public void invalidVerbIdThrows()
+    {
+        boolean threw = false;
+        try
+        {
+            Verb.fromId(-1);
+        }
+        catch (IllegalArgumentException e)
+        {
+            threw = true;
+        }
+        assertTrue("Invalid verb identifier was valid", threw);
+    }
+
+    @Test
+    public void mutationVerbHasMutationHandler()
+    {
+        Verb mutationReqVerb = Verb.fromId(Verb.MUTATION_REQ.id);
+        assertEquals(MutationVerbHandler.instance, mutationReqVerb.handler());
+    }
+
+    @Test
+    public void addNewVerbWithConflictingId()
+    {
+        boolean threw = false;
+        try
+        {
+            addFakeVerb(Verb.UNUSED_CUSTOM_VERB.id, "FAKE_REQ");
+        }
+        catch (IllegalArgumentException ex)
+        {
+            threw = true;
+        }
+        assertTrue("Expected IllegalArgumentException when adding existing verb id", threw);
+    }
+
+    @Test
+    public void addingTwoVerbsHasDistinctIds()
+    {
+        Verb FAKE_REQ = addFakeVerb(1, "FAKE_REQ");
+        assertNotEquals(null, FAKE_REQ);
+        assertEquals(FAKE_REQ, Verb.fromId(FAKE_REQ.id));
+
+        Verb FAKE_REQ2 = addFakeVerb(256, "FAKE_REQ2");
+        assertEquals(FAKE_REQ2, Verb.fromId(FAKE_REQ2.id));
+        assertNotEquals(FAKE_REQ, Verb.fromId(FAKE_REQ2.id));
+    }
+
+    private Verb addFakeVerb(int id, String name)
+    {
+        return addFakeVerb(id, name, () -> MutationVerbHandler.instance);
+    }
+
+    private Verb addFakeVerb(int id, String name, Supplier<? extends IVerbHandler<?>> handler)
+    {
+        return Verb.addCustomVerb(name, id, Verb.Priority.P0, VerbTimeouts.writeTimeout, Stage.MUTATION, () -> NoPayload.serializer, handler, Verb.MUTATION_RSP);
+    }
+
+    private static class CountingVerbHandler implements IVerbHandler<Integer>
+    {
+        public int count;
+        @Override
+        public void doVerb(Message<Integer> message)
+        {
+            count++;
+        }
+    }
+
+    private static class DoubleCaller implements IVerbHandler<Integer>
+    {
+        IVerbHandler<Integer> handler;
+        public DoubleCaller(IVerbHandler<Integer> handler)
+        {
+           this.handler = handler;
+        }
+
+        @Override
+        public void doVerb(Message<Integer> message) throws IOException
+        {
+            handler.doVerb(message);
+            handler.doVerb(message);
+        }
+    }
+
+    @Test
+    public void decorateHandler() throws IOException
+    {
+        CountingVerbHandler handler = new CountingVerbHandler();
+        Verb decoratedVerb = addFakeVerb(23, "DECORATED_VERB", () -> handler);
+
+        Verb.decorateHandler(Arrays.asList(decoratedVerb), (oldHandler) -> new DoubleCaller((IVerbHandler<Integer>) oldHandler));
+        decoratedVerb.handler().doVerb(null);
+        assertEquals(2, handler.count);
     }
 }


### PR DESCRIPTION
Add support for:

- registering new verbs at runtime
- decorating existing verb handlers with another method
- running a callback after the `MessagingService` sends a message