### PR TITLE
STAR-1491 Use StorageProvider.getLocalPath in PathUtils.rename to ensure local paths when renaming files

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.Version;
-import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -46,7 +45,6 @@ import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
-import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -280,13 +278,10 @@ public class MetadataSerializer implements IMetadataSerializer
             Throwables.throwIfInstanceOf(e, FileNotFoundException.class);
             throw new FSWriteError(e, filePath);
         }
-        File toLocalFile = StorageProvider.instance.getLocalPath(descriptor.fileFor(Component.STATS));
         // we cant move a file on top of another file in windows:
         if (FBUtilities.isWindows)
-        {
-            toLocalFile.tryDelete();
-        }
-        filePath.move(toLocalFile);
+            descriptor.fileFor(Component.STATS).tryDelete();
+        filePath.move(descriptor.fileFor(Component.STATS));
     }
 
     public void updateSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> updatedComponents) throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.Version;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -279,11 +280,13 @@ public class MetadataSerializer implements IMetadataSerializer
             Throwables.throwIfInstanceOf(e, FileNotFoundException.class);
             throw new FSWriteError(e, filePath);
         }
+        File localPath = StorageProvider.instance.getLocalPath(descriptor.fileFor(Component.STATS));
         // we cant move a file on top of another file in windows:
         if (FBUtilities.isWindows)
-            descriptor.fileFor(Component.STATS).tryDelete();
-        filePath.move(descriptor.fileFor(Component.STATS));
-
+        {
+            localPath.tryDelete();
+        }
+        filePath.move(localPath);
     }
 
     public void updateSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> updatedComponents) throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -280,13 +280,13 @@ public class MetadataSerializer implements IMetadataSerializer
             Throwables.throwIfInstanceOf(e, FileNotFoundException.class);
             throw new FSWriteError(e, filePath);
         }
-        File localPath = StorageProvider.instance.getLocalPath(descriptor.fileFor(Component.STATS));
+        File toLocalFile = StorageProvider.instance.getLocalPath(descriptor.fileFor(Component.STATS));
         // we cant move a file on top of another file in windows:
         if (FBUtilities.isWindows)
         {
-            localPath.tryDelete();
+            toLocalFile.tryDelete();
         }
-        filePath.move(localPath);
+        filePath.move(toLocalFile);
     }
 
     public void updateSSTableMetadata(Descriptor descriptor, Map<MetadataType, MetadataComponent> updatedComponents) throws IOException

--- a/src/java/org/apache/cassandra/io/storage/StorageProvider.java
+++ b/src/java/org/apache/cassandra/io/storage/StorageProvider.java
@@ -83,6 +83,11 @@ public interface StorageProvider
     File getLocalPath(File path);
 
     /**
+     * @return local path if given path is remote path, otherwise returns itself
+     */
+    Path getLocalPath(Path path);
+
+    /**
      * update the given path with open options for the sstable components
      */
     File withOpenOptions(File ret, Component component);
@@ -117,6 +122,12 @@ public interface StorageProvider
     {
         @Override
         public File getLocalPath(File path)
+        {
+            return path;
+        }
+
+        @Override
+        public Path getLocalPath(Path path)
         {
             return path;
         }

--- a/src/java/org/apache/cassandra/io/util/PathUtils.java
+++ b/src/java/org/apache/cassandra/io/util/PathUtils.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 import static java.nio.file.StandardOpenOption.*;
@@ -459,7 +460,7 @@ public final class PathUtils
         // and Windows is picky about that.
         try
         {
-            atomicMoveWithFallback(from, to);
+            atomicMoveWithFallback(StorageProvider.instance.getLocalPath(from), StorageProvider.instance.getLocalPath(to));
             return true;
         }
         catch (IOException e)
@@ -476,7 +477,7 @@ public final class PathUtils
         // and Windows is picky about that.
         try
         {
-            atomicMoveWithFallback(from, to);
+            atomicMoveWithFallback(StorageProvider.instance.getLocalPath(from), StorageProvider.instance.getLocalPath(to));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Use StorageProvider.getLocalPath in PathUtils.rename to ensure local paths when renaming files.

Note: this will require CNDB to implement `StorageProvider.getLocalPath(Path path)` in addition to the existing method that takes a `File` parameter.