### PR TITLE
STAR-1878: Add additional configuration parameters and tests for UCS density

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionPick.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionPick.java
@@ -305,19 +305,6 @@ public class CompactionPick
         return Objects.hash(id, parent, sstables, expired);
     }
 
-    /**
-     * Checks to see if the chosen compaction is Adaptive or not.
-     * An adaptive compaction is a compaction triggered by changing the scaling parameter W
-     * @param currentThreshold is the threshold for the chosen level
-     * @param previousThreshold is the previous threshold before changing the scaling paremeter
-     * @return true if it is Adaptive and false otherwise
-     */
-    public boolean isAdaptive(int currentThreshold, int previousThreshold)
-    {
-        int numTables = sstables.size();
-        return (numTables >= currentThreshold && numTables < previousThreshold);
-    }
-
     @Override
     public boolean equals(Object obj)
     {

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -72,9 +72,16 @@ public interface ShardManager
     double rangeSpanned(Range<Token> tableRange);
 
     /**
-     * The total fraction of the local space covered by the local ranges.
+     * The total fraction of the token space covered by the local ranges.
      */
     double localSpaceCoverage();
+
+    /**
+     * The fraction of the token space covered by a shard set, i.e. the space that is split in the requested number of
+     * shards.
+     * If no disks are defined, this is the same as localSpaceCoverage(). Otherwise, it is the token coverage of a disk.
+     */
+    double shardSetCoverage();
 
     /**
      * Construct a boundary/shard iterator for the given number of shards.

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerDiskAware.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerDiskAware.java
@@ -76,6 +76,17 @@ public class ShardManagerDiskAware extends ShardManagerNoDisks
         assert diskIndex + 1 == diskBoundaryPositions.length : "Disk boundaries are not within local ranges";
     }
 
+    @Override
+    public double shardSetCoverage()
+    {
+        return localSpaceCoverage() / diskBoundaryPositions.length;
+        // The above is an approximation that works correctly for the normal allocation of disks.
+        // This can be properly calculated if a contained token is supplied as argument and the diskBoundaryPosition
+        // difference is retrieved for the disk containing that token.
+        // Unfortunately we don't currently have a way to get a representative position when an sstable writer is
+        // constructed for flushing.
+    }
+
     /**
      * Construct a boundary/shard iterator for the given number of shards.
      */

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
@@ -80,6 +80,12 @@ public class ShardManagerNoDisks implements ShardManager
     }
 
     @Override
+    public double shardSetCoverage()
+    {
+        return localSpaceCoverage();
+    }
+
+    @Override
     public ShardTracker boundaries(int shardCount)
     {
         return new BoundaryTracker(shardCount);

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
@@ -62,6 +62,12 @@ public class ShardManagerTrivial implements ShardManager
         return 1;
     }
 
+    @Override
+    public double shardSetCoverage()
+    {
+        return 1;
+    }
+
     ShardTracker iterator = new ShardTracker()
     {
         @Override

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -20,18 +20,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,6 +54,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTableMultiWriter;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Overlaps;
 
 import static org.apache.cassandra.utils.Throwables.perform;
 
@@ -219,10 +216,10 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
     private static List<Set<CompactionSSTable>> splitInNonOverlappingSets(List<CompactionSSTable> sstables)
     {
-        List<Set<CompactionSSTable>> overlapSets = constructOverlapSets(sstables,
-                                                                        UnifiedCompactionStrategy::startsAfter,
-                                                                        CompactionSSTable.firstKeyComparator,
-                                                                        CompactionSSTable.lastKeyComparator);
+        List<Set<CompactionSSTable>> overlapSets = Overlaps.constructOverlapSets(sstables,
+                                                                                 UnifiedCompactionStrategy::startsAfter,
+                                                                                 CompactionSSTable.firstKeyComparator,
+                                                                                 CompactionSSTable.lastKeyComparator);
         Set<CompactionSSTable> group = overlapSets.get(0);
         List<Set<CompactionSSTable>> groups = new ArrayList<>();
         for (int i = 1; i < overlapSets.size(); ++i)
@@ -330,7 +327,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                        LifecycleNewTracker lifecycleNewTracker)
     {
         ShardManager currentShardManager = getShardManager();
-        double flushDensity = realm.metrics().flushSizeOnDisk().get() / currentShardManager.localSpaceCoverage();
+        double flushDensity = realm.metrics().flushSizeOnDisk().get() * shardManager.shardSetCoverage() / currentShardManager.localSpaceCoverage();
         ShardTracker boundaries = currentShardManager.boundaries(controller.getNumShards(flushDensity));
         return new ShardedMultiWriter(realm,
                                       descriptor,
@@ -450,8 +447,9 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         int levelCount = 1; // Start at 1 to avoid division by zero if the aggregates list is empty.
         int runningCompactions = 0;
         long spaceAvailable = spaceOverheadLimit;
-        int runningAdaptiveCompactions = 0;
-        int maxAdaptiveCompactions = controller.getMaxAdaptiveCompactions(); //limit for number of compactions triggered by new W value
+        int remainingAdaptiveCompactions = controller.getMaxRecentAdaptiveCompactions(); //limit for number of compactions triggered by new W value
+        if (remainingAdaptiveCompactions == -1)
+            remainingAdaptiveCompactions = Integer.MAX_VALUE;
         for (CompactionPick compaction : backgroundCompactions.getCompactionsInProgress())
         {
             final int level = levelOf(compaction);
@@ -461,19 +459,18 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             ++runningCompactions;
             levelCount = Math.max(levelCount, level + 1);
             spaceAvailable -= controller.getOverheadSizeInBytes(compaction);
-            if (compaction.isAdaptive(controller.getThreshold(level), controller.getPreviousThreshold(level)))
-                runningAdaptiveCompactions++;
+            if (controller.isRecentAdaptive(compaction))
+                --remainingAdaptiveCompactions;
         }
 
-        CompactionLimits limits = new CompactionLimits(runningCompactions, 
+        CompactionLimits limits = new CompactionLimits(runningCompactions,
                                                        maxCompactions,
                                                        maxConcurrentCompactions,
                                                        perLevel,
                                                        levelCount,
                                                        spaceAvailable,
                                                        rateLimitLog,
-                                                       runningAdaptiveCompactions,
-                                                       maxAdaptiveCompactions);
+                                                       remainingAdaptiveCompactions);
         logger.debug("Selecting up to {} new compactions of up to {}, concurrency limit {}{}",
                      Math.max(0, limits.maxCompactions - limits.runningCompactions),
                      FBUtilities.prettyPrintMemory(limits.spaceAvailable),
@@ -496,19 +493,18 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         }
 
         final List<CompactionAggregate> selection = getSelection(pending,
+                                                                 controller,
                                                                  limits.maxCompactions,
                                                                  limits.levelCount,
                                                                  limits.perLevel,
                                                                  limits.spaceAvailable,
-                                                                 limits.runningAdaptiveCompactions,
-                                                                 limits.maxAdaptiveCompactions);
-        logger.debug("Starting {} compactions (out of {})", selection.size(), pending.stream().filter(agg -> !agg.getSelected().isEmpty()).count());
+                                                                 limits.remainingAdaptiveCompactions);
         return selection;
     }
 
     /**
      * Selects compactions to run next.
-     * 
+     *
      * @param gcBefore
      * @return a subset of compaction aggregates to run next
      */
@@ -534,7 +530,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
         return updateLevelCountWithParentAndGetSelection(limits, pending);
     }
-    
+
     /**
      * Selects compactions to run next from the passed aggregates.
      *
@@ -545,7 +541,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      * @param maxConcurrentCompactions the maximum number of concurrent compactions
      * @return a subset of compaction aggregates to run next
      */
-    public Collection<CompactionAggregate> getNextCompactionAggregates(Collection<CompactionAggregate.UnifiedAggregate> aggregates, 
+    public Collection<CompactionAggregate> getNextCompactionAggregates(Collection<CompactionAggregate.UnifiedAggregate> aggregates,
                                                                        int maxConcurrentCompactions)
     {
         final CompactionLimits limits = getCurrentLimits(maxConcurrentCompactions);
@@ -571,7 +567,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      * that the compaction statistics will be accurate.
      * <p/>
      * This is called by {@link UnifiedCompactionStrategy#getNextCompactionAggregates(int)}
-     * and externally after calling {@link UnifiedCompactionStrategy#getPendingCompactionAggregates(int)} 
+     * and externally after calling {@link UnifiedCompactionStrategy#getPendingCompactionAggregates(int)}
      * or before submitting tasks.
      *
      * Also, note that skipping the call to {@link BackgroundCompactions#setPending(CompactionStrategy, Collection)}
@@ -665,18 +661,30 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      * @param levelCount number of levels in use
      * @param perLevel int array with the number of in-progress compactions per level
      * @param spaceAvailable amount of space in bytes available for the new compactions
+     * @param remainingAdaptiveCompactions number of adaptive compactions (i.e. ones triggered by scaling parameter
+     *                                     change by the adaptive controller) that can still be scheduled
+     *
      */
-    List<CompactionAggregate> getSelection(List<CompactionAggregate.UnifiedAggregate> pending,
-                                           int totalCount,
-                                           int levelCount,
-                                           int[] perLevel,
-                                           long spaceAvailable,
-                                           int runningAdaptiveCompactions,
-                                           int maxAdaptiveCompactions)
+    static List<CompactionAggregate> getSelection(List<CompactionAggregate.UnifiedAggregate> pending,
+                                                  Controller controller,
+                                                  int totalCount,
+                                                  int levelCount,
+                                                  int[] perLevel,
+                                                  long spaceAvailable,
+                                                  int remainingAdaptiveCompactions)
     {
         // Prepare parameters for the selection.
-        int perLevelCount = totalCount / levelCount;   // each level has this number of tasks reserved for it
-        int remainder = totalCount % levelCount;       // and the remainder is distributed randomly, up to 1 per level
+        int reservedThreadsTarget = controller.getReservedThreadsPerLevel();
+        // Each level has this number of tasks reserved for it.
+        int perLevelCount = Math.min(totalCount / levelCount, reservedThreadsTarget);
+        // The remainder is distributed according to the prioritization.
+        int remainder = totalCount - perLevelCount * levelCount;
+        // If the user requested more than we can give, do not allow more than one extra per level.
+        boolean oneRemainderPerLevel = perLevelCount < reservedThreadsTarget;
+        // If the inclusion method is not transitive, we may have multiple buckets/selections for the same sstable.
+        boolean shouldCheckSSTableSelected = controller.overlapInclusionMethod() != Overlaps.InclusionMethod.TRANSITIVE;
+        // If so, make sure we only select one such compaction.
+        Set<CompactionSSTable> selectedSSTables = shouldCheckSSTableSelected ? new HashSet<>() : null;
 
         // Calculate how many new ones we can add in each level, and how many we can assign randomly.
         int remaining = totalCount;
@@ -689,11 +697,9 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         // Note: if we are in the middle of changes in the parameters or level count, remainder might become negative.
         // This is okay, some buckets will temporarily not get their rightful share until these tasks complete.
 
-        if (maxAdaptiveCompactions == -1)
-            maxAdaptiveCompactions = Integer.MAX_VALUE;
-
         // Let the controller prioritize the compactions.
         pending = controller.prioritize(pending);
+        int proposed = 0;
 
         // Select the first ones, permitting only the specified number per level.
         List<CompactionAggregate> selected = new ArrayList<>(pending.size());
@@ -707,35 +713,46 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 selected.add(aggregate);    // always add expired-only compactions, they are not subject to any limits
                 continue;
             }
-            if (controller.getOverheadSizeInBytes(pick) > spaceAvailable)
+            ++proposed;
+            long overheadSizeInBytes = controller.getOverheadSizeInBytes(pick);
+            if (overheadSizeInBytes > spaceAvailable)
                 continue; // compaction is too large for current cycle
 
             int currentLevel = levelOf(pick);
             assert currentLevel >= 0 : "Invalid level in " + pick + ": level -1 is only allowed for expired-only compactions";
-            if (perLevel[currentLevel] > perLevelCount)
-                continue;  // this level is already using up all its share + one, we can ignore candidate altogether
-            else if (perLevel[currentLevel] == perLevelCount)
+
+            boolean isAdaptive = controller.isRecentAdaptive(pick);
+            if (isAdaptive && remainingAdaptiveCompactions <= 0)
+                continue; // do not allow more than remainingAdaptiveCompactions to limit latency spikes upon changing W
+
+            if (shouldCheckSSTableSelected && !Collections.disjoint(selectedSSTables, pick.sstables()))
+                continue; // do not allow multiple selections on the same sstable
+
+            if (perLevel[currentLevel] >= perLevelCount)
             {
                 if (remainder <= 0)
-                    continue;   // share used up, no remainder to distribute
+                    continue;  // share used up and no remainder to distribute
+                if (oneRemainderPerLevel && perLevel[currentLevel] > perLevelCount)
+                    continue;  // this level is already using up all its share + one, we can ignore candidate altogether
                 --remainder;
             }
+            // Note: if any additional checks are added, make sure remainder is not decreased if they fail.
 
-            if (pick.isAdaptive(controller.getThreshold(currentLevel), controller.getPreviousThreshold(currentLevel)))
-            {
-                if (runningAdaptiveCompactions >= maxAdaptiveCompactions)
-                    continue; // do not allow more than maxAdaptiveCompactions to limit latency spikes upon changing W
-                runningAdaptiveCompactions++;
-            }
-
+            if (isAdaptive)
+                remainingAdaptiveCompactions--;
             --remaining;
             ++perLevel[currentLevel];
-            spaceAvailable -= controller.getOverheadSizeInBytes(aggregate.selected);
+            spaceAvailable -= overheadSizeInBytes;
             selected.add(aggregate);
+            if (shouldCheckSSTableSelected)
+                selectedSSTables.addAll(pick.sstables());
 
             if (remaining == 0)
                 break;
         }
+
+        logger.debug("Selected {} compactions (out of {} pending). Compactions per level {} (reservations {}{}) remaining reserved {} non-reserved {}.",
+                     selected.size(), proposed, perLevel, perLevelCount, oneRemainderPerLevel ? "+1" : "", remaining - remainder, remainder);
 
         return selected;
     }
@@ -923,154 +940,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     }
 
     /**
-     * Construct a minimal list of overlap sets, i.e. the sections of the range span when we have overlapping items,
-     * where we ensure:
-     * - non-overlapping items are never put in the same set
-     * - no item is present in non-consecutive sets
-     * - for any point where items overlap, the result includes a set listing all overlapping items
-     *
-     * For example, for inputs A[0, 4), B[2, 8), C[6, 10), D[1, 9) the result would be the sets ABD and BCD. We are not
-     * interested in the spans where A, B, or C are present on their own or in combination with D, only that there
-     * exists a set in the list that is a superset of any such combination, and that the non-overlapping A and C are
-     * never together in a set.
-     *
-     * Note that the full list of overlap sets A, AD, ABD, BD, BCD, CD, C is also an answer that satisfies the three
-     * conditions above, but it contains redundant sets (e.g. AD is already contained in ABD).
-     *
-     * @param items A list of items to distribute in overlap sets. This is assumed to be a transient list and the method
-     *              may modify or consume it. It is assumed that the start and end positions of an item are ordered,
-     *              and the items are non-empty.
-     * @param startsAfter Predicate determining if its left argument's start if fully after the right argument's end.
-     *                    This will only be used with arguments where left's start is known to be after right's start.
-     *                    It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
-     *                    and non-strict (>=) for end-exclusive.
-     * @param startsComparator Comparator of items' starting positions.
-     * @param endsComparator Comparator of items' ending positions.
-     * @return List of overlap sets.
-     */
-    @VisibleForTesting
-    static <E> List<Set<E>> constructOverlapSets(List<E> items,
-                                                 BiPredicate<E, E> startsAfter,
-                                                 Comparator<E> startsComparator,
-                                                 Comparator<E> endsComparator)
-    {
-        List<Set<E>> overlaps = new ArrayList<>();
-        if (items.isEmpty())
-            return overlaps;
-
-        PriorityQueue<E> active = new PriorityQueue<>(endsComparator);
-        items.sort(startsComparator);
-        for (E item : items)
-        {
-            if (!active.isEmpty() && startsAfter.test(item, active.peek()))
-            {
-                // New item starts after some active ends. It does not overlap with it, so:
-                // -- output the previous active set
-                overlaps.add(new HashSet<>(active));
-                // -- remove all items that also end before the current start
-                do
-                {
-                    active.poll();
-                }
-                while (!active.isEmpty() && startsAfter.test(item, active.peek()));
-            }
-
-            // Add the new item to the active state. We don't care if it starts later than others in the active set,
-            // the important point is that it overlaps with all of them.
-            active.add(item);
-        }
-
-        assert !active.isEmpty();
-        overlaps.add(new HashSet<>(active));
-
-        return overlaps;
-    }
-
-    interface BucketMaker<E, B>
-    {
-        B makeBucket(List<Set<E>> sets, int startIndexInclusive, int endIndexExclusive);
-    }
-
-    /**
-     * Assign overlap sections into buckets. Identify sections that have at least threshold-many overlapping
-     * items and apply the overlap inclusion method to combine with any neighbouring sections that contain
-     * selected sstables to make sure we make full use of any sstables selected for compaction (i.e. avoid
-     * recompacting, see {@link Controller#overlapInclusionMethod()}).
-     *
-     * @param threshold Threshold for selecting a bucket. Sets below this size will be ignored, unless they need to
-     *                  be grouped with a neighboring set due to overlap.
-     * @param overlapInclusionMethod NONE to only form buckets of the overlapping sets, SINGLE to include all
-     *                               sets that share an sstable with a selected bucket, or TRANSITIVE to include
-     *                               all sets that have an overlap chain to a selected bucket.
-     * @param overlaps An ordered list of overlap sets as returned by {@link #constructOverlapSets}.
-     * @param bucketer Method used to create a bucket out of the supplied set indexes.
-     * @param unselectedHandler Action to take on sets that are below the threshold and not included in any bucket.
-     */
-    @VisibleForTesting
-    static <E, B> List<B> assignOverlapsIntoBuckets(int threshold,
-                                                    Controller.OverlapInclusionMethod overlapInclusionMethod,
-                                                    List<Set<E>> overlaps,
-                                                    BucketMaker<E, B> bucketer,
-                                                    Consumer<Set<E>> unselectedHandler)
-    {
-        List<B> buckets = new ArrayList<>();
-        int regionCount = overlaps.size();
-        int lastEnd = 0;
-        for (int i = 0; i < regionCount; ++i)
-        {
-            Set<E> bucket = overlaps.get(i);
-            int maxOverlap = bucket.size();
-            if (maxOverlap < threshold)
-                continue;
-            int startIndex = i;
-            int endIndex = i + 1;
-
-            if (overlapInclusionMethod != Controller.OverlapInclusionMethod.NONE)
-            {
-                Set<E> allOverlapping = new HashSet<>(bucket);
-                Set<E> overlapTarget = overlapInclusionMethod == Controller.OverlapInclusionMethod.TRANSITIVE
-                                       ? allOverlapping
-                                       : bucket;
-                int j;
-                for (j = i - 1; j >= lastEnd; --j)
-                {
-                    Set<E> next = overlaps.get(j);
-                    if (!setsIntersect(next, overlapTarget))
-                        break;
-                    allOverlapping.addAll(next);
-                }
-                startIndex = j + 1;
-                for (j = i + 1; j < regionCount; ++j)
-                {
-                    Set<E> next = overlaps.get(j);
-                    if (!setsIntersect(next, overlapTarget))
-                        break;
-                    allOverlapping.addAll(next);
-                }
-                i = j - 1;
-                endIndex = j;
-            }
-            buckets.add(bucketer.makeBucket(overlaps, startIndex, endIndex));
-            for (int k = lastEnd; k < startIndex; ++k)
-                unselectedHandler.accept(overlaps.get(k));
-            lastEnd = endIndex;
-        }
-        for (int k = lastEnd; k < regionCount; ++k)
-            unselectedHandler.accept(overlaps.get(k));
-        return buckets;
-    }
-
-    private static <E> boolean setsIntersect(Set<E> s1, Set<E> s2)
-    {
-        // Note: optimized for small sets and O(1) lookup.
-        for (E s : s1)
-            if (s2.contains(s))
-                return true;
-
-        return false;
-    }
-
-    /**
      * A compaction arena contains the list of sstables that belong to this arena as well as the arena
      * selector used for comparison.
      */
@@ -1213,19 +1082,19 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 logger.trace("Creating compaction aggregate with sstable set {}", sstables);
 
 
-            List<Set<CompactionSSTable>> overlaps = constructOverlapSets(sstables,
-                                                                         UnifiedCompactionStrategy::startsAfter,
-                                                                         CompactionSSTable.firstKeyComparator,
-                                                                         CompactionSSTable.lastKeyComparator);
+            List<Set<CompactionSSTable>> overlaps = Overlaps.constructOverlapSets(sstables,
+                                                                                  UnifiedCompactionStrategy::startsAfter,
+                                                                                  CompactionSSTable.firstKeyComparator,
+                                                                                  CompactionSSTable.lastKeyComparator);
             for (Set<CompactionSSTable> overlap : overlaps)
                 maxOverlap = Math.max(maxOverlap, overlap.size());
             List<CompactionSSTable> unbucketed = new ArrayList<>();
 
-            List<Bucket> buckets = assignOverlapsIntoBuckets(threshold,
-                                                             controller.overlapInclusionMethod(),
-                                                             overlaps,
-                                                             this::makeBucket,
-                                                             unbucketed::addAll);
+            List<Bucket> buckets = Overlaps.assignOverlapsIntoBuckets(threshold,
+                                                                      controller.overlapInclusionMethod(),
+                                                                      overlaps,
+                                                                      this::makeBucket,
+                                                                      unbucketed::addAll);
 
             List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
             for (Bucket bucket : buckets)
@@ -1528,31 +1397,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
         Collection<CompactionSSTable> pullOldestSSTables(int overlapLimit)
         {
-            return pullLastWithOverlapLimit(allSSTablesSorted, overlapSets, overlapLimit);
-        }
-
-        static <T> Collection<T> pullLastWithOverlapLimit(List<T> allObjectsSorted, List<Set<T>> overlapSets, int limit)
-        {
-            // We want to select up to `limit` sstables in overlapping sets (more than `limit` in total). To achieve
-            // this, keep selecting the oldest sstable until the next one we would add would bring the number selected
-            // in some overlap section over `limit`.
-            int setsCount = overlapSets.size();
-            int[] selectedInBucket = new int[setsCount];
-            int allCount = allObjectsSorted.size();
-            for (int selectedCount = 0; selectedCount < allCount; ++selectedCount)
-            {
-                T candidate = allObjectsSorted.get(allCount - 1 - selectedCount);
-                for (int i = 0; i < setsCount; ++i)
-                {
-                    if (overlapSets.get(i).contains(candidate))
-                    {
-                        ++selectedInBucket[i];
-                        if (selectedInBucket[i] > limit)
-                            return pullLast(allObjectsSorted, selectedCount);
-                    }
-                }
-            }
-            return allObjectsSorted;
+            return Overlaps.pullLastWithOverlapLimit(allSSTablesSorted, overlapSets, overlapLimit);
         }
     }
 
@@ -1565,8 +1410,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         int levelCount;
         final long spaceAvailable;
         final String rateLimitLog;
-        final int runningAdaptiveCompactions;
-        final int maxAdaptiveCompactions;
+        final int remainingAdaptiveCompactions;
 
         public CompactionLimits(int runningCompactions,
                                 int maxCompactions,
@@ -1575,8 +1419,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                 int levelCount,
                                 long spaceAvailable,
                                 String rateLimitLog,
-                                int runningAdaptiveCompactions,
-                                int maxAdaptiveCompactions)
+                                int remainingAdaptiveCompactions)
         {
             this.runningCompactions = runningCompactions;
             this.maxCompactions = maxCompactions;
@@ -1585,16 +1428,15 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             this.levelCount = levelCount;
             this.spaceAvailable = spaceAvailable;
             this.rateLimitLog = rateLimitLog;
-            this.runningAdaptiveCompactions = runningAdaptiveCompactions;
-            this.maxAdaptiveCompactions = maxAdaptiveCompactions;
+            this.remainingAdaptiveCompactions = remainingAdaptiveCompactions;
         }
 
         @Override
         public String toString()
         {
-            return String.format("Current limits: running=%d, max=%d, maxConcurrent=%d, perLevel=%s, levelCount=%d, spaceAvailable=%s, rateLimitLog=%s, runningAdaptiveCompactions=%d, maxAdaptiveCompactions=%d",
+            return String.format("Current limits: running=%d, max=%d, maxConcurrent=%d, perLevel=%s, levelCount=%d, spaceAvailable=%s, rateLimitLog=%s, remainingAdaptiveCompactions=%d",
                                  runningCompactions, maxCompactions, maxConcurrentCompactions, Arrays.toString(perLevel), levelCount,
-                                 FBUtilities.prettyPrintMemory(spaceAvailable), rateLimitLog, runningAdaptiveCompactions, maxAdaptiveCompactions);
+                                 FBUtilities.prettyPrintMemory(spaceAvailable), rateLimitLog, remainingAdaptiveCompactions);
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
@@ -36,8 +36,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 /**
  * A {@link CompactionAwareWriter} that splits the output sstable at the partition boundaries of the compaction
- * shards used by {@link org.apache.cassandra.db.compaction.UnifiedCompactionStrategy} as long as the size of
- * the sstable so far is sufficiently large.
+ * shards used by {@link org.apache.cassandra.db.compaction.UnifiedCompactionStrategy}.
  */
 public class ShardedCompactionWriter extends CompactionAwareWriter
 {
@@ -66,7 +65,9 @@ public class ShardedCompactionWriter extends CompactionAwareWriter
     @Override
     protected boolean shouldSwitchWriterInCurrentLocation(DecoratedKey key)
     {
-        // If we have written anything and cross a shard boundary, switch to a new writer.
+        // If we have written anything and cross a shard boundary, switch to a new writer. We use the uncompressed
+        // file pointer here because there may be writes that are not yet reflected in the on-disk size, and we want
+        // to split as soon as there is content, regardless how small.
         final long uncompressedBytesWritten = sstableWriter.currentWriter().getFilePointer();
         if (boundaries.advanceTo(key.getToken()) && uncompressedBytesWritten > 0)
         {

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
@@ -70,16 +70,16 @@ public class ShardedMultiWriter implements SSTableMultiWriter
     private int currentWriter;
 
     public ShardedMultiWriter(CompactionRealm realm,
-                              Descriptor descriptor,
-                              long keyCount,
-                              long repairedAt,
-                              UUID pendingRepair,
-                              boolean isTransient,
-                              IntervalSet<CommitLogPosition> commitLogPositions,
-                              SerializationHeader header,
-                              Collection<Index.Group> indexGroups,
-                              LifecycleNewTracker lifecycleNewTracker,
-                              ShardTracker boundaries)
+                                Descriptor descriptor,
+                                long keyCount,
+                                long repairedAt,
+                                UUID pendingRepair,
+                                boolean isTransient,
+                                IntervalSet<CommitLogPosition> commitLogPositions,
+                                SerializationHeader header,
+                                Collection<Index.Group> indexGroups,
+                                LifecycleNewTracker lifecycleNewTracker,
+                                ShardTracker boundaries)
     {
         this.realm = realm;
         this.descriptor = descriptor;

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -22,11 +22,13 @@ import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileReader;
 import org.apache.cassandra.utils.MonotonicClock;
+import org.apache.cassandra.utils.Overlaps;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -48,37 +50,37 @@ public class StaticController extends Controller
     public StaticController(Environment env,
                             int[] scalingParameters,
                             double[] survivalFactors,
-                            long dataSetSizeMB,
-                            int numShards,
-                            long minSSTableSizeMB,
-                            long flushSizeOverrideMB,
+                            long dataSetSize,
+                            long minSSTableSize,
+                            long flushSizeOverride,
                             long currentFlushSize,
                             double maxSpaceOverhead,
                             int maxSSTablesToCompact,
                             long expiredSSTableCheckFrequency,
                             boolean ignoreOverlapsInExpirationCheck,
-                            boolean l0ShardsEnabled,
                             int baseShardCount,
-                            double targetSStableSize,
-                            OverlapInclusionMethod overlapInclusionMethod,
+                            long targetSStableSize,
+                            double sstableGrowthModifier,
+                            int reservedThreadsPerLevel,
+                            Overlaps.InclusionMethod overlapInclusionMethod,
                             String keyspaceName,
                             String tableName)
     {
         super(MonotonicClock.preciseTime,
               env,
               survivalFactors,
-              dataSetSizeMB,
-              numShards,
-              minSSTableSizeMB,
-              flushSizeOverrideMB,
+              dataSetSize,
+              minSSTableSize,
+              flushSizeOverride,
               currentFlushSize,
               maxSpaceOverhead,
               maxSSTablesToCompact,
               expiredSSTableCheckFrequency,
               ignoreOverlapsInExpirationCheck,
-              l0ShardsEnabled,
               baseShardCount,
               targetSStableSize,
+              sstableGrowthModifier,
+              reservedThreadsPerLevel,
               overlapInclusionMethod);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
@@ -87,18 +89,18 @@ public class StaticController extends Controller
 
     static Controller fromOptions(Environment env,
                                   double[] survivalFactors,
-                                  long dataSetSizeMB,
-                                  int numShards,
-                                  long minSSTableSizeMB,
-                                  long flushSizeOverrideMB,
+                                  long dataSetSize,
+                                  long minSSTableSize,
+                                  long flushSizeOverride,
                                   double maxSpaceOverhead,
                                   int maxSSTablesToCompact,
                                   long expiredSSTableCheckFrequency,
                                   boolean ignoreOverlapsInExpirationCheck,
-                                  boolean l0ShardsEnabled,
                                   int baseShardCount,
-                                  double targetSStableSize,
-                                  OverlapInclusionMethod overlapInclusionMethod,
+                                  long targetSStableSize,
+                                  double sstableGrowthModifier,
+                                  int reservedThreadsPerLevel,
+                                  Overlaps.InclusionMethod overlapInclusionMethod,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options)
@@ -108,14 +110,14 @@ public class StaticController extends Controller
             scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
         else
             scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
-        long currentFlushSize = flushSizeOverrideMB << 20;
+        long currentFlushSize = flushSizeOverride;
 
         File f = getControllerConfigPath(keyspaceName, tableName);
         try
         {
             JSONParser jsonParser = new JSONParser();
             JSONObject jsonObject = (JSONObject) jsonParser.parse(new FileReader(f));
-            if (jsonObject.get("current_flush_size") != null && flushSizeOverrideMB == 0)
+            if (jsonObject.get("current_flush_size") != null && flushSizeOverride == 0)
             {
                 currentFlushSize = (long) jsonObject.get("current_flush_size");
                 logger.debug("Successfully read stored current_flush_size from disk");
@@ -132,18 +134,18 @@ public class StaticController extends Controller
         return new StaticController(env,
                                     scalingParameters,
                                     survivalFactors,
-                                    dataSetSizeMB,
-                                    numShards,
-                                    minSSTableSizeMB,
-                                    flushSizeOverrideMB,
+                                    dataSetSize,
+                                    minSSTableSize,
+                                    flushSizeOverride,
                                     currentFlushSize,
                                     maxSpaceOverhead,
                                     maxSSTablesToCompact,
                                     expiredSSTableCheckFrequency,
                                     ignoreOverlapsInExpirationCheck,
-                                    l0ShardsEnabled,
                                     baseShardCount,
                                     targetSStableSize,
+                                    sstableGrowthModifier,
+                                    reservedThreadsPerLevel,
                                     overlapInclusionMethod,
                                     keyspaceName,
                                     tableName);
@@ -179,7 +181,13 @@ public class StaticController extends Controller
     }
 
     @Override
-    public int getMaxAdaptiveCompactions()
+    public boolean isRecentAdaptive(CompactionPick pick)
+    {
+        return false;
+    }
+
+    @Override
+    public int getMaxRecentAdaptiveCompactions()
     {
         return Integer.MAX_VALUE;
     }
@@ -193,6 +201,6 @@ public class StaticController extends Controller
     @Override
     public String toString()
     {
-        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSstableSizeMB, Arrays.toString(survivalFactors), printScalingParameters(scalingParameters), calculator);
+        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSSTableSize, Arrays.toString(survivalFactors), printScalingParameters(scalingParameters), calculator);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
@@ -53,7 +53,7 @@ public class UnifiedCompactionTask extends CompactionTask
                                                           Set<SSTableReader> nonExpiredSSTables)
     {
         double density = shardManager.calculateCombinedDensity(nonExpiredSSTables);
-        int numShards = controller.getNumShards(density);
+        int numShards = controller.getNumShards(density * shardManager.shardSetCoverage());
         return new ShardedCompactionWriter(realm, directories, txn, nonExpiredSSTables, keepOriginals, shardManager.boundaries(numShards));
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0.svg
+++ b/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0.svg
@@ -1,0 +1,2164 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-06-14T09:59:51.356040</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.7.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+L 450 26.88 
+L 69.59 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 115.586572 136.24 
+L 115.586572 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m2c961f9aa1" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 176.114145 136.24 
+L 176.114145 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 236.641717 136.24 
+L 236.641717 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 297.16929 136.24 
+L 297.16929 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 357.696863 136.24 
+L 357.696863 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 418.224436 136.24 
+L 418.224436 26.88 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="ma9b25f6482" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma9b25f6482" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- density -->
+     <g transform="translate(241.462187 164.516562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_63">
+      <path d="M 69.59 131.269091 
+L 450 131.269091 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <defs>
+       <path id="mf2bc6b05d1" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{4}$ -->
+      <g transform="translate(56.19 135.06831) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34" transform="translate(0 0.09375)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_65">
+      <path d="M 69.59 98.129697 
+L 450 98.129697 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="98.129697" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{64}$ -->
+      <g transform="translate(49.79 101.928916) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_67">
+      <path d="M 69.59 64.990303 
+L 450 64.990303 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="64.990303" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{1024}$ -->
+      <g transform="translate(37.09 68.789522) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.78125)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0.78125)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(190.869141 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_69">
+      <path d="M 69.59 31.850909 
+L 450 31.850909 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{16384}$ -->
+      <g transform="translate(30.69 35.650128) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0.78125)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0.78125)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(190.869141 0.78125)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(254.492188 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- shards -->
+     <g transform="translate(24.610312 98.144375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-68" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-61" x="115.478516"/>
+      <use xlink:href="#DejaVuSans-72" x="176.757812"/>
+      <use xlink:href="#DejaVuSans-64" x="216.121094"/>
+      <use xlink:href="#DejaVuSans-73" x="279.597656"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_71">
+    <path d="M 86.881364 131.269091 
+L 221.349502 131.269091 
+L 221.713915 122.984242 
+L 239.570117 122.984242 
+L 239.93453 114.699394 
+L 257.790732 114.699394 
+L 258.155145 106.414545 
+L 276.011347 106.414545 
+L 276.37576 98.129697 
+L 294.231962 98.129697 
+L 294.596375 89.844848 
+L 312.452577 89.844848 
+L 312.81699 81.56 
+L 330.673192 81.56 
+L 331.037605 73.275152 
+L 348.893807 73.275152 
+L 349.25822 64.990303 
+L 367.114422 64.990303 
+L 367.478835 56.705455 
+L 385.335037 56.705455 
+L 385.69945 48.420606 
+L 403.555652 48.420606 
+L 403.920065 40.135758 
+L 421.776267 40.135758 
+L 422.14068 31.850909 
+L 432.708636 31.850909 
+L 432.708636 31.850909 
+" clip-path="url(#p321abaea0c)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 69.59 136.24 
+L 69.59 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 450 136.24 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 69.59 26.88 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Shard count -->
+    <g transform="translate(223.501562 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-68" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-61" x="126.855469"/>
+     <use xlink:href="#DejaVuSans-72" x="188.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="227.498047"/>
+     <use xlink:href="#DejaVuSans-20" x="290.974609"/>
+     <use xlink:href="#DejaVuSans-63" x="322.761719"/>
+     <use xlink:href="#DejaVuSans-6f" x="377.742188"/>
+     <use xlink:href="#DejaVuSans-75" x="438.923828"/>
+     <use xlink:href="#DejaVuSans-6e" x="502.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="565.681641"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+L 450 194.28 
+L 69.59 194.28 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_57">
+     <g id="line2d_72">
+      <path d="M 115.586572 303.64 
+L 115.586572 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_74">
+      <path d="M 176.114145 303.64 
+L 176.114145 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_76">
+      <path d="M 236.641717 303.64 
+L 236.641717 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_78">
+      <path d="M 297.16929 303.64 
+L 297.16929 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_80">
+      <path d="M 357.696863 303.64 
+L 357.696863 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_82">
+      <path d="M 418.224436 303.64 
+L 418.224436 194.28 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m2c961f9aa1" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_65">
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_75">
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_76">
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_77">
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_78">
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_79">
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_80">
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_81">
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_82">
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_83">
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_84">
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_85">
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_86">
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_87">
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_88">
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_89">
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_90">
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_91">
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_92">
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_93">
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_94">
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_95">
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_96">
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_97">
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_98">
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_99">
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_100">
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_101">
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_102">
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_103">
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_104">
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_105">
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_106">
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_107">
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_108">
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_109">
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_110">
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_111">
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_112">
+     <g id="line2d_133">
+      <g>
+       <use xlink:href="#ma9b25f6482" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- density -->
+     <g transform="translate(241.462187 331.916562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_134">
+      <path d="M 69.59 295.254162 
+L 450 295.254162 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_135">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="295.254162" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 10 MB -->
+      <g transform="translate(31.197813 299.05338) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="245.3125"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_136">
+      <path d="M 69.59 250.503477 
+L 450 250.503477 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_137">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="250.503477" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 100 MB -->
+      <g transform="translate(24.835313 254.302696) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_138">
+      <path d="M 69.59 205.752793 
+L 450 205.752793 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_139">
+      <g>
+       <use xlink:href="#mf2bc6b05d1" x="69.59" y="205.752793" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 1 GB -->
+      <g transform="translate(38.44 209.552012) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_140">
+      <defs>
+       <path id="m8e77107765" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="302.18613" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_141">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="299.590951" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="297.301841" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_143">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="281.782863" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="273.902659" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_145">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="268.311565" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="263.974776" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_147">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="260.431361" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="257.435446" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_149">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="254.840267" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="252.551156" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_151">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="237.032179" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="229.151975" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_153">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="223.560881" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="219.224091" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_155">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="215.680676" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="212.684762" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_157">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="210.089582" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m8e77107765" x="69.59" y="207.800472" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- SSTable size -->
+     <g transform="translate(18.755625 279.524844) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+      <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+      <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+      <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+      <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+      <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+      <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+      <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+      <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+      <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_159">
+    <path d="M 86.881364 298.669091 
+L 221.349502 199.250909 
+L 221.713915 212.452781 
+L 239.570117 199.250909 
+L 239.93453 212.452781 
+L 257.790732 199.250909 
+L 258.155145 212.452781 
+L 276.011347 199.250909 
+L 276.37576 212.452781 
+L 294.231962 199.250909 
+L 294.596375 212.452781 
+L 312.452577 199.250909 
+L 312.81699 212.452781 
+L 330.673192 199.250909 
+L 331.037605 212.452781 
+L 348.893807 199.250909 
+L 349.25822 212.452781 
+L 367.114422 199.250909 
+L 367.478835 212.452781 
+L 385.335037 199.250909 
+L 385.69945 212.452781 
+L 403.555652 199.250909 
+L 403.920065 212.452781 
+L 421.776267 199.250909 
+L 422.14068 212.452781 
+L 432.708636 204.639428 
+L 432.708636 204.639428 
+" clip-path="url(#p0383f30a0d)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 69.59 303.64 
+L 69.59 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 450 303.64 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 69.59 194.28 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- SSTable size -->
+    <g transform="translate(223.117187 188.28) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+     <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+     <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+     <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+     <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+     <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+     <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+     <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p321abaea0c">
+   <rect x="69.59" y="26.88" width="380.41" height="109.36"/>
+  </clipPath>
+  <clipPath id="p0383f30a0d">
+   <rect x="69.59" y="194.28" width="380.41" height="109.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0_33.svg
+++ b/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0_33.svg
@@ -1,0 +1,2187 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-06-14T10:02:58.661558</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.7.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+L 450 26.88 
+L 69.59 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 115.586572 136.24 
+L 115.586572 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="md86424bd9c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md86424bd9c" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 176.114145 136.24 
+L 176.114145 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md86424bd9c" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 236.641717 136.24 
+L 236.641717 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#md86424bd9c" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 297.16929 136.24 
+L 297.16929 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#md86424bd9c" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 357.696863 136.24 
+L 357.696863 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#md86424bd9c" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 418.224436 136.24 
+L 418.224436 26.88 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#md86424bd9c" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="mca5858cc1e" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mca5858cc1e" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- density -->
+     <g transform="translate(241.462187 164.516562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_63">
+      <path d="M 69.59 131.269091 
+L 450 131.269091 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <defs>
+       <path id="m4ad74489b4" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{1}$ -->
+      <g transform="translate(56.19 135.06831) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.09375)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_65">
+      <path d="M 69.59 98.129697 
+L 450 98.129697 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="98.129697" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{8}$ -->
+      <g transform="translate(56.19 101.928916) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38" transform="translate(0 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_67">
+      <path d="M 69.59 64.990303 
+L 450 64.990303 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="64.990303" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{64}$ -->
+      <g transform="translate(49.79 68.789522) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_69">
+      <path d="M 69.59 31.850909 
+L 450 31.850909 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{512}$ -->
+      <g transform="translate(43.49 35.650128) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0.78125)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- shards -->
+     <g transform="translate(37.410313 98.144375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-68" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-61" x="115.478516"/>
+      <use xlink:href="#DejaVuSans-72" x="176.757812"/>
+      <use xlink:href="#DejaVuSans-64" x="216.121094"/>
+      <use xlink:href="#DejaVuSans-73" x="279.597656"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_71">
+    <path d="M 86.881364 131.269091 
+L 189.645632 131.269091 
+L 190.010045 120.222626 
+L 216.612142 120.222626 
+L 216.976555 109.176162 
+L 243.943065 109.176162 
+L 244.307477 98.129697 
+L 271.273987 98.129697 
+L 271.6384 87.083232 
+L 298.240498 87.083232 
+L 298.60491 76.036768 
+L 325.57142 76.036768 
+L 325.935832 64.990303 
+L 352.53793 64.990303 
+L 352.902343 53.943838 
+L 379.868853 53.943838 
+L 380.233265 42.897374 
+L 407.199775 42.897374 
+L 407.564188 31.850909 
+L 432.708636 31.850909 
+L 432.708636 31.850909 
+" clip-path="url(#pa3d9439321)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 69.59 136.24 
+L 69.59 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 450 136.24 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 69.59 26.88 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Shard count -->
+    <g transform="translate(223.501562 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-68" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-61" x="126.855469"/>
+     <use xlink:href="#DejaVuSans-72" x="188.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="227.498047"/>
+     <use xlink:href="#DejaVuSans-20" x="290.974609"/>
+     <use xlink:href="#DejaVuSans-63" x="322.761719"/>
+     <use xlink:href="#DejaVuSans-6f" x="377.742188"/>
+     <use xlink:href="#DejaVuSans-75" x="438.923828"/>
+     <use xlink:href="#DejaVuSans-6e" x="502.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="565.681641"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+L 450 194.28 
+L 69.59 194.28 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_57">
+     <g id="line2d_72">
+      <path d="M 115.586572 303.64 
+L 115.586572 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#md86424bd9c" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_74">
+      <path d="M 176.114145 303.64 
+L 176.114145 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#md86424bd9c" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_76">
+      <path d="M 236.641717 303.64 
+L 236.641717 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#md86424bd9c" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_78">
+      <path d="M 297.16929 303.64 
+L 297.16929 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#md86424bd9c" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_80">
+      <path d="M 357.696863 303.64 
+L 357.696863 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#md86424bd9c" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_82">
+      <path d="M 418.224436 303.64 
+L 418.224436 194.28 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#md86424bd9c" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_65">
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_75">
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_76">
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_77">
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_78">
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_79">
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_80">
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_81">
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_82">
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_83">
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_84">
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_85">
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_86">
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_87">
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_88">
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_89">
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_90">
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_91">
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_92">
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_93">
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_94">
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_95">
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_96">
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_97">
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_98">
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_99">
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_100">
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_101">
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_102">
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_103">
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_104">
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_105">
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_106">
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_107">
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_108">
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_109">
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_110">
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_111">
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_112">
+     <g id="line2d_133">
+      <g>
+       <use xlink:href="#mca5858cc1e" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- density -->
+     <g transform="translate(241.462187 331.916562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_134">
+      <path d="M 69.59 282.975116 
+L 450 282.975116 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_135">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="282.975116" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 100 MB -->
+      <g transform="translate(24.835313 286.774335) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_136">
+      <path d="M 69.59 249.882927 
+L 450 249.882927 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_137">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="249.882927" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 1 GB -->
+      <g transform="translate(38.44 253.682146) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_138">
+      <path d="M 69.59 216.790737 
+L 450 216.790737 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_139">
+      <g>
+       <use xlink:href="#m4ad74489b4" x="69.59" y="216.790737" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 10 GB -->
+      <g transform="translate(32.0775 220.589956) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_140">
+      <defs>
+       <path id="m85832d117c" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="300.278319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_141">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="296.143823" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="292.936858" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_143">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="290.316577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="288.101161" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_145">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="286.182081" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="284.489332" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_147">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="273.013375" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="267.186129" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_149">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="263.051633" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="259.844669" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_151">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="257.224388" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="255.008972" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_153">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="253.089891" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="251.397142" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_155">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="239.921185" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="234.09394" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_157">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="229.959444" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="226.752479" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_159">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="224.132198" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="221.916782" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_161">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="219.997702" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="218.304953" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_163">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="206.828996" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="201.00175" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_165">
+      <g>
+       <use xlink:href="#m85832d117c" x="69.59" y="196.867254" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- SSTable size -->
+     <g transform="translate(18.755625 279.524844) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+      <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+      <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+      <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+      <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+      <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+      <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+      <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+      <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+      <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_166">
+    <path d="M 86.881364 298.669091 
+L 189.645632 242.484868 
+L 190.010045 252.247375 
+L 216.612142 237.703232 
+L 216.976555 247.465739 
+L 243.943065 232.722361 
+L 244.307477 242.484868 
+L 271.273987 227.74149 
+L 271.6384 237.503997 
+L 298.240498 222.959854 
+L 298.60491 232.722361 
+L 325.57142 217.978983 
+L 325.935832 227.74149 
+L 352.53793 213.197347 
+L 352.902343 222.959854 
+L 379.868853 208.216477 
+L 380.233265 217.978983 
+L 407.199775 203.235606 
+L 407.564188 212.998113 
+L 432.708636 199.250909 
+L 432.708636 199.250909 
+" clip-path="url(#pf698c90118)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 69.59 303.64 
+L 69.59 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 450 303.64 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 69.59 194.28 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- SSTable size -->
+    <g transform="translate(223.117187 188.28) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+     <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+     <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+     <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+     <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+     <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+     <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+     <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa3d9439321">
+   <rect x="69.59" y="26.88" width="380.41" height="109.36"/>
+  </clipPath>
+  <clipPath id="pf698c90118">
+   <rect x="69.59" y="194.28" width="380.41" height="109.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0_5.svg
+++ b/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_0_5.svg
@@ -1,0 +1,2222 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-06-14T10:01:47.825040</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.7.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+L 450 26.88 
+L 69.59 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 115.586572 136.24 
+L 115.586572 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m7eb3810557" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7eb3810557" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 176.114145 136.24 
+L 176.114145 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m7eb3810557" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 236.641717 136.24 
+L 236.641717 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m7eb3810557" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 297.16929 136.24 
+L 297.16929 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m7eb3810557" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 357.696863 136.24 
+L 357.696863 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m7eb3810557" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 418.224436 136.24 
+L 418.224436 26.88 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m7eb3810557" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="m9046c8e55b" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9046c8e55b" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- density -->
+     <g transform="translate(241.462187 164.516562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_63">
+      <path d="M 69.59 131.269091 
+L 450 131.269091 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <defs>
+       <path id="m518b3ffc74" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{1}$ -->
+      <g transform="translate(56.19 135.06831) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.09375)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_65">
+      <path d="M 69.59 98.129697 
+L 450 98.129697 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="98.129697" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{8}$ -->
+      <g transform="translate(56.19 101.928916) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38" transform="translate(0 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_67">
+      <path d="M 69.59 64.990303 
+L 450 64.990303 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="64.990303" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{64}$ -->
+      <g transform="translate(49.79 68.789522) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_69">
+      <path d="M 69.59 31.850909 
+L 450 31.850909 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{512}$ -->
+      <g transform="translate(43.49 35.650128) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0.78125)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- shards -->
+     <g transform="translate(37.410313 98.144375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-68" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-61" x="115.478516"/>
+      <use xlink:href="#DejaVuSans-72" x="176.757812"/>
+      <use xlink:href="#DejaVuSans-64" x="216.121094"/>
+      <use xlink:href="#DejaVuSans-73" x="279.597656"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_71">
+    <path d="M 86.881364 131.269091 
+L 133.526138 131.269091 
+L 133.89055 120.222626 
+L 151.746753 120.222626 
+L 152.111165 109.176162 
+L 169.967368 109.176162 
+L 170.33178 98.129697 
+L 248.680425 98.129697 
+L 249.044837 87.083232 
+L 285.121655 87.083232 
+L 285.486067 76.036768 
+L 321.562885 76.036768 
+L 321.927297 64.990303 
+L 358.004115 64.990303 
+L 358.368527 53.943838 
+L 394.445345 53.943838 
+L 394.809757 42.897374 
+L 430.886575 42.897374 
+L 431.250987 31.850909 
+L 432.708636 31.850909 
+L 432.708636 31.850909 
+" clip-path="url(#p5e8c4de7ed)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 69.59 136.24 
+L 69.59 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 450 136.24 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 69.59 26.88 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Shard count -->
+    <g transform="translate(223.501562 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-68" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-61" x="126.855469"/>
+     <use xlink:href="#DejaVuSans-72" x="188.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="227.498047"/>
+     <use xlink:href="#DejaVuSans-20" x="290.974609"/>
+     <use xlink:href="#DejaVuSans-63" x="322.761719"/>
+     <use xlink:href="#DejaVuSans-6f" x="377.742188"/>
+     <use xlink:href="#DejaVuSans-75" x="438.923828"/>
+     <use xlink:href="#DejaVuSans-6e" x="502.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="565.681641"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+L 450 194.28 
+L 69.59 194.28 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_57">
+     <g id="line2d_72">
+      <path d="M 115.586572 303.64 
+L 115.586572 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m7eb3810557" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_74">
+      <path d="M 176.114145 303.64 
+L 176.114145 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m7eb3810557" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_76">
+      <path d="M 236.641717 303.64 
+L 236.641717 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m7eb3810557" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_78">
+      <path d="M 297.16929 303.64 
+L 297.16929 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m7eb3810557" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_80">
+      <path d="M 357.696863 303.64 
+L 357.696863 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m7eb3810557" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_82">
+      <path d="M 418.224436 303.64 
+L 418.224436 194.28 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m7eb3810557" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_65">
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_75">
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_76">
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_77">
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_78">
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_79">
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_80">
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_81">
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_82">
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_83">
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_84">
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_85">
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_86">
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_87">
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_88">
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_89">
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_90">
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_91">
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_92">
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_93">
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_94">
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_95">
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_96">
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_97">
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_98">
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_99">
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_100">
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_101">
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_102">
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_103">
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_104">
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_105">
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_106">
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_107">
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_108">
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_109">
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_110">
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_111">
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_112">
+     <g id="line2d_133">
+      <g>
+       <use xlink:href="#m9046c8e55b" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- density -->
+     <g transform="translate(241.462187 331.916562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_134">
+      <path d="M 69.59 284.273331 
+L 450 284.273331 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_135">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="284.273331" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 100 MB -->
+      <g transform="translate(24.835313 288.07255) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_136">
+      <path d="M 69.59 253.918547 
+L 450 253.918547 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_137">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="253.918547" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 1 GB -->
+      <g transform="translate(38.44 257.717766) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_138">
+      <path d="M 69.59 223.563763 
+L 450 223.563763 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_139">
+      <g>
+       <use xlink:href="#m518b3ffc74" x="69.59" y="223.563763" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 10 GB -->
+      <g transform="translate(32.0775 227.362982) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_140">
+      <defs>
+       <path id="m671bd7745c" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="300.145203" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_141">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="296.352714" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="293.411032" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_143">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="291.007502" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="288.975347" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_145">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="287.215014" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="285.66229" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_147">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="275.135631" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="269.790419" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_149">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="265.99793" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="263.056248" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_151">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="260.652718" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="258.620563" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_153">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="256.86023" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="255.307506" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_155">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="244.780847" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="239.435634" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_157">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="235.643146" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="232.701464" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_159">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="230.297934" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="228.265779" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_161">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="226.505446" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="224.952722" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_163">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="214.426062" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="209.08085" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_165">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="205.288362" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_166">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="202.346679" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_167">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="199.94315" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_168">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="197.910994" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_169">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="196.150661" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_170">
+      <g>
+       <use xlink:href="#m671bd7745c" x="69.59" y="194.597938" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- SSTable size -->
+     <g transform="translate(18.755625 279.524844) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+      <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+      <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+      <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+      <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+      <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+      <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+      <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+      <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+      <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_171">
+    <path d="M 86.881364 298.669091 
+L 133.526138 275.276578 
+L 133.89055 284.231524 
+L 151.746753 275.276578 
+L 152.111165 284.231524 
+L 169.967368 275.276578 
+L 170.33178 284.231524 
+L 248.680425 244.939412 
+L 249.044837 253.894358 
+L 285.121655 235.801711 
+L 285.486067 244.756658 
+L 321.562885 226.664011 
+L 321.927297 235.618957 
+L 358.004115 217.52631 
+L 358.368527 226.481257 
+L 394.445345 208.38861 
+L 394.809757 217.343556 
+L 430.886575 199.250909 
+L 431.250987 208.205856 
+L 432.708636 207.47484 
+L 432.708636 207.47484 
+" clip-path="url(#pca8863437a)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 69.59 303.64 
+L 69.59 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 450 303.64 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 69.59 194.28 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- SSTable size -->
+    <g transform="translate(223.117187 188.28) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+     <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+     <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+     <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+     <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+     <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+     <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+     <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5e8c4de7ed">
+   <rect x="69.59" y="26.88" width="380.41" height="109.36"/>
+  </clipPath>
+  <clipPath id="pca8863437a">
+   <rect x="69.59" y="194.28" width="380.41" height="109.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_1.svg
+++ b/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_1.svg
@@ -1,0 +1,1860 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-06-14T10:06:53.579133</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.7.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+L 450 26.88 
+L 69.59 26.88 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 115.586572 136.24 
+L 115.586572 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m99b41d0da3" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m99b41d0da3" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 176.114145 136.24 
+L 176.114145 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 236.641717 136.24 
+L 236.641717 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 297.16929 136.24 
+L 297.16929 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 357.696863 136.24 
+L 357.696863 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 150.838437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 418.224436 136.24 
+L 418.224436 26.88 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 150.838437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="mc50d4081ef" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc50d4081ef" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- density -->
+     <g transform="translate(241.462187 164.516562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_63">
+      <path d="M 69.59 131.269091 
+L 450 131.269091 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <defs>
+       <path id="mee738894df" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{1}$ -->
+      <g transform="translate(56.19 135.06831) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.09375)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_65">
+      <path d="M 69.59 101.341236 
+L 450 101.341236 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="101.341236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{2}$ -->
+      <g transform="translate(56.19 105.140455) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32" transform="translate(0 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_67">
+      <path d="M 69.59 71.413381 
+L 450 71.413381 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="71.413381" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{4}$ -->
+      <g transform="translate(56.19 75.2126) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34" transform="translate(0 0.09375)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_69">
+      <path d="M 69.59 31.850909 
+L 450 31.850909 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10}$ -->
+      <g transform="translate(49.79 35.650128) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.78125)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.78125)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- shards -->
+     <g transform="translate(43.710313 98.144375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-68" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-61" x="115.478516"/>
+      <use xlink:href="#DejaVuSans-72" x="176.757812"/>
+      <use xlink:href="#DejaVuSans-64" x="216.121094"/>
+      <use xlink:href="#DejaVuSans-73" x="279.597656"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_71">
+    <path d="M 86.881364 131.269091 
+L 133.526138 131.269091 
+L 133.89055 101.341236 
+L 151.746753 101.341236 
+L 152.111165 71.413381 
+L 169.967368 71.413381 
+L 170.33178 41.485526 
+L 175.797965 41.485526 
+L 176.162377 31.850909 
+L 432.708636 31.850909 
+L 432.708636 31.850909 
+" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 69.59 136.24 
+L 69.59 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 450 136.24 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 69.59 136.24 
+L 450 136.24 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 69.59 26.88 
+L 450 26.88 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Shard count -->
+    <g transform="translate(223.501562 20.88) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-68" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-61" x="126.855469"/>
+     <use xlink:href="#DejaVuSans-72" x="188.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="227.498047"/>
+     <use xlink:href="#DejaVuSans-20" x="290.974609"/>
+     <use xlink:href="#DejaVuSans-63" x="322.761719"/>
+     <use xlink:href="#DejaVuSans-6f" x="377.742188"/>
+     <use xlink:href="#DejaVuSans-75" x="438.923828"/>
+     <use xlink:href="#DejaVuSans-6e" x="502.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="565.681641"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+L 450 194.28 
+L 69.59 194.28 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_57">
+     <g id="line2d_72">
+      <path d="M 115.586572 303.64 
+L 115.586572 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 MB -->
+      <g transform="translate(96.709228 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4d" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="308.935547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_74">
+      <path d="M 176.114145 303.64 
+L 176.114145 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 GB -->
+      <g transform="translate(164.039145 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_59">
+     <g id="line2d_76">
+      <path d="M 236.641717 303.64 
+L 236.641717 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 10 GB -->
+      <g transform="translate(221.385467 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-47" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="236.523438"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_60">
+     <g id="line2d_78">
+      <path d="M 297.16929 303.64 
+L 297.16929 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 GB -->
+      <g transform="translate(278.73179 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_61">
+     <g id="line2d_80">
+      <path d="M 357.696863 303.64 
+L 357.696863 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1 TB -->
+      <g transform="translate(346.442176 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-54" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="156.494141"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_62">
+     <g id="line2d_82">
+      <path d="M 418.224436 303.64 
+L 418.224436 194.28 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#m99b41d0da3" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 10 TB -->
+      <g transform="translate(403.788499 318.238438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-54" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-42" x="220.117188"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_63">
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_64">
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_65">
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_66">
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_67">
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_68">
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_69">
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_70">
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_71">
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_72">
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_73">
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_74">
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_75">
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_76">
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_77">
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_78">
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_79">
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_80">
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_81">
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_82">
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_83">
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_84">
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_85">
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_86">
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_87">
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_88">
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_89">
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_90">
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_91">
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_92">
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_93">
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_94">
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_95">
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_96">
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_97">
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_98">
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_99">
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_100">
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_101">
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_102">
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_103">
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_104">
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_105">
+     <g id="line2d_126">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_106">
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_107">
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_108">
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_109">
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_110">
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_111">
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_112">
+     <g id="line2d_133">
+      <g>
+       <use xlink:href="#mc50d4081ef" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- density -->
+     <g transform="translate(241.462187 331.916562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="188.378906"/>
+      <use xlink:href="#DejaVuSans-69" x="240.478516"/>
+      <use xlink:href="#DejaVuSans-74" x="268.261719"/>
+      <use xlink:href="#DejaVuSans-79" x="307.470703"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_134">
+      <path d="M 69.59 267.574208 
+L 450 267.574208 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_135">
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="267.574208" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 1 GB -->
+      <g transform="translate(38.44 271.373426) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-47" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-42" x="172.900391"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_136">
+      <path d="M 69.59 225.390208 
+L 450 225.390208 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_137">
+      <g>
+       <use xlink:href="#mee738894df" x="69.59" y="225.390208" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 100 GB -->
+      <g transform="translate(25.715 229.189427) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-47" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-42" x="300.146484"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_23">
+     <!-- SSTable size -->
+     <g transform="translate(19.635313 279.524844) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+      <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+      <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+      <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+      <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+      <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+      <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+      <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+      <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+      <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_138">
+    <path d="M 86.881364 298.669091 
+L 133.526138 282.41482 
+L 133.89055 288.637158 
+L 151.746753 282.41482 
+L 152.111165 288.637158 
+L 169.967368 282.41482 
+L 170.33178 288.637158 
+L 175.797965 286.732361 
+L 176.162377 288.6494 
+L 432.708636 199.250909 
+L 432.708636 199.250909 
+" clip-path="url(#pf633062729)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 69.59 303.64 
+L 69.59 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 450 303.64 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 69.59 303.64 
+L 450 303.64 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 69.59 194.28 
+L 450 194.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_24">
+    <!-- SSTable size -->
+    <g transform="translate(223.117187 188.28) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-54" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-61" x="171.537109"/>
+     <use xlink:href="#DejaVuSans-62" x="232.816406"/>
+     <use xlink:href="#DejaVuSans-6c" x="296.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="324.076172"/>
+     <use xlink:href="#DejaVuSans-20" x="385.599609"/>
+     <use xlink:href="#DejaVuSans-73" x="417.386719"/>
+     <use xlink:href="#DejaVuSans-69" x="469.486328"/>
+     <use xlink:href="#DejaVuSans-7a" x="497.269531"/>
+     <use xlink:href="#DejaVuSans-65" x="549.759766"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p77222f8fef">
+   <rect x="69.59" y="26.88" width="380.41" height="109.36"/>
+  </clipPath>
+  <clipPath id="pf633062729">
+   <rect x="69.59" y="194.28" width="380.41" height="109.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/java/org/apache/cassandra/tools/CompactionLogAnalyzer.java
+++ b/src/java/org/apache/cassandra/tools/CompactionLogAnalyzer.java
@@ -230,7 +230,7 @@ public class CompactionLogAnalyzer
 
     private static long parseHumanReadableSize(String datum)
     {
-        return (long) FBUtilities.parseHumanReadable(datum, null, "B");
+        return FBUtilities.parseHumanReadableBytes(datum);
     }
 
     private static long parseHumanReadableRate(String datum)

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -1116,6 +1116,38 @@ public class FBUtilities
         return v;
     }
 
+    public static long parseHumanReadableBytes(String value)
+    {
+        return (long) parseHumanReadable(value, null, "B");
+    }
+
+    /**
+     * Parse a double where both a direct value and a percentage are accepted.
+     * For example, for inputs "0.1" and "10%", this function will return 0.1.
+     */
+    public static double parsePercent(String value)
+    {
+        value = value.trim();
+        if (value.endsWith("%"))
+        {
+            value = value.substring(0, value.length() - 1).trim();
+            return Double.parseDouble(value) / 100.0;
+        }
+        else
+            return Double.parseDouble(value);
+    }
+
+    /**
+     * Parse an integer value, allowing the string "max" to mean Integer.MAX_VALUE.
+     */
+    public static int parseIntAllowingMax(String value)
+    {
+        if (value.equalsIgnoreCase("max"))
+            return Integer.MAX_VALUE;
+        else
+            return Integer.parseInt(value);
+    }
+
     /**
      * Starts and waits for the given @param pb to finish.
      * @throws java.io.IOException on non-zero exit code

--- a/src/java/org/apache/cassandra/utils/Overlaps.java
+++ b/src/java/org/apache/cassandra/utils/Overlaps.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+
+public class Overlaps
+{
+    /**
+     * Construct a minimal list of overlap sets, i.e. the sections of the range span when we have overlapping items,
+     * where we ensure:
+     * - non-overlapping items are never put in the same set
+     * - no item is present in non-consecutive sets
+     * - for any point where items overlap, the result includes a set listing all overlapping items
+     * <p>
+     * For example, for inputs A[0, 4), B[2, 8), C[6, 10), D[1, 9) the result would be the sets ABD and BCD. We are not
+     * interested in the spans where A, B, or C are present on their own or in combination with D, only that there
+     * exists a set in the list that is a superset of any such combination, and that the non-overlapping A and C are
+     * never together in a set.
+     * <p>
+     * Note that the full list of overlap sets A, AD, ABD, BD, BCD, CD, C is also an answer that satisfies the three
+     * conditions above, but it contains redundant sets (e.g. AD is already contained in ABD).
+     *
+     * @param items            A list of items to distribute in overlap sets. This is assumed to be a transient list and the method
+     *                         may modify or consume it. It is assumed that the start and end positions of an item are ordered,
+     *                         and the items are non-empty.
+     * @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
+     *                         This will only be used with arguments where left's start is known to be after right's start.
+     *                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
+     *                         and non-strict (>=) for end-exclusive.
+     * @param startsComparator Comparator of items' starting positions.
+     * @param endsComparator   Comparator of items' ending positions.
+     * @return List of overlap sets.
+     */
+    public static <E> List<Set<E>> constructOverlapSets(List<E> items,
+                                                        BiPredicate<E, E> startsAfter,
+                                                        Comparator<E> startsComparator,
+                                                        Comparator<E> endsComparator)
+    {
+        List<Set<E>> overlaps = new ArrayList<>();
+        if (items.isEmpty())
+            return overlaps;
+
+        PriorityQueue<E> active = new PriorityQueue<>(endsComparator);
+        items.sort(startsComparator);
+        for (E item : items)
+        {
+            if (!active.isEmpty() && startsAfter.test(item, active.peek()))
+            {
+                // New item starts after some active ends. It does not overlap with it, so:
+                // -- output the previous active set
+                overlaps.add(new HashSet<>(active));
+                // -- remove all items that also end before the current start
+                do
+                {
+                    active.poll();
+                }
+                while (!active.isEmpty() && startsAfter.test(item, active.peek()));
+            }
+
+            // Add the new item to the active state. We don't care if it starts later than others in the active set,
+            // the important point is that it overlaps with all of them.
+            active.add(item);
+        }
+
+        assert !active.isEmpty();
+        overlaps.add(new HashSet<>(active));
+
+        return overlaps;
+    }
+
+    public enum InclusionMethod
+    {
+        NONE, SINGLE, TRANSITIVE;
+    }
+
+    public interface BucketMaker<E, B>
+    {
+        B makeBucket(List<Set<E>> sets, int startIndexInclusive, int endIndexExclusive);
+    }
+
+    /**
+     * Assign overlap sections into buckets. Identify sections that have at least threshold-many overlapping
+     * items and apply the overlap inclusion method to combine with any neighbouring sections that contain
+     * selected sstables to make sure we make full use of any sstables selected for compaction (i.e. avoid
+     * recompacting, see {@link org.apache.cassandra.db.compaction.unified.Controller#overlapInclusionMethod()}).
+     *
+     * @param threshold       Threshold for selecting a bucket. Sets below this size will be ignored, unless they need
+     *                        to be grouped with a neighboring set due to overlap.
+     * @param inclusionMethod NONE to only form buckets of the overlapping sets, SINGLE to include all
+     *                        sets that share an sstable with a selected bucket, or TRANSITIVE to include
+     *                        all sets that have an overlap chain to a selected bucket.
+     * @param overlaps        An ordered list of overlap sets as returned by {@link #constructOverlapSets}.
+     * @param bucketer        Method used to create a bucket out of the supplied set indexes.
+     * @param unselectedHandler Action to take on sets that are below the threshold and not included in any bucket.
+     */
+    public static <E, B> List<B> assignOverlapsIntoBuckets(int threshold,
+                                                           InclusionMethod inclusionMethod,
+                                                           List<Set<E>> overlaps,
+                                                           BucketMaker<E, B> bucketer,
+                                                           Consumer<Set<E>> unselectedHandler)
+    {
+        List<B> buckets = new ArrayList<>();
+        int regionCount = overlaps.size();
+        int lastEnd = 0;
+        for (int i = 0; i < regionCount; ++i)
+        {
+            Set<E> bucket = overlaps.get(i);
+            int maxOverlap = bucket.size();
+            if (maxOverlap < threshold)
+                continue;
+            int startIndex = i;
+            int endIndex = i + 1;
+
+            if (inclusionMethod != InclusionMethod.NONE)
+            {
+                Set<E> allOverlapping = new HashSet<>(bucket);
+                Set<E> overlapTarget = inclusionMethod == InclusionMethod.TRANSITIVE
+                                       ? allOverlapping
+                                       : bucket;
+                int j;
+                for (j = i - 1; j >= lastEnd; --j)
+                {
+                    Set<E> next = overlaps.get(j);
+                    if (!setsIntersect(next, overlapTarget))
+                        break;
+                    allOverlapping.addAll(next);
+                }
+                startIndex = j + 1;
+                for (j = i + 1; j < regionCount; ++j)
+                {
+                    Set<E> next = overlaps.get(j);
+                    if (!setsIntersect(next, overlapTarget))
+                        break;
+                    allOverlapping.addAll(next);
+                }
+                i = j - 1;
+                endIndex = j;
+            }
+            buckets.add(bucketer.makeBucket(overlaps, startIndex, endIndex));
+            for (int k = lastEnd; k < startIndex; ++k)
+                unselectedHandler.accept(overlaps.get(k));
+            lastEnd = endIndex;
+        }
+        for (int k = lastEnd; k < regionCount; ++k)
+            unselectedHandler.accept(overlaps.get(k));
+        return buckets;
+    }
+
+    private static <E> boolean setsIntersect(Set<E> s1, Set<E> s2)
+    {
+        // Note: optimized for small sets and O(1) lookup.
+        for (E s : s1)
+            if (s2.contains(s))
+                return true;
+
+        return false;
+    }
+
+    /**
+     * Pull the last elements from the given list, up to the given limit.
+     */
+    public static <T> List<T> pullLast(List<T> source, int limit)
+    {
+        List<T> result = new ArrayList<>(limit);
+        while (--limit >= 0)
+            result.add(source.remove(source.size() - 1));
+        return result;
+    }
+
+    /**
+     * Select up to `limit` sstables from each overlapping set (more than `limit` in total) by taking the last entries
+     * from `allObjectsSorted`. To achieve this, keep selecting the last sstable until the next one we would add would
+     * bring the number selected in some overlap section over `limit`.
+     */
+    public static <T> Collection<T> pullLastWithOverlapLimit(List<T> allObjectsSorted, List<Set<T>> overlapSets, int limit)
+    {
+        int setsCount = overlapSets.size();
+        int[] selectedInBucket = new int[setsCount];
+        int allCount = allObjectsSorted.size();
+        for (int selectedCount = 0; selectedCount < allCount; ++selectedCount)
+        {
+            T candidate = allObjectsSorted.get(allCount - 1 - selectedCount);
+            for (int i = 0; i < setsCount; ++i)
+            {
+                if (overlapSets.get(i).contains(candidate))
+                {
+                    ++selectedInBucket[i];
+                    if (selectedInBucket[i] > limit)
+                        return pullLast(allObjectsSorted, selectedCount);
+                }
+            }
+        }
+        return allObjectsSorted;
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/UnifiedCompactionDensitiesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/UnifiedCompactionDensitiesTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.util.LongSummaryStatistics;
+
+import org.junit.Test;
+
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+import org.hamcrest.Matchers;
+
+import static org.apache.cassandra.cql3.TombstonesWithIndexedSSTableTest.makeRandomString;
+import static org.junit.Assert.assertThat;
+
+public class UnifiedCompactionDensitiesTest extends TestBaseImpl
+{
+    @Test
+    public void testTargetSSTableSize1Node1Dir() throws IOException
+    {
+        testTargetSSTableSize(1, 1);
+    }
+
+    @Test
+    public void testTargetSSTableSize1Node2Dirs() throws IOException
+    {
+        testTargetSSTableSize(1, 2);
+    }
+
+    @Test
+    public void testTargetSSTableSize2Nodes1Dir() throws IOException
+    {
+        testTargetSSTableSize(2, 1);
+    }
+
+    @Test
+    public void testTargetSSTableSize2Nodes3Dirs() throws IOException
+    {
+        testTargetSSTableSize(2, 3);
+    }
+
+    private void testTargetSSTableSize(int nodeCount, int dataDirs) throws IOException
+    {
+        try (Cluster cluster = init(builder().withNodes(nodeCount)
+                                             .withDataDirCount(dataDirs)
+                                             .withConfig(cfg -> cfg.set("memtable_heap_space_in_mb", "100"))
+                                             .start()))
+        {
+            cluster.schemaChange(withKeyspace("alter keyspace %s with replication = {'class': 'SimpleStrategy', 'replication_factor':1}"));
+            cluster.schemaChange(withKeyspace("create table %s.tbl (id bigint primary key, value text) with compaction = {'class':'UnifiedCompactionStrategy', 'target_sstable_size' : '1MiB'}"));
+            long targetSize = 1L<<20;
+            long targetMin = targetSize * 10 / 16;  // Size must be within sqrt(0.5), sqrt(2) of target, use 1.6 to account for estimations
+            long targetMax = targetSize * 16 / 10;
+            long toWrite = targetSize * nodeCount * dataDirs * 8; // 8 MiB per data directory, to be guaranteed to be over the 1MiB target size, and also different from the base shard count
+            int payloadSize = 1024;
+            cluster.forEach(x -> x.nodetool("disableautocompaction"));
+
+            // The first flush will not have the flush size metric initialized, so first check distribution after compaction.
+            int i = 0;
+            for (; i < 2; ++i)
+            {
+                writeData(cluster, i * toWrite, toWrite, payloadSize);
+                cluster.forEach(x -> x.flush(KEYSPACE));
+            }
+
+            cluster.forEach(x -> x.forceCompact(KEYSPACE, "tbl"));
+            checkSSTableSizes(nodeCount, cluster, targetMin, targetMax);
+
+            // Now check that the sstables created by flushes are of the right size.
+            for (; i < 2; ++i)
+            {
+                writeData(cluster, i * toWrite, toWrite, payloadSize);
+                cluster.forEach(x -> x.flush(KEYSPACE));
+            }
+            checkSSTableSizes(nodeCount, cluster, targetMin, targetMax);
+
+            // Compact again, as this time there will be independent buckets whose splitting must also work correctly.
+            cluster.forEach(x -> x.forceCompact(KEYSPACE, "tbl"));
+            checkSSTableSizes(nodeCount, cluster, targetMin, targetMax);
+        }
+    }
+
+    private static void writeData(Cluster cluster, long offset, long toWrite, int payloadSize)
+    {
+        for (int i = 0; i < toWrite; i += payloadSize)
+            cluster.coordinator(1).execute(withKeyspace("insert into %s.tbl (id, value) values (?, ?)"), ConsistencyLevel.ONE, i + offset, makeRandomString(payloadSize));
+    }
+
+    private void checkSSTableSizes(int nodeCount, Cluster cluster, long targetMin, long targetMax)
+    {
+        for (int i = 1; i <= nodeCount; ++i)
+        {
+            LongSummaryStatistics stats = cluster.get(i).callOnInstance(() -> {
+                ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl");
+                return cfs.getLiveSSTables().stream().mapToLong(SSTableReader::onDiskLength).summaryStatistics();
+            });
+            long sstableCount = stats.getCount();
+            long minSize = stats.getMin();
+            long maxSize = stats.getMax();
+
+            LoggerFactory.getLogger(getClass()).info("Node {} sstables {} min/max size: {}/{} avg {} total {}",
+                                                     i,
+                                                     sstableCount,
+                                                     FBUtilities.prettyPrintMemory(minSize),
+                                                     FBUtilities.prettyPrintMemory(maxSize),
+                                                     FBUtilities.prettyPrintBinary(stats.getAverage(), "", "B"),
+                                                     FBUtilities.prettyPrintMemory(stats.getSum()));
+            assertThat(sstableCount, Matchers.greaterThan(0L));
+            assertThat(minSize, Matchers.greaterThan(targetMin));
+            assertThat(maxSize, Matchers.lessThan(targetMax));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
@@ -99,7 +99,6 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSstableSizeBytes);
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
-        when(controller.areL0ShardsEnabled()).thenReturn(true);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.prioritize(anyList())).thenAnswer(answ -> answ.getArgument(0));
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
@@ -109,9 +108,9 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         // all will be allowed to run. The calculation below assumes (1) that compactions are considered "oversized"
         // if they are more than 1/2 of the max shard size; (2) that mockSSTables uses 15% less than the max SSTable
         // size for that bucket.
-        long topBucketMaxSstableSize = (long) (minSstableSizeBytes * Math.pow(F, numBuckets));
-        long minShardSizeWithoutOversizedCompactions = T * topBucketMaxSstableSize * 2;
-        when(controller.getShardSizeBytes()).thenReturn(minShardSizeWithoutOversizedCompactions);
+//        long topBucketMaxSstableSize = (long) (minSstableSizeBytes * Math.pow(F, numBuckets));
+//        long minShardSizeWithoutOversizedCompactions = T * topBucketMaxSstableSize * 2;
+//        when(controller.getShardSizeBytes()).thenReturn(minShardSizeWithoutOversizedCompactions);
 
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
         List<Collection<SSTableReader>> testBuckets = new ArrayList<>(numBuckets * 2);
@@ -162,7 +161,6 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSize);
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
-        when(controller.areL0ShardsEnabled()).thenReturn(true);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.prioritize(anyList())).thenAnswer(answ -> answ.getArgument(0));
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.agrona.collections.IntArrayList;
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.compaction.unified.Controller;
+import org.apache.cassandra.db.compaction.unified.UnifiedCompactionTask;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Splitter;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Interval;
+import org.apache.cassandra.utils.Overlaps;
+import org.apache.cassandra.utils.Pair;
+import org.hamcrest.Matchers;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStrategyTest
+{
+    @Test
+    public void testGetSelection_Modifier1_Reservations0()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier1_Reservations1()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), 1, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier1_ReservationsMax()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), Integer.MAX_VALUE, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0_Reservations0()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0_Reservations1()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), 1, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0_ReservationsMax()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), Integer.MAX_VALUE, compactors, levels, 100L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0pt5_Reservations0()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), 0, compactors, levels, 20L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0pt5_Reservations1()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), 1, compactors, levels, 20L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    @Test
+    public void testGetSelection_Modifier0pt5_ReservationsMax()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), Integer.MAX_VALUE, compactors, levels, 20L << 30, random.nextInt(20) + 1);
+            }
+    }
+
+    private List<CompactionAggregate.UnifiedAggregate> generateCompactions(int levels, int perLevel, long startSize, double sizeModifier)
+    {
+        double growth = Math.pow(2, 1 - sizeModifier);
+        List<CompactionAggregate.UnifiedAggregate> list = new ArrayList<>();
+        long size = startSize;
+        List<CompactionSSTable> fakeSet = ImmutableList.of(Mockito.mock(CompactionSSTable.class));
+        for (int i = 0; i < levels; ++i)
+        {
+            for (int j = 0; j < perLevel; ++j)
+            {
+                int overlap = (int) Math.max(0, random.nextGaussian() * 5 + 15);
+                CompactionPick pick = CompactionPick.create(UUID.randomUUID(),
+                                                            i,
+                                                            fakeSet,
+                                                            Collections.emptySet(),
+                                                            random.nextInt(20) == 0 ? -1 : 1,
+                                                            size,
+                                                            size);
+                CompactionAggregate.UnifiedAggregate aggregate = Mockito.mock(CompactionAggregate.UnifiedAggregate.class, Mockito.withSettings().stubOnly());
+                when(aggregate.getSelected()).thenReturn(pick);
+                when(aggregate.maxOverlap()).thenReturn(overlap);
+                when(aggregate.toString()).thenAnswer(inv -> toString((CompactionAggregate) inv.getMock()));
+                list.add(aggregate);
+            }
+            size *= growth;
+        }
+        return list;
+    }
+
+    @Test
+    public void testGetSelection_Modifier0_Reservations0_Repeats()
+    {
+        long startSize = 1L << 30;
+        for (int levels = 1; levels < 5; ++levels)
+            for (int compactors = 1; compactors <= 32; compactors *= 2)
+            {
+                testGetSelection(generateCompactionsWithRepeats(levels, 8 + compactors * 4, startSize, 0.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1, false);
+            }
+    }
+
+    private List<CompactionAggregate.UnifiedAggregate> generateCompactionsWithRepeats(int levels, int perLevel, long startSize, double sizeModifier)
+    {
+        double growth = Math.pow(2, 1 - sizeModifier);
+        List<CompactionAggregate.UnifiedAggregate> list = new ArrayList<>();
+        long size = startSize;
+        List<List<CompactionSSTable>> sets = IntStream.range(0, levels * perLevel)
+                                                      .mapToObj(i -> ImmutableList.of(Mockito.mock(CompactionSSTable.class)))
+                                                      .collect(Collectors.toList());
+        ImmutableList.of(Mockito.mock(CompactionSSTable.class));
+        for (int i = 0; i < levels; ++i)
+        {
+            for (int j = 0; j < perLevel; ++j)
+            {
+                int overlap = (int) Math.max(0, random.nextGaussian() * 5 + 15);
+                CompactionPick pick = CompactionPick.create(UUID.randomUUID(),
+                                                            i,
+                                                            sets.get(getRepeatIndex(levels * perLevel, i * perLevel + j)),
+                                                            Collections.emptySet(),
+                                                            random.nextInt(20) == 0 ? -1 : 1,
+                                                            size,
+                                                            size);
+                CompactionAggregate.UnifiedAggregate aggregate = Mockito.mock(CompactionAggregate.UnifiedAggregate.class, Mockito.withSettings().stubOnly());
+                when(aggregate.getSelected()).thenReturn(pick);
+                when(aggregate.maxOverlap()).thenReturn(overlap);
+                when(aggregate.toString()).thenAnswer(inv -> toString((CompactionAggregate) inv.getMock()));
+                list.add(aggregate);
+            }
+            size *= growth;
+        }
+        return list;
+    }
+
+    private int getRepeatIndex(int size, int index)
+    {
+        double d = random.nextGaussian();
+        if (d <= 0.5 || d > 1)
+            return index;
+        else
+            return (int) (d * size - 1);    // high likelihood of hitting the same index
+    }
+
+    static String toString(CompactionAggregate a)
+    {
+        CompactionAggregate.UnifiedAggregate u = (CompactionAggregate.UnifiedAggregate) a;
+        CompactionPick p = u.getSelected();
+        return String.format("level %d size %s overlap %d%s", levelOf(p), FBUtilities.prettyPrintMemory(p.totSizeInBytes()), u.maxOverlap(), p.hotness() < 0 ? " adaptive" : "");
+    }
+
+    public void testGetSelection(List<CompactionAggregate.UnifiedAggregate> compactions, int reservations, int totalCount, int levelCount, long spaceAvailable, int adaptiveLimit)
+    {
+        testGetSelection(compactions, reservations, totalCount, levelCount, spaceAvailable, adaptiveLimit, true);  // do not reject repeated sstables when we only mock one
+    }
+
+    public void testGetSelection(List<CompactionAggregate.UnifiedAggregate> compactions, int reservations, int totalCount, int levelCount, long spaceAvailable, int adaptiveLimit, boolean ignoreRepeats)
+    {
+        System.out.println(String.format("Starting testGetSelection: reservations %d, totalCount %d, levelCount %d, spaceAvailable %s, adaptiveLimit %d",
+                                         reservations,
+                                         totalCount,
+                                         levelCount,
+                                         FBUtilities.prettyPrintMemory(spaceAvailable),
+                                         adaptiveLimit));
+
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
+        when(controller.random()).thenAnswer(inv -> ThreadLocalRandom.current());
+        when(controller.prioritize(anyList())).thenCallRealMethod();
+        when(controller.getReservedThreadsPerLevel()).thenReturn(reservations);
+        when(controller.getOverheadSizeInBytes(any())).thenAnswer(inv -> ((CompactionPick) inv.getArgument(0)).totSizeInBytes());
+        when(controller.isRecentAdaptive(any())).thenAnswer(inv -> ((CompactionPick) inv.getArgument(0)).hotness() < 0);  // hotness is used to mock adaptive
+        when(controller.overlapInclusionMethod()).thenReturn(ignoreRepeats ? Overlaps.InclusionMethod.TRANSITIVE : Overlaps.InclusionMethod.NONE);
+
+        int[] perLevel = new int[levelCount];
+        long remainder = totalCount - levelCount * (long) reservations; // long to deal with MAX_VALUE
+        int allowedExtra = remainder >= 0 ? (int) remainder : totalCount % levelCount == 0 ? 0 : 1; // one remainder per level if reservations cannot be matched
+        if (remainder < 0)
+        {
+            remainder = totalCount % levelCount;
+            reservations = totalCount / levelCount;
+        }
+
+        List<CompactionAggregate> running = new ArrayList<>();
+
+        while (!compactions.isEmpty())
+        {
+            Arrays.fill(perLevel, 0);
+            long spaceTaken = 0;
+            int adaptiveUsed = 0;
+            for (CompactionAggregate aggregate : running)
+            {
+                CompactionPick compaction = aggregate.getSelected();
+                final int level = levelOf(compaction);
+                ++perLevel[level];
+                spaceTaken += compaction.totSizeInBytes();
+                if (controller.isRecentAdaptive(compaction))
+                    ++adaptiveUsed;
+            }
+
+            List<CompactionAggregate> result = UnifiedCompactionStrategy.getSelection(compactions,
+                                                                                      controller,
+                                                                                      totalCount,
+                                                                                      levelCount,
+                                                                                      perLevel,
+                                                                                      spaceAvailable - spaceTaken,
+                                                                                      adaptiveLimit - adaptiveUsed);
+
+            System.out.println("Selected " + result.size() + ": " + result.stream()
+                                                                          .map(a -> toString(a))
+                                                                          .collect(Collectors.joining(", ")));
+            if (result.isEmpty())
+            {
+                Assert.assertFalse(running.isEmpty());
+                // if running is not empty, run through to remove something from it and try again
+            }
+
+
+            compactions.removeAll(result);
+            running.addAll(result);
+
+            Arrays.fill(perLevel, 0);
+            spaceTaken = 0;
+            adaptiveUsed = 0;
+            for (CompactionAggregate aggregate : running)
+            {
+                CompactionPick compaction = aggregate.getSelected();
+                final int level = levelOf(compaction);
+                ++perLevel[level];
+                spaceTaken += compaction.totSizeInBytes();
+                if (controller.isRecentAdaptive(compaction))
+                    ++adaptiveUsed;
+            }
+
+            // Check that restrictions are honored
+            Assert.assertThat(running.size(), Matchers.lessThanOrEqualTo(totalCount));
+            Assert.assertThat(spaceTaken, Matchers.lessThanOrEqualTo(spaceAvailable));
+            Assert.assertThat(adaptiveUsed, Matchers.lessThanOrEqualTo(adaptiveLimit));
+            long remainderUsed = 0;
+            for (int i = 0; i < levelCount; ++i)
+            {
+                Assert.assertThat(perLevel[i], Matchers.lessThanOrEqualTo(reservations + allowedExtra));
+                if (perLevel[i] > reservations)
+                    remainderUsed += perLevel[i] - reservations;
+            }
+            Assert.assertThat(remainderUsed, Matchers.lessThanOrEqualTo(remainder));
+
+            // Check that we do select what we can select
+            if (running.size() < totalCount)
+            {
+                for (int i = 0; i < levelCount; ++i)
+                {
+                    if (perLevel[i] < reservations || (perLevel[i] < reservations + allowedExtra && remainderUsed < remainder))
+                    {
+                        List<CompactionAggregate.UnifiedAggregate> failures = getSelectablePicks(compactions,
+                                                                                                 ignoreRepeats
+                                                                                                   ? Collections.emptySet()
+                                                                                                   : running.stream().flatMap(a -> a.getSelected().sstables().stream()).collect(Collectors.toSet()),
+                                                                                                 spaceAvailable - spaceTaken,
+                                                                                                 adaptiveUsed == adaptiveLimit,
+                                                                                                 controller,
+                                                                                                 i);
+                        Assert.assertThat(failures, Matchers.hasSize(0));
+                    }
+                }
+            }
+
+            // Check priorities were respected
+            for (CompactionAggregate c : result)
+            {
+                CompactionPick p = c.getSelected();
+                int level = levelOf(p);
+                for (CompactionAggregate.UnifiedAggregate other : getSelectablePicks(compactions,
+                                                                                     ignoreRepeats
+                                                                                       ? Collections.emptySet()
+                                                                                       : running.stream().flatMap(a -> a.getSelected().sstables().stream()).collect(Collectors.toSet()),
+                                                                                     spaceAvailable - spaceTaken + p.totSizeInBytes(),
+                                                                                     controller.isRecentAdaptive(p) ? false : adaptiveUsed == adaptiveLimit,
+                                                                                     controller,
+                                                                                     level))
+                {
+                    final CompactionAggregate.UnifiedAggregate unifiedAggregate = (CompactionAggregate.UnifiedAggregate) c;
+                    Assert.assertThat(other.maxOverlap(), Matchers.lessThanOrEqualTo(unifiedAggregate.maxOverlap()));
+                    if (other.maxOverlap() == unifiedAggregate.maxOverlap())
+                        Assert.assertThat(other.bucketIndex(), Matchers.lessThanOrEqualTo(unifiedAggregate.bucketIndex()));
+                }
+            }
+
+
+            // randomly simulate some of them completing
+            int toRemove = (running.size() + 1) / 2; // round up, to remove one for size == 1
+            for (int i = 0; i < toRemove; ++i)
+                running.remove(random.nextInt(running.size()));
+        }
+    }
+
+    private static <T extends CompactionAggregate> List<T> getSelectablePicks(List<T> compactions, Set<CompactionSSTable> rejectIfContained, long spaceRemaining, boolean adaptiveAtLimit, Controller controller, int level)
+    {
+        List<T> failures = new ArrayList<>();
+        for (T compaction : compactions)
+        {
+            CompactionPick x = compaction.getSelected();
+            if (!isSelectable(rejectIfContained, spaceRemaining, adaptiveAtLimit, controller, level, x))
+                continue;
+
+            failures.add(compaction);
+        }
+        return failures;
+    }
+
+    private static boolean isSelectable(Set<CompactionSSTable> rejectIfContained, long spaceRemaining, boolean adaptiveAtLimit, Controller controller, int level, CompactionPick x)
+    {
+        if (levelOf(x) != level) return false;
+        if (x.totSizeInBytes() > spaceRemaining) return false;
+        if (adaptiveAtLimit && controller.isRecentAdaptive(x)) return false;
+        if (!Collections.disjoint(x.sstables(), rejectIfContained)) return false;
+        return true;
+    }
+
+    private static int levelOf(CompactionPick x)
+    {
+        return (int) x.parent();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -165,18 +165,18 @@ public class StaticControllerTest extends ControllerTest
         StaticController controller = new StaticController(env,
                                                            Ws,
                                                            Controller.DEFAULT_SURVIVAL_FACTORS,
-                                                           dataSizeGB << 10,
-                                                           numShards,
-                                                           sstableSizeMB,
+                                                           dataSizeGB << 30,
+                                                           0,
                                                            0,
                                                            0,
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
                                                            Controller.DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
-                                                           Controller.DEFAULT_L0_SHARDS_ENABLED,
-                                                           Controller.DEFAULT_BASE_SHARD_COUNT,
-                                                           Controller.DEFAULT_TARGET_SSTABLE_SIZE,
+                                                           numShards,
+                                                           sstableSizeMB << 20,
+                                                           Controller.DEFAULT_SSTABLE_GROWTH,
+                                                           Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);
@@ -189,18 +189,18 @@ public class StaticControllerTest extends ControllerTest
         StaticController controller = new StaticController(env,
                                                            Ws,
                                                            Controller.DEFAULT_SURVIVAL_FACTORS,
-                                                           dataSizeGB << 10,
-                                                           numShards,
-                                                           sstableSizeMB,
+                                                           dataSizeGB << 30,
+                                                           0,
                                                            0,
                                                            0,
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
                                                            Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
-                                                           Controller.DEFAULT_L0_SHARDS_ENABLED,
-                                                           Controller.DEFAULT_BASE_SHARD_COUNT,
-                                                           Controller.DEFAULT_TARGET_SSTABLE_SIZE,
+                                                           numShards,
+                                                           sstableSizeMB << 20,
+                                                           Controller.DEFAULT_SSTABLE_GROWTH,
+                                                           Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);
@@ -213,18 +213,18 @@ public class StaticControllerTest extends ControllerTest
         StaticController controller = new StaticController(env,
                                                            Ws,
                                                            Controller.DEFAULT_SURVIVAL_FACTORS,
-                                                           dataSizeGB << 10,
-                                                           numShards,
-                                                           sstableSizeMB,
+                                                           dataSizeGB << 30,
+                                                           0,
                                                            0,
                                                            0,
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
                                                            Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
-                                                           Controller.DEFAULT_L0_SHARDS_ENABLED,
-                                                           Controller.DEFAULT_BASE_SHARD_COUNT,
-                                                           Controller.DEFAULT_TARGET_SSTABLE_SIZE,
+                                                           numShards,
+                                                           sstableSizeMB << 20,
+                                                           Controller.DEFAULT_SSTABLE_GROWTH,
+                                                           Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);
@@ -232,9 +232,11 @@ public class StaticControllerTest extends ControllerTest
     }
 
     @Test
-    public void testMaxSpaceOverhead()
+    public void testV1MaxSpaceOverhead()
     {
         Map<String, String> options = new HashMap<>();
+        options.put(Controller.NUM_SHARDS_OPTION, Integer.toString(numShards));
+        options.put(Controller.MIN_SSTABLE_SIZE_OPTION, "20MiB");
 
         Controller controller = testFromOptions(false, options);
         assertTrue(controller instanceof StaticController);
@@ -279,11 +281,11 @@ public class StaticControllerTest extends ControllerTest
     {
         Map<String, String> options = new HashMap<>();
         Controller controller = testFromOptions(false, options);
-        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSizeMB * controller.maxSpaceOverhead / controller.minSstableSizeMB);
+        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSize * controller.maxSpaceOverhead / controller.minSSTableSize);
 
         options.put(Controller.MAX_SPACE_OVERHEAD_OPTION, "0.1");
         controller = testFromOptions(false, options);
-        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSizeMB * controller.maxSpaceOverhead / controller.minSstableSizeMB);
+        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSize * controller.maxSpaceOverhead / controller.minSSTableSize);
 
         options.put(Controller.MAX_SSTABLES_TO_COMPACT_OPTION, "100");
         controller = testFromOptions(false, options);
@@ -291,7 +293,7 @@ public class StaticControllerTest extends ControllerTest
 
         options.put(Controller.MAX_SSTABLES_TO_COMPACT_OPTION, "0");
         controller = testFromOptions(false, options);
-        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSizeMB * controller.maxSpaceOverhead / controller.minSstableSizeMB);
+        assertTrue(controller.maxSSTablesToCompact <= controller.dataSetSize * controller.maxSpaceOverhead / controller.minSSTableSize);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/utils/OverlapsTest.java
+++ b/test/unit/org/apache/cassandra/utils/OverlapsTest.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.common.collect.Ordering;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.agrona.collections.IntArrayList;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class OverlapsTest
+{
+    Random random = new Random(1);
+
+    @Test
+    public void testConstructOverlapsMap()
+    {
+        Interval<Integer, String>[] input = new Interval[]{
+        Interval.create(1, 5, "A"),
+        Interval.create(1, 3, "B"),
+        Interval.create(1, 3, "C"),
+        // expected 1 - 2, ABC
+        Interval.create(2, 6, "D"),
+        // expected 2 - 3, ABCD
+        Interval.create(3, 7, "E"),
+        // expected 3 - 5 ADE
+        Interval.create(5, 7, "F"),
+        // expected 5 - 6 DEF
+        // expected 6 - 7 EF
+        Interval.create(7, 9, "G"),
+        // hole
+        // expected 7 - 9 G
+        Interval.create(10, 13, "H"),
+        // expected 10 - 11 H
+        Interval.create(11, 12, "I"),
+        // expected 11 - 12 HI
+        // expected 12 - 13 H
+        Interval.create(1399, 1799, "J"),
+        Interval.create(1402, 1798, "K"),
+
+        Interval.create(2102, 2402, "L"),
+        Interval.create(2099, 2398, "M"),
+
+        Interval.create(2502, 2998, "N"),
+        Interval.create(2499, 2601, "O"),
+        Interval.create(2602, 3001, "P"),
+        Interval.create(2799, 3401, "Q"),
+
+        Interval.create(3502, 3998, "R"),
+        Interval.create(3499, 3602, "S"),
+        Interval.create(3601, 4001, "T"),
+        };
+        String[] allOverlapsManual = new String[]{
+        "ABC",
+        "ABCD",
+        "ADE",
+        "DEF",
+        "EF",
+        "G",
+        "",
+        "H",
+        "HI",
+        "H",
+        "",
+        "J",
+        "JK",
+        "J",
+        "",
+        "M",
+        "LM",
+        "L",
+        "",
+        "O",
+        "NO",
+        "N",
+        "NP",
+        "NPQ",
+        "PQ",
+        "Q",
+        "",
+        "S",
+        "RS",
+        "RST",
+        "RT",
+        "T"
+        };
+        String[] expectedSubsumed = new String[]{
+        "ABCD",
+        "ADE",
+        "DEF",
+        "G",
+        "HI",
+        "JK",
+        "LM",
+        "NO",
+        "NPQ",
+        "RST",
+        };
+        List<String> allOverlaps = getAllOverlaps(input, false);
+        assertEquals(Arrays.asList(allOverlapsManual), allOverlaps);
+
+        List<String> subsumed = subsumeContainedNeighbours(allOverlaps);
+        assertEquals(Arrays.asList(expectedSubsumed), subsumed);
+
+        List<Set<Interval<Integer, String>>> overlaps = Overlaps.constructOverlapSets(Arrays.asList(input),
+                                                                                      (x, y) -> x.min >= y.max,
+                                                                                      Comparator.comparingInt(x -> x.min),
+                                                                                      Comparator.comparingInt(x -> x.max));
+
+        List<String> result = mapOverlapSetsToStrings(overlaps);
+        assertEquals(subsumed, result);
+    }
+
+    private static List<String> mapOverlapSetsToStrings(List<Set<Interval<Integer, String>>> overlaps)
+    {
+        List<String> result = overlaps.stream()
+                                      .map(set -> set.stream()
+                                                     .map(x -> x.data)
+                                                     .sorted()
+                                                     .collect(Collectors.joining()))
+                                      .collect(Collectors.toList());
+        return result;
+    }
+
+    @Test
+    public void testConstructOverlapsMapRandom()
+    {
+        int size;
+        int range = 100;
+        Random rand = new Random();
+        for (int i = 0; i < 1000; ++i)
+        {
+            size = rand.nextInt(range) + 2;
+            Interval<Integer, String>[] input = new Interval[size];
+            char c = 'A';
+            for (int j = 0; j < size; ++j)
+            {
+                int start = rand.nextInt(range);
+                input[j] = (new Interval<>(start, start + 1 + random.nextInt(range - start), Character.toString(c++)));
+            }
+
+            boolean endInclusive = rand.nextBoolean();
+            List<String> expected = subsumeContainedNeighbours(getAllOverlaps(input, endInclusive));
+
+            List<Set<Interval<Integer, String>>> overlaps =
+            Overlaps.constructOverlapSets(Arrays.asList(input),
+                                          endInclusive ? (x, y) -> x.min > y.max
+                                                       : (x, y) -> x.min >= y.max,
+                                          Comparator.comparingInt(x -> x.min),
+                                          Comparator.comparingInt(x -> x.max));
+            List<String> result = mapOverlapSetsToStrings(overlaps);
+            assertEquals("Input " + Arrays.asList(input), expected, result);
+        }
+    }
+
+    private static List<String> getAllOverlaps(Interval<Integer, String>[] input, boolean endInclusive)
+    {
+        int min = Arrays.stream(input).mapToInt(x -> x.min).min().getAsInt();
+        int max = Arrays.stream(input).mapToInt(x -> x.max).max().getAsInt();
+        List<String> allOverlaps = new ArrayList<>();
+        IntStream.range(min, max)
+                 .mapToObj(i -> Arrays.stream(input)
+                                      .filter(iv -> i >= iv.min && (i < iv.max || endInclusive && i == iv.max))
+                                      .map(iv -> iv.data)
+                                      .collect(Collectors.joining()))
+                 .reduce(null, (prev, curr) -> {
+                     if (curr.equals(prev))
+                         return prev;
+                     allOverlaps.add(curr);
+                     return curr;
+                 });
+        return allOverlaps;
+    }
+
+    private List<String> subsumeContainedNeighbours(List<String> allOverlaps)
+    {
+        List<String> subsumed = new ArrayList<>();
+        String last = "";
+        for (String overlap : allOverlaps)
+        {
+            if (containsAll(last, overlap))
+                continue;
+            if (containsAll(overlap, last))
+            {
+                last = overlap;
+                continue;
+            }
+            subsumed.add(last);
+            last = overlap;
+        }
+        assert !last.isEmpty();
+        subsumed.add(last);
+        return subsumed;
+    }
+
+    boolean containsAll(String a, String b)
+    {
+        if (a.contains(b))
+            return true;
+        return asSet(a).containsAll(asSet(b));
+    }
+
+    private static Set<Character> asSet(String a)
+    {
+        Set<Character> as = new HashSet<>();
+        for (int i = 0; i < a.length(); ++i)
+            as.add(a.charAt(i));
+        return as;
+    }
+
+
+    @Test
+    public void testAssignOverlapsIntoBuckets()
+    {
+        String[] sets = new String[]{
+        "ABCD",
+        "ADE",
+        "EF",
+        "HI",
+        "LN",
+        "NO",
+        "NPQ",
+        "RST",
+        };
+        String[] none3 = new String[]{
+        "ABCD",
+        "ADE",
+        "NPQ",
+        "RST",
+        };
+        int[] noneUnselected = new int[]{2, 3, 4, 5};
+        String[] single3 = new String[]{
+        "ABCDE",
+        "LNOPQ",
+        "RST",
+        };
+        int[] singleUnselected = new int[]{2, 3};
+        String[] transitive3 = new String[]{
+        "ABCDEF",
+        "LNOPQ",
+        "RST",
+        };
+        int[] transitiveUnselected = new int[]{3};
+
+        List<Set<Character>> input = Arrays.stream(sets).map(OverlapsTest::asSet).collect(Collectors.toList());
+
+        verifyAssignment(Overlaps.InclusionMethod.NONE, input, none3, noneUnselected);
+
+        verifyAssignment(Overlaps.InclusionMethod.SINGLE, input, single3, singleUnselected);
+
+        verifyAssignment(Overlaps.InclusionMethod.TRANSITIVE, input, transitive3, transitiveUnselected);
+    }
+
+    private void verifyAssignment(Overlaps.InclusionMethod method, List<Set<Character>> input, String[] expected, int[] expectedUnselected)
+    {
+        List<String> actual;
+        IntArrayList unselected = new IntArrayList();
+        actual = Overlaps.assignOverlapsIntoBuckets(3, method, input, this::makeBucket, s -> unselected.add(input.indexOf(s)));
+        assertEquals(Arrays.asList(expected), actual);
+        assertArrayEquals(expectedUnselected, unselected.toIntArray());
+    }
+
+    private String makeBucket(List<Set<Character>> sets, int startIndex, int endIndex)
+    {
+        Set<Character> bucket = new HashSet<>();
+        for (int i = startIndex; i < endIndex; ++i)
+            bucket.addAll(sets.get(i));
+        return bucket.stream()
+                     .sorted()
+                     .map(x -> x.toString())
+                     .collect(Collectors.joining());
+    }
+
+    @Test
+    public void testMultiSetPullOldest()
+    {
+        // In this test each letter stands for an sstable, ordered alphabetically (i.e. A is oldest)
+        Assert.assertEquals("ABCD", pullLast(3, "ACD", "BCD"));
+        Assert.assertEquals("ABC", pullLast(2, "ACD", "BCD"));
+        Assert.assertEquals("BC", pullLast(2, "CDE", "BCD"));
+    }
+
+
+    @Test
+    public void testMultiSetPullOldestRandom()
+    {
+        int size;
+        int range = 100;
+        Random rand = new Random();
+        for (int i = 0; i < 100; ++i)
+        {
+            size = rand.nextInt(range) + 2;
+            Interval<Integer, String>[] input = new Interval[size];
+            char c = 'A';
+            for (int j = 0; j < size; ++j)
+            {
+                int start = rand.nextInt(range);
+                input[j] = (new Interval<>(start, start + 1 + random.nextInt(range - start), Character.toString(c++)));
+            }
+
+            List<Set<Interval<Integer, String>>> overlaps = Overlaps.constructOverlapSets(Arrays.asList(input),
+                                                                                          (x, y) -> x.min >= y.max,
+                                                                                          Comparator.comparingInt(x -> x.min),
+                                                                                          Comparator.comparingInt(x -> x.max));
+            String[] overlapSets = mapOverlapSetsToStrings(overlaps).toArray(new String[0]);
+            int maxOverlap = Arrays.stream(overlapSets).mapToInt(String::length).max().getAsInt();
+            for (int limit = 1; limit <= maxOverlap + 1; ++limit)
+            {
+                String pulled = pullLast(limit, overlapSets);
+                String message = pulled + " from " + overlapSets + " limit " + limit;
+                Assert.assertTrue(message + ", size " + pulled.length(), pulled.length() >= Math.min(size, limit));
+                String e = "";
+                for (char j = 'A'; j < pulled.length() + 'A'; ++j)
+                    e += Character.toString(j);
+                Assert.assertEquals("Must select oldest " + message, e, pulled);
+                int countAtLimit = 0;
+                for (String set : overlapSets)
+                {
+                    int count = 0;
+                    for (int j = 0; j < set.length(); ++j)
+                        if (pulled.indexOf(set.charAt(j)) >= 0)
+                            ++count;
+                    Assert.assertTrue(message + " set " + set + " elements " + count, count <= limit);
+                    if (count == limit)
+                        ++countAtLimit;
+                }
+                if (pulled.length() < size)
+                    Assert.assertTrue(message + " must have at least one set of size " + limit, countAtLimit > 0);
+                else
+                    Assert.assertTrue(message,limit >= maxOverlap);
+            }
+        }
+    }
+
+    String pullLast(int limit, String... inputOverlapSets)
+    {
+        List<Set<String>> overlapSets = Arrays.stream(inputOverlapSets)
+                                              .map(s -> IntStream.range(0, s.length())
+                                                                 .mapToObj(i -> Character.toString(s.charAt(i)))
+                                                                 .collect(Collectors.toSet()))
+                                              .collect(Collectors.toList());
+
+        List<String> allObjectsSorted = overlapSets.stream()
+                                                   .flatMap(x -> x.stream())
+                                                   .sorted(Ordering.natural().reversed())
+                                                   .distinct()
+                                                   .collect(Collectors.toList());
+
+        Collection<String> pulled = Overlaps.pullLastWithOverlapLimit(allObjectsSorted, overlapSets, limit);
+        return pulled.stream().sorted().collect(Collectors.joining());
+    }
+}


### PR DESCRIPTION
Add `sstable_growth` and `reserved_threads_per_level`.
Add support for V1-compatible mode.
Prioritize lower levels on equal overlap.
Remove `l0_shards_enabled` parameter, use `base_shard_count: 1`.
Correct rounding in `getNumShards`.
Deal with sstable repetition in non-transitive modes.
Extract Overlaps class.
Improve documentation.
Add a lot more tests.
