### PR TITLE
Avoiding sorting node ordinals for level 0

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/ExtendedHnswGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/ExtendedHnswGraph.java
@@ -46,7 +46,7 @@ public abstract class ExtendedHnswGraph extends HnswGraph
         }
         var sortedNodes = new int[nodesOnLevel.size()];
 
-        // for instance, level 0
+        // if all ordinals appear on level (for instance, level 0), generate all ordinals in sorted order
         if (nodesOnLevel.size() == hnsw.size())
         {
             Arrays.setAll(sortedNodes, i -> i);

--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/ExtendedHnswGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/ExtendedHnswGraph.java
@@ -46,6 +46,13 @@ public abstract class ExtendedHnswGraph extends HnswGraph
         }
         var sortedNodes = new int[nodesOnLevel.size()];
 
+        // for instance, level 0
+        if (nodesOnLevel.size() == hnsw.size())
+        {
+            Arrays.setAll(sortedNodes, i -> i);
+            return sortedNodes;
+        }
+
         for(var n = 0; nodesOnLevel.hasNext(); n++) {
             sortedNodes[n] = nodesOnLevel.nextInt();
         }


### PR DESCRIPTION
Some low-hanging fruit.

When writing the HNSW to disk, we:
- go through levels
- grab all ordinals showing up at that level in the HNSW
- sort the ordinals
- write them to disk

At level 0, we know every ordinal of the HNSW will necessarily show up, so we should be able to avoid any need to sort here.