### PR TITLE
STAR-1600 DSE changes around schema changes for offline services

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -403,11 +403,14 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         indexManager.reload();
 
         memtableFactory = metadata().params.memtable.factory;
-        Memtable currentMemtable = data.getView().getCurrentMemtable();
-        if (currentMemtable.shouldSwitch(FlushReason.SCHEMA_CHANGE))
-            switchMemtableIfCurrent(currentMemtable, FlushReason.SCHEMA_CHANGE);
-        else
-            currentMemtable.metadataUpdated();
+        if (!data.getView().liveMemtables.isEmpty())
+        {
+            Memtable currentMemtable = data.getView().getCurrentMemtable();
+            if (currentMemtable.shouldSwitch(FlushReason.SCHEMA_CHANGE))
+                switchMemtableIfCurrent(currentMemtable, FlushReason.SCHEMA_CHANGE);
+            else
+                currentMemtable.metadataUpdated();
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3325,7 +3325,17 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         if (DatabaseDescriptor.isAutoSnapshot())
             snapshot(Keyspace.getTimestampedSnapshotNameWithPrefix(name, ColumnFamilyStore.SNAPSHOT_DROP_PREFIX));
 
-        CommitLog.instance.forceRecycleAllSegments(Collections.singleton(metadata.id));
+        if (getTracker().isDummy())
+        {
+            // offline services (e.g. standalone compactor) don't have Memtables or CommitLog. An attempt to flush would
+            // throw an exception
+            logger.debug("Memtables and CommitLog are disabled; not recycling or flushing {}", metadata);
+        }
+        else
+        {
+            logger.debug("Recycling CL segments for dropping {}", metadata);
+            CommitLog.instance.forceRecycleAllSegments(Collections.singleton(metadata.id));
+        }
 
         strategyContainer.shutdown();
 

--- a/src/java/org/apache/cassandra/db/Keyspace.java
+++ b/src/java/org/apache/cassandra/db/Keyspace.java
@@ -415,7 +415,10 @@ public class Keyspace
     // disassociate a cfs from this keyspace instance.
     private void unloadCf(ColumnFamilyStore cfs, boolean dropData)
     {
-        cfs.unloadCf();
+        // offline services (e.g. standalone compactor) don't have Memtables or CommitLog. An attempt to flush would
+        // throw an exception
+        if (!cfs.getTracker().isDummy())
+            cfs.unloadCf();
         cfs.invalidate(true, dropData);
     }
 


### PR DESCRIPTION
Offline services don't create memtables and thus may not flush on schema changes 
and tenant unassignment. Without the ported changes the following (or similar) 
exceptions were thrown.
```
java.lang.IndexOutOfBoundsException: Index: -1
        at java.base/java.util.Collections$EmptyList.get(Collections.java:4483)
        at org.apache.cassandra.db.lifecycle.View.getCurrentMemtable(View.java:106)
        at org.apache.cassandra.db.ColumnFamilyStore.reload(ColumnFamilyStore.java:406)
        at org.apache.cassandra.schema.Schema.alterTable(Schema.java:787)
        at org.apache.cassandra.schema.Schema.lambda$alterKeyspace$17(Schema.java:696)
        at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:407)
        at org.apache.cassandra.schema.Schema.alterKeyspace(Schema.java:696)
        at org.apache.cassandra.schema.Schema.lambda$merge$12(Schema.java:667)
        at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:407)
        at org.apache.cassandra.schema.Schema.merge(Schema.java:667)
        at org.apache.cassandra.schema.Schema.mergeAndUpdateVersion(Schema.java:633)
        at com.datastax.cndb.metadata.schema.CloudSchemaUpdateHandler.updateSchemaLocally(CloudSchemaUpdateHandler.java:284)
        at com.datastax.cndb.metadata.schema.CloudSchemaUpdateHandler.onNewSchemaVersion(CloudSchemaUpdateHandler.java:118)
        at com.datastax.cndb.metadata.schema.SchemaTracker.onNewSchema(SchemaTracker.java:440)
        at com.datastax.cndb.metadata.schema.SchemaTracker.onNewSchema(SchemaTracker.java:431)
        at com.datastax.cndb.metadata.schema.SchemaTracker.lambda$startTracker$1(SchemaTracker.java:136)
        at io.etcd.jetcd.Watch$1.onNext(Watch.java:163)
        at com.datastax.cndb.etcd.ResilientWatcher$ProxyListener.onNext(ResilientWatcher.java:190)
        at io.etcd.jetcd.WatchImpl$WatcherImpl.onNext(WatchImpl.java:268)
        at io.etcd.jetcd.WatchImpl$WatcherImpl.onNext(WatchImpl.java:101)
        at io.etcd.jetcd.shaded.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onMessage(ClientCalls.java:465)
        at io.etcd.jetcd.shaded.io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
        at io.etcd.jetcd.shaded.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:652)
        at io.etcd.jetcd.shaded.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:637)
        at io.etcd.jetcd.shaded.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.etcd.jetcd.shaded.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834), ERROR [pulsar-external-listener-7-1]

```