### PR TITLE
STAR-1880: Permit a mode where UCS reserved threads are also used for lower levels

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.commitlog.IntervalSet;
 import org.apache.cassandra.db.compaction.unified.Controller;
+import org.apache.cassandra.db.compaction.unified.Reservations;
 import org.apache.cassandra.db.compaction.unified.ShardedMultiWriter;
 import org.apache.cassandra.db.compaction.unified.UnifiedCompactionTask;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -483,23 +484,31 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                                       List<CompactionAggregate.UnifiedAggregate> pending)
     {
         long totalCompactionLimit = controller.maxCompactionSpaceBytes();
+        int levelCount = limits.levelCount;
         for (CompactionAggregate.UnifiedAggregate aggregate : pending)
         {
             warnIfSizeAbove(aggregate, totalCompactionLimit);
 
+            // Make sure the level count includes all levels for which we have sstables (to be ready to compact
+            // as soon as the threshold is crossed)...
+            levelCount = Math.max(levelCount, aggregate.bucketIndex() + 1);
             CompactionPick selected = aggregate.getSelected();
             if (selected != null)
-                limits.levelCount = Math.max(limits.levelCount, levelOf(selected));
+            {
+                // ... and also the levels that a layout-preserving selection would create.
+                levelCount = Math.max(levelCount, levelOf(selected) + 1);
+            }
         }
+        int[] perLevel = limits.perLevel;
+        if (levelCount != perLevel.length)
+            perLevel = Arrays.copyOf(perLevel, levelCount);
 
-        final List<CompactionAggregate> selection = getSelection(pending,
-                                                                 controller,
-                                                                 limits.maxCompactions,
-                                                                 limits.levelCount,
-                                                                 limits.perLevel,
-                                                                 limits.spaceAvailable,
-                                                                 limits.remainingAdaptiveCompactions);
-        return selection;
+        return getSelection(pending,
+                            controller,
+                            limits.maxCompactions,
+                            perLevel,
+                            limits.spaceAvailable,
+                            limits.remainingAdaptiveCompactions);
     }
 
     /**
@@ -514,19 +523,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
         List<CompactionAggregate.UnifiedAggregate> pending = getPendingCompactionAggregates(limits.spaceAvailable, gcBefore);
         setPendingCompactionAggregates(pending);
-
-        for (CompactionAggregate.UnifiedAggregate aggregate : pending)
-        {
-            // Make sure the level count includes all levels for which we have sstables (to be ready to compact
-            // as soon as the threshold is crossed)...
-            limits.levelCount = Math.max(limits.levelCount, aggregate.bucketIndex() + 1);
-            CompactionPick selected = aggregate.getSelected();
-            if (selected != null)
-            {
-                // ... and also the levels that a layout-preserving selection would create.
-                limits.levelCount = Math.max(limits.levelCount, levelOf(selected) + 1);
-            }
-        }
 
         return updateLevelCountWithParentAndGetSelection(limits, pending);
     }
@@ -640,7 +636,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                         FBUtilities.prettyPrintMemory(spaceOverheadLimit),
                         controller.getMaxSpaceOverhead() * 100,
                         FBUtilities.prettyPrintMemory(controller.getDataSetSizeBytes()),
-                        Controller.DATASET_SIZE_OPTION_GB,
+                        Controller.DATASET_SIZE_OPTION,
                         Controller.MAX_SPACE_OVERHEAD_OPTION);
     }
 
@@ -658,7 +654,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      *
      * @param pending list of all current aggregates with possible selection for each bucket
      * @param totalCount maximum number of compactions permitted to run
-     * @param levelCount number of levels in use
      * @param perLevel int array with the number of in-progress compactions per level
      * @param spaceAvailable amount of space in bytes available for the new compactions
      * @param remainingAdaptiveCompactions number of adaptive compactions (i.e. ones triggered by scaling parameter
@@ -668,32 +663,23 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     static List<CompactionAggregate> getSelection(List<CompactionAggregate.UnifiedAggregate> pending,
                                                   Controller controller,
                                                   int totalCount,
-                                                  int levelCount,
                                                   int[] perLevel,
                                                   long spaceAvailable,
                                                   int remainingAdaptiveCompactions)
     {
-        // Prepare parameters for the selection.
-        int reservedThreadsTarget = controller.getReservedThreadsPerLevel();
-        // Each level has this number of tasks reserved for it.
-        int perLevelCount = Math.min(totalCount / levelCount, reservedThreadsTarget);
-        // The remainder is distributed according to the prioritization.
-        int remainder = totalCount - perLevelCount * levelCount;
-        // If the user requested more than we can give, do not allow more than one extra per level.
-        boolean oneRemainderPerLevel = perLevelCount < reservedThreadsTarget;
+        Reservations reservations = Reservations.create(totalCount,
+                                                        perLevel,
+                                                        controller.getReservedThreads(),
+                                                        controller.getReservationsType());
         // If the inclusion method is not transitive, we may have multiple buckets/selections for the same sstable.
         boolean shouldCheckSSTableSelected = controller.overlapInclusionMethod() != Overlaps.InclusionMethod.TRANSITIVE;
         // If so, make sure we only select one such compaction.
         Set<CompactionSSTable> selectedSSTables = shouldCheckSSTableSelected ? new HashSet<>() : null;
 
-        // Calculate how many new ones we can add in each level, and how many we can assign randomly.
         int remaining = totalCount;
-        for (int i = 0; i < levelCount; ++i)
-        {
-            remaining -= perLevel[i];
-            if (perLevel[i] > perLevelCount)
-                remainder -= perLevel[i] - perLevelCount;
-        }
+        for (int countInLevel : perLevel)
+            remaining -= countInLevel;
+
         // Note: if we are in the middle of changes in the parameters or level count, remainder might become negative.
         // This is okay, some buckets will temporarily not get their rightful share until these tasks complete.
 
@@ -726,22 +712,15 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 continue; // do not allow more than remainingAdaptiveCompactions to limit latency spikes upon changing W
 
             if (shouldCheckSSTableSelected && !Collections.disjoint(selectedSSTables, pick.sstables()))
-                continue; // do not allow multiple selections on the same sstable
+                continue; // do not allow multiple selections of the same sstable
 
-            if (perLevel[currentLevel] >= perLevelCount)
-            {
-                if (remainder <= 0)
-                    continue;  // share used up and no remainder to distribute
-                if (oneRemainderPerLevel && perLevel[currentLevel] > perLevelCount)
-                    continue;  // this level is already using up all its share + one, we can ignore candidate altogether
-                --remainder;
-            }
-            // Note: if any additional checks are added, make sure remainder is not decreased if they fail.
+            if (!reservations.accept(currentLevel))
+                continue; // honor the reserved thread counts
+            // Note: the reservations tracker assumes it is the last check and a pick is accepted if it returns true.
 
             if (isAdaptive)
                 remainingAdaptiveCompactions--;
             --remaining;
-            ++perLevel[currentLevel];
             spaceAvailable -= overheadSizeInBytes;
             selected.add(aggregate);
             if (shouldCheckSSTableSelected)
@@ -751,9 +730,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 break;
         }
 
-        logger.debug("Selected {} compactions (out of {} pending). Compactions per level {} (reservations {}{}) remaining reserved {} non-reserved {}.",
-                     selected.size(), proposed, perLevel, perLevelCount, oneRemainderPerLevel ? "+1" : "", remaining - remainder, remainder);
-
+        reservations.debugOutput(selected.size(), proposed, remaining);
         return selected;
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -112,6 +112,7 @@ public class AdaptiveController extends Controller
                               long targetSStableSize,
                               double sstableGrowthModifier,
                               int reservedThreadsPerLevel,
+                              Reservations.Type reservationsType,
                               Overlaps.InclusionMethod overlapInclusionMethod,
                               int intervalSec,
                               int minScalingParameter,
@@ -137,6 +138,7 @@ public class AdaptiveController extends Controller
               targetSStableSize,
               sstableGrowthModifier,
               reservedThreadsPerLevel,
+              reservationsType,
               overlapInclusionMethod);
 
         this.scalingParameters = scalingParameters;
@@ -164,6 +166,7 @@ public class AdaptiveController extends Controller
                                   long targetSSTableSize,
                                   double sstableGrowthModifier,
                                   int reservedThreadsPerLevel,
+                                  Reservations.Type reservationsType,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   String keyspaceName,
                                   String tableName,
@@ -260,6 +263,7 @@ public class AdaptiveController extends Controller
                                       targetSSTableSize,
                                       sstableGrowthModifier,
                                       reservedThreadsPerLevel,
+                                      reservationsType,
                                       overlapInclusionMethod,
                                       intervalSec,
                                       minScalingParameter,

--- a/src/java/org/apache/cassandra/db/compaction/unified/Reservations.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Reservations.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reservations management for compaction. Defines the two types of reservations, and implements the code for accepting
+ * or rejecting compactions to satisfy the reservation requirements.
+ */
+public abstract class Reservations
+{
+    public enum Type
+    {
+        /** The given number of reservations can be used only for the level. */
+        PER_LEVEL,
+        /** The reservations can be used for the level, or any one below it. */
+        LEVEL_OR_BELOW
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(Reservations.class);
+
+    /** Number of compactions to reserve for each level. */
+    final int perLevelCount;
+    /** Remainder of compactions to be distributed among the levels. */
+    final int remainder;
+    /** Whether only one compaction over the reservation count is allowed per level. */
+    final boolean oneRemainderPerLevel;
+    /** Number of compactions already running or selected in each level. */
+    final int[] perLevel;
+
+    private Reservations(int totalCount, int[] perLevel, int reservedThreadsTarget)
+    {
+        this.perLevel = perLevel;
+
+        int levelCount = perLevel.length;
+        // Each level has this number of tasks reserved for it.
+        perLevelCount = Math.min(totalCount / levelCount, reservedThreadsTarget);
+        // The remainder is distributed according to the prioritization.
+        remainder = totalCount - perLevelCount * levelCount;
+        // If the user requested more than we can give, do not allow more than one extra per level.
+        oneRemainderPerLevel = perLevelCount < reservedThreadsTarget;
+    }
+
+    public abstract boolean accept(int inLevel);
+    public abstract void debugOutput(int selectedCount, int proposedCount, int remaining);
+
+    public static Reservations create(int totalCount, int[] perLevel, int reservedThreadsTarget, Type reservationsType)
+    {
+        if (reservedThreadsTarget == 0)
+            return new Trivial(totalCount, perLevel);
+        return reservationsType == Type.PER_LEVEL
+               ? new PerLevel(totalCount, perLevel, reservedThreadsTarget)
+               : new LevelOrBelow(totalCount, perLevel, reservedThreadsTarget);
+    }
+
+    /**
+     * Trivial tracker used when there are no reservations. All compactions are accepted.
+     */
+    private static class Trivial extends Reservations
+    {
+        private Trivial(int totalCount, int[] perLevel)
+        {
+            super(totalCount, perLevel, 0);
+        }
+
+        @Override
+        public boolean accept(int inLevel)
+        {
+            ++perLevel[inLevel];
+            return true;
+        }
+
+        @Override
+        public void debugOutput(int selectedCount, int proposedCount, int remaining)
+        {
+            logger.debug("Selected {} compactions (out of {} pending). Compactions per level {} (no reservations) remaining {}.",
+                         selectedCount, proposedCount, perLevel, remaining);
+        }
+    }
+
+    /**
+     * Per-level tracker.
+     * <p>
+     * Reservations are applied by tracking how much of the remainder threads are being used, and only allowing
+     * compactions in a level if their number is below the per-level count, or if there is a remainder slot to be given.
+     */
+    private static class PerLevel extends Reservations
+    {
+        int remainderDistributed;
+
+        PerLevel(int totalCount, int[] perLevel, int reservedThreadsTarget)
+        {
+            super(totalCount, perLevel, reservedThreadsTarget);
+
+            remainderDistributed = 0;
+            for (int countInLevel : perLevel)
+                if (countInLevel > perLevelCount)
+                    remainderDistributed += countInLevel - perLevelCount;
+        }
+
+        @Override
+        public boolean accept(int inLevel)
+        {
+            if (perLevel[inLevel] >= perLevelCount)
+            {
+                if (remainderDistributed >= remainder)
+                    return false;  // share used up and no remainder to distribute
+                if (oneRemainderPerLevel && perLevel[inLevel] > perLevelCount)
+                    return false;  // this level is already using up all its share + one
+                ++remainderDistributed;
+            }
+            ++perLevel[inLevel];
+            return true;
+        }
+
+        @Override
+        public void debugOutput(int selectedCount, int proposedCount, int remaining)
+        {
+            int remainingNonReserved = remainder - remainderDistributed;
+            logger.debug("Selected {} compactions (out of {} pending). Compactions per level {} (reservations {}{}) remaining reserved {} non-reserved {}.",
+                         selectedCount, proposedCount, perLevel, perLevelCount, oneRemainderPerLevel ? "+1" : "", remaining - remainingNonReserved, remainingNonReserved);
+        }
+    }
+
+    /**
+     * Tracker for the level or below case.
+     * <p>
+     * For any given level, the reservations are satisfied if the total sum of compactions for the level and all levels
+     * above it is at most the product of the number of levels and the per-level count, plus any remainder (up to the
+     * number of levels when oneRemainderPerLevel is true).
+     * <p>
+     * To permit a compaction, we gather this sum for all levels above, and make sure this property will not be violated
+     * by adding the new compaction for the current, as well as all levels below it. The latter is necessary because
+     * a lower level may have already used up all allocations for this one.
+     */
+    private static class LevelOrBelow extends Reservations
+    {
+        LevelOrBelow(int totalCount, int[] perLevel, int reservedThreadsTarget)
+        {
+            super(totalCount, perLevel, reservedThreadsTarget);
+        }
+
+        @Override
+        public boolean accept(int inLevel)
+        {
+            // Limit the sum of the number of threads of any level and all higher to their number
+            // times perLevelCount, plus any remainder (up to the number when oneRemainderPerLevel is true).
+            int sum = 0;
+            int permitted = 0;
+            int permittedRemainder = oneRemainderPerLevel ? 0 : remainder;
+            int level = perLevel.length - 1;
+            // For all higher levels, calculate the total number of threads used and permitted.
+            for (; level > inLevel; --level)
+            {
+                sum += perLevel[level];
+                permitted += perLevelCount;
+                if (oneRemainderPerLevel && permittedRemainder < remainder)
+                    ++permittedRemainder;
+            }
+
+            // For this level and all below, check that the limit is not yet hit.
+            for (; level >= 0; --level)
+            {
+                sum += perLevel[level];
+                permitted += perLevelCount;
+                if (oneRemainderPerLevel && permittedRemainder < remainder)
+                    ++permittedRemainder;
+                if (sum >= permitted + permittedRemainder)
+                    return false; // some lower level used up our share
+            }
+            ++perLevel[inLevel];
+            return true;
+        }
+
+        @Override
+        public void debugOutput(int selectedCount, int proposedCount, int remaining)
+        {
+            logger.debug("Selected {} compactions (out of {} pending). Compactions per level {} (reservations level or below {}{}) remaining {}.",
+                         selectedCount, proposedCount, perLevel, perLevelCount, oneRemainderPerLevel ? "+1" : "", remaining);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -62,6 +62,7 @@ public class StaticController extends Controller
                             long targetSStableSize,
                             double sstableGrowthModifier,
                             int reservedThreadsPerLevel,
+                            Reservations.Type reservationsType,
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             String keyspaceName,
                             String tableName)
@@ -81,6 +82,7 @@ public class StaticController extends Controller
               targetSStableSize,
               sstableGrowthModifier,
               reservedThreadsPerLevel,
+              reservationsType,
               overlapInclusionMethod);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
@@ -100,6 +102,7 @@ public class StaticController extends Controller
                                   long targetSStableSize,
                                   double sstableGrowthModifier,
                                   int reservedThreadsPerLevel,
+                                  Reservations.Type reservationsType,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   String keyspaceName,
                                   String tableName,
@@ -146,6 +149,7 @@ public class StaticController extends Controller
                                     targetSStableSize,
                                     sstableGrowthModifier,
                                     reservedThreadsPerLevel,
+                                    reservationsType,
                                     overlapInclusionMethod,
                                     keyspaceName,
                                     tableName);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -69,6 +69,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.compaction.unified.AdaptiveController;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.CostsCalculator;
+import org.apache.cassandra.db.compaction.unified.Reservations;
 import org.apache.cassandra.db.compaction.unified.StaticController;
 import org.apache.cassandra.db.compaction.unified.Environment;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
@@ -404,6 +405,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          targetSSTableSizeMB << 20,
                                                          0,
                                                          0,
+                                                         Reservations.Type.PER_LEVEL,
                                                          overlapInclusionMethod,
                                                          updateTimeSec,
                                                          minW,
@@ -428,6 +430,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        targetSSTableSizeMB << 20,
                                                        0,
                                                        0,
+                                                       Reservations.Type.PER_LEVEL,
                                                        overlapInclusionMethod,
                                                        "ks",
                                                        "tbl");

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionTest.java
@@ -16,172 +16,103 @@
 
 package org.apache.cassandra.db.compaction;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.agrona.collections.IntArrayList;
-import org.apache.cassandra.db.BufferDecoratedKey;
-import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.compaction.unified.Controller;
-import org.apache.cassandra.db.compaction.unified.UnifiedCompactionTask;
-import org.apache.cassandra.dht.IPartitioner;
-import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Splitter;
-import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.db.compaction.unified.Reservations;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.Overlaps;
-import org.apache.cassandra.utils.Pair;
 import org.hamcrest.Matchers;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
+@RunWith(Parameterized.class)
 public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStrategyTest
 {
-    @Test
-    public void testGetSelection_Modifier1_Reservations0()
+    @Parameterized.Parameter(0)
+    public double modifier;
+
+    @Parameterized.Parameter(1)
+    public int reservations;
+
+    @Parameterized.Parameter(2)
+    public Reservations.Type reservationsType;
+
+    @Parameterized.Parameter(3)
+    public int levels;
+
+    @Parameterized.Parameter(4)
+    public int compactors;
+
+    static final long START_SIZE = 1L << 30;
+
+
+    @Parameterized.Parameters(name = "Type {2} Reservations {1} Modifier {0} Levels {3} Compactors {4}")
+    public static List<Object[]> params()
     {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
+        ArrayList<Object[]> params = new ArrayList<>();
+        for (Reservations.Type reservationsType : Reservations.Type.values())
+            for (int reservations : new int[]{ 0, 1, Integer.MAX_VALUE })
+                for (double modifier : new double[]{ 0.0, 0.5, 1.0 })
+                    for (int levels = 1; levels < 5; ++levels)
+                        for (int compactors : new int[] {1, 4, 12, 30})
+                            params.add(new Object[]{ modifier, reservations, reservationsType, levels, compactors });
+        return params;
     }
 
     @Test
-    public void testGetSelection_Modifier1_Reservations1()
+    public void testGetSelection()
     {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), 1, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
+        testGetSelection(generateCompactions(levels, 8 + compactors * 4, START_SIZE, modifier),
+                         reservations,
+                         reservationsType,
+                         compactors,
+                         levels,
+                         100L << 30,
+                         random.nextInt(20) + 1);
     }
 
-    @Test
-    public void testGetSelection_Modifier1_ReservationsMax()
+    boolean ignoreRepeats()
     {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 1.0), Integer.MAX_VALUE, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
+        return true;
     }
 
-    @Test
-    public void testGetSelection_Modifier0_Reservations0()
+    List<CompactionSSTable> getSSTablesSet(List<List<CompactionSSTable>> sets, int levels, int perLevel, int level, int sstableInLevel)
     {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
+        return sets.get(0);
     }
 
-    @Test
-    public void testGetSelection_Modifier0_Reservations1()
+    List<List<CompactionSSTable>> prepareSSTablesSets(int levels, int perLevel)
     {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), 1, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
+        // We are reusing the same set, the construction will ignore it
+        final List<CompactionSSTable> fakeSet = ImmutableList.of(Mockito.mock(CompactionSSTable.class));
+        return ImmutableList.of(fakeSet);
     }
 
-    @Test
-    public void testGetSelection_Modifier0_ReservationsMax()
-    {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.0), Integer.MAX_VALUE, compactors, levels, 100L << 30, random.nextInt(20) + 1);
-            }
-    }
-
-    @Test
-    public void testGetSelection_Modifier0pt5_Reservations0()
-    {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), 0, compactors, levels, 20L << 30, random.nextInt(20) + 1);
-            }
-    }
-
-    @Test
-    public void testGetSelection_Modifier0pt5_Reservations1()
-    {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), 1, compactors, levels, 20L << 30, random.nextInt(20) + 1);
-            }
-    }
-
-    @Test
-    public void testGetSelection_Modifier0pt5_ReservationsMax()
-    {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactions(levels, 8 + compactors * 4, startSize, 0.5), Integer.MAX_VALUE, compactors, levels, 20L << 30, random.nextInt(20) + 1);
-            }
-    }
-
-    private List<CompactionAggregate.UnifiedAggregate> generateCompactions(int levels, int perLevel, long startSize, double sizeModifier)
+    List<CompactionAggregate.UnifiedAggregate> generateCompactions(int levels, int perLevel, long startSize, double sizeModifier)
     {
         double growth = Math.pow(2, 1 - sizeModifier);
         List<CompactionAggregate.UnifiedAggregate> list = new ArrayList<>();
+        List<List<CompactionSSTable>> sets = prepareSSTablesSets(levels, perLevel);
         long size = startSize;
-        List<CompactionSSTable> fakeSet = ImmutableList.of(Mockito.mock(CompactionSSTable.class));
         for (int i = 0; i < levels; ++i)
         {
             for (int j = 0; j < perLevel; ++j)
@@ -189,7 +120,7 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
                 int overlap = (int) Math.max(0, random.nextGaussian() * 5 + 15);
                 CompactionPick pick = CompactionPick.create(UUID.randomUUID(),
                                                             i,
-                                                            fakeSet,
+                                                            getSSTablesSet(sets, levels, perLevel, i, j),
                                                             Collections.emptySet(),
                                                             random.nextInt(20) == 0 ? -1 : 1,
                                                             size,
@@ -203,58 +134,6 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
             size *= growth;
         }
         return list;
-    }
-
-    @Test
-    public void testGetSelection_Modifier0_Reservations0_Repeats()
-    {
-        long startSize = 1L << 30;
-        for (int levels = 1; levels < 5; ++levels)
-            for (int compactors = 1; compactors <= 32; compactors *= 2)
-            {
-                testGetSelection(generateCompactionsWithRepeats(levels, 8 + compactors * 4, startSize, 0.0), 0, compactors, levels, 100L << 30, random.nextInt(20) + 1, false);
-            }
-    }
-
-    private List<CompactionAggregate.UnifiedAggregate> generateCompactionsWithRepeats(int levels, int perLevel, long startSize, double sizeModifier)
-    {
-        double growth = Math.pow(2, 1 - sizeModifier);
-        List<CompactionAggregate.UnifiedAggregate> list = new ArrayList<>();
-        long size = startSize;
-        List<List<CompactionSSTable>> sets = IntStream.range(0, levels * perLevel)
-                                                      .mapToObj(i -> ImmutableList.of(Mockito.mock(CompactionSSTable.class)))
-                                                      .collect(Collectors.toList());
-        ImmutableList.of(Mockito.mock(CompactionSSTable.class));
-        for (int i = 0; i < levels; ++i)
-        {
-            for (int j = 0; j < perLevel; ++j)
-            {
-                int overlap = (int) Math.max(0, random.nextGaussian() * 5 + 15);
-                CompactionPick pick = CompactionPick.create(UUID.randomUUID(),
-                                                            i,
-                                                            sets.get(getRepeatIndex(levels * perLevel, i * perLevel + j)),
-                                                            Collections.emptySet(),
-                                                            random.nextInt(20) == 0 ? -1 : 1,
-                                                            size,
-                                                            size);
-                CompactionAggregate.UnifiedAggregate aggregate = Mockito.mock(CompactionAggregate.UnifiedAggregate.class, Mockito.withSettings().stubOnly());
-                when(aggregate.getSelected()).thenReturn(pick);
-                when(aggregate.maxOverlap()).thenReturn(overlap);
-                when(aggregate.toString()).thenAnswer(inv -> toString((CompactionAggregate) inv.getMock()));
-                list.add(aggregate);
-            }
-            size *= growth;
-        }
-        return list;
-    }
-
-    private int getRepeatIndex(int size, int index)
-    {
-        double d = random.nextGaussian();
-        if (d <= 0.5 || d > 1)
-            return index;
-        else
-            return (int) (d * size - 1);    // high likelihood of hitting the same index
     }
 
     static String toString(CompactionAggregate a)
@@ -264,12 +143,13 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
         return String.format("level %d size %s overlap %d%s", levelOf(p), FBUtilities.prettyPrintMemory(p.totSizeInBytes()), u.maxOverlap(), p.hotness() < 0 ? " adaptive" : "");
     }
 
-    public void testGetSelection(List<CompactionAggregate.UnifiedAggregate> compactions, int reservations, int totalCount, int levelCount, long spaceAvailable, int adaptiveLimit)
-    {
-        testGetSelection(compactions, reservations, totalCount, levelCount, spaceAvailable, adaptiveLimit, true);  // do not reject repeated sstables when we only mock one
-    }
-
-    public void testGetSelection(List<CompactionAggregate.UnifiedAggregate> compactions, int reservations, int totalCount, int levelCount, long spaceAvailable, int adaptiveLimit, boolean ignoreRepeats)
+    public void testGetSelection(List<CompactionAggregate.UnifiedAggregate> compactions,
+                                 int reservations,
+                                 Reservations.Type reservationType,
+                                 int totalCount,
+                                 int levelCount,
+                                 long spaceAvailable,
+                                 int adaptiveLimit)
     {
         System.out.println(String.format("Starting testGetSelection: reservations %d, totalCount %d, levelCount %d, spaceAvailable %s, adaptiveLimit %d",
                                          reservations,
@@ -277,23 +157,22 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
                                          levelCount,
                                          FBUtilities.prettyPrintMemory(spaceAvailable),
                                          adaptiveLimit));
+        boolean ignoreRepeats = ignoreRepeats();
 
         Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.random()).thenAnswer(inv -> ThreadLocalRandom.current());
         when(controller.prioritize(anyList())).thenCallRealMethod();
-        when(controller.getReservedThreadsPerLevel()).thenReturn(reservations);
+        when(controller.getReservedThreads()).thenReturn(reservations);
+        when(controller.getReservationsType()).thenReturn(reservationType);
         when(controller.getOverheadSizeInBytes(any())).thenAnswer(inv -> ((CompactionPick) inv.getArgument(0)).totSizeInBytes());
         when(controller.isRecentAdaptive(any())).thenAnswer(inv -> ((CompactionPick) inv.getArgument(0)).hotness() < 0);  // hotness is used to mock adaptive
         when(controller.overlapInclusionMethod()).thenReturn(ignoreRepeats ? Overlaps.InclusionMethod.TRANSITIVE : Overlaps.InclusionMethod.NONE);
 
         int[] perLevel = new int[levelCount];
-        long remainder = totalCount - levelCount * (long) reservations; // long to deal with MAX_VALUE
-        int allowedExtra = remainder >= 0 ? (int) remainder : totalCount % levelCount == 0 ? 0 : 1; // one remainder per level if reservations cannot be matched
-        if (remainder < 0)
-        {
-            remainder = totalCount % levelCount;
-            reservations = totalCount / levelCount;
-        }
+        int maxReservations = totalCount / levelCount;
+        boolean oneExtra = maxReservations < reservations;
+        reservations = Math.min(reservations, maxReservations);
+        int remainder = totalCount - levelCount * reservations;
 
         List<CompactionAggregate> running = new ArrayList<>();
 
@@ -315,7 +194,6 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
             List<CompactionAggregate> result = UnifiedCompactionStrategy.getSelection(compactions,
                                                                                       controller,
                                                                                       totalCount,
-                                                                                      levelCount,
                                                                                       perLevel,
                                                                                       spaceAvailable - spaceTaken,
                                                                                       adaptiveLimit - adaptiveUsed);
@@ -350,21 +228,14 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
             Assert.assertThat(running.size(), Matchers.lessThanOrEqualTo(totalCount));
             Assert.assertThat(spaceTaken, Matchers.lessThanOrEqualTo(spaceAvailable));
             Assert.assertThat(adaptiveUsed, Matchers.lessThanOrEqualTo(adaptiveLimit));
-            long remainderUsed = 0;
-            for (int i = 0; i < levelCount; ++i)
-            {
-                Assert.assertThat(perLevel[i], Matchers.lessThanOrEqualTo(reservations + allowedExtra));
-                if (perLevel[i] > reservations)
-                    remainderUsed += perLevel[i] - reservations;
-            }
-            Assert.assertThat(remainderUsed, Matchers.lessThanOrEqualTo(remainder));
+            boolean extrasExhausted = verifyReservations(reservationType, reservations, levelCount, perLevel, remainder, oneExtra);
 
             // Check that we do select what we can select
             if (running.size() < totalCount)
             {
                 for (int i = 0; i < levelCount; ++i)
                 {
-                    if (perLevel[i] < reservations || (perLevel[i] < reservations + allowedExtra && remainderUsed < remainder))
+                    if (hasRoomInLevel(reservationType, reservations, remainder, oneExtra, extrasExhausted, perLevel, i))
                     {
                         List<CompactionAggregate.UnifiedAggregate> failures = getSelectablePicks(compactions,
                                                                                                  ignoreRepeats
@@ -406,6 +277,96 @@ public class UnifiedCompactionStrategyGetSelectionTest extends BaseCompactionStr
             for (int i = 0; i < toRemove; ++i)
                 running.remove(random.nextInt(running.size()));
         }
+    }
+
+    private static boolean verifyReservations(Reservations.Type type, int reservations, int levelCount, int[] perLevel, int remainder, boolean oneExtra)
+    {
+        switch (type)
+        {
+            case PER_LEVEL:
+                return verifyReservationsPerLevel(reservations, levelCount, perLevel, remainder, oneExtra);
+            case LEVEL_OR_BELOW:
+                return verifyReservationsLevelOrBelow(reservations, levelCount, perLevel, remainder, oneExtra);
+            default:
+                throw new AssertionError();
+        }
+    }
+    private static boolean verifyReservationsPerLevel(int reservations, int levelCount, int[] perLevel, int remainder, boolean oneExtra)
+    {
+        int remainderUsed = 0;
+        int allowedExtra = oneExtra ? 1 : remainder;
+        for (int i = 0; i < levelCount; ++i)
+        {
+            Assert.assertThat(perLevel[i], Matchers.lessThanOrEqualTo(reservations + allowedExtra));
+            if (perLevel[i] > reservations)
+                remainderUsed += perLevel[i] - reservations;
+        }
+        Assert.assertThat(remainderUsed, Matchers.lessThanOrEqualTo(remainder));
+        return remainderUsed >= remainder;
+    }
+
+    private static boolean verifyReservationsLevelOrBelow(int reservations, int levelCount, int[] perLevel, long remainder, boolean oneExtra)
+    {
+        long sum = 0;
+        long allowed = oneExtra ? 0 : remainder;
+        int count = 0;
+        for (int i = levelCount - 1; i >= 0; --i)
+        {
+            sum += perLevel[i];
+            allowed += reservations;
+            if (++count <= remainder && oneExtra)
+                ++allowed;
+            Assert.assertThat(sum, Matchers.lessThanOrEqualTo(allowed));
+        }
+        Assert.assertThat(sum, Matchers.lessThanOrEqualTo(remainder + levelCount * reservations));
+        assertEquals(allowed, remainder + levelCount * reservations);   // if failed, the problem is in the test
+        return sum >= remainder + levelCount * reservations;
+    }
+
+    private static boolean isAcceptableLevelOrBelow(int reservations, int levelCount, int[] perLevel, long remainder, boolean oneExtra)
+    {
+        long sum = 0;
+        long allowed = oneExtra ? 0 : remainder;
+        int count = 0;
+        for (int i = levelCount - 1; i >= 0; --i)
+        {
+            sum += perLevel[i];
+            allowed += reservations;
+            if (++count <= remainder && oneExtra)
+                ++allowed;
+            if (sum > allowed)
+                return false;
+        }
+        return true;
+    }
+
+    private static boolean hasRoomInLevel(Reservations.Type type, int reservations, int remainder, boolean oneExtra, boolean extrasExhausted, int perLevel[], int level)
+    {
+        switch (type)
+        {
+            case PER_LEVEL:
+                return hasRoomInLevelPerLevel(reservations, remainder, oneExtra, extrasExhausted, perLevel, level);
+            case LEVEL_OR_BELOW:
+                return hasRoomInLevelOrAbove(reservations, remainder, oneExtra, extrasExhausted, perLevel, level);
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    private static boolean hasRoomInLevelPerLevel(int reservations, int remainder, boolean oneExtra, boolean extrasExhausted, int perLevel[], int level)
+    {
+        int allowedExtra = extrasExhausted ? 0 : (oneExtra ? 1 : remainder);
+        return perLevel[level] < reservations + allowedExtra;
+    }
+
+    private static boolean hasRoomInLevelOrAbove(int reservations, int remainder, boolean oneExtra, boolean extrasExhausted, int perLevel[], int level)
+    {
+        if (extrasExhausted)
+            return false;
+        ++perLevel[level];
+        boolean result = isAcceptableLevelOrBelow(reservations, perLevel.length, perLevel, remainder, oneExtra);
+        --perLevel[level];
+        return result;
     }
 
     private static <T extends CompactionAggregate> List<T> getSelectablePicks(List<T> compactions, Set<CompactionSSTable> rejectIfContained, long spaceRemaining, boolean adaptiveAtLimit, Controller controller, int level)

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionWithRepeatsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyGetSelectionWithRepeatsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public class UnifiedCompactionStrategyGetSelectionWithRepeatsTest extends UnifiedCompactionStrategyGetSelectionTest
+{
+    @Override
+    boolean ignoreRepeats()
+    {
+        return false;
+    }
+
+    @Override
+    List<CompactionSSTable> getSSTablesSet(List<List<CompactionSSTable>> sets, int levels, int perLevel, int level, int inLevel)
+    {
+        return sets.get(getRepeatIndex(levels * perLevel, level * perLevel + inLevel));
+    }
+
+    @Override
+    List<List<CompactionSSTable>> prepareSSTablesSets(int levels, int perLevel)
+    {
+        return IntStream.range(0, levels * perLevel)
+                        .mapToObj(i -> ImmutableList.of(Mockito.mock(CompactionSSTable.class)))
+                        .collect(Collectors.toList());
+    }
+
+    private int getRepeatIndex(int size, int index)
+    {
+        double d = random.nextGaussian();
+        if (d <= 0.5 || d > 1)
+            return index;
+        else
+            return (int) (d * size - 1);    // high likelihood of hitting the same index
+    }
+
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -82,6 +82,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       sstableSizeMB << 20,
                                       Controller.DEFAULT_SSTABLE_GROWTH,
                                       Controller.DEFAULT_RESERVED_THREADS,
+                                      Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                       interval,
                                       minW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -412,7 +412,7 @@ public abstract class ControllerTest
         // Check NaN
         assertEquals(3, controller.getNumShards(Double.NaN));
 
-        assertEquals(Integer.MAX_VALUE, controller.getReservedThreadsPerLevel());
+        assertEquals(Integer.MAX_VALUE, controller.getReservedThreads());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -177,6 +177,7 @@ public class StaticControllerTest extends ControllerTest
                                                            sstableSizeMB << 20,
                                                            Controller.DEFAULT_SSTABLE_GROWTH,
                                                            Controller.DEFAULT_RESERVED_THREADS,
+                                                           Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);
@@ -201,6 +202,7 @@ public class StaticControllerTest extends ControllerTest
                                                            sstableSizeMB << 20,
                                                            Controller.DEFAULT_SSTABLE_GROWTH,
                                                            Controller.DEFAULT_RESERVED_THREADS,
+                                                           Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);
@@ -225,6 +227,7 @@ public class StaticControllerTest extends ControllerTest
                                                            sstableSizeMB << 20,
                                                            Controller.DEFAULT_SSTABLE_GROWTH,
                                                            Controller.DEFAULT_RESERVED_THREADS,
+                                                           Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            keyspaceName,
                                                            tableName);


### PR DESCRIPTION
Last piece of the UCS improvements, to avoid making people choose between thread utilization and compaction responsiveness.

These fallout tests demonstrate the effect (1TB test):
- 30 threads max overlap graph [per level](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/54d3ee9d-7cf8-4f05-b1f1-e79cf2f6f9ba/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables) vs. [no reservations](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/a554772f-f651-4e28-8e7a-4dc2bbf0c827/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables) vs. [level or below](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/c005c5d8-ee4a-44f6-8237-f1eb611973ca/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables)
- 12 threads max overlap graph [per level](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/d77a1e2d-3fcd-4a40-8344-2aa32924898c/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables) vs. [no reservations](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/244cc059-40bc-4edd-8120-4e066b564ea3/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables) vs. [level or below](http://fallout.aws.dsinternal.org/tests/ui/branimir.lambov@datastax.com/EC2-CC-1TB-key-value/f47b2b37-9464-4b7a-a466-c15702296584/artifacts/server/node0/cassandra_logs/compaction_report.html?metric=Max_overlapping_SSTables)

It seems to work best in all these cases, not letting compaction fall behind with fewer threads, and not overshooting the target max overlap when the thread count is higher.