### PR TITLE
STAR-1422: Increase the schema agreement timeout in SAI tests to 60s

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SAIUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SAIUtil.java
@@ -124,7 +124,7 @@ public class SAIUtil
 
     public static void waitForSchemaAgreement(Cluster cluster)
     {
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(60, TimeUnit.SECONDS)
                .until(() -> schemaAgrees(cluster));
     }
 


### PR DESCRIPTION
Addresses:

org.awaitility.core.ConditionTimeoutException: Condition with lambda expression in org.apache.cassandra.distributed.test.sai.SAIUtil that uses org.apache.cassandra.distributed.Cluster was not fulfilled within 10 seconds.
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:165)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:895)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:864)
	at org.apache.cassandra.distributed.test.sai.SAIUtil.waitForSchemaAgreement(SAIUtil.java:128)
	at org.apache.cassandra.distributed.test.sai.SAIUtil.getIndexes(SAIUtil.java:117)