### PR TITLE
STAR-1691: Port more bits of CNDB-4090

### DIFF
--- a/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.compress.CorruptBlockException;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.utils.ChecksumType;
 
 public abstract class CompressedChunkReader extends AbstractReaderFileProxy implements ChunkReader
@@ -161,6 +162,8 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
             }
             catch (CorruptBlockException e)
             {
+                StorageProvider.instance.invalidateFileSystemCache(channel.getFile());
+
                 // Make sure reader does not see stale data.
                 uncompressed.position(0).limit(0);
                 throw new CorruptSSTableException(e, channel.filePath());


### PR DESCRIPTION
In STAR-1335 we ported most of CNDB-4090 but we missed out a call to StorageProvider.invalidateFileSystemCache() which is required to invalidate the remote storage cache in CNDB whenever we encounter corruption.

This was discovered because the RemoteFileCacheCorruptedPageTest unit test is failing.