### PR TITLE
STAR-1502: Fix JVMStabilityInspector behavior on CorruptSSTableException

### DIFF
--- a/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
+++ b/src/java/org/apache/cassandra/service/DefaultFSErrorHandler.java
@@ -50,6 +50,10 @@ public class DefaultFSErrorHandler implements FSErrorHandler
                 logger.error("Stopping transports as disk_failure_policy is " + DatabaseDescriptor.getDiskFailurePolicy());
                 StorageService.instance.stopTransports();
                 break;
+
+            case die:
+                JVMStabilityInspector.killCurrentJVM(e, false);
+                break;
         }
     }
 

--- a/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
+++ b/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
@@ -135,10 +135,6 @@ public final class JVMStabilityInspector
             isUnstable = true;
         }
 
-        if (DatabaseDescriptor.getDiskFailurePolicy() == Config.DiskFailurePolicy.die)
-            if (t instanceof FSError || t instanceof CorruptSSTableException)
-                isUnstable = true;
-
         fn.accept(t);
 
         // Check for file handle exhaustion


### PR DESCRIPTION
The problem here was that JVMStabilityInspector killed JVM in face of
CorruptSSTableException when the policy was set to die, regardless what
handlers were set.