### PR TITLE
STAR-934 extend native library API for serverless

### DIFF
--- a/src/java/org/apache/cassandra/utils/INativeLibrary.java
+++ b/src/java/org/apache/cassandra/utils/INativeLibrary.java
@@ -94,6 +94,11 @@ public interface INativeLibrary
     int tryOpenDirectory(File path);
 
     /**
+     * try to open given directory
+     */
+    int tryOpenDirectory(String path);
+
+    /**
      * try fsync on given file
      */
     void trySync(int fd);

--- a/src/java/org/apache/cassandra/utils/NativeLibrary.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibrary.java
@@ -302,7 +302,12 @@ public class NativeLibrary implements INativeLibrary
     @Override
     public int tryOpenDirectory(File file)
     {
-        String path = file.path();
+        return tryOpenDirectory(file.path());
+    }
+
+    @Override
+    public int tryOpenDirectory(String path)
+    {
         int fd = -1;
 
         try


### PR DESCRIPTION
Extends the API of NativeLibrary to create a directory by providing
the path as string, so specialized implementations of a file system
don't to do additional conversion into Cassandra File, which is then
converted into string representation.