### PR TITLE
STAR-1229: Fix resource leaks on unhappy path

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -60,13 +60,12 @@ public class SSTableIndex
 
     public SSTableIndex(SSTableContext sstableContext, IndexContext indexContext)
     {
-        this.sstableContext = sstableContext.sharedCopy();
+        assert indexContext.getValidator() != null;
+        this.searchableIndex = sstableContext.indexDescriptor.newSearchableIndex(sstableContext, indexContext);
+
+        this.sstableContext = sstableContext.sharedCopy(); // this line must not be before any code that may throw
         this.indexContext = indexContext;
         this.sstable = sstableContext.sstable;
-
-        assert indexContext.getValidator() != null;
-
-        this.searchableIndex = sstableContext.indexDescriptor.newSearchableIndex(sstableContext, indexContext);
     }
 
     public IndexContext getIndexContext()


### PR DESCRIPTION
Generally try not to throw in constructors and if
an exception in a constructor is thrown,
make sure happens before allocating resources.

This fixes resource leaks reported by
SingleNodeFailureTest.testFailedBkdReaderOnMultiIndexesQuery.