### PR TITLE
Vector 65

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
@@ -79,6 +80,14 @@ public class ReadExecutionController implements AutoCloseable
         {
             repairedDataInfo = RepairedDataInfo.NO_OP_REPAIRED_DATA_INFO;
         }
+
+        if (Tracing.isTracing())
+            Tracing.instance.setRangeQuery(isRangeCommand());
+    }
+
+    public boolean isRangeCommand()
+    {
+        return command.isRangeRequest();
     }
 
     public ReadExecutionController indexReadController()

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryViewBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryViewBuilder.java
@@ -107,8 +107,12 @@ public class QueryViewBuilder
         {
             if (Tracing.isTracing())
             {
-                var indexNames = referencedIndexes.stream().map(i -> i.getIndexContext().getIndexName()).collect(Collectors.toList());
-                Tracing.trace("Querying storage-attached indexes {}", indexNames);
+                var groupedIndexes = referencedIndexes.stream().collect(
+                    Collectors.groupingBy(i -> i.getIndexContext().getIndexName(), Collectors.counting()));
+                var summary = groupedIndexes.entrySet().stream()
+                                            .map(e -> String.format("%s (%s sstables)", e.getKey(), e.getValue()))
+                                            .collect(Collectors.joining(", "));
+                Tracing.trace("Querying storage-attached indexes {}", summary);
             }
         }
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -187,7 +187,8 @@ public class BigTableReader extends SSTableReader
             if (!bf.isPresent((DecoratedKey)key))
             {
                 listener.onSSTableSkipped(this, SkippingReason.BLOOM_FILTER);
-                Tracing.trace("Bloom filter allows skipping sstable {}", descriptor.id);
+                if (Tracing.traceSinglePartitions())
+                    Tracing.trace("Bloom filter allows skipping sstable {}", descriptor.id);
                 getBloomFilterTracker().addTrueNegative();
                 return null;
             }

--- a/src/java/org/apache/cassandra/tracing/TraceState.java
+++ b/src/java/org/apache/cassandra/tracing/TraceState.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.utils.progress.ProgressListener;
  */
 public abstract class TraceState implements ProgressEventNotifier
 {
-
     public final UUID sessionId;
     public final InetAddressAndPort coordinator;
     public final Stopwatch watch;
@@ -51,6 +50,7 @@ public abstract class TraceState implements ProgressEventNotifier
     public final int ttl;
     public final ClientState clientState;
 
+    private boolean rangeQuery;
     private String tracedKeyspace;
 
     private boolean notify;
@@ -109,6 +109,16 @@ public abstract class TraceState implements ProgressEventNotifier
     {
         assert traceType == Tracing.TraceType.REPAIR;
         listeners.remove(listener);
+    }
+
+    public boolean isRangeQuery()
+    {
+        return rangeQuery;
+    }
+
+    public void setRangeQuery(boolean rangeQuery)
+    {
+        this.rangeQuery = rangeQuery;
     }
 
     /**

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -134,7 +134,7 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
                 logger.error(String.format("Cannot use class %s for tracing, ignoring by defaulting to normal tracing", customTracingClass), e);
             }
         }
-        instance = null != tracing ? tracing : new TracingImpl();
+        instance = tracing == null ? new TracingImpl() : tracing;
     }
 
     public UUID getSessionId()

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -29,8 +29,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,6 +151,17 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
     {
         assert isTracing();
         return state.get().ttl;
+    }
+
+    public static boolean traceSinglePartitions()
+    {
+        return instance.get() != null && !instance.get().isRangeQuery();
+    }
+
+    public void setRangeQuery(boolean rangeQuery)
+    {
+        assert isTracing();
+        state.get().setRangeQuery(rangeQuery);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/tracing/TracingTestImpl.java
+++ b/test/unit/org/apache/cassandra/tracing/TracingTestImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tracing;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.service.ClientState;
+
+public final class TracingTestImpl extends Tracing
+{
+    private final List<String> traces;
+
+    private final Map<String, ByteBuffer> payloads = new HashMap<>();
+
+    public TracingTestImpl()
+    {
+        this(new ArrayList<>());
+    }
+
+    public TracingTestImpl(List<String> traces)
+    {
+        this.traces = traces;
+    }
+
+    public void stopSessionImpl()
+    {
+    }
+
+    public TraceState begin(String request, InetAddress ia, Map<String, String> map)
+    {
+        traces.add(request);
+        return get();
+    }
+
+    @Override
+    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, Map<String, ByteBuffer> customPayload)
+    {
+        if (!customPayload.isEmpty())
+            logger.info("adding custom payload items {}", StringUtils.join(customPayload.keySet(), ','));
+
+        payloads.putAll(customPayload);
+        return super.newSession(state, sessionId, traceType, customPayload);
+    }
+
+    @Override
+    protected TraceState newTraceState(ClientState state, InetAddressAndPort ia, UUID uuid, TraceType tt)
+    {
+        return new TraceState(state, ia, uuid, tt)
+        {
+            protected void traceImpl(String string)
+            {
+                traces.add(string);
+            }
+
+            protected void waitForPendingEvents()
+            {
+            }
+        };
+    }
+
+    @Override
+    public void trace(ClientState state, ByteBuffer bb, String message, int i)
+    {
+        traces.add(message);
+    }
+
+    public Map<String, ByteBuffer> getPayloads()
+    {
+        return payloads;
+    }
+
+    public List<String> getTraces()
+    {
+        return traces;
+    }
+}


### PR DESCRIPTION
- add Tracing.traceSinglePartitions to avoid cluttering range and index queries with noise
- update QueryViewBuilder to include a count of sstables per index accessed
