### PR TITLE
STAR-1438 Avoid NPE in DatabaseDescriptor.getNumTokens

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1592,7 +1592,7 @@ public class DatabaseDescriptor
 
     public static int getNumTokens()
     {
-        return conf.num_tokens;
+        return conf.num_tokens == null ? -1 : conf.num_tokens;
     }
 
     public static InetAddressAndPort getReplaceAddress()


### PR DESCRIPTION
  The Config.num_tokens is an Integer and does not have
  a default setting. DatabaseDescriptor.getNumTokens
  returns an int so if num_tokens is not initialised
  it will result in an NPE. This checks for null and
  returns -1. This is the default behaviour for DSE