### PR TITLE
STAR-1233: Use Guava concurrent hash set instead of Apache Mina

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -31,7 +31,8 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import org.apache.mina.util.ConcurrentHashSet;
+import com.google.common.collect.Sets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     private final TableStateMetrics stateMetrics;
     private final IndexGroupMetrics groupMetrics;
     
-    private final Set<StorageAttachedIndex> indices = new ConcurrentHashSet<>();
+    private final Set<StorageAttachedIndex> indices = Sets.newConcurrentHashSet();
     private final ColumnFamilyStore baseCfs;
 
     private final SSTableContextManager contextManager;


### PR DESCRIPTION
Apache Mina is not really in the direct dependencies
of the project. It compiled accidentally because it
got onto the classpath through one of the
transitive dependencies of Netty.