### PR TITLE
Vector 6 take 2: reapply Vector-6 commit and fix NPE in SelectStatement

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Ordering.java
+++ b/src/java/org/apache/cassandra/cql3/Ordering.java
@@ -52,6 +52,8 @@ public class Ordering
         {
             throw new UnsupportedOperationException();
         }
+
+        ColumnMetadata getColumn();
     }
 
     /**
@@ -65,6 +67,12 @@ public class Ordering
         public SingleColumn(ColumnMetadata column)
         {
             this.column = column;
+        }
+
+        @Override
+        public ColumnMetadata getColumn()
+        {
+            return column;
         }
     }
 
@@ -93,6 +101,12 @@ public class Ordering
         public SingleRestriction toRestriction()
         {
             return new SingleColumnRestriction.AnnRestriction(column, vectorValue);
+        }
+
+        @Override
+        public ColumnMetadata getColumn()
+        {
+            return column;
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -120,6 +120,15 @@ public abstract class MultiColumnRestriction implements SingleRestriction
     }
 
     @Override
+    public final Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        for (Index index : indexRegistry.listIndexes())
+            if (isSupportingIndex(index))
+                return index;
+        return null;
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (ColumnMetadata column : columnDefs)

--- a/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
@@ -74,6 +74,14 @@ public interface Restriction
     public boolean hasSupportingIndex(IndexRegistry indexRegistry);
 
     /**
+     * Find first supporting index for current restriction
+     *
+     * @param indexRegistry the index registry
+     * @return <code>index</code> if the restriction is on indexed columns, <code>null</code>
+     */
+    public Index findSupportingIndex(IndexRegistry indexRegistry);
+
+    /**
      * Returns whether this restriction would need filtering if the specified index group were used.
      *
      * @param indexGroup an index group

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -99,6 +99,12 @@ public abstract class RestrictionSet implements Restrictions
         }
 
         @Override
+        public Index findSupportingIndex(IndexRegistry indexRegistry)
+        {
+            return null;
+        }
+
+        @Override
         public boolean needsFiltering(Index.Group indexGroup)
         {
             return false;
@@ -273,6 +279,18 @@ public abstract class RestrictionSet implements Restrictions
                 if (restriction.hasSupportingIndex(indexRegistry))
                     return true;
             return false;
+        }
+
+        @Override
+        public Index findSupportingIndex(IndexRegistry indexRegistry)
+        {
+            for (SingleRestriction restriction : restrictionsMap.values())
+            {
+                Index index = restriction.findSupportingIndex(indexRegistry);
+                if (index != null)
+                    return index;
+            }
+            return null;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
@@ -85,6 +85,12 @@ class RestrictionSetWrapper implements Restrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return restrictions.findSupportingIndex(indexRegistry);
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -83,6 +83,16 @@ public abstract class SingleColumnRestriction implements SingleRestriction
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        for (Index index : indexRegistry.listIndexes())
+            if (isSupportedBy(index))
+                return index;
+
+        return null;
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (Index index : indexGroup.getIndexes())
@@ -804,6 +814,11 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         {
             super(columnDef);
             this.value = value;
+        }
+
+        public ByteBuffer value(QueryOptions options)
+        {
+            return value.bindAndGet(options);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -331,6 +331,12 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return restrictions.findSupportingIndex(indexRegistry);
+    }
+
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -124,6 +124,11 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
+    public Index findSupportingIndex(IndexRegistry indexRegistry)
+    {
+        return null;
+    }
+    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return false;

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1106,7 +1106,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                 verifyOrderingIsAllowed(restrictions, orderingColumns);
                 orderingComparator = getOrderingComparator(selection, restrictions, orderingColumns);
                 isReversed = isReversed(table, orderingColumns, restrictions);
-                if (isReversed)
+                if (isReversed && orderingComparator != null)
                     orderingComparator = orderingComparator.reverse();
             }
 
@@ -1179,14 +1179,21 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         }
 
         /**
-         * Returns the columns used to order the data.
-         * @return the columns used to order the data.
+         * Returns the columns in the same order as given list used to order the data.
+         * @return the columns in the same order as given list used to order the data.
          */
         private Map<ColumnMetadata, Ordering> getOrderingColumns(List<Ordering> orderings)
         {
-            return orderings.stream()
-                            .collect(Collectors.toMap(o -> o.expression.getColumn(),
-                                                      java.util.function.Function.identity()));
+            if (orderings.isEmpty())
+                return Collections.emptyMap();
+
+            Map<ColumnMetadata, Ordering> orderingColumns = new LinkedHashMap<>();
+            for (Ordering ordering : orderings)
+            {
+                ColumnMetadata column = ordering.expression.getColumn();
+                orderingColumns.put(column, ordering);
+            }
+            return orderingColumns;
         }
 
         private List<Ordering> getOrderings(TableMetadata table)

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cql3.Ordering;
 import org.apache.cassandra.cql3.restrictions.*;
@@ -34,7 +35,11 @@ import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.restrictions.ExternalRestriction;
+import org.apache.cassandra.cql3.restrictions.Restrictions;
+import org.apache.cassandra.cql3.restrictions.SingleRestriction;
 import org.apache.cassandra.guardrails.Guardrails;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -118,7 +123,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     /**
      * The comparator used to orders results when multiple keys are selected (using IN).
      */
-    private final Comparator<List<ByteBuffer>> orderingComparator;
+    private final ColumnComparator<List<ByteBuffer>> orderingComparator;
 
     // Used by forSelection below
     private static final Parameters defaultParameters = new Parameters(Collections.emptyList(),
@@ -135,7 +140,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            StatementRestrictions restrictions,
                            boolean isReversed,
                            AggregationSpecification aggregationSpec,
-                           Comparator<List<ByteBuffer>> orderingComparator,
+                           ColumnComparator<List<ByteBuffer>> orderingComparator,
                            Term limit,
                            Term perPartitionLimit)
     {
@@ -305,10 +310,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      * is unnecessary in this case. That applies to the page size defined in rows - if the page size is defined in bytes
      * we cannot say anything about the relation beteween the user rows limit and the page size.
      */
-    private boolean canSkipPaging(DataLimits userLimits, PageSize pageSize)
+    private boolean canSkipPaging(DataLimits userLimits, PageSize pageSize, boolean topK)
     {
         return !pageSize.isDefined() ||
-               pageSize.getUnit() == PageSize.PageUnit.ROWS && !pageSize.isCompleted(userLimits.count(), PageSize.PageUnit.ROWS);
+               pageSize.getUnit() == PageSize.PageUnit.ROWS && !pageSize.isCompleted(userLimits.count(), PageSize.PageUnit.ROWS) ||
+               topK;
     }
 
     public ResultMessage.Rows execute(QueryState queryState, QueryOptions options, long queryStartNanoTime)
@@ -330,7 +336,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         if (query.limits().isGroupByLimit() && pageSize != null && pageSize.isDefined() && pageSize.getUnit() == PageSize.PageUnit.BYTES)
             throw new InvalidRequestException("Paging in bytes cannot be specified for aggregation queries");
 
-        if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize))
+        if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize, query.isTopK()))
             return execute(query, options, queryState, selectors, nowInSec, userLimit, queryStartNanoTime);
 
         QueryPager pager = getPager(query, options);
@@ -494,7 +500,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         // Please note that the isExhausted state of the pager only gets updated when we've closed the page, so this
         // shouldn't be moved inside the 'try' above.
-        if (!pager.isExhausted())
+        if (!pager.isExhausted() && !pager.pager.isTopK())
             msg.result.metadata.setHasMorePages(pager.state());
 
         return msg;
@@ -532,7 +538,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         try (ReadExecutionController executionController = query.executionController())
         {
-            if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize))
+            if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize, query.isTopK()))
             {
                 try (PartitionIterator data = query.executeInternal(executionController))
                 {
@@ -771,7 +777,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         // If we do post ordering we need to get all the results sorted before we can trim them.
         if (aggregationSpec != AggregationSpecification.AGGREGATE_EVERYTHING)
         {
-            if (!needsPostQueryOrdering())
+            if (!needsToSkipUserLimit())
                 cqlRowLimit = userLimit;
             cqlPerPartitionLimit = perPartitionLimit;
         }
@@ -896,7 +902,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         ResultSet cqlRows = result.build();
 
-        orderResults(cqlRows);
+        orderResults(cqlRows, options);
 
         cqlRows.trim(userLimit);
 
@@ -994,21 +1000,34 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         }
     }
 
+    private boolean needsToSkipUserLimit()
+    {
+        // if post query ordering is required, and it's not ANN
+        return needsPostQueryOrdering() && !needIndexOrdering();
+    }
+
     private boolean needsPostQueryOrdering()
     {
-        // We need post-query ordering only for queries with IN on the partition key and an ORDER BY.
-        return restrictions.keyIsInRelation() && !parameters.orderings.isEmpty();
+        // We need post-query ordering only for queries with IN on the partition key and an ORDER BY or index restriction reordering
+        return restrictions.keyIsInRelation() && !parameters.orderings.isEmpty() || needIndexOrdering();
+    }
+
+    private boolean needIndexOrdering()
+    {
+        return orderingComparator != null && orderingComparator.indexOrdering();
     }
 
     /**
      * Orders results when multiple keys are selected (using IN)
      */
-    private void orderResults(ResultSet cqlRows)
+    private void orderResults(ResultSet cqlRows, QueryOptions options)
     {
         if (cqlRows.size() == 0 || !needsPostQueryOrdering())
             return;
 
-        Collections.sort(cqlRows.rows, orderingComparator);
+        Comparator<List<ByteBuffer>> comparator = orderingComparator.prepareFor(table, options);
+        if (comparator != null)
+            Collections.sort(cqlRows.rows, comparator);
     }
 
     public static class RawStatement extends QualifiedStatement<SelectStatement>
@@ -1055,9 +1074,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
             // If we order post-query, the sorted column needs to be in the ResultSet for sorting,
             // even if we don't ultimately ship them to the client (CASSANDRA-4911).
-            Map<ColumnMetadata, Boolean> orderingColumns = getOrderingColumns(orderings);
-            Set<ColumnMetadata> resultSetOrderingColumns = restrictions.keyIsInRelation() ? orderingColumns.keySet()
-                                                                                          : Collections.emptySet();
+            Map<ColumnMetadata, Ordering> orderingColumns = getOrderingColumns(orderings);
+            Set<ColumnMetadata> resultSetOrderingColumns = getResultSetOrdering(restrictions, orderingColumns);
 
             Selection selection = prepareSelection(table,
                                                    selectables,
@@ -1079,17 +1097,17 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             checkFalse(aggregationSpec == AggregationSpecification.AGGREGATE_EVERYTHING && perPartitionLimit != null,
                        "PER PARTITION LIMIT is not allowed with aggregate queries.");
 
-            Comparator<List<ByteBuffer>> orderingComparator = null;
+            ColumnComparator<List<ByteBuffer>> orderingComparator = null;
             boolean isReversed = false;
 
             if (!orderingColumns.isEmpty())
             {
                 assert !forView;
-                verifyOrderingIsAllowed(restrictions);
+                verifyOrderingIsAllowed(restrictions, orderingColumns);
                 orderingComparator = getOrderingComparator(selection, restrictions, orderingColumns);
                 isReversed = isReversed(table, orderingColumns, restrictions);
                 if (isReversed)
-                    orderingComparator = Collections.reverseOrder(orderingComparator);
+                    orderingComparator = orderingComparator.reverse();
             }
 
             checkDisjunctionIsSupported(table, restrictions);
@@ -1107,6 +1125,13 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        orderingComparator,
                                        prepareLimit(bindVariables, limit, ks, limitReceiver()),
                                        prepareLimit(bindVariables, perPartitionLimit, ks, perPartitionLimitReceiver()));
+        }
+
+        private Set<ColumnMetadata> getResultSetOrdering(StatementRestrictions restrictions, Map<ColumnMetadata, Ordering> orderingColumns)
+        {
+            if (restrictions.keyIsInRelation() || orderingColumns.values().stream().anyMatch(o -> o.expression.hasNonClusteredOrdering()))
+                return orderingColumns.keySet();
+            return Collections.emptySet();
         }
 
         private Selection prepareSelection(TableMetadata table,
@@ -1157,22 +1182,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
          * Returns the columns used to order the data.
          * @return the columns used to order the data.
          */
-        private Map<ColumnMetadata, Boolean> getOrderingColumns(List<Ordering> orderings)
+        private Map<ColumnMetadata, Ordering> getOrderingColumns(List<Ordering> orderings)
         {
-            if (orderings.isEmpty())
-                return Collections.emptyMap();
-
-            Map<ColumnMetadata, Boolean> orderingColumns = new LinkedHashMap<>();
-            for (Ordering ordering : orderings)
-            {
-                if (ordering.expression instanceof Ordering.SingleColumn)
-                {
-                    ColumnMetadata column = ((Ordering.SingleColumn) ordering.expression).column;
-                    boolean reversed = (ordering.direction == Ordering.Direction.DESC);
-                    orderingColumns.put(column, reversed);
-                }
-            }
-            return orderingColumns;
+            return orderings.stream()
+                            .collect(Collectors.toMap(o -> o.expression.getColumn(),
+                                                      java.util.function.Function.identity()));
         }
 
         private List<Ordering> getOrderings(TableMetadata table)
@@ -1219,8 +1233,10 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             return prepLimit;
         }
 
-        private static void verifyOrderingIsAllowed(StatementRestrictions restrictions) throws InvalidRequestException
+        private static void verifyOrderingIsAllowed(StatementRestrictions restrictions, Map<ColumnMetadata, Ordering> orderingColumns) throws InvalidRequestException
         {
+            if (orderingColumns.values().stream().anyMatch(o -> o.expression.hasNonClusteredOrdering()))
+                return;
             checkFalse(restrictions.usesSecondaryIndexing(), "ORDER BY with 2ndary indexes is not supported.");
             checkFalse(restrictions.isKeyRange(), "ORDER BY is only supported when the partition key is restricted by an EQ or an IN.");
         }
@@ -1307,11 +1323,20 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             return AggregationSpecification.aggregatePkPrefix(metadata.comparator, clusteringPrefixSize);
         }
 
-        private Comparator<List<ByteBuffer>> getOrderingComparator(Selection selection,
-                                                                   StatementRestrictions restrictions,
-                                                                   Map<ColumnMetadata, Boolean> orderingColumns)
+        private ColumnComparator<List<ByteBuffer>> getOrderingComparator(Selection selection,
+                                                                         StatementRestrictions restrictions,
+                                                                         Map<ColumnMetadata, Ordering> orderingColumns)
                                                                    throws InvalidRequestException
         {
+            for (Map.Entry<ColumnMetadata, Ordering> e : orderingColumns.entrySet())
+            {
+                if (e.getValue().expression.hasNonClusteredOrdering())
+                {
+                    Preconditions.checkState(orderingColumns.size() == 1);
+                    return new IndexColumnComparator<>(e.getValue().expression.toRestriction(), selection.getOrderingIndex(e.getKey()));
+                }
+            }
+
             if (!restrictions.keyIsInRelation())
                 return null;
 
@@ -1323,22 +1348,28 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                 idToSort.add(selection.getOrderingIndex(orderingColumn));
                 sorters.add(orderingColumn.type);
             }
+
             return idToSort.size() == 1 ? new SingleColumnComparator(idToSort.get(0), sorters.get(0))
                     : new CompositeComparator(sorters, idToSort);
         }
 
-        private boolean isReversed(TableMetadata table, Map<ColumnMetadata, Boolean> orderingColumns, StatementRestrictions restrictions) throws InvalidRequestException
+        private boolean isReversed(TableMetadata table, Map<ColumnMetadata, Ordering> orderingColumns, StatementRestrictions restrictions) throws InvalidRequestException
         {
+            // FIXME exception for ANN until we properly support general ORDER BY
+            if (orderingColumns.values().stream().anyMatch(o -> o.expression.hasNonClusteredOrdering()))
+                return false;
+
             Boolean[] reversedMap = new Boolean[table.clusteringColumns().size()];
             int i = 0;
-            for (Map.Entry<ColumnMetadata, Boolean> entry : orderingColumns.entrySet())
+            for (var entry : orderingColumns.entrySet())
             {
                 ColumnMetadata def = entry.getKey();
-                boolean reversed = entry.getValue();
+                Ordering ordering = entry.getValue();
+                boolean reversed = ordering.direction == Ordering.Direction.DESC;
 
+                // TODO move this to verifyOrderingIsAllowed?
                 checkTrue(def.isClusteringColumn(),
                           "Order by is currently only supported on the clustered columns of the PRIMARY KEY, got %s", def.name);
-
                 while (i != def.position())
                 {
                     checkTrue(restrictions.isColumnRestrictedByEq(table.clusteringColumns().get(i++)),
@@ -1447,8 +1478,44 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
             return bValue == null ? 1 : comparator.compare(aValue, bValue);
         }
+
+        public ColumnComparator<T> reverse()
+        {
+            return new ReversedColumnComparator<>(this);
+        }
+
+        /**
+         * @return true if ordering is performed by index
+         */
+        public boolean indexOrdering()
+        {
+            return false;
+        }
+
+        /**
+         * Produces a prepared {@link ColumnComparator} for current table and query-options
+         */
+        public Comparator<T> prepareFor(TableMetadata table, QueryOptions options)
+        {
+            return this;
+        }
     }
 
+    private static class ReversedColumnComparator<T> extends ColumnComparator<T>
+    {
+        private final ColumnComparator<T> wrapped;
+
+        public ReversedColumnComparator(ColumnComparator<T> wrapped)
+        {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public int compare(T o1, T o2)
+        {
+            return wrapped.compare(o2, o1);
+        }
+    }
     /**
      * Used in orderResults(...) method when single 'ORDER BY' condition where given
      */
@@ -1466,6 +1533,39 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         public int compare(List<ByteBuffer> a, List<ByteBuffer> b)
         {
             return compare(comparator, a.get(index), b.get(index));
+        }
+    }
+
+    private static class IndexColumnComparator<T> extends ColumnComparator<List<ByteBuffer>>
+    {
+        private final SingleRestriction restriction;
+        private final int columnIndex;
+
+        // TODO maybe cache in prepared statement
+        public IndexColumnComparator(SingleRestriction restriction, int columnIndex)
+        {
+            this.restriction = restriction;
+            this.columnIndex = columnIndex;
+        }
+
+        @Override
+        public boolean indexOrdering()
+        {
+            return true;
+        }
+
+        @Override
+        public Comparator<List<ByteBuffer>> prepareFor(TableMetadata table, QueryOptions options)
+        {
+            Index index = restriction.findSupportingIndex(IndexRegistry.obtain(table));
+            assert index != null;
+            return index.getPostQueryOrdering(restriction, columnIndex, options);
+        }
+
+        @Override
+        public int compare(List<ByteBuffer> o1, List<ByteBuffer> o2)
+        {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -263,6 +263,7 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         return dataRange.isReversed();
     }
 
+    @Override
     public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime, queryState.getClientState());
@@ -400,18 +401,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         }
         if (!dataRange.isUnrestricted())
             sb.append(dataRange.toCQLString(metadata()));
-    }
-
-    /**
-     * Allow to post-process the result of the query after it has been reconciled on the coordinator
-     * but before it is passed to the CQL layer to return the ResultSet.
-     *
-     * See CASSANDRA-8717 for why this exists.
-     */
-    public PartitionIterator postReconciliationProcessing(PartitionIterator result)
-    {
-        Index.QueryPlan queryPlan = indexQueryPlan();
-        return queryPlan == null ? result : queryPlan.postProcessor(this).apply(result);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -224,9 +224,7 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan;
     }
 
-    /**
-     * @return true given read query is a top-k request
-     */
+    @Override
     public boolean isTopK()
     {
         return indexQueryPlan != null && indexQueryPlan.isTopK();

--- a/src/java/org/apache/cassandra/db/ReadQuery.java
+++ b/src/java/org/apache/cassandra/db/ReadQuery.java
@@ -254,4 +254,12 @@ public interface ReadQuery
     default void maybeValidateIndex()
     {
     }
+
+    /**
+     * @return true given read query is a top-k request
+     */
+    default boolean isTopK()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -23,6 +23,8 @@ package org.apache.cassandra.index;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -33,6 +35,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.restrictions.Restriction;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -413,6 +417,19 @@ public interface Index
      *         the index was used to narrow the initial result set
      */
     public RowFilter getPostIndexQueryFilter(RowFilter filter);
+
+    /**
+     * Return a comparator that reorders query result before sending to client
+     *
+     * @param restriction restriction that requires current index
+     * @param columnIndex idx of the indexed column in returned row
+     * @param options query options
+     * @return comparator that for post-query ordering; or null if not supported
+     */
+    default Comparator<List<ByteBuffer>> getPostQueryOrdering(Restriction restriction, int columnIndex, QueryOptions options)
+    {
+        return null;
+    }
 
     /**
      * Return an estimate of the number of results this index is expected to return for any given

--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/CassandraOnHeapHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/CassandraOnHeapHnsw.java
@@ -31,9 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -54,8 +51,6 @@ import org.apache.lucene.util.hnsw.NeighborQueue;
 
 public class CassandraOnHeapHnsw<T>
 {
-    private static final Logger logger = LoggerFactory.getLogger(CassandraOnHeapHnsw.class);
-
     private final ConcurrentVectorValues vectorValues;
     private final ConcurrentHnswGraphBuilder<float[]> builder;
     private final VectorType.VectorSerializer serializer;
@@ -212,10 +207,6 @@ public class CassandraOnHeapHnsw<T>
 
             Map<String, String> vectorConfigs = Map.of("SEGMENT_ID", ByteBufferUtil.bytesToHex(ByteBuffer.wrap(StringHelper.randomId())));
             metadataMap.put(IndexComponent.VECTOR, -1, vectorOffset, vectorLength, vectorConfigs);
-
-            logger.debug("## write vector index termsOffset={} termsLength={}\n", termsOffset, termsLength);
-            logger.debug("## write vector index postingsOffset={} postingsLength={}\n", postingsOffset, postingsLength);
-            logger.debug("## write vector index vectorOffset={} vectorLength={}\n", vectorOffset, vectorLength);
 
             return metadataMap;
         }

--- a/src/java/org/apache/cassandra/service/pager/AggregationQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/AggregationQueryPager.java
@@ -139,6 +139,12 @@ public final class AggregationQueryPager implements QueryPager
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean isTopK()
+    {
+        return subPager.isTopK();
+    }
+
     /**
      * <code>PartitionIterator</code> that automatically fetch a new sub-page of data if needed when the current iterator is
      * exhausted.

--- a/src/java/org/apache/cassandra/service/pager/PartitionRangeQueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/PartitionRangeQueryPager.java
@@ -143,6 +143,12 @@ public class PartitionRangeQueryPager extends AbstractQueryPager<PartitionRangeR
     }
 
     @Override
+    public boolean isTopK()
+    {
+        return query.isTopK();
+    }
+
+    @Override
     public String toString()
     {
         return new StringJoiner(", ", PartitionRangeQueryPager.class.getSimpleName() + "[", "]")

--- a/src/java/org/apache/cassandra/service/pager/QueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/QueryPager.java
@@ -149,4 +149,12 @@ public interface QueryPager
      * @return a new <code>QueryPager</code> that use the new limits
      */
     public QueryPager withUpdatedLimit(DataLimits newLimits);
+
+    /**
+     * @return true given read query is a top-k request
+     */
+    default boolean isTopK()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
@@ -26,7 +26,6 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
-import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.service.QueryInfoTracker;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -130,18 +130,23 @@ public class VectorDistributedTest extends TestBaseImpl
         int limit = Math.min(getRandom().nextIntBetween(10, 50), vectors.size());
         float[] queryVector = randomVector();
         Object[][] result = searchWithLimit(queryVector, limit);
-        double memtableRecall = getRecall(vectors, queryVector, getVectors(result));
+
+        List<float[]> resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
+        double memtableRecall = getRecall(vectors, queryVector, resultVectors);
         assertThat(memtableRecall).isGreaterThanOrEqualTo(MIN_RECALL);
 
         assertThatThrownBy(() -> searchWithoutLimit(randomVector(), vectorCount))
         .hasMessageContaining(INVALID_LIMIT_MESSAGE);
 
-        // Recall is lower with page size:
-        int pageSize = getRandom().nextIntBetween(2, 10);
+        int pageSize = getRandom().nextIntBetween(40, 70);
         limit = getRandom().nextIntBetween(20, 50);
         result = searchWithPageAndLimit(queryVector, pageSize, limit);
-        double memtableRecallWithPaging = getRecall(vectors, queryVector, getVectors(result));
-        assertThat(memtableRecallWithPaging).isGreaterThanOrEqualTo(0).isLessThan(memtableRecall);
+
+        resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
+        double memtableRecallWithPaging = getRecall(vectors, queryVector, resultVectors);
+        assertThat(memtableRecallWithPaging).isGreaterThanOrEqualTo(MIN_RECALL);
 
         assertThatThrownBy(() -> searchWithPageWithoutLimit(randomVector(), 10))
         .hasMessageContaining(INVALID_LIMIT_MESSAGE);
@@ -190,6 +195,8 @@ public class VectorDistributedTest extends TestBaseImpl
         Object[][] result = searchWithLimit(queryVector, limit);
 
         // expect recall to be at least 0.8
+        List<float[]> resultVectors = getVectors(result);
+        assertDescendingScore(queryVector, resultVectors);
         double recall = getRecall(allVectors, queryVector, getVectors(result));
         assertThat(recall).isGreaterThanOrEqualTo(MIN_RECALL);
     }
@@ -337,6 +344,19 @@ public class VectorDistributedTest extends TestBaseImpl
         assertThat(result).hasSize(1);
         float[] output = getVectors(result).get(0);
         assertThat(output).isEqualTo(vectors.get(key));
+    }
+
+    private void assertDescendingScore(float[] queryVector, List<float[]> resultVectors)
+    {
+        float prevScore = -1;
+        for (float[] current : resultVectors)
+        {
+            float score = function.compare(current, queryVector);
+            if (prevScore >= 0)
+                assertThat(score).isLessThanOrEqualTo(prevScore);
+
+            prevScore = score;
+        }
     }
 
     private double getRecall(List<float[]> vectors, float[] query, List<float[]> result)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -79,12 +79,16 @@ public class VectorLocalTest extends SAITester
 
         // query memtable index
         int limit = Math.min(getRandom().nextIntBetween(30, 50), vectors.size());
-        search(randomVector(), limit);
+        float[] queryVector = randomVector();
+        UntypedResultSet resultSet = search(queryVector, limit);
+        assertDescendingScore(queryVector, getVectorsFromResult(resultSet));
 
         flush();
 
         // query on-disk index
-        search(randomVector(), limit);
+        queryVector = randomVector();
+        resultSet = search(queryVector, limit);
+        assertDescendingScore(queryVector, getVectorsFromResult(resultSet));
 
         // populate some more vectors
         int additionalVectorCount = getRandom().nextIntBetween(500, 1000);
@@ -95,17 +99,23 @@ public class VectorLocalTest extends SAITester
         vectors.addAll(additionalVectors);
 
         // query both memtable index and on-disk index
-        search(randomVector(), limit);
+        queryVector = randomVector();
+        resultSet = search(queryVector, limit);
+        assertDescendingScore(queryVector, getVectorsFromResult(resultSet));
 
         flush();
 
         // query multiple on-disk indexes
-        search(randomVector(), limit);
+        queryVector = randomVector();
+        resultSet = search(queryVector, limit);
+        assertDescendingScore(queryVector, getVectorsFromResult(resultSet));
 
         compact();
 
         // query compacted on-disk index
-        search(randomVector(), limit);
+        queryVector = randomVector();
+        resultSet = search(queryVector, limit);
+        assertDescendingScore(queryVector, getVectorsFromResult(resultSet));
     }
 
     @Test
@@ -143,6 +153,8 @@ public class VectorLocalTest extends SAITester
 
         // expect recall to be at least 0.8
         List<float[]> resultVectors = getVectorsFromResult(resultSet);
+        assertDescendingScore(queryVector, resultVectors);
+
         double recall = getRecall(allVectors, queryVector, resultVectors, limit);
         assertThat(recall).isGreaterThanOrEqualTo(0.8);
     }
@@ -273,6 +285,8 @@ public class VectorLocalTest extends SAITester
             float[] queryVector = word2vec.get(word2vec.words[getRandom().nextIntBetween(0, vectorCount - 1)]);
 
             List<float[]> resultVectors = searchWithRange(queryVector, minToken, maxToken, expected.size());
+            assertDescendingScore(queryVector, resultVectors);
+
             if (expected.isEmpty())
                 assertThat(resultVectors).isEmpty();
             else
@@ -302,6 +316,8 @@ public class VectorLocalTest extends SAITester
             float[] queryVector = word2vec.get(word2vec.words[getRandom().nextIntBetween(0, vectorCount - 1)]);
 
             List<float[]> resultVectors = searchWithRange(queryVector, minToken, maxToken, expected.size());
+            assertDescendingScore(queryVector, resultVectors);
+
             double recall = recallMatch(expected, resultVectors, expected.size());
             assertThat(recall).isGreaterThanOrEqualTo(0.8);
         }
@@ -348,6 +364,8 @@ public class VectorLocalTest extends SAITester
 
             // expect recall to be at least 0.8
             List<float[]> resultVectors = getVectorsFromResult(resultSet);
+            assertDescendingScore(queryVector, resultVectors);
+
             double recall = getRecall(vectorsByStringValue.get(stringValue), queryVector, resultVectors, limit);
             assertThat(recall).isGreaterThanOrEqualTo(0.8);
         }
@@ -404,6 +422,19 @@ public class VectorLocalTest extends SAITester
             rawVector[i] = getRandom().nextFloat();
         }
         return rawVector;
+    }
+
+    private void assertDescendingScore(float[] queryVector, List<float[]> resultVectors)
+    {
+        float prevScore = -1;
+        for (float[] current : resultVectors)
+        {
+            float score = function.compare(current, queryVector);
+            if (prevScore >= 0)
+                assertThat(score).isLessThanOrEqualTo(prevScore);
+
+            prevScore = score;
+        }
     }
 
     private double getRecall(Collection<float[]> vectors, float[] query, List<float[]> result, int topK) throws IOException

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -429,7 +429,7 @@ public class VectorLocalTest extends SAITester
         float prevScore = -1;
         for (float[] current : resultVectors)
         {
-            float score = function.compare(current, queryVector);
+            float score = VectorSimilarityFunction.COSINE.compare(current, queryVector);
             if (prevScore >= 0)
                 assertThat(score).isLessThanOrEqualTo(prevScore);
 


### PR DESCRIPTION
- fix NPE in SelectStatement by skipping reversed() for null ColumnComparator
- fix getOrderingColumns() to return LinkedHashMap to preverse ordering columns' order
- fix VectorLocalTest compilation
- remove debug log in CassandraOnHeapHnsw