### PR TITLE
STAR-1160 allow truncateBlocking to get set of endpoints

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
@@ -78,7 +78,7 @@ public class TruncateStatement extends QualifiedStatement<TruncateStatement> imp
             if (metaData.isVirtual())
                 throw new InvalidRequestException("Cannot truncate virtual tables");
 
-            StorageProxy.truncateBlocking(keyspace(), name());
+            StorageProxy.instance.truncateBlocking(keyspace(), name());
         }
         catch (UnavailableException | TimeoutException e)
         {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -87,6 +87,7 @@ import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.RequestFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.RequestTimeoutException;
+import org.apache.cassandra.exceptions.TruncateException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
@@ -2298,9 +2299,11 @@ public class StorageProxy implements StorageProxyMBean
      * @param keyspace
      * @param cfname
      * @throws UnavailableException If some of the hosts in the ring are down.
-     * @throws TimeoutException
+     * @throws TimeoutException If the truncate operation doesn't complete within the truncation timeout limit.
+     * @throws TruncateException If the truncate operation fails on some replica.
      */
-    public static void truncateBlocking(String keyspace, String cfname) throws UnavailableException, TimeoutException
+    public void truncateBlocking(String keyspace, String cfname)
+    throws UnavailableException, TimeoutException, TruncateException
     {
         logger.debug("Starting a blocking truncate operation on keyspace {}, CF {}", keyspace, cfname);
         if (isAnyStorageHostDown())
@@ -2314,7 +2317,27 @@ public class StorageProxy implements StorageProxyMBean
         }
 
         Set<InetAddressAndPort> allEndpoints = StorageService.instance.getLiveRingMembers(true);
+        truncateBlocking(allEndpoints, keyspace, cfname);
+    }
 
+    /**
+     * Performs the truncate operatoin, which effectively deletes all data from
+     * the column family cfname.
+     * This method sends truncate requests and waits for the answers. It assumes taht all endpoints
+     * are live. This is either enforced by {@link StorageProxy#truncateBlocking(String, String)} or by the CNDB
+     * override.
+     *
+     * @param allEndpoints All endpoints where to send truncate requests.
+     * @param keyspace
+     * @param cfname
+     * @throws UnavailableException If some of the hosts in the ring are down (all nodes need to be up to perform
+     *                              a truncate operation).
+     * @throws TimeoutException If the truncate operation doesn't complete within the truncation timeout limit.
+     * @throws TruncateException If the truncate operation fails on some replica.
+     */
+    public void truncateBlocking(Set<InetAddressAndPort> allEndpoints, String keyspace, String cfname)
+    throws UnavailableException, TimeoutException, TruncateException
+    {
         int blockFor = allEndpoints.size();
         final TruncateResponseHandler responseHandler = new TruncateResponseHandler(blockFor);
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5070,7 +5070,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         try
         {
-            StorageProxy.truncateBlocking(keyspace, table);
+            StorageProxy.instance.truncateBlocking(keyspace, table);
         }
         catch (UnavailableException e)
         {

--- a/src/java/org/apache/cassandra/service/TruncateResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/TruncateResponseHandler.java
@@ -54,7 +54,7 @@ public class TruncateResponseHandler implements RequestCallback<TruncateResponse
         start = System.nanoTime();
     }
 
-    public void get() throws TimeoutException
+    public void get() throws TimeoutException, TruncateException
     {
         long timeoutNanos = DatabaseDescriptor.getTruncateRpcTimeout(NANOSECONDS) - (System.nanoTime() - start);
         boolean completedInTime;


### PR DESCRIPTION
Refactors truncateBlocking in StorageProxy to provide set of endpoints.
The method is not static any more, so it can be tested in Cassandra
extensions like CNDB.

Needed for CNDB and is port of fixes for CNDB-1462 and CNDB-909.