### PR TITLE
Add vector top-k filter at replica side before returning to coordinator

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -450,6 +450,11 @@ public abstract class ReadCommand extends AbstractReadQuery
                  */
                 iterator = filter.filter(iterator, nowInSec());
 
+                /*
+                 * Allow to post-process the result of the local index query before it is passed to coordinator.
+                 */
+                iterator = (null == searcher) ? iterator : indexQueryPlan.postIndexQueryProcessor(this).apply(iterator);
+
                 // apply the limits/row counter; this transformation is stopping and would close the iterator as soon
                 // as the count is observed; if that happens in the middle of an open RT, its end bound will not be included.
                 // If tracking repaired data, the counter is needed for overreading repaired data, otherwise we can

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -871,6 +871,17 @@ public interface Index
         }
 
         /**
+         * Return a function which performs post processing on the results of local index query before results are passed
+         * to coordinator. This is used by vector index to return top-k results to coordinator.
+         *
+         * @param command the read command being executed
+         */
+        default Function<UnfilteredPartitionIterator, UnfilteredPartitionIterator> postIndexQueryProcessor(ReadCommand command)
+        {
+            return partitions -> partitions;
+        }
+
+        /**
          * Transform an initial {@link RowFilter} into the filter that will still need to applied to a set of Rows after
          * the index has performed it's initial scan.
          *

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -30,6 +30,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
@@ -136,7 +137,20 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
             return partitions -> partitions;
 
         // in case of top-k query, filter out rows that are not actually global top-K
-        return new VectorTopKProcessor(command, this)::filter;
+        return partitions -> (PartitionIterator) new VectorTopKProcessor(command, this).filter(partitions);
+    }
+
+    /**
+     * Called on replica after reading local index data before returning to coordinator
+     */
+    @Override
+    public Function<UnfilteredPartitionIterator, UnfilteredPartitionIterator> postIndexQueryProcessor(ReadCommand command)
+    {
+        if (!isTopK())
+            return partitions -> partitions;
+
+        // in case of top-k query, filter out rows that are not actually global top-K
+        return partitions -> (UnfilteredPartitionIterator) new VectorTopKProcessor(command, this).filter(partitions);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/utils/InMemoryPartitionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/InMemoryPartitionIterator.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.schema.TableMetadata;
+
+public class InMemoryPartitionIterator implements PartitionIterator
+{
+    private final ReadCommand command;
+    private final Iterator<Map.Entry<PartitionInfo, TreeSet<Unfiltered>>> partitions;
+
+    public InMemoryPartitionIterator(ReadCommand command, TreeMap<PartitionInfo, TreeSet<Unfiltered>> rowsByPartitions)
+    {
+        this.command = command;
+        this.partitions = rowsByPartitions.entrySet().iterator();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return partitions.hasNext();
+    }
+
+    @Override
+    public RowIterator next()
+    {
+        return new InMemoryRowIterator(partitions.next());
+    }
+
+
+    private class InMemoryRowIterator implements RowIterator
+    {
+        private final PartitionInfo partitionInfo;
+        private final Iterator<Unfiltered> rows;
+
+        public InMemoryRowIterator(Map.Entry<PartitionInfo, TreeSet<Unfiltered>> rows)
+        {
+            this.partitionInfo = rows.getKey();
+            this.rows = rows.getValue().iterator();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return rows.hasNext();
+        }
+
+        @Override
+        public Row next()
+        {
+            return (Row) rows.next();
+        }
+
+        @Override
+        public TableMetadata metadata()
+        {
+            return command.metadata();
+        }
+
+        @Override
+        public boolean isReverseOrder()
+        {
+            return command.isReversed();
+        }
+
+        @Override
+        public RegularAndStaticColumns columns()
+        {
+            return command.metadata().regularAndStaticColumns();
+        }
+
+        @Override
+        public DecoratedKey partitionKey()
+        {
+            return partitionInfo.key;
+        }
+
+        @Override
+        public Row staticRow()
+        {
+            return partitionInfo.staticRow;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/utils/InMemoryUnfilteredPartitionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/InMemoryUnfilteredPartitionIterator.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.EncodingStats;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.schema.TableMetadata;
+
+public class InMemoryUnfilteredPartitionIterator implements UnfilteredPartitionIterator
+{
+    private final ReadCommand command;
+    private final Iterator<Map.Entry<PartitionInfo, TreeSet<Unfiltered>>> partitions;
+
+    public InMemoryUnfilteredPartitionIterator(ReadCommand command, TreeMap<PartitionInfo, TreeSet<Unfiltered>> rowsByPartitions)
+    {
+        this.command = command;
+        this.partitions = rowsByPartitions.entrySet().iterator();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return partitions.hasNext();
+    }
+
+    @Override
+    public UnfilteredRowIterator next()
+    {
+        return new InMemoryUnfilteredRowIterator(partitions.next());
+    }
+
+    @Override
+    public TableMetadata metadata()
+    {
+        return command.metadata();
+    }
+
+
+    private class InMemoryUnfilteredRowIterator implements UnfilteredRowIterator
+    {
+        private final PartitionInfo partitionInfo;
+        private final Iterator<Unfiltered> unfiltereds;
+
+        public InMemoryUnfilteredRowIterator(Map.Entry<PartitionInfo, TreeSet<Unfiltered>> partition)
+        {
+            this.partitionInfo = partition.getKey();
+            this.unfiltereds = partition.getValue().iterator();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return unfiltereds.hasNext();
+        }
+
+        @Override
+        public Unfiltered next()
+        {
+            return unfiltereds.next();
+        }
+
+        @Override
+        public TableMetadata metadata()
+        {
+            return command.metadata();
+        }
+
+        @Override
+        public boolean isReverseOrder()
+        {
+            return command.isReversed();
+        }
+
+        @Override
+        public RegularAndStaticColumns columns()
+        {
+            return command.metadata().regularAndStaticColumns();
+        }
+
+        @Override
+        public DecoratedKey partitionKey()
+        {
+            return partitionInfo.key;
+        }
+
+        @Override
+        public Row staticRow()
+        {
+            return partitionInfo.staticRow;
+        }
+
+        @Override
+        public DeletionTime partitionLevelDeletion()
+        {
+            return partitionInfo.partitionDeletion;
+        }
+
+        @Override
+        public EncodingStats stats()
+        {
+            return partitionInfo.encodingStats;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/utils/PartitionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PartitionInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.rows.BaseRowIterator;
+import org.apache.cassandra.db.rows.EncodingStats;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+
+public class PartitionInfo
+{
+    public final DecoratedKey key;
+    public final Row staticRow;
+
+    // present if it's unfiltered partition iterator
+    @Nullable
+    public final DeletionTime partitionDeletion;
+
+    // present if it's unfiltered partition iterator
+    @Nullable
+    public final EncodingStats encodingStats;
+
+    public PartitionInfo(DecoratedKey key, Row staticRow)
+    {
+        this.key = key;
+        this.staticRow = staticRow;
+        this.partitionDeletion = null;
+        this.encodingStats = null;
+    }
+
+    public PartitionInfo(DecoratedKey key, Row staticRow, DeletionTime partitionDeletion, EncodingStats encodingStats)
+    {
+        this.key = key;
+        this.staticRow = staticRow;
+
+        this.partitionDeletion = partitionDeletion;
+        this.encodingStats = encodingStats;
+    }
+
+    public static <U extends Unfiltered, R extends BaseRowIterator<U>> PartitionInfo create(R baseRowIterator)
+    {
+        return baseRowIterator instanceof UnfilteredRowIterator
+               ? new PartitionInfo(baseRowIterator.partitionKey(), baseRowIterator.staticRow(),
+                                   ((UnfilteredRowIterator) baseRowIterator).partitionLevelDeletion(),
+                                   ((UnfilteredRowIterator) baseRowIterator).stats())
+               : new PartitionInfo(baseRowIterator.partitionKey(), baseRowIterator.staticRow());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PartitionInfo that = (PartitionInfo) o;
+        return Objects.equals(key, that.key) && Objects.equals(staticRow, that.staticRow)
+               && Objects.equals(partitionDeletion, that.partitionDeletion) && Objects.equals(encodingStats, that.encodingStats);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(key, staticRow, partitionDeletion, encodingStats);
+    }
+}


### PR DESCRIPTION
* added `QueryPlan#postIndexQueryProcessor` to filter top-k at replica side before sending response to coordinator

Summary:
- Updated `VectorTopKProcessor` so it can handle `PartitionIterator` at coordinator and `UnfilteredPartitionIterator` at replica.
- Updated `VectorTopKProcessor` to collect top-k rows and all tombstones at replica side.
- Added some utility classes (`InMemoryPartitionIterator` and `InMemoryUnfilteredPartitionIterator`) to return collected top-k rows and tombstones in primary key order.