### PR TITLE
VECTOR-42: Check columns exist to avoid NPE during ANN expr binding

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Ordering.java
+++ b/src/java/org/apache/cassandra/cql3/Ordering.java
@@ -174,7 +174,7 @@ public class Ordering
             @Override
             public Ordering.Expression bind(TableMetadata table, VariableSpecifications boundNames)
             {
-                ColumnMetadata column = table.getColumn(columnId);
+                ColumnMetadata column = table.getExistingColumn(columnId);
                 Term value = vectorValue.prepare(table.keyspace, column);
                 value.collectMarkerSpecification(boundNames);
                 return new Ordering.Ann(column, value);

--- a/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.Slices;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.ClientState;
 
@@ -60,23 +59,5 @@ public class SelectStatementTest
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c > 10 AND c <= 10").makeSlices(QueryOptions.DEFAULT));
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c < 10 AND c >= 10").makeSlices(QueryOptions.DEFAULT));
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c < 10 AND c > 10").makeSlices(QueryOptions.DEFAULT));
-    }
-
-    @Test
-    public void testInvalidColumnNameWithAnn()
-    {
-        String tableName = "ks.tbl";
-        QueryProcessor.executeOnceInternal(String.format("CREATE TABLE %s (k int, c int, v int, primary key (k, c))", tableName));
-        try
-        {
-            QueryProcessor.executeOnceInternal(String.format("SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1", tableName));
-        }
-        catch (InvalidRequestException ex)
-        {
-            String expected = String.format("Undefined column name bad_col in table %s", tableName);
-            Assert.assertEquals(expected, ex.getMessage());
-            return;
-        }
-        Assert.assertFalse("Invalid SELECT should throw InvalidRequestException", true);
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/SelectStatementTest.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.ClientState;
 
@@ -59,5 +60,23 @@ public class SelectStatementTest
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c > 10 AND c <= 10").makeSlices(QueryOptions.DEFAULT));
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c < 10 AND c >= 10").makeSlices(QueryOptions.DEFAULT));
         Assert.assertEquals(Slices.NONE, parseSelect("SELECT * FROM ks.tbl WHERE k=100 AND c < 10 AND c > 10").makeSlices(QueryOptions.DEFAULT));
+    }
+
+    @Test
+    public void testInvalidColumnNameWithAnn()
+    {
+        String tableName = "ks.tbl";
+        QueryProcessor.executeOnceInternal(String.format("CREATE TABLE %s (k int, c int, v int, primary key (k, c))", tableName));
+        try
+        {
+            QueryProcessor.executeOnceInternal(String.format("SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1", tableName));
+        }
+        catch (InvalidRequestException ex)
+        {
+            String expected = String.format("Undefined column name bad_col in table %s", tableName);
+            Assert.assertEquals(expected, ex.getMessage());
+            return;
+        }
+        Assert.assertFalse("Invalid SELECT should throw InvalidRequestException", true);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.apache.cassandra.inject.Expression;
@@ -402,5 +405,14 @@ public class VectorTypeTest extends VectorTester
                              "SELECT similarity_cosine([1, 2, 3], value) FROM %s WHERE pk=0");
         assertInvalidMessage("Required 2 elements, but saw 3",
                              "SELECT similarity_cosine([1, 2], [3, 4, 5]) FROM %s WHERE pk=0");
+    }
+
+
+    @Test
+    public void testInvalidColumnNameWithAnn() throws Throwable
+    {
+        String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
+        assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + "." + table),
+                             "SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1");
     }
 }


### PR DESCRIPTION
Using an non-existent column with an ANN expression triggers an NPE like so,

  java.lang.NullPointerException: null
  	at org.apache.cassandra.cql3.ArrayLiteral.forReceiver(ArrayLiteral.java:43)
  	at org.apache.cassandra.cql3.ArrayLiteral.prepare(ArrayLiteral.java:54)
  	at org.apache.cassandra.cql3.Ordering$Raw$Ann.bind(Ordering.java:178)
  	at org.apache.cassandra.cql3.Ordering$Raw.bind(Ordering.java:139)

Use TM.getExistingColumn() which throws InvalidRequestException if the column is undefined.