### PR TITLE
STAR-1321: Fix flaky DescribeStatementTest.testDescribeFunctionAndAggregate

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -155,6 +155,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Pair;
+import org.awaitility.Awaitility;
 
 import static com.datastax.driver.core.SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS;
 import static com.datastax.driver.core.SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS;
@@ -197,8 +198,7 @@ public abstract class CQLTester
     private static final Map<Pair<User, ProtocolVersion>, Cluster> clusters = new HashMap<>();
     protected static final Map<Pair<User, ProtocolVersion>, Session> sessions = new HashMap<>();
 
-    // needed in GuardrailsOnTableTest to check whether dropping schema tasks have been finished
-    protected static final ThreadPoolExecutor schemaCleanup =
+    private static final ThreadPoolExecutor schemaCleanup =
     new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
 
 
@@ -472,6 +472,14 @@ public abstract class CQLTester
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    /**
+     * Blocks until the previous schema cleanup task finished.
+     */
+    public void waitForSchemaCleanupCompleted(long timeout, TimeUnit unit)
+    {
+        Awaitility.await().atMost(timeout, unit).until(() -> schemaCleanup.getActiveCount() == 0);
     }
 
     public static List<String> buildNodetoolArgs(List<String> args)

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.cql3.statements;
 
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -76,6 +77,8 @@ public class DescribeStatementTest extends CQLTester
     @Test
     public void testDescribeFunctionAndAggregate() throws Throwable
     {
+        waitForSchemaCleanupCompleted(60, TimeUnit.SECONDS);
+
         String fNonOverloaded = createFunction(KEYSPACE,
                                                "",
                                                "CREATE OR REPLACE FUNCTION %s() " +
@@ -262,6 +265,8 @@ public class DescribeStatementTest extends CQLTester
     {
         try
         {
+            waitForSchemaCleanupCompleted(60, TimeUnit.SECONDS);
+
             execute("CREATE KEYSPACE test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1};");
             execute("CREATE TABLE test.users ( userid text PRIMARY KEY, firstname text, lastname text, age int);");
             execute("CREATE INDEX myindex ON test.users (age);");

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailsOnTableTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.ImmutableSet;
@@ -82,12 +83,7 @@ public class GuardrailsOnTableTest extends GuardrailTester
     @Test
     public void testTableLimit() throws Throwable
     {
-        // check previous async dropping schema tasks have been finished...
-        int waitInSeconds = 30;
-        while (schemaCleanup.getActiveCount() > 0 && waitInSeconds-- >= 0)
-        {
-            Thread.sleep(1000);
-        }
+        waitForSchemaCleanupCompleted(30, TimeUnit.SECONDS);
 
         int currentTables = Schema.instance.getUserKeyspaces().stream().map(ksm -> Keyspace.open(ksm.name))
                                            .mapToInt(keyspace -> keyspace.getColumnFamilyStores().size()).sum();


### PR DESCRIPTION
Wait until schema cleanup is completed before launching the
tests that rely on clean state. Some tests retrieve the
whole schema or the list of functions / aggregates, and they
don't expect objects left by other tests.