### PR TITLE
Merge CASSANDRA-18504 vector grammar

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1483,8 +1483,8 @@ collectionLiteral returns [Term.Raw value]
 
 listLiteral returns [Term.Raw value]
     @init {List<Term.Raw> l = new ArrayList<Term.Raw>();}
-    @after {$value = new Lists.Literal(l);}
-    : '[' ( t1=term { l.add(t1); } ( ',' tn=term { l.add(tn); } )* )? ']' { $value = new Lists.Literal(l); }
+    @after {$value = new ArrayLiteral(l);}
+    : '[' ( t1=term { l.add(t1); } ( ',' tn=term { l.add(tn); } )* )? ']'
     ;
 
 usertypeLiteral returns [UserTypes.Literal ut]
@@ -1824,8 +1824,8 @@ tuple_type returns [CQL3Type.Raw t]
     ;
 
 vector_type returns [CQL3Type.Raw vt]
-    : K_FLOAT K_VECTOR  '[' d=INTEGER ']'
-        { $vt = CQL3Type.Raw.vector(Integer.parseInt($d.text)); }
+    : K_VECTOR '<' t1=comparatorType ','  d=INTEGER '>'
+        { $vt = CQL3Type.Raw.vector(t1, Integer.parseInt($d.text)); }
     ;
 
 username
@@ -1894,6 +1894,7 @@ basic_unreserved_keyword returns [String str]
         | K_STATIC
         | K_FROZEN
         | K_TUPLE
+        | K_VECTOR
         | K_FUNCTION
         | K_FUNCTIONS
         | K_AGGREGATE

--- a/src/java/org/apache/cassandra/cql3/AbstractMarker.java
+++ b/src/java/org/apache/cassandra/cql3/AbstractMarker.java
@@ -85,10 +85,6 @@ public abstract class AbstractMarker extends Term.NonTerminal
             {
                 return new UserTypes.Marker(bindIndex, receiver);
             }
-            else if (receiver.type.isVector())
-            {
-                return new Vectors.Marker(bindIndex, receiver);
-            }
 
             return new Constants.Marker(bindIndex, receiver);
         }

--- a/src/java/org/apache/cassandra/cql3/ArrayLiteral.java
+++ b/src/java/org/apache/cassandra/cql3/ArrayLiteral.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.util.List;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
+/**
+ * Represents {@code [a, b, c, d]} in CQL.  Mutliple {@link AbstractType} use array literals,
+ * so this class is meant to act as a proxy once the real type is known.
+ */
+public class ArrayLiteral extends Term.Raw
+{
+    private final List<Term.Raw> elements;
+
+    public ArrayLiteral(List<Term.Raw> elements)
+    {
+        this.elements = elements;
+    }
+
+    private Term.Raw forReceiver(ColumnSpecification receiver)
+    {
+        AbstractType<?> type = receiver.type.unwrap();
+        if (type instanceof VectorType)
+            return new Vectors.Literal(elements);
+        if (type instanceof ListType)
+            return new Lists.Literal(elements);
+        throw new InvalidRequestException(String.format("Unexpected receiver type '%s'; only list and vector are expected", type.asCQL3Type()));
+    }
+
+    @Override
+    public Term prepare(String keyspace, ColumnSpecification receiver) throws InvalidRequestException
+    {
+        return forReceiver(receiver).prepare(keyspace, receiver);
+    }
+
+    @Override
+    public TestResult testAssignment(String keyspace, ColumnSpecification receiver)
+    {
+        return forReceiver(receiver).testAssignment(keyspace, receiver);
+    }
+
+    @Override
+    public AbstractType<?> getExactTypeIfKnown(String keyspace)
+    {
+        // without knowing the receiver, can't say if this is a ListType or a VectorType
+        return null;
+    }
+
+    @Override
+    public String getText()
+    {
+        return Lists.listToString(elements, Term.Raw::getText);
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/Operation.java
+++ b/src/java/org/apache/cassandra/cql3/Operation.java
@@ -186,9 +186,6 @@ public abstract class Operation
             if (receiver.type.isUDT())
                 return new UserTypes.Setter(receiver, v);
 
-            if (receiver.type.isVector())
-                return new Vectors.Setter(receiver, v);
-
             return new Constants.Setter(receiver, v);
         }
 

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -279,6 +279,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return false;
     }
 
+    public AbstractType<T> unwrap()
+    {
+        return isReversed() ? ((ReversedType<T>) this).baseType.unwrap() : this;
+    }
+
     public boolean isVector()
     {
         return false;
@@ -460,6 +465,16 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     public final boolean isValueLengthFixed()
     {
         return valueLengthIfFixed() != VARIABLE_LENGTH;
+    }
+
+    public boolean isNull(ByteBuffer bb)
+    {
+        return isNull(bb, ByteBufferAccessor.instance);
+    }
+
+    public <V> boolean isNull(V buffer, ValueAccessor<V> accessor)
+    {
+        return getSerializer().isNull(buffer, accessor);
     }
 
     // This assumes that no empty values are passed

--- a/src/java/org/apache/cassandra/db/marshal/ValueAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/ValueAccessor.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.utils.vint.VIntCoding;
 
 import static org.apache.cassandra.db.ClusteringPrefix.Kind.*;
 
@@ -121,6 +122,13 @@ public interface ValueAccessor<V>
     default int sizeWithShortLength(V value)
     {
         return 2 + size(value);
+    }
+
+    default int remaining(V value, int offset)
+    {
+        int size = size(value);
+        int rem = size - offset;
+        return rem > 0 ? rem : 0;
     }
 
     /**
@@ -309,6 +317,10 @@ public interface ValueAccessor<V>
     int toInt(V value);
     /** returns an int from offset {@param offset} */
     int getInt(V value, int offset);
+    default int getUnsignedVInt32(V value, int offset)
+    {
+        return VIntCoding.getUnsignedVInt32(value, this, offset);
+    }
     /** returns a long from offset 0 */
     long toLong(V value);
     /** returns a long from offset {@param offset} */
@@ -329,6 +341,11 @@ public interface ValueAccessor<V>
      */
     int putByte(V dst, int offset, byte value);
 
+    default int putBytes(V dst, int offset, byte[] src, int srcOffset, int length)
+    {
+        return ByteArrayAccessor.instance.copyTo(src, srcOffset, dst, this, offset, length);
+    }
+
     /**
      * writes the short value {@param value} to {@param dst} at offset {@param offset}
      * @return the number of bytes written to {@param value}
@@ -346,6 +363,11 @@ public interface ValueAccessor<V>
      * @return the number of bytes written to {@param value}
      */
     int putLong(V dst, int offset, long value);
+
+    default int putUnsignedVInt32(V dst, int offset, int value)
+    {
+        return VIntCoding.writeUnsignedVInt32(value, dst, offset, this);
+    }
 
     /** return a value with a length of 0 */
     V empty();

--- a/src/java/org/apache/cassandra/db/marshal/VectorType.java
+++ b/src/java/org/apache/cassandra/db/marshal/VectorType.java
@@ -18,56 +18,87 @@
 
 package org.apache.cassandra.db.marshal;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Term;
-import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.cql3.Vectors;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
+import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
-public class VectorType extends AbstractType<float[]>
+public final class VectorType<T> extends AbstractType<List<T>>
 {
-    private static final ConcurrentHashMap<Integer, VectorType> instances = new ConcurrentHashMap<>();
-
-    public final int dimensions;
-    public final Serializer serializer;
-
-    public static VectorType getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
+    private static class Key
     {
-        int dimensions = parser.getVectorDimensions();
-        if (dimensions <= 0)
-            throw new ConfigurationException("VectorType dimensions must be > 0");
+        private final AbstractType<?> type;
+        private final int dimension;
 
-        return getInstance(dimensions);
+        private Key(AbstractType<?> type, int dimension)
+        {
+            this.type = type;
+            this.dimension = dimension;
+        }
+
+        private VectorType<?> create()
+        {
+            return new VectorType<>(type, dimension);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Key key = (Key) o;
+            return dimension == key.dimension && Objects.equals(type, key.type);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(type, dimension);
+        }
+    }
+    private static final ConcurrentHashMap<Key, VectorType> instances = new ConcurrentHashMap<>();
+
+    public final AbstractType<T> elementType;
+    public final int dimension;
+    private final TypeSerializer<T> elementSerializer;
+    private final int valueLengthIfFixed;
+    private final VectorSerializer serializer;
+
+    private VectorType(AbstractType<T> elementType, int dimension)
+    {
+        super(ComparisonType.CUSTOM);
+        if (dimension <= 0)
+            throw new InvalidRequestException(String.format("vectors may only have positive dimentions; given %d", dimension));
+        this.elementType = elementType;
+        this.dimension = dimension;
+        this.elementSerializer = elementType.getSerializer();
+        this.valueLengthIfFixed = elementType.isValueLengthFixed() ?
+                                  elementType.valueLengthIfFixed() * dimension :
+                                  super.valueLengthIfFixed();
+        this.serializer = elementType.isValueLengthFixed() ?
+                          new FixedLengthSerializer() :
+                          new VariableLengthSerializer();
     }
 
-    public static VectorType getInstance(int dimensions)
+    public static <T> VectorType<T> getInstance(AbstractType<T> elements, int dimension)
     {
-        VectorType type = instances.get(dimensions);
-        return null == type
-               ? instances.computeIfAbsent(dimensions, k -> new VectorType(dimensions))
-               : type;
-    }
-
-    private VectorType(int dimensions)
-    {
-        super(ComparisonType.BYTE_ORDER);
-        this.dimensions = dimensions;
-        this.serializer = new Serializer(dimensions);
-    }
-
-    /**
-     * @return num of dimensions of current vector type
-     */
-    public int getDimensions()
-    {
-        return dimensions;
+        Key key = new Key(elements, dimension);
+        return instances.computeIfAbsent(key, Key::create);
     }
 
     @Override
@@ -77,115 +108,522 @@ public class VectorType extends AbstractType<float[]>
     }
 
     @Override
+    public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
+    {
+        return getSerializer().compareCustom(left, accessorL, right, accessorR);
+    }
+
+    @Override
+    public int valueLengthIfFixed()
+    {
+        return valueLengthIfFixed;
+    }
+
+    @Override
+    public VectorSerializer getSerializer()
+    {
+        return serializer;
+    }
+
+    public List<ByteBuffer> split(ByteBuffer buffer)
+    {
+        return split(buffer, ByteBufferAccessor.instance);
+    }
+
+    public <V> List<V> split(V buffer, ValueAccessor<V> accessor)
+    {
+        return getSerializer().split(buffer, accessor);
+    }
+
+    public float[] composeAsFloat(ByteBuffer input)
+    {
+        return composeAsFloat(input, ByteBufferAccessor.instance);
+    }
+
+    public <V> float[] composeAsFloat(V input, ValueAccessor<V> accessor)
+    {
+        if (!(elementType instanceof FloatType))
+            throw new IllegalStateException("Attempted to read as float, but element type is " + elementType.asCQL3Type());
+
+        if (isNull(input, accessor))
+            return null;
+        float[] array = new float[dimension];
+        int offset = 0;
+        for (int i = 0; i < dimension; i++)
+        {
+            array[i] = accessor.getFloat(input, offset);
+            offset += Float.BYTES;
+        }
+        return array;
+    }
+
+    public ByteBuffer decomposeRaw(List<ByteBuffer> elements)
+    {
+        return decomposeRaw(elements, ByteBufferAccessor.instance);
+    }
+
+    public <V> V decomposeRaw(List<V> elements, ValueAccessor<V> accessor)
+    {
+        return getSerializer().serializeRaw(elements, accessor);
+    }
+
+    @Override
+    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V value, ByteComparable.Version version)
+    {
+        if (isNull(value, accessor))
+            return null;
+        ByteSource[] srcs = new ByteSource[dimension];
+        List<V> split = split(value, accessor);
+        for (int i = 0; i < dimension; i++)
+            srcs[i] = elementType.asComparableBytes(accessor, split.get(i), version);
+        return ByteSource.withTerminator(version == ByteComparable.Version.LEGACY ? 0x00 : ByteSource.TERMINATOR, srcs);
+    }
+
+    @Override
+    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, ByteComparable.Version version)
+    {
+        if (comparableBytes == null)
+            return accessor.empty();
+        assert version != ByteComparable.Version.LEGACY; // legacy translation is not reversible
+
+        List<V> buffers = new ArrayList<>();
+        int separator = comparableBytes.next();
+        while (separator != ByteSource.TERMINATOR)
+        {
+            buffers.add(elementType.fromComparableBytes(accessor, comparableBytes, version));
+            separator = comparableBytes.next();
+        }
+        return decomposeRaw(buffers, accessor);
+    }
+
+    @Override
     public CQL3Type asCQL3Type()
     {
-        return new CQL3Type.Vector(dimensions);
+        return new CQL3Type.Vector(this);
+    }
+
+    public AbstractType<T> getElementsType()
+    {
+        return elementType;
+    }
+
+    // vector of nested types is hard to parse, so fall back to bytes string matching ListType
+    @Override
+    public <V> String getString(V value, ValueAccessor<V> accessor)
+    {
+        return BytesType.instance.getString(value, accessor);
     }
 
     @Override
     public ByteBuffer fromString(String source) throws MarshalException
     {
-        return null;
+        try
+        {
+            return ByteBufferUtil.hexToBytes(source);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new MarshalException(String.format("cannot parse '%s' as hex bytes", source), e);
+        }
+    }
+
+    @Override
+    public List<AbstractType<?>> subTypes()
+    {
+        return Collections.singletonList(elementType);
+    }
+
+    @Override
+    public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
+    {
+        return toJSONString(buffer, ByteBufferAccessor.instance, protocolVersion);
+    }
+
+    @Override
+    public <V> String toJSONString(V value, ValueAccessor<V> accessor, ProtocolVersion protocolVersion)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        List<V> split = split(value, accessor);
+        for (int i = 0; i < dimension; i++)
+        {
+            if (i > 0)
+                sb.append(", ");
+            sb.append(elementType.toJSONString(split.get(i), accessor, protocolVersion));
+        }
+        sb.append(']');
+        return sb.toString();
     }
 
     @Override
     public Term fromJSONObject(Object parsed) throws MarshalException
     {
-        return null;
+        if (parsed instanceof String)
+            parsed = Json.decodeJson((String) parsed);
+
+        if (!(parsed instanceof List))
+            throw new MarshalException(String.format(
+            "Expected a list, but got a %s: %s", parsed.getClass().getSimpleName(), parsed));
+
+        List<?> list = (List<?>) parsed;
+        if (list.size() != dimension)
+            throw new MarshalException(String.format("List had incorrect size: expected %d but given %d; %s", dimension, list.size(), list));
+        List<Term> terms = new ArrayList<>(list.size());
+        for (Object element : list)
+        {
+            if (element == null)
+                throw new MarshalException("Invalid null element in list");
+            terms.add(elementType.fromJSONObject(element));
+        }
+
+        return new Vectors.DelayedValue<>(this, terms);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VectorType<?> that = (VectorType<?>) o;
+        return dimension == that.dimension && Objects.equals(elementType, that.elementType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(elementType, dimension);
     }
 
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append(getClass().getName());
-        builder.append('(');
-        builder.append(dimensions);
-        builder.append(')');
-        return builder.toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName());
+        sb.append('(');
+        sb.append(elementType);
+        sb.append(", ");
+        sb.append(dimension);
+        sb.append(')');
+        return sb.toString();
     }
 
-    @Override
-    public TypeSerializer<float[]> getSerializer()
+    private void check(List<?> values)
     {
-        return serializer;
-    }
+        if (values.size() != dimension)
+            throw new MarshalException(String.format("Required %d elements, but saw %d", dimension, values.size()));
 
-    public static class Serializer extends TypeSerializer<float[]>
-    {
-        private final int dimensions;
-
-        private Serializer(int dimensions)
+        // This code base always works with a list that is RandomAccess, so can use .get to avoid allocation
+        for (int i = 0; i < dimension; i++)
         {
-            this.dimensions = dimensions;
+            Object value = values.get(i);
+            if (value == null || (value instanceof ByteBuffer && elementSerializer.isNull((ByteBuffer) value)))
+                throw new MarshalException(String.format("Element at index %d is null (expected type %s); given %s", i, elementType.asCQL3Type(), values));
         }
+    }
 
-        public int getDimensions()
+    public abstract class VectorSerializer extends TypeSerializer<List<T>>
+    {
+        public abstract <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR);
+
+        public abstract <V> List<V> split(V buffer, ValueAccessor<V> accessor);
+        public abstract <V> V serializeRaw(List<V> elements, ValueAccessor<V> accessor);
+        public abstract <V> float[] deserializeFloatArray(V input, ValueAccessor<V> accessor);
+
+        @Override
+        public String toString(List<T> value)
         {
-            return dimensions;
+            StringBuilder sb = new StringBuilder();
+            boolean isFirst = true;
+            sb.append('[');
+            for (T element : value)
+            {
+                if (isFirst)
+                    isFirst = false;
+                else
+                    sb.append(", ");
+                sb.append(elementSerializer.toString(element));
+            }
+            sb.append(']');
+            return sb.toString();
         }
 
         @Override
-        public ByteBuffer serialize(float[] value)
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public Class<List<T>> getType()
         {
-            return getByteBuffer(value);
+            return (Class) List.class;
+        }
+    }
+
+    private class FixedLengthSerializer extends VectorSerializer
+    {
+        private FixedLengthSerializer()
+        {
         }
 
-        public static ByteBuffer getByteBuffer(float[] value)
+        @Override
+        public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL,
+                                          VR right, ValueAccessor<VR> accessorR)
+        {
+            if (elementType.isByteOrderComparable)
+                return ValueAccessor.compare(left, accessorL, right, accessorR);
+            if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
+                return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
+            int offset = 0;
+            int elementLength = elementType.valueLengthIfFixed();
+            for (int i = 0; i < dimension; i++)
+            {
+                VL leftBytes = accessorL.slice(left, offset, elementLength);
+                VR rightBytes = accessorR.slice(right, offset, elementLength);
+                int rc = elementType.compare(leftBytes, accessorL, rightBytes, accessorR);
+                if (rc != 0)
+                    return rc;
+
+                offset += elementLength;
+            }
+            return 0;
+        }
+
+        @Override
+        public <V> List<V> split(V buffer, ValueAccessor<V> accessor)
+        {
+            List<V> result = new ArrayList<>(dimension);
+            int offset = 0;
+            int elementLength = elementType.valueLengthIfFixed();
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = accessor.slice(buffer, offset, elementLength);
+                offset += elementLength;
+                elementSerializer.validate(bb, accessor);
+                result.add(bb);
+            }
+            if (!accessor.isEmptyFromOffset(buffer, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+
+            return result;
+        }
+
+        @Override
+        public <V> V serializeRaw(List<V> value, ValueAccessor<V> accessor)
         {
             if (value == null)
-                return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+                return accessor.empty();
+            check(value);
 
-            var bb = ByteBuffer.allocate(4 * value.length);
-            for (var v : value)
-                bb.putFloat(v);
-            bb.position(0);
+            int size = elementType.valueLengthIfFixed();
+            V bb = accessor.allocate(size * dimension);
+            int position = 0;
+            for (V v : value)
+                position += accessor.copyTo(v, 0, bb, accessor, position, size);
             return bb;
         }
 
         @Override
-        public <V> float[] deserialize(V value, ValueAccessor<V> accessor)
+        public ByteBuffer serialize(List<T> value)
         {
-            if (value == null || accessor.isEmpty(value))
-                return null;
+            if (value == null)
+                return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+            check(value);
 
-            var vector = new float[dimensions];
-            for (int i = 0, offset = 0; i < dimensions; offset += 4, i++)
-                vector[i] = accessor.getFloat(value, offset);
-            return vector;
+            ByteBuffer bb = ByteBuffer.allocate(elementType.valueLengthIfFixed() * dimension);
+            for (T v : value)
+                bb.put(elementSerializer.serialize(v).duplicate());
+            bb.flip();
+            return bb;
         }
 
         @Override
-        public <V> void validate(V value, ValueAccessor<V> accessor) throws MarshalException
+        public <V> List<T> deserialize(V input, ValueAccessor<V> accessor)
+        {
+            if (isNull(input, accessor))
+                return null;
+            List<T> result = new ArrayList<>(dimension);
+            int offset = 0;
+            int elementLength = elementType.valueLengthIfFixed();
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = accessor.slice(input, offset, elementLength);
+                offset += elementLength;
+                elementSerializer.validate(bb, accessor);
+                result.add(elementSerializer.deserialize(bb, accessor));
+            }
+            if (!accessor.isEmptyFromOffset(input, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+
+            return result;
+        }
+
+        public <V> float[] deserializeFloatArray(V input, ValueAccessor<V> accessor)
+        {
+            if (isNull(input, accessor))
+                return null;
+            float[] result = new float[dimension];
+            int offset = 0;
+            int elementLength = elementType.valueLengthIfFixed();
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = accessor.slice(input, offset, elementLength);
+                offset += elementLength;
+                elementSerializer.validate(bb, accessor);
+                result[i] = (float)elementSerializer.deserialize(bb, accessor);
+            }
+            if (!accessor.isEmptyFromOffset(input, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+
+            return result;
+        }
+
+        @Override
+        public <V> void validate(V input, ValueAccessor<V> accessor) throws MarshalException
         {
             int offset = 0;
-            try
+            int elementSize = elementType.valueLengthIfFixed();
+            for (int i = 0; i < dimension; i++)
             {
-                for (int index = 0; index < dimensions; offset += 4, index++)
-                {
-                    var a = accessor.getFloat(value, offset);
-                    if (!Float.isFinite(a))
-                        throw new MarshalException("Invalid float value " + a);
-                }
-                if (!accessor.isEmptyFromOffset(value, offset))
-                    throw new MarshalException("Unexpected extraneous bytes after vector value");
+                V bb = accessor.slice(input, offset, elementSize);
+                offset += elementSize;
+                elementSerializer.validate(bb, accessor);
             }
-            catch (BufferUnderflowException | IndexOutOfBoundsException e)
-            {
-                throw new MarshalException(String.format("Not enough bytes to read a vector of %s dimensions", dimensions));
-            }
+            if (!accessor.isEmptyFromOffset(input, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+        }
+    }
+
+    private class VariableLengthSerializer extends VectorSerializer
+    {
+        private VariableLengthSerializer()
+        {
         }
 
         @Override
-        public String toString(float[] value)
+        public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL,
+                                          VR right, ValueAccessor<VR> accessorR)
         {
-            return Arrays.toString(value);
+            if (accessorL.isEmpty(left) || accessorR.isEmpty(right))
+                return Boolean.compare(accessorR.isEmpty(right), accessorL.isEmpty(left));
+
+            int leftOffset = 0;
+            int rightOffset = 0;
+            for (int i = 0; i < dimension; i++)
+            {
+                VL leftBytes = readValue(left, accessorL, leftOffset);
+                leftOffset += sizeOf(leftBytes, accessorL);
+
+                VR rightBytes = readValue(right, accessorR, rightOffset);
+                rightOffset += sizeOf(rightBytes, accessorR);
+
+                int rc = elementType.compare(leftBytes, accessorL, rightBytes, accessorR);
+                if (rc != 0)
+                    return rc;
+            }
+            return 0;
+        }
+
+        private <V> V readValue(V input, ValueAccessor<V> accessor, int offset)
+        {
+            int size = accessor.getUnsignedVInt32(input, offset);
+            if (size < 0)
+                throw new AssertionError("Invalidate data at offset " + offset + "; saw size of " + size + " but only >= 0 is expected");
+
+            return accessor.slice(input, offset + TypeSizes.sizeofUnsignedVInt(size), size);
+        }
+
+        private <V> int writeValue(V src, V dst, ValueAccessor<V> accessor, int offset)
+        {
+            int size = accessor.size(src);
+            int written = 0;
+            written += accessor.putUnsignedVInt32(dst, offset + written, size);
+            written += accessor.copyTo(src, 0, dst, accessor, offset + written, size);
+            return written;
+        }
+
+        private <V> int sizeOf(V bb, ValueAccessor<V> accessor)
+        {
+            return accessor.sizeWithVIntLength(bb);
         }
 
         @Override
-        public Class<float[]> getType()
+        public <V> List<V> split(V buffer, ValueAccessor<V> accessor)
         {
-            return float[].class;
+            List<V> result = new ArrayList<>(dimension);
+            int offset = 0;
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = readValue(buffer, accessor, offset);
+                offset += sizeOf(bb, accessor);
+                elementSerializer.validate(bb, accessor);
+                result.add(bb);
+            }
+            if (!accessor.isEmptyFromOffset(buffer, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+
+            return result;
+        }
+
+        @Override
+        public <V> V serializeRaw(List<V> value, ValueAccessor<V> accessor)
+        {
+            if (value == null)
+                return accessor.empty();
+            check(value);
+
+            V bb = accessor.allocate(value.stream().mapToInt(v -> sizeOf(v, accessor)).sum());
+            int offset = 0;
+            for (V b : value)
+                offset += writeValue(b, bb, accessor, offset);
+            return bb;
+        }
+
+        @Override
+        public ByteBuffer serialize(List<T> value)
+        {
+            if (value == null)
+                return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+            check(value);
+
+            List<ByteBuffer> bbs = new ArrayList<>(dimension);
+            for (int i = 0; i < dimension; i++)
+                bbs.add(elementSerializer.serialize(value.get(i)));
+            return serializeRaw(bbs, ByteBufferAccessor.instance);
+        }
+
+        @Override
+        public <V> List<T> deserialize(V input, ValueAccessor<V> accessor)
+        {
+            if (isNull(input, accessor))
+                return null;
+            List<T> result = new ArrayList<>(dimension);
+            int offset = 0;
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = readValue(input, accessor, offset);
+                offset += sizeOf(bb, accessor);
+                elementSerializer.validate(bb, accessor);
+                result.add(elementSerializer.deserialize(bb, accessor));
+            }
+            if (!accessor.isEmptyFromOffset(input, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
+
+            return result;
+        }
+
+        public <V> float[] deserializeFloatArray(V input, ValueAccessor<V> accessor)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <V> void validate(V input, ValueAccessor<V> accessor) throws MarshalException
+        {
+            int offset = 0;
+            for (int i = 0; i < dimension; i++)
+            {
+                V bb = readValue(input, accessor, offset);
+                offset += sizeOf(bb, accessor);
+                elementSerializer.validate(bb, accessor);
+            }
+            if (!accessor.isEmptyFromOffset(input, offset))
+                throw new MarshalException("Unexpected extraneous bytes after list value");
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/ConcurrentVectorValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/ConcurrentVectorValues.java
@@ -32,12 +32,12 @@ import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
 
 public class ConcurrentVectorValues implements RandomAccessVectorValues<float[]>
 {
-    private final VectorType.Serializer serializer;
+    private final int dimensions;
     private final Map<Integer, float[]> values = new ConcurrentHashMap<>();
 
-    public ConcurrentVectorValues(VectorType.Serializer serializer)
+    public ConcurrentVectorValues(int dimensions)
     {
-        this.serializer = serializer;
+        this.dimensions = dimensions;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class ConcurrentVectorValues implements RandomAccessVectorValues<float[]>
     @Override
     public int dimension()
     {
-        return serializer.getDimensions();
+        return dimensions;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
@@ -30,13 +30,11 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
@@ -46,6 +44,7 @@ import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
+import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.concurrent.OpOrder;
@@ -103,7 +102,7 @@ public class VectorMemtableIndex implements MemtableIndex
         assert expr.getOp() == Expression.Op.ANN : "Only ANN is supported for vector search, received " + expr.getOp();
 
         var buffer = expr.lower.value.raw;
-        float[] qv = (float[])indexContext.getValidator().getSerializer().deserialize(buffer);
+        float[] qv = TypeUtil.decomposeVector(indexContext, buffer);
 
         Bits bits = null;
         // key range doesn't full token ring, we need to filter keys inside ANN search

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.index.sai.utils.SegmentOrdering;
+import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.lucene.util.SparseFixedBitSet;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
@@ -99,7 +100,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
         SparseFixedBitSet bits = bitsetForKeyRange(keyRange);
 
         ByteBuffer buffer = exp.lower.value.raw;
-        float[] queryVector = (float[])indexContext.getValidator().getSerializer().deserialize(buffer.duplicate());
+        float[] queryVector = TypeUtil.decomposeVector(indexContext, buffer.duplicate());
         return graph.search(queryVector, limit, bits, Integer.MAX_VALUE);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/VectorTopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/VectorTopKProcessor.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.utils.InMemoryPartitionIterator;
 import org.apache.cassandra.index.sai.utils.InMemoryUnfilteredPartitionIterator;
 import org.apache.cassandra.index.sai.utils.PartitionInfo;
+import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
@@ -142,7 +143,7 @@ public class VectorTopKProcessor
                           if (sai == null)
                               return null;
 
-                          float[] qv = (float[]) sai.getIndexContext().getValidator().getSerializer().deserialize(e.getIndexValue().duplicate());
+                          float[] qv = TypeUtil.decomposeVector(sai.getIndexContext(), e.getIndexValue().duplicate());
                           return Pair.create(sai, qv);
                       }).filter(Objects::nonNull)
                       .collect(Collectors.toMap(p -> p.left, p -> p.right));
@@ -171,7 +172,7 @@ public class VectorTopKProcessor
             ByteBuffer value = indexContext.getValueOf(key, row, FBUtilities.nowInSeconds());
             if (value != null)
             {
-                float[] vector = (float[]) indexContext.getValidator().getSerializer().deserialize(value.duplicate());
+                float[] vector = TypeUtil.decomposeVector(indexContext, value.duplicate());
                 score += indexContext.getIndexWriterConfig().getSimilarityFunction().compare(vector, e.getValue());
             }
         }

--- a/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
@@ -41,8 +41,10 @@ import org.apache.cassandra.db.marshal.InetAddressType;
 import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.db.marshal.ReversedType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ComplexColumnData;
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.MarshalException;
@@ -311,6 +313,13 @@ public class TypeUtil
             return FastByteOperations::compareUnsigned;
 
         return type;
+    }
+
+    public static float[] decomposeVector(IndexContext indexContext, ByteBuffer byteBuffer)
+    {
+        return ((VectorType.VectorSerializer)indexContext.getValidator()
+                                                         .getSerializer())
+               .deserializeFloatArray(byteBuffer, ByteBufferAccessor.instance);
     }
 
     private static ByteBuffer cellValue(ColumnMetadata column, IndexTarget.Type indexType, Cell cell)

--- a/src/java/org/apache/cassandra/serializers/TypeSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/TypeSerializer.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.serializers;
 
 import java.nio.ByteBuffer;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 
@@ -60,6 +62,16 @@ public abstract class TypeSerializer<T>
         return buffer == null || !buffer.hasRemaining()
                ? "null"
                : toString(deserialize(buffer));
+    }
+
+    public final boolean isNull(@Nullable ByteBuffer buffer)
+    {
+        return isNull(buffer, ByteBufferAccessor.instance);
+    }
+
+    public <V> boolean isNull(@Nullable V buffer, ValueAccessor<V> accessor)
+    {
+        return buffer == null || accessor.isEmpty(buffer);
     }
 }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -60,8 +60,8 @@ public class VectorDistributedTest extends TestBaseImpl
     public SAITester.FailureWatcher failureRule = new SAITester.FailureWatcher();
 
     private static final String CREATE_KEYSPACE = "CREATE KEYSPACE %%s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': %d}";
-    private static final String CREATE_TABLE = "CREATE TABLE %%s (pk int primary key, val float vector[%d])";
-    private static final String CREATE_TABLE_TWO_VECTORS = "CREATE TABLE %%s (pk int primary key, val1 float vector[%d], val2 float vector[%d])";
+    private static final String CREATE_TABLE = "CREATE TABLE %%s (pk int primary key, val vector<float, %d>)";
+    private static final String CREATE_TABLE_TWO_VECTORS = "CREATE TABLE %%s (pk int primary key, val1 vector<float, %d>, val2 float vector[%d])";
     private static final String CREATE_INDEX = "CREATE CUSTOM INDEX ON %%s(%s) USING 'StorageAttachedIndex'";
 
     private static final VectorSimilarityFunction function = IndexWriterConfig.DEFAULT_SIMILARITY_FUNCTION;
@@ -402,7 +402,13 @@ public class VectorDistributedTest extends TestBaseImpl
 
         // verify results are part of inserted vectors
         for (Object[] obj: result)
-            vectors.add((float[]) obj[0]);
+        {
+            List<Float> list = (List<Float>) obj[0];
+            float[] array = new float[list.size()];
+            for (int index = 0; index < list.size(); index++)
+                array[index] = list.get(index);
+            vectors.add(array);
+        }
 
         return vectors;
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.SAITester;
@@ -57,7 +58,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void randomizedTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val float vector[%d], PRIMARY KEY(pk))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimensionCount));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -102,7 +103,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void multiSSTablesTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val float vector[%d], PRIMARY KEY(pk))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimensionCount));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
         disableCompaction(keyspace());
@@ -138,7 +139,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void partitionRestrictedTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val float vector[%d], PRIMARY KEY(pk))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimensionCount));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -180,7 +181,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void partitionRestrictedWidePartitionTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, ck int, val float vector[%d], PRIMARY KEY(pk, ck))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, ck int, val vector<float, %d>, PRIMARY KEY(pk, ck))", dimensionCount));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -229,7 +230,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void rangeRestrictedTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val float vector[%d], PRIMARY KEY(pk))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimensionCount));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -292,7 +293,7 @@ public class VectorLocalTest extends SAITester
     @Test
     public void multipleNonAnnSegmentsTest() throws Throwable
     {
-        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val float vector[%d], PRIMARY KEY(pk))", dimensionCount));
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimensionCount));
         disableCompaction(KEYSPACE);
 
         int sstableCount = getRandom().nextIntBetween(3, 6);
@@ -412,12 +413,12 @@ public class VectorLocalTest extends SAITester
     private List<float[]> getVectorsFromResult(UntypedResultSet result)
     {
         List<float[]> vectors = new ArrayList<>();
-        VectorType vectorType = VectorType.getInstance(dimensionCount);
+        VectorType vectorType = VectorType.getInstance(FloatType.instance, dimensionCount);
 
         // verify results are part of inserted vectors
         for (UntypedResultSet.Row row: result)
         {
-            vectors.add(vectorType.compose(row.getBytes("val")));
+            vectors.add(vectorType.composeAsFloat(row.getBytes("val")));
         }
 
         return vectors;

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
@@ -28,7 +28,7 @@ public class VectorSegmentationTest extends SAITester
     @Test
     public void test() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, val float vector[4], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, val vector<float, 4>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -42,13 +42,13 @@ public class VectorSegmentationTest extends SAITester
         System.out.println(makeRowStrings(resultSet));
     }
 
-    private float[] nextVector()
+    private Vector nextVector()
     {
-        float[] vector = new float[4];
+        Float[] vector = new Float[4];
 
         for (int index = 0; index < vector.length; index++)
             vector[index] = getRandom().nextFloat();
 
-        return vector;
+        return new Vector<Float>(vector);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -50,7 +50,7 @@ public class VectorSiftSmallTest extends SAITester
         var groundTruth = readIvecs(String.format("test/data/%s/%s_groundtruth.ivecs", siftName, siftName));
 
         // Create table and index
-        createTable("CREATE TABLE %s (pk int, val float vector[128], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -33,7 +32,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void endToEndTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -94,7 +93,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testTwoPredicates() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, b boolean, v float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
@@ -118,7 +117,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testThreePredicates() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, b boolean, v float vector[3], str text, PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, str text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str) USING 'StorageAttachedIndex'");
@@ -143,7 +142,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testSameVectorMultipleRows() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -165,7 +164,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testQueryEmptyTable() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -176,7 +175,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testQueryTableWithNulls() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -192,7 +191,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testLimitLessThanInsertedRowCount() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -209,7 +208,7 @@ public class VectorTypeTest extends SAITester
     @Test
     public void testQueryMoreRowsThanInserted() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -222,17 +221,17 @@ public class VectorTypeTest extends SAITester
     @Test
     public void cannotInsertWrongNumberOfDimensions()
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
 
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0])"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Invalid number of dimensions 2 in list literal for val of type float vector[3]");
+        .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
     }
 
     @Test
     public void cannotQueryWrongNumberOfDimensions() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
@@ -243,13 +242,13 @@ public class VectorTypeTest extends SAITester
 
         assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE val ann of [2.5, 3.5] LIMIT 5"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Invalid number of dimensions 2 in list literal for val of type float vector[3]");
+        .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
     }
 
     @Test
     public void changingOptionsTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = " +
                     "{'maximum_node_connections' : 10, 'construction_beam_width' : 200, 'similarity_function' : 'euclidean' }");
         waitForIndexQueryable();
@@ -284,16 +283,16 @@ public class VectorTypeTest extends SAITester
     @Test
     public void bindVariablesTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", new float[] {1.0f, 2.0f ,3.0f});
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", new float[] {2.0f ,3.0f, 4.0f});
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", new float[] {3.0f, 4.0f, 5.0f});
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', ?)", new float[] {4.0f, 5.0f, 6.0f});
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1.0f, 2.0f ,3.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2.0f ,3.0f, 4.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", vector(3.0f, 4.0f, 5.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', ?)", vector(4.0f, 5.0f, 6.0f));
 
-        UntypedResultSet result = execute("SELECT * FROM %s WHERE val ann of ? LIMIT 3", new float[] {2.5f, 3.5f, 4.5f});
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val ann of ? LIMIT 3", vector(2.5f, 3.5f, 4.5f));
         assertThat(result).hasSize(3);
         System.out.println(makeRowStrings(result));
     }
@@ -303,16 +302,16 @@ public class VectorTypeTest extends SAITester
     {
         // check that we correctly get back the two rows with str_val=B even when those are not
         // the closest rows to the query vector
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", Lists.newArrayList(1.0, 2.0 ,3.0));
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", Lists.newArrayList(2.0 ,3.0, 4.0));
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", Lists.newArrayList(3.0, 4.0, 5.0));
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'B', ?)", Lists.newArrayList(4.0, 5.0, 6.0));
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'E', ?)", Lists.newArrayList(5.0, 6.0, 7.0));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1.0f, 2.0f ,3.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2.0f ,3.0f, 4.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", vector(3.0f, 4.0f, 5.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'B', ?)", vector(4.0f, 5.0f, 6.0f));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'E', ?)", vector(5.0f, 6.0f, 7.0f));
 
         UntypedResultSet result = execute("SELECT * FROM %s WHERE str_val = 'B' AND val ann of [2.5, 3.5, 4.5] LIMIT 2");
         assertThat(result).hasSize(2);
@@ -327,16 +326,16 @@ public class VectorTypeTest extends SAITester
     @Test
     public void nullVectorTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int, str_val text, val float vector[3], PRIMARY KEY(pk))");
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
 
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", Lists.newArrayList(1.0, 2.0 ,3.0));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1.0f, 2.0f ,3.0f));
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 'B')");
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", Lists.newArrayList(3.0, 4.0, 5.0));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', ?)", vector(3.0f, 4.0f, 5.0f));
         execute("INSERT INTO %s (pk, str_val) VALUES (3, 'D')");
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'E', ?)", Lists.newArrayList(5.0, 6.0, 7.0));
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'E', ?)", vector(5.0f, 6.0f, 7.0f));
 
         UntypedResultSet result = execute("SELECT * FROM %s WHERE str_val = 'B' AND val ann of [2.5, 3.5, 4.5] LIMIT 2");
         assertThat(result).hasSize(0);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfigTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfigTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -35,7 +36,7 @@ public class IndexWriterConfigTest
     @Test
     public void defaultsTest()
     {
-        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), new HashMap<>());
+        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), new HashMap<>());
 
         assertThat(config.getMaximumNodeConnections()).isEqualTo(16);
         assertThat(config.getConstructionBeamWidth()).isEqualTo(100);
@@ -47,21 +48,21 @@ public class IndexWriterConfigTest
     {
         Map<String, String> options = new HashMap<>();
         options.put(IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS, "10");
-        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options);
+        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options);
         assertThat(config.getMaximumNodeConnections()).isEqualTo(10);
 
         options.put(IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS, "-1");
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Maximum number of connections for index test cannot be <= 0 or > 512, was -1");
 
         options.put(IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS, Integer.toString(IndexWriterConfig.MAXIMUM_MAXIMUM_NODE_CONNECTIONS + 1));
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Maximum number of connections for index test cannot be <= 0 or > 512, was " + (IndexWriterConfig.MAXIMUM_MAXIMUM_NODE_CONNECTIONS + 1));
 
         options.put(IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS, "abc");
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Maximum number of connections abc is not a valid integer for index test");
     }
@@ -71,21 +72,21 @@ public class IndexWriterConfigTest
     {
         Map<String, String> options = new HashMap<>();
         options.put(IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH, "150");
-        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options);
+        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options);
         assertThat(config.getConstructionBeamWidth()).isEqualTo(150);
 
         options.put(IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH, "-1");
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Construction beam width for index test cannot be <= 0 or > 3200, was -1");
 
         options.put(IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH, Integer.toString(IndexWriterConfig.MAXIMUM_CONSTRUCTION_BEAM_WIDTH + 1));
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Construction beam width for index test cannot be <= 0 or > 3200, was " + (IndexWriterConfig.MAXIMUM_CONSTRUCTION_BEAM_WIDTH + 1));
 
         options.put(IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH, "abc");
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Construction beam width abc is not a valid integer for index test");
     }
@@ -95,15 +96,15 @@ public class IndexWriterConfigTest
     {
         Map<String, String> options = new HashMap<>();
         options.put(IndexWriterConfig.SIMILARITY_FUNCTION, "DOT_PRODUCT");
-        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options);
+        IndexWriterConfig config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options);
         assertThat(config.getSimilarityFunction()).isEqualTo(VectorSimilarityFunction.DOT_PRODUCT);
 
         options.put(IndexWriterConfig.SIMILARITY_FUNCTION, "euclidean");
-        config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options);
+        config = IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options);
         assertThat(config.getSimilarityFunction()).isEqualTo(VectorSimilarityFunction.EUCLIDEAN);
 
         options.put(IndexWriterConfig.SIMILARITY_FUNCTION, "blah");
-        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(3), options))
+        assertThatThrownBy(() -> IndexWriterConfig.fromOptions("test", VectorType.getInstance(FloatType.instance, 3), options))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Similarity function BLAH was not recognized for index test. Valid values are: EUCLIDEAN, DOT_PRODUCT, COSINE");
     }

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.AbstractBounds;
@@ -101,7 +102,7 @@ public class VectorMemtableIndexTest extends SAITester
         cfs = MockSchema.newCFS(tableMetadata);
         partitioner = cfs.getPartitioner();
         dimensionCount = getRandom().nextIntBetween(1, 2048);
-        indexContext = SAITester.createIndexContext("index", VectorType.getInstance(dimensionCount), cfs);
+        indexContext = SAITester.createIndexContext("index", VectorType.getInstance(FloatType.instance, dimensionCount), cfs);
         indexSearchCounter.reset();
         keyMap = new TreeMap<>();
         rowMap = new HashMap<Integer, ByteBuffer>();
@@ -166,11 +167,11 @@ public class VectorMemtableIndexTest extends SAITester
     }
 
     private ByteBuffer randomVector() {
-        float[] rawVector = new float[dimensionCount];
+        List<Float> rawVector = new ArrayList<>(dimensionCount);
         for (int i = 0; i < dimensionCount; i++) {
-            rawVector[i] = getRandom().nextFloat();
+            rawVector.add(getRandom().nextFloat());
         }
-        return VectorType.getInstance(dimensionCount).getSerializer().serialize(rawVector);
+        return VectorType.getInstance(FloatType.instance, dimensionCount).getSerializer().serialize(rawVector);
     }
 
     private AbstractBounds<PartitionPosition> generateRandomBounds(List<DecoratedKey> keys)


### PR DESCRIPTION
 - Now uses vector<type, dimension> to describe vector
 - This commit does not bring in the whole 18504 patch only the essential grammar and type parts of the patch