### PR TITLE
STAR-1639: Use repo.datastax.com/dse as alternative repository

### DIFF
--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -54,8 +54,9 @@
 
         <typedef uri="antlib:org.apache.maven.resolver.ant" resource="org/apache/maven/resolver/ant/antlib.xml" classpathref="resolver-ant-tasks.classpath" />
         <resolver:remoterepos id="all">
-            <remoterepo id="resolver-central" url="${artifact.remoteRepository.central}"/>
-            <remoterepo id="resolver-apache" url="${artifact.remoteRepository.apache}"/>
+            <remoterepo id="resolver-central"  url="${artifact.remoteRepository.central}"/>
+            <remoterepo id="resolver-apache"   url="${artifact.remoteRepository.apache}"/>
+            <remoterepo id="resolver-datastax" url="${artifact.remoteRepository.datastax}"/>
         </resolver:remoterepos>
 
         <macrodef name="resolve">

--- a/build.properties.default
+++ b/build.properties.default
@@ -1,4 +1,4 @@
 # Maven2 Repository Locations (you can override these in "build.properties" to point to a local proxy, e.g. Nexus)
 artifact.remoteRepository.central:     https://repo1.maven.org/maven2
 artifact.remoteRepository.apache:      https://repo.maven.apache.org/maven2
-
+artifact.remoteRepository.datastax:    https://repo.datastax.com/dse


### PR DESCRIPTION
Basically, use repo.datastax.com as additional repository rather than a replacement of the public repos.