### PR TITLE
Overlaps should be refreshed regardless if ignoreOverlaps is activated

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -105,12 +105,6 @@ public class CompactionController implements AutoCloseable
             return;
         }
 
-        if (ignoreOverlaps())
-        {
-            logger.debug("not refreshing overlaps - running with ignoreOverlaps activated");
-            return;
-        }
-
         for (SSTableReader reader : overlappingSSTables)
         {
             if (reader.isMarkedCompacted())
@@ -129,7 +123,7 @@ public class CompactionController implements AutoCloseable
         if (this.overlappingSSTables != null)
             close();
 
-        if (compacting == null || ignoreOverlaps())
+        if (compacting == null)
             overlappingSSTables = Refs.tryRef(Collections.<SSTableReader>emptyList());
         else
             overlappingSSTables = cfs.getAndReferenceOverlappingLiveSSTables(compacting);


### PR DESCRIPTION
Fix for [CASSANDRA-18756](https://issues.apache.org/jira/browse/CASSANDRA-18756)

`CompactionController` now updates the created overlap iterator even if `unsafe_aggressive_sstable_expiration` is set.