### PR TITLE
CNDB-6976 Set SEVER_VERSION and PRODUCT_TYPE

### DIFF
--- a/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
@@ -34,6 +34,8 @@ import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Compressor;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.ProductType;
 
 /**
  * Message to indicate that the server is ready to receive requests.
@@ -82,6 +84,8 @@ public class OptionsMessage extends Message.Request
         supported.put(StartupMessage.PROTOCOL_VERSIONS, ProtocolVersion.supportedVersions());
         supported.put(StartupMessage.EMULATE_DBAAS_DEFAULTS, Collections.singletonList(String.valueOf(DatabaseDescriptor.isEmulateDbaasDefaults())));
         supported.put(StartupMessage.PAGE_UNIT, supportedPageUnits);
+        supported.put(StartupMessage.SERVER_VERSION, Collections.singletonList(FBUtilities.getReleaseVersionString()));
+        supported.put(StartupMessage.PRODUCT_TYPE, Collections.singletonList(ProductType.getProduct().toString()));
 
         return new SupportedMessage(supported);
     }

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -42,6 +42,8 @@ public class StartupMessage extends Message.Request
     public static final String THROW_ON_OVERLOAD = "THROW_ON_OVERLOAD";
     public static final String EMULATE_DBAAS_DEFAULTS = "EMULATE_DBAAS_DEFAULTS";
     public static final String PAGE_UNIT = "PAGE_UNIT";
+    public static final String SERVER_VERSION = "SERVER_VERSION";
+    public static final String PRODUCT_TYPE = "PRODUCT_TYPE";
 
     public static final Message.Codec<StartupMessage> codec = new Message.Codec<StartupMessage>()
     {

--- a/src/java/org/apache/cassandra/utils/ProductType.java
+++ b/src/java/org/apache/cassandra/utils/ProductType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProductType
+{
+    private static final Logger logger = LoggerFactory.getLogger(ProductType.class);
+
+    public static Product product = getProduct();
+
+    public enum Product
+    {
+        /**
+         * On-Premises product
+         */
+        DATASTAX_CASSANDRA,
+
+        /**
+         * Datastax constellation database-as-a-service product (NOT referring to dse-db, aka. apollo)
+         */
+        DATASTAX_APOLLO
+    }
+
+    @VisibleForTesting
+    public static Product getProduct()
+    {
+        Product defaultType = Product.DATASTAX_CASSANDRA;
+        String productType = System.getProperty("dse.product_type", defaultType.name());
+        try
+        {
+            return Product.valueOf(productType.toUpperCase());
+        }
+        catch (IllegalArgumentException e)
+        {
+            logger.info("Unknown product type '{}', will use default product type '{}'.", productType, defaultType.name());
+            return defaultType;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/ProductTypeTest.java
+++ b/test/unit/org/apache/cassandra/utils/ProductTypeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class ProductTypeTest
+{
+    @AfterClass
+    public static void cleanup()
+    {
+        System.clearProperty("dse.product_type");
+    }
+
+    @Test
+    public void testDefault()
+    {
+        System.clearProperty("dse.product_type");
+        assertEquals(ProductType.Product.DATASTAX_CASSANDRA, ProductType.getProduct());
+    }
+
+    @Test
+    public void testDatastaxApollo()
+    {
+        System.setProperty("dse.product_type", "DATASTAX_APOLLO");
+        assertEquals(ProductType.Product.DATASTAX_APOLLO, ProductType.getProduct());
+
+        System.setProperty("dse.product_type", "datastax_apollo");
+        assertEquals(ProductType.Product.DATASTAX_APOLLO, ProductType.getProduct());
+    }
+}


### PR DESCRIPTION
Converged Cassandra needs to set SERVER_VERSION and PRODUCT_TYPE in the OPTIONS message returned to drivers on connection. The drivers use those OPTIONS to know they are talking to astra and to change the default CL to LOCAL_QUORUM for writes.