### PR TITLE
STAR-1492: Track compaction ops during validation

### DIFF
--- a/src/java/org/apache/cassandra/db/repair/CassandraValidationIterator.java
+++ b/src/java/org/apache/cassandra/db/repair/CassandraValidationIterator.java
@@ -279,6 +279,12 @@ public class CassandraValidationIterator extends ValidationPartitionIterator
     }
 
     @Override
+    public CompactionIterator getCompactionIterator()
+    {
+        return ci;
+    }
+
+    @Override
     public boolean hasNext()
     {
         return ci.hasNext();

--- a/src/java/org/apache/cassandra/repair/ValidationPartitionIterator.java
+++ b/src/java/org/apache/cassandra/repair/ValidationPartitionIterator.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.repair;
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.cassandra.db.compaction.CompactionIterator;
 import org.apache.cassandra.db.partitions.AbstractUnfilteredPartitionIterator;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
@@ -30,4 +31,5 @@ public abstract class ValidationPartitionIterator extends AbstractUnfilteredPart
     public abstract long getEstimatedBytes();
     public abstract long estimatedPartitions();
     public abstract Map<Range<Token>, Long> getRangePartitionCounts();
+    public abstract CompactionIterator getCompactionIterator();
 }


### PR DESCRIPTION
This is required to fix `RegionRepairTest.testContinuousRepairNonZcs` because the validation scanned metrics are checked.