### PR TITLE
STAR-1586 Fix SelectiveIntersectionTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/SelectiveIntersectionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SelectiveIntersectionTest.java
@@ -62,6 +62,7 @@ public class SelectiveIntersectionTest extends SAITester
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v3"));
+        waitForIndexQueryable();
 
         for (int i = 0; i < 100; ++i)
         {


### PR DESCRIPTION
  The setup phase of this test was not waiting
  for indexes to be queryable before inserting
  data and flushing. This was resulting in a
  race condition during the flush leading to a
  random occurence of higher posting reader
  usage than expected.