### PR TITLE
STAR-1477: Port the rest of cndb-1116 to fix billing during tracing

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -791,6 +791,7 @@ public class QueryProcessor implements QueryHandler
     throws RequestExecutionException, RequestValidationException
     {
         ClientState clientState = queryState.getClientState().cloneWithKeyspaceIfSet(options.getKeyspace());
+        Tracing.setupTracedKeyspace(batch);
         batch.authorize(clientState);
         batch.validate();
         batch.validate(queryState);

--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -269,6 +269,8 @@ public class QueryProcessor implements QueryHandler
         statement.authorize(clientState);
         statement.validate(queryState);
 
+        Tracing.setupTracedKeyspace(statement);
+
         for (QueryInterceptor interceptor: interceptors)
         {
             ResultMessage result = interceptor.interceptStatement(statement, queryState, options, queryStartNanoTime);

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -155,17 +155,6 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
         return state.get().ttl;
     }
 
-    @Nullable
-    public String getKeyspace()
-    {
-        assert isTracing();
-
-        if (state.get().clientState instanceof TracingClientState)
-            return ((TracingClientState) state.get().clientState).tracedKeyspace();
-
-        return null;
-    }
-
     /**
      * set traced keyspace into trace state which is later used to for billing to track source tenant at replicas.
      */

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,9 @@ import org.slf4j.LoggerFactory;
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.concurrent.ExecutorLocal;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.cql3.statements.ModificationStatement;
 import org.apache.cassandra.db.marshal.TimeUUIDType;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -160,6 +164,30 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
             return ((TracingClientState) state.get().clientState).tracedKeyspace();
 
         return null;
+    }
+
+    /**
+     * set traced keyspace into trace state which is later used to for billing to track source tenant at replicas.
+     */
+    public static void setupTracedKeyspace(CQLStatement statement)
+    {
+        if (!Tracing.isTracing())
+            return;
+
+        String keyspace = null;
+        if (statement instanceof CQLStatement.SingleKeyspaceCqlStatement)
+        {
+            keyspace = ((CQLStatement.SingleKeyspaceCqlStatement) statement).keyspace();
+        }
+
+        if (keyspace == null && statement instanceof BatchStatement)
+        {
+            // for batch statement, just pick any keyspace, as it's only used to extract tenant id in BillingQueryInfoTracker
+            List<ModificationStatement> batches = ((BatchStatement) statement).getStatements();
+            if (batches.size() > 0)
+                keyspace = batches.get(0).keyspace();
+        }
+        Tracing.instance.get().tracedKeyspace(keyspace);
     }
 
     /**
@@ -329,7 +357,7 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
 
         addToMutable.put(ParamType.TRACE_SESSION, Tracing.instance.getSessionId());
         addToMutable.put(ParamType.TRACE_TYPE, Tracing.instance.getTraceType());
-        String keyspace = Tracing.instance.getKeyspace();
+        String keyspace = Tracing.instance.get().tracedKeyspace();
         if (keyspace != null)
         {
             addToMutable.put(ParamType.TRACE_KEYSPACE, keyspace);

--- a/test/unit/org/apache/cassandra/tracing/TracingTest.java
+++ b/test/unit/org/apache/cassandra/tracing/TracingTest.java
@@ -181,7 +181,7 @@ public final class TracingTest
 
         assert keyspace.equals(((TracingClientState)tracing.get().clientState).tracedKeyspace());
         assert keyspace.equals(((TracingClientState)tracing.get(sessionId).clientState).tracedKeyspace());
-        assert keyspace.equals(tracing.getKeyspace());
+        assert keyspace.equals(tracing.get().tracedKeyspace());
 
         Map<ParamType, Object> headers = tracing.addTraceHeaders(new HashMap<>());
         assert keyspace.equals(headers.get(ParamType.TRACE_KEYSPACE));


### PR DESCRIPTION
We need to set the tracing keyspace per-statement since this info needs
to be passed from the coordinator to the writers in CNDB.

Without this change, the writer knows that a query is being traced but
not the keyspace/tenant and instead it'll bill the shared tenant.