### PR TITLE
STAR-1694 Configure max compaction overhead

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Gauge;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.CompactionAggregate;
+import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.CompactionRealm;
 import org.apache.cassandra.db.compaction.CompactionStrategy;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
@@ -794,6 +795,11 @@ public abstract class Controller
     public double maxThroughput()
     {
         return env.maxThroughput();
+    }
+
+    public long getOverheadSizeInBytes(CompactionPick compactionPick)
+    {
+        return env.getOverheadSizeInBytes(compactionPick);
     }
 
     public int maxConcurrentCompactions()

--- a/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
@@ -108,13 +108,17 @@ public interface Environment
 
     /**
      * This method returns the expected temporary space overhead of performing
-     * a compaction. The default implementation looks at the size of the data
-     * files of the input compaction, assuming that the output compaction will
-     * be just as large. The overhead is due to the fact that whilst compactions
+     * a compaction. This overhead is due to the fact that whilst compactions
      * are in progress, both input and output sstables need to be present, since
      * the input sstables can only be deleted after compaction has completed.
-     *
-     * @return the overhead size in bytes that results from compacting the sstables in the pick
+     * <p/>
+     * The default implementation looks at the size of the data files of the
+     * input compaction, assuming that the output compaction will
+     * be just as large. A future improvement could be to consider the size of
+     * metadata components too, especially when SAI indexes are present.
+     * <p/>
+     * @return the overhead size in bytes that results from compacting the sstables
+     * in the compaction pick passed in.
      */
     long getOverheadSizeInBytes(CompactionPick compactionPick);
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
@@ -21,6 +21,7 @@ import java.util.Random;
 
 import org.agrona.collections.IntArrayList;
 import org.apache.cassandra.db.compaction.CompactionAggregate;
+import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.utils.MovingAverage;
 
 /**
@@ -104,4 +105,16 @@ public interface Environment
      * @return the maximum compaction throughput
      */
     double maxThroughput();
+
+    /**
+     * This method returns the expected temporary space overhead of performing
+     * a compaction. The default implementation looks at the size of the data
+     * files of the input compaction, assuming that the output compaction will
+     * be just as large. The overhead is due to the fact that whilst compactions
+     * are in progress, both input and output sstables need to be present, since
+     * the input sstables can only be deleted after compaction has completed.
+     *
+     * @return the overhead size in bytes that results from compacting the sstables in the pick
+     */
+    long getOverheadSizeInBytes(CompactionPick compactionPick);
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/RealEnvironment.java
@@ -25,6 +25,7 @@ import org.agrona.collections.IntArrayList;
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.CompactionAggregate;
+import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.CompactionRealm;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.schema.CompressionParams;
@@ -159,6 +160,13 @@ class RealEnvironment implements Environment
         if (compactionThroughputMbPerSec <= 0)
             return Double.MAX_VALUE;
         return compactionThroughputMbPerSec * 1024.0 * 1024.0;
+    }
+
+    @Override
+    public long getOverheadSizeInBytes(CompactionPick compactionPick)
+    {
+        // The estimate the compaction overhead to be the same as the size of the input sstables
+        return compactionPick.totSizeInBytes();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -643,6 +643,12 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
         }
 
         @Override
+        public long getOverheadSizeInBytes(CompactionPick compactionPick)
+        {
+            return compactionPick.totSizeInBytes();
+        }
+
+        @Override
         public String toString()
         {
             return String.format("Read latency: %d us / partition, flush latency: %d us / KiB, compaction latency: %d us / KiB, bfpr: %f, measured WA: %.2f, flush size %s",

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -631,6 +631,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getDataSetSizeBytes()).thenReturn(topBucketMaxCompactionSize * numShards);
         when(controller.random()).thenCallRealMethod();
 
+        when(controller.getOverheadSizeInBytes(any(CompactionPick.class))).thenAnswer(inv -> ((CompactionPick)inv.getArgument(0)).totSizeInBytes());
+
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
         List<SSTableReader> allSstables = new ArrayList<>();
 

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -270,7 +270,9 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
             for (int i = 0; i < expectedTs.length; i++)
             {
                 UnifiedCompactionStrategy.Bucket bucket = buckets.get(i);
-                if (bucket.sstables.size() >= expectedTs[i])
+                assertEquals(i, bucket.getIndex());
+
+                if (bucket.getSSTables().size() >= expectedTs[i])
                     assertFalse(bucket.getCompactionAggregate(entry.getKey(), Collections.EMPTY_SET, controller, dataSetSizeBytes).isEmpty());
                 else
                     assertTrue(bucket.getCompactionAggregate(entry.getKey(), Collections.EMPTY_SET, controller, dataSetSizeBytes).isEmpty());


### PR DESCRIPTION
Port of https://github.com/riptano/bdp/pull/20372

This patch adds a way to customize the compaction overhead, i.e. the transient
amount of space required by a compaction whilst both input and output sstables
are present. In BDP this is just estimated to be the size of the input sstables.

It's unclear if we can improve this in CNDB, but I kept the refactoring because
initially I got confused thinking that in CNDB we could just waive this requirement
since the input sstables are in the file cache. So I think it's good to spell
out why we use the input sstable sizes by encapsulating the calculation in a
method with javadoc.

The patch also adds a warning to the logs: if a compaction cannot be performed
because the space overhead is larger than the space available, then the logs now
contain this information. Without this, troubleshooting why compaction tasks are
skipped is quite hard. This warning was already present in BDP but was missing
for CNDB.

