### PR TITLE
STAR-1497 Fixes for CNDB SchemaTest

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -27,17 +27,6 @@ options {
     private final List<ErrorListener> listeners = new ArrayList<ErrorListener>();
     protected final List<ColumnIdentifier> bindVariables = new ArrayList<ColumnIdentifier>();
 
-    public static final Set<String> reservedTypeNames = new HashSet<String>()
-    {{
-        add("byte");
-        add("complex");
-        add("enum");
-        add("date");
-        add("interval");
-        add("macaddr");
-        add("bitstring");
-    }};
-
     public AbstractMarker.Raw newBindVariables(ColumnIdentifier name)
     {
         AbstractMarker.Raw marker = new AbstractMarker.Raw(bindVariables.size());
@@ -1845,7 +1834,7 @@ mbean
 // Basically the same as cident, but we need to exlude existing CQL3 types
 // (which for some reason are not reserved otherwise)
 non_type_ident returns [ColumnIdentifier id]
-    : t=IDENT                    { if (reservedTypeNames.contains($t.text)) addRecognitionError("Invalid (reserved) user type name " + $t.text); $id = new ColumnIdentifier($t.text, false); }
+    : t=IDENT                    { if (ReservedTypeNames.isReserved($t.text)) addRecognitionError("Invalid (reserved) user type name " + $t.text); $id = new ColumnIdentifier($t.text, false); }
     | t=QUOTED_NAME              { $id = new ColumnIdentifier($t.text, true); }
     | k=basic_unreserved_keyword { $id = new ColumnIdentifier(k, false); }
     | kk=K_KEY                   { $id = new ColumnIdentifier($kk.text, false); }

--- a/src/java/org/apache/cassandra/cql3/ColumnIdentifier.java
+++ b/src/java/org/apache/cassandra/cql3/ColumnIdentifier.java
@@ -228,6 +228,16 @@ public class ColumnIdentifier implements IMeasurableMemory, Comparable<ColumnIde
     {
         if (UNQUOTED_IDENTIFIER.matcher(text).matches() && !ReservedKeywords.isReserved(text))
             return text;
+        return quote(text);
+    }
+
+    /**
+     * Adds double quotes to the given text
+     * @param text the text to double-quote
+     * @return the double-quoted text
+     */
+    public static String quote(String text)
+    {
         return '"' + PATTERN_DOUBLE_QUOTE.matcher(text).replaceAll(ESCAPED_DOUBLE_QUOTE) + '"';
     }
 }

--- a/src/java/org/apache/cassandra/cql3/CqlBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/CqlBuilder.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.cql3.functions.FunctionName;
 import org.apache.cassandra.db.marshal.AbstractType;
 
@@ -64,6 +66,19 @@ public final class CqlBuilder
         indentIfNeeded();
         builder.append(str);
         return this;
+    }
+
+    public CqlBuilder appendTypeQuotingIfNeeded(String str)
+    {
+        return append(maybeQuoteTypeName(str));
+    }
+
+    @VisibleForTesting
+    public static String maybeQuoteTypeName(String nameAsString)
+    {
+        return ReservedTypeNames.isReserved(nameAsString)
+               ? ColumnIdentifier.quote(nameAsString)
+               : ColumnIdentifier.maybeQuote(nameAsString);
     }
 
     public CqlBuilder appendQuotingIfNeeded(String str)

--- a/src/java/org/apache/cassandra/cql3/ReservedTypeNames.java
+++ b/src/java/org/apache/cassandra/cql3/ReservedTypeNames.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Set of reserved type names. When creating a user type via CQL, if the type's name is included in this
+ * set, the statement will fail unless the name is double quoted.
+ */
+public class ReservedTypeNames
+{
+    public static final Set<String> reservedTypeNames = Sets.newHashSet(
+    "byte",
+    "complex",
+    "enum",
+    "date",
+    "interval",
+    "macaddr",
+    "bitstring");
+
+    public static boolean isReserved(String typeName)
+    {
+        return reservedTypeNames.contains(typeName);
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -484,7 +484,7 @@ public class UserType extends TupleType implements SchemaElement
 
         builder.appendQuotingIfNeeded(keyspace)
                .append('.')
-               .appendQuotingIfNeeded(getNameAsString())
+               .appendTypeQuotingIfNeeded(getNameAsString())
                .append(" (")
                .newLine()
                .increaseIndent();
@@ -495,7 +495,7 @@ public class UserType extends TupleType implements SchemaElement
                 builder.append(",")
                        .newLine();
 
-            builder.append(fieldNameAsString(i))
+            builder.append(ColumnIdentifier.maybeQuote(fieldNameAsString(i)))
                    .append(' ')
                    .append(fieldType(i));
         }

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -199,8 +199,8 @@ public class GuardrailsConfig
                        Collections.<String>emptySet(),
                        new LinkedHashSet<>(TableAttributes.allKeywords().stream()
                                                           .sorted()
-                                                          .filter(p -> !p.equals(TableParams.Option.DEFAULT_TIME_TO_LIVE.name()) &&
-                                                                       !p.equals(TableParams.Option.COMMENT.name()))
+                                                          .filter(p -> !p.equals(TableParams.Option.DEFAULT_TIME_TO_LIVE.toString()) &&
+                                                                       !p.equals(TableParams.Option.COMMENT.toString()))
                                                           .collect(Collectors.toList())));
 
         // for node status

--- a/test/unit/org/apache/cassandra/cql3/ReservedTypeNamesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/ReservedTypeNamesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import org.apache.cassandra.exceptions.SyntaxException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class ReservedTypeNamesTest
+{
+    @Test
+    public void testUnquotedReservedTypeNames()
+    {
+        for (String reservedTypeName : ReservedTypeNames.reservedTypeNames)
+        {
+            assertTypeCreationParseFails(reservedTypeName);
+        }
+    }
+
+    @Test
+    public void testQuotedReservedTypeNames()
+    {
+        for (String reservedTypeName : ReservedTypeNames.reservedTypeNames)
+        {
+            String doubleQuotedName = CqlBuilder.maybeQuoteTypeName(reservedTypeName);
+            assertEquals('"' + reservedTypeName + '"', doubleQuotedName);
+
+            parseCreateType(doubleQuotedName);
+        }
+    }
+
+    @Test
+    public void testUnreservedNames()
+    {
+        Set<String> unreservedNames = Sets.newHashSet("mytype", "niceType", "hello", "cassandra");
+
+        for (String unreservedName: unreservedNames)
+        {
+            assertFalse(ReservedTypeNames.isReserved(unreservedName));
+            parseCreateType(unreservedName);
+        }
+    }
+
+    private void assertTypeCreationParseFails(String typeName)
+    {
+        try
+        {
+            parseCreateType(typeName);
+            fail(String.format("Reserved type name %s should not have parsed", typeName));
+        }
+        catch (SyntaxException exception)
+        {
+            // Expected
+        }
+    }
+
+    private void parseCreateType(String typeName)
+    {
+        QueryProcessor.parseStatement(String.format("CREATE TYPE ks.%s (id int)", typeName));
+    }
+}


### PR DESCRIPTION
The following fixes are included in this PR:

- Bring in CNDB-1889 changes from DSE to allow  quoting of user type reserved names
- Fix comparison of table options in table_properties_ignored guardrail