### PR TITLE
STAR-912 Add InternalRequestExecutionException

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
+++ b/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
@@ -20,15 +20,18 @@ package org.apache.cassandra.db.filter;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.exceptions.UncheckedInternalRequestExecutionException;
+import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.marshal.*;
 
-public class TombstoneOverwhelmingException extends RuntimeException
+public class TombstoneOverwhelmingException extends UncheckedInternalRequestExecutionException
 {
     public TombstoneOverwhelmingException(long numTombstones, String query, TableMetadata metadata, DecoratedKey lastPartitionKey, ClusteringPrefix<?> lastClustering)
     {
-        super(String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partion key was (%s)); query aborted",
+        super(RequestFailureReason.READ_TOO_MANY_TOMBSTONES,
+              String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partion key was (%s)); query aborted", 
                             numTombstones, query, lastPartitionKey.getToken(), makePKString(metadata, lastPartitionKey.getKey(), lastClustering)));
     }
 

--- a/src/java/org/apache/cassandra/exceptions/IncompatibleSchemaException.java
+++ b/src/java/org/apache/cassandra/exceptions/IncompatibleSchemaException.java
@@ -19,10 +19,18 @@ package org.apache.cassandra.exceptions;
 
 import java.io.IOException;
 
-public class IncompatibleSchemaException extends IOException
+public class IncompatibleSchemaException extends IOException implements InternalRequestExecutionException
 {
-    public IncompatibleSchemaException(String msg)
+    private final RequestFailureReason reason;
+
+    public IncompatibleSchemaException(RequestFailureReason reason, String msg)
     {
         super(msg);
+        this.reason = reason;
+    }
+
+    public RequestFailureReason getReason()
+    {
+        return reason;
     }
 }

--- a/src/java/org/apache/cassandra/exceptions/InternalRequestExecutionException.java
+++ b/src/java/org/apache/cassandra/exceptions/InternalRequestExecutionException.java
@@ -15,17 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.cassandra.exceptions;
 
-import org.apache.cassandra.schema.TableId;
-
-public class UnknownTableException extends IncompatibleSchemaException
+/**
+ * Indicates an "expected" exception during the execution of a request on a
+ * replica.
+ * <p>
+ * This groups exceptions that can happen on replicas but aren't unexpected in
+ * the sense that the circumstance for it happening is understood and a result
+ * of a user error, which we simply couldn't detect on the coordinator.
+ * <p>
+ * Such failures include an index query while the index is not built yet, or a
+ * 'TombstoneOverwhelmingException' for instance.
+ */
+public interface InternalRequestExecutionException
 {
-    public final TableId id;
-
-    public UnknownTableException(String msg, TableId id)
-    {
-        super(RequestFailureReason.UNKNOWN_TABLE, msg);
-        this.id = id;
-    }
+    RequestFailureReason getReason();
 }

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -36,7 +36,10 @@ public enum RequestFailureReason
     READ_TOO_MANY_TOMBSTONES (1),
     TIMEOUT                  (2),
     INCOMPATIBLE_SCHEMA      (3),
-    INDEX_NOT_AVAILABLE      (4);
+    INDEX_NOT_AVAILABLE      (4),
+    UNKNOWN_COLUMN           (5),
+    UNKNOWN_TABLE            (6),
+    REMOTE_STORAGE_FAILURE   (7);
 
     public static final Serializer serializer = new Serializer();
 

--- a/src/java/org/apache/cassandra/exceptions/UncheckedInternalRequestExecutionException.java
+++ b/src/java/org/apache/cassandra/exceptions/UncheckedInternalRequestExecutionException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cassandra.exceptions;
+
+public class UncheckedInternalRequestExecutionException extends RuntimeException implements InternalRequestExecutionException
+{
+    public final RequestFailureReason reason;
+
+    protected UncheckedInternalRequestExecutionException(RequestFailureReason reason, Throwable cause)
+    {
+        super(cause);
+        this.reason = reason;
+    }
+
+    protected UncheckedInternalRequestExecutionException(RequestFailureReason reason, String message, Throwable cause)
+    {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    public UncheckedInternalRequestExecutionException(RequestFailureReason reason, String message)
+    {
+        this(reason, message, null);
+    }
+
+    public RequestFailureReason getReason()
+    {
+        return reason;
+    }
+}

--- a/src/java/org/apache/cassandra/exceptions/UnknownColumnException.java
+++ b/src/java/org/apache/cassandra/exceptions/UnknownColumnException.java
@@ -21,6 +21,6 @@ public final class UnknownColumnException extends IncompatibleSchemaException
 {
     public UnknownColumnException(String msg)
     {
-        super(msg);
+        super(RequestFailureReason.UNKNOWN_COLUMN, msg);
     }
 }

--- a/src/java/org/apache/cassandra/index/IndexNotAvailableException.java
+++ b/src/java/org/apache/cassandra/index/IndexNotAvailableException.java
@@ -18,10 +18,13 @@
 
 package org.apache.cassandra.index;
 
+import org.apache.cassandra.exceptions.UncheckedInternalRequestExecutionException;
+import org.apache.cassandra.exceptions.RequestFailureReason;
+
 /**
  * Thrown if a secondary index is not currently available.
  */
-public final class IndexNotAvailableException extends RuntimeException
+public final class IndexNotAvailableException extends UncheckedInternalRequestExecutionException
 {
     /**
      * Creates a new <code>IndexNotAvailableException</code> for the specified index.
@@ -29,6 +32,7 @@ public final class IndexNotAvailableException extends RuntimeException
      */
     public IndexNotAvailableException(Index index)
     {
-        super(String.format("The secondary index '%s' is not yet available", index.getIndexMetadata().name));
+        super(RequestFailureReason.INDEX_NOT_AVAILABLE,
+              String.format("The secondary index '%s' is not yet available", index.getIndexMetadata().name));
     }
 }


### PR DESCRIPTION
Adding `InternalRequestExecutionException` as an interface so that it can be used with exceptions that extend `RuntimeException` as well as checked exceptions.

Also added `RequestFailureReason` codes for exceptions that implement IREE.
