### PR TITLE
STAR-1199 Test replayer on truncate

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -303,6 +303,11 @@ public class CommitLogReplayer implements CommitLogReadHandler
                                 newPUCollector = new Mutation.PartitionUpdateCollector(mutation.getKeyspaceName(), mutation.key());
                             newPUCollector.add(update);
                             replayedCount++;
+                            onReplayed(update);
+                        }
+                        else
+                        {
+                            onSkipped(update);
                         }
                     }
                     if (newPUCollector != null)
@@ -316,6 +321,16 @@ public class CommitLogReplayer implements CommitLogReadHandler
                 }
             };
             return Stage.MUTATION.submit(runnable, serializedSize);
+        }
+
+        protected void onReplayed(PartitionUpdate update)
+        {
+            // Override for test purposes
+        }
+
+        protected void onSkipped(PartitionUpdate update)
+        {
+            // Override for test purposes
         }
     }
 


### PR DESCRIPTION
Extends the wrapper around initiating mutations read from the log to
allow custom methods to be called on replay or skip. Use it to test
commit log replayer with TRUNCATE.

This port of DB-2721 and needed for a test in CNDB.