### PR TITLE
STAR-1739: Add a way to check the number of cached file chunks

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -339,4 +339,12 @@ public class ChunkCache
                 .map(policy -> policy.weightedSize().orElseGet(cache::estimatedSize))
                 .orElseGet(cache::estimatedSize);
     }
+
+    /**
+     * Returns the number of cached chunks of given file.
+     */
+    @VisibleForTesting
+    public int sizeOfFile(String filePath) {
+        return (int) cache.asMap().keySet().stream().filter(x -> x.path.equals(filePath)).count();
+    }
 }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2759,6 +2759,12 @@ public class DatabaseDescriptor
         return conf.file_cache_size_in_mb;
     }
 
+    public static void enableChunkCache(int sizeInMB)
+    {
+        conf.file_cache_enabled = true;
+        conf.file_cache_size_in_mb = sizeInMB;
+    }
+
     public static int getNetworkingCacheSizeInMB()
     {
         if (conf.networking_cache_size_in_mb == null)

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cache;
+
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.SequentialWriter;
+
+public class ChunkCacheTest
+{
+    @BeforeClass
+    public static void setupDD()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        DatabaseDescriptor.enableChunkCache(512);
+    }
+
+    @Test
+    public void testRandomAccessReaderCanUseCache() throws IOException
+    {
+        File file = FileUtils.createTempFile("foo", null);
+        file.deleteOnExit();
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+
+        try (SequentialWriter writer = new SequentialWriter(file))
+        {
+            writer.write(new byte[64]);
+            writer.flush();
+        }
+
+        try (FileHandle.Builder builder = new FileHandle.Builder(file).withChunkCache(ChunkCache.instance);
+             FileHandle h = builder.complete();
+             RandomAccessReader r = h.createReader())
+        {
+            r.reBuffer();
+
+            Assert.assertEquals(ChunkCache.instance.size(), 1);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 1);
+        }
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+    }
+
+}


### PR DESCRIPTION
Needed by CNDB tests.