### PR TITLE
Update version of common-codec to 1.15

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -500,7 +500,7 @@
           </dependency>
           <dependency groupId="org.hdrhistogram" artifactId="HdrHistogram" version="2.1.9"/>
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
-          <dependency groupId="commons-codec" artifactId="commons-codec" version="1.9"/>
+          <dependency groupId="commons-codec" artifactId="commons-codec" version="1.15"/>
           <dependency groupId="commons-io" artifactId="commons-io" version="2.6" scope="test"/>
           <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.11"/>
           <dependency groupId="org.apache.commons" artifactId="commons-math3" version="3.2"/>


### PR DESCRIPTION
CNDB uses methods from the later version of
org.apache.common.codec.binary.Hex and the methods are not available in
the current version 1.9. Thus updating the version, which is already
in use in DataStax, i.e., 1.15.

Needed to compile module cndb-common