### PR TITLE
STAR-1795 Fix JDK8 compilation error in CommitLogReplayer

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -260,7 +260,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
             {
                 ListenableFuture<CommitLogPosition> f = cfs.forceFlush(flushReason);
                 futures.add(f);
-                Futures.addCallback(f, new FutureCallback<>() {
+                Futures.addCallback(f, new FutureCallback<CommitLogPosition>() {
                     @Override
                     public void onSuccess(CommitLogPosition ignored)
                     {


### PR DESCRIPTION
The `ds-trunk` was failing to compile with JDK8 because:
```    [javac] /home/mike/repos/cassandra/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java:263: error: cannot infer type arguments for FutureCallback<V>
    [javac]                 Futures.addCallback(f, new FutureCallback<>() {
    [javac]                                                          ^
    [javac]   reason: cannot use '<>' with anonymous inner classes
    [javac]   where V is a type-variable:
    [javac]     V extends Object declared in interface FutureCallback
```