### PR TITLE
Return more specific exception on incorrect usage of : operator

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -290,7 +290,7 @@ public enum Operator
          */
         public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(": operation can only be computed by an indexed column with a configured analyzer");
         }
     };
 

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -280,7 +280,7 @@ public enum Operator
         @Override
         public String toString()
         {
-            return ": '<term>'";
+            return ":";
         }
 
         /**

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -783,7 +783,7 @@ public abstract class ColumnCondition
 
             // Analyzer matches operator is only supported on SAI indexes for now
             if (operator == Operator.ANALYZER_MATCHES)
-                throw invalidRequest(": operation can only be computed by an indexed column with a configured analyzer");
+                throw invalidRequest("LWT Conditions do not support the : operator");
 
             if (collectionElement != null)
             {

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -781,6 +781,10 @@ public abstract class ColumnCondition
             if (receiver.type instanceof CounterColumnType)
                 throw invalidRequest("Conditions on counters are not supported");
 
+            // Analyzer matches operator is only supported on SAI indexes for now
+            if (operator == Operator.ANALYZER_MATCHES)
+                throw invalidRequest(": operation can only be computed by an indexed column with a configured analyzer");
+
             if (collectionElement != null)
             {
                 if (!(receiver.type.isCollection()))

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -921,12 +921,8 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                         ByteBuffer foundValue = getValue(metadata, partitionKey, row);
                         return foundValue != null && mapType.getSerializer().getSerializedValue(foundValue, value, mapType.getKeysType()) != null;
                     }
-                case ANALYZER_MATCHES:
-                    // The analyzer is unable to filter raw rows. It can only match analyzed columns.
-                    // Building the query restrictions should prevent reaching this code block.
-                    throw new UnsupportedOperationException("The analyzer is unable to filter raw rows. It can only match analyzed columns.");
             }
-            throw new AssertionError();
+            throw new AssertionError("Unsupported operator: " + operator);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -921,6 +921,10 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                         ByteBuffer foundValue = getValue(metadata, partitionKey, row);
                         return foundValue != null && mapType.getSerializer().getSerializedValue(foundValue, value, mapType.getKeysType()) != null;
                     }
+                case ANALYZER_MATCHES:
+                    // The analyzer is unable to filter raw rows. It can only match analyzed columns.
+                    // Building the query restrictions should prevent reaching this code block.
+                    throw new UnsupportedOperationException("The analyzer is unable to filter raw rows. It can only match analyzed columns.");
             }
             throw new AssertionError();
         }

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -422,4 +422,19 @@ public class AllowFilteringTest extends SAITester
         assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, "c"), "SELECT * FROM %s WHERE c LIKE 'Test'");
         assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, "d"), "SELECT * FROM %s WHERE d LIKE 'Test'");
     }
+
+    @Test
+    public void testIndexedColumnDoesNotSupportAnalyzerRestriction() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a text, b text, c text, d text, PRIMARY KEY (a, b))");
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", StorageAttachedIndex.class.getName()));
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", StorageAttachedIndex.class.getName()));
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(d) USING '%s'", StorageAttachedIndex.class.getName()));
+
+        // Analyzer restriction
+        assertInvalidMessage(String.format(": restriction is only supported on properly indexed columns. a : 'Test' is not valid."), "SELECT * FROM %s WHERE a : 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'b'), "SELECT * FROM %s WHERE b : 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'c'), "SELECT * FROM %s WHERE c : 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'd'), "SELECT * FROM %s WHERE d : 'Test'");
+    }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.index.sai.cql;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 
 import static org.apache.cassandra.index.sai.cql.VectorTypeTest.assertContainsInt;
@@ -48,17 +49,17 @@ public class LuceneUpdateDeleteTest extends SAITester
 
         // DELETE fails
         assertThatThrownBy(() -> execute("DELETE FROM %s WHERE val : 'dog'"))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("Invalid query. DELETE does not support use of secondary indices, but val : 'dog' restriction requires a secondary index.");
 
         // UPDATE fails
         assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE val : 'dog'"))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("Invalid query. UPDATE does not support use of secondary indices, but val : 'dog' restriction requires a secondary index.");
 
         // UPDATE with LWT fails (different error message because it fails at a different point)
         assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE id = 0 IF val : 'dog'"))
-        .isInstanceOf(UnsupportedOperationException.class)
+        .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining(": operation can only be computed by an indexed column with a configured analyzer");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -60,7 +60,7 @@ public class LuceneUpdateDeleteTest extends SAITester
         // UPDATE with LWT fails (different error message because it fails at a different point)
         assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE id = 0 IF val : 'dog'"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessageContaining(": operation can only be computed by an indexed column with a configured analyzer");
+        .hasMessageContaining("LWT Conditions do not support the : operator");
     }
 
     // No flushes

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -55,6 +55,11 @@ public class LuceneUpdateDeleteTest extends SAITester
         assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE val : 'dog'"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Invalid query. UPDATE does not support use of secondary indices, but val : 'dog' restriction requires a secondary index.");
+
+        // UPDATE with LWT fails (different error message because it fails at a different point)
+        assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE id = 0 IF val : 'dog'"))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining(": operation can only be computed by an indexed column with a configured analyzer");
     }
 
     // No flushes


### PR DESCRIPTION
* When the `:` operator is used for indexes that do not support it, the current error is a recommendation to `ALLOW FILTERING` or an `AssertionError`. Instead, we should match the `LIKE` behavior and reject queries that attempt to use the `:` operator on columns that are not properly indexed. The `LIKE` conditional is slightly modified to simplify the logic for rejecting unsupported queries.
* When the `:` operator is used for `DELETE` and `UPDATE` queries, return a helpful error message.
* Update the `toString` method on the `ANALYZER_MATCHES` enum. The `toString` method is used to generate error messages, and it is confusing to see an error message with `: '<term>'` when it really should just be `:`.