### PR TITLE
STAR-1150

### DIFF
--- a/src/java/org/apache/cassandra/auth/AllowAllAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/AllowAllAuthorizer.java
@@ -47,8 +47,9 @@ public class AllowAllAuthorizer implements IAuthorizer
     {
     }
 
-    public void revokeAllOn(IResource droppedResource)
+    public Set<RoleResource> revokeAllOn(IResource droppedResource)
     {
+        return Collections.emptySet();
     }
 
     public Set<PermissionDetails> list(AuthenticatedUser performer, Set<Permission> permissions, IResource resource, RoleResource of)

--- a/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
+++ b/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
@@ -19,10 +19,12 @@ package org.apache.cassandra.auth;
 
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Datacenters;
+import org.apache.cassandra.utils.Pair;
 
 /**
  * Returned from IAuthenticator#authenticate(), represents an authenticated user everywhere internally.
@@ -115,6 +117,19 @@ public class AuthenticatedUser
     {
         return permissionsCache.getPermissions(this, resource);
     }
+
+    @VisibleForTesting
+    public static void clearCache()
+    {
+        permissionsCache.invalidate();
+    }
+
+    @VisibleForTesting
+    public static void clearCache(RoleResource roleResource)
+    {
+        permissionsCache.invalidate(Pair.create(new AuthenticatedUser(roleResource.getRoleName()), roleResource));
+    }
+
 
     /**
      * Check whether this user has login privileges.

--- a/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
@@ -141,6 +141,7 @@ public class CassandraAuthorizer implements IAuthorizer
     // Called after a resource is removed (DROP KEYSPACE, DROP TABLE, etc.).
     // Execute a logged batch removing all the permissions for the resource
     // as well as the index table entry
+    @Override
     public Set<RoleResource> revokeAllOn(IResource droppedResource)
     {
         Set<RoleResource> affectedRoles = new HashSet<>();

--- a/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
@@ -141,8 +141,9 @@ public class CassandraAuthorizer implements IAuthorizer
     // Called after a resource is removed (DROP KEYSPACE, DROP TABLE, etc.).
     // Execute a logged batch removing all the permissions for the resource
     // as well as the index table entry
-    public void revokeAllOn(IResource droppedResource)
+    public Set<RoleResource> revokeAllOn(IResource droppedResource)
     {
+        Set<RoleResource> affectedRoles = new HashSet<>();
         try
         {
             UntypedResultSet rows = process(String.format("SELECT role FROM %s.%s WHERE resource = '%s'",
@@ -153,10 +154,12 @@ public class CassandraAuthorizer implements IAuthorizer
             List<CQLStatement> statements = new ArrayList<>();
             for (UntypedResultSet.Row row : rows)
             {
+                String role = row.getString("role");
+                affectedRoles.add(RoleResource.role(role));
                 statements.add(QueryProcessor.getStatement(String.format("DELETE FROM %s.%s WHERE role = '%s' AND resource = '%s'",
                                                                          SchemaConstants.AUTH_KEYSPACE_NAME,
                                                                          AuthKeyspace.ROLE_PERMISSIONS,
-                                                                         escape(row.getString("role")),
+                                                                         escape(role),
                                                                          escape(droppedResource.getName())),
                                                            ClientState.forInternalCalls()));
             }
@@ -173,6 +176,8 @@ public class CassandraAuthorizer implements IAuthorizer
         {
             logger.warn(String.format("CassandraAuthorizer failed to revoke all permissions on %s", droppedResource), e);
         }
+
+        return affectedRoles;
     }
 
     private void executeLoggedBatch(List<CQLStatement> statements)

--- a/src/java/org/apache/cassandra/auth/IAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/IAuthorizer.java
@@ -128,9 +128,10 @@ public interface IAuthorizer
      * not support it should be sure to throw UnsupportedOperationException.
      *
      * @param droppedResource The resource to revoke all permissions on.
+     * @return the roles that had permissions on {@code droppedResource}
      * @throws java.lang.UnsupportedOperationException
      */
-    void revokeAllOn(IResource droppedResource);
+    Set<RoleResource> revokeAllOn(IResource droppedResource);
 
     /**
      * Set of resources that should be made inaccessible to users and only accessible internally.

--- a/src/java/org/apache/cassandra/auth/IRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/IRoleManager.java
@@ -153,13 +153,13 @@ public interface IRoleManager
      }
 
     /**
-     * Return the set of roles that are member of the given role.
+     * Return the set of roles that are direct members of the given role (non-recursive).
      * @return any non-{@code null} value means the found reverse-memberships.
      *         {@code null} means that the functionality is not supported.
      * @throws RequestValidationException
      * @throws RequestExecutionException
      */
-    Set<RoleResource> getRoleMemberOf(RoleResource role);
+    Set<RoleResource> getMembersOf(RoleResource role);
 
     /**
      * Called during the execution of an unqualified LIST ROLES query.

--- a/src/java/org/apache/cassandra/auth/IRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/IRoleManager.java
@@ -153,6 +153,15 @@ public interface IRoleManager
      }
 
     /**
+     * Return the set of roles that are member of the given role.
+     * @return any non-{@code null} value means the found reverse-memberships.
+     *         {@code null} means that the functionality is not supported.
+     * @throws RequestValidationException
+     * @throws RequestExecutionException
+     */
+    Set<RoleResource> getRoleMemberOf(RoleResource role);
+
+    /**
      * Called during the execution of an unqualified LIST ROLES query.
      * Returns the total set of distinct roles in the system.
      *

--- a/src/java/org/apache/cassandra/auth/Roles.java
+++ b/src/java/org/apache/cassandra/auth/Roles.java
@@ -59,6 +59,12 @@ public class Roles
         cache.invalidate();
     }
 
+    @VisibleForTesting
+    public static void clearCache(RoleResource roleResource)
+    {
+        cache.invalidate(roleResource);
+    }
+
     /**
      * Identify all roles granted to the supplied Role, including both directly granted
      * and inherited roles.

--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.auth;
 
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,19 +63,25 @@ public class CassandraRoleManagerTest
 
         // simple role with no grants
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
+        checkRoleMemberOf(roleManager, ImmutableSet.of(), ImmutableSet.of(ROLE_A));
+        
         // single level of grants
         grantRolesTo(roleManager, ROLE_A, ROLE_B, ROLE_C);
+        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_A), ImmutableSet.of(ROLE_B, ROLE_C));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
 
         // multi level role hierarchy
         grantRolesTo(roleManager, ROLE_B, ROLE_B_1, ROLE_B_2, ROLE_B_3);
+        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_B), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
         grantRolesTo(roleManager, ROLE_C, ROLE_C_1, ROLE_C_2, ROLE_C_3);
+        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_C), ImmutableSet.of(ROLE_C_1, ROLE_C_2, ROLE_C_3));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
 
         // Check that when granted roles appear multiple times in parallel levels of the hierarchy, we don't
         // do redundant reads. E.g. here role_b_1, role_b_2 and role_b3 are granted to both role_b and role_c
         // but we only want to actually read them once
         grantRolesTo(roleManager, ROLE_C, ROLE_B_1, ROLE_B_2, ROLE_B_3);
+        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_B, ROLE_C), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
     }
 
@@ -84,5 +91,13 @@ public class CassandraRoleManagerTest
         Set<Role> granted = roleManager.getRoleDetails(primaryRole);
         long after = getReadCount();
         assertEquals(granted.size(), after - before);
+    }
+    
+    private void checkRoleMemberOf(IRoleManager roleManager, Set<RoleResource> expectedMembers, Set<RoleResource> rolesToCheck)
+    {
+        for (RoleResource roleToCheck : rolesToCheck)
+        {
+            assertEquals(expectedMembers, roleManager.getRoleMemberOf(roleToCheck));
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -63,25 +63,25 @@ public class CassandraRoleManagerTest
 
         // simple role with no grants
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
-        checkRoleMemberOf(roleManager, ImmutableSet.of(), ImmutableSet.of(ROLE_A));
+        assertRoleMembers(roleManager, ImmutableSet.of(), ImmutableSet.of(ROLE_A));
         
         // single level of grants
         grantRolesTo(roleManager, ROLE_A, ROLE_B, ROLE_C);
-        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_A), ImmutableSet.of(ROLE_B, ROLE_C));
+        assertRoleMembers(roleManager, ImmutableSet.of(ROLE_A), ImmutableSet.of(ROLE_B, ROLE_C));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
 
         // multi level role hierarchy
         grantRolesTo(roleManager, ROLE_B, ROLE_B_1, ROLE_B_2, ROLE_B_3);
-        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_B), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
+        assertRoleMembers(roleManager, ImmutableSet.of(ROLE_B), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
         grantRolesTo(roleManager, ROLE_C, ROLE_C_1, ROLE_C_2, ROLE_C_3);
-        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_C), ImmutableSet.of(ROLE_C_1, ROLE_C_2, ROLE_C_3));
+        assertRoleMembers(roleManager, ImmutableSet.of(ROLE_C), ImmutableSet.of(ROLE_C_1, ROLE_C_2, ROLE_C_3));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
 
         // Check that when granted roles appear multiple times in parallel levels of the hierarchy, we don't
         // do redundant reads. E.g. here role_b_1, role_b_2 and role_b3 are granted to both role_b and role_c
         // but we only want to actually read them once
         grantRolesTo(roleManager, ROLE_C, ROLE_B_1, ROLE_B_2, ROLE_B_3);
-        checkRoleMemberOf(roleManager, ImmutableSet.of(ROLE_B, ROLE_C), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
+        assertRoleMembers(roleManager, ImmutableSet.of(ROLE_B, ROLE_C), ImmutableSet.of(ROLE_B_1, ROLE_B_2, ROLE_B_3));
         fetchRolesAndCheckReadCount(roleManager, ROLE_A);
     }
 
@@ -93,11 +93,11 @@ public class CassandraRoleManagerTest
         assertEquals(granted.size(), after - before);
     }
     
-    private void checkRoleMemberOf(IRoleManager roleManager, Set<RoleResource> expectedMembers, Set<RoleResource> rolesToCheck)
+    private void assertRoleMembers(IRoleManager roleManager, Set<RoleResource> expectedMembers, Set<RoleResource> rolesToCheck)
     {
         for (RoleResource roleToCheck : rolesToCheck)
         {
-            assertEquals(expectedMembers, roleManager.getRoleMemberOf(roleToCheck));
+            assertEquals(expectedMembers, roleManager.getMembersOf(roleToCheck));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/auth/RoleOptionsTest.java
+++ b/test/unit/org/apache/cassandra/auth/RoleOptionsTest.java
@@ -182,7 +182,7 @@ public class RoleOptionsTest
                 return null;
             }
 
-            public Set<RoleResource> getRoleMemberOf(RoleResource role)
+            public Set<RoleResource> getMembersOf(RoleResource role)
             {
                 return null;
             }

--- a/test/unit/org/apache/cassandra/auth/RoleOptionsTest.java
+++ b/test/unit/org/apache/cassandra/auth/RoleOptionsTest.java
@@ -182,6 +182,11 @@ public class RoleOptionsTest
                 return null;
             }
 
+            public Set<RoleResource> getRoleMemberOf(RoleResource role)
+            {
+                return null;
+            }
+
             public Set<RoleResource> getAllRoles() throws RequestValidationException, RequestExecutionException
             {
                 return null;

--- a/test/unit/org/apache/cassandra/auth/StubAuthorizer.java
+++ b/test/unit/org/apache/cassandra/auth/StubAuthorizer.java
@@ -98,11 +98,19 @@ public class StubAuthorizer implements IAuthorizer
                 userPermissions.remove(key);
     }
 
-    public void revokeAllOn(IResource droppedResource)
+    public Set<RoleResource> revokeAllOn(IResource droppedResource)
     {
+        Set<RoleResource> roles = userPermissions.keySet()
+                                                 .stream()
+                                                 .filter(key -> key.right.equals(droppedResource))
+                                                 .map(key -> RoleResource.role(key.left))
+                                                 .collect(Collectors.toSet());
+
         for (Pair<String, IResource> key : userPermissions.keySet())
             if (key.right.equals(droppedResource))
                 userPermissions.remove(key);
+        
+        return roles;
     }
 
     public Set<? extends IResource> protectedResources()

--- a/test/unit/org/apache/cassandra/auth/StubAuthorizer.java
+++ b/test/unit/org/apache/cassandra/auth/StubAuthorizer.java
@@ -100,15 +100,13 @@ public class StubAuthorizer implements IAuthorizer
 
     public Set<RoleResource> revokeAllOn(IResource droppedResource)
     {
-        Set<RoleResource> roles = userPermissions.keySet()
-                                                 .stream()
-                                                 .filter(key -> key.right.equals(droppedResource))
-                                                 .map(key -> RoleResource.role(key.left))
-                                                 .collect(Collectors.toSet());
-
+        Set<RoleResource> roles = new HashSet<>();
         for (Pair<String, IResource> key : userPermissions.keySet())
             if (key.right.equals(droppedResource))
+            {
                 userPermissions.remove(key);
+                roles.add(RoleResource.role(key.left));
+            }
         
         return roles;
     }


### PR DESCRIPTION
Provide means for `IRoleManager` and `IAuthorizer` implementations to be able to invalidate/clear associated `RolesCache` and `PermissionsCache` entries when roles and permissions change.

* Add public `clearCache` methods to `Roles` and `AuthenticatedUser` for use by `IRoleManager` and `IAuthorizer` implementations
* Return affected roles from `IAuthorizer.revokeAllOn` 
* Add `IRoleManager.getRoleMemberOf` returning the set of roles that are member of the given role.