### PR TITLE
STAR-909 Port DynamicSnitchSeverityProvider from bdp/cndb

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -197,7 +197,10 @@ public enum CassandraRelevantProperties
     /**
      * Which class to use for creating guardrails
      */
-    CUSTOM_GUARDRAILS_FACTORY_PROPERTY("cassandra.custom_guardrails_factory_class");
+    CUSTOM_GUARDRAILS_FACTORY_PROPERTY("cassandra.custom_guardrails_factory_class"),
+    
+    /** Which class to use for dynamic snitch severity values */
+    DYNAMIC_SNITCH_SEVERITY_PROVIDER("cassandra.dynamic_snitch_severity_provider");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -271,7 +271,7 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
 
     private void updateScores() // this is expensive
     {
-        if (!StorageService.instance.isGossipActive())
+        if (!DynamicSnitchSeverityProvider.instance.isReady())
             return;
         if (!registered)
         {
@@ -361,22 +361,15 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
 
     public void setSeverity(double severity)
     {
-        Gossiper.instance.addLocalApplicationState(ApplicationState.SEVERITY, StorageService.instance.valueFactory.severity(severity));
+        DynamicSnitchSeverityProvider.instance.setSeverity(FBUtilities.getBroadcastAddressAndPort(), severity);
     }
 
     private double getSeverity(InetAddressAndPort endpoint)
     {
-        EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
-        if (state == null)
-            return 0.0;
-
-        VersionedValue event = state.getApplicationState(ApplicationState.SEVERITY);
-        if (event == null)
-            return 0.0;
-
-        return Double.parseDouble(event.value);
+        return DynamicSnitchSeverityProvider.instance.getSeverity(endpoint);
     }
 
+    @Override
     public double getSeverity()
     {
         return getSeverity(FBUtilities.getBroadcastAddressAndPort());

--- a/src/java/org/apache/cassandra/locator/DynamicSnitchSeverityProvider.java
+++ b/src/java/org/apache/cassandra/locator/DynamicSnitchSeverityProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.locator;
+
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.DYNAMIC_SNITCH_SEVERITY_PROVIDER;
+
+
+/**
+ * Class to abstract gossiper out of dynamic snitch
+ */
+public interface DynamicSnitchSeverityProvider
+{
+    DynamicSnitchSeverityProvider instance = DYNAMIC_SNITCH_SEVERITY_PROVIDER.getString() == null ?
+                                             new DefaultProvider() : make(DYNAMIC_SNITCH_SEVERITY_PROVIDER.getString());
+
+    /**
+     * @return true if initialization is completed and ready to update dynamic snitch scores
+     */
+    boolean isReady();
+
+    /**
+     * update the severity for given endpoint
+     *
+     * @param endpoint endpoint to be updated
+     * @param severity severity for the endpoint
+     */
+    void setSeverity(InetAddressAndPort endpoint, double severity);
+
+    /**
+     * @return severity for the endpoint or 0.0 if not found
+     */
+    double getSeverity(InetAddressAndPort endpoint);
+
+    static DynamicSnitchSeverityProvider make(String customImpl)
+    {
+        try
+        {
+            return (DynamicSnitchSeverityProvider) Class.forName(customImpl).newInstance();
+        }
+        catch (Throwable ex)
+        {
+            throw new IllegalStateException("Unknown dynamic snitch severity provider: " + customImpl);
+        }
+    }
+
+    class DefaultProvider implements DynamicSnitchSeverityProvider
+    {
+        @Override
+        public boolean isReady()
+        {
+            // to resolve circular initializer dependency deadlock from CASSANDRA-1756
+            return StorageService.instance.isGossipActive();
+        }
+
+        @Override
+        public void setSeverity(InetAddressAndPort endpoint, double severity)
+        {
+            if (!endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
+                throw new UnsupportedOperationException("Default severity provider only supports setting local severity, but got " + endpoint);
+
+            Gossiper.instance.addLocalApplicationState(ApplicationState.SEVERITY, StorageService.instance.valueFactory.severity(severity));
+        }
+
+        @Override
+        public double getSeverity(InetAddressAndPort endpoint)
+        {
+            EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+            if (state == null)
+                return 0.0;
+
+            VersionedValue event = state.getApplicationState(ApplicationState.SEVERITY);
+            if (event == null)
+                return 0.0;
+
+            return Double.parseDouble(event.value);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
@@ -20,8 +20,8 @@ package org.apache.cassandra.locator;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,6 +60,22 @@ public class DynamicEndpointSnitchTest
             rlist.add(ReplicaUtils.full(endpoint));
         }
         return rlist.build();
+    }
+
+    @Test
+    public void testDynamicSnitchSetSeverity()
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        DatabaseDescriptor.setDynamicBadnessThreshold(0.1);
+        StorageService.instance.unsafeInitialize();
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+        double origSeverity = dsnitch.getSeverity();
+        double updSeverity = origSeverity + 1.0d;
+        dsnitch.setSeverity(updSeverity);
+        Assert.assertEquals(updSeverity, dsnitch.getSeverity(), 0.0d);
+        dsnitch.setSeverity(origSeverity);
     }
 
     @Test


### PR DESCRIPTION
Ports `DynamicSnitchSeverityProvider` in `cndb/bdp` that was introduced with [cndb-745 PR](https://github.com/riptano/bdp/pull/19400).

Note: C* 4.0/CC use `InetAddressAndPort` rather than `InetAddress` and I have made that change in this port.