### PR TITLE
Remove ability to configure unique query_analyzer

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -146,9 +146,7 @@ public class IndexContext
             this.indexWriterConfig = IndexWriterConfig.fromOptions(fullIndexName, validator, config.options);
             this.isAnalyzed = AbstractAnalyzer.isAnalyzed(config.options);
             this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), config.options);
-            this.queryAnalyzerFactory = AbstractAnalyzer.hasQueryAnalyzer(config.options)
-                                        ? AbstractAnalyzer.fromOptionsQueryAnalyzer(getValidator(), config.options)
-                                        : this.analyzerFactory;
+            this.queryAnalyzerFactory = this.analyzerFactory;
             this.segmentCompactionEnabled = Boolean.parseBoolean(config.options.getOrDefault(ENABLE_SEGMENT_COMPACTION_OPTION_NAME, "false"));
         }
         else

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -165,8 +165,7 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS,
                                                                      IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH,
                                                                      IndexWriterConfig.SIMILARITY_FUNCTION,
-                                                                     LuceneAnalyzer.INDEX_ANALYZER,
-                                                                     LuceneAnalyzer.QUERY_ANALYZER);
+                                                                     LuceneAnalyzer.INDEX_ANALYZER);
 
     public static final Set<CQL3Type> SUPPORTED_TYPES = ImmutableSet.of(CQL3Type.Native.ASCII, CQL3Type.Native.BIGINT, CQL3Type.Native.DATE,
                                                                         CQL3Type.Native.DOUBLE, CQL3Type.Native.FLOAT, CQL3Type.Native.INT,

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -88,30 +88,12 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
         resetInternal(input);
     }
 
-    public static boolean hasQueryAnalyzer(Map<String, String> options)
-    {
-       return options.containsKey(LuceneAnalyzer.QUERY_ANALYZER);
-    }
-
     public interface AnalyzerFactory extends Closeable
     {
         AbstractAnalyzer create();
 
         default void close()
         {
-        }
-    }
-
-    public static AnalyzerFactory fromOptionsQueryAnalyzer(final AbstractType<?> type, final Map<String, String> options)
-    {
-        final String json = options.get(LuceneAnalyzer.QUERY_ANALYZER);
-        try
-        {
-            return toAnalyzerFactory(json, type, options);
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidRequestException("CQL type " + type.asCQL3Type() + " cannot be analyzed json="+json, ex);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
@@ -42,7 +42,6 @@ import org.apache.lucene.util.CharsRefBuilder;
 public class LuceneAnalyzer extends AbstractAnalyzer
 {
     public static final String INDEX_ANALYZER = "index_analyzer";
-    public static final String QUERY_ANALYZER = "query_analyzer";
     private AbstractType<?> type;
     private boolean hasNext = false;
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.index.sai.cql;
 import org.junit.Test;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 
@@ -34,7 +35,7 @@ public class LuceneAnalyzerTest extends SAITester
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
                     "'index_analyzer': '[\n" +
                     "\t{\"tokenizer\":\"ngram\", \"minGramSize\":\"2\", \"maxGramSize\":\"3\"},\n" +
                     "\t{\"filter\":\"lowercase\"}\n" +
@@ -42,16 +43,9 @@ public class LuceneAnalyzerTest extends SAITester
                     "'query_analyzer': '[\n" +
                     "\t{\"tokenizer\":\"whitespace\"},\n" +
                     "\t{\"filter\":\"porterstem\"}\n" +
-                    "]'};");
-
-        waitForIndexQueryable();
-
-        execute("INSERT INTO %s (id, val) VALUES ('1', 'the query')");
-
-        // TODO: randomize flushing... not sure how
-        flush();
-
-        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'query'").size());
+                    "]'};"))
+        .hasCauseInstanceOf(ConfigurationException.class)
+        .hasRootCauseMessage("Properties specified [query_analyzer] are not understood by StorageAttachedIndex");
     }
 
     @Test


### PR DESCRIPTION
Remove the option to configure a separate query analyzer from the index's analyzer. This may be added back in the future, though we'll want to make sure that the semantics work correctly for both `:` and `=`. https://github.com/datastax/cassandra/pull/709 has some context on potential issues.