### PR TITLE
STAR-1538 Add metadata_directory to InstanceConfig

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -80,6 +80,7 @@ public class InstanceConfig implements IInstanceConfig
                            String commitlog_directory,
                            String hints_directory,
                            String cdc_raw_directory,
+                           String metadata_directory,
                            String initial_token,
                            int storage_port,
                            int native_transport_port)
@@ -97,6 +98,7 @@ public class InstanceConfig implements IInstanceConfig
                 .set("commitlog_directory", commitlog_directory)
                 .set("hints_directory", hints_directory)
                 .set("cdc_raw_directory", cdc_raw_directory)
+                .set("metadata_directory", metadata_directory)
                 .set("initial_token", initial_token)
                 .set("partitioner", "org.apache.cassandra.dht.Murmur3Partitioner")
                 .set("start_native_transport", true)
@@ -274,6 +276,7 @@ public class InstanceConfig implements IInstanceConfig
                                   String.format("%s/node%d/commitlog", root, nodeNum),
                                   String.format("%s/node%d/hints", root, nodeNum),
                                   String.format("%s/node%d/cdc", root, nodeNum),
+                                  String.format("%s/node%d/metadata", root, nodeNum),
                                   token,
                                   provisionStrategy.storagePort(nodeNum),
                                   provisionStrategy.nativeTransportPort(nodeNum));


### PR DESCRIPTION
Adds missing `metadata_directory` to `InstanceConfig` so that tests can start.