### PR TITLE
STAR-1660: Fix and prevent direct memory leaks in dtests

### DIFF
--- a/src/java/org/apache/cassandra/hints/HintsWriteExecutor.java
+++ b/src/java/org/apache/cassandra/hints/HintsWriteExecutor.java
@@ -70,6 +70,10 @@ final class HintsWriteExecutor
         {
             throw new AssertionError(e);
         }
+        finally
+        {
+            FileUtils.clean(writeBuffer);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -1524,7 +1524,7 @@ public class BufferPool
             if (parent != null)
                 parent.free(slab);
             else
-                FileUtils.clean(slab);
+                FileUtils.cleanWithAttachment(slab);
         }
 
         static void unsafeRecycle(Chunk chunk)

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -774,7 +774,13 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
 
         return CompletableFuture.runAsync(ThrowingRunnable.toRunnable(future::get), isolatedExecutor)
                                 .thenRun(super::shutdown)
-                                .thenRun(() -> startedAt.set(0L));
+                                .thenRun(() -> startedAt.set(0L))
+                                .thenRun(() -> {
+                                    // when the instance is eventually stopped, we need to release buffer pools manually
+                                    // they are assumed to gone along with JVM, but this is not the case in dtests
+                                    BufferPools.forNetworking().unsafeReset();
+                                    BufferPools.forChunkCache().unsafeReset();
+                                });
     }
 
     @Override


### PR DESCRIPTION
There are a couple of things here:
- `unsafeFree` method in `BufferPool` did not do what it was probably expected to do - that is, the direct buffer was not released properly because when it is allocated in `allocateDirectAligned` the method actually returns a slice of the original buffer, while the only reference to the original buffer is in `attachment` field of the returned buffer. It was mitigated by using a new method to clean, which can release the parent buffer by recursively go through the attachment hierarchy
- for in-jvm dtests, releasing of all buffers in buffer pools was added as the very last step of instance shutdown; it fixes memory leaking between the subsequent instance restarts; in production run, we just stop the JVM and the buffers are lost, but in case of those dtest we need to deal with that explicitly
- added also some sentinel to detect leaks in in-jvm dtests