### PR TITLE
CNDB-7135 Adaptive UCS Metrics in CNDB

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1028,6 +1028,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return keyspace.metric;
     }
 
+    public void publishMetrics()
+    {
+        data.publishMetrics();
+    }
+
     public Descriptor newSSTableDescriptor(File directory)
     {
         return newSSTableDescriptor(directory, SSTableFormat.Type.current().info.getLatestVersion(), SSTableFormat.Type.current());

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1023,6 +1023,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return keyspace.getName();
     }
 
+    public Tracker getData()
+    {
+        return data;
+    }
+
     public KeyspaceMetrics getKeyspaceMetrics()
     {
         return keyspace.metric;
@@ -1030,7 +1035,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     public void publishMetrics()
     {
-        data.publishMetrics();
+        getData().publishMetrics(getBytesInserted(), getReadRequests(), getFlushSize(), getSstablePartitionReadLatency(), getFlushTimePerKb());
     }
 
     public Descriptor newSSTableDescriptor(File directory)
@@ -3100,6 +3105,21 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     public long getBytesInserted()
     {
         return metric == null ? 0 : metric.bytesInserted.getCount();
+    }
+
+    public double getFlushSize()
+    {
+        return metric == null ? 0 : metric.flushSizeOnDisk().get();
+    }
+
+    public double getSstablePartitionReadLatency()
+    {
+        return metric == null ? 0 : metric.sstablePartitionReadLatency.get();
+    }
+
+    public double getFlushTimePerKb()
+    {
+        return metric == null ? 0 : metric.flushTimePerKb.get();
     }
 
     /** true if this CFS contains secondary index data */

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3102,21 +3102,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return metric == null ? 0 : metric.bytesInserted.getCount();
     }
 
-    public double getFlushSize()
-    {
-        return metric == null ? 0 : metric.flushSizeOnDisk().get();
-    }
-
-    public double getSstablePartitionReadLatency()
-    {
-        return metric == null ? 0 : metric.sstablePartitionReadLatency.get();
-    }
-
-    public double getFlushTimePerKb()
-    {
-        return metric == null ? 0 : metric.flushTimePerKb.get();
-    }
-
     /** true if this CFS contains secondary index data */
     public boolean isIndex()
     {

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1023,7 +1023,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return keyspace.getName();
     }
 
-    public Tracker getData()
+    @VisibleForTesting
+    public Tracker getSSTableTracker()
     {
         return data;
     }
@@ -1035,7 +1036,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     public void publishMetrics()
     {
-        getData().publishMetrics(getBytesInserted(), getReadRequests(), getFlushSize(), getSstablePartitionReadLatency(), getFlushTimePerKb());
+        getSSTableTracker().publishMetrics(metrics().createMetricsNotification());
     }
 
     public Descriptor newSSTableDescriptor(File directory)

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1023,12 +1023,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return keyspace.getName();
     }
 
-    @VisibleForTesting
-    public Tracker getSSTableTracker()
-    {
-        return data;
-    }
-
     public KeyspaceMetrics getKeyspaceMetrics()
     {
         return keyspace.metric;
@@ -1036,7 +1030,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     public void publishMetrics()
     {
-        getSSTableTracker().publishMetrics(metrics().createMetricsNotification());
+        getTracker().publishMetrics(metrics().createMetricsNotification());
     }
 
     public Descriptor newSSTableDescriptor(File directory)

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -237,7 +237,7 @@ public class CompactionManager implements CompactionManagerMBean
             {
                 continue;
             }
-            for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+            for (ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
             {
                 cfs.publishMetrics();
             }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -232,6 +232,7 @@ public class CompactionManager implements CompactionManagerMBean
         }
     }
 
+    @VisibleForTesting
     public static void publishMetrics()
     {
         for (String keyspace : Schema.instance.getKeyspaces())

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -148,6 +148,9 @@ public class CompactionManager implements CompactionManagerMBean
     public static final int NO_GC = Integer.MIN_VALUE;
     public static final int GC_ALL = Integer.MAX_VALUE;
 
+    //This is needed for Adaptive UCS to run in CNDB
+    public static final int PUBLISH_METRICS_INTERVAL = Integer.getInteger(Config.PROPERTY_PREFIX + "publish_metrics_interval_minutes", 0);
+
     // A thread local that tells us if the current thread is owned by the compaction manager. Used
     // by CounterContext to figure out if it should log a warning for invalid counter shards.
     public static final FastThreadLocal<Boolean> isCompactionManager = new FastThreadLocal<Boolean>()
@@ -176,8 +179,9 @@ public class CompactionManager implements CompactionManagerMBean
         /*Store Controller Config for UCS every hour*/
         ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(CompactionManager::storeControllerConfig, 10, 60, TimeUnit.MINUTES);
 
-        /*publish metrics used by AdaptiveController for each cfs every 5 minutes. This is needed for Adaptive Compaction to work in CNDB*/
-        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(CompactionManager::publishMetrics, 5, 5, TimeUnit.MINUTES);
+        /*publish metrics used by AdaptiveController for each cfs. This is needed for Adaptive Compaction to work in CNDB*/
+        if (PUBLISH_METRICS_INTERVAL > 0)
+            ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(CompactionManager::publishMetrics, 1, PUBLISH_METRICS_INTERVAL, TimeUnit.MINUTES);
     }
 
     private final CompactionExecutor executor = new CompactionExecutor();

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -604,6 +604,21 @@ public class Tracker
             subscriber.handleNotification(notification, this);
     }
 
+    public void publishMetrics()
+    {
+        long bytesInserted = cfstore.metrics().bytesInserted.getCount();
+        long partitionsRead = cfstore.metrics().readRequests.getCount();
+        double flushSize = cfstore.metrics().flushSizeOnDisk().get();
+        double sstablePartitionReadLatencyNanos = cfstore.metrics().sstablePartitionReadLatency.get();
+        double flushTimePerKbNanos = cfstore.metrics().flushTimePerKb.get();
+
+        INotification notification = new MetricsNotification(bytesInserted, partitionsRead, flushSize, sstablePartitionReadLatencyNanos, flushTimePerKbNanos);
+        for (INotificationConsumer subscriber : subscribers)
+        {
+            subscriber.handleNotification(notification, this);
+        }
+    }
+
     public boolean isDummy()
     {
         return cfstore == null || !DatabaseDescriptor.enableMemtableAndCommitLog();

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -604,14 +604,8 @@ public class Tracker
             subscriber.handleNotification(notification, this);
     }
 
-    public void publishMetrics()
+    public void publishMetrics(long bytesInserted, long partitionsRead, double flushSize, double sstablePartitionReadLatencyNanos, double flushTimePerKbNanos)
     {
-        long bytesInserted = cfstore.metrics().bytesInserted.getCount();
-        long partitionsRead = cfstore.metrics().readRequests.getCount();
-        double flushSize = cfstore.metrics().flushSizeOnDisk().get();
-        double sstablePartitionReadLatencyNanos = cfstore.metrics().sstablePartitionReadLatency.get();
-        double flushTimePerKbNanos = cfstore.metrics().flushTimePerKb.get();
-
         INotification notification = new MetricsNotification(bytesInserted, partitionsRead, flushSize, sstablePartitionReadLatencyNanos, flushTimePerKbNanos);
         for (INotificationConsumer subscriber : subscribers)
         {

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -606,10 +606,7 @@ public class Tracker
 
     public void publishMetrics(MetricsNotification metricsNotification)
     {
-        for (INotificationConsumer subscriber : subscribers)
-        {
-            subscriber.handleNotification(metricsNotification, this);
-        }
+        notify(metricsNotification);
     }
 
     public boolean isDummy()

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -604,12 +604,11 @@ public class Tracker
             subscriber.handleNotification(notification, this);
     }
 
-    public void publishMetrics(long bytesInserted, long partitionsRead, double flushSize, double sstablePartitionReadLatencyNanos, double flushTimePerKbNanos)
+    public void publishMetrics(MetricsNotification metricsNotification)
     {
-        INotification notification = new MetricsNotification(bytesInserted, partitionsRead, flushSize, sstablePartitionReadLatencyNanos, flushTimePerKbNanos);
         for (INotificationConsumer subscriber : subscribers)
         {
-            subscriber.handleNotification(notification, this);
+            subscriber.handleNotification(metricsNotification, this);
         }
     }
 

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.metrics.Sampler.SamplerType;
+import org.apache.cassandra.notifications.MetricsNotification;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
@@ -1071,6 +1072,11 @@ public class TableMetrics
 
         if (intersectingCount > 0)
             sstablePartitionReadLatency.update(elapsedNanos / (double) intersectingCount);
+    }
+
+    public MetricsNotification createMetricsNotification()
+    {
+        return new MetricsNotification(bytesInserted.getCount(), readRequests.getCount(), flushSizeOnDisk().get(), sstablePartitionReadLatency.get(), flushTimePerKb.get());
     }
 
     /**

--- a/src/java/org/apache/cassandra/notifications/MetricsNotification.java
+++ b/src/java/org/apache/cassandra/notifications/MetricsNotification.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.notifications;
+
+public class MetricsNotification implements INotification
+{
+    private final long bytesInserted;
+    private final long partitionsRead;
+    private final double flushSize;
+    private final double sstablePartitionReadLatencyNanos;
+    private final double flushTimePerKbNanos;
+
+    public MetricsNotification(long bytesInserted, long partitionsRead, double flushSize, double sstablePartitionReadLatencyNanos, double flushTimePerKbNanos)
+    {
+        this.bytesInserted = bytesInserted;
+        this.partitionsRead = partitionsRead;
+        this.flushSize = flushSize;
+        this.sstablePartitionReadLatencyNanos = sstablePartitionReadLatencyNanos;
+        this.flushTimePerKbNanos = flushTimePerKbNanos;
+    }
+
+    public long getBytesInserted()
+    {
+        return bytesInserted;
+    }
+    public long getPartitionsRead()
+    {
+        return partitionsRead;
+    }
+    public double getFlushSize()
+    {
+        return flushSize;
+    }
+    public double getSstablePartitionReadLatencyNanos()
+    {
+        return sstablePartitionReadLatencyNanos;
+    }
+    public double getFlushTimePerKbNanos()
+    {
+        return flushTimePerKbNanos;
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -31,8 +31,10 @@ import org.apache.cassandra.db.compaction.unified.AdaptiveController;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.StaticController;
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.notifications.MetricsNotification;
 
 import static org.apache.cassandra.distributed.shared.FutureUtils.waitOn;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
@@ -172,6 +174,28 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              //verify that the file was deleted
                                              assert !Controller.getControllerConfigPath("does_not", "exist").exists();
 
+                                         });
+
+        }
+    }
+
+    @Test
+    public void testPublishMetrics() throws Throwable
+    {
+        try(Cluster cluster = init(Cluster.build(1).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};"));
+            cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = " +
+                                              "{'class': 'UnifiedCompactionStrategy', " +
+                                              "'adaptive': 'false', " +
+                                              "'scaling_parameters': '0'};"));
+
+            cluster.get(1).runOnInstance(() ->
+                                         {
+                                             CompactionManager.publishMetrics();
+                                             ColumnFamilyStore cfs = Keyspace.open("ks").getColumnFamilyStore("tbl");
+                                             MetricsNotification metricsNotification = cfs.metrics().createMetricsNotification();
+                                             assertNotNull(metricsNotification);
                                          });
 
         }

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
@@ -36,6 +36,8 @@ import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.StaticController;
 import org.apache.cassandra.db.lifecycle.Tracker;
 import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.metrics.TableMetrics;
+import org.apache.cassandra.notifications.MetricsNotification;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.Pair;
 import org.mockito.Mock;
@@ -487,25 +489,18 @@ public class BackgroundCompactionsTest
     @Test
     public void testPublishMetrics()
     {
-        long bytesInserted = 1;
-        long partitionsRead = 1;
-        double flushSize = 1;
-        double sstablePartitionReadLatency = 1;
-        double flushTimePerKb = 1;
-
         ColumnFamilyStore cfs = mock(ColumnFamilyStore.class);
         Tracker data = mock(Tracker.class);
+        TableMetrics tableMetrics = mock(TableMetrics.class);
+        MetricsNotification metricsNotification = mock(MetricsNotification.class);
 
-        when(cfs.getData()).thenReturn(data);
-        when(cfs.getBytesInserted()).thenReturn(bytesInserted);
-        when(cfs.getReadRequests()).thenReturn(partitionsRead);
-        when(cfs.getFlushSize()).thenReturn(flushSize);
-        when(cfs.getSstablePartitionReadLatency()).thenReturn(sstablePartitionReadLatency);
-        when(cfs.getFlushTimePerKb()).thenReturn(flushTimePerKb);
+        when(cfs.metrics()).thenReturn(tableMetrics);
+        when(tableMetrics.createMetricsNotification()).thenReturn(metricsNotification);
+        when(cfs.getSSTableTracker()).thenReturn(data);
         doCallRealMethod().when(cfs).publishMetrics();
 
         cfs.publishMetrics();
-        Mockito.verify(data, times(1)).publishMetrics(bytesInserted, partitionsRead, flushSize, sstablePartitionReadLatency, flushTimePerKb);
+        Mockito.verify(data, times(1)).publishMetrics(metricsNotification);
 
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
@@ -496,7 +496,7 @@ public class BackgroundCompactionsTest
 
         when(cfs.metrics()).thenReturn(tableMetrics);
         when(tableMetrics.createMetricsNotification()).thenReturn(metricsNotification);
-        when(cfs.getSSTableTracker()).thenReturn(data);
+        when(cfs.getTracker()).thenReturn(data);
         doCallRealMethod().when(cfs).publishMetrics();
 
         cfs.publishMetrics();

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionsTest.java
@@ -489,10 +489,22 @@ public class BackgroundCompactionsTest
     @Test
     public void testPublishMetrics()
     {
+        long bytesInserted = 10;
+        long partitionsRead = 5;
+        double flushSize = 1024;
+        double readLatency = 20;
+        double flushTime = 15;
+
         ColumnFamilyStore cfs = mock(ColumnFamilyStore.class);
         Tracker data = mock(Tracker.class);
         TableMetrics tableMetrics = mock(TableMetrics.class);
-        MetricsNotification metricsNotification = mock(MetricsNotification.class);
+        MetricsNotification metricsNotification = new MetricsNotification(bytesInserted, partitionsRead, flushSize, readLatency, flushTime);
+
+        assertEquals(bytesInserted, metricsNotification.getBytesInserted());
+        assertEquals(partitionsRead, metricsNotification.getPartitionsRead());
+        assertEquals(flushSize, metricsNotification.getFlushSize(), 0.01);
+        assertEquals(readLatency, metricsNotification.getSstablePartitionReadLatencyNanos(), 0.01);
+        assertEquals(flushTime, metricsNotification.getFlushTimePerKbNanos(), 0.01);
 
         when(cfs.metrics()).thenReturn(tableMetrics);
         when(tableMetrics.createMetricsNotification()).thenReturn(metricsNotification);

--- a/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
@@ -466,4 +466,15 @@ public class TrackerTest
         listener.received.clear();
     }
 
+    @Test
+    public void testPublishMetrics()
+    {
+        ColumnFamilyStore cfs = MockSchema.newCFS();
+        Tracker tracker = Tracker.newDummyTracker(cfs.metadata);
+        MockListener listener = new MockListener(false);
+        tracker.subscribe(listener);
+        tracker.publishMetrics(1, 1, 1, 1, 1);
+        assert(listener.received.get(0) instanceof MetricsNotification);
+    }
+
 }

--- a/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
@@ -53,6 +53,7 @@ import org.mockito.Mockito;
 
 import static com.google.common.collect.ImmutableSet.copyOf;
 import static java.util.Collections.singleton;
+import static org.mockito.Mockito.mock;
 
 @RunWith(BMUnitRunner.class)
 public class TrackerTest
@@ -470,10 +471,11 @@ public class TrackerTest
     public void testPublishMetrics()
     {
         ColumnFamilyStore cfs = MockSchema.newCFS();
+        MetricsNotification metricsNotification = mock(MetricsNotification.class);
         Tracker tracker = Tracker.newDummyTracker(cfs.metadata);
         MockListener listener = new MockListener(false);
         tracker.subscribe(listener);
-        tracker.publishMetrics(1, 1, 1, 1, 1);
+        tracker.publishMetrics(metricsNotification);
         assert(listener.received.get(0) instanceof MetricsNotification);
     }
 


### PR DESCRIPTION
In order for Adaptive UCS to make good decisions, the compaction leader needs access to various metrics from writers:

- time to flush 1kb of data
- time per query on sstable
- number of read requests

In order to ensure the compaction leader is receiving metrics from each writer, writers periodically publish a `MetricsNotification` which translates to a `MetricsEvent` in CNDB. The `MetricsEvent` is published to etcd and contains the necessary writer metrics that the adaptive controller needs to make informed decisions. The `UnifiedCompactionEnvironment` in CNDB listens for these events and updates the respective values.

*Note* This currently only includes writer metrics. Compactor metrics will require something similar