### PR TITLE
STAR-1239: Fix NPE in ReadCommand when index unavailable

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -979,15 +979,18 @@ public abstract class ReadCommand extends AbstractReadQuery
             if (hasIndex)
             {
                 IndexMetadata index = deserializeIndexMetadata(in, version, metadata);
-                Index.Group indexGroup =  Keyspace.openAndGetStore(metadata).indexManager.getIndexGroup(index);
-                if (indexGroup != null)
-                    indexQueryPlan = indexGroup.queryPlanFor(rowFilter);
+                if (index != null)
+                {
+                    Index.Group indexGroup = Keyspace.openAndGetStore(metadata).indexManager.getIndexGroup(index);
+                    if (indexGroup != null)
+                        indexQueryPlan = indexGroup.queryPlanFor(rowFilter);
+                }
             }
 
             return kind.selectionDeserializer.deserialize(in, version, isDigest, digestVersion, acceptsTransient, metadata, nowInSec, columnFilter, rowFilter, limits, indexQueryPlan);
         }
 
-        private IndexMetadata deserializeIndexMetadata(DataInputPlus in, int version, TableMetadata metadata) throws IOException
+        private @Nullable IndexMetadata deserializeIndexMetadata(DataInputPlus in, int version, TableMetadata metadata) throws IOException
         {
             try
             {

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -44,6 +44,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1300,7 +1301,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
         return removed;
     }
 
-    public Index getIndex(IndexMetadata metadata)
+    public Index getIndex(@Nonnull IndexMetadata metadata)
     {
         return indexes.get(metadata.name);
     }
@@ -1329,7 +1330,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
      * associated to any group
      */
     @Nullable
-    public Index.Group getIndexGroup(IndexMetadata metadata)
+    public Index.Group getIndexGroup(@Nonnull IndexMetadata metadata)
     {
         Index index = getIndex(metadata);
         return index == null ? null : getIndexGroup(index);


### PR DESCRIPTION
Fixes the following null pointer exception that may be raised
during a read query using index if the schema with that
index hasn't been fully propagated yet:

```
java.lang.RuntimeException: Can not deserialize message MessageImpl{verb=7, bytes=c22adae7cf7b0ca710070100817502041d84a560b22111ec9c92efe6fdbada366247a1a80300100c616262726576696174696f6e066163746976650d617265615f73715f6d696c65730c6176675f646d765f77616974036764700269640269700b6d75726465725f72617465106d7572646572735f7065725f79656172046e616d650b6e6f6e5f696e64657865640a706f70756c6174696f6e0b74656d706f72616c5f69641574696e795f6d7572646572735f7065725f79656172077669736974656411766973697465645f74696d657374616d7000020c616262726576696174696f6e0b74656d706f72616c5f6964000100000b74656d706f72616c5f6964000000000010ee6136d2d17c11e8a8d5f2801f1b9fd100000005f07ffffffff07fffffff00d80b847dd5ec3bf69f98e41d9bf0ea9c00000002040200000008d55555555555555502000000082aaaaaaaaaaaaaa9000001010000060000000402000000082aaaaaaaaaaaaaa902000000087ffffffffffffffd00000101000006000000, id=142042, version=100, from=/127.0.0.1:7012}
	at org.apache.cassandra.distributed.impl.Instance.deserializeMessage(Instance.java:398)
	at org.apache.cassandra.distributed.impl.Instance.receiveMessageWithInvokingThread(Instance.java:419)
	at org.apache.cassandra.distributed.impl.Instance.lambda$receiveMessage$6(Instance.java:405)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
	at org.apache.cassandra.index.SecondaryIndexManager.getIndex(SecondaryIndexManager.java:1264)
	at org.apache.cassandra.index.SecondaryIndexManager.getIndexGroup(SecondaryIndexManager.java:1293)
	at org.apache.cassandra.db.ReadCommand$Serializer.deserialize(ReadCommand.java:982)
	at org.apache.cassandra.db.ReadCommand$Serializer.deserialize(ReadCommand.java:880)
	at org.apache.cassandra.net.Message$Serializer.deserializePost40(Message.java:797)
	at org.apache.cassandra.net.Message$Serializer.deserialize(Message.java:655)
	at org.apache.cassandra.distributed.impl.Instance.deserializeMessage(Instance.java:394)
	... 8 more
```