### PR TITLE
STAR-1126 Get replication strategy using KeyspaceMetadata.createReplicationStrategy

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -134,7 +134,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (table.isView())
             throw ire("Secondary indexes on materialized views aren't supported");
 
-        if (Keyspace.open(table.keyspace).getReplicationStrategy().hasTransientReplicas())
+        if (keyspace.createReplicationStrategy().hasTransientReplicas())
             throw new InvalidRequestException("Secondary indexes are not supported on transiently replicated keyspaces");
 
         List<IndexTarget> indexTargets = Lists.newArrayList(transform(rawIndexTargets, t -> t.prepare(table)));


### PR DESCRIPTION
I wish I could elaborate a better rationale for this change, but all I have knowledge to say is that a) other `Statement` classes use `keyspace.createReplicationStrategy()` this way and b) no other `Statement` class uses `Keysapce.open()`.