### PR TITLE
CNDB-6522 port riptano/bdp/pull/20676

### DIFF
--- a/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
@@ -92,6 +92,7 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
     @Override
     public void recordEviction(int weight)
     {
+        evictions.increment(weight);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/metrics/MicrometerChunkCacheMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/MicrometerChunkCacheMetricsTest.java
@@ -123,6 +123,17 @@ public class MicrometerChunkCacheMetricsTest
     }
 
     @Test
+    public void testEvictionRecording()
+    {
+        long initialEvictionCount = chunkCacheMetrics.snapshot().evictionCount();
+        chunkCacheMetrics.recordEviction(4);
+        assertEquals(initialEvictionCount + 4, chunkCacheMetrics.snapshot().evictionCount());
+
+        chunkCacheMetrics.recordEviction();
+        assertEquals(initialEvictionCount + 4 + 1, chunkCacheMetrics.snapshot().evictionCount());
+    }
+
+    @Test
     public void testRegister()
     {
         ((MicrometerChunkCacheMetrics) chunkCacheMetrics).register(new SimpleMeterRegistry(), Tags.of("tagKey", "tagValue"));


### PR DESCRIPTION
Original description:

> It was noted that Chunk Cache evictions are not showing up in metrics and are always zero.
recordEvictions() in MicrometerChunkCacheMetrics now is properly overridden so that both overloadings increment the evictions counter.