### PR TITLE
Union the results from multiple segments per index

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdPostingList.java
@@ -43,7 +43,7 @@ public class SSTableRowIdPostingList implements PostingList
     public long nextPosting() throws IOException
     {
         long segmentRowId = segmentPostingList.nextPosting();
-        return segmentRowId + segmentOffset;
+        return segmentRowId == PostingList.END_OF_STREAM ? segmentRowId : segmentRowId + segmentOffset;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -205,7 +205,7 @@ public class QueryController
             List<RangeIterator<PrimaryKey>> sstableIntersections = queryView.view.entrySet()
                                                                                  .stream()
                                                                                  .map(e -> {
-                                                                                     RangeIterator<Long> it = createRowIdIterator(op, e.getValue(), defer);
+                                                                                     RangeIterator<Long> it = createRowIdIterator(op, e.getValue(), defer, annExpressionInHybridSearch != null);
                                                                                      if (annExpressionInHybridSearch != null)
                                                                                          return reorderAndLimitBySSTableRowIds(it, e.getKey(), annExpressionInHybridSearch);
                                                                                      return convertToPrimaryKeyIterator(e.getKey(), it);
@@ -216,7 +216,7 @@ public class QueryController
                                                                                        .stream()
                                                                                        .map(e -> {
                                                                                            // we need to do all the intersections at the index level, or ordering won't work
-                                                                                           RangeIterator<PrimaryKey> it = buildIterator(op, e.getValue());
+                                                                                           RangeIterator<PrimaryKey> it = buildIterator(op, e.getValue(), annExpressionInHybridSearch != null);
                                                                                            if (annExpressionInHybridSearch != null)
                                                                                                it = reorderAndLimitBy(it, e.getKey(), annExpressionInHybridSearch);
                                                                                            return it;
@@ -296,7 +296,7 @@ public class QueryController
         return L.size() == 1 ? L.get(0) : null;
     }
 
-    private RangeIterator<Long> createRowIdIterator(Operation.OperationType op, List<QueryViewBuilder.IndexExpression> indexExpressions, boolean defer)
+    private RangeIterator<Long> createRowIdIterator(Operation.OperationType op, List<QueryViewBuilder.IndexExpression> indexExpressions, boolean defer, boolean hasAnn)
     {
         var subIterators = indexExpressions
                            .stream()
@@ -318,15 +318,21 @@ public class QueryController
                                     }).collect(Collectors.toList());
 
         // we need to do all the intersections at the index level, or ordering won't work
-        return buildIterator(op, subIterators);
+        return buildIterator(op, subIterators, hasAnn);
     }
 
-    private static <T extends Comparable<T>> RangeIterator<T> buildIterator(Operation.OperationType op, List<RangeIterator<T>> subIterators)
+    private static <T extends Comparable<T>> RangeIterator<T> buildIterator(Operation.OperationType op, List<RangeIterator<T>> subIterators, boolean hasAnn)
     {
-        var builder = op == Operation.OperationType.OR
-                      ? RangeUnionIterator.<T>builder(subIterators.size())
-                      // By default, pick 2 most selective indexes
-                      : RangeIntersectionIterator.<T>builder();
+        RangeIterator.Builder<T> builder = null;
+        if (op == Operation.OperationType.OR)
+            builder = RangeUnionIterator.<T>builder(subIterators.size());
+        else if (hasAnn)
+            // if there is ANN, intersect all available indexes so result will be correct top-k
+            builder = RangeIntersectionIterator.<T>builder(subIterators.size());
+        else
+            // Otherwise, pick 2 most selective indexes for better performance
+            builder = RangeIntersectionIterator.<T>builder();
+
         return builder.add(subIterators).build();
     }
 

--- a/src/java/org/apache/cassandra/index/sai/view/View.java
+++ b/src/java/org/apache/cassandra/index/sai/view/View.java
@@ -57,7 +57,9 @@ public class View implements Iterable<SSTableIndex>
         for (SSTableIndex sstableIndex : indexes)
         {
             this.view.put(sstableIndex.getSSTable().descriptor, sstableIndex);
-            termTreeBuilder.add(sstableIndex);
+            if (!sstableIndex.getIndexContext().isVector())
+                termTreeBuilder.add(sstableIndex);
+
             keyIntervals.add(Interval.create(new Key(sstableIndex.minKey()),
                                              new Key(sstableIndex.maxKey()),
                                              sstableIndex));

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.PostingListRangeIterator;
+import org.apache.cassandra.index.sai.disk.SSTableRowIdsRangeIterator;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
@@ -119,7 +120,7 @@ public class QueryTimeoutTest extends SAITester
     public void delayDuringTokenLookupShouldProvokeTimeoutInRangeIterator() throws Throwable
     {
         Injection token_lookup_delay = Injections.newPause("token_lookup_delay", DELAY)
-                                                 .add(newInvokePoint().onClass(PostingListRangeIterator.class)
+                                                 .add(newInvokePoint().onClass(SSTableRowIdsRangeIterator.class)
                                                                             .onMethod("computeNext")
                                                                             .at("INVOKE QueryContext.checkpoint"))
                                                  .build();

--- a/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
@@ -58,7 +58,7 @@ public class SingleNodeQueryFailureTest extends SAITester
     @Test
     public void testFailedRangeIteratorOnMultiIndexesQuery() throws Throwable
     {
-        testFailedMultiIndexesQuery("range_iterator", PostingListRangeIterator.class, "getNextRowId");
+        testFailedMultiIndexesQuery("range_iterator", SSTableRowIdsRangeIterator.class, "getNextRowId");
     }
 
     @Test


### PR DESCRIPTION
- Union the results from multiple segments per index
- Revert intersection behavior to pick 2 most selective indexes if there is no ANN
- Fix SSTableRowIdPostingList to return END_OF_STREAM if next row is END_OF_STREAM
- Fixes:
  - VectorMemtableIndexTest#randomQueryTest
  - SegmentMergerTest
  - SingleNodeQueryFailureTest#testFailedRangeIteratorOnMultiIndexesQuery
  - SelectiveIntersectionTest
  - QueryTimeoutTest