### PR TITLE
Accept OPTIONS formatted with single quotes for SAI analyzer config

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Json.java
+++ b/src/java/org/apache/cassandra/cql3/Json.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3;
 import java.io.IOException;
 import java.util.*;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -34,6 +35,12 @@ import org.apache.cassandra.serializers.MarshalException;
 public class Json
 {
     public static final ObjectMapper JSON_OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper PERMISSIVE_JSON_OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        PERMISSIVE_JSON_OBJECT_MAPPER.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        PERMISSIVE_JSON_OBJECT_MAPPER.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    }
 
     public static final ColumnIdentifier JSON_COLUMN_ID = new ColumnIdentifier("[json]", true);
 
@@ -44,6 +51,23 @@ public class Json
     {
         // In future should update to directly use `JsonStringEncoder.getInstance()` but for now:
         return new String(JsonStringEncoder.getInstance().quoteAsString(s));
+    }
+
+    public static Object decodeJson(String json, boolean isStrict)
+    {
+        if (isStrict)
+            return decodeJson(json);
+        else
+        {
+            try
+            {
+                return PERMISSIVE_JSON_OBJECT_MAPPER.readValue(json, Object.class);
+            }
+            catch (IOException exc)
+            {
+                throw new MarshalException("Error decoding JSON string: " + exc.getMessage());
+            }
+        }
     }
 
     public static Object decodeJson(String json)

--- a/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
@@ -43,7 +43,7 @@ public class JSONAnalyzerParser
 
     public static Analyzer parse(String json) throws IOException
     {
-        List<Map<String,String>> list = (List<Map<String,String>>) Json.decodeJson(json);
+        List<Map<String,String>> list = (List<Map<String,String>>) Json.decodeJson(json, false);
         CustomAnalyzer.Builder builder = CustomAnalyzer.builder();
         for (int x = 0; x < list.size(); x++)
         {


### PR DESCRIPTION
This PR increases the acceptable syntax for configuring SAI analyzers. The current formatting requires correctly escaped double quotes around all JSON keys and string values. After this change, it will be possible to use single quotes without escaping when combined with the `$$` string literal wrapper. It will also be possible to optionally drop the quotes from the JSON keys. See the test for further explanation and for examples of correctly and incorrectly formatted options.