### PR TITLE
Vector 53: fix data visibility issue during flush and optimize partition restricted on-disk searcher

### DIFF
--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -469,10 +469,11 @@ public class Tracker
         Throwable fail;
         fail = updateSizeTracking(emptySet(), sstables, null);
 
-        notifyDiscarded(memtable);
-
         // TODO: if we're invalidated, should we notifyadded AND removed, or just skip both?
         fail = notifyAdded(sstables, OperationType.FLUSH, operationId, false, memtable, fail);
+
+        // make sure SAI sees newly flushed index files before discarding memtable index
+        notifyDiscarded(memtable);
 
         fail = dropOrUnloadSSTablesIfInvalid("during flush", fail);
 

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -94,7 +94,7 @@ public class IndexContext
     private final String keyspace;
     private final String table;
     private final ColumnMetadata column;
-    private final IndexTarget.Type indexType;;
+    private final IndexTarget.Type indexType;
     private final AbstractType<?> validator;
     private final Memtable.Owner owner;
 

--- a/src/java/org/apache/cassandra/index/sai/SSTableQueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableQueryContext.java
@@ -62,7 +62,7 @@ public class SSTableQueryContext
     /**
      * Create a bitset to ignore ordinals corresponding to shadowed primary keys
      */
-    public Bits bitsetForShadowedPrimaryKeys(SegmentMetadata metadata, PrimaryKeyMap primaryKeyMap, CassandraOnDiskHnsw graph) throws IOException
+    public Bits bitsForShadowedPrimaryKeys(SegmentMetadata metadata, PrimaryKeyMap primaryKeyMap, CassandraOnDiskHnsw graph) throws IOException
     {
         Set<Integer> ignoredOrdinals = null;
         try (var ordinalsView = graph.getOrdinalsView())

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
@@ -31,6 +31,8 @@ import org.apache.cassandra.utils.Throwables;
 @NotThreadSafe
 public interface PostingList extends Closeable
 {
+    PostingList EMPTY = new EmptyPostingList();
+
     long OFFSET_NOT_FOUND = -1;
     long END_OF_STREAM = Long.MAX_VALUE;
 
@@ -192,6 +194,27 @@ public interface PostingList extends Closeable
         public void close() throws IOException
         {
             wrapped.close();
+        }
+    }
+
+    class EmptyPostingList implements PostingList
+    {
+        @Override
+        public long nextPosting() throws IOException
+        {
+            return END_OF_STREAM;
+        }
+
+        @Override
+        public long size()
+        {
+            return 0;
+        }
+
+        @Override
+        public long advance(long targetRowID) throws IOException
+        {
+            return END_OF_STREAM;
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.hnsw.CassandraOnDiskHnsw;
 import org.apache.cassandra.index.sai.disk.v1.postings.ReorderingPostingList;
 import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.ArrayPostingList;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
@@ -255,37 +256,34 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
         private final Bits bits;
         private final PostingList postingList;
 
-        private final boolean skipANN;
         public BitSetOrPostingList(@Nullable Bits bits)
         {
             this.bits = bits;
             this.postingList = null;
-            this.skipANN = false;
         }
 
         public BitSetOrPostingList(PostingList postingList)
         {
             this.bits = null;
             this.postingList = Preconditions.checkNotNull(postingList);
-            this.skipANN = true;
         }
 
         @Nullable
         public Bits getBits()
         {
-            Preconditions.checkState(!skipANN);
+            Preconditions.checkState(!skipANN());
             return bits;
         }
 
         public PostingList postingList()
         {
-            Preconditions.checkState(skipANN);
+            Preconditions.checkState(skipANN());
             return postingList;
         }
 
         public boolean skipANN()
         {
-            return skipANN;
+            return postingList != null;
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -146,7 +146,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
 
         // if num of matches are not bigger than limit, skip ANN
         var nRows = maxSSTableRowId - minSSTableRowId + 1;
-        if (nRows <= maxBruteForceRows)
+        if (nRows <= Math.max(maxBruteForceRows, limit))
         {
             IntArrayList postings = new IntArrayList(Math.toIntExact(nRows), -1);
             for (long sstableRowId = minSSTableRowId; sstableRowId <= maxSSTableRowId; sstableRowId++)
@@ -194,7 +194,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
         // are from our own token range so we can use row ids to order the results by vector similarity.
         var maxSegmentRowId = metadata.segmentedRowId(metadata.maxSSTableRowId);
         SparseFixedBitSet bits = new SparseFixedBitSet(graph.size());
-        int[] bruteForceRows = new int[Math.min(limit, maxBruteForceRows)];
+        int[] bruteForceRows = new int[Math.max(limit, this.maxBruteForceRows)];
         int n = 0;
         try (var ordinalsView = graph.getOrdinalsView())
         {

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -219,16 +219,18 @@ public class QueryController
         if (isAnnHybridSearch)
             expressions = expressions.stream().filter(e -> e != annExpressionInHybridSearch).collect(Collectors.toList());
 
-        var queryView = new QueryViewBuilder(expressions, mergeRange).build();
-        // in case of ANN query in hybrid search, we have to reference ANN sstable indexes separately because queryView doesn't include ANN sstable indexes
-        var annQueryViewInHybridSearch = isAnnHybridSearch ? new QueryViewBuilder(Collections.singleton(annExpressionInHybridSearch), mergeRange).build() : null;
-
+        // search memtable before referencing sstable indexes; otherwise we may miss newly flushed memtable index
         Map<Memtable, List<RangeIterator<PrimaryKey>>> iteratorsByMemtable = expressions
                                                                     .stream()
                                                                     .flatMap(expr -> {
                                                                         return expr.context.iteratorsForSearch(expr, mergeRange, getLimit()).stream();
                                                                     }).collect(Collectors.groupingBy(pair -> pair.left,
                                                                                                      Collectors.mapping(pair -> pair.right, Collectors.toList())));
+
+        var queryView = new QueryViewBuilder(expressions, mergeRange).build();
+        // in case of ANN query in hybrid search, we have to reference ANN sstable indexes separately because queryView doesn't include ANN sstable indexes
+        var annQueryViewInHybridSearch = isAnnHybridSearch ? new QueryViewBuilder(Collections.singleton(annExpressionInHybridSearch), mergeRange).build() : null;
+
         try
         {
             List<RangeIterator<PrimaryKey>> sstableIntersections = queryView.view.entrySet()
@@ -246,7 +248,7 @@ public class QueryController
                                                                                        .stream()
                                                                                        .map(e -> {
                                                                                            // we need to do all the intersections at the index level, or ordering won't work
-                                                                                           RangeIterator<PrimaryKey> it = buildIterator(op, e.getValue(), annExpressionInHybridSearch != null);
+                                                                                           RangeIterator<PrimaryKey> it = buildIterator(op, e.getValue(), isAnnHybridSearch);
                                                                                            if (isAnnHybridSearch)
                                                                                                it = reorderAndLimitBy(it, e.getKey(), annExpressionInHybridSearch);
                                                                                            return it;
@@ -329,6 +331,9 @@ public class QueryController
         return expressions.stream().filter(e -> e.operation == Expression.Op.ANN).findFirst().orElse(null);
     }
 
+    /**
+     * Create row id iterator from different indexes' on-disk searcher of the same sstable
+     */
     private RangeIterator<Long> createRowIdIterator(Operation.OperationType op, List<QueryViewBuilder.IndexExpression> indexExpressions, boolean defer, boolean hasAnn)
     {
         var subIterators = indexExpressions
@@ -339,7 +344,7 @@ public class QueryController
                                         {
                                             var sstContext = queryContext.getSSTableQueryContext(ie.index.getSSTable());
                                             List<RangeIterator<Long>> iterators = ie.index.searchSSTableRowIds(ie.expression, mergeRange, sstContext, defer, getLimit());
-                                            // union the result from multiple segments for the same index
+                                            // concate the result from multiple segments for the same index
                                             return RangeConcatIterator.build(iterators);
                                         }
                                         catch (Throwable ex)
@@ -354,13 +359,13 @@ public class QueryController
         return buildIterator(op, subIterators, hasAnn);
     }
 
-    private static <T extends Comparable<T>> RangeIterator<T> buildIterator(Operation.OperationType op, List<RangeIterator<T>> subIterators, boolean hasAnn)
+    private static <T extends Comparable<T>> RangeIterator<T> buildIterator(Operation.OperationType op, List<RangeIterator<T>> subIterators, boolean isAnnHybridSearch)
     {
         RangeIterator.Builder<T> builder = null;
         if (op == Operation.OperationType.OR)
             builder = RangeUnionIterator.<T>builder(subIterators.size());
-        else if (hasAnn)
-            // if there is ANN, intersect all available indexes so result will be correct top-k
+        else if (isAnnHybridSearch)
+            // if it's ANN with other indexes, intersect all available indexes so result will be correct top-k
             builder = RangeIntersectionIterator.<T>builder(subIterators.size(), subIterators.size());
         else
             // Otherwise, pick 2 most selective indexes for better performance

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -344,7 +344,7 @@ public class QueryController
                                         {
                                             var sstContext = queryContext.getSSTableQueryContext(ie.index.getSSTable());
                                             List<RangeIterator<Long>> iterators = ie.index.searchSSTableRowIds(ie.expression, mergeRange, sstContext, defer, getLimit());
-                                            // concate the result from multiple segments for the same index
+                                            // concat the result from multiple segments for the same index
                                             return RangeConcatIterator.build(iterators);
                                         }
                                         catch (Throwable ex)

--- a/src/java/org/apache/cassandra/index/sai/utils/ArrayPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/ArrayPostingList.java
@@ -17,12 +17,12 @@
  */
 package org.apache.cassandra.index.sai.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.v1.postings.OrdinalPostingList;
 
-//TODO Change this whole lot to use longs
 public class ArrayPostingList implements OrdinalPostingList
 {
     private final int[] postings;
@@ -81,6 +81,7 @@ public class ArrayPostingList implements OrdinalPostingList
                           .toString();
     }
 
+    @VisibleForTesting
     public void reset()
     {
         idx = 0;
@@ -89,13 +90,5 @@ public class ArrayPostingList implements OrdinalPostingList
     public int getPostingAt(int i)
     {
         return postings[i];
-    }
-
-    public static class LookupException extends RuntimeException
-    {
-        public LookupException(long idx)
-        {
-            super("Failed on lookup at index " + idx + "!");
-        }
     }
 }

--- a/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
+++ b/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
@@ -183,7 +183,8 @@ public class LongVectorTest extends SAITester
             if (isEmpty())
                 throw new IllegalStateException();
             var i = ThreadLocalRandom.current().nextInt(ordinal.get());
-            return keys.get(i);
+            // in case there is race with add(key), retry another random
+            return keys.containsKey(i) ? keys.get(i) : getRandom();
         }
 
         public boolean isEmpty()

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -218,7 +218,7 @@ public class VectorDistributedTest extends TestBaseImpl
         // query memtable index
         for (int executionCount = 0; executionCount < 50; executionCount++)
         {
-            int key = getRandom().nextIntBetween(1, vectorCount);
+            int key = getRandom().nextIntBetween(0, vectorCount - 1);
             float[] queryVector = randomVector();
             searchByKeyWithLimit(key, queryVector, 1, vectors);
         }
@@ -228,7 +228,7 @@ public class VectorDistributedTest extends TestBaseImpl
         // query on-disk index
         for (int executionCount = 0; executionCount < 50; executionCount++)
         {
-            int key = getRandom().nextIntBetween(1, vectorCount);
+            int key = getRandom().nextIntBetween(0, vectorCount - 1);
             float[] queryVector = randomVector();
             searchByKeyWithLimit(key, queryVector, 1, vectors);
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingListTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingListTest.java
@@ -262,10 +262,6 @@ public class MergePostingListTest extends SaiRandomizedTest
                         {
                             return postingList.advance(rowID);
                         }
-                        catch (ArrayPostingList.LookupException ignore)
-                        {
-                            // continue
-                        }
                         catch (Exception e)
                         {
                             fail();
@@ -308,10 +304,6 @@ public class MergePostingListTest extends SaiRandomizedTest
                 {
                     rowID = merged.advance(targetRowID);
                     break;
-                }
-                catch (ArrayPostingList.LookupException ignore)
-                {
-                    // continue
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
- fix `primaryKeySearchTest` and `partitionKeySearchTest` to use correct selector and similarity function
- fix data visibility issue during flush: make sure `SSTableAddedNotification` is sent before `MemtableDiscardedNotification` and search memtable indexes before referencing sstable indexes
- optimize VectorIndexSearcher#searchPosting for partition/range restricted query
  - return empty posting if key range is not found in current sstable
  - return empty posting if all row ids are shadowed
  - skip ANN if matching row ids are less than max of limit and brute-force-rows