### PR TITLE
CNDB-7007 return expired tables level from getLevels

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -839,6 +839,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     // used by CNDB to deserialize aggregates
     public Level getLevel(int index, double min, double max)
     {
+        if (index == EXPIRED_TABLES_LEVEL.index)
+            return EXPIRED_TABLES_LEVEL;
         return new Level(controller, index, min, max);
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -1588,4 +1588,24 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         dataTracker.removeUnsafe(allSSTables);
     }
 
+    @Test
+    public void testGetLevel()
+    {
+        Controller controller = Mockito.mock(Controller.class);
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
+
+        UnifiedCompactionStrategy.Level level = strategy.getLevel(1, 0.25d, 0.5d);
+        assertEquals(1, level.index);
+        assertEquals(0.25d, level.min, 0);
+        assertEquals(0.5d, level.max, 0);
+    }
+
+    @Test
+    public void testGetExpiredLevel()
+    {
+        Controller controller = Mockito.mock(Controller.class);
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
+
+        assertEquals(strategy.getLevel(-1, 0, 0), UnifiedCompactionStrategy.EXPIRED_TABLES_LEVEL);
+    }
 }


### PR DESCRIPTION
Avoids the following exception when getting level for expired tables.

```
ERROR [compaction-scheduler] 2023-06-06 10:06:30,585 CompactionTasksOrganizer.java:536 - Error whilst supplying compaction tasks for "35376531663064332d313431372d343166662d393565372d353563666135313964656664_data_endpoint_auth"."token":
java.lang.IllegalArgumentException: Index should be >= 0: -1
	at org.apache.cassandra.db.compaction.unified.StaticController.getScalingParameter(StaticController.java:134)
	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy$Level.<init>(UnifiedCompactionStrategy.java:1167)
	at org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.getLevel(UnifiedCompactionStrategy.java:820)
	at com.datastax.cndb.compactor.CompactionTasksOrganizer.createAggregate(CompactionTasksOrganizer.java:1028)
	at com.datastax.cndb.compactor.CompactionTasksOrganizer.lambda$selectStrategyTasks$16(CompactionTasksOrganizer.java:625)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
```