### PR TITLE
CNDB-6522 add NativeMemoryMetrics

### DIFF
--- a/src/java/org/apache/cassandra/io/util/Memory.java
+++ b/src/java/org/apache/cassandra/io/util/Memory.java
@@ -360,7 +360,7 @@ public class Memory implements AutoCloseable
 
     public void free()
     {
-        if (peer != 0) MemoryUtil.free(peer);
+        if (peer != 0) MemoryUtil.free(peer, size);
         else assert size == 0;
         peer = 0;
     }

--- a/src/java/org/apache/cassandra/io/util/SafeMemory.java
+++ b/src/java/org/apache/cassandra/io/util/SafeMemory.java
@@ -88,7 +88,7 @@ public class SafeMemory extends Memory implements SharedCloseable
         {
             /** see {@link Memory#Memory(long)} re: null pointers*/
             if (peer != 0)
-                MemoryUtil.free(peer);
+                MemoryUtil.free(peer, size);
         }
 
         public String name()

--- a/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.metrics;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
@@ -33,14 +33,6 @@ public class CodehaleNativeMemoryMetrics implements NativeMemoryMetrics
 
     private final MetricNameFactory factory;
 
-    /** The total number of page-aligned direct byte buffer allocations that were done using
-     * {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED} */
-    private final Meter totalAlignedAllocations;
-
-    /** The number of page-aligned direct byte buffer allocations that are less than the small buffer threshold defined above,
-     * currently 16k, and that were done using {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED} */
-    private final Meter smallAlignedAllocations;
-
     /** Total size of memory allocated directly by calling Native.malloc via {@link UnsafeMemoryAccess}, bypassing the JVM.
      * This is in addition to nio direct memory, for example off-heap memtables will use this type of memory. */
     private final Gauge<Long> rawNativeMemory;
@@ -78,9 +70,6 @@ public class CodehaleNativeMemoryMetrics implements NativeMemoryMetrics
         if (directBufferPool == null)
             logger.error("Direct memory buffer pool MBean not present, native memory metrics will be missing for nio buffers");
 
-        totalAlignedAllocations = Metrics.meter(factory.createMetricName("TotalAlignedAllocations"));
-        smallAlignedAllocations = Metrics.meter(factory.createMetricName("SmallAlignedAllocations"));
-
         rawNativeMemory = Metrics.register(factory.createMetricName("RawNativeMemory"), this::rawNativeMemory);
         bloomFilterMemory = Metrics.register(factory.createMetricName("BloomFilterMemory"), this::bloomFilterMemory);
         usedNioDirectMemory = Metrics.register(factory.createMetricName("UsedNioDirectMemory"), this::usedNioDirectMemory);
@@ -88,18 +77,6 @@ public class CodehaleNativeMemoryMetrics implements NativeMemoryMetrics
         networkDirectMemory = Metrics.register(factory.createMetricName("NetworkDirectMemory"), this::networkDirectMemory);
         nioDirectBufferCount = Metrics.register(factory.createMetricName("NioDirectBufferCount"), this::nioDirectBufferCount);
         totalMemory = Metrics.register(factory.createMetricName("TotalMemory"), this::totalMemory);
-    }
-
-    @Override
-    public void alignedAllocation()
-    {
-        totalAlignedAllocations.mark();
-    }
-
-    @Override
-    public void smallAlignedAllocation()
-    {
-        smallAlignedAllocations.mark();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Gauge;
-import org.apache.cassandra.utils.UnsafeMemoryAccess;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
@@ -32,7 +32,7 @@ public class CodehaleNativeMemoryMetrics implements NativeMemoryMetrics
 
     private final MetricNameFactory factory;
 
-    /** Total size of memory allocated directly by calling Native.malloc via {@link UnsafeMemoryAccess}, bypassing the JVM.
+    /** Total size of memory allocated directly by calling Native.malloc via {@link MemoryUtil}, bypassing the JVM.
      * This is in addition to nio direct memory, for example off-heap memtables will use this type of memory. */
     private final Gauge<Long> rawNativeMemory;
 

--- a/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodehaleNativeMemoryMetrics.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Gauge;
+import org.apache.cassandra.utils.UnsafeMemoryAccess;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+public class CodehaleNativeMemoryMetrics implements NativeMemoryMetrics
+{
+    private static final Logger logger = LoggerFactory.getLogger(CodehaleNativeMemoryMetrics.class);
+
+    private final MetricNameFactory factory;
+
+    /** The total number of page-aligned direct byte buffer allocations that were done using
+     * {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED} */
+    private final Meter totalAlignedAllocations;
+
+    /** The number of page-aligned direct byte buffer allocations that are less than the small buffer threshold defined above,
+     * currently 16k, and that were done using {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED} */
+    private final Meter smallAlignedAllocations;
+
+    /** Total size of memory allocated directly by calling Native.malloc via {@link UnsafeMemoryAccess}, bypassing the JVM.
+     * This is in addition to nio direct memory, for example off-heap memtables will use this type of memory. */
+    private final Gauge<Long> rawNativeMemory;
+
+    /**
+     * Total size of memory used by bloom filters, part of {@link this#rawNativeMemory}.
+     */
+    private final Gauge<Long> bloomFilterMemory;
+
+    /** The memory allocated for direct byte buffers, aligned or otherwise, without counting any padding due to alignment.
+     *  If {@code -Dio.netty.directMemory} is not set to {@code 0}, the direct memory used by Netty is <em>not</em> included in this value. */
+    private final Gauge<Long> usedNioDirectMemory;
+
+    /** The total memory allocated for direct byte buffers, aligned or otherwise, including any padding due to alignment.
+     * If -Dsun.nio.PageAlignDirectMemory=true is not set then this will be identical to usedNioDirectMemory.
+     * If {@code -Dio.netty.directMemory} is not set to {@code 0}, the direct memory used by Netty is <em>not</em> included in this value. */
+    private final Gauge<Long> totalNioDirectMemory;
+
+    /** The memory used by direct byte buffers allocated via the Netty library. These buffers are used for network communications.
+     * A limit can be set with "-Dio.netty.maxDirectMemory". When this property is zero (the default in jvm.options), then
+     * Netty will use the JVM NIO direct memory. Therefore, this value will be included in {@link #usedNioDirectMemory}
+     * and {@link #totalNioDirectMemory} only when the property is set to zero, otherwise this value is extra. */
+    private final Gauge<Long> networkDirectMemory;
+
+    /** The total number of direct byte buffers allocated, aligned or otherwise. */
+    private final Gauge<Long> nioDirectBufferCount;
+
+    /** The total memory allocated, including direct byte buffers, network direct memory, and raw malloc memory */
+    private final Gauge<Long> totalMemory;
+
+    public CodehaleNativeMemoryMetrics()
+    {
+        factory = new DefaultNameFactory("NativeMemory");
+
+        if (directBufferPool == null)
+            logger.error("Direct memory buffer pool MBean not present, native memory metrics will be missing for nio buffers");
+
+        totalAlignedAllocations = Metrics.meter(factory.createMetricName("TotalAlignedAllocations"));
+        smallAlignedAllocations = Metrics.meter(factory.createMetricName("SmallAlignedAllocations"));
+
+        rawNativeMemory = Metrics.register(factory.createMetricName("RawNativeMemory"), this::rawNativeMemory);
+        bloomFilterMemory = Metrics.register(factory.createMetricName("BloomFilterMemory"), this::bloomFilterMemory);
+        usedNioDirectMemory = Metrics.register(factory.createMetricName("UsedNioDirectMemory"), this::usedNioDirectMemory);
+        totalNioDirectMemory = Metrics.register(factory.createMetricName("TotalNioDirectMemory"), this::totalNioDirectMemory);
+        networkDirectMemory = Metrics.register(factory.createMetricName("NetworkDirectMemory"), this::networkDirectMemory);
+        nioDirectBufferCount = Metrics.register(factory.createMetricName("NioDirectBufferCount"), this::nioDirectBufferCount);
+        totalMemory = Metrics.register(factory.createMetricName("TotalMemory"), this::totalMemory);
+    }
+
+    @Override
+    public void alignedAllocation()
+    {
+        totalAlignedAllocations.mark();
+    }
+
+    @Override
+    public void smallAlignedAllocation()
+    {
+        smallAlignedAllocations.mark();
+    }
+
+    @Override
+    public long usedNioDirectMemoryValue()
+    {
+        return usedNioDirectMemory.getValue();
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 
@@ -38,19 +37,11 @@ public class MicrometerNativeMemoryMetrics extends MicrometerMetrics implements 
     public static final String TOTAL_NIO_MEMORY = METRICS_PREFIX + "_total_nio_direct_memory";
     public static final String NIO_DIRECT_BUFFER_COUNT = METRICS_PREFIX + "_nio_direct_buffer_count";
     public static final String TOTAL_MEMORY = METRICS_PREFIX + "_total_memory";
-    public static final String TOTAL_ALIGNED_ALLOCATIONS = METRICS_PREFIX + "_total_aligned_allocations_total";
-    public static final String SMALL_ALIGNED_ALLOCATIONS = METRICS_PREFIX + "_small_aligned_allocations_total";
-
-    private volatile Counter totalAlignedAllocations;
-    private volatile Counter smallAlignedAllocations;
 
     public MicrometerNativeMemoryMetrics()
     {
         if (directBufferPool == null)
             logger.error("Direct memory buffer pool MBean not present, native memory metrics will be missing for nio buffers");
-
-        this.totalAlignedAllocations = counter(TOTAL_ALIGNED_ALLOCATIONS);
-        this.smallAlignedAllocations = counter(SMALL_ALIGNED_ALLOCATIONS);
     }
 
     @Override
@@ -65,21 +56,6 @@ public class MicrometerNativeMemoryMetrics extends MicrometerMetrics implements 
         gauge(TOTAL_NIO_MEMORY, this, NativeMemoryMetrics::totalNioDirectMemory);
         gauge(NIO_DIRECT_BUFFER_COUNT, this, NativeMemoryMetrics::nioDirectBufferCount);
         gauge(TOTAL_MEMORY, this, NativeMemoryMetrics::totalMemory);
-
-        this.totalAlignedAllocations = counter(TOTAL_ALIGNED_ALLOCATIONS);
-        this.smallAlignedAllocations = counter(SMALL_ALIGNED_ALLOCATIONS);
-    }
-
-    @Override
-    public void alignedAllocation()
-    {
-        this.totalAlignedAllocations.increment();
-    }
-
-    @Override
-    public void smallAlignedAllocation()
-    {
-        this.smallAlignedAllocations.increment();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+public class MicrometerNativeMemoryMetrics extends MicrometerMetrics implements NativeMemoryMetrics
+{
+    private static final Logger logger = LoggerFactory.getLogger(MicrometerNativeMemoryMetrics.class);
+
+    private static final String METRICS_PREFIX = "jvm_native_memory";
+
+    public static final String RAW_NATIVE_MEMORY = METRICS_PREFIX + "_raw_native_memory";
+    public static final String BLOOM_FILTER_MEMORY = METRICS_PREFIX + "_bloom_filter_memory";
+    public static final String NETWORK_DIRECT_MEMORY = METRICS_PREFIX + "_network_direct_memory";
+    public static final String USED_NIO_DIRECT_MEMORY = METRICS_PREFIX + "_used_nio_direct_memory";
+    public static final String TOTAL_NIO_MEMORY = METRICS_PREFIX + "_total_nio_direct_memory";
+    public static final String NIO_DIRECT_BUFFER_COUNT = METRICS_PREFIX + "_nio_direct_buffer_count";
+    public static final String TOTAL_MEMORY = METRICS_PREFIX + "_total_memory";
+    public static final String TOTAL_ALIGNED_ALLOCATIONS = METRICS_PREFIX + "_total_aligned_allocations_total";
+    public static final String SMALL_ALIGNED_ALLOCATIONS = METRICS_PREFIX + "_small_aligned_allocations_total";
+
+    private volatile Counter totalAlignedAllocations;
+    private volatile Counter smallAlignedAllocations;
+
+    public MicrometerNativeMemoryMetrics()
+    {
+        if (directBufferPool == null)
+            logger.error("Direct memory buffer pool MBean not present, native memory metrics will be missing for nio buffers");
+
+        this.totalAlignedAllocations = counter(TOTAL_ALIGNED_ALLOCATIONS);
+        this.smallAlignedAllocations = counter(SMALL_ALIGNED_ALLOCATIONS);
+    }
+
+    @Override
+    public synchronized void register(MeterRegistry newRegistry, Tags newTags)
+    {
+        super.register(newRegistry, newTags);
+
+        gauge(RAW_NATIVE_MEMORY, this, NativeMemoryMetrics::rawNativeMemory);
+        gauge(BLOOM_FILTER_MEMORY, this, NativeMemoryMetrics::bloomFilterMemory);
+        gauge(NETWORK_DIRECT_MEMORY, this, NativeMemoryMetrics::networkDirectMemory);
+        gauge(USED_NIO_DIRECT_MEMORY, this, NativeMemoryMetrics::usedNioDirectMemory);
+        gauge(TOTAL_NIO_MEMORY, this, NativeMemoryMetrics::totalNioDirectMemory);
+        gauge(NIO_DIRECT_BUFFER_COUNT, this, NativeMemoryMetrics::nioDirectBufferCount);
+        gauge(TOTAL_MEMORY, this, NativeMemoryMetrics::totalMemory);
+
+        this.totalAlignedAllocations = counter(TOTAL_ALIGNED_ALLOCATIONS);
+        this.smallAlignedAllocations = counter(SMALL_ALIGNED_ALLOCATIONS);
+    }
+
+    @Override
+    public void alignedAllocation()
+    {
+        this.totalAlignedAllocations.increment();
+    }
+
+    @Override
+    public void smallAlignedAllocation()
+    {
+        this.smallAlignedAllocations.increment();
+    }
+
+    @Override
+    public long usedNioDirectMemoryValue()
+    {
+        return usedNioDirectMemory();
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+
+package org.apache.cassandra.metrics;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+
+import io.netty.util.internal.PlatformDependent;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.utils.UnsafeMemoryAccess;
+import org.apache.cassandra.utils.obs.OffHeapBitSet;
+
+public interface NativeMemoryMetrics
+{
+    long smallBufferThreshold = 4 * UnsafeMemoryAccess.pageSize();
+
+    BufferPoolMXBean directBufferPool = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
+                                                         .stream()
+                                                         .filter(bpMBean -> bpMBean.getName().equals("direct"))
+                                                         .findFirst()
+                                                         .orElse(null);
+
+    NativeMemoryMetrics instance = CassandraRelevantProperties.USE_MICROMETER.getBoolean() ? new MicrometerNativeMemoryMetrics()
+                                                               : new CodehaleNativeMemoryMetrics();
+
+    void alignedAllocation();
+
+    void smallAlignedAllocation();
+
+    long usedNioDirectMemoryValue();
+
+    default long rawNativeMemory()
+    {
+        return UnsafeMemoryAccess.allocated();
+    }
+
+    default long bloomFilterMemory()
+    {
+        return OffHeapBitSet.memoryAllocated();
+    }
+
+    default long usedNioDirectMemory()
+    {
+        return directBufferPool == null ? 0 : directBufferPool.getMemoryUsed();
+    }
+
+    default long totalNioDirectMemory()
+    {
+        return directBufferPool == null ? 0 : directBufferPool.getTotalCapacity();
+    }
+
+    default long nioDirectBufferCount()
+    {
+        return directBufferPool == null ? 0 : directBufferPool.getCount();
+    }
+
+    default long networkDirectMemory()
+    {
+        return PlatformDependent.usedDirectMemory();
+    }
+
+    default boolean usingNioMemoryForNetwork()
+    {
+        return !PlatformDependent.useDirectBufferNoCleaner();
+    }
+
+    default long totalMemory()
+    {
+        // Use totalNioDirectMemory() instead of usedNioDirectMemory() because without
+        // -Dsun.nio.PageAlignDirectMemory=true the two are identical. If someone adds
+        // this flag again, we would prefer to include the JVM padding in the total memory.
+        // Also only add the network memory if it's not allocated as NIO direct memory
+        return rawNativeMemory() + totalNioDirectMemory() + (usingNioMemoryForNetwork() ? 0 : networkDirectMemory());
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -37,7 +37,6 @@ public interface NativeMemoryMetrics
     NativeMemoryMetrics instance = CassandraRelevantProperties.USE_MICROMETER.getBoolean()
                                    ? new MicrometerNativeMemoryMetrics()
                                    : new CodehaleNativeMemoryMetrics();
-                                                               : new CodehaleNativeMemoryMetrics();
 
     long usedNioDirectMemoryValue();
 

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -34,7 +34,9 @@ public interface NativeMemoryMetrics
                                                          .findFirst()
                                                          .orElse(null);
 
-    NativeMemoryMetrics instance = CassandraRelevantProperties.USE_MICROMETER.getBoolean() ? new MicrometerNativeMemoryMetrics()
+    NativeMemoryMetrics instance = CassandraRelevantProperties.USE_MICROMETER.getBoolean()
+                                   ? new MicrometerNativeMemoryMetrics()
+                                   : new CodehaleNativeMemoryMetrics();
                                                                : new CodehaleNativeMemoryMetrics();
 
     long usedNioDirectMemoryValue();

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -18,21 +18,16 @@
 
 package org.apache.cassandra.metrics;
 
-
-package org.apache.cassandra.metrics;
-
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 
 import io.netty.util.internal.PlatformDependent;
 import org.apache.cassandra.config.CassandraRelevantProperties;
-import org.apache.cassandra.utils.UnsafeMemoryAccess;
-import org.apache.cassandra.utils.obs.OffHeapBitSet;
+import org.apache.cassandra.utils.BloomFilter;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 public interface NativeMemoryMetrics
 {
-    long smallBufferThreshold = 4 * UnsafeMemoryAccess.pageSize();
-
     BufferPoolMXBean directBufferPool = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
                                                          .stream()
                                                          .filter(bpMBean -> bpMBean.getName().equals("direct"))
@@ -46,12 +41,12 @@ public interface NativeMemoryMetrics
 
     default long rawNativeMemory()
     {
-        return UnsafeMemoryAccess.allocated();
+        return MemoryUtil.allocated();
     }
 
     default long bloomFilterMemory()
     {
-        return OffHeapBitSet.memoryAllocated();
+        return BloomFilter.memoryLimiter.memoryAllocated();
     }
 
     default long usedNioDirectMemory()

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -42,10 +42,6 @@ public interface NativeMemoryMetrics
     NativeMemoryMetrics instance = CassandraRelevantProperties.USE_MICROMETER.getBoolean() ? new MicrometerNativeMemoryMetrics()
                                                                : new CodehaleNativeMemoryMetrics();
 
-    void alignedAllocation();
-
-    void smallAlignedAllocation();
-
     long usedNioDirectMemoryValue();
 
     default long rawNativeMemory()

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.sun.jna.Native;
 
@@ -32,6 +33,7 @@ public abstract class MemoryUtil
 {
     private static final long UNSAFE_COPY_THRESHOLD = 1024 * 1024L; // copied from java.nio.Bits
 
+    private static final AtomicLong memoryAllocated = new AtomicLong(0);
     private static final Unsafe unsafe;
     private static final Class<?> DIRECT_BYTE_BUFFER_CLASS, RO_DIRECT_BYTE_BUFFER_CLASS;
     private static final long DIRECT_BYTE_BUFFER_ADDRESS_OFFSET;
@@ -55,14 +57,19 @@ public abstract class MemoryUtil
             Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
             field.setAccessible(true);
             unsafe = (sun.misc.Unsafe) field.get(null);
-            Class<?> clazz = ByteBuffer.allocateDirect(0).getClass();
+            // OpenJDK for some reason allocates bytes when capacity == 0. When -Dsun.nio.PageAlignDirectMemory is false
+            // DirectByteBuffer allocates 1 byte, when true a whole page is allocated.
+            // This breaks our native memory metrics tests that don't expect Bits.RESERVED_MEMORY > Bits.TOTAL_CAPACITY.
+            // Allocate the buffer with capacity of 1 byte, to mitigate the problem.
+            ByteBuffer byteBuffer = ByteBuffer.allocateDirect(1);
+            Class<?> clazz = byteBuffer.getClass();
             DIRECT_BYTE_BUFFER_ADDRESS_OFFSET = unsafe.objectFieldOffset(Buffer.class.getDeclaredField("address"));
             DIRECT_BYTE_BUFFER_CAPACITY_OFFSET = unsafe.objectFieldOffset(Buffer.class.getDeclaredField("capacity"));
             DIRECT_BYTE_BUFFER_LIMIT_OFFSET = unsafe.objectFieldOffset(Buffer.class.getDeclaredField("limit"));
             DIRECT_BYTE_BUFFER_POSITION_OFFSET = unsafe.objectFieldOffset(Buffer.class.getDeclaredField("position"));
             DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET = unsafe.objectFieldOffset(clazz.getDeclaredField("att"));
             DIRECT_BYTE_BUFFER_CLASS = clazz;
-            RO_DIRECT_BYTE_BUFFER_CLASS = ByteBuffer.allocateDirect(0).asReadOnlyBuffer().getClass();
+            RO_DIRECT_BYTE_BUFFER_CLASS = byteBuffer.asReadOnlyBuffer().getClass();
 
             clazz = ByteBuffer.allocate(0).getClass();
             BYTE_BUFFER_OFFSET_OFFSET = unsafe.objectFieldOffset(ByteBuffer.class.getDeclaredField("offset"));
@@ -90,12 +97,19 @@ public abstract class MemoryUtil
 
     public static long allocate(long size)
     {
+        memoryAllocated.addAndGet(size);
         return Native.malloc(size);
     }
 
-    public static void free(long peer)
+    public static void free(long peer, long size)
     {
+        memoryAllocated.addAndGet(-size);
         Native.free(peer);
+    }
+
+    public static long allocated()
+    {
+        return memoryAllocated.get();
     }
 
     public static void setByte(long address, byte b)

--- a/src/java/org/apache/cassandra/utils/memory/NativeAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/NativeAllocator.java
@@ -178,7 +178,7 @@ public class NativeAllocator extends MemtableAllocator
         if (currentRegion.compareAndSet(current, next))
             regions.add(next);
         else if (!raceAllocated.stash(next))
-            MemoryUtil.free(next.peer);
+            MemoryUtil.free(next.peer, next.capacity);
     }
 
     private long allocateOversize(int size)
@@ -198,7 +198,7 @@ public class NativeAllocator extends MemtableAllocator
     public void setDiscarded()
     {
         for (Region region : regions)
-            MemoryUtil.free(region.peer);
+            MemoryUtil.free(region.peer, region.capacity);
 
         super.setDiscarded();
     }

--- a/test/unit/org/apache/cassandra/metrics/MicrometerNativeMemoryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/MicrometerNativeMemoryMetricsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.junit.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MicrometerNativeMemoryMetricsTest
+{
+    @Test
+    public void testRegisteringNativeMetrics()
+    {
+        MicrometerNativeMemoryMetrics metrics = new MicrometerNativeMemoryMetrics();
+
+        MeterRegistry registry = mock(MeterRegistry.class);
+        Tags tags = Tags.of("tag_key", "tag_value");
+        metrics.register(registry, tags);
+
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.RAW_NATIVE_MEMORY), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.TOTAL_MEMORY), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.BLOOM_FILTER_MEMORY), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.NETWORK_DIRECT_MEMORY), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.TOTAL_NIO_MEMORY), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.NIO_DIRECT_BUFFER_COUNT), eq(tags), any(), any());
+        verify(registry).gauge(eq(MicrometerNativeMemoryMetrics.USED_NIO_DIRECT_MEMORY), eq(tags), any(), any());
+    }
+}

--- a/test/unit/org/apache/cassandra/metrics/NativeMemoryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/NativeMemoryMetricsTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.memory.MemoryUtil;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class NativeMemoryMetricsTest
 {
@@ -65,6 +66,9 @@ public class NativeMemoryMetricsTest
 
         logger.debug("Total Nio Memory: {}, Reserved Nio Memory: {}, Num Nio buffers: {}",
                      totalNioDirectMemory, usedNioDirectMemory, nioDirectBufferCount);
+
+        assertFalse("sun.nio.PageAlignDirectMemory should not be set for this test",
+                    Boolean.getBoolean("sun.nio.PageAlignDirectMemory"));
 
         assertEquals("Total and reserved nio memory should be equal since -Dsun.nio.PageAlignDirectMemory=true should not be set",
                      totalNioDirectMemory, usedNioDirectMemory);

--- a/test/unit/org/apache/cassandra/metrics/NativeMemoryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/NativeMemoryMetricsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.UnsafeMemoryAccess;
+
+import static org.junit.Assert.assertEquals;
+
+public class NativeMemoryMetricsTest
+{
+    private final static Logger logger = LoggerFactory.getLogger(NativeMemoryMetricsTest.class);
+    private static NativeMemoryMetrics nativeMemoryMetrics;
+    private static BufferPoolMXBean directBufferPool;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        // Meter depends on LongAdder, which depends on TPC, which needs DD
+        DatabaseDescriptor.daemonInitialization();
+
+        nativeMemoryMetrics = NativeMemoryMetrics.instance;
+
+        directBufferPool = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
+                                            .stream()
+                                            .filter(bpMBean -> bpMBean.getName().equals("direct"))
+                                            .findFirst()
+                                            .orElse(null);
+    }
+
+    @Test
+    public void testNioDirectMemory()
+    {
+        long totalNioDirectMemory = nativeMemoryMetrics.totalNioDirectMemory();
+        long usedNioDirectMemory = nativeMemoryMetrics.usedNioDirectMemory();
+        long nioDirectBufferCount = nativeMemoryMetrics.nioDirectBufferCount();
+
+        logger.debug("Total Nio Memory: {}, Reserved Nio Memory: {}, Num Nio buffers: {}",
+                     totalNioDirectMemory, usedNioDirectMemory, nioDirectBufferCount);
+
+        assertEquals("Total and reserved nio memory should be equal since -Dsun.nio.PageAlignDirectMemory=true should not be set",
+                     totalNioDirectMemory, usedNioDirectMemory);
+
+        assertEquals("Total nio memory should be equal to total memory since no unsafe allocations should have been done",
+                     totalNioDirectMemory, nativeMemoryMetrics.totalMemory());
+
+        assertEquals(directBufferPool.getMemoryUsed(), nativeMemoryMetrics.usedNioDirectMemory());
+        assertEquals(directBufferPool.getTotalCapacity(), nativeMemoryMetrics.totalNioDirectMemory());
+        assertEquals(directBufferPool.getCount(), nativeMemoryMetrics.nioDirectBufferCount());
+
+        ByteBuffer buffer = ByteBuffer.allocateDirect(128);
+
+        assertEquals(totalNioDirectMemory + 128, nativeMemoryMetrics.totalNioDirectMemory());
+        assertEquals(usedNioDirectMemory + 128, nativeMemoryMetrics.usedNioDirectMemory());
+        assertEquals(nioDirectBufferCount + 1, nativeMemoryMetrics.nioDirectBufferCount());
+
+        FileUtils.clean(buffer);
+
+        assertEquals(totalNioDirectMemory, nativeMemoryMetrics.totalNioDirectMemory());
+        assertEquals(usedNioDirectMemory, nativeMemoryMetrics.usedNioDirectMemory());
+        assertEquals(nioDirectBufferCount, nativeMemoryMetrics.nioDirectBufferCount());
+    }
+
+    @Test
+    public void testUnsafeNativeMemory()
+    {
+        assertEquals(0, nativeMemoryMetrics.rawNativeMemory());
+
+        long peer = UnsafeMemoryAccess.allocate(128);
+        assertEquals(128, nativeMemoryMetrics.rawNativeMemory());
+
+        UnsafeMemoryAccess.free(peer, 128);
+        assertEquals(0, nativeMemoryMetrics.rawNativeMemory());
+    }
+}


### PR DESCRIPTION
Port `NativeMemoryMetrics` to CC. Go commit by commit. 

Note that `NativeMemoryMetrics` are not explicitly registered in CC, this is done in CNDB.