### PR TITLE
CNDB-6142 Don't directly use ClientMetrics in AbstractMessageHandler

### DIFF
--- a/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
@@ -33,7 +33,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
-import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameDecoder.CorruptFrame;
 import org.apache.cassandra.net.FrameDecoder.Frame;
 import org.apache.cassandra.net.FrameDecoder.FrameProcessor;
@@ -219,6 +218,11 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
         return true;
     }
 
+    /**
+     * React to the decoder being reactivated
+     */
+    protected abstract void onDecoderReactivated();
+
     private boolean processIntactFrame(IntactFrame frame, Limit endpointReserve, Limit globalReserve) throws IOException
     {
         if (frame.isSelfContained)
@@ -311,7 +315,7 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
                 decoder.reactivate();
 
                 if (decoder.isActive())
-                    ClientMetrics.instance.unpauseConnection();
+                    onDecoderReactivated();
             }
         }
         catch (Throwable t)

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -118,6 +118,12 @@ public class InboundMessageHandler extends AbstractMessageHandler
         this.consumer = consumer;
     }
 
+    @Override
+    protected void onDecoderReactivated()
+    {
+        // No-op for this implementation, as the InboundMessageHandler should not use ClientMetrics
+    }
+
     protected boolean processOneContainedMessage(ShareableBytes bytes, Limit endpointReserve, Limit globalReserve) throws IOException
     {
         ByteBuffer buf = bytes.get();

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -143,6 +143,12 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
         return super.process(frame);
     }
 
+    @Override
+    protected void onDecoderReactivated()
+    {
+        ClientMetrics.instance.unpauseConnection();
+    }
+
     /**
      * Checks limits on bytes in flight and the request rate limiter (if enabled), then takes one of three actions:
      * 


### PR DESCRIPTION
This is alternative solution for https://github.com/riptano/cndb/issues/6142

The idea is to not directly touch `ClientMetrics` from `AbstractMessageHandler`. Probably cleaner than the other solution proposed here: https://github.com/datastax/cassandra/pull/603

@jtgrabowski @jasonstack please let me know what you think