### PR TITLE
STAR-1485 Ports code from DSE to clear AuthCache entries using a filter

### DIFF
--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -18,11 +18,14 @@
 
 package org.apache.cassandra.auth;
 
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,6 +144,18 @@ public class AuthCache<K, V> implements AuthCacheMBean
     {
         if (cache != null)
             cache.invalidate(k);
+    }
+
+    public void maybeInvalidateByFilter(Predicate<? super K> filter)
+    {
+        if (cache != null)
+        {
+            Collection<K> iterable = cache.asMap().keySet()
+                                          .stream()
+                                          .filter(filter)
+                                          .collect(Collectors.toSet());
+            cache.invalidateAll(iterable);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
+++ b/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
@@ -24,7 +24,6 @@ import com.google.common.base.Objects;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Datacenters;
-import org.apache.cassandra.utils.Pair;
 
 /**
  * Returned from IAuthenticator#authenticate(), represents an authenticated user everywhere internally.
@@ -118,16 +117,30 @@ public class AuthenticatedUser
         return permissionsCache.getPermissions(this, resource);
     }
 
+    /**
+     * Clears all entries from the permissions cache.
+     * 
+     * Used by CNDB Authorizer to clear all entries from the cache.
+     */
     @VisibleForTesting
     public static void clearCache()
     {
         permissionsCache.invalidate();
     }
 
+    /**
+     * Clears all entries belonging to the given {@link RoleResource}
+     * from the permissions cache.
+     * 
+     * Used by CNDB Authorizer to clear entries after permissions are granted
+     * or revoked.
+     * 
+     * @param roleResource the {@link RoleResource} to clear from the cache 
+     */
     @VisibleForTesting
     public static void clearCache(RoleResource roleResource)
     {
-        permissionsCache.invalidate(Pair.create(new AuthenticatedUser(roleResource.getRoleName()), roleResource));
+        permissionsCache.maybeInvalidateByFilter(key -> key.left.equals(new AuthenticatedUser(roleResource.getRoleName())));
     }
 
 

--- a/src/java/org/apache/cassandra/auth/Roles.java
+++ b/src/java/org/apache/cassandra/auth/Roles.java
@@ -59,6 +59,14 @@ public class Roles
         cache.invalidate();
     }
 
+    /**
+     * Clears the given {@link RoleResource} from the roles cache.
+     * 
+     * Used by CNDB RoleManager to clear cache entries after grant, alter
+     * or drop operatons on a role.
+     * 
+     * @param roleResource the {@link RoleResource} to clear from the cache
+     */
     @VisibleForTesting
     public static void clearCache(RoleResource roleResource)
     {

--- a/test/unit/org/apache/cassandra/auth/AuthCacheTest.java
+++ b/test/unit/org/apache/cassandra/auth/AuthCacheTest.java
@@ -224,6 +224,39 @@ public class AuthCacheTest
         }
     }
 
+    @Test
+    public void testMaybeInvalidateByFilter()
+    {
+        TestCache<String, Integer> authCache = new TestCache<>(this::countingLoader, this::setValidity, () -> validity, () -> isCacheEnabled);
+
+        // Load cache
+        int result = authCache.get("10");
+        assertEquals(10, result);
+        assertEquals(1, loadCounter);
+        
+        result = authCache.get("20");
+        assertEquals(20, result);
+        assertEquals(2, loadCounter);
+        
+        // Additional reads are from cache
+        assertEquals(10, authCache.get("10").longValue());
+        assertEquals(20, authCache.get("20").longValue());
+        assertEquals(2, loadCounter);
+
+        // Invalidate using a filter
+        authCache.maybeInvalidateByFilter(s -> s.equals("10"));
+
+        // Getting invalidated value requires loading
+        result = authCache.get("10");
+        assertEquals(10, result);
+        assertEquals(3, loadCounter);
+        
+        // Other values are still cached
+        result = authCache.get("20");
+        assertEquals(20, result);
+        assertEquals(3, loadCounter);
+    }
+
     private void setValidity(int validity)
     {
         this.validity = validity;


### PR DESCRIPTION
This is used by cndb to clear all permission cache entries for a given user (RoleResource).
Add javadoc to otherwise unused methods to make it more clear they are used by cndb
