### PR TITLE
STAR-1253: Fix resource leak in SAI MergeOneDimPointValues

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
@@ -120,14 +120,13 @@ public class MergeOneDimPointValues extends MutableOneDimPointValues
                     }
                     else
                     {
-                        queue.pop();
+                        queue.pop().close();
                     }
                 }
                 else
                 {
                     // iterator is exhausted
-                    BKDReader.IteratorState iterator = queue.pop();
-                    iterator.close();
+                    queue.pop().close();
                 }
             }
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
@@ -38,12 +38,14 @@ import org.apache.lucene.util.bkd.BKDWriter;
  */
 public class MergeOneDimPointValues extends MutableOneDimPointValues
 {
-    private final byte[] scratch;
     private final MergeQueue queue;
+
+    public final int bytesPerDim;
 
     public long minRowID = Long.MAX_VALUE;
     public long maxRowID = Long.MIN_VALUE;
     public long numRows = 0;
+
 
     public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, AbstractType termComparator)
     {
@@ -53,7 +55,7 @@ public class MergeOneDimPointValues extends MutableOneDimPointValues
     public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, int bytesPerDim)
     {
         queue = new MergeQueue(iterators.size());
-        this.scratch = new byte[bytesPerDim];
+        this.bytesPerDim = bytesPerDim;
         for (BKDReader.IteratorState iterator : iterators)
         {
             if (iterator.hasNext())
@@ -121,7 +123,7 @@ public class MergeOneDimPointValues extends MutableOneDimPointValues
     @Override
     public int getBytesPerDimension()
     {
-        return scratch.length;
+        return bytesPerDim;
     }
 
     private static class MergeQueue extends PriorityQueue<BKDReader.IteratorState>

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
@@ -45,12 +45,12 @@ public class MergeOneDimPointValues extends MutableOneDimPointValues
     public long maxRowID = Long.MIN_VALUE;
     public long numRows = 0;
 
-    public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, AbstractType termComparator) throws IOException
+    public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, AbstractType termComparator)
     {
         this(iterators, TypeUtil.fixedSizeOf(termComparator));
     }
 
-    public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, int bytesPerDim) throws IOException
+    public MergeOneDimPointValues(List<BKDReader.IteratorState> iterators, int bytesPerDim)
     {
         queue = new MergeQueue(iterators.size());
         this.scratch = new byte[bytesPerDim];

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
@@ -331,7 +331,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
         }
         finally
         {
-            postingsFile.close();
+            FileUtils.closeQuietly(kdtreeFile, postingsFile);
         }
     }
 

--- a/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
All iterators added to MergeOneDimPointValues should
be eventually closed after use or immediately if unused.

Fixes code introduced in STAR-121.
Fixes flaky KDTreeSegmentMergerTest.