### PR TITLE
STAR-1505 doTruncateBlocking should be called from execute not executeLocally so it can be overridden by alternate implementations.

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
@@ -99,7 +99,7 @@ public class TruncateStatement implements CQLStatement, CQLStatement.SingleKeysp
 
             doTruncateBlocking();
         }
-        catch (UnavailableException | TimeoutException e)
+        catch (UnavailableException | TimeoutException | InvalidRequestException e)
         {
             throw new TruncateException(e);
         }

--- a/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TruncateStatement.java
@@ -88,26 +88,9 @@ public class TruncateStatement implements CQLStatement, CQLStatement.SingleKeysp
         try
         {
             TableMetadata metaData = Schema.instance.getTableMetadata(keyspace(), name());
-            if (metaData.isView())
-                throw new InvalidRequestException("Cannot TRUNCATE materialized view directly; must truncate base table instead");
+            if (metaData == null)
+                throw new InvalidRequestException(String.format("Unknown keyspace/table %s.%s", keyspace(), name()));
 
-            if (metaData.isVirtual())
-                throw new InvalidRequestException("Cannot truncate virtual tables");
-
-            StorageProxy.instance.truncateBlocking(keyspace(), name());
-        }
-        catch (UnavailableException | TimeoutException e)
-        {
-            throw new TruncateException(e);
-        }
-        return null;
-    }
-
-    public ResultMessage executeLocally(QueryState state, QueryOptions options)
-    {
-        try
-        {
-            TableMetadata metaData = Schema.instance.getTableMetadata(keyspace(), name());
             if (metaData.isView())
                 throw new InvalidRequestException("Cannot TRUNCATE materialized view directly; must truncate base table instead");
 
@@ -116,17 +99,40 @@ public class TruncateStatement implements CQLStatement, CQLStatement.SingleKeysp
 
             doTruncateBlocking();
         }
-        catch (Exception e)
+        catch (UnavailableException | TimeoutException e)
         {
             throw new TruncateException(e);
         }
         return null;
     }
 
-    protected void doTruncateBlocking()
+    protected void doTruncateBlocking() throws TimeoutException
     {
-        ColumnFamilyStore cfs = Keyspace.open(keyspace()).getColumnFamilyStore(name());
-        cfs.truncateBlocking();
+        StorageProxy.instance.truncateBlocking(keyspace(), name());
+    }
+
+    public ResultMessage executeLocally(QueryState state, QueryOptions options)
+    {
+        try
+        {
+            TableMetadata metaData = Schema.instance.getTableMetadata(keyspace(), name());
+            if (metaData == null)
+                throw new InvalidRequestException(String.format("Unknown keyspace/table %s.%s", keyspace(), name()));
+
+            if (metaData.isView())
+                throw new InvalidRequestException("Cannot TRUNCATE materialized view directly; must truncate base table instead");
+
+            if (metaData.isVirtual())
+                throw new InvalidRequestException("Cannot truncate virtual tables");
+
+            ColumnFamilyStore cfs = Keyspace.open(keyspace()).getColumnFamilyStore(name());
+            cfs.truncateBlocking();
+        }
+        catch (Exception e)
+        {
+            throw new TruncateException(e);
+        }
+        return null;
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/ServerTestUtils.java
+++ b/test/unit/org/apache/cassandra/ServerTestUtils.java
@@ -29,13 +29,11 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.audit.AuditLogManager;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.AbstractEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
-import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.security.ThreadAwareSecurityManager;
 
 /**


### PR DESCRIPTION
Updates `TruncateStatement` to call `doTruncateBlocking` from `execute` (not `executeLocally`) so that it can be overridden by alt. implementations (via `TruncateStatementProvider`).

It also adds some tests to improve test coverage (required by SonarCloud).

The CNDB changes are: https://github.com/riptano/cndb/pull/5214