### PR TITLE
STAR-1265: Support for ULID based identifiers (additionally to UUID)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -648,6 +648,7 @@
           <dependency groupId="de.jflex" artifactId="jflex" version="${jflex.version}">
             <exclusion groupId="org.apache.ant" artifactId="ant"/>
           </dependency>
+          <dependency groupId="de.huxhorn.sulky" artifactId="de.huxhorn.sulky.ulid" version="8.2.0"/>
           <dependency groupId="com.googlecode.concurrent-trees" artifactId="concurrent-trees" version="2.4.0" />
           <dependency groupId="com.github.ben-manes.caffeine" artifactId="caffeine" version="2.5.6" />
           <dependency groupId="org.jctools" artifactId="jctools-core" version="3.1.0"/>
@@ -825,6 +826,7 @@
         <!-- don't need jamm unless running a server in which case it needs to be a -javagent to be used anyway -->
         <dependency groupId="com.github.jbellis" artifactId="jamm"/>
 
+        <dependency groupId="de.huxhorn.sulky" artifactId="de.huxhorn.sulky.ulid"/>
         <dependency groupId="io.netty" artifactId="netty-bom"  type="pom"  />
         <dependency groupId="io.netty" artifactId="netty-all"/>
         <dependency groupId="net.openhft" artifactId="chronicle-queue"/>

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -280,9 +280,9 @@ public enum CassandraRelevantProperties
     SYSTEM_DISTRIBUTED_NTS_RF_OVERRIDE_PROPERTY("cassandra.system_distributed_replication_per_dc"),
     SYSTEM_DISTRIBUTED_NTS_DC_OVERRIDE_PROPERTY("cassandra.system_distributed_replication_dc_names"),
 
-    ;
-
-
+    // in OSS, when UUID based SSTable generation identifiers are enabled, they use TimeUUID
+    // though, for CNDB we want they use ULID - this property allows for that
+    SSTABLE_UUID_IMPL("cassandra.sstable.id.uuid_impl", "uuid");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -281,7 +281,8 @@ public enum CassandraRelevantProperties
     SYSTEM_DISTRIBUTED_NTS_DC_OVERRIDE_PROPERTY("cassandra.system_distributed_replication_dc_names"),
 
     // in OSS, when UUID based SSTable generation identifiers are enabled, they use TimeUUID
-    // though, for CNDB we want they use ULID - this property allows for that
+    // though, for CNDB we want to use ULID - this property allows for that
+    // valid values for this property are: uuid, ulid
     SSTABLE_UUID_IMPL("cassandra.sstable.id.uuid_impl", "uuid");
 
     CassandraRelevantProperties(String key, String defaultVal)

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -129,7 +129,7 @@ public final class SystemKeyspace
     public static final String PEERS_V2 = "peers_v2";
     public static final String PEER_EVENTS_V2 = "peer_events_v2";
     public static final String COMPACTION_HISTORY = "compaction_history";
-    public static final String SSTABLE_ACTIVITY_V2 = "sstable_activity_v2"; // v2 has modified generation column type (v1 - int, v2 - blob), see CASSANDRA-17048
+    public static final String SSTABLE_ACTIVITY_V2 = "sstable_activity_v2"; // v2 has modified generation column type (v1 - int, v2 - text), see CASSANDRA-17048
     public static final String TABLE_ESTIMATES = "table_estimates";
     public static final String TABLE_ESTIMATES_TYPE_PRIMARY = "primary";
     public static final String TABLE_ESTIMATES_TYPE_LOCAL_PRIMARY = "local_primary";

--- a/src/java/org/apache/cassandra/io/sstable/SSTableId.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableId.java
@@ -18,10 +18,11 @@
 
 package org.apache.cassandra.io.sstable;
 
-import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import org.apache.cassandra.io.util.File;
 
 /**
  * Represents a unique identifier in the sstable descriptor filename.

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdFactory.java
@@ -22,11 +22,33 @@ import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.utils.TimeUUID;
 
 public class SSTableIdFactory
 {
     public static final SSTableIdFactory instance = new SSTableIdFactory();
+
+    private static boolean isULIDImpl()
+    {
+        String impl = CassandraRelevantProperties.SSTABLE_UUID_IMPL.getString().toLowerCase();
+        if ("uuid".equals(impl))
+            return false;
+        else if ("ulid".equals(impl))
+            return true;
+        else
+            throw new IllegalArgumentException("Unsupported value for property " + CassandraRelevantProperties.SSTABLE_UUID_IMPL.getKey() + ": " + impl);
+    }
+
+    private Stream<SSTableId.Builder<?>> buildersStream()
+    {
+        return isULIDImpl()
+               ? Stream.of(ULIDBasedSSTableId.Builder.instance, UUIDBasedSSTableId.Builder.instance, SequenceBasedSSTableId.Builder.instance)
+               : Stream.of(UUIDBasedSSTableId.Builder.instance, ULIDBasedSSTableId.Builder.instance, SequenceBasedSSTableId.Builder.instance);
+    }
 
     /**
      * Constructs the instance of {@link SSTableId} from the given string representation.
@@ -37,18 +59,17 @@ public class SSTableIdFactory
      */
     public SSTableId fromString(String str) throws IllegalArgumentException
     {
-        return Stream.of(UUIDBasedSSTableId.Builder.instance, SequenceBasedSSTableId.Builder.instance)
-                     .filter(b -> b.isUniqueIdentifier(str))
-                     .findFirst()
-                     .map(b -> b.fromString(str))
-                     .orElseThrow(() -> new IllegalArgumentException("String '" + str + "' does not match any SSTable identifier format"));
+        return buildersStream().filter(b -> b.isUniqueIdentifier(str))
+                               .findFirst()
+                               .map(b -> b.fromString(str))
+                               .orElseThrow(() -> new IllegalArgumentException("String '" + str + "' does not match any SSTable identifier format"));
     }
 
     /**
      * Constructs the instance of {@link SSTableId} from the given bytes.
      * It finds the right builder by verifying whether the given buffer is the representation of the related identifier
      * type using {@link SSTableId.Builder#isUniqueIdentifier(ByteBuffer)} method.
-     *
+     * <p>
      * The method expects the identifier is encoded in all remaining bytes of the buffer. The method does not move the
      * pointer of the buffer.
      *
@@ -56,11 +77,10 @@ public class SSTableIdFactory
      */
     public SSTableId fromBytes(ByteBuffer bytes)
     {
-        return Stream.of(UUIDBasedSSTableId.Builder.instance, SequenceBasedSSTableId.Builder.instance)
-                     .filter(b -> b.isUniqueIdentifier(bytes))
-                     .findFirst()
-                     .map(b -> b.fromBytes(bytes))
-                     .orElseThrow(() -> new IllegalArgumentException("Byte buffer of length " + bytes.remaining() + " does not match any SSTable identifier format"));
+        return buildersStream().filter(b -> b.isUniqueIdentifier(bytes))
+                               .findFirst()
+                               .map(b -> b.fromBytes(bytes))
+                               .orElseThrow(() -> new IllegalArgumentException("Byte buffer of length " + bytes.remaining() + " does not match any SSTable identifier format"));
     }
 
     /**
@@ -70,7 +90,9 @@ public class SSTableIdFactory
     public SSTableId.Builder<SSTableId> defaultBuilder()
     {
         SSTableId.Builder<? extends SSTableId> builder = DatabaseDescriptor.isUUIDSSTableIdentifiersEnabled()
-                                                         ? UUIDBasedSSTableId.Builder.instance
+                                                         ? isULIDImpl()
+                                                           ? ULIDBasedSSTableId.Builder.instance
+                                                           : UUIDBasedSSTableId.Builder.instance
                                                          : SequenceBasedSSTableId.Builder.instance;
         return (SSTableId.Builder<SSTableId>) builder;
     }
@@ -78,20 +100,17 @@ public class SSTableIdFactory
     /**
      * Compare sstable identifiers so that UUID based identifier is always greater than sequence based identifier
      */
-    public final static Comparator<SSTableId> COMPARATOR = Comparator.nullsFirst((id1, id2) -> {
-        if (id1 instanceof UUIDBasedSSTableId)
-        {
-            UUIDBasedSSTableId uuidId1 = (UUIDBasedSSTableId) id1;
-            return (id2 instanceof UUIDBasedSSTableId) ? uuidId1.compareTo((UUIDBasedSSTableId) id2) : 1;
-        }
-        else if (id1 instanceof SequenceBasedSSTableId)
-        {
-            SequenceBasedSSTableId seqId1 = (SequenceBasedSSTableId) id1;
-            return (id2 instanceof SequenceBasedSSTableId) ? seqId1.compareTo((SequenceBasedSSTableId) id2) : -1;
-        }
+    public final static Comparator<SSTableId> COMPARATOR = Comparator.nullsFirst(Comparator.comparing(SSTableIdFactory::asTimeUUID));
+
+    private static Pair<TimeUUID, Integer> asTimeUUID(SSTableId id)
+    {
+        if (id instanceof UUIDBasedSSTableId)
+            return Pair.of(((UUIDBasedSSTableId) id).uuid, null);
+        else if (id instanceof ULIDBasedSSTableId)
+            return Pair.of(((ULIDBasedSSTableId) id).approximateTimeUUID, null);
+        else if (id instanceof SequenceBasedSSTableId)
+            return Pair.of(null, ((SequenceBasedSSTableId) id).generation);
         else
-        {
-            throw new AssertionError("Unsupported comparison between " + id1.getClass().getName() + " and  " + id2.getClass().getName());
-        }
-    });
+            throw new AssertionError("Unsupported sstable identifier type " + id.getClass().getName());
+    }
 }

--- a/src/java/org/apache/cassandra/io/sstable/ULIDBasedSSTableId.java
+++ b/src/java/org/apache/cassandra/io/sstable/ULIDBasedSSTableId.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
+
+import de.huxhorn.sulky.ulid.ULID;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.TimeUUID;
+
+/**
+ * SSTable generation identifiers that can be stored across nodes in one directory/bucket
+ * Uses the ULID based identifiers
+ */
+public final class ULIDBasedSSTableId implements SSTableId, Comparable<ULIDBasedSSTableId>
+{
+    public final static int STRING_LEN = 26;
+    public final static int BYTES_LEN = 16;
+
+    final ULID.Value ulid;
+    final TimeUUID approximateTimeUUID;
+
+    public ULIDBasedSSTableId(ULID.Value ulid)
+    {
+        this.ulid = ulid;
+        this.approximateTimeUUID = TimeUUID.approximateFromULID(ulid);
+    }
+
+    @Override
+    public ByteBuffer asBytes()
+    {
+        return ByteBuffer.wrap(ulid.toBytes());
+    }
+
+    @Override
+    public String toString()
+    {
+        return ulid.toString();
+    }
+
+    @Override
+    public int compareTo(ULIDBasedSSTableId o)
+    {
+        if (o == null)
+            return 1;
+        else if (o == this)
+            return 0;
+
+        return ulid.compareTo(o.ulid);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ULIDBasedSSTableId that = (ULIDBasedSSTableId) o;
+        return ulid.equals(that.ulid);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(ulid);
+    }
+
+    public static class Builder implements SSTableId.Builder<ULIDBasedSSTableId>
+    {
+        private static final Pattern PATTERN = Pattern.compile("[0-9a-z]{26}", Pattern.CASE_INSENSITIVE);
+
+        public static final Builder instance = new Builder();
+
+        private static final ULID ulid = new ULID();
+        private static final AtomicReference<ULID.Value> prevRef = new AtomicReference<>();
+
+        /**
+         * Creates a new ULID based identifiers generator.
+         *
+         * @param existingIdentifiers not used by UUID based generator
+         */
+        @Override
+        public Supplier<ULIDBasedSSTableId> generator(Stream<SSTableId> existingIdentifiers)
+        {
+            return () -> {
+                ULID.Value prevVal;
+                ULID.Value newVal = null;
+                do
+                {
+                    prevVal = prevRef.get();
+                    if (prevVal != null)
+                    {
+                        Optional<ULID.Value> newValOpt = ulid.nextStrictlyMonotonicValue(prevVal);
+                        if (!newValOpt.isPresent())
+                            continue;
+                        newVal = newValOpt.get();
+                    }
+                    else
+                    {
+                        newVal = ulid.nextValue();
+                    }
+                } while (newVal != null && !prevRef.compareAndSet(prevVal, newVal));
+                return new ULIDBasedSSTableId(newVal);
+            };
+        }
+
+        @Override
+        public boolean isUniqueIdentifier(String str)
+        {
+            return str != null && str.length() == STRING_LEN && PATTERN.matcher(str).matches();
+        }
+
+        @Override
+        public boolean isUniqueIdentifier(ByteBuffer bytes)
+        {
+            return bytes != null && bytes.remaining() == BYTES_LEN;
+        }
+
+        @Override
+        public ULIDBasedSSTableId fromString(@Nonnull String s) throws IllegalArgumentException
+        {
+            Matcher m = PATTERN.matcher(s);
+            if (!m.matches())
+                throw new IllegalArgumentException("String '" + s + "' is not a valid ULID based sstable identifier");
+
+            ULID.Value ulid = ULID.parseULID(s);
+            return new ULIDBasedSSTableId(ulid);
+        }
+
+        @Override
+        public ULIDBasedSSTableId fromBytes(@Nonnull ByteBuffer bytes) throws IllegalArgumentException
+        {
+            Preconditions.checkArgument(bytes.remaining() == ULIDBasedSSTableId.BYTES_LEN,
+                                        "Buffer does not have a valid number of bytes remaining. Expecting: %s but was: %s",
+                                        ULIDBasedSSTableId.BYTES_LEN, bytes.remaining());
+
+            ULID.Value ulid = ULID.fromBytes(ByteBufferUtil.getArray(bytes));
+            return new ULIDBasedSSTableId(ulid);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/ULIDBasedSSTableId.java
+++ b/src/java/org/apache/cassandra/io/sstable/ULIDBasedSSTableId.java
@@ -40,8 +40,8 @@ import org.apache.cassandra.utils.TimeUUID;
  */
 public final class ULIDBasedSSTableId implements SSTableId, Comparable<ULIDBasedSSTableId>
 {
-    public final static int STRING_LEN = 26;
-    public final static int BYTES_LEN = 16;
+    public static final int STRING_LEN = 26;
+    public static final int BYTES_LEN = 16;
 
     final ULID.Value ulid;
     final TimeUUID approximateTimeUUID;
@@ -149,8 +149,7 @@ public final class ULIDBasedSSTableId implements SSTableId, Comparable<ULIDBased
             if (!m.matches())
                 throw new IllegalArgumentException("String '" + s + "' is not a valid ULID based sstable identifier");
 
-            ULID.Value ulid = ULID.parseULID(s);
-            return new ULIDBasedSSTableId(ulid);
+            return new ULIDBasedSSTableId(ULID.parseULID(s));
         }
 
         @Override
@@ -160,8 +159,7 @@ public final class ULIDBasedSSTableId implements SSTableId, Comparable<ULIDBased
                                         "Buffer does not have a valid number of bytes remaining. Expecting: %s but was: %s",
                                         ULIDBasedSSTableId.BYTES_LEN, bytes.remaining());
 
-            ULID.Value ulid = ULID.fromBytes(ByteBufferUtil.getArray(bytes));
-            return new ULIDBasedSSTableId(ulid);
+            return new ULIDBasedSSTableId(ULID.fromBytes(ByteBufferUtil.getArray(bytes)));
         }
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/UUIDBasedSSTableId.java
+++ b/src/java/org/apache/cassandra/io/sstable/UUIDBasedSSTableId.java
@@ -41,7 +41,7 @@ public final class UUIDBasedSSTableId implements SSTableId, Comparable<UUIDBased
     public final static int STRING_LEN = 28;
     public final static int BYTES_LEN = 16;
 
-    private final TimeUUID uuid;
+    final TimeUUID uuid;
     private final String repr;
 
     public UUIDBasedSSTableId(TimeUUID uuid)

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -29,20 +29,6 @@ public class TimeUUID implements Comparable<TimeUUID>
     protected static final long TIMESTAMP_UUID_VERSION_IN_MSB = 0x1000L;
     protected static final long UUID_VERSION_BITS_IN_MSB = 0xf000L;
 
-    /*
-     * The min and max possible lsb for a UUID.
-     * Note that his is not 0 and all 1's because Cassandra TimeUUIDType
-     * compares the lsb parts as a signed byte array comparison. So the min
-     * value is 8 times -128 and the max is 8 times +127.
-     *
-     * Note that we ignore the uuid variant (namely, MIN_CLOCK_SEQ_AND_NODE
-     * have variant 2 as it should, but MAX_CLOCK_SEQ_AND_NODE have variant 0).
-     * I don't think that has any practical consequence and is more robust in
-     * case someone provides a UUID with a broken variant.
-     */
-    private static final long MIN_CLOCK_SEQ_AND_NODE = 0x8080808080808080L;
-    private static final long MAX_CLOCK_SEQ_AND_NODE = 0x7f7f7f7f7f7f7f7fL;
-
     final long uuidTimestamp, lsb;
 
     public TimeUUID(long uuidTimestamp, long lsb)

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.utils;
 
 import java.util.UUID;
 
+import de.huxhorn.sulky.ulid.ULID;
+
 public class TimeUUID implements Comparable<TimeUUID>
 {
     // A grand day! millis at 00:00:00.000 15 Oct 1582.
@@ -50,27 +52,6 @@ public class TimeUUID implements Comparable<TimeUUID>
         this.lsb = lsb;
     }
 
-    public static TimeUUID atUnixMicrosWithLsb(long unixMicros, long uniqueLsb)
-    {
-        return new TimeUUID(unixMicrosToRawTimestamp(unixMicros), uniqueLsb);
-    }
-
-    public static UUID atUnixMicrosWithLsbAsUUID(long unixMicros, long uniqueLsb)
-    {
-        return new UUID(rawTimestampToMsb(unixMicrosToRawTimestamp(unixMicros)), uniqueLsb);
-    }
-
-    /**
-     * Returns the smaller possible type 1 UUID having the provided timestamp.
-     *
-     * <b>Warning:</b> this method should only be used for querying as this
-     * doesn't at all guarantee the uniqueness of the resulting UUID.
-     */
-    public static TimeUUID minAtUnixMillis(long unixMillis)
-    {
-        return new TimeUUID(unixMillisToRawTimestamp(unixMillis, 0), MIN_CLOCK_SEQ_AND_NODE);
-    }
-
     public static TimeUUID fromUuid(UUID uuid)
     {
         return fromBytes(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
@@ -79,6 +60,12 @@ public class TimeUUID implements Comparable<TimeUUID>
     public static TimeUUID fromBytes(long msb, long lsb)
     {
         return new TimeUUID(msbToRawTimestamp(msb), lsb);
+    }
+
+    public static TimeUUID approximateFromULID(ULID.Value ulid)
+    {
+        long rawTimestamp = unixMillisToRawTimestamp(ulid.timestamp(), (10_000L * (ulid.getMostSignificantBits() & 0xFFFF)) >> 16);
+        return new TimeUUID(rawTimestamp, ulid.getLeastSignificantBits());
     }
 
     public UUID asUUID()
@@ -110,11 +97,6 @@ public class TimeUUID implements Comparable<TimeUUID>
         return unixMillis * 10000 - (UUID_EPOCH_UNIX_MILLIS * 10000) + tenthsOfAMicro;
     }
 
-    public static long unixMicrosToRawTimestamp(long unixMicros)
-    {
-        return unixMicros * 10 - (UUID_EPOCH_UNIX_MILLIS * 10000);
-    }
-
     public static long msbToRawTimestamp(long msb)
     {
         assert (UUID_VERSION_BITS_IN_MSB & msb) == TIMESTAMP_UUID_VERSION_IN_MSB;
@@ -139,20 +121,12 @@ public class TimeUUID implements Comparable<TimeUUID>
     }
 
     @Override
-    public boolean equals(Object that)
+    public boolean equals(Object o)
     {
-        return (that instanceof UUID && equals((UUID) that))
-               || (that instanceof TimeUUID && equals((TimeUUID) that));
-    }
-
-    public boolean equals(TimeUUID that)
-    {
-        return that != null && uuidTimestamp == that.uuidTimestamp && lsb == that.lsb;
-    }
-
-    public boolean equals(UUID that)
-    {
-        return that != null && uuidTimestamp == that.timestamp() && lsb == that.getLeastSignificantBits();
+        if (this == o) return true;
+        if (!(o instanceof TimeUUID)) return false;
+        TimeUUID timeUUID = (TimeUUID) o;
+        return uuidTimestamp == timeUUID.uuidTimestamp && lsb == timeUUID.lsb;
     }
 
     @Override
@@ -167,6 +141,11 @@ public class TimeUUID implements Comparable<TimeUUID>
         return this.uuidTimestamp != that.uuidTimestamp
                ? Long.compare(this.uuidTimestamp, that.uuidTimestamp)
                : Long.compare(this.lsb, that.lsb);
+    }
+
+    public long unixMillis()
+    {
+        return (uuidTimestamp / 10_000L) + UUID_EPOCH_UNIX_MILLIS;
     }
 
     public static class Generator


### PR DESCRIPTION
Unlike in CNDB, universally unique identifiers were implemented in OSS using TimeUUID rather than ULID. Since CC needs to be able to at least read identifiers generated by CNDB, this patch adds back support for ULID based identifiers (in addition to TimeUUID based identifiers).
