### PR TITLE
Add ANALYZER_MATCHES operation; Disallow = on analyzed SAI columns 

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1684,6 +1684,7 @@ relationType returns [Operator op]
     | '>'  { $op = Operator.GT; }
     | '>=' { $op = Operator.GTE; }
     | '!=' { $op = Operator.NEQ; }
+    | ':'  { $op = Operator.ANALYZER_MATCHES; }
     ;
 
 relation[WhereClause.Builder clauses]

--- a/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
@@ -192,6 +192,12 @@ public class MultiColumnRelation extends Relation
     }
 
     @Override
+    protected Restriction newAnalyzerMatchesRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        throw invalidRequest("%s cannot be used for multi-column relations", operator());
+    }
+
+    @Override
     protected Term toTerm(List<? extends ColumnSpecification> receivers,
                           Raw raw,
                           String keyspace,

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -283,6 +283,11 @@ public enum Operator
             return ": '<term>'";
         }
 
+        /**
+         * This method is not supported for this operator. The operator itself does not have the context to know
+         * the correct result because an analyzed column can be analyzed in different ways. Therefore, this operator
+         * relies on the index implementation to perform to determine satisfaction.
+         */
         public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -272,7 +272,10 @@ public enum Operator
             return true;
         }
     },
-    ANALYZER_MATCHES(16)
+    /**
+     * An operator that only performs matching against analyzed columns.
+     */
+    ANALYZER_MATCHES(100)
     {
         @Override
         public String toString()

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -271,6 +271,19 @@ public enum Operator
         {
             return true;
         }
+    },
+    ANALYZER_MATCHES(16)
+    {
+        @Override
+        public String toString()
+        {
+            return ": '<term>'";
+        }
+
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            throw new UnsupportedOperationException();
+        }
     };
 
     /**

--- a/src/java/org/apache/cassandra/cql3/Relation.java
+++ b/src/java/org/apache/cassandra/cql3/Relation.java
@@ -157,6 +157,8 @@ public abstract class Relation
                 return newLikeRestriction(table, boundNames, relationType);
             case ANN:
                 return newAnnRestriction(table, boundNames);
+            case ANALYZER_MATCHES:
+                return newAnalyzerMatchesRestriction(table, boundNames);
             default: throw invalidRequest("Unsupported \"!=\" relation: %s", this);
         }
     }
@@ -215,6 +217,11 @@ public abstract class Relation
      * Creates a new ANN restriction instance.
      */
     protected abstract Restriction newAnnRestriction(TableMetadata table, VariableSpecifications boundNames);
+
+    /**
+     * Creates a new Analyzer Matches restriction instance.
+     */
+    protected abstract Restriction newAnalyzerMatchesRestriction(TableMetadata table, VariableSpecifications boundNames);
 
     /**
      * Converts the specified <code>Raw</code> into a <code>Term</code>.

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -275,6 +275,18 @@ public final class SingleColumnRelation extends Relation
         return new SingleColumnRestriction.AnnRestriction(columnDef, term);
     }
 
+    @Override
+    protected Restriction newAnalyzerMatchesRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        if (mapKey != null)
+            throw invalidRequest("%s can't be used with collections.", operator());
+
+        ColumnMetadata columnDef = table.getExistingColumn(entity);
+        Term term = toTerm(toReceivers(columnDef), value, table.keyspace, boundNames);
+
+        return new SingleColumnRestriction.AnalyzerMatchesRestriction(columnDef, term);
+    }
+
     /**
      * Returns the receivers for this relation.
      * @param columnDef the column definition

--- a/src/java/org/apache/cassandra/cql3/TokenRelation.java
+++ b/src/java/org/apache/cassandra/cql3/TokenRelation.java
@@ -125,6 +125,12 @@ public final class TokenRelation extends Relation
     }
 
     @Override
+    protected Restriction newAnalyzerMatchesRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        throw invalidRequest("%s cannot be used for token relations", operator());
+    }
+
+    @Override
     protected Term toTerm(List<? extends ColumnSpecification> receivers,
                           Raw raw,
                           String keyspace,

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -866,4 +866,65 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             return index.supportsExpression(columnDef, Operator.ANN);
         }
     }
+
+    public static final class AnalyzerMatchesRestriction extends SingleColumnRestriction
+    {
+        private final Term value;
+
+        public AnalyzerMatchesRestriction(ColumnMetadata columnDef, Term value)
+        {
+            super(columnDef);
+            this.value = value;
+        }
+
+        public ByteBuffer value(QueryOptions options)
+        {
+            return value.bindAndGet(options);
+        }
+
+        @Override
+        public void addFunctionsTo(List<Function> functions)
+        {
+            value.addFunctionsTo(functions);
+        }
+
+        @Override
+        MultiColumnRestriction toMultiColumnRestriction()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addToRowFilter(RowFilter.Builder filter,
+                                   IndexRegistry indexRegistry,
+                                   QueryOptions options)
+        {
+            filter.add(columnDef, Operator.ANALYZER_MATCHES, value.bindAndGet(options));
+        }
+
+        @Override
+        public MultiCBuilder appendTo(MultiCBuilder builder, QueryOptions options)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("ANALYZER_MATCHES(%s)", value);
+        }
+
+        @Override
+        public SingleRestriction doMergeWith(SingleRestriction otherRestriction)
+        {
+            throw invalidRequest("%s cannot be restricted by more than one relation if it includes a :", columnDef.name);
+        }
+
+
+        @Override
+        protected boolean isSupportedBy(Index index)
+        {
+            return index.supportsExpression(columnDef, Operator.ANALYZER_MATCHES);
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -411,7 +411,12 @@ public class IndexContext
     public boolean supports(Operator op)
     {
         if (op.isLike() || op == Operator.LIKE) return false;
-        if (isAnalyzed && op == Operator.ANALYZER_MATCHES) return true;
+        if (isAnalyzed)
+        {
+            if (op == Operator.ANALYZER_MATCHES) return true;
+            // Analyzed columns store the indexed result and are unable to compute raw equality
+            if (op == Operator.EQ) return false;
+        }
 
         // ANN is only supported against vectors, and vector indexes only support ANN
         if (column.type instanceof VectorType)

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -411,12 +411,9 @@ public class IndexContext
     public boolean supports(Operator op)
     {
         if (op.isLike() || op == Operator.LIKE) return false;
-        if (isAnalyzed)
-        {
-            if (op == Operator.ANALYZER_MATCHES) return true;
-            // Analyzed columns store the indexed result and are unable to compute raw equality
-            if (op == Operator.EQ) return false;
-        }
+        // Analyzed columns store the indexed result, so we are unable to compute raw equality.
+        // The only supported operator is ANALYZER_MATCHES.
+        if (isAnalyzed) return op == Operator.ANALYZER_MATCHES;
 
         // ANN is only supported against vectors, and vector indexes only support ANN
         if (column.type instanceof VectorType)

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -107,6 +107,7 @@ public class IndexContext
     private final IndexMetrics indexMetrics;
     private final ColumnQueryMetrics columnQueryMetrics;
     private final IndexWriterConfig indexWriterConfig;
+    private final boolean isAnalyzed;
     private final AbstractAnalyzer.AnalyzerFactory analyzerFactory;
     private final AbstractAnalyzer.AnalyzerFactory queryAnalyzerFactory;
     private final PrimaryKey.Factory primaryKeyFactory;
@@ -143,6 +144,7 @@ public class IndexContext
         {
             String fullIndexName = String.format("%s.%s.%s", this.keyspace, this.table, this.config.name);
             this.indexWriterConfig = IndexWriterConfig.fromOptions(fullIndexName, validator, config.options);
+            this.isAnalyzed = AbstractAnalyzer.isAnalyzed(config.options);
             this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), config.options);
             this.queryAnalyzerFactory = AbstractAnalyzer.hasQueryAnalyzer(config.options)
                                         ? AbstractAnalyzer.fromOptionsQueryAnalyzer(getValidator(), config.options)
@@ -152,6 +154,7 @@ public class IndexContext
         else
         {
             this.indexWriterConfig = IndexWriterConfig.emptyConfig();
+            this.isAnalyzed = AbstractAnalyzer.isAnalyzed(Collections.EMPTY_MAP);
             this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), Collections.EMPTY_MAP);
             this.queryAnalyzerFactory = this.analyzerFactory;
             this.segmentCompactionEnabled = true;
@@ -408,6 +411,7 @@ public class IndexContext
     public boolean supports(Operator op)
     {
         if (op.isLike() || op == Operator.LIKE) return false;
+        if (isAnalyzed && op == Operator.ANALYZER_MATCHES) return true;
 
         // ANN is only supported against vectors, and vector indexes only support ANN
         if (column.type instanceof VectorType)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -94,7 +94,7 @@ public class InvertedIndexSearcher extends IndexSearcher
         if (logger.isTraceEnabled())
             logger.trace(indexContext.logMessage("Searching on expression '{}'..."), exp);
 
-        if (!exp.getOp().isEquality())
+        if (!exp.getOp().isEquality() && exp.getOp() != Expression.Op.MATCH)
             throw new IllegalArgumentException(indexContext.logMessage("Unsupported expression: " + exp));
 
         final ByteComparable term = ByteComparable.fixedLength(exp.lower.value.encoded);

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -76,6 +76,7 @@ public class Expression
                     return PREFIX;
 
                 case LIKE_MATCHES:
+                case ANALYZER_MATCHES:
                     return MATCH;
 
                 case IN:
@@ -133,6 +134,7 @@ public class Expression
         {
             case LIKE_PREFIX:
             case LIKE_MATCHES:
+            case ANALYZER_MATCHES:
             case EQ:
             case CONTAINS:
             case CONTAINS_KEY:

--- a/test/long/index/sai/cql/AnalyzerQueryLongTest.java
+++ b/test/long/index/sai/cql/AnalyzerQueryLongTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnalyzerQueryLongTest extends CQLTester
+{
+    @Test
+    public void manyWritesTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, not_analyzed int, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndex(KEYSPACE, currentTable(), "val");
+        var iterations = 15000;
+        for (int i = 0; i < iterations; i++)
+        {
+            var x = i % 100;
+            if (i % 100 == 0)
+            {
+                execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (?, ?, ?)", i, x, "this will be tokenized");
+            }
+            else if (i % 2 == 0)
+            {
+                execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (?, ?, ?)", i, x, "this is different");
+            }
+            else
+            {
+                execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (?, ?, ?)", i, x, "basic test");
+            }
+        }
+        var result = execute("SELECT * FROM %s WHERE val : 'tokenized'");
+        assertThat(result).hasSize(iterations / 100);
+        result = execute("SELECT * FROM %s WHERE val : 'this'");
+        assertThat(result).hasSize(iterations / 2);
+        result = execute("SELECT * FROM %s WHERE val : 'test'");
+        assertThat(result).hasSize(iterations / 2);
+    }
+
+    @Test
+    public void manyWritesAndUpsertsTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndex(KEYSPACE, currentTable(), "val");
+        var iterations = 15000;
+        for (int i = 0; i < iterations; i++)
+        {
+            if (i % 999 == 0) {
+                // flush on irregular cadence so that final queries are executed based on paritially flushed data
+                flush();
+            }
+            if (i % 2 == 0)
+            {
+                // Upsert the same entry many times
+                execute("INSERT INTO %s (pk, val) VALUES (0, 'text to be analyzed')");
+            }
+            else
+            {
+                execute("INSERT INTO %s (pk, val) VALUES (?, 'different text to be analyzed')", i);
+            }
+        }
+        var result = execute("SELECT * FROM %s WHERE val : 'different'");
+        assertThat(result).hasSize(iterations / 2);
+        result = execute("SELECT * FROM %s WHERE val : 'text'");
+        assertThat(result).hasSize(iterations / 2 + 1);
+    }
+    @Test
+    public void manyWritesUpsertsAndDeletesForSamePKTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndex(KEYSPACE, currentTable(), "val");
+        var iterations = 15000;
+        for (int i = 0; i < iterations; i++)
+        {
+            if (i % 999 == 0) {
+                // flush on irregular cadence so that final queries are executed based on paritially flushed data
+                flush();
+            }
+            // 3 works well because 14999 is the last value for i, and it is not divisible by 3
+            // Further, it by using 3, we first insert, then upsert, then delet, and repeat.
+            if (i % 3 == 0)
+            {
+                // Upsert the same entry many times
+                execute("DELETE FROM %s WHERE pk = 0");
+            }
+            else if (i % 2 == 0)
+            {
+                execute("INSERT INTO %s (pk, val) VALUES (0, 'text to be analyzed')");
+            }
+            else
+            {
+                execute("INSERT INTO %s (pk, val) VALUES (0, 'completely different value')");
+            }
+        }
+        // 'completely different value' wins
+        var result = execute("SELECT * FROM %s WHERE val : 'text'");
+        assertThat(result).hasSize(0);
+        result = execute("SELECT * FROM %s WHERE val : 'value'");
+        assertThat(result).hasSize(1);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -96,7 +96,8 @@ public class LuceneAnalyzerTest extends SAITester
         assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE val : 'dog'"))
         .isInstanceOf(InvalidRequestException.class);;
 
-        // Equality still works
+        // Equality still works because indexed value is not analyzed, and so the search can be performed without
+        // filtering.
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -67,10 +67,10 @@ public class LuceneAnalyzerTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'The quick brown fox jumps over the lazy DOG.')");
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
 
         flush();
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
     }
 
     // Technically, the NoopAnalyzer is applied, but that maps each field without modification, so any operator
@@ -87,9 +87,10 @@ public class LuceneAnalyzerTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES (1, 'dog')");
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+        assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE val : 'dog'"))
+        .isInstanceOf(InvalidRequestException.class);;
 
-        flush();
+        // Equality still works
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
     }
 
@@ -153,7 +154,7 @@ public class LuceneAnalyzerTest extends SAITester
 
         flush();
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'hello'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'hello'").size());
     }
 
     @Test
@@ -173,9 +174,9 @@ public class LuceneAnalyzerTest extends SAITester
 
         flush();
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'do'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'og'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'do'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'og'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
     }
 
     @Test
@@ -192,9 +193,9 @@ public class LuceneAnalyzerTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'DoG')");
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'do'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'og'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'do'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'og'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
     }
 
     @Test
@@ -212,10 +213,10 @@ public class LuceneAnalyzerTest extends SAITester
 
         flush();
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'hello'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'twice'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'the'").size()); // test stop word
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'and'").size()); // test stop word
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'hello'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'twice'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size()); // test stop word
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'and'").size()); // test stop word
     }
 
     @Test
@@ -234,10 +235,10 @@ public class LuceneAnalyzerTest extends SAITester
 
         flush();
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'hello'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'twice'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'the'").size()); // test stop word
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'and'").size()); // test stop word
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'hello'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'twice'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size()); // test stop word
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'and'").size()); // test stop word
     }
 
     @Test
@@ -256,8 +257,8 @@ public class LuceneAnalyzerTest extends SAITester
 
         flush();
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'the'").size()); // stop word test
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'query'").size());
-        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'queries'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size()); // stop word test
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'query'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'queries'").size());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -51,7 +51,7 @@ public class LuceneAnalyzerTest extends SAITester
         // TODO: randomize flushing... not sure how
         flush();
 
-        assertEquals(0, execute("SELECT * FROM %s WHERE val = 'query'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'query'").size());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -20,12 +20,16 @@ package org.apache.cassandra.index.sai.cql;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.SAITester;
 
+import static org.apache.cassandra.index.sai.cql.VectorTypeTest.assertContainsInt;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class LuceneUpdateDeleteTest extends SAITester
 {
+    // No flushes
     @Test
     public void removeUpdateAndDeleteTextInMemoryTest() throws Throwable
     {
@@ -72,4 +76,459 @@ public class LuceneUpdateDeleteTest extends SAITester
         assertEquals(0, execute("SELECT * FROM %s WHERE val : 'happy'").size());
         assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
     }
+
+    // Flush after every insert/update/delete
+    @Test
+    public void removeUpdateAndDeleteTextOnDiskTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+
+        waitForIndexQueryable();
+
+        // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
+        // Note that capitalization is covered as well as tokenization.
+        execute("INSERT INTO %s (id, val) VALUES (0, 'a sad doG.')");
+        execute("INSERT INTO %s (id, val) VALUES (1, 'A Happy DOG.')");
+
+        flush();
+
+        // Prove initial assumptions about data structures are correct.
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = null WHERE id = 0");
+        flush();
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = 'the dog' WHERE id = 0");
+        flush();
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("DELETE from %s WHERE id = 1");
+        flush();
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("INSERT INTO %s (id, val) VALUES (1, 'A Happy DOG.')");
+        flush();
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+    }
+
+    // Insert entries, flush them, then perform updates without flushing.
+    @Test
+    public void removeUpdateAndDeleteTextMixInMemoryOnDiskTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+
+        waitForIndexQueryable();
+
+        // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
+        // Note that capitalization is covered as well as tokenization.
+        execute("INSERT INTO %s (id, val) VALUES (0, 'a sad doG.')");
+        execute("INSERT INTO %s (id, val) VALUES (1, 'A Happy DOG.')");
+
+        flush();
+
+        // Prove initial assumptions about data structures are correct.
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = null WHERE id = 0");
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = 'the dog' WHERE id = 0");
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("DELETE from %s WHERE id = 1");
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("INSERT INTO %s (id, val) VALUES (1, 'A Happy DOG.')");
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+    }
+
+    // row delete will trigger UpdateTransaction#onUpdated
+    @Test
+    public void rowDeleteRowInMemoryAndFlushTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, str_val text, val text, PRIMARY KEY(pk, ck))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (0, 0, 'A', 'dog 0')");
+        execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (1, 1, 'B', 'dog 1')");
+        execute("DELETE from %s WHERE pk = 1 and ck = 1");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'dog'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+
+        flush();
+
+        result = execute("SELECT * FROM %s WHERE val : 'dog'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+    }
+
+    // range delete won't trigger UpdateTransaction#onUpdated
+    @Test
+    public void rangeDeleteRowInMemoryAndFlushTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck, ck2))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (0, 0, 0, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (1, 1, 1, 'B', 'second insert')");
+        execute("DELETE from %s WHERE pk = 1 and ck = 1");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+
+        flush();
+
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+    }
+
+    @Test
+    public void updateRowInMemoryAndFlushTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
+        execute("UPDATE %s SET val = null WHERE pk = 1");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+
+        flush();
+
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+    }
+
+    @Test
+    public void deleteRowPostFlushTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(2);
+        flush();
+
+        execute("UPDATE %s SET val = null WHERE pk = 0");
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 1);
+
+        execute("DELETE from %s WHERE pk = 1");
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).isEmpty();
+        flush();
+
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void deletedInOtherSSTablesTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', 'third insert')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'first'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+        flush();
+
+        execute("DELETE from %s WHERE pk = 0");
+        execute("DELETE from %s WHERE pk = 1");
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 2);
+    }
+
+    @Test
+    public void deletedInOtherSSTablesMultiIndexTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', 'second insert')");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'A', 'third insert')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE str_val = 'A' AND val : 'first'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+        flush();
+
+        execute("DELETE from %s WHERE pk = 0");
+        execute("DELETE from %s WHERE pk = 1");
+        result = execute("SELECT * FROM %s WHERE str_val = 'A' AND val : 'insert'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 2);
+    }
+
+    @Test
+    public void rangeDeletedInOtherSSTablesTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck1, ck2))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', 'first insert')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', 'second insert')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 1, 3, 'C', 'third insert')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 1, 4, 'D', 'fourth insert')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(4);
+        flush();
+
+        execute("DELETE from %s WHERE pk = 0 and ck1 = 0");
+
+        result = execute("SELECT * FROM %s WHERE val : 'insert'");
+        assertThat(result).hasSize(2);
+        assertContainsInt(result, "ck2", 3);
+        assertContainsInt(result, "ck2", 4);
+    }
+
+    @Test
+    public void partitionDeletedInOtherSSTablesTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck1, ck2))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', 'some text')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', 'updated text')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (1, 1, 3, 'C', 'another text')");
+        execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (1, 1, 4, 'D', 'more text')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'updated'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+        flush();
+
+        execute("DELETE from %s WHERE pk = 0");
+
+        result = execute("SELECT * FROM %s WHERE val : 'another'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 1);
+
+
+        result = execute("SELECT * FROM %s WHERE val : 'text'");
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void upsertTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, not_analyzed text, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (1, 'B', 'different tokenized text')");
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE val : 'tokenized'");
+        assertThat(result).hasSize(2);
+        assertContainsInt(result, "pk", 0);
+        assertContainsInt(result, "pk", 1);
+        flush();
+
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
+        result = execute("SELECT * FROM %s WHERE val : 'tokenized'");
+        assertThat(result).hasSize(2);
+        assertContainsInt(result, "pk", 0);
+        assertContainsInt(result, "pk", 1);
+        flush();
+
+        result = execute("SELECT * FROM %s WHERE val : 'tokenized'");
+        assertThat(result).hasSize(2);
+        assertContainsInt(result, "pk", 0);
+        assertContainsInt(result, "pk", 1);
+    }
+
+    @Test
+    public void updateOtherColumnsTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, val text, not_analyzed text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val, not_analyzed) VALUES (0, 'a sad doG.', 'more text')");
+        execute("INSERT INTO %s (id, val, not_analyzed) VALUES (1, 'A Happy DOG.', 'different text')");
+        execute("UPDATE %s SET not_analyzed='A' WHERE id=0");
+
+        var result = execute("SELECT * FROM %s WHERE val : 'dog'");
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void updateManySSTablesTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'this is')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'a test')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'of the emergency')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'broadcast system')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'this is only')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'a test')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'if this were')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'a real emergency')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'you would be instructed')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'where to tune in your area')");
+        flush();
+        execute("INSERT INTO %s (pk, val) VALUES (0, 'for news and official information')");
+        flush();
+
+        var result = execute("SELECT * FROM %s WHERE val : 'news'");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+        result = execute("SELECT * FROM %s WHERE val : 'this'");
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void shadowedPrimaryKeyInDifferentSSTable() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val text, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // flush a sstable with one vector
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'an indexed phrase')");
+        flush();
+
+        // flush another sstable to shadow the vector row
+        execute("DELETE FROM %s where pk = 0");
+        flush();
+
+        // flush another sstable with one new vector row
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'something different')");
+        flush();
+
+        // the shadow vector has the highest score
+        var result = execute("SELECT * FROM %s WHERE val : 'something'");
+        assertThat(result).hasSize(1);
+    }
+
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.SAITester;
+
+import static org.junit.Assert.assertEquals;
+
+public class LuceneUpdateDeleteTest extends SAITester
+{
+    @Test
+    public void removeUpdateAndDeleteTextInMemoryTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+
+        waitForIndexQueryable();
+
+        // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
+        // Note that capitalization is covered as well as tokenization.
+        execute("INSERT INTO %s (id, val) VALUES (0, 'a sad doG.')");
+        execute("INSERT INTO %s (id, val) VALUES (1, 'A Happy DOG.')");
+
+        // Prove initial assumptions about data structures are correct.
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = null WHERE id = 0");
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("UPDATE %s SET val = 'the dog' WHERE id = 0");
+
+        // Prove that we can remove a row when we update the data
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'the'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+
+        execute("DELETE from %s WHERE id = 1");
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'a'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'happy'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'sad'").size());
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -295,9 +295,9 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'Camel'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'Camel'").size());
 
-        assertEquals(0, execute("SELECT id FROM %s WHERE val = 'camel'").size());
+        assertEquals(0, execute("SELECT id FROM %s WHERE val : 'camel'").size());
     }
 
     @Test
@@ -310,7 +310,7 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'camel'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'camel'").size());
     }
 
     @Test
@@ -339,10 +339,10 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'Cam\u00E1l'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'Cam\u00E1l'").size());
 
         // Both \u00E1 and \u0061\u0301 are visible as the character á, but without NFC normalization, they won't match.
-        assertEquals(0, execute("SELECT id FROM %s WHERE val = 'Cam\u0061\u0301l'").size());
+        assertEquals(0, execute("SELECT id FROM %s WHERE val : 'Cam\u0061\u0301l'").size());
     }
 
     @Test
@@ -355,7 +355,7 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'Cam\u0061\u0301l'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'Cam\u0061\u0301l'").size());
     }
 
     @Test
@@ -368,7 +368,7 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'cam\u0061\u0301l'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'cam\u0061\u0301l'").size());
     }
 
     @Test
@@ -381,7 +381,7 @@ public class NativeIndexDDLTest extends SAITester
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Éppinger')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'eppinger'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'eppinger'").size());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+
+import static org.apache.cassandra.index.sai.cql.VectorTypeTest.assertContainsInt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class VectorAndLuceneTest extends VectorTester
+{
+
+    @Test
+    public void basicVectorLuceneSelectTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'" +
+                    " WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        // The str_val is set up to make sure that tokens are properly analyzed and lowercased.
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'One Duplicate phrase', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'This duplicate PHRASE', [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'A different Phrase', [3.0, 4.0, 5.0])");
+
+        // 'phrase' is in all rows, so expect all rows to be returned.
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE str_val : 'phrase' ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 3");
+        assertThat(result).hasSize(3);
+
+        // 'missing' is in no rows, so expect no rows to be returned.
+        result = execute("SELECT * FROM %s WHERE str_val : 'missing' ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 3");
+        assertThat(result).hasSize(0);
+
+        // Use limit to 1 to be the limiting condition. 'phrase' matches all three str_val. Matches row 1 becuase the vector is closer.
+        result = execute("SELECT * FROM %s WHERE str_val : 'phrase' ORDER BY val ann of [2.1, 3.1, 4.1] LIMIT 1");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 1);
+
+        // 'one' only matches for row 0. The vector is the same as the one in the 2nd row.
+        result = execute("SELECT * FROM %s WHERE str_val : 'one' ORDER BY val ann of [3.0, 4.0, 5.0] LIMIT 3");
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 0);
+
+        // 'duplicate' matches rows 0 and 1. The vector matches row 2, but that doesn't match the WHERE clause.
+        result = execute("SELECT * FROM %s WHERE str_val : 'duplicate' ORDER BY val ann of [3.0, 4.0, 5.0] LIMIT 3");
+        assertThat(result).hasSize(2);
+        assertContainsInt(result, "pk", 0);
+        assertContainsInt(result, "pk", 1);
+
+    }
+
+    // partition delete won't trigger UpdateTransaction#onUpdated
+    @Test
+    public void partitionDeleteVectorInMemoryTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'" +
+                    " WITH OPTIONS = { 'index_analyzer': '[{\"tokenizer\": \"standard\"}, {\"filter\": \"lowercase\"}]' }");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'this test has tokens', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'not so plural token', [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'another test too', [3.0, 4.0, 5.0])");
+
+        UntypedResultSet result = execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 3");
+        assertThat(result).hasSize(3);
+
+        execute("UPDATE %s SET val = null WHERE pk = 0");
+
+        assertEquals(1, execute("SELECT * FROM %s WHERE str_val : 'tokens' ORDER BY val ann of [1.1, 2.1, 3.1] LIMIT 2").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE str_val : 'token'").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE str_val : 'test'").size());
+
+        result = execute("SELECT * FROM %s ORDER BY val ann of [1.1, 2.1, 3.1] LIMIT 1"); // closer to row 0
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 1);
+
+        execute("DELETE from %s WHERE pk = 1");
+        result = execute("SELECT * FROM %s ORDER BY val ann of [2.1, 3.1, 4.1] LIMIT 1"); // closer to row 1
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 2);
+
+        flush();
+
+        result = execute("SELECT * FROM %s ORDER BY val ann of [2.1, 3.1, 4.1] LIMIT 1");  // closer to row 1
+        assertThat(result).hasSize(1);
+        assertContainsInt(result, "pk", 2);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
@@ -88,7 +88,7 @@ public class VectorAndLuceneTest extends VectorTester
 
         execute("UPDATE %s SET val = null WHERE pk = 0");
 
-        assertEquals(1, execute("SELECT * FROM %s WHERE str_val : 'tokens' ORDER BY val ann of [1.1, 2.1, 3.1] LIMIT 2").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE str_val : 'tokens' ORDER BY val ann of [1.1, 2.1, 3.1] LIMIT 2").size());
         assertEquals(1, execute("SELECT * FROM %s WHERE str_val : 'token'").size());
         assertEquals(2, execute("SELECT * FROM %s WHERE str_val : 'test'").size());
 


### PR DESCRIPTION
* Adds the `:` operator, a.k.a the ANALYZER_MATCHES operator. This operator only works on SAI indexes that are analyzed where analyzed means the values stored in the index are derivative values from the raw value in the column. The new operator uses the enum value `100` to prevent future collisions with the upstream CQL implementation.
* Disambiguate the `=` operator so that it cannot perform matches on an `SAI` column that is indexed. The primary motivation for this change is to prevent surprising matches. If a query is attempted using `=` where the target column only has analyzed indexes, the query must include `ALLOW FILTERING`.
* Updated many tests.