### PR TITLE
Fix failing KDTreeIndexSearcherTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.disk.v1;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -210,7 +211,12 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
             assertEquals(results.getMinimum(), results.getCurrent());
             assertTrue(results.hasNext());
 
-            assertEquals(expectedTokenList, results);
+            var actualTokenList = new ArrayList<>();
+            for (RangeIterator<Long> it = results; it.hasNext(); )
+            {
+                actualTokenList.add(it.next());
+            }
+            assertEquals(expectedTokenList, actualTokenList);
         }
 
         try (RangeIterator results = indexSearcher.search(new Expression(SAITester.createIndexContext("meh", rawType))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcherTest.java
@@ -19,12 +19,12 @@ package org.apache.cassandra.index.sai.disk.v1;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.DecimalType;
@@ -211,11 +211,7 @@ public class KDTreeIndexSearcherTest extends SaiRandomizedTest
             assertEquals(results.getMinimum(), results.getCurrent());
             assertTrue(results.hasNext());
 
-            var actualTokenList = new ArrayList<>();
-            for (RangeIterator<Long> it = results; it.hasNext(); )
-            {
-                actualTokenList.add(it.next());
-            }
+            var actualTokenList = Lists.newArrayList(results);
             assertEquals(expectedTokenList, actualTokenList);
         }
 


### PR DESCRIPTION
https://github.com/datastax/cassandra/pull/680 included a change that makes 5 of the `KDTreeIndexSearcherTest` tests fail. This PR essentially reverts back to the old behavior, and all of the failing tests pass.