### PR TITLE
STAR-550 Handle SAI AbortedOperationException

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -95,6 +96,9 @@ public enum RequestFailureReason
 
         if (t instanceof IncompatibleSchemaException)
             return INCOMPATIBLE_SCHEMA;
+
+        if (t instanceof AbortedOperationException)
+            return TIMEOUT;
 
         return UNKNOWN;
     }

--- a/src/java/org/apache/cassandra/net/InboundSink.java
+++ b/src/java/org/apache/cassandra/net/InboundSink.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 
+import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.slf4j.LoggerFactory;
 
 import net.openhft.chronicle.core.util.ThrowingConsumer;
@@ -99,6 +100,10 @@ public class InboundSink implements InboundMessageHandlers.MessageConsumer
         catch (Throwable t)
         {
             fail(message.header, t);
+
+            // The site throwing AbortedOperationException is responsible for logging it.
+            if (t instanceof AbortedOperationException)
+                return;
 
             if (t instanceof TombstoneOverwhelmingException || t instanceof IndexNotAvailableException)
                 noSpamLogger.error(t.getMessage());


### PR DESCRIPTION
AbortedOperationException is thrown by SAI when index search hits a timeout. Now instead of allowing this exception to bubble up to the top and be eventually logged as error, we catch and swallow it in the InboundSink after creating the query response. Additionally now we also we set a proper error code (TIMEOUT) in the response, so the client has a hint on what happened.