### PR TITLE
VECTOR-6: return vector results to client in ANN order instead of token order

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -120,6 +120,15 @@ public abstract class MultiColumnRestriction implements SingleRestriction
     }
 
     @Override
+    public final Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        for (Index index : indexRegistry.listIndexes())
+            if (isSupportingIndex(index))
+                return index;
+        return null;
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (ColumnMetadata column : columnDefs)

--- a/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
@@ -74,6 +74,14 @@ public interface Restriction
     public boolean hasSupportingIndex(IndexRegistry indexRegistry);
 
     /**
+     * Find first supporting index for current restriction
+     *
+     * @param indexRegistry the index registry
+     * @return <code>index</code> if the restriction is on indexed columns, <code>null</code>
+     */
+    public Index findSupportingIndex(IndexRegistry indexRegistry);
+
+    /**
      * Returns whether this restriction would need filtering if the specified index group were used.
      *
      * @param indexGroup an index group

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -99,6 +99,12 @@ public abstract class RestrictionSet implements Restrictions
         }
 
         @Override
+        public Index findSupportingIndex(IndexRegistry indexRegistry)
+        {
+            return null;
+        }
+
+        @Override
         public boolean needsFiltering(Index.Group indexGroup)
         {
             return false;
@@ -273,6 +279,18 @@ public abstract class RestrictionSet implements Restrictions
                 if (restriction.hasSupportingIndex(indexRegistry))
                     return true;
             return false;
+        }
+
+        @Override
+        public Index findSupportingIndex(IndexRegistry indexRegistry)
+        {
+            for (SingleRestriction restriction : restrictionsMap.values())
+            {
+                Index index = restriction.findSupportingIndex(indexRegistry);
+                if (index != null)
+                    return index;
+            }
+            return null;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
@@ -85,6 +85,12 @@ class RestrictionSetWrapper implements Restrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return restrictions.findSupportingIndex(indexRegistry);
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -83,6 +83,16 @@ public abstract class SingleColumnRestriction implements SingleRestriction
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        for (Index index : indexRegistry.listIndexes())
+            if (isSupportedBy(index))
+                return index;
+
+        return null;
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (Index index : indexGroup.getIndexes())
@@ -812,7 +822,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public boolean isAnn()
+        public boolean needsPostQueryOrdering()
         {
             return true;
         }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -806,6 +806,17 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             this.value = value;
         }
 
+        public ByteBuffer value(QueryOptions options)
+        {
+            return value.bindAndGet(options);
+        }
+
+        @Override
+        public boolean isAnn()
+        {
+            return true;
+        }
+
         @Override
         public void addFunctionsTo(List<Function> functions)
         {

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
@@ -36,7 +36,7 @@ public interface SingleRestriction extends Restriction
         return false;
     }
 
-    public default boolean isAnn()
+    public default boolean needsPostQueryOrdering()
     {
         return false;
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
@@ -36,6 +36,11 @@ public interface SingleRestriction extends Restriction
         return false;
     }
 
+    public default boolean isAnn()
+    {
+        return false;
+    }
+
     public default boolean isLIKE()
     {
         return false;

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -832,6 +832,42 @@ public class StatementRestrictions
                            .anyMatch(p -> ((SingleRestriction) p).isEQ());
     }
 
+    public List<SingleRestriction> getAnnRestrictions()
+    {
+        List<SingleRestriction> annRestrictions = null;
+        if (partitionKeyRestrictions instanceof PartitionKeySingleRestrictionSet)
+        {
+            for (SingleRestriction restriction : ((PartitionKeySingleRestrictionSet) partitionKeyRestrictions).restrictions())
+            {
+                if (restriction.isAnn())
+                {
+                    annRestrictions = new ArrayList<>();
+                    annRestrictions.add(restriction);
+                }
+            }
+        }
+
+        for (SingleRestriction restriction : clusteringColumnsRestrictions.restrictions())
+        {
+            if (restriction.isAnn())
+            {
+                annRestrictions = new ArrayList<>();
+                annRestrictions.add(restriction);
+            }
+        }
+
+        for (SingleRestriction restriction : nonPrimaryKeyRestrictions.restrictions())
+        {
+            if (restriction.isAnn())
+            {
+                annRestrictions = new ArrayList<>();
+                annRestrictions.add(restriction);
+            }
+        }
+
+        return annRestrictions == null ? List.of() : annRestrictions;
+    }
+
     /**
      * Returns the <code>Restrictions</code> for the specified type of columns.
      *

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -832,14 +832,14 @@ public class StatementRestrictions
                            .anyMatch(p -> ((SingleRestriction) p).isEQ());
     }
 
-    public List<SingleRestriction> getAnnRestrictions()
+    public List<SingleRestriction> getPostQueryOrderingRestrictions()
     {
         List<SingleRestriction> annRestrictions = null;
         if (partitionKeyRestrictions instanceof PartitionKeySingleRestrictionSet)
         {
             for (SingleRestriction restriction : ((PartitionKeySingleRestrictionSet) partitionKeyRestrictions).restrictions())
             {
-                if (restriction.isAnn())
+                if (restriction.needsPostQueryOrdering())
                 {
                     annRestrictions = new ArrayList<>();
                     annRestrictions.add(restriction);
@@ -849,7 +849,7 @@ public class StatementRestrictions
 
         for (SingleRestriction restriction : clusteringColumnsRestrictions.restrictions())
         {
-            if (restriction.isAnn())
+            if (restriction.needsPostQueryOrdering())
             {
                 annRestrictions = new ArrayList<>();
                 annRestrictions.add(restriction);
@@ -858,7 +858,7 @@ public class StatementRestrictions
 
         for (SingleRestriction restriction : nonPrimaryKeyRestrictions.restrictions())
         {
-            if (restriction.isAnn())
+            if (restriction.needsPostQueryOrdering())
             {
                 annRestrictions = new ArrayList<>();
                 annRestrictions.add(restriction);

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -331,6 +331,12 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return restrictions.findSupportingIndex(indexRegistry);
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -124,6 +124,11 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return null;
+    }
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return false;

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1004,13 +1004,18 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     private boolean needsToSkipUserLimit()
     {
         // if post query ordering is required, and it's not ANN
-        return needsPostQueryOrdering() && (orderingComparator == null || !orderingComparator.isAnn());
+        return needsPostQueryOrdering() && !needAnnOrdering();
     }
 
     private boolean needsPostQueryOrdering()
     {
         // We need post-query ordering only for queries with IN on the partition key and an ORDER BY or ANN
-        return restrictions.keyIsInRelation() && !parameters.orderings.isEmpty() || (orderingComparator != null && orderingComparator.isAnn());
+        return restrictions.keyIsInRelation() && !parameters.orderings.isEmpty() || needAnnOrdering();
+    }
+
+    private boolean needAnnOrdering()
+    {
+        return orderingComparator != null && orderingComparator.isAnn();
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -263,6 +263,7 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         return dataRange.isReversed();
     }
 
+    @Override
     public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime, queryState.getClientState());
@@ -400,18 +401,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         }
         if (!dataRange.isUnrestricted())
             sb.append(dataRange.toCQLString(metadata()));
-    }
-
-    /**
-     * Allow to post-process the result of the query after it has been reconciled on the coordinator
-     * but before it is passed to the CQL layer to return the ResultSet.
-     *
-     * See CASSANDRA-8717 for why this exists.
-     */
-    public PartitionIterator postReconciliationProcessing(PartitionIterator result)
-    {
-        Index.QueryPlan queryPlan = indexQueryPlan();
-        return queryPlan == null ? result : queryPlan.postProcessor(this).apply(result);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -224,9 +224,7 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan;
     }
 
-    /**
-     * @return true given read query is a top-k request
-     */
+    @Override
     public boolean isTopK()
     {
         return indexQueryPlan != null && indexQueryPlan.isTopK();

--- a/src/java/org/apache/cassandra/db/ReadQuery.java
+++ b/src/java/org/apache/cassandra/db/ReadQuery.java
@@ -254,4 +254,12 @@ public interface ReadQuery
     default void maybeValidateIndex()
     {
     }
+
+    /**
+     * @return true given read query is a top-k request
+     */
+    default boolean isTopK()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -23,6 +23,8 @@ package org.apache.cassandra.index;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -33,6 +35,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.restrictions.Restriction;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -413,6 +417,19 @@ public interface Index
      *         the index was used to narrow the initial result set
      */
     public RowFilter getPostIndexQueryFilter(RowFilter filter);
+
+    /**
+     * Return a comparator that reorders query result before sending to client
+     *
+     * @param restriction restriction that requires current index
+     * @param columnIndex idx of the indexed column in returned row
+     * @param options query options
+     * @return comparator that for post-query ordering; or null if not supported
+     */
+    default Comparator<List<ByteBuffer>> getPostQueryOrdering(Restriction restriction, int columnIndex, QueryOptions options)
+    {
+        return null;
+    }
 
     /**
      * Return an estimate of the number of results this index is expected to return for any given

--- a/src/java/org/apache/cassandra/service/pager/AggregationQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/AggregationQueryPager.java
@@ -139,6 +139,12 @@ public final class AggregationQueryPager implements QueryPager
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean isTopK()
+    {
+        return subPager.isTopK();
+    }
+
     /**
      * <code>PartitionIterator</code> that automatically fetch a new sub-page of data if needed when the current iterator is
      * exhausted.

--- a/src/java/org/apache/cassandra/service/pager/PartitionRangeQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/PartitionRangeQueryPager.java
@@ -143,6 +143,12 @@ public class PartitionRangeQueryPager extends AbstractQueryPager<PartitionRangeR
     }
 
     @Override
+    public boolean isTopK()
+    {
+        return query.isTopK();
+    }
+
+    @Override
     public String toString()
     {
         return new StringJoiner(", ", PartitionRangeQueryPager.class.getSimpleName() + "[", "]")

--- a/src/java/org/apache/cassandra/service/pager/QueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/QueryPager.java
@@ -149,4 +149,12 @@ public interface QueryPager
      * @return a new <code>QueryPager</code> that use the new limits
      */
     public QueryPager withUpdatedLimit(DataLimits newLimits);
+
+    /**
+     * @return true given read query is a top-k request
+     */
+    default boolean isTopK()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
@@ -26,7 +26,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
-import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.service.QueryInfoTracker;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -130,18 +130,23 @@ public class VectorDistributedTest extends TestBaseImpl
         int limit = Math.min(getRandom().nextIntBetween(10, 50), vectors.size());
         float[] queryVector = randomVector();
         Object[][] result = searchWithLimit(queryVector, limit);
-        double memtableRecall = getRecall(vectors, queryVector, getVectors(result));
+
+        List<float[]> resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
+        double memtableRecall = getRecall(vectors, queryVector, resultVectors);
         assertThat(memtableRecall).isGreaterThanOrEqualTo(MIN_RECALL);
 
         assertThatThrownBy(() -> searchWithoutLimit(randomVector(), vectorCount))
         .hasMessageContaining(INVALID_LIMIT_MESSAGE);
 
-        // Recall is lower with page size:
-        int pageSize = getRandom().nextIntBetween(2, 10);
+        int pageSize = getRandom().nextIntBetween(40, 70);
         limit = getRandom().nextIntBetween(20, 50);
         result = searchWithPageAndLimit(queryVector, pageSize, limit);
-        double memtableRecallWithPaging = getRecall(vectors, queryVector, getVectors(result));
-        assertThat(memtableRecallWithPaging).isGreaterThanOrEqualTo(0).isLessThan(memtableRecall);
+
+        resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
+        double memtableRecallWithPaging = getRecall(vectors, queryVector, resultVectors);
+        assertThat(memtableRecallWithPaging).isGreaterThanOrEqualTo(MIN_RECALL);
 
         assertThatThrownBy(() -> searchWithPageWithoutLimit(randomVector(), 10))
         .hasMessageContaining(INVALID_LIMIT_MESSAGE);
@@ -190,6 +195,8 @@ public class VectorDistributedTest extends TestBaseImpl
         Object[][] result = searchWithLimit(queryVector, limit);
 
         // expect recall to be at least 0.8
+        List<float[]> resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
         double recall = getRecall(allVectors, queryVector, getVectors(result));
         assertThat(recall).isGreaterThanOrEqualTo(MIN_RECALL);
     }
@@ -364,6 +371,19 @@ public class VectorDistributedTest extends TestBaseImpl
         assertThat(result).hasSize(1);
         float[] output = getVectors(result).get(0);
         assertThat(output).isEqualTo(vectors.get(key));
+    }
+
+    private void assertDescendingScore(float[] queryVector, List<float[]> resultVectors)
+    {
+        float prevScore = -1;
+        for (float[] current : resultVectors)
+        {
+            float score = function.compare(current, queryVector);
+            if (prevScore >= 0)
+                assertThat(score).isLessThanOrEqualTo(prevScore);
+
+            prevScore = score;
+        }
     }
 
     private double getRecall(List<float[]> vectors, float[] query, List<float[]> result)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -274,6 +274,8 @@ public class VectorLocalTest extends SAITester
 
             float[] queryVector = randomVector();
             List<float[]> resultVectors = searchWithRange(queryVector, minToken, maxToken, expected.size());
+            assertDescendingScore(queryVector, resultVectors);
+
             double recall = getRecall(resultVectors, queryVector, expected);
             assertThat(recall).isGreaterThanOrEqualTo(0.8);
         }
@@ -297,6 +299,8 @@ public class VectorLocalTest extends SAITester
 
             float[] queryVector = randomVector();
             List<float[]> resultVectors = searchWithRange(queryVector, minToken, maxToken, expected.size());
+            assertDescendingScore(queryVector, resultVectors);
+
             double recall = getRecall(resultVectors, queryVector, expected);
             assertThat(recall).isGreaterThanOrEqualTo(0.8);
         }


### PR DESCRIPTION
* paging request with ANN will be executed as non-paging request.
* added a new method to `Index` interface to reorder rows: `Comparator<List<ByteBuffer>> getPostQueryOrdering(Restriction restriction, int columnIndex, QueryOptions options)`
* `SelectStatement#orderingComparator` is used to reorder results in ANN order when processing results. Coordinator is computing score twice: at top-k processor and at `SelectStatement#orderResults()`
  * An alternative approach will be to directly return list of sorted rows from top-k processor and avoid using `PartitionIterator` for the remaining code path. It reduces the num of score calculations but looks ugly.

This patch doesn't include scores into`Row`, so score has to be computed at replica HNSW graph, replica top-k processor, coordinator top-k processor, and post-result-ordering.