### PR TITLE
STAR-1478 Add Types parameter to DroppedColumn.prepare to avoid keyspace lookup

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -446,7 +446,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
             TableMetadata.Builder builder = table.unbuild().params(params);
             for (DroppedColumn.Raw record : attrs.droppedColumnRecords())
-                builder.recordColumnDrop(record.prepare(keyspaceName, tableName));
+                builder.recordColumnDrop(record.prepare(keyspaceName, tableName, keyspace.types));
 
             return keyspace.withSwapped(keyspace.tables.withSwapped(builder.build()));
         }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -328,7 +328,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
             });
         }
         for (DroppedColumn.Raw record : attrs.droppedColumnRecords())
-            builder.recordColumnDrop(record.prepare(keyspaceName, tableName));
+            builder.recordColumnDrop(record.prepare(keyspaceName, tableName, types));
         return builder;
     }
 

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -97,10 +97,10 @@ public final class DroppedColumn
             this.timestamp = timestamp;
         }
 
-        public DroppedColumn prepare(String keyspace, String table)
+        public DroppedColumn prepare(String keyspace, String table, Types types)
         {
             ColumnMetadata.Kind kind = isStatic ? ColumnMetadata.Kind.STATIC : ColumnMetadata.Kind.REGULAR;
-            AbstractType<?> parsedType = type.prepare(keyspace).getType();
+            AbstractType<?> parsedType = type.prepare(keyspace, types).getType();
             if (parsedType.referencesUserTypes())
                 throw invalidRequest("Invalid type %s for DROPPED COLUMN RECORD on %s: dropped column types should "
                                      + "not have user types", type, name);


### PR DESCRIPTION
This is needed in CNDB to avoid keyspace lookups that may fail when applying a schema during tenant assignment; this specifically is needed in `CommitLogTest. testCommitLogReplayAfterSchemaChange`