### PR TITLE
STAR-1245 Refactor and expose startCompactionTasks in CompactionManager

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -233,6 +233,11 @@ public class CompactionManager implements CompactionManagerMBean
         return backgroundCompactionRunner.getOngoingCompactionsCount();
     }
 
+    public CompletableFuture<?>[] startCompactionTasks(ColumnFamilyStore cfs, Collection<AbstractCompactionTask> tasks)
+    {
+        return backgroundCompactionRunner.startCompactionTasks(cfs, tasks);
+    }
+    
     public int getOngoingBackgroundUpgradesCount()
     {
         return backgroundCompactionRunner.getOngoingUpgradesCount();


### PR DESCRIPTION
STAR-1245 Refactor and expose startCompactionTasks in CompactionManager.
Make handleCompactionError public in BackgroundCompactionRunner.

These changes will allow cndb to submit compaction tasks in https://github.com/riptano/cndb/pull/4448