### PR TITLE
Consider SAI with configured query analyzer as an analyzed column

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -141,7 +141,9 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
     }
 
     public static boolean isAnalyzed(Map<String, String> options) {
-        return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER) || NonTokenizingOptions.hasNonDefaultOptions(options);
+        return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER)
+               || options.containsKey(LuceneAnalyzer.QUERY_ANALYZER)
+               || NonTokenizingOptions.hasNonDefaultOptions(options);
     }
 
     public static AnalyzerFactory fromOptions(AbstractType<?> type, Map<String, String> options)


### PR DESCRIPTION
* This PR updates the SAI logic so that it considers an index with a query analyzer configured to be "analyzed".
* The underlying question: is it valid to have a query analyzer configured without also configuring an index analyzer?
* Further, what are the cases where the query analyzer should be different than the index analyzer?