### PR TITLE
STAR-1262: Fix multiple bugs in BufferPool and LongBufferPoolTest

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -102,6 +102,18 @@ import static org.apache.cassandra.utils.memory.MemoryUtil.isExactlyDirect;
  *
  * Note: even though partially freed chunks improves cache utilization when chunk cache holds outstanding buffer for
  * arbitrary period, there is still fragmentation in the partially freed chunk because of non-uniform allocation size.
+ * <p/>
+ *
+ * The lifecycle of a normal Chunk:
+ * <pre>
+ *    new                      acquire                      release                    recycle
+ * ────────→ in GlobalPool ──────────────→ in LocalPool ──────────────→ EVICTED  ──────────────────┐
+ *           owner = null                  owner = LocalPool            owner = null               │
+ *           status = IN_USE               status = IN_USE              status = EVICTED           │
+ *              ready                      serves get / free            serves free only           │
+ *                ↑                                                                                │
+ *                └────────────────────────────────────────────────────────────────────────────────┘
+ * </pre>
  */
 public class BufferPool
 {
@@ -286,12 +298,27 @@ public class BufferPool
         return globalPool;
     }
 
+    /**
+     * Forces to recycle free local chunks back to the global pool.
+     * This is needed because if buffers were freed by a different thread than the one
+     * that allocated them, recycling might not have happened and the local pool may still own some
+     * fully empty chunks.
+     */
+    @VisibleForTesting
+    public void releaseLocal()
+    {
+        localPool.get().release();
+    }
+
     interface Debug
     {
         public static Debug NO_OP = new Debug()
         {
             @Override
             public void registerNormal(Chunk chunk) {}
+
+            @Override
+            public void acquire(Chunk chunk) {}
             @Override
             public void recycleNormal(Chunk oldVersion, Chunk newVersion) {}
             @Override
@@ -299,6 +326,7 @@ public class BufferPool
         };
 
         void registerNormal(Chunk chunk);
+        void acquire(Chunk chunk);
         void recycleNormal(Chunk oldVersion, Chunk newVersion);
         void recyclePartial(Chunk chunk);
     }
@@ -362,6 +390,14 @@ public class BufferPool
 
         /** Return a chunk, the caller will take owership of the parent chunk. */
         public Chunk get()
+        {
+            Chunk chunk = getInternal();
+            if (chunk != null)
+                debug.acquire(chunk);
+            return chunk;
+        }
+
+        private Chunk getInternal()
         {
             Chunk chunk = chunks.poll();
             if (chunk != null)
@@ -593,10 +629,11 @@ public class BufferPool
 
         private void clearForEach(Consumer<Chunk> consumer)
         {
+            int oldCount = count;
             Chunk chunk0 = this.chunk0, chunk1 = this.chunk1, chunk2 = this.chunk2;
-            this.chunk0 = this.chunk1 = this.chunk2 = null;
-            forEach(consumer, count, chunk0, chunk1, chunk2);
             count = 0;
+            this.chunk0 = this.chunk1 = this.chunk2 = null;
+            forEach(consumer, oldCount, chunk0, chunk1, chunk2);
         }
 
         private static void forEach(Consumer<Chunk> consumer, int count, Chunk chunk0, Chunk chunk1, Chunk chunk2)
@@ -714,6 +751,9 @@ public class BufferPool
         private final LocalPoolRef leakRef;
 
         private final MicroQueueOfChunks chunks = new MicroQueueOfChunks();
+
+        private final Thread owningThread = Thread.currentThread();
+
         /**
          * If we are on outer LocalPool, whose chunks are == NORMAL_CHUNK_SIZE, we may service allocation requests
          * for buffers much smaller than
@@ -777,41 +817,39 @@ public class BufferPool
                 return;
             }
 
-            // ask the free method to take exclusive ownership of the act of recycling if chunk is owned by ourselves
-            long free = chunk.free(buffer, owner == this && recycleWhenFree);
-            // free:
-            // *     0L: current pool must be the owner. we can fully recyle the chunk.
-            // *    -1L:
-            //          * for normal chunk:
-            //              a) if it has owner, do nothing.
-            //              b) if it not owner, try to recyle it either fully or partially if not already recyled.
-            //          * for tiny chunk:
-            //              a) if it has owner, do nothing.
-            //              b) if it has not owner, recycle the tiny chunk back to parent chunk
-            // * others:
-            //          * for normal chunk:  partial recycle the chunk if it can be partially recycled but not yet recycled.
-            //          * for tiny chunk: do nothing.
-            if (free == 0L)
+            long free = chunk.free(buffer);
+
+            if (free == -1L && owner == this && owningThread == Thread.currentThread() && recycleWhenFree)
             {
-                assert owner == this;
-                // 0L => we own recycling responsibility, so must recycle;
-                // We must remove the Chunk from our local queue
+                // The chunk was fully freed, and we're the owner - let's release the chunk from this pool
+                // and give it back to the parent.
+                //
+                // We can remove the chunk from our local queue only if we're the owner of the chunk,
+                // and we're running this code on the thread that owns this local pool
+                // because the local queue is not thread safe.
+                //
+                // Please note that we may end up running `put` on a different thread when we're called
+                // from chunk.tryRecycle() on a child chunk which was previously owned by tinyPool of this pool.
+                // Such tiny chunk will point to this pool with its recycler reference. Thanks to the recycler, a thread
+                // that returns the tiny chunk can end up here in a LocalPool that's not neccessarily local to the
+                // calling thread, as there is no guarantee a child chunk is returned to the pool
+                // by the same thread that originally allocated it.
+                // It is ok we skip recycling in such case, and it does not cause
+                // a leak because those chunks are still referenced by the local pool.
                 remove(chunk);
-                chunk.recycle();
+                chunk.release();
             }
-            else if (free == -1L && owner != this && chunk.owner == null && !chunk.recycler.canRecyclePartially())
+            else if (chunk.owner == null)
             {
-                // although we try to take recycle ownership cheaply, it is not always possible to do so if the owner is racing to unset.
-                // we must also check after completely freeing if the owner has since been unset, and try to recycle
+                // The chunk has no owner, so we can attempt to recycle it from any thread because we don't need
+                // to remove it from the local pool.
+                // For normal chunk this would recycle the chunk fully or partially if not already recycled.
+                // For tiny chunk, this would recycle the tiny chunk back to the parent chunk,
+                // if this chunk is completely free.
                 chunk.tryRecycle();
             }
-            else if (chunk.owner == null && chunk.recycler.canRecyclePartially() && chunk.setInUse(Chunk.Status.EVICTED))
-            {
-                // re-cirlate partially freed normal chunk to global list
-                chunk.partiallyRecycle();
-            }
 
-            if (owner == this)
+            if (owner == this && owningThread == Thread.currentThread())
             {
                 MemoryUtil.setAttachment(buffer, null);
                 MemoryUtil.setDirectByteBuffer(buffer, 0, 0);
@@ -929,6 +967,7 @@ public class BufferPool
         {
             ByteBuffer buffer = chunk.slab;
             Chunk parentChunk = Chunk.getParentChunk(buffer);
+            assert parentChunk != null;  // tiny chunk always has a parent chunk
             put(buffer, parentChunk);
         }
 
@@ -973,19 +1012,18 @@ public class BufferPool
                     // releasing tiny chunks may result in releasing current evicted chunk
                     tinyPool.chunks.removeIf((child, parent) -> Chunk.getParentChunk(child.slab) == parent, evict);
                 evict.release();
-                // Mark it as evicted and will be eligible for partial recyle if recycler allows
-                evict.setEvicted(Chunk.Status.IN_USE);
             }
         }
 
         public void release()
         {
+            if (tinyPool != null)
+                tinyPool.release();
+
             chunks.release();
             reuseObjects.clear();
             localPoolReferences.remove(leakRef);
             leakRef.clear();
-            if (tinyPool != null)
-                tinyPool.release();
         }
 
         @VisibleForTesting
@@ -1130,8 +1168,7 @@ public class BufferPool
         }
 
         /**
-         * Acquire the chunk for future allocations: set the owner and prep
-         * the free slots mask.
+         * Acquire the chunk for future allocations: set the owner
          */
         void acquire(LocalPool owner)
         {
@@ -1147,26 +1184,92 @@ public class BufferPool
         void release()
         {
             this.owner = null;
+            boolean statusUpdated = setEvicted();
+            assert statusUpdated : "Status of chunk " + this + " was not IN_USE.";
             tryRecycle();
         }
 
+        /**
+         * If the chunk is free, changes the chunk's status to IN_USE and returns the chunk to the pool
+         * that it was acquired from.
+         *
+         * Can recycle the chunk partially if the recycler supports it.
+         * This method can be called from multiple threads safely.
+         *
+         * Calling this method on a chunk that's currently in use (either owned by a LocalPool or already recycled)
+         * has no effect.
+         */
         void tryRecycle()
         {
-            assert owner == null;
-            if (isFree() && freeSlotsUpdater.compareAndSet(this, -1L, 0L))
-                recycle();
+            // Note that this may race with release(), therefore the order of those checks does matter.
+            // The EVICTED check may fail if the chunk was already partially recycled.
+            if (status != Status.EVICTED)
+                return;
+            if (owner != null)
+                return;
+
+            // We must use consistently either tryRecycleFully or tryRecycleFullyOrPartially,
+            // but we must not mix those for a single chunk, because they use a different mechanism for guarding
+            // that the chunk would be recycled at most once until the next acquire.
+            //
+            // If the recycler cannot recycle blocks partially, we have to make sure freeSlots was zeroed properly.
+            // Only one thread can transition freeSlots from -1 to 0 atomically, so this is a good way
+            // of ensuring only one thread recycles the block. In this case the chunk's status is
+            // updated only after freeSlots CAS succeeds.
+            //
+            // If the recycler can recycle blocks partially, we use the status field
+            // to guard at-most-once recycling. We cannot rely on atomically updating freeSlots from -1 to 0, because
+            // in this case we cannot expect freeSlots to be -1 (if it was, it wouldn't be partial).
+            if (recycler.canRecyclePartially())
+                tryRecycleFullyOrPartially();
+            else
+                tryRecycleFully();
         }
 
-        void recycle()
+        /**
+         * Returns this chunk to the pool where it was acquired from, if it wasn't returned already.
+         * The chunk does not have to be totally free, but should have some free bits.
+         * However, if the chunk is fully free, it is released fully, not partially.
+         */
+        private void tryRecycleFullyOrPartially()
         {
-            assert freeSlots == 0L;
-            recycler.recycle(this);
+            assert recycler.canRecyclePartially();
+            if (free() > 0 && setInUse())
+            {
+                assert owner == null;
+                if (!tryRecycleFully())   // prefer to recycle fully, as fully free chunks are returned to a higher priority queue
+                    recyclePartially();
+            }
         }
 
-        public void partiallyRecycle()
+        private boolean tryRecycleFully()
+        {
+            if (!isFree() || !freeSlotsUpdater.compareAndSet(this, -1L, 0L))
+                return false;
+
+            recycleFully();
+            return true;
+        }
+
+        private void recyclePartially()
         {
             assert owner == null;
+            assert status == Status.IN_USE;
+
             recycler.recyclePartially(this);
+        }
+
+        private void recycleFully()
+        {
+            assert owner == null;
+            assert freeSlots == 0L;
+
+            Status expectedStatus = recycler.canRecyclePartially() ? Status.IN_USE : Status.EVICTED;
+            boolean statusUpdated = setStatus(expectedStatus, Status.IN_USE);
+            // impossible: could only happen if another thread updated the status in the meantime
+            assert statusUpdated : "Status of chunk " + this + " was not " + expectedStatus;
+
+            recycler.recycle(this);
         }
 
         /**
@@ -1344,11 +1447,10 @@ public class BufferPool
 
         /**
          * Release a buffer. Return:
-         *    0L if the buffer must be recycled after the call;
          *   -1L if it is free (and so we should tryRecycle if owner is now null)
          *    some other value otherwise
          **/
-        long free(ByteBuffer buffer, boolean tryRelease)
+        long free(ByteBuffer buffer)
         {
             if (!releaseAttachment(buffer))
                 return 1L;
@@ -1369,8 +1471,6 @@ public class BufferPool
                 long cur = freeSlots;
                 next = cur | shiftedSlotBits;
                 assert next == (cur ^ shiftedSlotBits); // ensure no double free
-                if (tryRelease && (next == -1L))
-                    next = 0L;
                 if (freeSlotsUpdater.compareAndSet(this, cur, next))
                     return next;
             }
@@ -1408,7 +1508,7 @@ public class BufferPool
         @Override
         public String toString()
         {
-            return String.format("[slab %s, slots bitmap %s, capacity %d, free %d]", slab, Long.toBinaryString(freeSlots), capacity(), free());
+            return String.format("[slab %s, slots bitmap %s, capacity %d, free %d, owner %s, recycler %s]", slab, Long.toBinaryString(freeSlots), capacity(), free(), owner, recycler);
         }
 
         @VisibleForTesting
@@ -1422,7 +1522,7 @@ public class BufferPool
         {
             Chunk parent = getParentChunk(slab);
             if (parent != null)
-                parent.free(slab, false);
+                parent.free(slab);
             else
                 FileUtils.clean(slab);
         }
@@ -1433,7 +1533,7 @@ public class BufferPool
             {
                 chunk.owner = null;
                 chunk.freeSlots = 0L;
-                chunk.recycle();
+                chunk.recycleFully();
             }
         }
 
@@ -1447,14 +1547,14 @@ public class BufferPool
             return statusUpdater.compareAndSet(this, current, update);
         }
 
-        boolean setInUse(Status prev)
+        private boolean setInUse()
         {
-            return setStatus(prev, Status.IN_USE);
+            return setStatus(Status.EVICTED, Status.IN_USE);
         }
 
-        boolean setEvicted(Status prev)
+        private boolean setEvicted()
         {
-            return setStatus(prev, Status.EVICTED);
+            return setStatus(Status.IN_USE, Status.EVICTED);
         }
     }
 

--- a/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
+++ b/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.AfterClass;
@@ -75,7 +75,8 @@ public class LongBufferPoolTest
     {
         static class DebugChunk
         {
-            volatile long lastRecycled;
+            volatile long lastAcquired = 0; // the number of last round when the chunk was acquired from the global pool
+            volatile long lastRecycled = 0; // the number of last round when the chunk was recycled back to the global pool
             static DebugChunk get(BufferPool.Chunk chunk)
             {
                 if (chunk.debugAttachment == null)
@@ -83,7 +84,7 @@ public class LongBufferPoolTest
                 return (DebugChunk) chunk.debugAttachment;
             }
         }
-        long recycleRound = 1;
+        AtomicLong recycleRound = new AtomicLong(1);
         final List<BufferPool.Chunk> normalChunks = new ArrayList<>();
 
         public synchronized void registerNormal(BufferPool.Chunk chunk)
@@ -91,20 +92,39 @@ public class LongBufferPoolTest
             chunk.debugAttachment = new DebugChunk();
             normalChunks.add(chunk);
         }
+
+        @Override
+        public void acquire(BufferPool.Chunk chunk)
+        {
+            DebugChunk.get(chunk).lastAcquired = recycleRound.get();
+        }
+
+        @Override
         public void recycleNormal(BufferPool.Chunk oldVersion, BufferPool.Chunk newVersion)
         {
             newVersion.debugAttachment = oldVersion.debugAttachment;
-            DebugChunk.get(oldVersion).lastRecycled = recycleRound;
+            DebugChunk.get(oldVersion).lastRecycled = recycleRound.get();
         }
+
+        @Override
         public void recyclePartial(BufferPool.Chunk chunk)
         {
-            DebugChunk.get(chunk).lastRecycled = recycleRound;
+            DebugChunk.get(chunk).lastRecycled = recycleRound.get();
         }
+
         public synchronized void check()
         {
+            long lastRecycledMax = 0;
+            long currentRound = recycleRound.get();
             for (BufferPool.Chunk chunk : normalChunks)
-                assert DebugChunk.get(chunk).lastRecycled == recycleRound;
-            recycleRound++;
+            {
+                DebugChunk dc = DebugChunk.get(chunk);
+                assert dc.lastRecycled >= dc.lastAcquired: "Last recycled " + dc.lastRecycled + " < last acquired " + dc.lastAcquired;
+                lastRecycledMax = Math.max(lastRecycledMax, dc.lastRecycled);
+            }
+            assert lastRecycledMax == currentRound : "No chunk recycled in round " + currentRound + ". " +
+                                                     "Last chunk recycled in round " + lastRecycledMax + '.';
+            recycleRound.incrementAndGet();
         }
     }
 
@@ -122,18 +142,18 @@ public class LongBufferPoolTest
     }
 
     @Test
-    public void testPoolAllocateWithRecyclePartially() throws InterruptedException, ExecutionException
+    public void testPoolAllocateWithRecyclePartially() throws InterruptedException, ExecutionException, BrokenBarrierException, TimeoutException
     {
         testPoolAllocate(true);
     }
 
     @Test
-    public void testPoolAllocateWithoutRecyclePartially() throws InterruptedException, ExecutionException
+    public void testPoolAllocateWithoutRecyclePartially() throws InterruptedException, ExecutionException, BrokenBarrierException, TimeoutException
     {
         testPoolAllocate(false);
     }
 
-    private void testPoolAllocate(boolean recyclePartially) throws InterruptedException, ExecutionException
+    private void testPoolAllocate(boolean recyclePartially) throws InterruptedException, ExecutionException, BrokenBarrierException, TimeoutException
     {
         BufferPool pool = new BufferPool("test_pool", 16 << 20, recyclePartially);
         testAllocate(pool, Runtime.getRuntime().availableProcessors() * 2, TimeUnit.MINUTES.toNanos(2L));
@@ -174,9 +194,13 @@ public class LongBufferPoolTest
         final long until;
         final CountDownLatch latch;
         final SPSCQueue<BufferCheck>[] sharedRecycle;
-        final AtomicBoolean[] makingProgress;
-        final AtomicBoolean burnFreed;
-        final AtomicBoolean[] freedAllMemory;
+
+        volatile boolean shouldFreeMemoryAndSuspend = false;
+
+        final CyclicBarrier stopAllocationsBarrier;
+        final CyclicBarrier freedAllMemoryBarrier;
+        final CyclicBarrier resumeAllocationsBarrier;
+
         final ExecutorService executorService;
         final List<Future<Boolean>> threadResultFuture;
         final int targetSizeQuanta;
@@ -189,17 +213,18 @@ public class LongBufferPoolTest
             until = System.nanoTime() + duration;
             latch = new CountDownLatch(threadCount);
             sharedRecycle = new SPSCQueue[threadCount];
-            makingProgress = new AtomicBoolean[threadCount];
-            burnFreed = new AtomicBoolean(false);
-            freedAllMemory = new AtomicBoolean[threadCount];
+
+            // N worker threads + burner thread + main thread:
+            stopAllocationsBarrier = new CyclicBarrier(threadCount + 2);
+            freedAllMemoryBarrier = new CyclicBarrier(threadCount + 2);
+            resumeAllocationsBarrier = new CyclicBarrier(threadCount + 2);
+
             executorService = Executors.newFixedThreadPool(threadCount + 2, new NamedThreadFactory("test"));
             threadResultFuture = new ArrayList<>(threadCount);
 
             for (int i = 0; i < sharedRecycle.length; i++)
             {
                 sharedRecycle[i] = new SPSCQueue<>();
-                makingProgress[i] = new AtomicBoolean(false);
-                freedAllMemory[i] = new AtomicBoolean(false);
             }
 
             // Divide the poolSize across our threads, deliberately over-subscribing it.  Threads
@@ -217,17 +242,6 @@ public class LongBufferPoolTest
             threadResultFuture.add(future);
         }
 
-        int countStalledThreads()
-        {
-            int stalledThreads = 0;
-
-            for (AtomicBoolean progress : makingProgress)
-            {
-                if (!progress.getAndSet(false))
-                    stalledThreads++;
-            }
-            return stalledThreads;
-        }
 
         int countDoneThreads()
         {
@@ -259,7 +273,7 @@ public class LongBufferPoolTest
         }
     }
 
-    public void testAllocate(BufferPool bufferPool, int threadCount, long duration) throws InterruptedException, ExecutionException
+    public void testAllocate(BufferPool bufferPool, int threadCount, long duration) throws InterruptedException, ExecutionException, BrokenBarrierException, TimeoutException
     {
         logger.info("{} - testing {} threads for {}m", DATE_FORMAT.format(new Date()), threadCount, TimeUnit.NANOSECONDS.toMinutes(duration));
         logger.info("Testing BufferPool with memoryUsageThreshold={} and enabling BufferPool.DEBUG", bufferPool.memoryUsageThreshold());
@@ -273,21 +287,31 @@ public class LongBufferPoolTest
         for (int threadIdx = 0; threadIdx < threadCount; threadIdx++)
             testEnv.addCheckedFuture(startWorkerThread(bufferPool, testEnv, threadIdx));
 
-        while (!testEnv.latch.await(10L, TimeUnit.SECONDS))
+        while (!testEnv.latch.await(1L, TimeUnit.SECONDS))
         {
-            int stalledThreads = testEnv.countStalledThreads();
-            int doneThreads = testEnv.countDoneThreads();
-
-            if (doneThreads == 0) // If any threads have completed, they will stop making progress/recycling buffers.
-            {                     // Assertions failures on the threads will be caught below.
-                assert stalledThreads == 0;
-                boolean allFreed = testEnv.burnFreed.getAndSet(false);
-                for (AtomicBoolean freedMemory : testEnv.freedAllMemory)
-                    allFreed = allFreed && freedMemory.getAndSet(false);
-                if (allFreed)
-                    debug.check();
-                else
-                    logger.info("All threads did not free all memory in this time slot - skipping buffer recycle check");
+            try
+            {
+                // request all threads to release all buffers to the bufferPool
+                testEnv.shouldFreeMemoryAndSuspend = true;
+                // wait until allocations stop
+                testEnv.stopAllocationsBarrier.await(10, TimeUnit.SECONDS);
+                // wait until all memory released
+                testEnv.freedAllMemoryBarrier.await(10, TimeUnit.SECONDS);
+                // now all buffers should be back in the pool, and no more allocations happening
+                assert bufferPool.usedSizeInBytes() == 0 : "Some buffers haven't been freed. Memory in use = "
+                                                           + bufferPool.usedSizeInBytes() + " (expected 0)";
+                debug.check();
+                // resume threads only after debug.cycleRound has been increased
+                testEnv.shouldFreeMemoryAndSuspend = false;
+                testEnv.resumeAllocationsBarrier.await(10, TimeUnit.SECONDS);
+            }
+            catch (TimeoutException e)
+            {
+                if (testEnv.countDoneThreads() == 0)
+                {
+                    logger.error("Some threads have stalled and didn't reach the barrier", e);
+                    return;
+                }
             }
         }
 
@@ -319,23 +343,29 @@ public class LongBufferPoolTest
             final SPSCQueue<BufferCheck> shareFrom = testEnv.sharedRecycle[threadIdx];
             final DynamicList<BufferCheck> checks = new DynamicList<>((int) Math.max(1, targetSize / (1 << 10)));
             final SPSCQueue<BufferCheck> shareTo = testEnv.sharedRecycle[(threadIdx + 1) % testEnv.threadCount];
+            final Future<Boolean> neighbourResultFuture = testEnv.threadResultFuture.get((threadIdx + 1) % testEnv.threadCount);
             final ThreadLocalRandom rand = ThreadLocalRandom.current();
             int totalSize = 0;
             int freeingSize = 0;
             int size = 0;
 
-            void checkpoint()
-            {
-                if (!testEnv.makingProgress[threadIdx].get())
-                    testEnv.makingProgress[threadIdx].set(true);
-            }
-
             void testOne() throws Exception
             {
-                long currentTargetSize = (rand.nextInt(testEnv.poolSize / 1024) == 0 || !testEnv.freedAllMemory[threadIdx].get()) ? 0 : targetSize;
+                if (testEnv.shouldFreeMemoryAndSuspend)
+                    freeAllAndSuspend();
+
+                long currentTargetSize = rand.nextInt(testEnv.poolSize / 1024) == 0 ? 0 : targetSize;
                 int spinCount = 0;
                 while (totalSize > currentTargetSize - freeingSize)
                 {
+                    // Don't get stuck in this loop if other threads might be suspended:
+                    if (testEnv.shouldFreeMemoryAndSuspend)
+                        return;
+
+                    // Don't get stuck in this loop if the neighbour thread exited:
+                    if (neighbourResultFuture.isDone())
+                        return;
+
                     // free buffers until we're below our target size
                     if (checks.size() == 0)
                     {
@@ -381,9 +411,6 @@ public class LongBufferPoolTest
                     }
                 }
 
-                if (currentTargetSize == 0)
-                    testEnv.freedAllMemory[threadIdx].compareAndSet(false, true);
-
                 // allocate a new buffer
                 size = (int) Math.max(1, AVG_BUFFER_SIZE + (STDEV_BUFFER_SIZE * rand.nextGaussian()));
                 if (size <= BufferPool.NORMAL_CHUNK_SIZE)
@@ -414,6 +441,31 @@ public class LongBufferPoolTest
 
                 // free all of our neighbour's remaining shared buffers
                 while (recycleFromNeighbour());
+            }
+
+            void freeAllAndSuspend() throws BrokenBarrierException, InterruptedException
+            {
+                testEnv.stopAllocationsBarrier.await();   // make sure other threads don't allocate any more buffers
+
+                while (checks.size() > 0)
+                {
+                    BufferCheck check = sample();
+                    checks.remove(check.listnode);
+                    check.validate();
+                    bufferPool.put(check.buffer);
+                }
+
+                BufferCheck check;
+                while ((check = shareFrom.poll()) != null)
+                {
+                    check.validate();
+                    bufferPool.put(check.buffer);
+                }
+
+                bufferPool.releaseLocal();
+
+                testEnv.freedAllMemoryBarrier.await();    // notify others we freed everything
+                testEnv.resumeAllocationsBarrier.await(); // wait until the main thread is done with all the checks
             }
 
             void cleanup()
@@ -487,6 +539,8 @@ public class LongBufferPoolTest
     private void startBurnerThreads(BufferPool bufferPool, TestEnvironment testEnv)
     {
         // setup some high churn allocate/deallocate, without any checking
+
+        final AtomicLong pendingBuffersCount = new AtomicLong(0);
         final SPSCQueue<ByteBuffer> burn = new SPSCQueue<>();
         final CountDownLatch doneAdd = new CountDownLatch(1);
         testEnv.addCheckedFuture(testEnv.executorService.submit(new TestUntil(bufferPool, testEnv.until)
@@ -497,10 +551,16 @@ public class LongBufferPoolTest
             {
                 if (count * BufferPool.NORMAL_CHUNK_SIZE >= testEnv.poolSize / 10)
                 {
-                    if (burn.exhausted)
+                    if (pendingBuffersCount.get() == 0)
                     {
                         count = 0;
-                        testEnv.burnFreed.compareAndSet(false, true);
+                        if (testEnv.shouldFreeMemoryAndSuspend)
+                        {
+                            testEnv.stopAllocationsBarrier.await();
+                            bufferPool.releaseLocal();
+                            testEnv.freedAllMemoryBarrier.await();
+                            testEnv.resumeAllocationsBarrier.await();
+                        }
                     } else
                     {
                         Thread.yield();
@@ -522,8 +582,10 @@ public class LongBufferPoolTest
                 if (rand.nextBoolean())
                     bufferPool.put(buffer);
                 else
+                {
+                    pendingBuffersCount.incrementAndGet();
                     burn.add(buffer);
-
+                }
                 count++;
             }
             void cleanup()
@@ -542,6 +604,7 @@ public class LongBufferPoolTest
                     return;
                 }
                 bufferPool.put(buffer);
+                pendingBuffersCount.decrementAndGet();
             }
             void cleanup()
             {

--- a/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
@@ -64,6 +64,26 @@ public class BufferPoolTest
         assertEquals(0, bufferPool.usedSizeInBytes());
     }
 
+    @Test
+    public void testTryGet()
+    {
+        final int size = RandomAccessReader.DEFAULT_BUFFER_SIZE;
+
+        ByteBuffer buffer = bufferPool.tryGet(size);
+        assertNotNull(buffer);
+        assertEquals(size, buffer.capacity());
+        assertEquals(true, buffer.isDirect());
+        assertEquals(size, bufferPool.usedSizeInBytes());
+
+        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
+        assertNotNull(chunk);
+        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
+
+        bufferPool.put(buffer);
+        assertEquals(null, bufferPool.unsafeCurrentChunk());
+        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
+        assertEquals(0, bufferPool.usedSizeInBytes());
+    }
 
     @Test
     public void testPageAligned()
@@ -99,10 +119,12 @@ public class BufferPoolTest
         ByteBuffer buffer1 = bufferPool.get(size1, BufferType.OFF_HEAP);
         assertNotNull(buffer1);
         assertEquals(size1, buffer1.capacity());
+        assertEquals(size1, bufferPool.usedSizeInBytes());
 
         ByteBuffer buffer2 = bufferPool.get(size2, BufferType.OFF_HEAP);
         assertNotNull(buffer2);
         assertEquals(size2, buffer2.capacity());
+        assertEquals(size1 + size2, bufferPool.usedSizeInBytes());
 
         BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
         assertNotNull(chunk);
@@ -113,6 +135,7 @@ public class BufferPoolTest
 
         assertEquals(null, bufferPool.unsafeCurrentChunk());
         assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
+        assertEquals(0, bufferPool.usedSizeInBytes());
     }
 
     @Test


### PR DESCRIPTION
LocalPool is meant to be managed by a single thread.
Unfortunately there was a code path that allowed
a thread enter the context of the LocalPool owned by another
thread by attempting to recycle a chunk using its
recycler reference.

The patch detects that situation and avoids attempts to recycle
a chunk from a wrong thread.

Fixes the following intermittent errors thrown by LongBufferPoolTest:

java.lang.AssertionError
	at org.apache.cassandra.utils.memory.BufferPool$Chunk.get(BufferPool.java:1315)
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.get(BufferPool.java:576)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGetInternal(BufferPool.java:900)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.lambda$new$0(BufferPool.java:739)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.addChunkFromParent(BufferPool.java:952)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGetInternal(BufferPool.java:907)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGet(BufferPool.java:893)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.access$000(BufferPool.java:710)
	at org.apache.cassandra.utils.memory.BufferPool.tryGet(BufferPool.java:205)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$2.testOne(LongBufferPoolTest.java:517)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$TestUntil.call(LongBufferPoolTest.java:579)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$TestUntil.call(LongBufferPoolTest.java:557)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)

java.lang.NullPointerException
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.add(BufferPool.java:513)
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.access$2200(BufferPool.java:480)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.addChunk(BufferPool.java:963)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.addChunkFromParent(BufferPool.java:956)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGetInternal(BufferPool.java:907)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.lambda$new$0(BufferPool.java:739)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.addChunkFromParent(BufferPool.java:952)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGetInternal(BufferPool.java:907)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGet(BufferPool.java:893)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.access$000(BufferPool.java:710)
	at org.apache.cassandra.utils.memory.BufferPool.tryGet(BufferPool.java:205)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$2.testOne(LongBufferPoolTest.java:517)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$TestUntil.call(LongBufferPoolTest.java:579)
	at org.apache.cassandra.utils.memory.LongBufferPoolTest$TestUntil.call(LongBufferPoolTest.java:557)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)