### PR TITLE
STAR-1470 Avoid NPE in UCS metrics collection

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
@@ -71,7 +71,7 @@ class RealEnvironment implements Environment
     @Override
     public double bloomFilterFpRatio()
     {
-        return metrics().bloomFilterFalseRatio.getValue();
+        return metrics() == null ? 0.0 : metrics().bloomFilterFalseRatio.getValue();
     }
 
     @Override
@@ -87,31 +87,31 @@ class RealEnvironment implements Environment
     @Override
     public long partitionsRead()
     {
-        return metrics().readRequests.getCount();
+        return metrics() == null ? 0 : metrics().readRequests.getCount();
     }
 
     @Override
     public double sstablePartitionReadLatencyNanos()
     {
-        return metrics().sstablePartitionReadLatency.get();
+        return metrics() == null ? 0.0 : metrics().sstablePartitionReadLatency.get();
     }
 
     @Override
     public double compactionTimePerKbInNanos()
     {
-        return metrics().compactionTimePerKb.get();
+        return metrics() == null ? 0.0 : metrics().compactionTimePerKb.get();
     }
 
     @Override
     public double flushTimePerKbInNanos()
     {
-        return metrics().flushTimePerKb.get();
+        return metrics() == null ? 0.0 : metrics().flushTimePerKb.get();
     }
 
     @Override
     public long bytesInserted()
     {
-        return metrics().bytesInserted.getCount();
+        return metrics() == null ? 0 : metrics().bytesInserted.getCount();
     }
 
     @Override
@@ -123,7 +123,7 @@ class RealEnvironment implements Environment
     @Override
     public double flushSize()
     {
-        return metrics().flushSizeOnDisk().get();
+        return metrics() == null ? 0.0 : metrics().flushSizeOnDisk().get();
     }
 
     /**


### PR DESCRIPTION
  It is possible in CNDB for a CFS to not have its
  metrics set. In this case the UCS RealEnvironment
  must check for the null condition and return a
  default (0) value for a metric.