### PR TITLE
STAR-1176 Add custom replayer filter

### DIFF
--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -211,6 +211,7 @@ public abstract class CommitLogTest
     public void afterTest()
     {
         System.clearProperty("cassandra.replayList");
+        System.clearProperty("cassandra.custom_replay_filter_class");
         testKiller.reset();
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -1024,6 +1024,10 @@ public abstract class CommitLogTest
         Assert.assertEquals(0, replayedKeyspaces.size());
     }
 
+    /**
+     * Test that Custom filter class is being called by the fact that the custom filter has 
+     * different behavior than default. It filters everything and nothing is replayed.
+     */
     @Test
     public void testUnwriteableFlushRecoveryCustomExcludingFilter() throws ExecutionException, InterruptedException, IOException
     {


### PR DESCRIPTION
Extends the commit log replayer to provide custom replayer filter
implementation.

It is port of CNDB-1285 and needed for CNBD.