### PR TITLE
STAR-1103 Port DSE code for uncompressed, non-memory mapped commit log segments needed to support remote storage

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1277,6 +1277,9 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                             writerIterator.remove();
                         }
                     }
+
+                    // This can throw on remote storage, e.g. if a file cannot be uploaded
+                    txn.prepareToCommit();
                 }
                 catch (Throwable t)
                 {
@@ -1285,8 +1288,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                     t = txn.abort(t);
                     Throwables.propagate(t);
                 }
-
-                txn.prepareToCommit();
 
                 Throwable accumulate = null;
                 for (SSTableMultiWriter writer : flushResults)

--- a/src/java/org/apache/cassandra/db/commitlog/UncompressedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/UncompressedSegment.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.db.commitlog;
 
 import java.nio.ByteBuffer;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.utils.SyncUtil;
@@ -41,6 +43,8 @@ public class UncompressedSegment extends FileDirectSegment
     UncompressedSegment(CommitLog commitLog, AbstractCommitLogSegmentManager manager)
     {
         super(commitLog, manager);
+        Preconditions.checkState(BufferType.OFF_HEAP == manager.getBufferPool().getPreferredReusableBufferType(),
+                                 "Invalid BufferType %s, expected OFF_HEAP", manager.getBufferPool().getPreferredReusableBufferType());
     }
 
     ByteBuffer createBuffer(CommitLog commitLog)

--- a/src/java/org/apache/cassandra/db/commitlog/UncompressedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/UncompressedSegment.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.commitlog;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.utils.SyncUtil;
+
+/**
+ * Uncompressed commit log segment. Provides an in-memory buffer for the mutation threads. On sync writes anything
+ * unwritten to disk and waits for the writes to materialize.
+ *
+ * The format of the uncompressed commit log is as follows:
+ * - standard commit log header (as written by {@link CommitLogDescriptor#writeHeader(ByteBuffer, CommitLogDescriptor)})
+ * - a series of 'sync segments' that are written every time the commit log is sync()'ed
+ * -- a sync section header, see {@link CommitLogSegment#writeSyncMarker(long, ByteBuffer, int, int, int)}
+ * -- a block of uncompressed data
+ */
+public class UncompressedSegment extends FileDirectSegment
+{
+    /**
+     * Constructs a new segment file.
+     */
+    UncompressedSegment(CommitLog commitLog, AbstractCommitLogSegmentManager manager)
+    {
+        super(commitLog, manager);
+    }
+
+    ByteBuffer createBuffer(CommitLog commitLog)
+    {
+        return manager.getBufferPool().createBuffer();
+    }
+
+    @Override
+    synchronized void write(int startMarker, int nextMarker)
+    {
+        int contentStart = startMarker + SYNC_MARKER_SIZE;
+        int length = nextMarker - contentStart;
+        // The length may be 0 when the segment is being closed.
+        assert length > 0 || length == 0 && !isStillAllocating();
+
+        try
+        {
+            writeSyncMarker(id, buffer, startMarker, startMarker, nextMarker);
+
+            ByteBuffer inputBuffer = buffer.duplicate();
+            inputBuffer.limit(nextMarker).position(startMarker);
+
+            // Only one thread can be here at a given time.
+            // Protected by synchronization on CommitLogSegment.sync().
+            manager.addSize(inputBuffer.remaining());
+            channel.write(inputBuffer);
+            lastWrittenPos = nextMarker;
+            assert channel.position() == nextMarker;
+            SyncUtil.force(channel, true);
+        }
+        catch (Exception e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    @Override
+    public long onDiskSize()
+    {
+        return lastWrittenPos;
+    }
+}

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -110,11 +110,11 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
         {
             if (file.exists())
             {
-                return FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
+                return FileChannel.open(file.toPath(), StandardOpenOption.WRITE);
             }
             else
             {
-                FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+                FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
                 try
                 {
                     SyncUtil.trySyncDir(file.parent());

--- a/src/java/org/apache/cassandra/io/util/SimpleCachedBufferPool.java
+++ b/src/java/org/apache/cassandra/io/util/SimpleCachedBufferPool.java
@@ -81,6 +81,11 @@ public class SimpleCachedBufferPool
     {
         return bufferHolder.getBuffer(size);
     }
+    
+    public BufferType getPreferredReusableBufferType()
+    {
+        return preferredReusableBufferType;
+    }
 
     public void releaseBuffer(ByteBuffer buffer)
     {

--- a/test/unit/org/apache/cassandra/db/commitlog/BatchCommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/BatchCommitLogTest.java
@@ -38,9 +38,9 @@ public class BatchCommitLogTest extends CommitLogTest
 {
     private static final long CL_BATCH_SYNC_WINDOW = 1000; // 1 second
     
-    public BatchCommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public BatchCommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode diskAccessMode)
     {
-        super(commitLogCompression, encryptionContext);
+        super(commitLogCompression, encryptionContext, diskAccessMode);
     }
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -57,6 +57,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Config.DiskFailurePolicy;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.ParameterizedClass;
@@ -125,22 +126,30 @@ public abstract class CommitLogTest
     private static JVMKiller oldKiller;
     private static KillerForTests testKiller;
 
-    public CommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public CommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode diskAccessMode)
     {
         DatabaseDescriptor.setCommitLogCompression(commitLogCompression);
         DatabaseDescriptor.setEncryptionContext(encryptionContext);
+        if (diskAccessMode != null)
+            DatabaseDescriptor.setDiskAccessMode(diskAccessMode);
     }
 
     @Parameters()
     public static Collection<Object[]> generateData()
     {
-        return Arrays.asList(new Object[][]{
-            {null, EncryptionContextGenerator.createDisabledContext()}, // No compression, no encryption
-            {null, EncryptionContextGenerator.createContext(true)}, // Encryption
-            {new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+        List<Object[]> params = new ArrayList<>();
+        for (Config.DiskAccessMode mode : Config.DiskAccessMode.values())
+        {
+            params.addAll(Arrays.asList(new Object[][]{ 
+            { null, EncryptionContextGenerator.createDisabledContext(), mode }, // No compression, no encryption
+            { null, EncryptionContextGenerator.createContext(true), mode }, // Encryption
+            { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), mode },
+            { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), mode },
+            { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), mode },
+            { new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), mode },
+            }));
+        }
+        return params;
     }
 
     public static void beforeClass() throws ConfigurationException

--- a/test/unit/org/apache/cassandra/db/commitlog/GroupCommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/GroupCommitLogTest.java
@@ -27,9 +27,9 @@ import org.apache.cassandra.security.EncryptionContext;
 
 public class GroupCommitLogTest extends CommitLogTest
 {
-    public GroupCommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public GroupCommitLogTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode diskAccessMode)
     {
-        super(commitLogCompression, encryptionContext);
+        super(commitLogCompression, encryptionContext, diskAccessMode);
     }
 
     @BeforeClass


### PR DESCRIPTION
These changes come from [CNDB-153 changes in #18944](https://github.com/riptano/bdp/pull/18944/files).

I applied the changes that appeared to be relevant and tried to be careful to compare with current `6.8.-cndb` branch code.

There are a couple things I was not certain about:

1. In `CommitLogSegment`, DSE used `DatabaseDescriptor.getCommitlogAccessMode()` but CC has only `getDiskAccessMode` so that is what I used. If commit log access mode needs to be configured separately, it will need to be added.

2a. `UncompressedSegment` was ported from DSE under the assumption it will be needed as a non-memory mapped alternative.

2b. In `UncompressedSegment`, DSE explicitly set the `SimpleCacheBufferPool.preferredReusableBufferType` to `BufferType.OFF_HEAP`. In DSE the default was always `ON_HEAP`. However, in CC, it is a final field and `AbstractCommitLogSegmentManager` attempts to choose the correct value based on config values - I kept this and extended the logic in a similar manner as in `CommitLogSegment.createSegment` when creating the segment.
