### PR TITLE
STAR-1598 port CNDB-3932

### DIFF
--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -557,6 +557,7 @@ public class TableMetadata implements SchemaElement
             || !regularAndStaticColumns.equals(updated.regularAndStaticColumns)
             || !indexes.equals(updated.indexes)
             || params.defaultTimeToLive != updated.params.defaultTimeToLive
+            || params.cdc != updated.params.cdc
             || params.gcGraceSeconds != updated.params.gcGraceSeconds
             || ( !Flag.isCQLTable(flags) && Flag.isCQLTable(updated.flags) );
     }

--- a/test/unit/org/apache/cassandra/schema/TableMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/TableMetadataTest.java
@@ -148,4 +148,23 @@ public class TableMetadataTest
         assertThat(memtableParams.factory).isInstanceOf(CustomMemtableFactory.class);
         assertThat(memtableParams.options).isEmpty();
     }
+
+    @Test
+    public void testCdcParamsChangeAffectsPreparedStatements()
+    {
+        String keyspaceName = "ks1";
+        String tableName = "tbl1";
+        TableParams noCdcParams = TableParams.builder().cdc(false).build();
+        TableParams cdcParams = TableParams.builder().cdc(true).build();
+
+        TableMetadata metadata = TableMetadata.builder(keyspaceName, tableName)
+                                              .addPartitionKeyColumn("key", UTF8Type.instance)
+                                              .params(noCdcParams)
+                                              .build();
+        TableMetadata updated = TableMetadata.builder(keyspaceName, tableName)
+                                             .addPartitionKeyColumn("key", UTF8Type.instance)
+                                             .params(cdcParams)
+                                             .build();
+        assertThat(metadata.changeAffectsPreparedStatements(updated)).isTrue();
+    }
 }


### PR DESCRIPTION
If a user creates a prepared statement for a table and then enables the
CDC param, the prepared statement must be invalidated.

If we don't invalidate the prepared statement it'll be executed using
the old TableMetadata object and take the non-CDC write path and go
directly to CNDB writers instead of via Pulsar topics.