### PR TITLE
STAR-1233: Fix CME in StorageAttachedIndexGroup

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -27,9 +27,11 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import org.apache.mina.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +70,7 @@ import org.apache.cassandra.utils.Throwables;
 /**
  * Orchestrates building of storage-attached indices, and manages lifecycle of resources shared between them.
  */
+@ThreadSafe
 public class StorageAttachedIndexGroup implements Index.Group, INotificationConsumer
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -76,7 +79,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     private final TableStateMetrics stateMetrics;
     private final IndexGroupMetrics groupMetrics;
     
-    private final Set<StorageAttachedIndex> indices = new HashSet<>();
+    private final Set<StorageAttachedIndex> indices = new ConcurrentHashSet<>();
     private final ColumnFamilyStore baseCfs;
 
     private final SSTableContextManager contextManager;


### PR DESCRIPTION
StorageAttachedIndexGroup was not thread safe and accessed
from multiple threads both for reads and writes, which resulted
in the following exception:

```
ERROR [MutationStage-1] node2 2022-03-31 11:11:31,938 AbstractLocalAwareExecutorService.java:169 - Uncaught exception on thread Thread[MutationStage-1,5,node2]
java.lang.RuntimeException: null for ks: sai_query_keyspace, table: table_2
	at org.apache.cassandra.db.ColumnFamilyStore.apply(ColumnFamilyStore.java:1430)
	at org.apache.cassandra.db.CassandraTableWriteHandler.write(CassandraTableWriteHandler.java:40)
	at org.apache.cassandra.db.Keyspace.applyInternal(Keyspace.java:649)
	at org.apache.cassandra.db.Keyspace.applyFuture(Keyspace.java:478)
	at org.apache.cassandra.db.Mutation.applyFuture(Mutation.java:218)
	at org.apache.cassandra.db.MutationVerbHandler.doVerb(MutationVerbHandler.java:62)
	at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:78)
	at org.apache.cassandra.net.InboundSink$Filtered.accept(InboundSink.java:64)
	at org.apache.cassandra.net.InboundSink$Filtered.accept(InboundSink.java:50)
	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:97)
	at org.apache.cassandra.distributed.impl.Instance.lambda$receiveMessageWithInvokingThread$7(Instance.java:423)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.ConcurrentModificationException: null
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1585)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at org.apache.cassandra.index.sai.StorageAttachedIndexGroup.indexerFor(StorageAttachedIndexGroup.java:185)
	at org.apache.cassandra.index.SecondaryIndexManager.lambda$newUpdateTransaction$33(SecondaryIndexManager.java:1323)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:546)
	at java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:505)
	at org.apache.cassandra.index.SecondaryIndexManager.newUpdateTransaction(SecondaryIndexManager.java:1331)
	at org.apache.cassandra.db.ColumnFamilyStore.newUpdateTransaction(ColumnFamilyStore.java:1437)
	at org.apache.cassandra.db.ColumnFamilyStore.apply(ColumnFamilyStore.java:1408)
	... 16 common frames omitted
```