### PR TITLE
STAR-881: Fix FailingRepairTest after making Verb an object

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
@@ -80,12 +80,12 @@ public class FailingRepairTest extends TestBaseImpl implements Serializable
 {
     private static ICluster<IInvokableInstance> CLUSTER;
 
-    private final Verb messageType;
+    private final int messageType;
     private final RepairParallelism parallelism;
     private final boolean withTracing;
     private final SerializableRunnable setup;
 
-    public FailingRepairTest(Verb messageType, RepairParallelism parallelism, boolean withTracing, SerializableRunnable setup)
+    public FailingRepairTest(int messageType, RepairParallelism parallelism, boolean withTracing, SerializableRunnable setup)
     {
         this.messageType = messageType;
         this.parallelism = parallelism;
@@ -101,15 +101,16 @@ public class FailingRepairTest extends TestBaseImpl implements Serializable
         {
             for (Boolean withTracing : Arrays.asList(Boolean.TRUE, Boolean.FALSE))
             {
-                tests.add(new Object[]{ Verb.VALIDATION_REQ, parallelism, withTracing, failingReaders(Verb.VALIDATION_REQ, parallelism, withTracing) });
+                tests.add(new Object[]{ Verb.VALIDATION_REQ.id, parallelism, withTracing, failingReaders(Verb.VALIDATION_REQ.id, parallelism, withTracing) });
             }
         }
         return tests;
     }
 
-    private static SerializableRunnable failingReaders(Verb type, RepairParallelism parallelism, boolean withTracing)
+    private static SerializableRunnable failingReaders(int typeId, RepairParallelism parallelism, boolean withTracing)
     {
         return () -> {
+            Verb type = Verb.fromId(typeId);
             String cfName = getCfName(type, parallelism, withTracing);
             ColumnFamilyStore cf = Keyspace.open(KEYSPACE).getColumnFamilyStore(cfName);
             cf.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
@@ -172,7 +173,7 @@ public class FailingRepairTest extends TestBaseImpl implements Serializable
     {
         final int replica = 1;
         final int coordinator = 2;
-        String tableName = getCfName(messageType, parallelism, withTracing);
+        String tableName = getCfName(Verb.fromId(messageType), parallelism, withTracing);
         String fqtn = KEYSPACE + "." + tableName;
 
         CLUSTER.schemaChange("CREATE TABLE " + fqtn + " (k INT, PRIMARY KEY (k))");


### PR DESCRIPTION
FailingRepairTest uses serialization to pass Verbs back and forth
between the nodes during the test. Unforuntately, Verbs aren't
serializable anymore because they're no longer enums and this broke
the test.

Instead of passing a verb around, pass the verb Id and lookup the
verb inside of the test method.