### PR TITLE
STAR-540: Fix missing endpoint state updates after bootstrap

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -1596,6 +1596,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     }
 
     // notify that an application state has changed
+    @VisibleForTesting
     public void doOnChangeNotifications(InetAddressAndPort addr, ApplicationState state, VersionedValue value)
     {
         for (IEndpointStateChangeSubscriber subscriber : subscribers)

--- a/src/java/org/apache/cassandra/service/IEndpointLifecycleSubscriber.java
+++ b/src/java/org/apache/cassandra/service/IEndpointLifecycleSubscriber.java
@@ -35,33 +35,33 @@ public interface IEndpointLifecycleSubscriber
      *
      * @param endpoint the newly added endpoint.
      */
-    public void onJoinCluster(InetAddressAndPort endpoint);
+    default void onJoinCluster(InetAddressAndPort endpoint) {}
 
     /**
      * Called when a new node leave the cluster (decommission or removeToken).
      *
      * @param endpoint the endpoint that is leaving.
      */
-    public void onLeaveCluster(InetAddressAndPort endpoint);
+    default void onLeaveCluster(InetAddressAndPort endpoint) {}
 
     /**
      * Called when a node is marked UP.
      *
      * @param endpoint the endpoint marked UP.
      */
-    public void onUp(InetAddressAndPort endpoint);
+    default void onUp(InetAddressAndPort endpoint) {}
 
     /**
      * Called when a node is marked DOWN.
      *
      * @param endpoint the endpoint marked DOWN.
      */
-    public void onDown(InetAddressAndPort endpoint);
+    default void onDown(InetAddressAndPort endpoint) {}
 
     /**
      * Called when a node has moved (to a new token).
      *
      * @param endpoint the endpoint that has moved.
      */
-    public void onMove(InetAddressAndPort endpoint);
+    default void onMove(InetAddressAndPort endpoint) {}
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/TestBaseImpl.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/TestBaseImpl.java
@@ -43,9 +43,8 @@ import org.apache.cassandra.distributed.api.ICluster;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.shared.DistributedTestBase;
-import org.apache.cassandra.gms.EndpointState;
-import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.StorageService;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.BOOTSTRAP_SCHEMA_DELAY_MS;
 import static org.apache.cassandra.distributed.action.GossipHelper.withProperty;
@@ -134,8 +133,7 @@ public class TestBaseImpl extends DistributedTestBase
             .atMost(90, TimeUnit.SECONDS)
             .untilAsserted(() -> {
                 assert cluster.stream().allMatch(node -> node.isShutdown() || node.callOnInstance(() -> {
-                    EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(address);
-                    return state != null && state.isNormalState();
+                    return StorageService.instance.getTokenMetadata().isMember(address);
                 })) : "New node should be seen in NORMAL state by the other nodes in the cluster";
         });
     }


### PR DESCRIPTION
When a new node bootstraps, it first joins the ring
and the existing nodes receive the IEndpointStateChangeSubscriber#onJoin
event. But because the new node is bootstrapping, the endpoint states
such as INDEX_STATUS, NET_VERSION or SCHEMA are ignored on the existing
nodes and warnings gets displayed.

This commit makes sure those state updates are reapplied
after the new node becomes a part of the ring, that is when
IEndpointLifecycleSubscriber#onJoinCluster is fired.

There are also some minor cleanups:
* The StorageService doesn't accidentally force Gossiper onChange
  notifications to be sent to all subscribers whenever onJoin event
  happens. The fact that SS is on the subscriber list should not
  affect the other subscribers of Gossiper.
* IEndpOintLifecycleSubscriber methods get no-op defaults.
* TestBaseImpl#bootstrapAndJoinNode checks if the node became
  a member of the ring instead of testing its status in Gossip.