### PR TITLE
STAR-1492: Print message when repair syncing starts

### DIFF
--- a/src/java/org/apache/cassandra/repair/SyncTask.java
+++ b/src/java/org/apache/cassandra/repair/SyncTask.java
@@ -70,7 +70,7 @@ public abstract class SyncTask extends AbstractFuture<SyncStat> implements Runna
      */
     public final void run()
     {
-        if (Tracing.isTracing())
+        if (logger.isTraceEnabled())
             logger.trace("{} Starting sync {} <-> {}", previewKind.logPrefix(desc.sessionId), nodePair.coordinator, nodePair.peer);
 
         startTime = System.currentTimeMillis();

--- a/src/java/org/apache/cassandra/repair/SyncTask.java
+++ b/src/java/org/apache/cassandra/repair/SyncTask.java
@@ -70,6 +70,9 @@ public abstract class SyncTask extends AbstractFuture<SyncStat> implements Runna
      */
     public final void run()
     {
+        if (Tracing.isTracing())
+            logger.trace("{} Starting sync {} <-> {}", previewKind.logPrefix(desc.sessionId), nodePair.coordinator, nodePair.peer);
+
         startTime = System.currentTimeMillis();
 
 


### PR DESCRIPTION
This string is expected by CNDB's `RegionRepairTest.testRepairWithTruncate()` and adding it fixes that test for Converged Cassandra.