### PR TITLE
Ignore default analyzer settings when classifying an SAI as analyzed

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -141,7 +141,7 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
     }
 
     public static boolean isAnalyzed(Map<String, String> options) {
-        return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER) || hasNonTokenizingOptions(options);
+        return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER) || NonTokenizingOptions.hasNonDefaultOptions(options);
     }
 
     public static AnalyzerFactory fromOptions(AbstractType<?> type, Map<String, String> options)
@@ -159,7 +159,7 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
             }
         }
 
-        if (hasNonTokenizingOptions(options))
+        if (NonTokenizingOptions.hasNonDefaultOptions(options))
         {
             if (TypeUtil.isIn(type, ANALYZABLE_TYPES))
             {
@@ -174,10 +174,5 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
             }
         }
         return NoOpAnalyzer::new;
-    }
-
-    private static boolean hasNonTokenizingOptions(Map<String, String> options)
-    {
-        return options.get(NonTokenizingOptions.ASCII) != null || options.containsKey(NonTokenizingOptions.CASE_SENSITIVE) || options.containsKey(NonTokenizingOptions.NORMALIZE);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/analyzer/NonTokenizingOptions.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/NonTokenizingOptions.java
@@ -30,6 +30,9 @@ public class NonTokenizingOptions
     public static final String NORMALIZE = "normalize";
     public static final String CASE_SENSITIVE = "case_sensitive";
     public static final String ASCII = "ascii";
+    static final boolean NORMALIZE_DEFAULT = false;
+    static final boolean CASE_SENSITIVE_DEFAULT = true;
+    static final boolean ASCII_DEFAULT = false;
 
     private boolean caseSensitive;
     private boolean normalized;
@@ -67,9 +70,9 @@ public class NonTokenizingOptions
 
     public static class OptionsBuilder
     {
-        private boolean caseSensitive = true;
-        private boolean normalized = false;
-        private boolean ascii = false;
+        private boolean caseSensitive = CASE_SENSITIVE_DEFAULT;
+        private boolean normalized = NORMALIZE_DEFAULT;
+        private boolean ascii = ASCII_DEFAULT;
 
         OptionsBuilder() {}
 
@@ -152,5 +155,24 @@ public class NonTokenizingOptions
         }
 
         return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Returns true if any of the options are set to a non-default value. Can be used to determine whether the
+     * parameterized OPTIONS should be used to construct a {@link NonTokenizingAnalyzer}
+     * or a {@link NoOpAnalyzer} instance.
+     * @param options - index options
+     * @return true if and only if any of the options are set to a non-default value.
+     */
+    static boolean hasNonDefaultOptions(Map<String, String> options) {
+        return hasNonDefaultBooleanOption(options.get(CASE_SENSITIVE), CASE_SENSITIVE_DEFAULT)
+               || hasNonDefaultBooleanOption(options.get(NORMALIZE), NORMALIZE_DEFAULT)
+               || hasNonDefaultBooleanOption(options.get(ASCII), ASCII_DEFAULT);
+    }
+
+    private static boolean hasNonDefaultBooleanOption(String value, boolean defaultValue)
+    {
+        // Use string equality here to preven the need to parse the input string value.
+        return value != null && !Boolean.toString(defaultValue).equalsIgnoreCase(value);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -208,7 +208,7 @@ public class NativeIndexDDLTest extends SAITester
 
         assertThatThrownBy(() -> executeNet("CREATE CUSTOM INDEX ON %s(val) " +
                                             "USING 'StorageAttachedIndex' " +
-                                            "WITH OPTIONS = { 'case_sensitive' : true }")).isInstanceOf(InvalidQueryException.class);
+                                            "WITH OPTIONS = { 'case_sensitive' : false }")).isInstanceOf(InvalidQueryException.class);
     }
 
     @Test
@@ -290,14 +290,16 @@ public class NativeIndexDDLTest extends SAITester
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
+        // Case sensitive search is the default, and as such, it does not make the SAI qualify as "analyzed".
+        // The queries below use '=' and not ':' because : is limited to analyzed indexes.
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : true }");
         waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'Camel'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'Camel'").size());
 
-        assertEquals(0, execute("SELECT id FROM %s WHERE val : 'camel'").size());
+        assertEquals(0, execute("SELECT id FROM %s WHERE val = 'camel'").size());
     }
 
     @Test
@@ -334,15 +336,17 @@ public class NativeIndexDDLTest extends SAITester
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
+        // Normalize search is disabled by default, and as such, it does not make the SAI qualify as "analyzed".
+        // The queries below use '=' and not ':' because : is limited to analyzed indexes.
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'normalize' : false }");
         waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
-        assertEquals(1, execute("SELECT id FROM %s WHERE val : 'Cam\u00E1l'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'Cam\u00E1l'").size());
 
         // Both \u00E1 and \u0061\u0301 are visible as the character á, but without NFC normalization, they won't match.
-        assertEquals(0, execute("SELECT id FROM %s WHERE val : 'Cam\u0061\u0301l'").size());
+        assertEquals(0, execute("SELECT id FROM %s WHERE val = 'Cam\u0061\u0301l'").size());
     }
 
     @Test


### PR DESCRIPTION
### Problem
When creating an SAI, the `AbstractAnalyzer` creates an analyzer in cases where it should not because the logic is too naive.

### Details

Users can create SAI indexes with a `NonTokenizingAnalyzer` using the following queries where `?` can be replaced with `true` or `false`:

```
CREATE CUSTOM INDEX ON table(some-column) USING 'StorageAttachedIndex' WITH OPTIONS = { 'normalize' : ? }
CREATE CUSTOM INDEX ON table(some-column) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : ? }
CREATE CUSTOM INDEX ON table(some-column) USING 'StorageAttachedIndex' WITH OPTIONS = { 'ascii' : ? }
```

The options are known as "non tokenizing analyzers" because they "analyze" values but do not "tokenize" them. Practically speaking, these analyzers are projections where each input has one and only one output. Lucene calls projections "filters".

The `StorageAttachedIndex` default is for normalize = false, case_sensitive = true, and ascii = false. 

When a default value is passed for one of the options, the `AbstractAnalyzer` incorrectly classifies the index as "analyzed". Instead, the `AbstractAnalyzer` should return the `NoOpAnalyzer` and the index should not be classified as "analyzed".

### Solution

* Only construct the `NonTokenizingAnalyzer` when `normalize`, `case_sensitive`, or `ascii` are configured with non default values.
* Do not consider an SAI as analyzed if `normalize`, `case_sensitive`, or `ascii` are configured with default values.
* Updated some tests to use `=` on the non-analyzed SAI

