### PR TITLE
STAR-1641 Cached mutation serialization

### DIFF
--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -29,27 +29,27 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 
+import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.DeserializationHelper;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
-import static org.apache.cassandra.net.MessagingService.VERSION_30;
-import static org.apache.cassandra.net.MessagingService.VERSION_3014;
-import static org.apache.cassandra.net.MessagingService.VERSION_40;
-import static org.apache.cassandra.net.MessagingService.VERSION_41;
-import static org.apache.cassandra.net.MessagingService.VERSION_SG_10;
 import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 
 public class Mutation implements IMutation
@@ -70,6 +70,13 @@ public class Mutation implements IMutation
     final AtomicLong viewLockAcquireStart = new AtomicLong(0);
 
     private final boolean cdcEnabled;
+
+    // Contains serialized representations of this mutation.
+    // Note: there is no functionality to clear/remove serialized instances, because a mutation must never
+    // be modified (e.g. calling add(PartitionUpdate)) when it's being serialized.
+    private static final int CACHED_SERIALIZATIONS = MessagingService.Version.values().length;
+    private static final int CACHEABLE_MUTATION_SIZE_LIMIT = Integer.getInteger(Config.PROPERTY_PREFIX + "cacheable_mutation_size_limit_bytes", 2 * 1024 * 1024) - 24;
+    private final Serialization[] serializations = new Serialization[CACHED_SERIALIZATIONS];
 
     public Mutation(PartitionUpdate update)
     {
@@ -282,39 +289,14 @@ public class Mutation implements IMutation
         }
         return buff.append("])").toString();
     }
-    private int serializedSize30;
-    private int serializedSize3014;
-    private int serializedSize40;
-    private int serializedSize41;
-    private int serializedSizeSG10;
+
+    private int serializedSize;
 
     public int serializedSize(int version)
     {
-        switch (version)
-        {
-            case VERSION_30:
-                if (serializedSize30 == 0)
-                    serializedSize30 = (int) serializer.serializedSize(this, VERSION_30);
-                return serializedSize30;
-            case VERSION_3014:
-                if (serializedSize3014 == 0)
-                    serializedSize3014 = (int) serializer.serializedSize(this, VERSION_3014);
-                return serializedSize3014;
-            case VERSION_40:
-                if (serializedSize40 == 0)
-                    serializedSize40 = (int) serializer.serializedSize(this, VERSION_40);
-                return serializedSize40;
-            case VERSION_41:
-                if (serializedSize41 == 0)
-                    serializedSize41 = (int) serializer.serializedSize(this, VERSION_41);
-                return serializedSize41;
-            case VERSION_SG_10:
-                if (serializedSizeSG10 == 0)
-                    serializedSizeSG10 = (int) serializer.serializedSize(this, VERSION_SG_10);
-                return serializedSizeSG10;
-            default:
-                throw new IllegalStateException("Unknown serialization version: " + version);
-        }
+        if (serializedSize == 0)
+            serializedSize = (int) serializer.serializedSize(this, version);
+        return serializedSize;
     }
 
     /**
@@ -394,13 +376,94 @@ public class Mutation implements IMutation
 
         public void serialize(Mutation mutation, DataOutputPlus out, int version) throws IOException
         {
+            serialization(mutation, version).serialize(partitionUpdateSerializer, mutation, out, version);
+        }
+
+        /**
+         * Called early during request processing to prevent that {@link #serialization(Mutation)} is
+         * called concurrently.
+         * See {@link org.apache.cassandra.service.StorageProxy#sendToHintedEndpoints(Mutation, WriteEndpoints, WriteHandler, Verb.AckedRequest)}.
+         */
+        @SuppressWarnings("JavadocReference")
+        public void prepareSerializedBuffer(Mutation mutation, int version)
+        {
+            serialization(mutation, version);
+        }
+
+        /**
+         * Retrieve the cached serialization of this mutation, or computed and cache said serialization if it doesn't
+         * exists yet. Note that this method is _not_ synchronized even though it may (and will often) be called
+         * concurrently. Concurrent calls are still safe however, the only risk is that the value is not cached yet,
+         * multiple concurrent calls may compute it multiple times instead of just once. This is ok as in practice
+         * as we make sure this doesn't happen in the hot path by forcing the initial caching in
+         * {@link org.apache.cassandra.service.StorageProxy#sendToHintedEndpoints(Mutation, WriteEndpoints, WriteHandler, Verb.AckedRequest)}
+         * via {@link #prepareSerializedBuffer(Mutation)}, which is the only caller that passes
+         * {@code isPrepare==true}.
+         */
+        @SuppressWarnings("JavadocReference")
+        private Serialization serialization(Mutation mutation, int version)
+        {
+            int versionIndex = MessagingService.getVersion(version).ordinal();
+            // Retrieves the cached version, or build+cache it if it's not cached already.
+            Serialization serialization = mutation.serializations[versionIndex];
+            if (serialization == null)
+            {
+                // We need to use a capacity-limited DOB here. See DSP-19998
+                // If a mutation consists of one PartitionUpdate with one column that exceeds the
+                // "cacheable-mutation-size-limit", a capacity-limited DOB can handle that case and
+                // throw a BufferCapacityExceededException. "Huge" serialized mutations can have a
+                // bad impact to G1 GC, if the cached serialized mutation results in a
+                // "humonguous object" and also frequent re-allocations of the scratch buffer(s).
+                // I.e. large cached mutation objects cause GC pressure.
+                try (DataOutputBuffer dob = DataOutputBuffer.limitedScratchBuffer(CACHEABLE_MUTATION_SIZE_LIMIT))
+                {
+                    if (!serializeInternal(partitionUpdateSerializer, mutation, dob, version,true))
+                    {
+                        serialization = new NonCacheableSerialization();
+                    }
+                    else
+                    {
+                        serialization = new CachedSerialization(dob.toByteArray());
+                    }
+                }
+                catch (DataOutputBuffer.BufferCapacityExceededException tooBig)
+                {
+                    serialization = new NonCacheableSerialization();
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                mutation.serializations[versionIndex] = serialization;
+            }
+            return serialization;
+        }
+
+        static boolean serializeInternal(PartitionUpdate.PartitionUpdateSerializer serializer,
+                                         Mutation mutation,
+                                         DataOutputPlus out,
+                                         int version,
+                                         boolean isPrepare) throws IOException
+        {
+            Map<TableId, PartitionUpdate> modifications = mutation.modifications;
+
             /* serialize the modifications in the mutation */
-            int size = mutation.modifications.size();
+            int size = modifications.size();
             out.writeUnsignedVInt(size);
 
             assert size > 0;
-            for (Map.Entry<TableId, PartitionUpdate> entry : mutation.modifications.entrySet())
-                partitionUpdateSerializer.serialize(entry.getValue(), out, version);
+            for (PartitionUpdate partitionUpdate : modifications.values())
+            {
+                serializer.serialize(partitionUpdate, out, version);
+                if (isCacheableMutationSizeLimit(out, isPrepare))
+                    return false;
+            }
+            return true;
+        }
+
+        private static boolean isCacheableMutationSizeLimit(DataOutputPlus out, boolean isPrepare)
+        {
+            return isPrepare && out.position() > CACHEABLE_MUTATION_SIZE_LIMIT;
         }
 
         public Mutation deserialize(DataInputPlus in, int version, DeserializationHelper.Flag flag) throws IOException
@@ -431,10 +494,72 @@ public class Mutation implements IMutation
 
         public long serializedSize(Mutation mutation, int version)
         {
-            int size = TypeSizes.sizeofUnsignedVInt(mutation.modifications.size());
-            for (Map.Entry<TableId, PartitionUpdate> entry : mutation.modifications.entrySet())
-                size += partitionUpdateSerializer.serializedSize(entry.getValue(), version);
+            return serialization(mutation, version).serializedSize(partitionUpdateSerializer, mutation, version);
+        }
+    }
 
+    /**
+     * There are two implementations of this class. One that keeps the serialized representation on-heap for later
+     * reuse and one that doesn't. The original implementation of DB-370 always kept the serialized representation
+     * around. This may lead to "bad" GC pressure (G1 GC) due to humongous objects (see DSP-19998).
+     * By default serialized mutations up to 2MB are kept on-heap - see {@link #CACHEABLE_MUTATION_SIZE_LIMIT}.
+     */
+    private static abstract class Serialization
+    {
+        abstract void serialize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, DataOutputPlus out, int version) throws IOException;
+
+        abstract long serializedSize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, int version);
+    }
+
+    /**
+     * Represents the cached serialization of a {@link Mutation} as a {@code byte[]}.
+     */
+    private static final class CachedSerialization extends Serialization
+    {
+        private final byte[] serialized;
+
+        CachedSerialization(byte[] serialized)
+        {
+            this.serialized = Preconditions.checkNotNull(serialized);
+        }
+
+        @Override
+        void serialize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, DataOutputPlus out, int version) throws IOException
+        {
+            out.write(serialized);
+        }
+
+        @Override
+        long serializedSize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, int version)
+        {
+            return serialized.length;
+        }
+    }
+
+    /**
+     * Represents a non-cacheable serialization of a {@link Mutation}, only the size of the mutation is lazily cached.
+     */
+    private static final class NonCacheableSerialization extends Serialization
+    {
+        private volatile long size;
+
+        @Override
+        void serialize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, DataOutputPlus out, int version) throws IOException
+        {
+            MutationSerializer.serializeInternal(serializer, mutation, out, version,false);
+        }
+
+        @Override
+        long serializedSize(PartitionUpdate.PartitionUpdateSerializer serializer, Mutation mutation, int version)
+        {
+            long size = this.size;
+            if (size == 0L)
+            {
+                size = TypeSizes.sizeofUnsignedVInt(mutation.modifications.size());
+                for (PartitionUpdate partitionUpdate : mutation.modifications.values())
+                    size += serializer.serializedSize(partitionUpdate, version);
+                this.size = size;
+            }
             return size;
         }
     }

--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -403,7 +403,7 @@ public class Mutation implements IMutation
         @SuppressWarnings("JavadocReference")
         private Serialization serialization(Mutation mutation, int version)
         {
-            int versionIndex = MessagingService.getVersion(version).ordinal();
+            int versionIndex = MessagingService.getVersionIndex(version);
             // Retrieves the cached version, or build+cache it if it's not cached already.
             Serialization serialization = mutation.serializations[versionIndex];
             if (serialization == null)

--- a/src/java/org/apache/cassandra/io/util/DataOutputBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/DataOutputBuffer.java
@@ -57,22 +57,61 @@ public class DataOutputBuffer extends BufferedDataOutputStreamPlus
         @Override
         protected DataOutputBuffer initialValue()
         {
-            return new DataOutputBuffer()
-            {
-                public void close()
-                {
-                    if (buffer.capacity() <= MAX_RECYCLE_BUFFER_SIZE)
-                    {
-                        buffer.clear();
-                    }
-                    else
-                    {
-                        buffer = ByteBuffer.allocate(DEFAULT_INITIAL_BUFFER_SIZE);
-                    }
-                }
-            };
+            return new LimitingScratchBuffer();
         }
     };
+
+    /**
+     * Returns a {@link DataOutputBuffer} that is limited to a capacity of {@code limit} bytes.
+     * A {@code limit} of 0 means unlimited.
+     */
+    public static DataOutputBuffer limitedScratchBuffer(long limit)
+    {
+        LimitingScratchBuffer dob = (LimitingScratchBuffer) scratchBuffer.get();
+        dob.limit = limit;
+        return dob;
+    }
+
+    public static class BufferCapacityExceededException extends RuntimeException
+    {}
+
+    private static final class LimitingScratchBuffer extends DataOutputBuffer
+    {
+        private final ByteBuffer initialSizeBuffer;
+        long limit = 0L;
+
+        LimitingScratchBuffer()
+        {
+            super();
+            initialSizeBuffer = buffer;
+        }
+
+        @Override
+        long calculateNewSize(long count)
+        {
+            if (limit == 0L)
+                return super.calculateNewSize(count);
+
+            // capacity limited scratch buffer
+            long target = count + capacity();
+            long newSize = super.calculateNewSize(count);
+            newSize = Math.min(limit, newSize);
+            if (newSize < target)
+                throw new BufferCapacityExceededException();
+            return newSize;
+        }
+
+        @Override
+        public void close()
+        {
+            limit = 0L;
+            if (buffer.capacity() > MAX_RECYCLE_BUFFER_SIZE)
+            {
+                buffer = initialSizeBuffer;
+            }
+            buffer.clear();
+        }
+    }
 
     public DataOutputBuffer()
     {

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -219,7 +219,17 @@ public class MessagingService extends MessagingServiceMBeanImpl
     static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version);
     static AcceptVersions accept_streaming = new AcceptVersions(current_version, current_version);
 
-    static Map<Integer, Version> versionMap = Arrays.stream(Version.values()).collect(Collectors.toMap(version -> version.value, version -> version));
+    static Map<Integer, Integer> versionIndexMap = new HashMap<>();
+
+    static
+    {
+        versionIndexMap.put(VERSION_30, 0);
+        versionIndexMap.put(VERSION_3014, 1);
+        versionIndexMap.put(VERSION_40, 2);
+        versionIndexMap.put(VERSION_41, 3);
+        versionIndexMap.put(VERSION_SG_10, 4);
+        versionIndexMap.put(VERSION_DSE_68, 5);
+    }
 
     /**
      * This is an optimisation to speed up the translation of the serialization
@@ -228,10 +238,10 @@ public class MessagingService extends MessagingServiceMBeanImpl
      * @param version the serialization version
      * @return a {@link Version}
      */
-    public static Version getVersion(int version)
+    public static int getVersionIndex(int version)
     {
-        if (versionMap.containsKey(version))
-            return versionMap.get(version);
+        if (versionIndexMap.containsKey(version))
+            return versionIndexMap.get(version);
         throw new IllegalStateException("Unkown serialization version: " + version);
     }
 
@@ -243,8 +253,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
         VERSION_3014(MessagingService.VERSION_3014),
         VERSION_40(MessagingService.VERSION_40),
         VERSION_41(MessagingService.VERSION_41),
-        STARGAZER_10(MessagingService.VERSION_SG_10),
-        DSE_68(MessagingService.VERSION_DSE_68);
+        STARGAZER_10(MessagingService.VERSION_SG_10);
 
         public final int value;
 

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -19,10 +19,14 @@ package org.apache.cassandra.net;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -215,6 +219,22 @@ public class MessagingService extends MessagingServiceMBeanImpl
     static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version);
     static AcceptVersions accept_streaming = new AcceptVersions(current_version, current_version);
 
+    static Map<Integer, Version> versionMap = Arrays.stream(Version.values()).collect(Collectors.toMap(version -> version.value, version -> version));
+
+    /**
+     * This is an optimisation to speed up the translation of the serialization
+     * version to the {@link Version} enum.
+     *
+     * @param version the serialization version
+     * @return a {@link Version}
+     */
+    public static Version getVersion(int version)
+    {
+        if (versionMap.containsKey(version))
+            return versionMap.get(version);
+        throw new IllegalStateException("Unkown serialization version: " + version);
+    }
+
     public final static boolean NON_GRACEFUL_SHUTDOWN = Boolean.getBoolean("cassandra.test.messagingService.nonGracefulShutdown");
 
     public enum Version
@@ -223,7 +243,8 @@ public class MessagingService extends MessagingServiceMBeanImpl
         VERSION_3014(MessagingService.VERSION_3014),
         VERSION_40(MessagingService.VERSION_40),
         VERSION_41(MessagingService.VERSION_41),
-        STARGAZER_10(MessagingService.VERSION_SG_10);
+        STARGAZER_10(MessagingService.VERSION_SG_10),
+        DSE_68(MessagingService.VERSION_DSE_68);
 
         public final int value;
 

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1488,6 +1488,15 @@ public class StorageProxy implements StorageProxyMBean
 
         List<InetAddressAndPort> backPressureHosts = null;
 
+        // For performance, Mutation caches serialized buffers that are computed lazily in serializedBuffer(). That
+        // computation is not synchronized however and we will potentially call that method concurrently for each
+        // dispatched message (not that concurrent calls to serializedBuffer() are "unsafe" per se, just that they
+        // may result in multiple computations, making the caching optimization moot). So forcing the serialization
+        // here to make sure it's already cached/computed when it's concurrently used later.
+        // Side note: we have one cached buffers for each used EncodingVersion and this only pre-compute the one for
+        // the current version, but it's just an optimization and we're ok not optimizing for mixed-version clusters.
+        Mutation.serializer.prepareSerializedBuffer(mutation, MessagingService.current_version);
+
         for (Replica destination : plan.contacts())
         {
             checkHintOverload(destination);

--- a/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
+++ b/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
@@ -43,6 +43,8 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
+import static org.junit.Assert.fail;
+
 public class DataOutputTest
 {
     @BeforeClass
@@ -246,6 +248,32 @@ public class DataOutputTest
             checkThrowsException(validateReallocationCallable( write, 0), BufferOverflowException.class);
             checkThrowsException(validateReallocationCallable( write, 1), BufferOverflowException.class);
             checkThrowsIAE(validateReallocationCallable( write, -1));
+        }
+    }
+
+    @Test
+    public void testDataOutputBufferLimitingScratchBuffer() throws IOException
+    {
+        // Note the default minimum buffer size is 128 so our limit needs
+        // to be >128 bytes for this test to work
+        DataOutputBuffer write = DataOutputBuffer.limitedScratchBuffer(200);
+        // Should accept less than the limit
+        write.write(new byte[199]);
+        write.clear();
+
+        // Should accept the limit
+        write.write(new byte[200]);
+        write.clear();
+
+        // More than the limit will throw
+        try
+        {
+            write.write(new byte[201]);
+            fail("Should have failed with BufferCapacityExceededException");
+        }
+        catch (DataOutputBuffer.BufferCapacityExceededException e)
+        {
+            // Ignore as a pass
         }
     }
 


### PR DESCRIPTION
 This introduces a per-mutation cache of the
 serialized representation of the mutation.