### PR TITLE
STAR-1015 add new CL error policy to reject writes on sync errors

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -661,9 +661,27 @@ public class Config
 
     public enum CommitFailurePolicy
     {
+        /**
+         * This will stop Gossip and the inter-node transports, and kill the syncing thread.
+         */
         stop,
+        /**
+         * This will kill the syncing thread.
+         */
         stop_commit,
+        /**
+         * This will set a flag that will reject all mutations that require the CL. This flag
+         * will be cleared after a successful sync. This flag is only set for errors when sync-ing
+         * the CL segments, it is identical to ignore for other errors.
+         */
+        fail_writes,
+        /**
+         * This will ignore the error, a new sync will be attempted after a full polling period.
+         */
         ignore,
+        /**
+         * This will kill the process.
+         */
         die,
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -20,11 +20,14 @@ package org.apache.cassandra.db.commitlog;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.zip.CRC32;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.io.util.File;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -49,6 +52,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MBeanWrapper;
 import org.apache.cassandra.utils.MonotonicClock;
+import org.apache.cassandra.utils.NoSpamLogger;
 
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.Allocation;
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.CommitLogSegmentFileComparator;
@@ -63,6 +67,7 @@ import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
 public class CommitLog implements CommitLogMBean
 {
     private static final Logger logger = LoggerFactory.getLogger(CommitLog.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 10, TimeUnit.SECONDS);
 
     public static final CommitLog instance = CommitLog.construct();
 
@@ -264,6 +269,18 @@ public class CommitLog implements CommitLogMBean
     }
 
     /**
+     * If there was an exception when sync-ing, and if the commit log failure policy is
+     * {@link Config.CommitFailurePolicy#fail_writes} then mutations will be rejected until
+     * the sync error is cleared, which happens after a successful sync.
+     * @return
+     */
+    private boolean shouldRejectMutations()
+    {
+        return executor.getSyncError() &&
+                DatabaseDescriptor.getCommitFailurePolicy() == Config.CommitFailurePolicy.fail_writes;
+    }
+
+    /**
      * Add a Mutation to the commit log. If CDC is enabled, this can fail.
      *
      * @param mutation the Mutation to add to the log
@@ -274,6 +291,13 @@ public class CommitLog implements CommitLogMBean
         assert mutation != null;
 
         mutation.validateSize(MessagingService.current_version, ENTRY_OVERHEAD_SIZE);
+
+        if (shouldRejectMutations())
+        {
+            String errorMsg = "Rejecting mutation due to a failure sync-ing commit log segments";
+            noSpamLogger.error(errorMsg);
+            throw new FSWriteError(new IllegalStateException(errorMsg), segmentManager.allocatingFrom().getPath());
+        }
 
         try (DataOutputBuffer dob = DataOutputBuffer.scratchBuffer.get())
         {
@@ -510,6 +534,7 @@ public class CommitLog implements CommitLogMBean
             case stop_commit:
                 logger.error(String.format("%s. Commit disk failure policy is %s; terminating thread", message, DatabaseDescriptor.getCommitFailurePolicy()), t);
                 return false;
+            case fail_writes:
             case ignore:
                 logger.error(message, t);
                 return true;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -274,7 +274,8 @@ public class CommitLog implements CommitLogMBean
      * the sync error is cleared, which happens after a successful sync.
      * @return
      */
-    private boolean shouldRejectMutations()
+    @VisibleForTesting
+    public boolean shouldRejectMutations()
     {
         return executor.getSyncError() &&
                 DatabaseDescriptor.getCommitFailurePolicy() == Config.CommitFailurePolicy.fail_writes;

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogBytemanTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.SetType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.MemtableParams;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.KillerForTests;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+@RunWith(BMUnitRunner.class)
+public class CommitLogBytemanTest
+{
+    protected static final String KEYSPACE = "CommitLogBytemanTest";
+    protected static final String STANDARD = "Standard";
+    private static final String CUSTOM = "Custom";
+
+    private static JVMStabilityInspector.Killer oldKiller;
+    private static KillerForTests testKiller;
+
+    public static volatile boolean failSync = false;
+
+    @BeforeClass
+    public static void beforeClass() throws ConfigurationException
+    {
+        // Disable durable writes for system keyspaces to prevent system mutations, e.g. sstable_activity,
+        // to end up in CL segments and cause unexpected results in this test wrt counting CL segments,
+        // see CASSANDRA-12854
+        org.apache.cassandra.db.commitlog.CommitLogBytemanTest.failSync = false;
+        KeyspaceParams.DEFAULT_LOCAL_DURABLE_WRITES = false;
+
+        SchemaLoader.prepareServer();
+        StorageService.instance.getTokenMetadata().updateHostId(UUID.randomUUID(), FBUtilities.getBroadcastAddressAndPort());
+
+        MemtableParams skipListMemtable = MemtableParams.fromMap(ImmutableMap.of("class", "SkipListMemtable"));
+
+        TableMetadata.Builder custom =
+                TableMetadata.builder(KEYSPACE, CUSTOM)
+                        .addPartitionKeyColumn("k", IntegerType.instance)
+                        .addClusteringColumn("c1", MapType.getInstance(UTF8Type.instance, UTF8Type.instance, false))
+                        .addClusteringColumn("c2", SetType.getInstance(UTF8Type.instance, false))
+                        .addStaticColumn("s", IntegerType.instance)
+                        .memtable(skipListMemtable);
+
+        SchemaLoader.createKeyspace(KEYSPACE,
+                KeyspaceParams.simple(1),
+                SchemaLoader.standardCFMD(KEYSPACE, STANDARD, 0, AsciiType.instance, BytesType.instance).memtable(skipListMemtable),
+                custom);
+        CompactionManager.instance.disableAutoCompaction();
+
+        testKiller = new KillerForTests();
+
+        // While we don't want the JVM to be nuked from under us on a test failure, we DO want some indication of
+        // an error. If we hit a "Kill the JVM" condition while working with the CL when we don't expect it, an aggressive
+        // KillerForTests will assertion out on us.
+        oldKiller = JVMStabilityInspector.replaceKiller(testKiller);
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        JVMStabilityInspector.replaceKiller(oldKiller);
+    }
+
+    @Before
+    public void beforeTest() throws IOException
+    {
+        CommitLog.instance.resetUnsafe(true);
+    }
+
+    @After
+    public void afterTest()
+    {
+        testKiller.reset();
+    }
+
+    @Test
+    @BMRules(rules = { @BMRule(name = "Fail sync in CommitLog",
+            targetClass = "CommitLog",
+            targetMethod = "sync",
+            condition = "org.apache.cassandra.db.commitlog.CommitLogBytemanTest.failSync",
+            action = "throw new java.lang.RuntimeException();") } )
+    public void testFailWritesPolicies() throws InterruptedException
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(STANDARD);
+        Config.CommitFailurePolicy oldPolicy = DatabaseDescriptor.getCommitFailurePolicy();
+        DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.fail_writes);
+
+        Mutation m = new RowUpdateBuilder(cfs.metadata.get(), 0, "key")
+                .clustering("bytes")
+                .add("val", ByteBuffer.allocate(10 * 1024))
+                .build();
+        CommitLog.instance.add(m);
+
+        Thread awaitForSync = new Thread(CommitLogBytemanTest.class.getSimpleName() + " commit log waiting thread")
+        {
+            @Override
+            public void run()
+            {
+                failSync = true;
+                CommitLog.instance.add(m);
+            }
+        };
+        CommitLog.instance.requestExtraSync();
+
+        awaitForSync.start();
+        CommitLog.instance.requestExtraSync();
+        Assert.assertThrows(FSWriteError.class, () -> CommitLog.instance.add(m));
+        failSync = false;
+        try
+        {
+            awaitForSync.join();
+            CommitLog.instance.requestExtraSync();
+            CommitLog.instance.add(m);
+        } finally
+        {
+            DatabaseDescriptor.setCommitFailurePolicy(oldPolicy);
+        }
+
+    }
+}

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogFailurePolicyTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogFailurePolicyTest.java
@@ -138,4 +138,28 @@ public class CommitLogFailurePolicyTest
             JVMStabilityInspector.replaceKiller(originalKiller);
         }
     }
+
+    @Test
+    public void testCommitFailurePolicy_fail_writes()
+    {
+        CassandraDaemon daemon = new CassandraDaemon();
+        daemon.completeSetup(); //startup must be completed, otherwise commit log failure must kill JVM regardless of failure policy
+        StorageService.instance.registerDaemon(daemon);
+
+        KillerForTests killerForTests = new KillerForTests();
+        JVMStabilityInspector.Killer originalKiller = JVMStabilityInspector.replaceKiller(killerForTests);
+        Config.CommitFailurePolicy oldPolicy = DatabaseDescriptor.getCommitFailurePolicy();
+        try
+        {
+            DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.fail_writes);
+            CommitLog.handleCommitError("Testing ignore policy", new Throwable());
+            //error policy is set to IGNORE, so JVM must not be killed if error occurs after startup
+            Assert.assertFalse(killerForTests.wasKilled());
+        }
+        finally
+        {
+            DatabaseDescriptor.setCommitFailurePolicy(oldPolicy);
+            JVMStabilityInspector.replaceKiller(originalKiller);
+        }
+    }
 }

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogFailurePolicyTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogFailurePolicyTest.java
@@ -152,8 +152,8 @@ public class CommitLogFailurePolicyTest
         try
         {
             DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.fail_writes);
-            CommitLog.handleCommitError("Testing ignore policy", new Throwable());
-            //error policy is set to IGNORE, so JVM must not be killed if error occurs after startup
+            CommitLog.handleCommitError("Testing fail writes policy", new Throwable());
+            //error policy is set to fail_writes, so JVM must not be killed if error occurs after startup
             Assert.assertFalse(killerForTests.wasKilled());
         }
         finally

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogPolicyBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogPolicyBytemanTest.java
@@ -77,10 +77,6 @@ public class CommitLogPolicyBytemanTest
     @BeforeClass
     public static void beforeClass() throws ConfigurationException
     {
-        DatabaseDescriptor.daemonInitialization();
-        DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.group);
-        DatabaseDescriptor.setCommitLogSyncGroupWindow(1);
-
         // Disable durable writes for system keyspaces to prevent system mutations, e.g. sstable_activity,
         // to end up in CL segments and cause unexpected results in this test wrt counting CL segments,
         // see CASSANDRA-12854


### PR DESCRIPTION
Adds fail_writes policy to commit log failure policies, which rejects
writes on sync errors.