### PR TITLE
- AdaptiveController no longer uses STARTING_SCALING_PARAMETER.

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -215,12 +215,19 @@ public class AdaptiveController extends Controller
                     else
                         scalingParameters[i] = scalingParameters[i-1];
                 }
+                logger.info("Option: '{}' used to initialize scaling parameters for Adaptive Controller", STATIC_SCALING_FACTORS_OPTION);
             }
             else
                 Arrays.fill(scalingParameters, DEFAULT_STARTING_SCALING_PARAMETER);
         }
         else
+        {
             logger.debug("Successfully read stored scaling parameters from disk.");
+            if (options.containsKey(SCALING_PARAMETERS_OPTION))
+                logger.warn("Option: '{}' is defined but not used.  Stored configuration was used instead", SCALING_PARAMETERS_OPTION);
+            if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
+                logger.warn("Option: '{}' is defined but not used.  Stored configuration was used instead", STATIC_SCALING_FACTORS_OPTION);
+        }
         int[] previousScalingParameters = scalingParameters.clone();
 
         int minScalingParameter = options.containsKey(MIN_SCALING_PARAMETER) ? Integer.parseInt(options.get(MIN_SCALING_PARAMETER)) : DEFAULT_MIN_SCALING_PARAMETER;

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -193,6 +193,13 @@ public abstract class Controller
         OverlapInclusionMethod.valueOf(System.getProperty(PREFIX + OVERLAP_INCLUSION_METHOD_OPTION,
                                                           OverlapInclusionMethod.TRANSITIVE.toString()).toUpperCase());
 
+    /**
+     * The scaling parameters W, one per bucket index and separated by a comma.
+     * Higher indexes will use the value of the last index with a W specified.
+     */
+    static final String SCALING_PARAMETERS_OPTION = "scaling_parameters";
+    static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
+
     protected final MonotonicClock clock;
     protected final Environment env;
     protected final double[] survivalFactors;

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -41,10 +41,7 @@ public class StaticController extends Controller
      * The scaling parameters W, one per bucket index and separated by a comma.
      * Higher indexes will use the value of the last index with a W specified.
      */
-    static final String STATIC_SCALING_PARAMETERS_OPTION = "scaling_parameters";
-    static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
-    private final static String DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + STATIC_SCALING_PARAMETERS_OPTION, "T4");
-
+    private final static String DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + SCALING_PARAMETERS_OPTION, "T4");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation
@@ -110,7 +107,7 @@ public class StaticController extends Controller
         if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
             scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
         else
-            scalingParameters = parseScalingParameters(options.getOrDefault(STATIC_SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
+            scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
         long currentFlushSize = flushSizeOverrideMB << 20;
 
         File f = getControllerConfigPath(keyspaceName, tableName);
@@ -150,14 +147,14 @@ public class StaticController extends Controller
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
     {
-        String parameters = options.remove(STATIC_SCALING_PARAMETERS_OPTION);
+        String parameters = options.remove(SCALING_PARAMETERS_OPTION);
         if (parameters != null)
             parseScalingParameters(parameters);
         String factors = options.remove(STATIC_SCALING_FACTORS_OPTION);
         if (factors != null)
             parseScalingParameters(factors);
         if (parameters != null && factors != null)
-            throw new ConfigurationException(String.format("Either '%s' or '%s' should be used, not both", STATIC_SCALING_PARAMETERS_OPTION, STATIC_SCALING_FACTORS_OPTION));
+            throw new ConfigurationException(String.format("Either '%s' or '%s' should be used, not both", SCALING_PARAMETERS_OPTION, STATIC_SCALING_FACTORS_OPTION));
         return options;
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -41,7 +41,7 @@ public class StaticController extends Controller
      * The scaling parameters W, one per bucket index and separated by a comma.
      * Higher indexes will use the value of the last index with a W specified.
      */
-    private final static String DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + SCALING_PARAMETERS_OPTION, "T4");
+    private static final String DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + SCALING_PARAMETERS_OPTION, "T4");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -46,12 +46,10 @@ public class CompactionControllerConfigTest extends TestBaseImpl
             cluster.schemaChange(withKeyspace("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};"));
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +
-                                              "'adaptive': 'true', " +
-                                              "'adaptive_starting_scaling_parameter': '0'};"));
+                                              "'adaptive': 'true'};"));
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl2 (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +
-                                              "'adaptive': 'true', " +
-                                              "'adaptive_starting_scaling_parameter': '0'};"));
+                                              "'adaptive': 'true'};"));
             cluster.get(1).runOnInstance(() ->
                                              {
                                                  ColumnFamilyStore cfs = Keyspace.open("ks").getColumnFamilyStore("tbl");

--- a/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
@@ -149,7 +149,7 @@ public class CQLUnifiedCompactionTest extends CQLTester
                     String.format("'dataset_size_in_gb' : '%d', ", dataSetSizeGB) +
                     String.format("'base_shard_count' : '%d', ", numShards) +
                     String.format("'min_sstable_size_in_mb' : '%d', ", sstableSizeMB) +
-                    String.format("'adaptive_starting_scaling_parameter' : '%s', ", w) +
+                    String.format("'scaling_parameters' : '%s', ", w) +
                     String.format("'adaptive_min_scaling_parameter' : '%s', ", -6) +
                     String.format("'adaptive_max_scaling_parameter' : '%s', ", 16) +
                     String.format("'adaptive_interval_sec': '%d', ", 300) +

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -97,13 +97,13 @@ public class AdaptiveControllerTest extends ControllerTest
     public void testFromOptions()
     {
         Map<String, String> options = new HashMap<>();
-        options.put(AdaptiveController.STARTING_SCALING_PARAMETER, "0");
         options.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
         options.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
         options.put(AdaptiveController.INTERVAL_SEC, "120");
         options.put(AdaptiveController.THRESHOLD, "0.15");
         options.put(AdaptiveController.MIN_COST, "5");
         options.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
+        options.put(Controller.SCALING_PARAMETERS_OPTION, "T5");
 
         int[] scalingParameters = new int[30];
         Arrays.fill(scalingParameters, 1);
@@ -125,18 +125,43 @@ public class AdaptiveControllerTest extends ControllerTest
 
         for (int i = 0; i < 10; i++)
         {
-            assertEquals(0, controller2.getScalingParameter(i));
-            assertEquals(0, controller2.getPreviousScalingParameter(i));
+            assertEquals(3, controller2.getScalingParameter(i));
+            assertEquals(3, controller2.getPreviousScalingParameter(i));
         }
         AdaptiveController.getControllerConfigPath(keyspaceName, tableName).delete();
 
-        Controller controller3 = testFromOptions(true, options);
+        Map<String, String> options2 = new HashMap<>();
+        options2.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
+        options2.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
+        options2.put(AdaptiveController.INTERVAL_SEC, "120");
+        options2.put(AdaptiveController.THRESHOLD, "0.15");
+        options2.put(AdaptiveController.MIN_COST, "5");
+        options2.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
+        options2.put(Controller.SCALING_PARAMETERS_OPTION, "L5");
+        Controller controller3 = testFromOptions(true, options2);
         assertTrue(controller3 instanceof AdaptiveController);
 
         for (int i = 0; i < 10; i++)
         {
-            assertEquals(0, controller3.getScalingParameter(i));
-            assertEquals(0, controller3.getPreviousScalingParameter(i));
+            assertEquals(-3, controller3.getScalingParameter(i));
+            assertEquals(-3, controller3.getPreviousScalingParameter(i));
+        }
+
+        Map<String, String> options3 = new HashMap<>();
+        options3.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
+        options3.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
+        options3.put(AdaptiveController.INTERVAL_SEC, "120");
+        options3.put(AdaptiveController.THRESHOLD, "0.15");
+        options3.put(AdaptiveController.MIN_COST, "5");
+        options3.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
+        options3.put(Controller.STATIC_SCALING_FACTORS_OPTION, "4");
+        Controller controller4 = testFromOptions(true, options3);
+        assertTrue(controller4 instanceof AdaptiveController);
+
+        for (int i = 0; i < 10; i++)
+        {
+            assertEquals(4, controller4.getScalingParameter(i));
+            assertEquals(4, controller4.getPreviousScalingParameter(i));
         }
     }
 
@@ -144,7 +169,6 @@ public class AdaptiveControllerTest extends ControllerTest
     public void testValidateOptions()
     {
         Map<String, String> options = new HashMap<>();
-        options.put(AdaptiveController.STARTING_SCALING_PARAMETER, "0");
         options.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
         options.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
         options.put(AdaptiveController.INTERVAL_SEC, "120");
@@ -153,6 +177,28 @@ public class AdaptiveControllerTest extends ControllerTest
         options.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
 
         super.testValidateOptions(options, true);
+
+        Map<String, String> options2 = new HashMap<>();
+        options2.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
+        options2.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
+        options2.put(AdaptiveController.INTERVAL_SEC, "120");
+        options2.put(AdaptiveController.THRESHOLD, "0.15");
+        options2.put(AdaptiveController.MIN_COST, "5");
+        options2.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
+        options2.put(Controller.STATIC_SCALING_FACTORS_OPTION, "1,2,3");
+
+        super.testValidateOptions(options2, true);
+
+        Map<String, String> options3 = new HashMap<>();
+        options3.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");
+        options3.put(AdaptiveController.MAX_SCALING_PARAMETER, "32");
+        options3.put(AdaptiveController.INTERVAL_SEC, "120");
+        options3.put(AdaptiveController.THRESHOLD, "0.15");
+        options3.put(AdaptiveController.MIN_COST, "5");
+        options3.put(AdaptiveController.MAX_ADAPTIVE_COMPACTIONS, "-1");
+        options3.put(Controller.SCALING_PARAMETERS_OPTION, "1,2,3");
+
+        super.testValidateOptions(options3, true);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -61,7 +61,7 @@ public class StaticControllerTest extends ControllerTest
         String wStr = Arrays.stream(Ws)
                             .mapToObj(useIntegers ? Integer::toString : UnifiedCompactionStrategy::printScalingParameter)
                             .collect(Collectors.joining(","));
-        options.put(StaticController.STATIC_SCALING_PARAMETERS_OPTION, wStr);
+        options.put(StaticController.SCALING_PARAMETERS_OPTION, wStr);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class StaticControllerTest extends ControllerTest
         Map<String, String> options = new HashMap<>();
         addOptions(true, options);
         options.put(StaticController.STATIC_SCALING_FACTORS_OPTION,
-                    options.remove(StaticController.STATIC_SCALING_PARAMETERS_OPTION));
+                    options.remove(StaticController.SCALING_PARAMETERS_OPTION));
 
         Controller controller = testFromOptions(false, options);
         assertTrue(controller instanceof StaticController);
@@ -122,7 +122,7 @@ public class StaticControllerTest extends ControllerTest
         Map<String, String> options = new HashMap<>();
         addOptions(true, options);
         options.put(StaticController.STATIC_SCALING_FACTORS_OPTION,
-                    options.remove(StaticController.STATIC_SCALING_PARAMETERS_OPTION));
+                    options.remove(StaticController.SCALING_PARAMETERS_OPTION));
 
         super.testValidateOptions(options, false);
     }


### PR DESCRIPTION
- AdaptiveController now recognizes and uses SCALING_PARAMETER_OPTION or STATIC_SCALING_FACTOR_OPTION (deprecated) allowing initial scaling parameters to be set for each level instead of one scaling parameter applied to every level.  This also fixes potential schema inconsistencies when switching from static to adaptive.
- moved SCALING_PARAMETERS_OPTION and STATIC_SCALING_FACTORS_OPTION from StaticController to Controller since they are now used by both StaticController and AdaptiveController.