### PR TITLE
VECTOR-79: Simplify population of VectorCache

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/hnsw/RandomlyConnectedHnswGraph.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/hnsw/RandomlyConnectedHnswGraph.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -116,17 +118,21 @@ public class RandomlyConnectedHnswGraph extends ExtendedHnswGraph {
 
         public Builder addLevel(int level, List<Integer> nodeIds, int M) {
             Map<Integer, List<Integer>> nodeConnections = new HashMap<>();
-            for (Integer nodeId : nodeIds)
+            int n = nodeIds.size();
+            int maxNeighbors = Math.min(M, n - 1);
+            for (int i = 0; i < n; i++)
             {
-                List<Integer> neighbors = new ArrayList<>(M);
-                for (int i = 0; i < M; i++)
+                Set<Integer> neighborSet = new HashSet<>();
+                // need to avoid duplicate neighbors
+                while (neighborSet.size() < maxNeighbors)
                 {
-                    int neighbor = random.nextInt(nodeIds.size());
-                    if (neighbor == nodeId)
-                        neighbor = (neighbor + 1) % nodeIds.size();
-                    neighbors.add(neighbor);
+                    int neighborIdx = random.nextInt(n);
+                    if (neighborIdx == i)
+                        continue;
+                    neighborSet.add(nodeIds.get(neighborIdx));
                 }
-                nodeConnections.put(nodeId, neighbors);
+                List<Integer> neighbors = new ArrayList<>(neighborSet);
+                nodeConnections.put(nodeIds.get(i), neighbors);
             }
             this.nodes.put(level, nodeConnections);
             return this;
@@ -134,11 +140,12 @@ public class RandomlyConnectedHnswGraph extends ExtendedHnswGraph {
 
         public Builder addLevels(int levels, int totalNodes, int M)
         {
+            // TODO: Handle totalNodes < 2^(levels - 1); stabilize at 1 node/level eventually?
             List<Integer> nodeIds = IntStream.range(0, totalNodes).boxed().collect(Collectors.toList());
+            Collections.shuffle(nodeIds);
             for (int level = 0; level < levels; level++)
             {
                 addLevel(level, nodeIds, M);
-                Collections.shuffle(nodeIds);
                 nodeIds = new ArrayList<>(nodeIds.subList(0, nodeIds.size() / 2));
             }
             return this;

--- a/test/unit/org/apache/cassandra/index/sai/disk/hnsw/RandomlyConnectedHnswGraph.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/hnsw/RandomlyConnectedHnswGraph.java
@@ -122,8 +122,8 @@ public class RandomlyConnectedHnswGraph extends ExtendedHnswGraph {
             int maxNeighbors = Math.min(M, n - 1);
             for (int i = 0; i < n; i++)
             {
+                // staging in a Set first cleans up duplicate neighbors
                 Set<Integer> neighborSet = new HashSet<>();
-                // need to avoid duplicate neighbors
                 while (neighborSet.size() < maxNeighbors)
                 {
                     int neighborIdx = random.nextInt(n);

--- a/test/unit/org/apache/cassandra/index/sai/disk/hnsw/VectorCacheTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/hnsw/VectorCacheTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.hnsw;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.index.sai.disk.hnsw.CompactionVectorValues;
+import org.apache.cassandra.index.sai.disk.hnsw.OnDiskVectors;
+import org.apache.cassandra.index.sai.disk.hnsw.VectorCache;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.lucene.util.hnsw.HnswGraph;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VectorCacheTest
+{
+    private int dimension;
+    private int expectedCached;
+    private CompactionVectorValues vectorValues;
+    private Path testDirectory;
+    private OnDiskVectors onDiskVectors;
+    private HnswGraph hnsw;
+    private VectorCache cache;
+
+    @Before
+    public void setup() throws IOException
+    {
+        dimension = 10;
+        var topLevelCount = 20;
+        var M = 16;
+        expectedCached = M >> 1; // ensures BFS should visit entry node + a proper subset of its neighbors
+        var cacheCapacity = expectedCached * dimension * Float.BYTES;
+        var levels = 2;
+        // RandomlyConnectedHnswGraph cuts number of nodes in half as we go up levels
+        var totalOrdinals = (1 << (levels - 1)) * topLevelCount;
+        hnsw = new RandomlyConnectedHnswGraph.Builder().addLevels(levels, totalOrdinals, M).build();
+
+        testDirectory = Files.createTempDirectory("VectorCacheTest");
+        var vectorFile = new File(testDirectory, "vectors");
+        generateVectors(totalOrdinals);
+        var offset = writeVectorsToDisk(vectorFile);
+        var fh = new FileHandle.Builder(vectorFile).mmapped(true).complete();
+        onDiskVectors = new OnDiskVectors(fh, offset);
+        cache = VectorCache.load(hnsw, onDiskVectors, cacheCapacity);
+    }
+
+    private void generateVectors(int totalOrdinals)
+    {
+        var type = VectorType.getInstance(FloatType.instance, dimension);
+        vectorValues = new CompactionVectorValues(type);
+        for (int i = 0; i < totalOrdinals; i++)
+        {
+            List<Float> rawVector = new ArrayList<>(Collections.nCopies(dimension, (float) i));
+            var bb = type.getSerializer().serialize(rawVector);
+            vectorValues.add(i, bb);
+        }
+    }
+
+    private long writeVectorsToDisk(File vectorFile) throws IOException
+    {
+        var writerOption = SequentialWriterOption.newBuilder().finishOnClose(true).build();
+        var vectorsWriter = new SequentialWriter(vectorFile, writerOption);
+        var offset = vectorsWriter.getOnDiskFilePointer();
+        vectorValues.write(vectorsWriter);
+        vectorsWriter.close();
+        return offset;
+    }
+
+    @After
+    public void tearDown()
+    {
+        org.apache.commons.io.FileUtils.deleteQuietly(testDirectory.toFile());
+    }
+
+    @Test
+    public void testOnlyEntryNodeAndNeighborsCached() throws IOException
+    {
+        int n = hnsw.size();
+        int topLevel = hnsw.numLevels() - 1;
+        int entryNode = hnsw.entryNode();
+
+        Set<Integer> expectedCachedNeighbors = new HashSet<>();
+        hnsw.seek(topLevel, entryNode);
+        for (int i = 0; i < expectedCached - 1; i++)
+        {
+            var neighbor = hnsw.nextNeighbor();
+            assertThat(neighbor).isNotEqualTo(NO_MORE_DOCS);
+            expectedCachedNeighbors.add(neighbor);
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            var raw = cache.get(i);
+            // we only expect entry node and first expectedCached - 1 neighbors to be visited by BFS and cached
+            if (i == entryNode || expectedCachedNeighbors.contains(i))
+            {
+                assertThat(raw).isNotEqualTo(null);
+                var expectedRaw = vectorValues.vectorValue(i);
+                assertThat(raw).isEqualTo(expectedRaw);
+            }
+            else
+            {
+                assertThat(raw).isEqualTo(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is meant to simplify and "fix" how we populate the vector cache. As described, we are looking to run [breadth-first search](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L32-L35) at each level, but I don't believe we are quite achieving our goal.

**WHAT'S WRONG? AN EXAMPLE**
I initially confused myself a bit when attempting to track more complicated traversals in my head, so a really simple example may be best.

Consider the following example graph where maximum fanout `M` = 3 and `entry_node` = 0, let’s assume our cache can only accommodate 4 nodes:

![graph](https://github.com/datastax/cassandra/assets/11130580/06313f87-155a-4f7a-b44a-10d62c854772)


Let:
- `q` = node queue
- `visited` = visited set (which is cleared between levels)
- `cached_nodes` = global set of visited nodes across all levels
- `cache` = the actual cache of ordinal -> vector (will omit vectors in the following, for brevity)


To start, we:
- [populate `cache`](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L73) with [entry node 0’s neighbors](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L121-L135) -> `cache = {1, 2, 3}`
- add [entry node 0 to visited](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L121-L135) -> `visited = {0}`
- add [entry node 0 to cached_nodes](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L75) -> `cached_nodes = {0}`
-  Our state: `visited = {0}, cached_nodes = {0}, cache = {1, 2, 3}`

We then enter the top-level `L`:
- [enqueue visited nodes into `q`, and clear `visited`](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L81-L82) -> `q = [0], visited = {}`
- Our state: `q = [0], visited = {}, cached_nodes = {0}, cache = {1, 2, 3}`

Now we pop 0 from `q` -> `q = []`:
- 0 is not in `visited`, add it -> `visited = {0}`
- 0 is in `cached_nodes` already, no need to add it’s neighbors to `cache`
- [add all unvisited neighbors](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L105-L114) to `q` -> `q = [1, 2, 3]`
- Our state: `q = [1, 2, 3], visited = {0}, cached_nodes = {0}, cache = {1, 2, 3}` 

We then pop 1 from `q` -> `q = [2, 3]`:
- 1 is not in `visited`, add it -> `visited = {0, 1}`
- 1 is not in `cached_nodes` -> [populate `cache` with  as many of 1’s non-cached neighbors](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L121-L136), then [add 1 to `cached_nodes`](https://github.com/datastax/cassandra/blob/fab67bb13499691f813c893cd39a3bbd406653d2/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorCache.java#L102) -> `cache = {1, 2, 3, 4}, cached_nodes = {0, 1}`
- add all unvisited neighbors of 1 to `q` -> `q = [2, 3, 2, 3, 4]`
- Our state: `q = [2, 3, 2, 3, 4], visited = {0, 1}, cached_nodes = {0, 1}, cache = {1, 2, 3, 4}`

At this point, we’ve filled up our cache, and don’t even have our entry node 0 in it; if there were any node that we want to cache for a segment, it’s this one:
- it necessarily appears in all levels of the HNSW, hence for an arbitrary ANN query, there is higher probability we run into it on multiple levels
- every ANN search starts with a similarity computation against the entry node

As contrived as this example may seem, one can easily imagine the right set of real-world parameters that could result in this, e.g. a large fanout `M `+ large vector-dimensionality could exhaust a modestly-sized cache just with neighbors of the entry vector. 

Just as well, graphs where the entry node is not a neighbor of any of its own neighbors, we end up just caching its neighbors and could potentially never return in our traversal to cache the original entry node.

Slightly modifying our BFS resolves this, and would appear to match what was initially described for hydrating the vector cache.