### PR TITLE
STAR-1257 Port CNDB-2292 - fix memory leak due to lack of call to BackgroundCompactions.setPending

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
@@ -103,12 +103,14 @@ public class BackgroundCompactions
         // Then add all the pending aggregates
         for (CompactionAggregate aggregate : pending)
         {
-            CompactionAggregate prev = aggregatesMap.put(aggregate.getKey(), aggregate);
+            CompactionAggregate prev = aggregatesMap.get(aggregate.getKey());
             if (logger.isTraceEnabled())
-                logger.trace("Adding new pending aggregate: {}", aggregate);
+                logger.trace("Adding new pending aggregate: prev={}, current={}", prev, aggregate);
 
-            if (prev != null)
-                throw new IllegalArgumentException("Received pending aggregates with non unique keys: " + prev.getKey());
+            if (prev == null)
+                aggregatesMap.put(aggregate.getKey(), aggregate);
+            else
+                aggregatesMap.put(aggregate.getKey(), prev.withAdditionalCompactions(aggregate.getActive()));
         }
 
         // Then add the old aggregates but only if they have ongoing compactions

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -553,15 +553,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      * that the compaction statistics will be accurate.
      * <p/>
      * This is called by {@link UnifiedCompactionStrategy#getNextCompactionAggregates(int)}
-     * and by CNDB, after calling {@link UnifiedCompactionStrategy#getPendingCompactionAggregates(int)} in the leader,
-     * or before submitting tasks in the follower.
-     * <p/>
-     * The reason is twofold:
-     * <ul>
-     *     <li>the follower never calls {@link UnifiedCompactionStrategy#getPendingCompactionAggregates(int)} and,</li>
-     *     <li>there are aggregates published to etcd or being compacted by other processes, and these must be added to
-     *      the pending tasks else they get wiped in the background compactions and the statistics are not accurate.</li>
-     * </ul>
+     * and externally after calling {@link UnifiedCompactionStrategy#getPendingCompactionAggregates(int)} 
+     * or before submitting tasks.
      *
      * Also, note that skipping the call to {@link BackgroundCompactions#setPending(CompactionStrategy, Collection)}
      * would result in memory leaks: the aggregates added in {@link BackgroundCompactions#setSubmitted(CompactionStrategy, UUID, CompactionAggregate)}


### PR DESCRIPTION
Port CNDB-2292 - fix memory leak due to lack of call to BackgroundCompactions.setPending
Adds UnifiedCompactionStrategy.setPendingCompactionAggregates for use by external callers.

Co-authored-by: Stefania Alborghetti <stef1927@users.noreply.github.com>