### PR TITLE
STAR-1261: Don't try to establish TLSv1.1 connections in test

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/InternodeEncryptionOptionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/InternodeEncryptionOptionsTest.java
@@ -225,7 +225,7 @@ public class InternodeEncryptionOptionsTest extends AbstractEncryptionOptionsImp
             c.set("server_encryption_options",
                   ImmutableMap.builder().putAll(validKeystore)
                               .put("internode_encryption", "all")
-                              .put("accepted_protocols", Collections.singletonList("TLSv1.1"))
+                              .put("accepted_protocols", Collections.singletonList("TLSv1.3"))
                               .build());
         }).start())
         {
@@ -238,14 +238,19 @@ public class InternodeEncryptionOptionsTest extends AbstractEncryptionOptionsImp
             tls10Connection.assertReceivedHandshakeException();
 
             TlsConnection tls11Connection = new TlsConnection(address.getHostAddress(), port, Collections.singletonList("TLSv1.1"));
-            Assert.assertEquals("Should be possible to establish a TLSv1.1 connection",
-                                ConnectResult.NEGOTIATED, tls11Connection.connect());
-            Assert.assertEquals("TLSv1.1", tls11Connection.lastProtocol());
+            Assert.assertEquals("Should not be possible to establish a TLSv1.1 connection",
+                                ConnectResult.FAILED_TO_NEGOTIATE, tls11Connection.connect());
+            tls11Connection.assertReceivedHandshakeException();
 
             TlsConnection tls12Connection = new TlsConnection(address.getHostAddress(), port, Collections.singletonList("TLSv1.2"));
             Assert.assertEquals("Should not be possible to establish a TLSv1.2 connection",
                                 ConnectResult.FAILED_TO_NEGOTIATE, tls12Connection.connect());
             tls12Connection.assertReceivedHandshakeException();
+
+            TlsConnection tls13Connection = new TlsConnection(address.getHostAddress(), port, Collections.singletonList("TLSv1.3"));
+            Assert.assertEquals("Should be possible to establish a TLSv1.3 connection",
+                                ConnectResult.NEGOTIATED, tls13Connection.connect());
+            Assert.assertEquals("TLSv1.3", tls13Connection.lastProtocol());
         }
     }
 


### PR DESCRIPTION
TLSv1.1 has been disabled globally in OpenJDK and various
other JVMs in April 2021. Although it is possible to unlock it
by editing the java.security file, the test cannot unlock
it by itself. Settings in the java.security file are stronger
than the settings passed at runtime when building the SslContext.

Fortunately, support for TLSv1.3 landed in OpenJDK 8 some time
ago (but is not selected by default), so we can use that protocol
to test the protocol options.