### PR TITLE
STAR-1097 Store Raw CQL query inside statement

### DIFF
--- a/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
@@ -178,10 +178,11 @@ public class CassandraAuthorizer implements IAuthorizer
     private void executeLoggedBatch(List<CQLStatement> statements)
     throws RequestExecutionException, RequestValidationException
     {
-        BatchStatement batch = new BatchStatement(BatchStatement.Type.LOGGED,
-                                                  VariableSpecifications.empty(),
-                                                  Lists.newArrayList(Iterables.filter(statements, ModificationStatement.class)),
-                                                  Attributes.none());
+        BatchStatement batch = new BatchStatement(null,
+                BatchStatement.Type.LOGGED,
+                VariableSpecifications.empty(),
+                Lists.newArrayList(Iterables.filter(statements, ModificationStatement.class)),
+                Attributes.none());
         processBatch(batch);
     }
 

--- a/src/java/org/apache/cassandra/cql3/CQLStatement.java
+++ b/src/java/org/apache/cassandra/cql3/CQLStatement.java
@@ -29,6 +29,14 @@ import org.apache.cassandra.transport.messages.ResultMessage;
 public interface CQLStatement
 {
     /**
+     * The query string that produced that statement, if available.
+     *
+     * @return the raw query string that produced that statement, or {@code null} if said string is not available
+     * (typically because the statement has not be built from a string). Note that said string may contain bind markers.
+     */
+    public String getRawCQLStatement();
+
+    /**
      * Returns all bind variables for the statement
      */
     default List<ColumnSpecification> getBindVariables()
@@ -101,7 +109,18 @@ public interface CQLStatement
 
     public static abstract class Raw
     {
+        protected String rawCQLStatement;
         protected VariableSpecifications bindVariables;
+
+        public void setRawCQLStatement(String queryString)
+        {
+            this.rawCQLStatement = queryString;
+        }
+
+        public String getRawCQLStatement()
+        {
+            return rawCQLStatement;
+        }
 
         public void setBindVariables(List<ColumnIdentifier> variables)
         {

--- a/src/java/org/apache/cassandra/cql3/QueryEvents.java
+++ b/src/java/org/apache/cassandra/cql3/QueryEvents.java
@@ -112,7 +112,6 @@ public class QueryEvents
     }
 
     public void notifyExecuteSuccess(CQLStatement statement,
-                                     String query,
                                      QueryOptions options,
                                      QueryState state,
                                      long queryTime,
@@ -120,6 +119,7 @@ public class QueryEvents
     {
         try
         {
+            String query = statement.getRawCQLStatement();
             final String possiblyObfuscatedQuery = listeners.size() > 0 ? possiblyObfuscateQuery(statement, query) : query;
             for (Listener listener : listeners)
                 listener.executeSuccess(statement, possiblyObfuscatedQuery, options, state, queryTime, response);
@@ -137,7 +137,7 @@ public class QueryEvents
                                      Exception cause)
     {
         CQLStatement statement = prepared != null ? prepared.statement : null;
-        String query = prepared != null ? prepared.rawCQLStatement : null;
+        String query = prepared != null ? prepared.statement.getRawCQLStatement() : null;
         try
         {
             final String possiblyObfuscatedQuery = listeners.size() > 0 ? possiblyObfuscateQuery(statement, query) : query;
@@ -188,7 +188,7 @@ public class QueryEvents
             {
                 prepared.forEach(p -> {
                     statements.add(p.statement);
-                    queries.add(p.rawCQLStatement);
+                    queries.add(p.statement.getRawCQLStatement());
                 });
             }
             try
@@ -250,7 +250,7 @@ public class QueryEvents
         }
     }
 
-    private String possiblyObfuscateQuery(CQLStatement statement, String query)
+    private String possiblyObfuscateQuery(@Nullable CQLStatement statement, String query)
     {
         // Statement might be null as side-effect of failed parsing, originates from QueryMessage#execute
         return null == statement || statement instanceof AuthenticationStatement ? passwordObfuscator.obfuscate(query) : query;

--- a/src/java/org/apache/cassandra/cql3/QueryHandler.java
+++ b/src/java/org/apache/cassandra/cql3/QueryHandler.java
@@ -62,22 +62,9 @@ public interface QueryHandler
 
         public final MD5Digest resultMetadataId;
 
-        /**
-         * Contains the CQL statement source if the statement has been "regularly" perpared via
-         * {@link QueryHandler#prepare(String, ClientState, Map)}.
-         * Other usages of this class may or may not contain the CQL statement source.
-         */
-        public final String rawCQLStatement;
-
         public Prepared(CQLStatement statement)
         {
-            this(statement, "");
-        }
-
-        public Prepared(CQLStatement statement, String rawCQLStatement)
-        {
             this.statement = statement;
-            this.rawCQLStatement = rawCQLStatement;
             this.resultMetadataId = ResultSet.ResultMetadata.fromPrepared(statement).getResultMetadataId();
         }
     }

--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -441,7 +441,7 @@ public class QueryProcessor implements QueryHandler
             return existing;
 
         CQLStatement statement = getStatement(queryString, clientState);
-        Prepared prepared = new Prepared(statement, queryString);
+        Prepared prepared = new Prepared(statement);
 
         int boundTerms = statement.getBindVariables().size();
         if (boundTerms > FBUtilities.MAX_UNSIGNED_SHORT)
@@ -464,8 +464,8 @@ public class QueryProcessor implements QueryHandler
         if (existing == null)
             return null;
 
-        checkTrue(queryString.equals(existing.rawCQLStatement),
-                String.format("MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'", existing.rawCQLStatement));
+        checkTrue(queryString.equals(existing.statement.getRawCQLStatement()),
+                String.format("MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'", existing.statement.getRawCQLStatement()));
 
         ResultSet.PreparedMetadata preparedMetadata = ResultSet.PreparedMetadata.fromPrepared(existing.statement);
         ResultSet.ResultMetadata resultMetadata = ResultSet.ResultMetadata.fromPrepared(existing.statement);
@@ -578,7 +578,9 @@ public class QueryProcessor implements QueryHandler
     {
         try
         {
-            return CQLFragmentParser.parseAnyUnhandled(CqlParser::query, queryStr);
+            CQLStatement.Raw stmt = CQLFragmentParser.parseAnyUnhandled(CqlParser::query, queryStr);
+            stmt.setRawCQLStatement(queryStr);
+            return stmt;
         }
         catch (CassandraException ce)
         {

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -39,7 +39,6 @@ import org.slf4j.helpers.MessageFormatter;
 
 import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Attributes;
 import org.apache.cassandra.cql3.BatchQueryOptions;
 import org.apache.cassandra.cql3.CQLStatement;
@@ -69,9 +68,7 @@ import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageProxy;
-import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.transport.messages.ResultMessage;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.Pair;
 
@@ -88,6 +85,7 @@ public class BatchStatement implements CQLStatement
         LOGGED, UNLOGGED, COUNTER
     }
 
+    private final String rawCQLStatement;
     public final Type type;
     private final VariableSpecifications bindVariables;
     private final List<ModificationStatement> statements;
@@ -120,8 +118,10 @@ public class BatchStatement implements CQLStatement
      * @param statements the list of statements in the batch
      * @param attrs      additional attributes for statement (CL, timestamp, timeToLive)
      */
-    public BatchStatement(Type type, VariableSpecifications bindVariables, List<ModificationStatement> statements, Attributes attrs)
+    public BatchStatement(String queryString, Type type, VariableSpecifications bindVariables,
+            List<ModificationStatement> statements, Attributes attrs)
     {
+        this.rawCQLStatement = queryString;
         this.type = type;
         this.bindVariables = bindVariables;
         this.statements = statements;
@@ -153,6 +153,12 @@ public class BatchStatement implements CQLStatement
         this.updatesStaticRow = updateStatic;
         this.hasConditions = hasConditions;
         this.updatesVirtualTables = updatesVirtualTables;
+    }
+
+    @Override
+    public String getRawCQLStatement()
+    {
+        return rawCQLStatement;
     }
 
     @Override
@@ -643,7 +649,7 @@ public class BatchStatement implements CQLStatement
             Attributes prepAttrs = attrs.prepare("[batch]", "[batch]");
             prepAttrs.collectMarkerSpecification(bindVariables);
 
-            BatchStatement batchStatement = new BatchStatement(type, bindVariables, statements, prepAttrs);
+            BatchStatement batchStatement = new BatchStatement(rawCQLStatement, type, bindVariables, statements, prepAttrs);
             batchStatement.validate();
 
             return batchStatement;

--- a/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
@@ -43,14 +43,15 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
  */
 public class DeleteStatement extends ModificationStatement
 {
-    private DeleteStatement(VariableSpecifications bindVariables,
-                            TableMetadata cfm,
-                            Operations operations,
-                            StatementRestrictions restrictions,
-                            Conditions conditions,
-                            Attributes attrs)
+    private DeleteStatement(String queryString,
+            VariableSpecifications bindVariables,
+            TableMetadata cfm,
+            Operations operations,
+            StatementRestrictions restrictions,
+            Conditions conditions,
+            Attributes attrs)
     {
-        super(StatementType.DELETE, bindVariables, cfm, operations, restrictions, conditions, attrs);
+        super(queryString, StatementType.DELETE, bindVariables, cfm, operations, restrictions, conditions, attrs);
     }
 
     @Override
@@ -168,12 +169,13 @@ public class DeleteStatement extends ModificationStatement
                                                                  whereClause,
                                                                  conditions);
 
-            DeleteStatement stmt = new DeleteStatement(bindVariables,
-                                                       metadata,
-                                                       operations,
-                                                       restrictions,
-                                                       conditions,
-                                                       attrs);
+            DeleteStatement stmt = new DeleteStatement(rawCQLStatement,
+                    bindVariables,
+                    metadata,
+                    operations,
+                    restrictions,
+                    conditions,
+                    attrs);
 
             if (stmt.hasConditions() && !restrictions.hasAllPKColumnsRestrictedByEqualities())
             {

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -78,6 +78,8 @@ public abstract class ModificationStatement implements CQLStatement
 
     private static final ColumnIdentifier CAS_RESULT_COLUMN = new ColumnIdentifier("[applied]", false);
 
+    private final String rawCQLStatement;
+
     protected final StatementType type;
 
     protected final VariableSpecifications bindVariables;
@@ -97,14 +99,16 @@ public abstract class ModificationStatement implements CQLStatement
 
     private final RegularAndStaticColumns requiresRead;
 
-    public ModificationStatement(StatementType type,
-                                 VariableSpecifications bindVariables,
-                                 TableMetadata metadata,
-                                 Operations operations,
-                                 StatementRestrictions restrictions,
-                                 Conditions conditions,
-                                 Attributes attrs)
+    public ModificationStatement(String queryString,
+            StatementType type,
+            VariableSpecifications bindVariables,
+            TableMetadata metadata,
+            Operations operations,
+            StatementRestrictions restrictions,
+            Conditions conditions,
+            Attributes attrs)
     {
+        this.rawCQLStatement = queryString;
         this.type = type;
         this.bindVariables = bindVariables;
         this.metadata = metadata;
@@ -150,6 +154,12 @@ public abstract class ModificationStatement implements CQLStatement
         this.updatedColumns = modifiedColumns;
         this.conditionColumns = conditionColumnsBuilder.build();
         this.requiresRead = requiresReadBuilder.build();
+    }
+
+    @Override
+    public String getRawCQLStatement()
+    {
+        return rawCQLStatement;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -95,6 +95,7 @@ public class SelectStatement implements CQLStatement
 {
     private static final Logger logger = LoggerFactory.getLogger(SelectStatement.class);
 
+    private final String rawCQLStatement;
     public final VariableSpecifications bindVariables;
     public final TableMetadata table;
     public final Parameters parameters;
@@ -123,17 +124,19 @@ public class SelectStatement implements CQLStatement
                                                                        false,
                                                                        false);
 
-    public SelectStatement(TableMetadata table,
-                           VariableSpecifications bindVariables,
-                           Parameters parameters,
-                           Selection selection,
-                           StatementRestrictions restrictions,
-                           boolean isReversed,
-                           AggregationSpecification aggregationSpec,
-                           Comparator<List<ByteBuffer>> orderingComparator,
-                           Term limit,
-                           Term perPartitionLimit)
+    public SelectStatement(String queryString,
+            TableMetadata table,
+            VariableSpecifications bindVariables,
+            Parameters parameters,
+            Selection selection,
+            StatementRestrictions restrictions,
+            boolean isReversed,
+            AggregationSpecification aggregationSpec,
+            Comparator<List<ByteBuffer>> orderingComparator,
+            Term limit,
+            Term perPartitionLimit)
     {
+        this.rawCQLStatement = queryString;
         this.table = table;
         this.bindVariables = bindVariables;
         this.selection = selection;
@@ -144,6 +147,12 @@ public class SelectStatement implements CQLStatement
         this.parameters = parameters;
         this.limit = limit;
         this.perPartitionLimit = perPartitionLimit;
+    }
+
+    @Override
+    public String getRawCQLStatement()
+    {
+        return rawCQLStatement;
     }
 
     @Override
@@ -192,16 +201,17 @@ public class SelectStatement implements CQLStatement
     // queried data through processColumnFamily.
     static SelectStatement forSelection(TableMetadata table, Selection selection)
     {
-        return new SelectStatement(table,
-                                   VariableSpecifications.empty(),
-                                   defaultParameters,
-                                   selection,
-                                   StatementRestrictions.empty(table),
-                                   false,
-                                   null,
-                                   null,
-                                   null,
-                                   null);
+        return new SelectStatement(null,
+                table,
+                VariableSpecifications.empty(),
+                defaultParameters,
+                selection,
+                StatementRestrictions.empty(table),
+                false,
+                null,
+                null,
+                null,
+                null);
     }
 
     public ResultSet.ResultMetadata getResultMetadata()
@@ -1035,16 +1045,17 @@ public class SelectStatement implements CQLStatement
 
             checkNeedsFiltering(table, restrictions);
 
-            return new SelectStatement(table,
-                                       bindVariables,
-                                       parameters,
-                                       selection,
-                                       restrictions,
-                                       isReversed,
-                                       aggregationSpec,
-                                       orderingComparator,
-                                       prepareLimit(bindVariables, limit, keyspace(), limitReceiver()),
-                                       prepareLimit(bindVariables, perPartitionLimit, keyspace(), perPartitionLimitReceiver()));
+            return new SelectStatement(rawCQLStatement,
+                    table,
+                    bindVariables,
+                    parameters,
+                    selection,
+                    restrictions,
+                    isReversed,
+                    aggregationSpec,
+                    orderingComparator,
+                    prepareLimit(bindVariables, limit, keyspace(), limitReceiver()),
+                    prepareLimit(bindVariables, perPartitionLimit, keyspace(), perPartitionLimitReceiver()));
         }
 
         private Selection prepareSelection(TableMetadata table,

--- a/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
@@ -48,15 +48,16 @@ public class UpdateStatement extends ModificationStatement
 {
     private static final Constants.Value EMPTY = new Constants.Value(ByteBufferUtil.EMPTY_BYTE_BUFFER);
 
-    private UpdateStatement(StatementType type,
-                            VariableSpecifications bindVariables,
-                            TableMetadata metadata,
-                            Operations operations,
-                            StatementRestrictions restrictions,
-                            Conditions conditions,
-                            Attributes attrs)
+    private UpdateStatement(String queryString,
+            StatementType type,
+            VariableSpecifications bindVariables,
+            TableMetadata metadata,
+            Operations operations,
+            StatementRestrictions restrictions,
+            Conditions conditions,
+            Attributes attrs)
     {
-        super(type, bindVariables, metadata, operations, restrictions, conditions, attrs);
+        super(queryString, type, bindVariables, metadata, operations, restrictions, conditions, attrs);
     }
 
     @Override
@@ -184,13 +185,14 @@ public class UpdateStatement extends ModificationStatement
                                                                               false,
                                                                               false);
 
-            return new UpdateStatement(type,
-                                       bindVariables,
-                                       metadata,
-                                       operations,
-                                       restrictions,
-                                       conditions,
-                                       attrs);
+            return new UpdateStatement(rawCQLStatement,
+                    type,
+                    bindVariables,
+                    metadata,
+                    operations,
+                    restrictions,
+                    conditions,
+                    attrs);
         }
     }
 
@@ -252,13 +254,14 @@ public class UpdateStatement extends ModificationStatement
                                                                               false,
                                                                               false);
 
-            return new UpdateStatement(type,
-                                       bindVariables,
-                                       metadata,
-                                       operations,
-                                       restrictions,
-                                       conditions,
-                                       attrs);
+            return new UpdateStatement(rawCQLStatement,
+                    type,
+                    bindVariables,
+                    metadata,
+                    operations,
+                    restrictions,
+                    conditions,
+                    attrs);
         }
     }
 
@@ -315,13 +318,14 @@ public class UpdateStatement extends ModificationStatement
                                                                  whereClause,
                                                                  conditions);
 
-            return new UpdateStatement(type,
-                                       bindVariables,
-                                       metadata,
-                                       operations,
-                                       restrictions,
-                                       conditions,
-                                       attrs);
+            return new UpdateStatement(rawCQLStatement,
+                    type,
+                    bindVariables,
+                    metadata,
+                    operations,
+                    restrictions,
+                    conditions,
+                    attrs);
         }
     }
     

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
@@ -54,9 +54,9 @@ public final class AlterKeyspaceStatement extends AlterSchemaStatement
 
     private final KeyspaceAttributes attrs;
 
-    public AlterKeyspaceStatement(String keyspaceName, KeyspaceAttributes attrs)
+    public AlterKeyspaceStatement(String queryString, String keyspaceName, KeyspaceAttributes attrs)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.attrs = attrs;
     }
 
@@ -205,7 +205,7 @@ public final class AlterKeyspaceStatement extends AlterSchemaStatement
 
         public AlterKeyspaceStatement prepare(ClientState state)
         {
-            return new AlterKeyspaceStatement(keyspaceName, attrs);
+            return new AlterKeyspaceStatement(rawCQLStatement, keyspaceName, attrs);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
@@ -36,11 +36,19 @@ import org.apache.cassandra.transport.messages.ResultMessage;
 
 abstract class AlterSchemaStatement implements CQLStatement, SchemaTransformation
 {
+    private final String rawCQLStatement;
     protected final String keyspaceName; // name of the keyspace affected by the statement
 
-    protected AlterSchemaStatement(String keyspaceName)
+    protected AlterSchemaStatement(String queryString, String keyspaceName)
     {
+        this.rawCQLStatement = queryString;
         this.keyspaceName = keyspaceName;
+    }
+
+    @Override
+    public String getRawCQLStatement()
+    {
+        return rawCQLStatement;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -82,9 +82,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 {
     protected final String tableName;
 
-    public AlterTableStatement(String keyspaceName, String tableName)
+    public AlterTableStatement(String queryString, String keyspaceName, String tableName)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
     }
 
@@ -140,9 +140,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
      */
     public static class AlterColumn extends AlterTableStatement
     {
-        AlterColumn(String keyspaceName, String tableName)
+        AlterColumn(String queryString, String keyspaceName, String tableName)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
         }
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
@@ -184,9 +184,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             this.queryState = state;
         }
 
-        private AddColumns(String keyspaceName, String tableName, Collection<Column> newColumns)
+        private AddColumns(String queryString, String keyspaceName, String tableName, Collection<Column> newColumns)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
             this.newColumns = newColumns;
         }
 
@@ -275,9 +275,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         private final Set<ColumnIdentifier> removedColumns;
         private final Long timestamp;
 
-        private DropColumns(String keyspaceName, String tableName, Set<ColumnIdentifier> removedColumns, Long timestamp)
+        private DropColumns(String queryString, String keyspaceName, String tableName, Set<ColumnIdentifier> removedColumns, Long timestamp)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
             this.removedColumns = removedColumns;
             this.timestamp = timestamp;
         }
@@ -338,9 +338,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         private final Map<ColumnIdentifier, ColumnIdentifier> renamedColumns;
 
-        private RenameColumns(String keyspaceName, String tableName, Map<ColumnIdentifier, ColumnIdentifier> renamedColumns)
+        private RenameColumns(String queryString, String keyspaceName, String tableName, Map<ColumnIdentifier, ColumnIdentifier> renamedColumns)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
             this.renamedColumns = renamedColumns;
         }
 
@@ -404,9 +404,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         private final TableAttributes attrs;
 
-        private AlterOptions(String keyspaceName, String tableName, TableAttributes attrs)
+        private AlterOptions(String queryString, String keyspaceName, String tableName, TableAttributes attrs)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
             this.attrs = attrs;
         }
 
@@ -459,9 +459,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         private static final Logger logger = LoggerFactory.getLogger(AlterTableStatement.class);
         private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 5L, TimeUnit.MINUTES);
-        private DropCompactStorage(String keyspaceName, String tableName)
+        private DropCompactStorage(String queryString, String keyspaceName, String tableName)
         {
-            super(keyspaceName, tableName);
+            super(queryString, keyspaceName, tableName);
         }
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
@@ -587,12 +587,12 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
             switch (kind)
             {
-                case          ALTER_COLUMN: return new AlterColumn(keyspaceName, tableName);
-                case           ADD_COLUMNS: return new AddColumns(keyspaceName, tableName, addedColumns);
-                case          DROP_COLUMNS: return new DropColumns(keyspaceName, tableName, droppedColumns, dropTimestamp);
-                case        RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns);
-                case         ALTER_OPTIONS: return new AlterOptions(keyspaceName, tableName, attrs);
-                case  DROP_COMPACT_STORAGE: return new DropCompactStorage(keyspaceName, tableName);
+                case          ALTER_COLUMN: return new AlterColumn(rawCQLStatement, keyspaceName, tableName);
+                case           ADD_COLUMNS: return new AddColumns(rawCQLStatement, keyspaceName, tableName, addedColumns);
+                case          DROP_COLUMNS: return new DropColumns(rawCQLStatement, keyspaceName, tableName, droppedColumns, dropTimestamp);
+                case        RENAME_COLUMNS: return new RenameColumns(rawCQLStatement, keyspaceName, tableName, renamedColumns);
+                case         ALTER_OPTIONS: return new AlterOptions(rawCQLStatement, keyspaceName, tableName, attrs);
+                case  DROP_COMPACT_STORAGE: return new DropCompactStorage(rawCQLStatement, keyspaceName, tableName);
             }
 
             throw new AssertionError();

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -52,9 +52,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 {
     protected final String typeName;
 
-    public AlterTypeStatement(String keyspaceName, String typeName)
+    public AlterTypeStatement(String queryString, String keyspaceName, String typeName)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.typeName = typeName;
     }
 
@@ -101,9 +101,10 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
         private final CQL3Type.Raw type;
         private QueryState state;
 
-        private AddField(String keyspaceName, String typeName, FieldIdentifier fieldName, CQL3Type.Raw type)
+        private AddField(String queryString, String keyspaceName, String typeName,
+                FieldIdentifier fieldName, CQL3Type.Raw type)
         {
-            super(keyspaceName, typeName);
+            super(queryString, keyspaceName, typeName);
             this.fieldName = fieldName;
             this.type = type;
         }
@@ -157,9 +158,10 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
     {
         private final Map<FieldIdentifier, FieldIdentifier> renamedFields;
 
-        private RenameFields(String keyspaceName, String typeName, Map<FieldIdentifier, FieldIdentifier> renamedFields)
+        private RenameFields(String queryString, String keyspaceName, String typeName,
+                Map<FieldIdentifier, FieldIdentifier> renamedFields)
         {
-            super(keyspaceName, typeName);
+            super(queryString, keyspaceName, typeName);
             this.renamedFields = renamedFields;
         }
 
@@ -201,9 +203,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 
     private static final class AlterField extends AlterTypeStatement
     {
-        private AlterField(String keyspaceName, String typeName)
+        private AlterField(String queryString, String keyspaceName, String typeName)
         {
-            super(keyspaceName, typeName);
+            super(queryString, keyspaceName, typeName);
         }
 
         UserType apply(KeyspaceMetadata keyspace, UserType userType)
@@ -242,9 +244,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 
             switch (kind)
             {
-                case     ADD_FIELD: return new AddField(keyspaceName, typeName, newFieldName, newFieldType);
-                case RENAME_FIELDS: return new RenameFields(keyspaceName, typeName, renamedFields);
-                case   ALTER_FIELD: return new AlterField(keyspaceName, typeName);
+                case     ADD_FIELD: return new AddField(rawCQLStatement, keyspaceName, typeName, newFieldName, newFieldType);
+                case RENAME_FIELDS: return new RenameFields(rawCQLStatement, keyspaceName, typeName, renamedFields);
+                case   ALTER_FIELD: return new AlterField(rawCQLStatement, keyspaceName, typeName);
             }
 
             throw new AssertionError();

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
@@ -37,9 +37,10 @@ public final class AlterViewStatement extends AlterSchemaStatement
     private final TableAttributes attrs;
     private QueryState state;
 
-    public AlterViewStatement(String keyspaceName, String viewName, TableAttributes attrs)
+    public AlterViewStatement(String queryString, String keyspaceName, String viewName,
+            TableAttributes attrs)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.viewName = viewName;
         this.attrs = attrs;
     }
@@ -126,7 +127,7 @@ public final class AlterViewStatement extends AlterSchemaStatement
         public AlterViewStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new AlterViewStatement(keyspaceName, name.getName(), attrs);
+            return new AlterViewStatement(rawCQLStatement, keyspaceName, name.getName(), attrs);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateAggregateStatement.java
@@ -65,17 +65,18 @@ public final class CreateAggregateStatement extends AlterSchemaStatement
     private final boolean orReplace;
     private final boolean ifNotExists;
 
-    public CreateAggregateStatement(String keyspaceName,
-                                    String aggregateName,
-                                    List<CQL3Type.Raw> rawArgumentTypes,
-                                    CQL3Type.Raw rawStateType,
-                                    FunctionName stateFunctionName,
-                                    FunctionName finalFunctionName,
-                                    Term.Raw rawInitialValue,
-                                    boolean orReplace,
-                                    boolean ifNotExists)
+    public CreateAggregateStatement(String queryString,
+            String keyspaceName,
+            String aggregateName,
+            List<CQL3Type.Raw> rawArgumentTypes,
+            CQL3Type.Raw rawStateType,
+            FunctionName stateFunctionName,
+            FunctionName finalFunctionName,
+            Term.Raw rawInitialValue,
+            boolean orReplace,
+            boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.aggregateName = aggregateName;
         this.rawArgumentTypes = rawArgumentTypes;
         this.rawStateType = rawStateType;
@@ -320,15 +321,16 @@ public final class CreateAggregateStatement extends AlterSchemaStatement
         {
             String keyspaceName = aggregateName.hasKeyspace() ? aggregateName.keyspace : state.getKeyspace();
 
-            return new CreateAggregateStatement(keyspaceName,
-                                                aggregateName.name,
-                                                rawArgumentTypes,
-                                                rawStateType,
-                                                new FunctionName(keyspaceName, stateFunctionName),
-                                                null != finalFunctionName ? new FunctionName(keyspaceName, finalFunctionName) : null,
-                                                rawInitialValue,
-                                                orReplace,
-                                                ifNotExists);
+            return new CreateAggregateStatement(rawCQLStatement,
+                    keyspaceName,
+                    aggregateName.name,
+                    rawArgumentTypes,
+                    rawStateType,
+                    new FunctionName(keyspaceName, stateFunctionName),
+                    null != finalFunctionName ? new FunctionName(keyspaceName, finalFunctionName) : null,
+                    rawInitialValue,
+                    orReplace,
+                    ifNotExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
@@ -60,18 +60,19 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
     private final boolean orReplace;
     private final boolean ifNotExists;
 
-    public CreateFunctionStatement(String keyspaceName,
-                                   String functionName,
-                                   List<ColumnIdentifier> argumentNames,
-                                   List<CQL3Type.Raw> rawArgumentTypes,
-                                   CQL3Type.Raw rawReturnType,
-                                   boolean calledOnNullInput,
-                                   String language,
-                                   String body,
-                                   boolean orReplace,
-                                   boolean ifNotExists)
+    public CreateFunctionStatement(String queryString,
+            String keyspaceName,
+            String functionName,
+            List<ColumnIdentifier> argumentNames,
+            List<CQL3Type.Raw> rawArgumentTypes,
+            CQL3Type.Raw rawReturnType,
+            boolean calledOnNullInput,
+            String language,
+            String body,
+            boolean orReplace,
+            boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.functionName = functionName;
         this.argumentNames = argumentNames;
         this.rawArgumentTypes = rawArgumentTypes;
@@ -240,16 +241,17 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
         {
             String keyspaceName = name.hasKeyspace() ? name.keyspace : state.getKeyspace();
 
-            return new CreateFunctionStatement(keyspaceName,
-                                               name.name,
-                                               argumentNames,
-                                               rawArgumentTypes,
-                                               rawReturnType,
-                                               calledOnNullInput,
-                                               language,
-                                               body,
-                                               orReplace,
-                                               ifNotExists);
+            return new CreateFunctionStatement(rawCQLStatement,
+                    keyspaceName,
+                    name.name,
+                    argumentNames,
+                    rawArgumentTypes,
+                    rawReturnType,
+                    calledOnNullInput,
+                    language,
+                    body,
+                    orReplace,
+                    ifNotExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -71,14 +71,15 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         "com.datastax.bdp.search.solr.Cql3SolrSecondaryIndex"
     );
 
-    public CreateIndexStatement(String keyspaceName,
-                                String tableName,
-                                String indexName,
-                                List<IndexTarget.Raw> rawIndexTargets,
-                                IndexAttributes attrs,
-                                boolean ifNotExists)
+    public CreateIndexStatement(String queryString,
+            String keyspaceName,
+            String tableName,
+            String indexName,
+            List<IndexTarget.Raw> rawIndexTargets,
+            IndexAttributes attrs,
+            boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
         this.indexName = indexName;
         this.rawIndexTargets = rawIndexTargets;
@@ -330,7 +331,8 @@ public final class CreateIndexStatement extends AlterSchemaStatement
             if (indexName.hasKeyspace() && !keyspaceName.equals(indexName.getKeyspace()))
                 throw ire("Keyspace name '%s' doesn't match index name '%s'", keyspaceName, tableName);
 
-            return new CreateIndexStatement(keyspaceName, tableName.getName(), indexName.getName(), rawIndexTargets, attrs, ifNotExists);
+            return new CreateIndexStatement(rawCQLStatement, keyspaceName, tableName.getName(),
+                    indexName.getName(), rawIndexTargets, attrs, ifNotExists);
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
@@ -52,9 +52,10 @@ public final class CreateKeyspaceStatement extends AlterSchemaStatement
     private final KeyspaceAttributes attrs;
     private final boolean ifNotExists;
 
-    public CreateKeyspaceStatement(String keyspaceName, KeyspaceAttributes attrs, boolean ifNotExists)
+    public CreateKeyspaceStatement(String queryString, String keyspaceName,
+            KeyspaceAttributes attrs, boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.attrs = attrs;
         this.ifNotExists = ifNotExists;
     }
@@ -148,7 +149,7 @@ public final class CreateKeyspaceStatement extends AlterSchemaStatement
 
         public CreateKeyspaceStatement prepare(ClientState state)
         {
-            return new CreateKeyspaceStatement(keyspaceName, attrs, ifNotExists);
+            return new CreateKeyspaceStatement(rawCQLStatement, keyspaceName, attrs, ifNotExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -65,21 +65,22 @@ public final class CreateTableStatement extends AlterSchemaStatement
     private final boolean ifNotExists;
     private final boolean useCompactStorage;
 
-    public CreateTableStatement(String keyspaceName,
-                                String tableName,
+    public CreateTableStatement(String queryString,
+            String keyspaceName,
+            String tableName,
 
-                                Map<ColumnIdentifier, CQL3Type.Raw> rawColumns,
-                                Set<ColumnIdentifier> staticColumns,
-                                List<ColumnIdentifier> partitionKeyColumns,
-                                List<ColumnIdentifier> clusteringColumns,
+            Map<ColumnIdentifier, CQL3Type.Raw> rawColumns,
+            Set<ColumnIdentifier> staticColumns,
+            List<ColumnIdentifier> partitionKeyColumns,
+            List<ColumnIdentifier> clusteringColumns,
 
-                                LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
-                                TableAttributes attrs,
+            LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
+            TableAttributes attrs,
 
-                                boolean ifNotExists,
-                                boolean useCompactStorage)
+            boolean ifNotExists,
+            boolean useCompactStorage)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
 
         this.rawColumns = rawColumns;
@@ -525,19 +526,20 @@ public final class CreateTableStatement extends AlterSchemaStatement
             if (null == partitionKeyColumns)
                 throw ire("No PRIMARY KEY specifed for table '%s' (exactly one required)", name);
 
-            return new CreateTableStatement(keyspaceName,
-                                            name.getName(),
+            return new CreateTableStatement(rawCQLStatement,
+                    keyspaceName,
+                    name.getName(),
 
-                                            rawColumns,
-                                            staticColumns,
-                                            partitionKeyColumns,
-                                            clusteringColumns,
+                    rawColumns,
+                    staticColumns,
+                    partitionKeyColumns,
+                    clusteringColumns,
 
-                                            clusteringOrder,
-                                            attrs,
+                    clusteringOrder,
+                    attrs,
 
-                                            ifNotExists,
-                                            useCompactStorage);
+                    ifNotExists,
+                    useCompactStorage);
         }
 
         public String keyspace()

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTriggerStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTriggerStatement.java
@@ -36,9 +36,10 @@ public final class CreateTriggerStatement extends AlterSchemaStatement
     private final String triggerClass;
     private final boolean ifNotExists;
 
-    public CreateTriggerStatement(String keyspaceName, String tableName, String triggerName, String triggerClass, boolean ifNotExists)
+    public CreateTriggerStatement(String queryString, String keyspaceName, String tableName,
+            String triggerName, String triggerClass, boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
         this.triggerName = triggerName;
         this.triggerClass = triggerClass;
@@ -119,7 +120,8 @@ public final class CreateTriggerStatement extends AlterSchemaStatement
         public CreateTriggerStatement prepare(ClientState state)
         {
             String keyspaceName = tableName.hasKeyspace() ? tableName.getKeyspace() : state.getKeyspace();
-            return new CreateTriggerStatement(keyspaceName, tableName.getName(), triggerName, triggerClass, ifNotExists);
+            return new CreateTriggerStatement(rawCQLStatement, keyspaceName, tableName.getName(),
+                    triggerName, triggerClass, ifNotExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTypeStatement.java
@@ -52,13 +52,14 @@ public final class CreateTypeStatement extends AlterSchemaStatement
     private final List<CQL3Type.Raw> rawFieldTypes;
     private final boolean ifNotExists;
 
-    public CreateTypeStatement(String keyspaceName,
-                               String typeName,
-                               List<FieldIdentifier> fieldNames,
-                               List<CQL3Type.Raw> rawFieldTypes,
-                               boolean ifNotExists)
+    public CreateTypeStatement(String queryString,
+            String keyspaceName,
+            String typeName,
+            List<FieldIdentifier> fieldNames,
+            List<CQL3Type.Raw> rawFieldTypes,
+            boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.typeName = typeName;
         this.fieldNames = fieldNames;
         this.rawFieldTypes = rawFieldTypes;
@@ -184,7 +185,9 @@ public final class CreateTypeStatement extends AlterSchemaStatement
         public CreateTypeStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new CreateTypeStatement(keyspaceName, name.getStringTypeName(), fieldNames, rawFieldTypes, ifNotExists);
+            return new CreateTypeStatement(rawCQLStatement, keyspaceName,
+                    name.getStringTypeName(), fieldNames,
+                    rawFieldTypes, ifNotExists);
         }
 
         public void addField(FieldIdentifier name, CQL3Type.Raw type)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -70,22 +70,23 @@ public final class CreateViewStatement extends AlterSchemaStatement
     private final boolean ifNotExists;
     private QueryState state;
 
-    public CreateViewStatement(String keyspaceName,
-                               String tableName,
-                               String viewName,
+    public CreateViewStatement(String queryString,
+            String keyspaceName,
+            String tableName,
+            String viewName,
 
-                               List<RawSelector> rawColumns,
-                               List<ColumnIdentifier> partitionKeyColumns,
-                               List<ColumnIdentifier> clusteringColumns,
+            List<RawSelector> rawColumns,
+            List<ColumnIdentifier> partitionKeyColumns,
+            List<ColumnIdentifier> clusteringColumns,
 
-                               WhereClause whereClause,
+            WhereClause whereClause,
 
-                               LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
-                               TableAttributes attrs,
+            LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
+            TableAttributes attrs,
 
-                               boolean ifNotExists)
+            boolean ifNotExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
         this.viewName = viewName;
 
@@ -415,20 +416,21 @@ public final class CreateViewStatement extends AlterSchemaStatement
             if (null == partitionKeyColumns)
                 throw ire("No PRIMARY KEY specifed for view '%s' (exactly one required)", viewName);
 
-            return new CreateViewStatement(keyspaceName,
-                                           tableName.getName(),
-                                           viewName.getName(),
+            return new CreateViewStatement(rawCQLStatement,
+                    keyspaceName,
+                    tableName.getName(),
+                    viewName.getName(),
 
-                                           rawColumns,
-                                           partitionKeyColumns,
-                                           clusteringColumns,
+                    rawColumns,
+                    partitionKeyColumns,
+                    clusteringColumns,
 
-                                           whereClause,
+                    whereClause,
 
-                                           clusteringOrder,
-                                           attrs,
+                    clusteringOrder,
+                    attrs,
 
-                                           ifNotExists);
+                    ifNotExists);
         }
 
         public void setPartitionKeyColumns(List<ColumnIdentifier> columns)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropAggregateStatement.java
@@ -51,13 +51,14 @@ public final class DropAggregateStatement extends AlterSchemaStatement
     private final boolean argumentsSpeficied;
     private final boolean ifExists;
 
-    public DropAggregateStatement(String keyspaceName,
-                                  String aggregateName,
-                                  List<CQL3Type.Raw> arguments,
-                                  boolean argumentsSpeficied,
-                                  boolean ifExists)
+    public DropAggregateStatement(String queryString,
+            String keyspaceName,
+            String aggregateName,
+            List<CQL3Type.Raw> arguments,
+            boolean argumentsSpeficied,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.aggregateName = aggregateName;
         this.arguments = arguments;
         this.argumentsSpeficied = argumentsSpeficied;
@@ -173,7 +174,8 @@ public final class DropAggregateStatement extends AlterSchemaStatement
         public DropAggregateStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.keyspace : state.getKeyspace();
-            return new DropAggregateStatement(keyspaceName, name.name, arguments, argumentsSpecified, ifExists);
+            return new DropAggregateStatement(rawCQLStatement, keyspaceName, name.name,
+                    arguments, argumentsSpecified, ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropFunctionStatement.java
@@ -50,13 +50,14 @@ public final class DropFunctionStatement extends AlterSchemaStatement
     private final boolean argumentsSpeficied;
     private final boolean ifExists;
 
-    public DropFunctionStatement(String keyspaceName,
-                                 String functionName,
-                                 Collection<CQL3Type.Raw> arguments,
-                                 boolean argumentsSpeficied,
-                                 boolean ifExists)
+    public DropFunctionStatement(String queryString,
+            String keyspaceName,
+            String functionName,
+            Collection<CQL3Type.Raw> arguments,
+            boolean argumentsSpeficied,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.functionName = functionName;
         this.arguments = arguments;
         this.argumentsSpeficied = argumentsSpeficied;
@@ -181,7 +182,8 @@ public final class DropFunctionStatement extends AlterSchemaStatement
         public DropFunctionStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.keyspace : state.getKeyspace();
-            return new DropFunctionStatement(keyspaceName, name.name, arguments, argumentsSpecified, ifExists);
+            return new DropFunctionStatement(rawCQLStatement, keyspaceName, name.name, arguments,
+                    argumentsSpecified, ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropIndexStatement.java
@@ -36,9 +36,10 @@ public final class DropIndexStatement extends AlterSchemaStatement
     private final String indexName;
     private final boolean ifExists;
 
-    public DropIndexStatement(String keyspaceName, String indexName, boolean ifExists)
+    public DropIndexStatement(String queryString, String keyspaceName, String indexName,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.indexName = indexName;
         this.ifExists = ifExists;
     }
@@ -109,7 +110,7 @@ public final class DropIndexStatement extends AlterSchemaStatement
         public DropIndexStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new DropIndexStatement(keyspaceName, name.getName(), ifExists);
+            return new DropIndexStatement(rawCQLStatement, keyspaceName, name.getName(), ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropKeyspaceStatement.java
@@ -31,9 +31,9 @@ public final class DropKeyspaceStatement extends AlterSchemaStatement
 {
     private final boolean ifExists;
 
-    public DropKeyspaceStatement(String keyspaceName, boolean ifExists)
+    public DropKeyspaceStatement(String queryString, String keyspaceName, boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.ifExists = ifExists;
     }
 
@@ -82,7 +82,7 @@ public final class DropKeyspaceStatement extends AlterSchemaStatement
 
         public DropKeyspaceStatement prepare(ClientState state)
         {
-            return new DropKeyspaceStatement(keyspaceName, ifExists);
+            return new DropKeyspaceStatement(rawCQLStatement, keyspaceName, ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropTableStatement.java
@@ -39,9 +39,10 @@ public final class DropTableStatement extends AlterSchemaStatement
     private final String tableName;
     private final boolean ifExists;
 
-    public DropTableStatement(String keyspaceName, String tableName, boolean ifExists)
+    public DropTableStatement(String queryString, String keyspaceName, String tableName,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
         this.ifExists = ifExists;
     }
@@ -111,7 +112,7 @@ public final class DropTableStatement extends AlterSchemaStatement
         public DropTableStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new DropTableStatement(keyspaceName, name.getName(), ifExists);
+            return new DropTableStatement(rawCQLStatement, keyspaceName, name.getName(), ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropTriggerStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropTriggerStatement.java
@@ -34,9 +34,10 @@ public final class DropTriggerStatement extends AlterSchemaStatement
     private final String triggerName;
     private final boolean ifExists;
 
-    public DropTriggerStatement(String keyspaceName, String tableName, String triggerName, boolean ifExists)
+    public DropTriggerStatement(String queryString, String keyspaceName, String tableName,
+            String triggerName, boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.tableName = tableName;
         this.triggerName = triggerName;
         this.ifExists = ifExists;
@@ -103,7 +104,8 @@ public final class DropTriggerStatement extends AlterSchemaStatement
         public DropTriggerStatement prepare(ClientState state)
         {
             String keyspaceName = tableName.hasKeyspace() ? tableName.getKeyspace() : state.getKeyspace();
-            return new DropTriggerStatement(keyspaceName, tableName.getName(), triggerName, ifExists);
+            return new DropTriggerStatement(rawCQLStatement, keyspaceName, tableName.getName(),
+                    triggerName, ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropTypeStatement.java
@@ -47,9 +47,10 @@ public final class DropTypeStatement extends AlterSchemaStatement
     private final String typeName;
     private final boolean ifExists;
 
-    public DropTypeStatement(String keyspaceName, String typeName, boolean ifExists)
+    public DropTypeStatement(String queryString, String keyspaceName, String typeName,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.typeName = typeName;
         this.ifExists = ifExists;
     }
@@ -148,7 +149,8 @@ public final class DropTypeStatement extends AlterSchemaStatement
         public DropTypeStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new DropTypeStatement(keyspaceName, name.getStringTypeName(), ifExists);
+            return new DropTypeStatement(rawCQLStatement, keyspaceName, name.getStringTypeName(),
+                    ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropViewStatement.java
@@ -34,9 +34,10 @@ public final class DropViewStatement extends AlterSchemaStatement
     private final String viewName;
     private final boolean ifExists;
 
-    public DropViewStatement(String keyspaceName, String viewName, boolean ifExists)
+    public DropViewStatement(String queryString, String keyspaceName, String viewName,
+            boolean ifExists)
     {
-        super(keyspaceName);
+        super(queryString, keyspaceName);
         this.viewName = viewName;
         this.ifExists = ifExists;
     }
@@ -97,7 +98,7 @@ public final class DropViewStatement extends AlterSchemaStatement
         public DropViewStatement prepare(ClientState state)
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
-            return new DropViewStatement(keyspaceName, name.getName(), ifExists);
+            return new DropViewStatement(rawCQLStatement, keyspaceName, name.getName(), ifExists);
         }
     }
 }

--- a/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
@@ -179,7 +179,7 @@ public class BatchMessage extends Message.Request
                 if (query instanceof String)
                 {
                     statement = QueryProcessor.parseStatement((String)query, state.getClientState().cloneWithKeyspaceIfSet(options.getKeyspace()));
-                    p = new QueryHandler.Prepared(statement, (String) query);
+                    p = new QueryHandler.Prepared(statement);
                 }
                 else
                 {
@@ -204,7 +204,7 @@ public class BatchMessage extends Message.Request
             {
                 CQLStatement statement = prepared.get(i).statement;
                 if (queries != null)
-                    queries.add(prepared.get(i).rawCQLStatement);
+                    queries.add(statement.getRawCQLStatement());
                 batchOptions.prepareStatement(i, statement.getBindVariables());
 
                 if (!(statement instanceof ModificationStatement))
@@ -215,7 +215,8 @@ public class BatchMessage extends Message.Request
 
             // Note: It's ok at this point to pass a bogus value for the number of bound terms in the BatchState ctor
             // (and no value would be really correct, so we prefer passing a clearly wrong one).
-            BatchStatement batch = new BatchStatement(batchType, VariableSpecifications.empty(), statements, Attributes.none());
+            BatchStatement batch = new BatchStatement(null, batchType,
+                    VariableSpecifications.empty(), statements, Attributes.none());
 
             long queryTime = System.currentTimeMillis();
             Message.Response response = handler.processBatch(batch, state, batchOptions, getCustomPayload(), queryStartNanoTime);

--- a/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
@@ -137,7 +137,8 @@ public class ExecuteMessage extends Message.Request
 
             Message.Response response = handler.processPrepared(statement, state, queryOptions, getCustomPayload(), queryStartNanoTime);
 
-            QueryEvents.instance.notifyExecuteSuccess(prepared.statement, prepared.rawCQLStatement, options, state, requestStartTime, response);
+            QueryEvents.instance.notifyExecuteSuccess(prepared.statement, options, state,
+                    requestStartTime, response);
 
             if (response instanceof ResultMessage.Rows)
             {
@@ -192,7 +193,7 @@ public class ExecuteMessage extends Message.Request
         if (options.getSerialConsistency(state) != null)
             builder.put("serial_consistency_level", options.getSerialConsistency(state).name());
 
-        builder.put("query", prepared.rawCQLStatement);
+        builder.put("query", prepared.statement.getRawCQLStatement());
 
         for (int i = 0; i < prepared.statement.getBindVariables().size(); i++)
         {

--- a/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
@@ -116,9 +116,9 @@ public class BatchStatementBench
         {
             modifications.add((ModificationStatement) prepared.statement);
             parameters.add(Lists.newArrayList(bytes(uniquePartition ? i : 1), bytes(i), bytes(i)));
-            queryOrIdList.add(prepared.rawCQLStatement);
+            queryOrIdList.add(prepared.statement.getRawCQLStatement());
         }
-        bs = new BatchStatement(BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), modifications, Attributes.none());
+        bs = new BatchStatement(null, BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), modifications, Attributes.none());
         bqo = BatchQueryOptions.withPerStatementVariables(QueryOptions.DEFAULT, parameters, queryOrIdList);
     }
 

--- a/test/unit/org/apache/cassandra/cql3/CustomNowInSecondsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/CustomNowInSecondsTest.java
@@ -151,7 +151,7 @@ public class CustomNowInSecondsTest extends CQLTester
             statements.add((ModificationStatement) QueryProcessor.parseStatement(query, cs));
 
         BatchStatement batch =
-            new BatchStatement(BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), statements, Attributes.none());
+            new BatchStatement(null, BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), statements, Attributes.none());
 
         // execute an BATCH message with now set to [now + 1 day], with ttl = 1, making its effective ttl = 1 day + 1.
         QueryProcessor.instance.processBatch(batch, qs, batchQueryOptions(now + day), Collections.emptyMap(), System.nanoTime());

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UFAuthTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UFAuthTest.java
@@ -226,7 +226,7 @@ public class UFAuthTest extends CQLTester
             functions.add(functionName);
             statements.add(stmt);
         }
-        BatchStatement batch = new BatchStatement(BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
+        BatchStatement batch = new BatchStatement(null, BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
         assertUnauthorized(batch, functions);
 
         grantExecuteOnFunction(functions.get(0));

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UFIdentificationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UFIdentificationTest.java
@@ -308,7 +308,7 @@ public class UFIdentificationTest extends CQLTester
         statements.add(modificationStatement(cql("INSERT INTO %s (key, i_cc, t_cc) VALUES (2, 2, %s)",
                                                  functionCall(tFunc, "'foo'"))));
 
-        BatchStatement batch = new BatchStatement(BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
+        BatchStatement batch = new BatchStatement(null, BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
         assertFunctions(batch, iFunc, iFunc2, tFunc);
     }
 
@@ -321,7 +321,7 @@ public class UFIdentificationTest extends CQLTester
         statements.add(modificationStatement(cql("UPDATE %s SET i_val = %s WHERE key=0 AND i_cc=1 and t_cc='foo' IF s_val = %s",
                                                  functionCall(iFunc, "0"), functionCall(sFunc, "{1}"))));
 
-        BatchStatement batch = new BatchStatement(BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
+        BatchStatement batch = new BatchStatement(null, BatchStatement.Type.LOGGED, VariableSpecifications.empty(), statements, Attributes.none());
         assertFunctions(batch, iFunc, lFunc, sFunc);
     }
 


### PR DESCRIPTION
Original CQL string is needed in the implementation of Query
intercepter (STAR-1112). Converged Cassandra stored it in
QueryHandler.Prepared, which is difficult to access. It seems that it
is more straightforward to move storing CQL string into statements.

This commit changes to store query strings in statements and adds an
access method to the string to CQLStatement.