### PR TITLE
Fix NPE in LuceneAnalyzer#end

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
@@ -99,6 +99,8 @@ public class LuceneAnalyzer extends AbstractAnalyzer
     @Override
     public void end()
     {
+        if (tokenStream == null)
+            return;
         try
         {
             try

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/AnalzyerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/AnalzyerDistributedTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.index.sai.SAITester;
+
+import static org.apache.cassandra.cql3.CQLTester.getRandom;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnalzyerDistributedTest extends TestBaseImpl
+{
+    @Rule
+    public SAITester.FailureWatcher failureRule = new SAITester.FailureWatcher();
+
+    private static final String CREATE_KEYSPACE = "CREATE KEYSPACE %%s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': %d}";
+    private static final String CREATE_TABLE = "CREATE TABLE %%s (pk int PRIMARY KEY, not_analyzed int, val text)";
+    private static final String CREATE_INDEX = "CREATE CUSTOM INDEX ON %%s(%s) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard'}";
+    private static final int NUM_REPLICAS = 3;
+    private static final int RF = 2;
+
+    private static final AtomicInteger seq = new AtomicInteger();
+    private static String table;
+
+    private static Cluster cluster;
+
+    private static int dimensionCount;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception
+    {
+        cluster = Cluster.build(NUM_REPLICAS)
+                         .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                         .start();
+
+        cluster.schemaChange(withKeyspace(String.format(CREATE_KEYSPACE, RF)));
+    }
+
+    @AfterClass
+    public static void closeCluster()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @Before
+    public void before()
+    {
+        table = "table_" + seq.getAndIncrement();
+        dimensionCount = getRandom().nextIntBetween(100, 2048);
+    }
+
+    @After
+    public void after()
+    {
+        cluster.schemaChange(formatQuery("DROP TABLE IF EXISTS %s"));
+    }
+
+    @Test
+    public void testAnalyzerSearch()
+    {
+        cluster.schemaChange(formatQuery(String.format(CREATE_TABLE, dimensionCount)));
+        cluster.schemaChange(formatQuery(String.format(CREATE_INDEX, "val")));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+
+        var iterations = 15000;
+        for (int i = 0; i < iterations; i++)
+        {
+            var x = i % 100;
+            if (i % 100 == 0)
+            {
+                execute(String.format(
+                "INSERT INTO %s (pk, not_analyzed, val) VALUES (%s, %s, '%s')",
+                KEYSPACE + '.' + table, i, x, "this will be tokenized"));
+            }
+            else if (i % 2 == 0)
+            {
+                execute(String.format(
+                "INSERT INTO %s (pk, not_analyzed, val) VALUES (%s, %s, '%s')",
+                KEYSPACE + '.' + table, i, x, "this is different"));
+            }
+            else
+            {
+                execute(String.format(
+                "INSERT INTO %s (pk, not_analyzed, val) VALUES (%s, %s, '%s')",
+                KEYSPACE + '.' + table, i, x, "basic test"));
+            }
+        }
+        var result = execute("SELECT * FROM %s WHERE val : 'tokenized'");
+        assertThat(result).hasSize(iterations / 100);
+        result = execute("SELECT * FROM %s WHERE val : 'this'");
+        assertThat(result).hasSize(iterations / 2);
+        result = execute("SELECT * FROM %s WHERE val : 'test'");
+        assertThat(result).hasSize(iterations / 2);
+    }
+
+    private static Object[][] execute(String query)
+    {
+        return execute(query, ConsistencyLevel.QUORUM);
+    }
+
+    private static Object[][] execute(String query, ConsistencyLevel consistencyLevel)
+    {
+        return cluster.coordinator(1).execute(formatQuery(query), consistencyLevel);
+    }
+
+    private static String formatQuery(String query)
+    {
+        return String.format(query, KEYSPACE + '.' + table);
+    }
+}


### PR DESCRIPTION
When testing the analyzer with an integration test, I discovered an NPE from a part of the code that wasn't tested. 

Here is the code:

https://github.com/datastax/cassandra/blob/9cabec504d9f70ddfb345122dc4defed56a40f85/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java#L91-L100

We build the Analyzer to use one of its methods, but not to analyze any text, hence the NPE.

Here is the NPE:

```
ERROR [Native-Transport-Requests-1] 2023-08-31 14:35:38,695 QueryMessage.java:121 - Unexpected error during query
java.lang.NullPointerException: null
	at org.apache.cassandra.index.sai.analyzer.LuceneAnalyzer.end(LuceneAnalyzer.java:110)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.filterReplicaFilteringProtection(StorageAttachedIndexSearcher.java:99)
	at org.apache.cassandra.service.reads.DataResolver.lambda$preCountFilterForReplicaFilteringProtection$6(DataResolver.java:300)
	at org.apache.cassandra.service.reads.DataResolver.resolveInternal(DataResolver.java:341)
	at org.apache.cassandra.service.reads.DataResolver.resolveWithReadRepair(DataResolver.java:244)
	at org.apache.cassandra.service.reads.DataResolver.resolveWithReplicaFilteringProtection(DataResolver.java:284)
	at org.apache.cassandra.service.reads.DataResolver.resolve(DataResolver.java:130)
	at org.apache.cassandra.service.reads.range.SingleRangeResponse.waitForResponse(SingleRangeResponse.java:59)
	at org.apache.cassandra.service.reads.range.SingleRangeResponse.computeNext(SingleRangeResponse.java:65)
	at org.apache.cassandra.service.reads.range.SingleRangeResponse.computeNext(SingleRangeResponse.java:31)
	at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)
	at org.apache.cassandra.db.transform.BasePartitions.hasNext(BasePartitions.java:93)
	at org.apache.cassandra.service.reads.range.RangeCommandIterator.computeNext(RangeCommandIterator.java:123)
	at org.apache.cassandra.service.reads.range.RangeCommandIterator.computeNext(RangeCommandIterator.java:45)
	at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)
	at org.apache.cassandra.db.transform.BasePartitions.hasNext(BasePartitions.java:93)
	at org.apache.cassandra.db.partitions.PartitionIterators$1.hasNext(PartitionIterators.java:154)
	at org.apache.cassandra.db.transform.BasePartitions.hasNext(BasePartitions.java:93)
	at org.apache.cassandra.cql3.statements.SelectStatement.process(SelectStatement.java:892)
	at org.apache.cassandra.cql3.statements.SelectStatement.processResults(SelectStatement.java:518)
	at org.apache.cassandra.cql3.statements.SelectStatement.execute(SelectStatement.java:495)
	at org.apache.cassandra.cql3.statements.SelectStatement.execute(SelectStatement.java:341)
	at org.apache.cassandra.cql3.statements.SelectStatement.execute(SelectStatement.java:102)
	at org.apache.cassandra.cql3.QueryProcessor.processStatement(QueryProcessor.java:290)
	at org.apache.cassandra.cql3.QueryProcessor.process(QueryProcessor.java:394)
	at org.apache.cassandra.transport.messages.QueryMessage.execute(QueryMessage.java:108)
	at org.apache.cassandra.transport.Message$Request.execute(Message.java:242)
	at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:111)
	at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:131)
	at org.apache.cassandra.transport.Dispatcher.lambda$dispatch$0(Dispatcher.java:78)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

I am still new to query execution, but I am guessing the unit tests skip this filtering code. I added an integration test that fails without the fix.