### PR TITLE
STAR-1364 Use `Mutation.apply` instead of `applyUnsafe` to persist the commit log, so the expected mutations will be replayed.

### DIFF
--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
@@ -102,7 +102,7 @@ public class RecoveryManagerTruncateTest
             .clustering("cc")
             .add("val", "val1")
             .build()
-            .applyUnsafe();
+            .apply();
 
         // Make sure data was written
         assertTrue(Util.getAll(Util.cmd(cfs).build()).size() > 0);

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
@@ -110,7 +110,7 @@ public class RecoveryManagerTruncateTest
         // and now truncate it
         cfs.truncateBlocking();
         Map<Keyspace, Integer> replayed = CommitLog.instance.resetUnsafe(false);
-        assertFalse("Expect no mutation replayed, but got " + replayed, replayed.isEmpty());
+        assertFalse("Expected mutations to be replayed, but got " + replayed, replayed.isEmpty());
 
         // and validate truncation.
         Util.assertEmptyUnfiltered(Util.cmd(cfs).build());


### PR DESCRIPTION
Fixes a race condition making the test flakey by persisting mutations to commit log as in other tests in this class.