### PR TITLE
Fix flake in TrieMemtableMetricsTest

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3476,5 +3476,4 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         CommitLog.instance.forceRecycleAllSegments(Collections.singleton(metadata.id));
         CompactionManager.instance.interruptCompactionForCFs(concatWithIndexes(), (sstable) -> true, true);
     }
-
 }

--- a/test/unit/org/apache/cassandra/metrics/TrieMemtableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TrieMemtableMetricsTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,6 +44,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.schema.SchemaManager;
 import org.apache.cassandra.service.EmbeddedCassandraService;
 import org.apache.cassandra.service.StorageService;
+import org.awaitility.Awaitility;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -131,11 +133,20 @@ public class TrieMemtableMetricsTest extends SchemaLoader
 
         writeAndFlush(10);
         assertEquals(10, metrics.contendedPuts.getCount() + metrics.uncontendedPuts.getCount());
+
+        // lastFlushShardDataSize is updated asynchronously. Wait until we can see the result.
+        Awaitility.await()
+                  .atMost(30, TimeUnit.SECONDS)
+                  .until(() -> metrics.lastFlushShardDataSizes.maxGauge.getValue() > 0);
         Long maxShardSize = metrics.lastFlushShardDataSizes.maxGauge.getValue();
 
         // verify that metrics survive flush / memtable switching
         writeAndFlush(100);
         assertEquals(110, metrics.contendedPuts.getCount() + metrics.uncontendedPuts.getCount());
+        // lastFlushShardDataSize is updated asynchronously. Wait until we can see the result.
+        Awaitility.await()
+                  .atMost(30, TimeUnit.SECONDS)
+                  .until(() -> metrics.lastFlushShardDataSizes.maxGauge.getValue() > maxShardSize);
         assertEquals(metrics.lastFlushShardDataSizes.toString(), NUM_SHARDS, (int) metrics.lastFlushShardDataSizes.numSamplesGauge.getValue());
         assertThat(metrics.lastFlushShardDataSizes.maxGauge.getValue(), greaterThan(maxShardSize));
     }


### PR DESCRIPTION
The update is applied asynchronously and not waited for to complete flushes. This fixes the test to explicitly wait for the asynchronous reclamation task to complete before reading the metrics.