### PR TITLE
STAR-1192: Fix test assertion

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableLoaderEncryptionOptionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableLoaderEncryptionOptionsTest.java
@@ -101,6 +101,6 @@ public class SSTableLoaderEncryptionOptionsTest extends AbstractEncryptionOption
                                                             "--truststore-password", validTrustStorePassword,
                                                             "test/data/legacy-sstables/na/legacy_tables/legacy_na_clust");
         assertNotEquals(0, tool.getExitCode());
-        assertTrue(tool.getStdout().contains("SSLHandshakeException"));
+        assertTrue(tool.getStderr().contains("TransportException"));
     }
 }


### PR DESCRIPTION
Looks like SSTableLoader finally properly reports
errors to stderr, not stdout, but the test hasn't been updated.

Also, relying on a very specific exception on SSL failure is
very fragile. The exact type of exception is something that should be
tested by the java driver project, not here.