### PR TITLE
Revert "STAR-1293 Allow to read string value of Component.repr enum (#432)"

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/Component.java
+++ b/src/java/org/apache/cassandra/io/sstable/Component.java
@@ -72,7 +72,7 @@ public class Component
         // custom component, used by e.g. custom compaction strategy
         CUSTOM(null);
 
-        public final String repr;
+        final String repr;
 
         Type(String repr)
         {


### PR DESCRIPTION
This reverts commit ab7144312f4ee6e81841b765847f5bf1f3b61d85.
It was not needed as getter name(), which is already public, provides the same
value and thus should be used. CNDB is being already adjusted (see https://github.com/riptano/cndb/pull/4624).