### PR TITLE
Fail SAI index creation when using analyzer on column in primary key

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -261,18 +261,14 @@ public class StorageAttachedIndex implements Index
             throw new InvalidRequestException("Cannot create more than one storage-attached index on the same column: " + target.left);
         }
 
+        // Analyzer is not supported against PK columns
         String indexAnalyzer = options.get(LuceneAnalyzer.INDEX_ANALYZER);
-
         if (indexAnalyzer != null)
         {
-            Iterator<ColumnMetadata> primaryKeyColumns = metadata.primaryKeyColumns().iterator();
-            while (primaryKeyColumns.hasNext())
+            for (ColumnMetadata column : metadata.primaryKeyColumns())
             {
-                ColumnMetadata column = primaryKeyColumns.next();
                 if (column.name.equals(target.left.name))
-                {
                     throw new InvalidRequestException("Cannot specify index analyzer on primary key column: " + target.left);
-                }
             }
         }
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -261,6 +261,21 @@ public class StorageAttachedIndex implements Index
             throw new InvalidRequestException("Cannot create more than one storage-attached index on the same column: " + target.left);
         }
 
+        String indexAnalyzer = options.get(LuceneAnalyzer.INDEX_ANALYZER);
+
+        if (indexAnalyzer != null)
+        {
+            Iterator<ColumnMetadata> primaryKeyColumns = metadata.primaryKeyColumns().iterator();
+            while (primaryKeyColumns.hasNext())
+            {
+                ColumnMetadata column = primaryKeyColumns.next();
+                if (column.name.equals(target.left.name))
+                {
+                    throw new InvalidRequestException("Cannot specify index analyzer on primary key column: " + target.left);
+                }
+            }
+        }
+
         AbstractType<?> type = TypeUtil.cellValueType(target.left, target.right);
 
         // If we are indexing map entries we need to validate the sub-types

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -262,8 +262,7 @@ public class StorageAttachedIndex implements Index
         }
 
         // Analyzer is not supported against PK columns
-        String indexAnalyzer = options.get(LuceneAnalyzer.INDEX_ANALYZER);
-        if (indexAnalyzer != null)
+        if (AbstractAnalyzer.isAnalyzed(options))
         {
             for (ColumnMetadata column : metadata.primaryKeyColumns())
             {

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -140,6 +140,10 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
         }
     }
 
+    public static boolean isAnalyzed(Map<String, String> options) {
+        return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER) || hasNonTokenizingOptions(options);
+    }
+
     public static AnalyzerFactory fromOptions(AbstractType<?> type, Map<String, String> options)
     {
         if (options.containsKey(LuceneAnalyzer.INDEX_ANALYZER))

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -25,6 +25,7 @@
 package org.apache.cassandra.index.sai.memory;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -32,6 +33,7 @@ import java.util.SortedSet;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongConsumer;
 
+import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +52,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -102,6 +105,14 @@ public class TrieMemoryIndex extends MemoryIndex
             while (analyzer.hasNext())
             {
                 final ByteBuffer term = analyzer.next();
+                try
+                {
+                    logger.debug(ByteBufferUtil.string(term, Charsets.UTF_8));
+                }
+                catch (CharacterCodingException e)
+                {
+                    throw new RuntimeException(e);
+                }
 
                 setMinMaxTerm(term.duplicate());
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -25,7 +25,6 @@
 package org.apache.cassandra.index.sai.memory;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -33,7 +32,6 @@ import java.util.SortedSet;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongConsumer;
 
-import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +50,6 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
-import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -105,14 +102,6 @@ public class TrieMemoryIndex extends MemoryIndex
             while (analyzer.hasNext())
             {
                 final ByteBuffer term = analyzer.next();
-                try
-                {
-                    logger.debug(ByteBufferUtil.string(term, Charsets.UTF_8));
-                }
-                catch (CharacterCodingException e)
-                {
-                    throw new RuntimeException(e);
-                }
 
                 setMinMaxTerm(term.duplicate());
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -73,8 +73,10 @@ public class LuceneAnalyzerTest extends SAITester
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
     }
 
+    // Technically, the NoopAnalyzer is applied, but that maps each field without modification, so any operator
+    // that matches the SAI field will also match the PK field when compared later in the search (there are two phases).
     @Test
-    public void testNoopAnalyzerOnClusteredColumn() throws Throwable
+    public void testNoAnalyzerOnClusteredColumn() throws Throwable
     {
         createTable("CREATE TABLE %s (id int, val text, PRIMARY KEY (id, val))");
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -74,7 +74,25 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStandardAnalyzerInPrimaryKey() throws Throwable
+    public void testNoopAnalyzerOnClusteredColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int, val text, PRIMARY KEY (id, val))");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES (1, 'dog')");
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+
+        flush();
+        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+    }
+
+    @Test
+    public void testStandardAnalyzerInClusteringColumn() throws Throwable
     {
         createTable("CREATE TABLE %s (id int, val text, PRIMARY KEY (id, val))");
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -91,6 +91,7 @@ public class LuceneAnalyzerTest extends SAITester
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
     }
 
+    // Analyzers on clustering columns are not supported yet
     @Test
     public void testStandardAnalyzerInClusteringColumnFailsAtCreateIndex() throws Throwable
     {
@@ -99,6 +100,17 @@ public class LuceneAnalyzerTest extends SAITester
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }"
+        )).isInstanceOf(InvalidRequestException.class);
+
+        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) WITH OPTIONS = { 'ascii': true }"
+        )).isInstanceOf(InvalidRequestException.class);
+
+        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                                             "WITH OPTIONS = { 'case_sesnsitive': false }"
+        )).isInstanceOf(InvalidRequestException.class);
+
+        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                                             "WITH OPTIONS = { 'normalize': true }"
         )).isInstanceOf(InvalidRequestException.class);
     }
 


### PR DESCRIPTION
When the target column for an SAI is part of the primary key and is analyzed by the LuceneAnalyzer, queries do not return correct results. Until the underlying feature is solved, do not allow these kinds of indexes to be created.

This change is covered by a test to verify index creation and search works correctly for the `NoopAnalyzer` and another to verify index creation is rejected for the `LuceneAnalyzer`.