### PR TITLE
STAR-1748: Fix RepairRequestTimeoutTest

### DIFF
--- a/src/java/org/apache/cassandra/repair/messages/RepairMessage.java
+++ b/src/java/org/apache/cassandra/repair/messages/RepairMessage.java
@@ -91,7 +91,7 @@ public abstract class RepairMessage
     private static boolean supportsTimeouts(InetAddressAndPort from, UUID parentSessionId)
     {
         CassandraVersion remoteVersion = Nodes.peers().map(from, NodeInfo::getReleaseVersion, () -> null);
-        if (remoteVersion != null && remoteVersion.compareTo(SUPPORTS_TIMEOUTS) >= 0)
+        if (remoteVersion != null && remoteVersion.compareTo(SUPPORTS_TIMEOUTS, true) >= 0)
             return true;
         logger.warn("[#{}] Not failing repair due to remote host {} not supporting repair message timeouts (version = {})", parentSessionId, from, remoteVersion);
         return false;


### PR DESCRIPTION
So the problem here is that Cassandra since 4.0.7 supports timeouts of repair requests. Though, it is enabled only if version is >= 4.0.7-SNAPSHOT, according to the comparison rules in `CassandraVersion`. In Jenkins, we build 4.0.7-<sha> which, according to that comparison, is lower than 4.0.7-SNAPSHOT.