### PR TITLE
STAR-1626 Enable BatchTest and UUIDTests to run fully

### DIFF
--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -129,10 +129,10 @@ public class GuardrailsConfig
     public volatile Integer tombstone_warn_threshold;
     public volatile Integer tombstone_failure_threshold;
 
-    // Log WARN on any multiple-partition batch size that exceeds this value. 5kb per batch by default.
+    // Log WARN on any multiple-partition batch size that exceeds this value. 64kb per batch by default.
     // Use caution when increasing the size of this threshold as it can lead to node instability.
     public volatile Integer batch_size_warn_threshold_in_kb;
-    // Fail any multiple-partition batch that exceeds this value. The calculated default is 50kb (10x warn threshold).
+    // Fail any multiple-partition batch that exceeds this value. The calculated default is 640kb (10x warn threshold).
     public volatile Integer batch_size_fail_threshold_in_kb;
     // Log WARN on any batches not of type LOGGED than span across more partitions than this limit.
     public volatile Integer unlogged_batch_across_partitions_warn_threshold;

--- a/test/unit/org/apache/cassandra/cql3/BatchTest.java
+++ b/test/unit/org/apache/cassandra/cql3/BatchTest.java
@@ -30,7 +30,6 @@ import org.apache.cassandra.service.EmbeddedCassandraService;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -51,6 +50,10 @@ public class BatchTest
     @BeforeClass()
     public static void setup() throws ConfigurationException, IOException
     {
+        // Set batch sizes for guardrails to the same values as in Apache
+        // Needed for testOversizedBatch()
+        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeWarnThresholdInKB(5);
+        DatabaseDescriptor.getGuardrailsConfig().setBatchSizeFailThresholdInKB(50);
         cassandra = ServerTestUtils.startEmbeddedCassandraService();
 
         cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(DatabaseDescriptor.getNativeTransportPort()).build();
@@ -163,7 +166,6 @@ public class BatchTest
         sendBatch(BatchStatement.Type.LOGGED, true, false, false);
     }
 
-    @Ignore
     @Test(expected = InvalidQueryException.class)
     public void testOversizedBatch()
     {

--- a/test/unit/org/apache/cassandra/utils/UUIDTest.java
+++ b/test/unit/org/apache/cassandra/utils/UUIDTest.java
@@ -35,11 +35,11 @@ import org.junit.Test;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.db.marshal.TimeUUIDType;
-import org.apache.cassandra.utils.UUIDGen;
+
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 
 
-public class UUIDTests
+public class UUIDTest
 {
     @Test
     public void verifyType1()


### PR DESCRIPTION
Enable disabled test in BatchTest, which was broken due to previous name violation in BatchTests. It is fixed by setting batch size guardrail to the same number as in Apache Cassandra.

Updated default batch size number in the comment in accordance to actual values.

Fix name violation in UUIDTests to UUIDTest, so the tests are executed.