### PR TITLE
STAR-1431 Make sure SSTableWatcher is called in Trie SSTable open

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.Downsampling;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReaderBuilder;
@@ -975,6 +976,8 @@ public class TrieIndexSSTableReader extends SSTableReader
 
     public static TrieIndexSSTableReader open(Descriptor descriptor, Set<Component> components, TableMetadataRef metadata, boolean validate, boolean isOffline)
     {
+        components = SSTableWatcher.instance.discoverComponents(descriptor, components);
+
         checkRequiredComponents(descriptor, components, validate);
 
         EnumSet<MetadataType> types = EnumSet.of(MetadataType.VALIDATION, MetadataType.STATS, MetadataType.HEADER);


### PR DESCRIPTION
  The TrieIndexSSTableReader was not calling discoverComponents
  causing issues in CNDB with the SSTable components not being
  loaded correctly.