### PR TITLE
STAR-1697: Port keyspace renaming (KeyspaceMetadata::rename) from DB-…

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
@@ -21,16 +21,14 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.google.common.base.Objects;
+import org.apache.commons.lang3.text.StrBuilder;
 
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.CQL3Type.Tuple;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.CqlBuilder;
-import org.apache.cassandra.cql3.CqlBuilder.Appender;
 import org.apache.cassandra.db.marshal.AbstractType;
-
-import org.apache.commons.lang3.text.StrBuilder;
 
 import static java.util.stream.Collectors.toList;
 

--- a/src/java/org/apache/cassandra/cql3/functions/UDFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/UDFunction.java
@@ -100,6 +100,8 @@ public abstract class UDFunction extends AbstractFunction implements ScalarFunct
     "com/google/common/reflect/TypeToken",
     "java/io/IOException.class",
     "java/io/Serializable.class",
+    "java/io/ObjectOutputStream.class",
+    "java/io/ObjectInputStream.class",
     "java/lang/",
     "java/math/",
     "java/net/InetAddress.class",
@@ -684,6 +686,17 @@ public abstract class UDFunction extends AbstractFunction implements ScalarFunct
                          argNames,
                          Lists.newArrayList(transform(argTypes, t -> t.withUpdatedUserType(udt))),
                          returnType.withUpdatedUserType(udt),
+                         calledOnNullInput,
+                         language,
+                         body);
+    }
+
+    public UDFunction withNewKeyspace(String newKeyspace, Types types)
+    {
+        return tryCreate(new FunctionName(newKeyspace, name.name),
+                         argNames,
+                         Lists.newArrayList(transform(argTypes, t -> t.withUpdatedUserTypes(types))),
+                         returnType.withUpdatedUserTypes(types),
                          calledOnNullInput,
                          language,
                          body);

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -569,6 +569,22 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
+     * Returns an instance of this type with all references to the provided user types recursively replaced with their new
+     * definition.
+     */
+    public final AbstractType<?> withUpdatedUserTypes(Iterable<UserType> udts)
+    {
+        if (!referencesUserTypes())
+            return this;
+
+        AbstractType<?> type = this;
+        for (UserType udt : udts)
+            type = type.withUpdatedUserType(udt);
+
+        return type;
+    }
+
+    /**
      * Replace any instances of UserType with equivalent TupleType-s.
      *
      * We need it for dropped_columns, to allow safely dropping unused user types later without retaining any references

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -416,10 +416,10 @@ public class UserType extends TupleType implements SchemaElement
         {
             return isMultiCell == udt.isMultiCell
                  ? udt
-                 : new UserType(keyspace, name, udt.fieldNames(), udt.fieldTypes(), isMultiCell);
+                 : new UserType(udt.keyspace, name, udt.fieldNames(), udt.fieldTypes(), isMultiCell);
         }
 
-        return new UserType(keyspace,
+        return new UserType(udt.keyspace,
                             name,
                             fieldNames,
                             Lists.newArrayList(transform(fieldTypes(), t -> t.withUpdatedUserType(udt))),

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -252,6 +252,11 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         return new ColumnMetadata(ksName, cfName, name, type, position, kind, isDropped);
     }
 
+    public ColumnMetadata withNewKeyspace(String newKeyspace, Types udts)
+    {
+        return new ColumnMetadata(newKeyspace, cfName, name, type.withUpdatedUserTypes(udts), position, kind, isDropped);
+    }
+
     public ColumnMetadata withNewName(ColumnIdentifier newName)
     {
         return new ColumnMetadata(ksName, cfName, newName, type, position, kind, isDropped);

--- a/src/java/org/apache/cassandra/schema/DistributedSchema.java
+++ b/src/java/org/apache/cassandra/schema/DistributedSchema.java
@@ -30,7 +30,7 @@ public class DistributedSchema
 {
     public static final DistributedSchema EMPTY = new DistributedSchema(Keyspaces.none(), SchemaConstants.emptyVersion);
 
-    protected final Keyspaces keyspaces;
+    private final Keyspaces keyspaces;
     private final UUID version;
 
     public DistributedSchema(Keyspaces keyspaces, UUID version)

--- a/src/java/org/apache/cassandra/schema/DistributedSchema.java
+++ b/src/java/org/apache/cassandra/schema/DistributedSchema.java
@@ -30,7 +30,7 @@ public class DistributedSchema
 {
     public static final DistributedSchema EMPTY = new DistributedSchema(Keyspaces.none(), SchemaConstants.emptyVersion);
 
-    private final Keyspaces keyspaces;
+    protected final Keyspaces keyspaces;
     private final UUID version;
 
     public DistributedSchema(Keyspaces keyspaces, UUID version)

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -44,6 +44,11 @@ public final class DroppedColumn
         this.droppedTime = droppedTime;
     }
 
+    public DroppedColumn withNewKeyspace(String newKeyspace, Types udts)
+    {
+        return new DroppedColumn(column.withNewKeyspace(newKeyspace, udts), droppedTime);
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/src/java/org/apache/cassandra/schema/Functions.java
+++ b/src/java/org/apache/cassandra/schema/Functions.java
@@ -123,6 +123,14 @@ public final class Functions implements Iterable<Function>
         return builder().add(udfs).add(udas).build();
     }
 
+    public Functions withNewKeyspace(String newKeyspace, Types udts)
+    {
+        Collection<UDFunction> udfs = udfs().map(f -> f.withNewKeyspace(newKeyspace, udts)).collect(toList());
+        Collection<UDAggregate> udas = udas().map(f -> f.withNewKeyspace(newKeyspace, udfs, udts)).collect(toList());
+
+        return builder().add(udfs).add(udas).build();
+    }
+
     /**
      * @return a stream of aggregates that use the provided function as either a state or a final function
      * @param function the referree function

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -44,6 +44,7 @@ import org.github.jamm.Unmetered;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Maps.transformValues;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -588,6 +589,29 @@ public class TableMetadata implements SchemaElement
     boolean referencesUserType(ByteBuffer name)
     {
         return any(columns(), c -> c.type.referencesUserType(name));
+    }
+
+    /**
+     * Create a copy of this {@code TableMetadata} for a new keyspace.
+     *
+     * @param newKeyspace the name of the new keyspace
+     * @param udts the user defined types of the new keyspace
+     * @param tables the tables of the new keyspace
+     * @return a copy of this {@code TableMetadata} for a new keyspace
+     */
+    TableMetadata withNewKeyspace(String newKeyspace,
+                                  Types udts,
+                                  Map<String, TableMetadata> tables)
+    {
+        return builder(newKeyspace, name).partitioner(partitioner)
+                                         .kind(kind)
+                                         .params(params)
+                                         .flags(flags)
+                                         .addColumns(transform(columns(), c -> c.withNewKeyspace(newKeyspace, udts)))
+                                         .droppedColumns(transformValues(droppedColumns, c -> c.withNewKeyspace(newKeyspace, udts)))
+                                         .indexes(indexes)
+                                         .triggers(triggers)
+                                         .build();
     }
 
     public TableMetadata withUpdatedUserType(UserType udt)

--- a/src/java/org/apache/cassandra/schema/Tables.java
+++ b/src/java/org/apache/cassandra/schema/Tables.java
@@ -184,22 +184,12 @@ public final class Tables implements Iterable<TableMetadata>
     public Tables withNewKeyspace(String newName, Types udts)
     {
         Map<String, TableMetadata> updated = new HashMap<>();
-        for (TableMetadata table : getTablesOrderedByDependencies())
+        for (TableMetadata table : this)
         {
             updated.put(table.name, table.withNewKeyspace(newName, udts, tables));
         }
 
         return builder().add(updated.values()).build();
-    }
-
-    private Set<TableMetadata> getTablesOrderedByDependencies()
-    {
-        Set<TableMetadata> orderedTablesByDependencies = new LinkedHashSet<>();
-        for (TableMetadata table : this)
-        {
-            orderedTablesByDependencies.add(table);
-        }
-        return orderedTablesByDependencies;
     }
 
     MapDifference<String, TableMetadata> indexesDiff(Tables other)

--- a/src/java/org/apache/cassandra/schema/Tables.java
+++ b/src/java/org/apache/cassandra/schema/Tables.java
@@ -20,8 +20,10 @@ package org.apache.cassandra.schema;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -177,6 +179,27 @@ public final class Tables implements Iterable<TableMetadata>
         return any(this, t -> t.referencesUserType(udt.name))
              ? builder().add(transform(this, t -> t.withUpdatedUserType(udt))).build()
              : this;
+    }
+
+    public Tables withNewKeyspace(String newName, Types udts)
+    {
+        Map<String, TableMetadata> updated = new HashMap<>();
+        for (TableMetadata table : getTablesOrderedByDependencies())
+        {
+            updated.put(table.name, table.withNewKeyspace(newName, udts, tables));
+        }
+
+        return builder().add(updated.values()).build();
+    }
+
+    private Set<TableMetadata> getTablesOrderedByDependencies()
+    {
+        Set<TableMetadata> orderedTablesByDependencies = new LinkedHashSet<>();
+        for (TableMetadata table : this)
+        {
+            orderedTablesByDependencies.add(table);
+        }
+        return orderedTablesByDependencies;
     }
 
     MapDifference<String, TableMetadata> indexesDiff(Tables other)

--- a/src/java/org/apache/cassandra/schema/Types.java
+++ b/src/java/org/apache/cassandra/schema/Types.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -121,6 +122,32 @@ public final class Types implements Iterable<UserType>
     public Iterable<UserType> referencingUserType(ByteBuffer name)
     {
         return Iterables.filter(types.values(), t -> t.referencesUserType(name) && !t.name.equals(name));
+    }
+
+    /**
+     * Returns the types ordered by dependencies.
+     *
+     * @return the types ordered by dependencies.
+     */
+    private Set<UserType> getTypesOrderedByDependencies()
+    {
+        Set<UserType> orderedTypesByDependencies = new LinkedHashSet<>();
+        for (UserType type : this)
+        {
+            recordNestedTypes(type, orderedTypesByDependencies);
+        }
+        return orderedTypesByDependencies;
+    }
+
+    private void recordNestedTypes(AbstractType<?> userType, Set<UserType> userTypes)
+    {
+        for (AbstractType<?> subType : userType.subTypes())
+        {
+            recordNestedTypes(subType, userTypes);
+        }
+
+        if (userType.isUDT())
+            userTypes.add((UserType) userType);
     }
 
     public boolean isEmpty()
@@ -266,6 +293,33 @@ public final class Types implements Iterable<UserType>
 
         if (type.isUDT())
             types.add(((UserType) type).name);
+    }
+
+    /**
+     * Changes the keyspace of all the types.
+     *
+     * @param newKeyspace the name of the new keyspace
+     * @return the new types
+     */
+    public Types withNewKeyspace(String newKeyspace)
+    {
+        Map<ByteBuffer, UserType> updatedTypes = new HashMap<>();
+
+        for (UserType originalType : getTypesOrderedByDependencies())
+        {
+            UserType type = new UserType(newKeyspace,
+                                         originalType.name,
+                                         originalType.fieldNames(),
+                                         originalType.fieldTypes()
+                                                     .stream()
+                                                     .map(t -> t.withUpdatedUserTypes(updatedTypes.values()))
+                                                     .collect(Collectors.toList()),
+                                         true);
+
+            updatedTypes.put(type.name, type);
+        }
+
+        return new Types(ImmutableSortedMap.copyOf(updatedTypes));
     }
 
     public static final class Builder

--- a/test/unit/org/apache/cassandra/cql3/functions/UDAggregateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/UDAggregateTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.FieldIdentifier;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.UserType;
+import org.apache.cassandra.schema.Types;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class UDAggregateTest extends CQLTester
+{
+    @Test
+    public void testNewKeyspace()
+    {
+        String oldKeyspaceName = "old_ks";
+
+        UserType userType = new UserType(oldKeyspaceName, ByteBufferUtil.bytes("a"),
+                                         Arrays.asList(FieldIdentifier.forUnquoted("a1"),
+                                                       FieldIdentifier.forUnquoted("a2"),
+                                                       FieldIdentifier.forUnquoted("a3")),
+                                         Arrays.asList(IntegerType.instance,
+                                                       IntegerType.instance,
+                                                       IntegerType.instance),
+                                         true);
+
+        String functionName = "my_func";
+        UDFunction oldFunction = createUDFunction(oldKeyspaceName, functionName, userType);
+        UDAggregate aggr = UDAggregate.create(Collections.singleton(oldFunction),
+                                              new FunctionName(oldKeyspaceName, "my_aggregate"),
+                                              Arrays.asList(userType, Int32Type.instance),
+                                              Int32Type.instance,
+                                              new FunctionName(oldKeyspaceName, functionName),
+                                              null,
+                                              Int32Type.instance,
+                                              null);
+
+        String newKeyspaceName = "new_ks";
+        UDFunction newFunction = createUDFunction(newKeyspaceName, functionName, userType);
+        UDAggregate newAggr = aggr.withNewKeyspace(newKeyspaceName, Collections.singletonList(newFunction), Types.of(userType));
+
+        assertNotEquals(newAggr.name, aggr.name);
+        assertEquals(newAggr.elementKeyspace(), newKeyspaceName);
+    }
+
+    private UDFunction createUDFunction(String oldKeyspaceName, String functionName, UserType userType)
+    {
+        return UDFunction.create(new FunctionName(oldKeyspaceName, functionName),
+                                 Arrays.asList(ColumnIdentifier.getInterned("state", false),
+                                               ColumnIdentifier.getInterned("val", false),
+                                               ColumnIdentifier.getInterned("val2", false)),
+                                 Arrays.asList(Int32Type.instance, userType, Int32Type.instance),
+                                 Int32Type.instance,
+                                 true,
+                                 "java",
+                                 "return val2;");
+    }
+}

--- a/test/unit/org/apache/cassandra/schema/KeyspaceMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/KeyspaceMetadataTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableCollection;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.functions.Function;
+import org.apache.cassandra.cql3.functions.FunctionName;
+import org.apache.cassandra.cql3.functions.UDAggregate;
+import org.apache.cassandra.cql3.functions.UDFunction;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.UserType;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.psjava.util.AssertStatus.assertTrue;
+
+public class KeyspaceMetadataTest extends CQLTester
+{
+    private static final String NEW_KEYSPACE = "new_keyspace";
+
+    @Test
+    public void testRenameWithNestedTypes()
+    {
+        String type1 = createType("CREATE TYPE %s (a int, b int)");
+        String type2 = createType("CREATE TYPE %s (x frozen<set<" + type1 + ">>, b int)");
+
+        createTable("CREATE TABLE %s (pk int," +
+                    " c frozen<list<" + type1 + ">>," +
+                    " s frozen<map<" + type1 + "," +  type2 + ">> static," +
+                    " v " + type2 + "," +
+                    " v2 frozen<tuple<int, " + type1 + ">>," +
+                    " v3 frozen<set<" + type1 + ">>, PRIMARY KEY (pk, c))");
+
+        KeyspaceMetadata ksMetadata = Schema.instance.getKeyspaceMetadata(KEYSPACE);
+
+        checkKeyspaceRenaming(ksMetadata, NEW_KEYSPACE);
+    }
+
+    @Test
+    public void testRenameWithFunctions() throws Throwable
+    {
+        String type1 = createType("CREATE TYPE %s (a int, b int)");
+
+        String function1 = createFunction(KEYSPACE, "set<frozen<" + type1 + ">>," + type1, "CREATE FUNCTION %s (state set<frozen<" + type1 + ">>, val " + type1 + ") CALLED ON NULL INPUT RETURNS set<frozen<" + type1 + ">> LANGUAGE java AS ' state = state == null ? new HashSet<>() : state; state.add(val); return state;'");
+        String function2 = createFunction(KEYSPACE, "set<frozen<" + type1 + ">>", "CREATE FUNCTION %s (state set<frozen<" + type1 + ">>) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS ' return state == null ? 0 : state.size();'");
+        createAggregate(KEYSPACE, type1, "CREATE AGGREGATE %s (" + type1 + ") SFUNC " + StringUtils.substringAfter(function1, ".") + " STYPE set<frozen<" + type1 + ">> FINALFUNC " + StringUtils.substringAfter(function2, "."));
+
+        KeyspaceMetadata ksMetadata = Schema.instance.getKeyspaceMetadata(KEYSPACE);
+
+        checkKeyspaceRenaming(ksMetadata, NEW_KEYSPACE);
+    }
+
+    @Test
+    public void testRenameWithDroppedColumns() throws Throwable
+    {
+        String type1 = createType("CREATE TYPE %s (a int, b int)");
+        String type2 = createType("CREATE TYPE %s (x frozen<set<" + type1 + ">>, b int)");
+
+        createTable("CREATE TABLE %s (pk int, c frozen<" + type1 + ">, s int static, v " + type2 + ", v2 text, PRIMARY KEY (pk, c))");
+        execute("ALTER TABLE %s DROP v2");
+        execute("ALTER TABLE %s DROP s");
+
+        KeyspaceMetadata ksMetadata = Schema.instance.getKeyspaceMetadata(KEYSPACE);
+
+        checkKeyspaceRenaming(ksMetadata, NEW_KEYSPACE);
+    }
+
+    @Test
+    public void testRenameWithIndex() throws Throwable
+    {
+        String type1 = createType("CREATE TYPE %s (a int, b int)");
+
+        createTable("CREATE TABLE %s (pk int, c frozen<" + type1 + ">, s int static, v int, PRIMARY KEY (pk, c))");
+        createIndex("CREATE INDEX ON %s (c)");
+        createIndex("CREATE INDEX ON %s (v)");
+
+        KeyspaceMetadata ksMetadata = Schema.instance.getKeyspaceMetadata(KEYSPACE);
+
+        checkKeyspaceRenaming(ksMetadata, NEW_KEYSPACE);
+    }
+
+    @Test
+    public void testRenameWithMv() throws Throwable
+    {
+        String type1 = createType("CREATE TYPE %s (a int, b int)");
+
+        createTable("CREATE TABLE %s (pk int, c frozen<" + type1 + ">, v int, v2 text, PRIMARY KEY (pk, c))");
+        execute("CREATE MATERIALIZED VIEW " + KEYSPACE + ".mv AS SELECT c, v, pk FROM " + currentTable() + " WHERE v IS NOT NULL AND c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (v, pk, c);");
+
+        KeyspaceMetadata ksMetadata = Schema.instance.getKeyspaceMetadata(KEYSPACE);
+
+        checkKeyspaceRenaming(ksMetadata, NEW_KEYSPACE);
+    }
+
+    private void checkKeyspaceRenaming(KeyspaceMetadata original, String newName)
+    {
+        KeyspaceMetadata renamed = original.rename(newName);
+        assertEquals(newName, renamed.name);
+        assertEquals(original.kind, renamed.kind);
+        assertEquals(original.params, renamed.params);
+
+        original.types.forEach(t -> checkKeyspaceRenamingForType(newName, renamed.types, t, renamed.types.getNullable(t.name)));
+        checkKeyspaceRenamingForFunctions(newName, original, renamed);
+        original.tables.forEach(t -> checkKeyspaceRenamingForTable(newName, renamed.types, t, renamed.tables.getNullable(t.name)));
+        original.views.forEach(v -> checkKeyspaceRenamingForView(newName, renamed.types, v, renamed.views.getNullable(v.name())));
+    }
+
+    private void checkKeyspaceRenamingForFunctions(String newName, KeyspaceMetadata original, KeyspaceMetadata renamed)
+    {
+        Set<FunctionName> names = original.functions.stream().map(Function::name).collect(Collectors.toSet());
+        for (FunctionName name : names)
+        {
+            Iterator<Function> originalIter = original.functions.get(name).iterator();
+            Iterator<Function> updatedIter = renamed.functions.get(new FunctionName(newName, name.name)).iterator();
+            while (originalIter.hasNext() && updatedIter.hasNext())
+            {
+                checkKeyspaceRenamingForFunction(newName, renamed.functions, renamed.types, originalIter.next(), updatedIter.next());
+            }
+            assertFalse(originalIter.hasNext());
+            assertFalse(updatedIter.hasNext());
+        }
+    }
+
+    private void checkKeyspaceRenamingForType(String keyspace,
+                                              Types newTypes,
+                                              AbstractType<?> originalType,
+                                              AbstractType<?> updatedType)
+    {
+        if (originalType.isUDT())
+        {
+            assertTrue(updatedType.isUDT());
+            UserType updatedUserType = (UserType) updatedType;
+            UserType originalUserType = (UserType) originalType;
+
+            // Checks that the updated type is present in the updated Types
+            UserType tmp = newTypes.getNullable(updatedUserType.name);
+            tmp = updatedType.isMultiCell() ? tmp : tmp.freeze();
+            assertEquals(updatedType, tmp);
+
+            assertEquals(keyspace, updatedUserType.keyspace);
+            assertEquals(originalUserType.name, updatedUserType.name);
+            assertEquals(originalUserType.fieldNames(), updatedUserType.fieldNames());
+        }
+        else if (originalType.referencesUserTypes())
+        {
+            List<AbstractType<?>> originalSubTypes = originalType.subTypes();
+            List<AbstractType<?>> updatedSubTypes = updatedType.subTypes();
+
+            assertEquals(originalSubTypes.size(), updatedSubTypes.size());
+            for (int i = 0, m = originalSubTypes.size(); i < m; i++)
+            {
+                checkKeyspaceRenamingForType(keyspace, newTypes, originalSubTypes.get(i), updatedSubTypes.get(i));
+            }
+        }
+        else
+        {
+            assertEquals(originalType, updatedType);
+        }
+    }
+
+    private void checkKeyspaceRenamingForFunction(String keyspace,
+                                                  Functions newFunctions,
+                                                  Types newTypes,
+                                                  Function originalFunction,
+                                                  Function updatedFunction)
+    {
+        if (originalFunction.isNative())
+        {
+            assertEquals(originalFunction, updatedFunction);
+        }
+        else
+        {
+            // Checks that the updated function is present in the updated Types
+            Optional<Function> maybe = newFunctions.find(updatedFunction.name(), updatedFunction.argTypes());
+            assertTrue(maybe.isPresent());
+            assertEquals(updatedFunction, maybe.get());
+
+            assertEquals(keyspace, updatedFunction.name().keyspace);
+            assertNotEquals(originalFunction.name().keyspace, updatedFunction.name().keyspace);
+            assertEquals(originalFunction.name().name, updatedFunction.name().name);
+            assertEquals(originalFunction.isAggregate(), updatedFunction.isAggregate());
+
+            List<AbstractType<?>> originalArgTypes = originalFunction.argTypes();
+            List<AbstractType<?>> updatedArgTypes = updatedFunction.argTypes();
+            assertEquals(originalArgTypes.size(), updatedArgTypes.size());
+            for (int i = 0, m = originalArgTypes.size(); i < m; i++)
+            {
+                checkKeyspaceRenamingForType(keyspace, newTypes, originalArgTypes.get(i), updatedArgTypes.get(i));
+            }
+
+            if (originalFunction.isAggregate())
+            {
+                UDAggregate originalUa = (UDAggregate) originalFunction;
+                UDAggregate updatedUa = (UDAggregate) updatedFunction;
+
+                checkKeyspaceRenamingForFunction(keyspace,
+                                                 newFunctions,
+                                                 newTypes,
+                                                 originalUa.finalFunction(),
+                                                 updatedUa.finalFunction());
+                assertEquals(originalUa.initialCondition(), updatedUa.initialCondition());
+                checkKeyspaceRenamingForFunction(keyspace,
+                                                 newFunctions,
+                                                 newTypes,
+                                                 originalUa.stateFunction(),
+                                                 updatedUa.stateFunction());
+                checkKeyspaceRenamingForType(keyspace, newTypes, originalUa.stateType(), updatedUa.stateType());
+            }
+            else
+            {
+                UDFunction originalUdf = (UDFunction) originalFunction;
+                UDFunction updatedUdf = (UDFunction) updatedFunction;
+
+                assertEquals(originalUdf.language(), updatedUdf.language());
+                assertEquals(originalUdf.body(), updatedUdf.body());
+                assertEquals(originalUdf.isCalledOnNullInput(), updatedUdf.isCalledOnNullInput());
+            }
+        }
+    }
+
+    private void checkKeyspaceRenamingForTable(String keyspace,
+                                               Types updatedTypes,
+                                               TableMetadata originalTable,
+                                               TableMetadata updatedTable)
+    {
+        assertEquals(keyspace, updatedTable.keyspace);
+        assertNotEquals(originalTable.keyspace, updatedTable.keyspace);
+        assertNotEquals(originalTable.id, updatedTable.id);
+        assertEquals(originalTable.name, updatedTable.name);
+        assertEquals(originalTable.partitioner, updatedTable.partitioner);
+        assertEquals(originalTable.kind, updatedTable.kind);
+        assertEquals(originalTable.flags, updatedTable.flags);
+        assertEquals(originalTable.indexes, updatedTable.indexes);
+        assertEquals(originalTable.triggers, updatedTable.triggers);
+        assertEquals(originalTable.params, updatedTable.params);
+
+        originalTable.columns().forEach(c -> checkKeyspaceRenamingForColumn(keyspace,
+                                                                            updatedTypes,
+                                                                            c,
+                                                                            updatedTable.getColumn(c.name.bytes)));
+        ImmutableCollection<DroppedColumn> droppedColumns = originalTable.droppedColumns.values();
+        droppedColumns.forEach(c -> checkKeyspaceRenamingForColumn(keyspace,
+                                                                   updatedTypes,
+                                                                   c.column,
+                                                                   updatedTable.getDroppedColumn(c.column.name.bytes)));
+    }
+
+    private void checkKeyspaceRenamingForView(String keyspace,
+                                              Types updatedTypes,
+                                              ViewMetadata originalView,
+                                              ViewMetadata updatedView)
+    {
+        checkKeyspaceRenamingForTable(keyspace, updatedTypes, originalView.metadata, updatedView.metadata);
+
+        Iterator<ColumnMetadata> requiredOriginal = originalView.metadata.columns().iterator();
+        Iterator<ColumnMetadata> requiredUpdated = updatedView.metadata.columns().iterator();
+
+        while (requiredOriginal.hasNext() && requiredUpdated.hasNext())
+        {
+            checkKeyspaceRenamingForColumn(keyspace,
+                                           updatedTypes,
+                                           requiredOriginal.next(),
+                                           requiredUpdated.next());
+        }
+        assertFalse(requiredOriginal.hasNext());
+        assertFalse(requiredUpdated.hasNext());
+    }
+
+    private void checkKeyspaceRenamingForColumn(String keyspace,
+                                                Types updatedTypes,
+                                                ColumnMetadata originalColumn,
+                                                ColumnMetadata updatedColumn)
+    {
+        assertEquals(keyspace, updatedColumn.ksName);
+        assertNotEquals(originalColumn.ksName, updatedColumn.ksName);
+        assertEquals(originalColumn.cfName, updatedColumn.cfName);
+        assertEquals(originalColumn.name, updatedColumn.name);
+        checkKeyspaceRenamingForType(keyspace, updatedTypes, originalColumn.type, updatedColumn.type);
+    }
+}


### PR DESCRIPTION
…3896

Required by CNDB-3170 and CNDB-4909.

* Make DistributedSchema.keyspaces protected since it's accessed by CNDB.