### PR TITLE
STAR-1205 Add everywhere() to KeyspaceParams API

### DIFF
--- a/src/java/org/apache/cassandra/schema/KeyspaceParams.java
+++ b/src/java/org/apache/cassandra/schema/KeyspaceParams.java
@@ -99,6 +99,11 @@ public final class KeyspaceParams
         return new KeyspaceParams(false, ReplicationParams.simple(replicationFactor));
     }
 
+    public static KeyspaceParams everywhere()
+    {
+        return new KeyspaceParams(true, ReplicationParams.everywhere());
+    }
+
     public static KeyspaceParams nts(Object... args)
     {
         return new KeyspaceParams(true, ReplicationParams.nts(args));

--- a/src/java/org/apache/cassandra/schema/ReplicationParams.java
+++ b/src/java/org/apache/cassandra/schema/ReplicationParams.java
@@ -57,6 +57,11 @@ public final class ReplicationParams
         return new ReplicationParams(SimpleStrategy.class, ImmutableMap.of("replication_factor", replicationFactor));
     }
 
+    static ReplicationParams everywhere()
+    {
+        return new ReplicationParams(EverywhereStrategy.class, ImmutableMap.of());
+    }
+
     static ReplicationParams nts(Object... args)
     {
         assert args.length % 2 == 0;

--- a/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
@@ -249,4 +249,11 @@ public class SchemaKeyspaceTest
         assertTrue(SchemaManager.isKeyspaceWithLocalStrategy(SchemaManager.instance.getKeyspaceMetadata("local_ks")));
         assertFalse(SchemaManager.isKeyspaceWithLocalStrategy("simple_ks"));
     }
+
+    @Test
+    public void testEverywhere()
+    {
+        SchemaLoader.createKeyspace("everywhereKeyspace", KeyspaceParams.everywhere());
+        assertFalse(SchemaManager.isKeyspaceWithLocalStrategy("everywhereKeyspace"));
+    }
 }


### PR DESCRIPTION
To allow creating Keyspace with Everywhere strategy the correct
approach is to extend its API with everywhere() method. This is then
tested in a very simple test.

Needed for tests in CNDB.

The test is naive. If there are good ideas and it is important, let me know or create a separate ticket for more meaningful test.