### PR TITLE
STAR-1230 Provide CL API to update to remote storage

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -85,7 +85,7 @@ public class CommitLog implements CommitLogMBean
 
     public static final CommitLog instance = CommitLog.construct();
 
-    final public AbstractCommitLogSegmentManager segmentManager;
+    private volatile AbstractCommitLogSegmentManager segmentManager;
 
     public final CommitLogArchiver archiver;
     public final CommitLogMetrics metrics;
@@ -162,6 +162,20 @@ public class CommitLog implements CommitLogMBean
             started = false;
             throw t;
         }
+        return this;
+    }
+
+    /**
+     * Updates the commit log storage directory and re-initializes the segment manager accordingly.
+     * <p/>
+     * Used by CNDB.
+     *
+     * @param commitLogLocation storage directory to update to
+     * @return this commit log with updated storage directory
+     */
+    public CommitLog forPath(File commitLogLocation)
+    {
+        segmentManager = new CommitLogSegmentManagerStandard(this, commitLogLocation);
         return this;
     }
 
@@ -588,6 +602,11 @@ public class CommitLog implements CommitLogMBean
                                  msg, segmentSize, unallocatedSpace, DatabaseDescriptor.getCommitLogLocation());
         }
         return msg;
+    }
+
+    public AbstractCommitLogSegmentManager getSegmentManager()
+    {
+        return segmentManager;
     }
 
     public static final class Configuration

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -200,7 +200,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
     private void handleCDCReplayCompletion(File f) throws IOException
     {
         // Can only reach this point if CDC is enabled, thus we have a CDCSegmentManager
-        ((CommitLogSegmentManagerCDC)CommitLog.instance.segmentManager).addCDCSize(f.length());
+        ((CommitLogSegmentManagerCDC)CommitLog.instance.getSegmentManager()).addCDCSize(f.length());
 
         File dest = new File(DatabaseDescriptor.getCDCLogLocation(), f.name());
 

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -290,16 +290,16 @@ public abstract class CommitLogStressTest
         // Complete anything that's still left to write.
         commitLog.executor.syncBlocking();
         // Wait for any concurrent segment allocations to complete.
-        commitLog.segmentManager.awaitManagementTasksCompletion();
+        commitLog.getSegmentManager().awaitManagementTasksCompletion();
 
         long combinedSize = 0;
-        for (File f : commitLog.segmentManager.storageDirectory.tryList())
+        for (File f : commitLog.getSegmentManager().storageDirectory.tryList())
             combinedSize += f.length();
         Assert.assertEquals(combinedSize, commitLog.getActiveOnDiskSize());
 
         List<String> logFileNames = commitLog.getActiveSegmentNames();
         Map<String, Double> ratios = commitLog.getActiveSegmentCompressionRatios();
-        Collection<CommitLogSegment> segments = commitLog.segmentManager.getActiveSegments();
+        Collection<CommitLogSegment> segments = commitLog.getSegmentManager().getActiveSegments();
 
         for (CommitLogSegment segment : segments)
         {

--- a/test/unit/org/apache/cassandra/ServerTestUtils.java
+++ b/test/unit/org/apache/cassandra/ServerTestUtils.java
@@ -140,7 +140,7 @@ public final class ServerTestUtils
         mkdirs(); // Creates the directories if they does not exists
         cleanup(); // Ensure that the directories are all empty
         CommitLog.instance.restartUnsafe();
-        CommitLog.instance.segmentManager.awaitManagementTasksCompletion();
+        CommitLog.instance.getSegmentManager().awaitManagementTasksCompletion();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/OutOfSpaceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/OutOfSpaceTest.java
@@ -132,7 +132,7 @@ public class OutOfSpaceTest extends CQLTester
 
         // Make sure commit log wasn't discarded.
         TableId tableId = currentTableMetadata().id;
-        for (CommitLogSegment segment : CommitLog.instance.segmentManager.getActiveSegments())
+        for (CommitLogSegment segment : CommitLog.instance.getSegmentManager().getActiveSegments())
             if (segment.getDirtyTableIds().contains(tableId))
                 return;
         fail("Expected commit log to remain dirty for the affected table.");

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogApiTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogApiTest.java
@@ -50,7 +50,7 @@ public class CommitLogApiTest
     }
 
     @Test
-    public void forPath()
+    public void testForPath()
     {
         AbstractCommitLogSegmentManager original = CommitLog.instance.getSegmentManager();
         File location = Mockito.mock(File.class);

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogApiTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogApiTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.mockito.Mockito;
+
+public class CommitLogApiTest
+{
+    @BeforeClass
+    public static void beforeClass() throws ConfigurationException
+    {
+        // Disable durable writes for system keyspaces to prevent system mutations, e.g. sstable_activity,
+        // to end up in CL segments and cause unexpected results in this test wrt counting CL segments,
+        // see CASSANDRA-12854
+        KeyspaceParams.DEFAULT_LOCAL_DURABLE_WRITES = false;
+        SchemaLoader.prepareServer();
+    }
+
+    @Before
+    public void before() throws IOException
+    {
+        CommitLog.instance.resetUnsafe(true);
+    }
+
+    @Test
+    public void forPath()
+    {
+        AbstractCommitLogSegmentManager original = CommitLog.instance.getSegmentManager();
+        File location = Mockito.mock(File.class);
+        CommitLog.instance.forPath(location);
+        Assert.assertNotEquals(original, CommitLog.instance.getSegmentManager());
+        Assert.assertEquals(location, CommitLog.instance.getSegmentManager().storageDirectory);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogCQLTest.java
@@ -60,11 +60,11 @@ public class CommitLogCQLTest extends CQLTester
 
         execute("INSERT INTO %s (idx, data) VALUES (?, ?)", 15, Integer.toString(17));
 
-        Collection<CommitLogSegment> active = new ArrayList<>(CommitLog.instance.segmentManager.getActiveSegments());
+        Collection<CommitLogSegment> active = new ArrayList<>(CommitLog.instance.getSegmentManager().getActiveSegments());
         CommitLog.instance.forceRecycleAllSegments();
 
         // If one of the previous segments remains, it wasn't clean.
-        active.retainAll(CommitLog.instance.segmentManager.getActiveSegments());
+        active.retainAll(CommitLog.instance.getSegmentManager().getActiveSegments());
         assert active.isEmpty();
     }
     

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogInitWithExceptionTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogInitWithExceptionTest.java
@@ -91,7 +91,7 @@ public class CommitLogInitWithExceptionTest
             Assert.fail();
         }
 
-        Assert.assertEquals(Thread.State.TERMINATED, CommitLog.instance.segmentManager.managerThread.getState()); // exit successfully
+        Assert.assertEquals(Thread.State.TERMINATED, CommitLog.instance.getSegmentManager().managerThread.getState()); // exit successfully
     }
 
     private static class MockCommitLogSegmentMgr extends CommitLogSegmentManagerStandard {

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentBackpressureTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentBackpressureTest.java
@@ -111,7 +111,7 @@ public class CommitLogSegmentBackpressureTest
 
             dummyThread.start();
 
-            AbstractCommitLogSegmentManager clsm = CommitLog.instance.segmentManager;
+            AbstractCommitLogSegmentManager clsm = CommitLog.instance.getSegmentManager();
 
             Util.spinAssertEquals(3, () -> clsm.getActiveSegments().size(), 5);
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -404,13 +404,13 @@ public abstract class CommitLogTest
                       .build();
         CommitLog.instance.add(m2);
 
-        assertEquals(2, CommitLog.instance.segmentManager.getActiveSegments().size());
+        assertEquals(2, CommitLog.instance.getSegmentManager().getActiveSegments().size());
 
         TableId id2 = m2.getTableIds().iterator().next();
         CommitLog.instance.discardCompletedSegments(id2, CommitLogPosition.NONE, CommitLog.instance.getCurrentPosition());
 
         // Assert we still have both our segments
-        assertEquals(2, CommitLog.instance.segmentManager.getActiveSegments().size());
+        assertEquals(2, CommitLog.instance.getSegmentManager().getActiveSegments().size());
     }
 
     @Test
@@ -430,14 +430,14 @@ public abstract class CommitLogTest
         CommitLog.instance.add(rm);
         CommitLog.instance.add(rm);
 
-        assertEquals(1, CommitLog.instance.segmentManager.getActiveSegments().size());
+        assertEquals(1, CommitLog.instance.getSegmentManager().getActiveSegments().size());
 
         // "Flush": this won't delete anything
         TableId id1 = rm.getTableIds().iterator().next();
         CommitLog.instance.sync(true);
         CommitLog.instance.discardCompletedSegments(id1, CommitLogPosition.NONE, CommitLog.instance.getCurrentPosition());
 
-        assertEquals(1, CommitLog.instance.segmentManager.getActiveSegments().size());
+        assertEquals(1, CommitLog.instance.getSegmentManager().getActiveSegments().size());
 
         // Adding new mutation on another CF, large enough (including CL entry overhead) that a new segment is created
         Mutation rm2 = new RowUpdateBuilder(cfs2.metadata(), 0, "k")
@@ -449,7 +449,7 @@ public abstract class CommitLogTest
         CommitLog.instance.add(rm2);
         CommitLog.instance.add(rm2);
 
-        Collection<CommitLogSegment> segments = CommitLog.instance.segmentManager.getActiveSegments();
+        Collection<CommitLogSegment> segments = CommitLog.instance.getSegmentManager().getActiveSegments();
 
         assertEquals(String.format("Expected 3 segments but got %d (%s)", segments.size(), getDirtyCFIds(segments)),
                      3,
@@ -461,7 +461,7 @@ public abstract class CommitLogTest
         TableId id2 = rm2.getTableIds().iterator().next();
         CommitLog.instance.discardCompletedSegments(id2, CommitLogPosition.NONE, CommitLog.instance.getCurrentPosition());
 
-        segments = CommitLog.instance.segmentManager.getActiveSegments();
+        segments = CommitLog.instance.getSegmentManager().getActiveSegments();
 
         // Assert we still have both our segment
         assertEquals(String.format("Expected 1 segment but got %d (%s)", segments.size(), getDirtyCFIds(segments)),
@@ -768,13 +768,13 @@ public abstract class CommitLogTest
             for (int i = 0 ; i < 5 ; i++)
                 CommitLog.instance.add(m2);
 
-            assertEquals(2, CommitLog.instance.segmentManager.getActiveSegments().size());
+            assertEquals(2, CommitLog.instance.getSegmentManager().getActiveSegments().size());
             CommitLogPosition position = CommitLog.instance.getCurrentPosition();
             for (Keyspace keyspace : Keyspace.system())
                 for (ColumnFamilyStore syscfs : keyspace.getColumnFamilyStores())
                     CommitLog.instance.discardCompletedSegments(syscfs.metadata().id, CommitLogPosition.NONE, position);
             CommitLog.instance.discardCompletedSegments(cfs2.metadata().id, CommitLogPosition.NONE, position);
-            assertEquals(1, CommitLog.instance.segmentManager.getActiveSegments().size());
+            assertEquals(1, CommitLog.instance.getSegmentManager().getActiveSegments().size());
         }
         finally
         {
@@ -836,7 +836,7 @@ public abstract class CommitLogTest
         List<String> activeSegments = CommitLog.instance.getActiveSegmentNames();
         assertFalse(activeSegments.isEmpty());
 
-        File[] files = CommitLog.instance.segmentManager.storageDirectory.tryList((file, name) -> activeSegments.contains(name));
+        File[] files = CommitLog.instance.getSegmentManager().storageDirectory.tryList((file, name) -> activeSegments.contains(name));
         replayer.replayFiles(files);
 
         assertEquals(cellCount, replayer.cells);
@@ -857,7 +857,7 @@ public abstract class CommitLogTest
         List<String> activeSegments = CommitLog.instance.getActiveSegmentNames();
         assertFalse(activeSegments.isEmpty());
 
-        File[] files = CommitLog.instance.segmentManager.storageDirectory.tryList((file, name) -> activeSegments.contains(name));
+        File[] files = CommitLog.instance.getSegmentManager().storageDirectory.tryList((file, name) -> activeSegments.contains(name));
         replayer.replayFiles(files);
         assertEquals(1, replayer.cells);
 
@@ -896,7 +896,7 @@ public abstract class CommitLogTest
         List<String> activeSegments = CommitLog.instance.getActiveSegmentNames();
         assertFalse(activeSegments.isEmpty());
 
-        File[] files = CommitLog.instance.segmentManager.storageDirectory.tryList((file, name) -> activeSegments.contains(name));
+        File[] files = CommitLog.instance.getSegmentManager().storageDirectory.tryList((file, name) -> activeSegments.contains(name));
         replayer.replayFiles(files);
 
         assertEquals(cellCount, replayer.cells);


### PR DESCRIPTION
Extends CommitLog's API to allow update its directory, so a commit log
from remote storage can be replayed.