### PR TITLE
Optimize partition-aware queries to use bloom filter

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -73,7 +73,6 @@ public class V1SearchableIndex implements SearchableIndex
     private final long minSSTableRowId, maxSSTableRowId;
     private final long numRows;
     private PerIndexFiles indexFiles;
-    private SSTableReader ssTable;
 
     public V1SearchableIndex(SSTableContext sstableContext, IndexContext indexContext)
     {
@@ -106,8 +105,6 @@ public class V1SearchableIndex implements SearchableIndex
 
             this.minSSTableRowId = metadatas.get(0).minSSTableRowId;
             this.maxSSTableRowId = metadatas.get(metadatas.size() - 1).maxSSTableRowId;
-
-            this.ssTable = sstableContext.sstable();
         }
         catch (Throwable t)
         {
@@ -172,12 +169,6 @@ public class V1SearchableIndex implements SearchableIndex
                                             boolean defer,
                                             int limit) throws IOException
     {
-        if (keyRange instanceof Bounds && keyRange.left.equals(keyRange.right) && keyRange.left instanceof DecoratedKey)
-        {
-            if (!ssTable.getBloomFilter().isPresent((DecoratedKey)keyRange.left))
-                return Collections.emptyList();
-        }
-
         List<RangeIterator<Long>> iterators = new ArrayList<>();
 
         for (Segment segment : segments)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.virtual.SimpleDataSet;
 import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -174,7 +175,10 @@ public class V1SearchableIndex implements SearchableIndex
     {
         List<RangeIterator<Long>> iterators = new ArrayList<>();
 
-//        if(keyRange instanceof)
+        if(keyRange instanceof Bounds)
+        {
+
+        }
 
         for (Segment segment : segments)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,6 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.virtual.SimpleDataSet;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -43,7 +41,6 @@ import org.apache.cassandra.index.sai.utils.RangeUnionIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
-import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.Throwables;
 
 import static org.apache.cassandra.index.sai.virtual.SegmentsSystemView.CELL_COUNT;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -173,12 +173,13 @@ public class V1SearchableIndex implements SearchableIndex
                                             boolean defer,
                                             int limit) throws IOException
     {
-        if(keyRange instanceof Bounds)
-        {
-
-        }
-
         List<RangeIterator<Long>> iterators = new ArrayList<>();
+
+        if(keyRange instanceof Bounds && keyRange.left == keyRange.right && keyRange.left instanceof DecoratedKey)
+        {
+            if (!filter.isPresent((DecoratedKey)keyRange.left))
+                return iterators;
+        }
 
         for (Segment segment : segments)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.index.sai.utils.RangeUnionIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.Throwables;
 
 import static org.apache.cassandra.index.sai.virtual.SegmentsSystemView.CELL_COUNT;
@@ -69,6 +70,8 @@ public class V1SearchableIndex implements SearchableIndex
     private final ByteBuffer maxTerm;
     private final long minSSTableRowId, maxSSTableRowId;
     private final long numRows;
+
+    private final IFilter filter;
 
     private PerIndexFiles indexFiles;
 
@@ -103,6 +106,8 @@ public class V1SearchableIndex implements SearchableIndex
 
             this.minSSTableRowId = metadatas.get(0).minSSTableRowId;
             this.maxSSTableRowId = metadatas.get(metadatas.size() - 1).maxSSTableRowId;
+
+            this.filter = sstableContext.sstable().getBloomFilter();
         }
         catch (Throwable t)
         {
@@ -168,6 +173,8 @@ public class V1SearchableIndex implements SearchableIndex
                                             int limit) throws IOException
     {
         List<RangeIterator<Long>> iterators = new ArrayList<>();
+
+//        if(keyRange instanceof)
 
         for (Segment segment : segments)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -173,12 +173,12 @@ public class V1SearchableIndex implements SearchableIndex
                                             boolean defer,
                                             int limit) throws IOException
     {
-        List<RangeIterator<Long>> iterators = new ArrayList<>();
-
         if(keyRange instanceof Bounds)
         {
 
         }
+
+        List<RangeIterator<Long>> iterators = new ArrayList<>();
 
         for (Segment segment : segments)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -175,7 +175,7 @@ public class V1SearchableIndex implements SearchableIndex
     {
         List<RangeIterator<Long>> iterators = new ArrayList<>();
 
-        if(keyRange instanceof Bounds && keyRange.left == keyRange.right && keyRange.left instanceof DecoratedKey)
+        if(keyRange instanceof Bounds && keyRange.left.equals(keyRange.right) && keyRange.left instanceof DecoratedKey)
         {
             if (!filter.isPresent((DecoratedKey)keyRange.left))
                 return iterators;

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -138,26 +138,30 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForIndexQueryable(keyspace, table);
 
-        ResultSet rows1 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 3");
-        assertEquals(1, rows1.all().size());
+//        ResultSet rows1 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 3");
+//        assertEquals(1, rows1.all().size());
 
-        ResultSet rows2 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '36' and v1 < 40");
+        ResultSet rows2 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '36' and v1 < 51");
         assertEquals(1, rows2.all().size());
 
-        ResultSet rows3 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 > '31' and v1 = 43 ALLOW FILTERING");
+        ResultSet rows3 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '49' and v1 < 51 ALLOW FILTERING");
         assertEquals(1, rows3.all().size());
 
-        ResultSet rows4 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 > '21' and id1 < '34' and v1 = 23 ALLOW FILTERING");
+//        ResultSet rows4 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 > '21' and id1 < '34' and v1 >= 0 and v1 < 51 ALLOW FILTERING");
+//        assertEquals(13, rows4.all().size());
+
+        ResultSet rows4 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '21' and v1 >= 0 and v1 < 51 ALLOW FILTERING");
         assertEquals(1, rows4.all().size());
 
-        ResultSet rows5 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 < 24 and v1 > 11");
-        assertEquals(12, rows5.all().size());
+        ResultSet rows5 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '35' and v1 > 0");
+        assertEquals(1, rows5.all().size());
 
-        ResultSet rows6 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 20 and id1 = '20'");
+        ResultSet rows6 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 > 0 and id1 = '20'");
         assertEquals(1, rows6.all().size());
 
         ObjectName oName = objectNameNoIndex("SSTableIndexesHit", keyspace, table, PER_QUERY_METRIC_TYPE);
         CassandraMetricsRegistry.JmxHistogramMBean o = JMX.newMBeanProxy(jmxConnection, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
+
         assertTrue(o.getMean() < 2);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -132,7 +132,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForIndexQueryable(keyspace, table);
 
-        ResultSet rows = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '0' and v1 = 3");
+        ResultSet rows = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 > '1' and v1 = 3 ALLOW FILTERING");
 
         int actualRows = rows.all().size();
         assertEquals(1, actualRows);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -138,17 +138,11 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForIndexQueryable(keyspace, table);
 
-//        ResultSet rows1 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 3");
-//        assertEquals(1, rows1.all().size());
-
         ResultSet rows2 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '36' and v1 < 51");
         assertEquals(1, rows2.all().size());
 
         ResultSet rows3 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '49' and v1 < 51 ALLOW FILTERING");
         assertEquals(1, rows3.all().size());
-
-//        ResultSet rows4 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 > '21' and id1 < '34' and v1 >= 0 and v1 < 51 ALLOW FILTERING");
-//        assertEquals(13, rows4.all().size());
 
         ResultSet rows4 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '21' and v1 >= 0 and v1 < 51 ALLOW FILTERING");
         assertEquals(1, rows4.all().size());

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -138,9 +138,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForIndexQueryable(keyspace, table);
 
-        ResultSet rows6 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 20 and id1 = '20'");
-        assertEquals(1, rows6.all().size());
-
         ResultSet rows1 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 3");
         assertEquals(1, rows1.all().size());
 
@@ -155,6 +152,9 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         ResultSet rows5 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 < 24 and v1 > 11");
         assertEquals(12, rows5.all().size());
+
+        ResultSet rows6 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 = 20 and id1 = '20'");
+        assertEquals(1, rows6.all().size());
 
         ObjectName oName = objectNameNoIndex("SSTableIndexesHit", keyspace, table, PER_QUERY_METRIC_TYPE);
         CassandraMetricsRegistry.JmxHistogramMBean o = JMX.newMBeanProxy(jmxConnection, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);


### PR DESCRIPTION
check bloomFillter in `V1SearchableIndex#searchSSTableRowIds`, if the given keyRange is made of partition key, then check sstable BF and return empty iterator when BF check failed.

Here is the link to the issue: [Vector-72](https://datastax.jira.com/browse/VECTOR-72)