### PR TITLE
Star 1597

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -378,7 +378,7 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
 
     public void periodicReport(){
         CompactionLogger logger = this.getCompactionLogger();
-        if (compactionLogger != null && compactionLogger.enabled())
+        if (logger != null && logger.enabled())
             logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -375,4 +375,9 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
     {
         return true;
     }
+
+    public void periodicReport(){
+        CompactionLogger logger = this.getCompactionLogger();
+        logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+    }
 }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.beust.jcommander.internal.Nullable;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
@@ -378,15 +379,29 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
         return true;
     }
 
-    public void periodicReport(){
+    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroungCompactions){
         logCount++;
         CompactionLogger logger = this.getCompactionLogger();
-        int interval = options.getLogPeriodMinutes();
-        boolean logAll = options.isLogAll();
-        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+        if (options == null || backgroundCompactions == null)
         {
-            logCount = 0;
-            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+            int interval = testOptions.getLogPeriodMinutes();
+            boolean logAll = testOptions.isLogAll();
+            if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+            {
+                logCount = 0;
+                logger.statistics(this, "periodic", testBackgroungCompactions.getStatistics(this));
+            }
         }
+        else
+        {
+            int interval = options.getLogPeriodMinutes();
+            boolean logAll = options.isLogAll();
+            if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+            {
+                logCount = 0;
+                logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+            }
+        }
+
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -378,6 +378,7 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
 
     public void periodicReport(){
         CompactionLogger logger = this.getCompactionLogger();
-        logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+        if (compactionLogger != null && compactionLogger.enabled())
+            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -55,6 +55,8 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractCompactionStrategy.class);
 
+    private static int logCount = 0;
+
     protected final CompactionStrategyOptions options;
     /** The column family store should only be used when creating writers. However it is currently also used
      * by legacy strategies and compaction tasks.
@@ -377,8 +379,14 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
     }
 
     public void periodicReport(){
+        logCount++;
         CompactionLogger logger = this.getCompactionLogger();
-        if (logger != null && logger.enabled())
+        int interval = options.getLogPeriodMinutes();
+        boolean logAll = options.isLogAll();
+        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+        {
+            logCount = 0;
             logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+        }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -166,7 +166,7 @@ public class CompactionManager implements CompactionManagerMBean
         MBeanWrapper.instance.registerMBean(instance, MBEAN_OBJECT_NAME);
 
         /*Schedule periodic reports to run every minute*/
-        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> periodicReports(), 1, 1, TimeUnit.MINUTES);
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(CompactionManager::periodicReports, 1, 1, TimeUnit.MINUTES);
     }
 
     private final CompactionExecutor executor = new CompactionExecutor();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -70,6 +70,7 @@ import org.apache.cassandra.cache.AutoSavingCache;
 import org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor;
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -163,6 +164,18 @@ public class CompactionManager implements CompactionManagerMBean
         instance = new CompactionManager();
 
         MBeanWrapper.instance.registerMBean(instance, MBEAN_OBJECT_NAME);
+
+        /*Schedule periodic reports to run every minute*/
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
+            for (String keyspace : Schema.instance.getKeyspaces())
+            {
+                for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+                {
+                    CompactionStrategy strat = cfs.getCompactionStrategy();
+                    strat.periodicReport();
+                }
+            }
+        }, 1, 1, TimeUnit.MINUTES);
     }
 
     private final CompactionExecutor executor = new CompactionExecutor();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -172,7 +172,7 @@ public class CompactionManager implements CompactionManagerMBean
                 for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
                 {
                     CompactionStrategy strat = cfs.getCompactionStrategy();
-                    strat.periodicReport(null, null);
+                    strat.periodicReport();
                 }
             }
         }, 1, 1, TimeUnit.MINUTES);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -172,7 +172,7 @@ public class CompactionManager implements CompactionManagerMBean
                 for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
                 {
                     CompactionStrategy strat = cfs.getCompactionStrategy();
-                    strat.periodicReport();
+                    strat.periodicReport(null, null);
                 }
             }
         }, 1, 1, TimeUnit.MINUTES);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -165,20 +165,17 @@ public class CompactionManager implements CompactionManagerMBean
 
         MBeanWrapper.instance.registerMBean(instance, MBEAN_OBJECT_NAME);
 
-        //only want to schedule periodic reports if periodic reports are enabled ('log_all': 'all')
-        if (CompactionStrategyOptions.isLogAll())
-        {
-            ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
-                for (String keyspace : Schema.instance.getKeyspaces())
+        /*Schedule periodic reports to run every minute*/
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
+            for (String keyspace : Schema.instance.getKeyspaces())
+            {
+                for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
                 {
-                    for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
-                    {
-                        CompactionStrategy strat = cfs.getCompactionStrategy();
-                        strat.periodicReport();
-                    }
+                    CompactionStrategy strat = cfs.getCompactionStrategy();
+                    strat.periodicReport();
                 }
-            }, 1, CompactionStrategyOptions.getLogPeriodMinutes(), TimeUnit.MINUTES);
-        }
+            }
+        }, 1, 1, TimeUnit.MINUTES);
     }
 
     private final CompactionExecutor executor = new CompactionExecutor();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -165,12 +165,9 @@ public class CompactionManager implements CompactionManagerMBean
 
         MBeanWrapper.instance.registerMBean(instance, MBEAN_OBJECT_NAME);
 
-        /*Schedule periodic reports to run every minute*/
         //only want to schedule periodic reports if periodic reports are enabled ('log_all': 'all')
-        final String logging = System.getProperty(CompactionStrategyOptions.LOG_ALL_OPTION, CompactionStrategyOptions.DEFAULT_LOG_ALL_OPTION);
-        if (logging.equalsIgnoreCase("all"))
+        if (CompactionStrategyOptions.isLogAll())
         {
-            final int interval = Integer.parseInt(CompactionStrategyOptions.LOG_PERIOD_MINUTES_OPTION, Integer.parseInt(CompactionStrategyOptions.DEFAULT_LOG_PERIOD_MINUTES_OPTION));
             ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
                 for (String keyspace : Schema.instance.getKeyspaces())
                 {
@@ -180,7 +177,7 @@ public class CompactionManager implements CompactionManagerMBean
                         strat.periodicReport();
                     }
                 }
-            }, 1, interval, TimeUnit.MINUTES);
+            }, 1, CompactionStrategyOptions.getLogPeriodMinutes(), TimeUnit.MINUTES);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -166,16 +166,7 @@ public class CompactionManager implements CompactionManagerMBean
         MBeanWrapper.instance.registerMBean(instance, MBEAN_OBJECT_NAME);
 
         /*Schedule periodic reports to run every minute*/
-        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> {
-            for (String keyspace : Schema.instance.getKeyspaces())
-            {
-                for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
-                {
-                    CompactionStrategy strat = cfs.getCompactionStrategy();
-                    strat.periodicReport();
-                }
-            }
-        }, 1, 1, TimeUnit.MINUTES);
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> periodicReports(), 1, 1, TimeUnit.MINUTES);
     }
 
     private final CompactionExecutor executor = new CompactionExecutor();
@@ -193,6 +184,18 @@ public class CompactionManager implements CompactionManagerMBean
     private final AtomicInteger globalCompactionPauseCount = new AtomicInteger(0);
 
     private final RateLimiter compactionRateLimiter = RateLimiter.create(Double.MAX_VALUE);
+
+    protected static void periodicReports()
+    {
+        for (String keyspace : Schema.instance.getKeyspaces())
+        {
+            for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+            {
+                CompactionStrategy strat = cfs.getCompactionStrategy();
+                strat.periodicReport();
+            }
+        }
+    }
 
     public CompactionMetrics getMetrics()
     {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
@@ -198,4 +198,6 @@ public interface CompactionStrategy extends CompactionObserver
     {
         return true;
     }
+
+    public void periodicReport();
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import com.beust.jcommander.internal.Nullable;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.commitlog.IntervalSet;
@@ -200,5 +199,5 @@ public interface CompactionStrategy extends CompactionObserver
         return true;
     }
 
-    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions);
+    void periodicReport();
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import com.beust.jcommander.internal.Nullable;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.commitlog.IntervalSet;
@@ -199,5 +200,5 @@ public interface CompactionStrategy extends CompactionObserver
         return true;
     }
 
-    public void periodicReport();
+    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions);
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -315,7 +315,7 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
             writeLock.unlock();
         }
 
-        if (repaired.first().getOptions().isLogAll())
+        if (repaired.first().getOptions().isLogEnabled())
             compactionLogger.enable();
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -1106,6 +1106,15 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
         return supportsEarlyOpen;
     }
 
+    @Override
+    public void periodicReport()
+    {
+        CompactionLogger logger = this.getCompactionLogger();
+        BackgroundCompactions backgroundCompactions = new BackgroundCompactions(realm);
+        if (logger != null && logger.enabled())
+            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+    }
+
     public ReentrantReadWriteLock.WriteLock getWriteLock()
     {
         return this.writeLock;

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -1108,7 +1108,7 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
     }
 
     @Override
-    public void periodicReport()
+    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions)
     {
         logCount++;
         CompactionLogger logger = this.getCompactionLogger();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -91,7 +91,6 @@ import static org.apache.cassandra.db.compaction.AbstractStrategyHolder.GroupedS
 public class CompactionStrategyManager implements CompactionStrategyContainer
 {
     private static final Logger logger = LoggerFactory.getLogger(CompactionStrategyManager.class);
-    private static int logCount = 0;
     public final CompactionLogger compactionLogger;
     private final CompactionRealm realm;
     private final boolean partitionSSTablesByTokenRange;

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -91,6 +91,7 @@ import static org.apache.cassandra.db.compaction.AbstractStrategyHolder.GroupedS
 public class CompactionStrategyManager implements CompactionStrategyContainer
 {
     private static final Logger logger = LoggerFactory.getLogger(CompactionStrategyManager.class);
+    private static int logCount = 0;
     public final CompactionLogger compactionLogger;
     private final CompactionRealm realm;
     private final boolean partitionSSTablesByTokenRange;
@@ -1109,10 +1110,16 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
     @Override
     public void periodicReport()
     {
+        logCount++;
         CompactionLogger logger = this.getCompactionLogger();
         BackgroundCompactions backgroundCompactions = new BackgroundCompactions(realm);
-        if (logger != null && logger.enabled())
+        int interval = repaired.first().getOptions().getLogPeriodMinutes();
+        boolean logAll = repaired.first().getOptions().isLogAll();
+        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+        {
+            logCount = 0;
             logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+        }
     }
 
     public ReentrantReadWriteLock.WriteLock getWriteLock()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -1108,17 +1108,11 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
     }
 
     @Override
-    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions)
+    public void periodicReport()
     {
-        logCount++;
-        CompactionLogger logger = this.getCompactionLogger();
-        BackgroundCompactions backgroundCompactions = new BackgroundCompactions(realm);
-        int interval = repaired.first().getOptions().getLogPeriodMinutes();
-        boolean logAll = repaired.first().getOptions().isLogAll();
-        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+        for (CompactionStrategy strat : getAllStrategies())
         {
-            logCount = 0;
-            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+            strat.periodicReport();
         }
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
@@ -103,7 +103,6 @@ public class CompactionStrategyOptions
         tombstoneThreshold = Float.parseFloat(getOption(TOMBSTONE_THRESHOLD_OPTION, useDefault, DEFAULT_TOMBSTONE_THRESHOLD));
         tombstoneCompactionInterval = Long.parseLong(getOption(TOMBSTONE_COMPACTION_INTERVAL_OPTION, useDefault, DEFAULT_TOMBSTONE_COMPACTION_INTERVAL));
         uncheckedTombstoneCompaction = Boolean.parseBoolean(getOption(UNCHECKED_TOMBSTONE_COMPACTION_OPTION, useDefault, DEFAULT_UNCHECKED_TOMBSTONE_COMPACTION_OPTION));
-        //logAll = Boolean.parseBoolean(getOption(LOG_ALL_OPTION, useDefault, DEFAULT_LOG_ALL_OPTION));
         logAll = getOption(LOG_ALL_OPTION, useDefault, DEFAULT_LOG_ALL_OPTION);
         logPeriodMinutes = Integer.parseInt(getOption(LOG_PERIOD_MINUTES_OPTION, useDefault, DEFAULT_LOG_PERIOD_MINUTES_OPTION));
     }
@@ -407,5 +406,16 @@ public class CompactionStrategyOptions
         if (logAll.equalsIgnoreCase("all") || logAll.equalsIgnoreCase("events_only"))
             return true;
         return false;
+    }
+
+    public static boolean isLogAll()
+    {
+
+        return false;
+    }
+
+    public static int getLogPeriodMinutes()
+    {
+        return 1;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
@@ -408,14 +408,13 @@ public class CompactionStrategyOptions
         return false;
     }
 
-    public static boolean isLogAll()
+    public boolean isLogAll()
     {
-
-        return false;
+        return logAll.equalsIgnoreCase("all");
     }
 
-    public static int getLogPeriodMinutes()
+    public int getLogPeriodMinutes()
     {
-        return 1;
+        return logPeriodMinutes;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyOptions.java
@@ -55,7 +55,8 @@ public class CompactionStrategyOptions
     // minimum interval needed to perform tombstone removal compaction in seconds, default 86400 or 1 day.
     public static final String DEFAULT_TOMBSTONE_COMPACTION_INTERVAL = "86400";
     public static final String DEFAULT_UNCHECKED_TOMBSTONE_COMPACTION_OPTION = "false";
-    public static final String DEFAULT_LOG_ALL_OPTION = System.getProperty("default.compaction.logs", "none");
+    public static final String DEFAULT_LOG_ALL_OPTION = System.getProperty("default.compaction.logs", "false");
+    public static final String DEFAULT_PERIODIC_LOG_ALL_OPTION = System.getProperty("default.compaction.logs", "none");
     public static final String DEFAULT_LOG_PERIOD_MINUTES_OPTION = System.getProperty("default.compaction.log_minutes", "1");
 
     public static final String TOMBSTONE_THRESHOLD_OPTION = "tombstone_threshold";
@@ -63,6 +64,7 @@ public class CompactionStrategyOptions
     // disable range overlap check when deciding if an SSTable is candidate for tombstone compaction (CASSANDRA-6563)
     public static final String UNCHECKED_TOMBSTONE_COMPACTION_OPTION = "unchecked_tombstone_compaction";
     public static final String LOG_ALL_OPTION = "log_all";
+    public static final String PERIODIC_LOG_ALL_OPTION = "log";
     public static final String LOG_PERIOD_MINUTES_OPTION = "log_period_minutes";
     public static final String COMPACTION_ENABLED = "enabled";
 
@@ -72,7 +74,8 @@ public class CompactionStrategyOptions
     private final long tombstoneCompactionInterval;
     private final boolean uncheckedTombstoneCompaction;
     private boolean disableTombstoneCompactions = false;
-    private final String logAll;
+    private final boolean logAll;
+    private final String periodicLogAll;
     private final int logPeriodMinutes;
 
     public CompactionStrategyOptions(Class<? extends CompactionStrategy> klass, Map<String, String> options, boolean throwOnInvalidOption)
@@ -103,7 +106,8 @@ public class CompactionStrategyOptions
         tombstoneThreshold = Float.parseFloat(getOption(TOMBSTONE_THRESHOLD_OPTION, useDefault, DEFAULT_TOMBSTONE_THRESHOLD));
         tombstoneCompactionInterval = Long.parseLong(getOption(TOMBSTONE_COMPACTION_INTERVAL_OPTION, useDefault, DEFAULT_TOMBSTONE_COMPACTION_INTERVAL));
         uncheckedTombstoneCompaction = Boolean.parseBoolean(getOption(UNCHECKED_TOMBSTONE_COMPACTION_OPTION, useDefault, DEFAULT_UNCHECKED_TOMBSTONE_COMPACTION_OPTION));
-        logAll = getOption(LOG_ALL_OPTION, useDefault, DEFAULT_LOG_ALL_OPTION);
+        logAll = Boolean.parseBoolean(getOption(LOG_ALL_OPTION, useDefault, DEFAULT_LOG_ALL_OPTION));
+        periodicLogAll = getOption(PERIODIC_LOG_ALL_OPTION, useDefault, DEFAULT_PERIODIC_LOG_ALL_OPTION);
         logPeriodMinutes = Integer.parseInt(getOption(LOG_PERIOD_MINUTES_OPTION, useDefault, DEFAULT_LOG_PERIOD_MINUTES_OPTION));
     }
 
@@ -306,9 +310,15 @@ public class CompactionStrategyOptions
         }
 
         String logAll = options.get(LOG_ALL_OPTION);
-        if (logAll != null && !logAll.equalsIgnoreCase("all") && !logAll.equalsIgnoreCase("events_only") && !logAll.equalsIgnoreCase("none"))
+        if (logAll != null && !logAll.equalsIgnoreCase("true") && !logAll.equalsIgnoreCase("false"))
         {
-            throw new ConfigurationException(String.format("'%s' should either be 'all' or 'events_only' or 'none', not %s", LOG_ALL_OPTION, logAll));
+            throw new ConfigurationException(String.format("'%s' should either be 'true' or 'false', not %s", LOG_ALL_OPTION, logAll));
+        }
+
+        String periodicLogAll = options.get(PERIODIC_LOG_ALL_OPTION);
+        if (periodicLogAll != null && !periodicLogAll.equalsIgnoreCase("all") && !periodicLogAll.equalsIgnoreCase("events_only") && !periodicLogAll.equalsIgnoreCase("none"))
+        {
+            throw new ConfigurationException(String.format("'%s' should either be 'all' or 'events_only' or 'none', not %s", PERIODIC_LOG_ALL_OPTION, periodicLogAll));
         }
 
         String logPeriodMinutes = options.get(LOG_PERIOD_MINUTES_OPTION);
@@ -339,6 +349,7 @@ public class CompactionStrategyOptions
         uncheckedOptions.remove(TOMBSTONE_COMPACTION_INTERVAL_OPTION);
         uncheckedOptions.remove(UNCHECKED_TOMBSTONE_COMPACTION_OPTION);
         uncheckedOptions.remove(LOG_ALL_OPTION);
+        uncheckedOptions.remove(PERIODIC_LOG_ALL_OPTION);
         uncheckedOptions.remove(LOG_PERIOD_MINUTES_OPTION);
         uncheckedOptions.remove(COMPACTION_ENABLED);
         uncheckedOptions.remove(ONLY_PURGE_REPAIRED_TOMBSTONES);
@@ -403,14 +414,14 @@ public class CompactionStrategyOptions
 
     public boolean isLogEnabled()
     {
-        if (logAll.equalsIgnoreCase("all") || logAll.equalsIgnoreCase("events_only"))
+        if (logAll || periodicLogAll.equalsIgnoreCase("all") || periodicLogAll.equalsIgnoreCase("events_only"))
             return true;
         return false;
     }
 
     public boolean isLogAll()
     {
-        return logAll.equalsIgnoreCase("all");
+        return periodicLogAll.equalsIgnoreCase("all");
     }
 
     public int getLogPeriodMinutes()

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -344,7 +344,7 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
     }
 
     @Override
-    public void periodicReport()
+    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions)
     {
         logCount++;
         CompactionLogger logger = this.getCompactionLogger();

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -44,7 +44,6 @@ import org.apache.cassandra.schema.CompactionParams;
 
 public class UnifiedCompactionContainer implements CompactionStrategyContainer
 {
-    private static int logCount = 0;
     private final CompactionStrategyFactory factory;
     private final CompactionParams params;
     private final CompactionParams metadataParams;

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -342,6 +342,15 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
         return strategy.supportsEarlyOpen();
     }
 
+    @Override
+    public void periodicReport()
+    {
+        CompactionLogger logger = this.getCompactionLogger();
+        BackgroundCompactions backgroundCompactions = getBackgroundCompactions();
+        if (logger != null && logger.enabled())
+            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+    }
+
     BackgroundCompactions getBackgroundCompactions()
     {
         return strategy.backgroundCompactions;

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -344,19 +344,9 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
     }
 
     @Override
-    public void periodicReport(@Nullable CompactionStrategyOptions testOptions, @Nullable BackgroundCompactions testBackgroundCompactions)
+    public void periodicReport()
     {
-        logCount++;
-        CompactionLogger logger = this.getCompactionLogger();
-        BackgroundCompactions backgroundCompactions = getBackgroundCompactions();
-        int interval = strategy.options.getLogPeriodMinutes();
-        boolean logAll = strategy.options.isLogAll();
-        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
-        {
-            logCount = 0;
-            logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
-        }
-
+        strategy.periodicReport();
     }
 
     BackgroundCompactions getBackgroundCompactions()

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.schema.CompactionParams;
 
 public class UnifiedCompactionContainer implements CompactionStrategyContainer
 {
+    private static int logCount = 0;
     private final CompactionStrategyFactory factory;
     private final CompactionParams params;
     private final CompactionParams metadataParams;
@@ -345,10 +346,17 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
     @Override
     public void periodicReport()
     {
+        logCount++;
         CompactionLogger logger = this.getCompactionLogger();
         BackgroundCompactions backgroundCompactions = getBackgroundCompactions();
-        if (logger != null && logger.enabled())
+        int interval = strategy.options.getLogPeriodMinutes();
+        boolean logAll = strategy.options.isLogAll();
+        if (logger != null && logger.enabled() && logAll && logCount % interval == 0)
+        {
+            logCount = 0;
             logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
+        }
+
     }
 
     BackgroundCompactions getBackgroundCompactions()

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -68,7 +68,7 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
 
         factory.getCompactionLogger().strategyCreated(this.strategy);
 
-        if (this.strategy.getOptions().isLogAll())
+        if (this.strategy.getOptions().isLogEnabled())
             factory.getCompactionLogger().enable();
         else
             factory.getCompactionLogger().disable();

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -335,6 +335,6 @@ public class AdaptiveController extends Controller
     @Override
     public String toString()
     {
-        return String.format("m: %d, o: %s, W: %d - %s", minSstableSizeMB, Arrays.toString(survivalFactors), W, calculator);
+        return String.format("m: %d, o: %s, W: %s - %s", minSstableSizeMB, Arrays.toString(survivalFactors), W, calculator);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.Pair;
@@ -42,6 +43,8 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -439,5 +442,23 @@ public class BackgroundCompactionsTest
     {
         BackgroundCompactions backgroundCompactions = new BackgroundCompactions(cfs);
         backgroundCompactions.onCompleted(strategyContainer, null);
+    }
+
+    @Test
+    public void periodicReportsTest()
+    {
+        CompactionStrategyOptions options = mock(CompactionStrategyOptions.class);
+        BackgroundCompactions backgroundCompactions = mock(BackgroundCompactions.class);
+        UnifiedCompactionStrategy ucs = mock(UnifiedCompactionStrategy.class);
+        CompactionStrategyStatistics stats = mock(CompactionStrategyStatistics.class);
+
+        when(options.isLogAll()).thenReturn(true);
+        when(options.getLogPeriodMinutes()).thenReturn(1);
+        when(backgroundCompactions.getStatistics(ucs)).thenReturn(stats);
+        when(ucs.getCompactionLogger()).thenReturn(compactionLogger);
+        doCallRealMethod().when(ucs).periodicReport(options, backgroundCompactions);
+
+        ucs.periodicReport(options, backgroundCompactions);
+        Mockito.verify(compactionLogger, times(1)).statistics(eq(ucs), eq("periodic"), any(CompactionStrategyStatistics.class));
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
@@ -452,13 +452,15 @@ public class BackgroundCompactionsTest
         UnifiedCompactionStrategy ucs = mock(UnifiedCompactionStrategy.class);
         CompactionStrategyStatistics stats = mock(CompactionStrategyStatistics.class);
 
+        when(ucs.getOptions()).thenReturn(options);
+        when(ucs.getBackgroundCompactions()).thenReturn(backgroundCompactions);
         when(options.isLogAll()).thenReturn(true);
         when(options.getLogPeriodMinutes()).thenReturn(1);
         when(backgroundCompactions.getStatistics(ucs)).thenReturn(stats);
         when(ucs.getCompactionLogger()).thenReturn(compactionLogger);
-        doCallRealMethod().when(ucs).periodicReport(options, backgroundCompactions);
+        doCallRealMethod().when(ucs).periodicReport();
 
-        ucs.periodicReport(options, backgroundCompactions);
+        ucs.periodicReport();
         Mockito.verify(compactionLogger, times(1)).statistics(eq(ucs), eq("periodic"), any(CompactionStrategyStatistics.class));
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
@@ -855,4 +855,15 @@ public class CompactionsCQLTest extends CQLTester
         if (shouldFind)
             fail("No minor compaction triggered in "+maxWaitTime+"ms");
     }
+
+    @Test
+    public void testPeriodicCompactionsCall()
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY) WITH compaction = {'class': 'TestCompactionClass'}");
+        TestCompactionClass cs = (TestCompactionClass) getCurrentColumnFamilyStore().getCompactionStrategyContainer().getStrategies().get(0);
+        int prCount = cs.periodicReportsCalled;
+        CompactionManager.periodicReports();
+        assertTrue(cs.periodicReportsCalled > prCount);
+
+    }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/TestCompactionClass.java
+++ b/test/unit/org/apache/cassandra/db/compaction/TestCompactionClass.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.util.Map;
+
+public class TestCompactionClass extends SizeTieredCompactionStrategy
+{
+    int periodicReportsCalled = 0;
+
+    public TestCompactionClass(CompactionStrategyFactory factory, Map<String, String> options)
+    {
+        super(factory, options);
+    }
+
+    @Override
+    public void periodicReport()
+    {
+        super.periodicReport();
+        ++periodicReportsCalled;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -117,7 +117,7 @@ public class AdaptiveControllerTest extends ControllerTest
     @Test
     public void testValidateCompactionStrategyOptions()
     {
-        super.testValidateCompactionStrategyOptions();
+        super.testValidateCompactionStrategyOptions(true);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.cassandra.db.compaction.CompactionStrategyOptions;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.schema.CachingParams;

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.db.compaction.CompactionStrategyOptions;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.schema.CachingParams;
@@ -112,6 +113,12 @@ public class AdaptiveControllerTest extends ControllerTest
         options.put(AdaptiveController.MIN_COST, "5");
 
         super.testValidateOptions(options, true);
+    }
+
+    @Test
+    public void testValidateCompactionStrategyOptions()
+    {
+        super.testValidateCompactionStrategyOptions();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.cassandra.db.compaction.unified;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -27,6 +28,7 @@ import org.junit.Ignore;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionStrategyOptions;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.ReplicationFactor;
@@ -184,5 +186,19 @@ public abstract class ControllerTest
         assertNotNull(controller.getCalculator());
 
         controller.startup(strategy, executorService);
+    }
+
+    void testValidateCompactionStrategyOptions()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put(CompactionStrategyOptions.TOMBSTONE_THRESHOLD_OPTION, "0");
+        options.put(CompactionStrategyOptions.TOMBSTONE_COMPACTION_INTERVAL_OPTION, "1");
+        options.put(CompactionStrategyOptions.UNCHECKED_TOMBSTONE_COMPACTION_OPTION, "true");
+        options.put(CompactionStrategyOptions.LOG_ALL_OPTION, "true");
+        options.put(CompactionStrategyOptions.PERIODIC_LOG_ALL_OPTION, "all");
+        options.put(CompactionStrategyOptions.LOG_PERIOD_MINUTES_OPTION, "1");
+        options.put(CompactionStrategyOptions.COMPACTION_ENABLED, "true");
+
+        CompactionStrategyOptions.validateOptions(options);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -195,11 +195,6 @@ public abstract class ControllerTest
         controller.startup(strategy, executorService);
     }
 
-    void testFromCompactionStrategyOptions()
-    {
-
-    }
-
     void testValidateCompactionStrategyOptions()
     {
         Map<String, String> options = new HashMap<>();

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -61,7 +61,7 @@ public abstract class ControllerTest
     static final long tombstoneCompactionIntervalOption = 1;
     static final boolean uncheckedTombstoneCompactionOption = true;
     static final boolean logAllOption = true;
-    static final String periodicLogAllOption = "all";
+    static final String logTypeOption = "all";
     static final int logPeriodMinutesOption = 1;
     static final boolean compactionEnabled = true;
 
@@ -195,14 +195,18 @@ public abstract class ControllerTest
         controller.startup(strategy, executorService);
     }
 
-    void testValidateCompactionStrategyOptions()
+    void testValidateCompactionStrategyOptions(boolean testLogType)
     {
         Map<String, String> options = new HashMap<>();
         options.put(CompactionStrategyOptions.TOMBSTONE_THRESHOLD_OPTION, Float.toString(tombstoneThresholdOption));
         options.put(CompactionStrategyOptions.TOMBSTONE_COMPACTION_INTERVAL_OPTION, Long.toString(tombstoneCompactionIntervalOption));
         options.put(CompactionStrategyOptions.UNCHECKED_TOMBSTONE_COMPACTION_OPTION, Boolean.toString(uncheckedTombstoneCompactionOption));
-        options.put(CompactionStrategyOptions.LOG_ALL_OPTION, Boolean.toString(logAllOption));
-        options.put(CompactionStrategyOptions.PERIODIC_LOG_ALL_OPTION, periodicLogAllOption);
+
+        if (testLogType)
+            options.put(CompactionStrategyOptions.LOG_TYPE_OPTION, logTypeOption);
+        else
+            options.put(CompactionStrategyOptions.LOG_ALL_OPTION, Boolean.toString(logAllOption));
+
         options.put(CompactionStrategyOptions.LOG_PERIOD_MINUTES_OPTION, Integer.toString(logPeriodMinutesOption));
         options.put(CompactionStrategyOptions.COMPACTION_ENABLED, Boolean.toString(compactionEnabled));
 
@@ -212,8 +216,17 @@ public abstract class ControllerTest
         assertEquals(tombstoneThresholdOption, compactionStrategyOptions.getTombstoneThreshold(), epsilon);
         assertEquals(tombstoneCompactionIntervalOption, compactionStrategyOptions.getTombstoneCompactionInterval());
         assertEquals(uncheckedTombstoneCompactionOption, compactionStrategyOptions.isUncheckedTombstoneCompaction());
-        assertEquals((logAllOption || periodicLogAllOption.equals("all") || periodicLogAllOption.equals("events_only")), compactionStrategyOptions.isLogEnabled());
-        assertEquals(periodicLogAllOption.equals("all"), compactionStrategyOptions.isLogAll());
+
+        if (testLogType)
+        {
+            assertEquals((logTypeOption.equals("all") || logTypeOption.equals("events_only")), compactionStrategyOptions.isLogEnabled());
+            assertEquals(logTypeOption.equals("all"), compactionStrategyOptions.isLogAll());
+        }
+        else
+        {
+            assertEquals(logAllOption, compactionStrategyOptions.isLogEnabled());
+            assertEquals(logAllOption, compactionStrategyOptions.isLogAll());
+        }
         assertEquals(logPeriodMinutesOption, compactionStrategyOptions.getLogPeriodMinutes());
 
         Map<String, String> uncheckedOptions = CompactionStrategyOptions.validateOptions(options);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -57,6 +57,13 @@ public abstract class ControllerTest
     static final double maxSpaceOverhead = 0.3d;
     static final boolean allowOverlaps = false;
     static final long checkFrequency= 600L;
+    static final float tombstoneThresholdOption = 1;
+    static final long tombstoneCompactionIntervalOption = 1;
+    static final boolean uncheckedTombstoneCompactionOption = true;
+    static final boolean logAllOption = true;
+    static final String periodicLogAllOption = "all";
+    static final int logPeriodMinutesOption = 1;
+    static final boolean compactionEnabled = true;
 
     @Mock
     ColumnFamilyStore cfs;
@@ -188,17 +195,33 @@ public abstract class ControllerTest
         controller.startup(strategy, executorService);
     }
 
+    void testFromCompactionStrategyOptions()
+    {
+
+    }
+
     void testValidateCompactionStrategyOptions()
     {
         Map<String, String> options = new HashMap<>();
-        options.put(CompactionStrategyOptions.TOMBSTONE_THRESHOLD_OPTION, "0");
-        options.put(CompactionStrategyOptions.TOMBSTONE_COMPACTION_INTERVAL_OPTION, "1");
-        options.put(CompactionStrategyOptions.UNCHECKED_TOMBSTONE_COMPACTION_OPTION, "true");
-        options.put(CompactionStrategyOptions.LOG_ALL_OPTION, "true");
-        options.put(CompactionStrategyOptions.PERIODIC_LOG_ALL_OPTION, "all");
-        options.put(CompactionStrategyOptions.LOG_PERIOD_MINUTES_OPTION, "1");
-        options.put(CompactionStrategyOptions.COMPACTION_ENABLED, "true");
+        options.put(CompactionStrategyOptions.TOMBSTONE_THRESHOLD_OPTION, Float.toString(tombstoneThresholdOption));
+        options.put(CompactionStrategyOptions.TOMBSTONE_COMPACTION_INTERVAL_OPTION, Long.toString(tombstoneCompactionIntervalOption));
+        options.put(CompactionStrategyOptions.UNCHECKED_TOMBSTONE_COMPACTION_OPTION, Boolean.toString(uncheckedTombstoneCompactionOption));
+        options.put(CompactionStrategyOptions.LOG_ALL_OPTION, Boolean.toString(logAllOption));
+        options.put(CompactionStrategyOptions.PERIODIC_LOG_ALL_OPTION, periodicLogAllOption);
+        options.put(CompactionStrategyOptions.LOG_PERIOD_MINUTES_OPTION, Integer.toString(logPeriodMinutesOption));
+        options.put(CompactionStrategyOptions.COMPACTION_ENABLED, Boolean.toString(compactionEnabled));
 
-        CompactionStrategyOptions.validateOptions(options);
+        CompactionStrategyOptions compactionStrategyOptions = new CompactionStrategyOptions(UnifiedCompactionStrategy.class, options, true);
+        assertNotNull(compactionStrategyOptions);
+        assertNotNull(compactionStrategyOptions.toString());
+        assertEquals(tombstoneThresholdOption, compactionStrategyOptions.getTombstoneThreshold(), epsilon);
+        assertEquals(tombstoneCompactionIntervalOption, compactionStrategyOptions.getTombstoneCompactionInterval());
+        assertEquals(uncheckedTombstoneCompactionOption, compactionStrategyOptions.isUncheckedTombstoneCompaction());
+        assertEquals((logAllOption || periodicLogAllOption.equals("all") || periodicLogAllOption.equals("events_only")), compactionStrategyOptions.isLogEnabled());
+        assertEquals(periodicLogAllOption.equals("all"), compactionStrategyOptions.isLogAll());
+        assertEquals(logPeriodMinutesOption, compactionStrategyOptions.getLogPeriodMinutes());
+
+        Map<String, String> uncheckedOptions = CompactionStrategyOptions.validateOptions(options);
+        assertNotNull(uncheckedOptions);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -66,6 +66,12 @@ public class StaticControllerTest extends ControllerTest
     }
 
     @Test
+    public void testValidateCompactionStrategyOptions()
+    {
+        super.testValidateCompactionStrategyOptions();
+    }
+
+    @Test
     public void testSurvivalFactorForSharedStorage()
     {
         System.setProperty("unified_compaction.shared_storage", "true");

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -68,7 +68,7 @@ public class StaticControllerTest extends ControllerTest
     @Test
     public void testValidateCompactionStrategyOptions()
     {
-        super.testValidateCompactionStrategyOptions();
+        super.testValidateCompactionStrategyOptions(true);
     }
 
     @Test


### PR DESCRIPTION
At the moment a compaction log entry is only generated on a submission or completion of a compaction task. This works well only if the table is getting enough writes to cause frequent L0 compaction; if it is not (e.g. during “wait for compaction” phases in fallout tests), no compaction log entries are generated.

To be able to see a better view of the behaviour of compaction, we should also have periodic reporting, scheduled at low frequency (e.g. once a minute).