### PR TITLE
STAR-1177: Fix accidentally removed keycache invalidation after compaction

### DIFF
--- a/src/java/org/apache/cassandra/cache/AutoSavingCache.java
+++ b/src/java/org/apache/cassandra/cache/AutoSavingCache.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apache.cassandra.io.util.File;
 import org.cliffc.high_scale_lib.NonBlockingHashSet;
@@ -76,6 +78,8 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
 
     private final CacheSerializer<K, V> cacheLoader;
 
+    private final Supplier<Predicate<K>> keyFilterSupplier;
+
     /*
      * CASSANDRA-10155 required a format change to fix 2i indexes and caching.
      * 2.2 is already at version "c" and 3.0 is at "d".
@@ -115,11 +119,12 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
         AutoSavingCache.streamFactory = streamFactory;
     }
 
-    public AutoSavingCache(ICache<K, V> cache, CacheService.CacheType cacheType, CacheSerializer<K, V> cacheloader)
+    public AutoSavingCache(ICache<K, V> cache, CacheService.CacheType cacheType, CacheSerializer<K, V> cacheloader, Supplier<Predicate<K>> keyFilterSupplier)
     {
         super(cacheType, cache);
         this.cacheType = cacheType;
         this.cacheLoader = cacheloader;
+        this.keyFilterSupplier = keyFilterSupplier;
     }
 
     public File getCacheDataPath(String version)
@@ -298,6 +303,7 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
         private final OperationProgress info;
         private long keysWritten;
         private final long keysEstimate;
+        private final Predicate<K> keyFilter;
 
         protected Writer(int keysToSave)
         {
@@ -312,6 +318,7 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
                 keyIterator = hotKeyIterator(keysToSave);
                 keysEstimate = keysToSave;
             }
+            this.keyFilter = keyFilterSupplier.get();
 
             OperationType type;
             if (cacheType == CacheService.CacheType.KEY_CACHE)
@@ -359,7 +366,6 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
             Pair<File, File> cacheFilePaths = tempCacheFiles();
             try (WrappedDataOutputStreamPlus writer = new WrappedDataOutputStreamPlus(streamFactory.getOutputStream(cacheFilePaths.left, cacheFilePaths.right)))
             {
-
                 //Need to be able to check schema version because CF names are ambiguous
                 UUID schemaVersion = SchemaManager.instance.getVersion();
                 writer.writeLong(schemaVersion.getMostSignificantBits());
@@ -368,15 +374,20 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
                 while (keyIterator.hasNext())
                 {
                     K key = keyIterator.next();
+                    if (keyFilter == null || keyFilter.test(key))
+                    {
+                        ColumnFamilyStore cfs = SchemaManager.instance.getColumnFamilyStoreInstance(key.tableId);
+                        if (cfs == null)
+                            continue; // the table or 2i has been dropped.
+                        if (key.indexName != null)
+                            cfs = cfs.indexManager.getIndexByName(key.indexName).getBackingTable().orElse(null);
 
-                    ColumnFamilyStore cfs = SchemaManager.instance.getColumnFamilyStoreInstance(key.tableId);
-                    if (cfs == null)
-                        continue; // the table or 2i has been dropped.
-                    if (key.indexName != null)
-                        cfs = cfs.indexManager.getIndexByName(key.indexName).getBackingTable().orElse(null);
-
-                    cacheLoader.serialize(key, writer, cfs);
-
+                        cacheLoader.serialize(key, writer, cfs);
+                    }
+                    else
+                    {
+                        keyIterator.remove();
+                    }
                     keysWritten++;
                     if (keysWritten >= keysEstimate)
                         break;

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -240,10 +240,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             if (lowerbound.compareTo(latest.last) >= 0)
             {
                 if (!transaction.isObsolete(latest))
-                {
-                    latest.runOnClose(() -> CacheService.instance.obsoleteSSTable(latest.descriptor));
                     transaction.obsolete(latest);
-                }
 
                 continue;
             }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -19,13 +19,10 @@ package org.apache.cassandra.io.sstable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.cassandra.cache.KeyCacheKey;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
@@ -244,14 +241,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             {
                 if (!transaction.isObsolete(latest))
                 {
-                    latest.runOnClose(() -> {
-                        Iterator<KeyCacheKey> it = CacheService.instance.keyCache.keyIterator();
-                        while (it.hasNext()) {
-                            KeyCacheKey k = it.next();
-                            if (Objects.equals(k.desc, sstable.descriptor))
-                                it.remove();
-                        }
-                    });
+                    latest.runOnClose(() -> CacheService.instance.obsoleteSSTable(latest.descriptor));
                     transaction.obsolete(latest);
                 }
 

--- a/test/unit/org/apache/cassandra/db/KeyCacheTest.java
+++ b/test/unit/org/apache/cassandra/db/KeyCacheTest.java
@@ -323,23 +323,20 @@ public class KeyCacheTest
         Util.compactAll(cfs, Integer.MAX_VALUE).get();
         boolean noEarlyOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMB() < 0;
 
-        // after compaction cache should have entries for new SSTables,
-        // but since we have kept a reference to the old sstables,
-        // if we had 2 keys in cache previously it should become 4
-        assertKeyCacheSize(noEarlyOpen ? 2 : 4, KEYSPACE1, cf);
+        assertKeyCacheSize(2, KEYSPACE1, cf);
 
         refs.release();
 
         LifecycleTransaction.waitForDeletions();
 
         // after releasing the reference this should drop to 2
-        assertKeyCacheSize(2, KEYSPACE1, cf);
+        assertKeyCacheSize(0, KEYSPACE1, cf);
 
         // re-read same keys to verify that key cache didn't grow further
         Util.getAll(Util.cmd(cfs, "key1").build());
         Util.getAll(Util.cmd(cfs, "key2").build());
 
-        assertKeyCacheSize(noEarlyOpen ? 4 : 2, KEYSPACE1, cf);
+        assertKeyCacheSize(2, KEYSPACE1, cf);
     }
 
     @Test


### PR DESCRIPTION
As part of STAR-782 key cache migration during compaction has been removed which means we do nothing with the cached keys. This is not a problem in case of our default TrieIndex sstable format because key cache is not used there at all. However it is a bit of a problem when the legacy format is used. The problem is that we do not invalidate the old keys pointing to the obsoleted sstables - that has been addressed in this PR.