### PR TITLE
Drop vector column from ResultSet when not selected

### DIFF
--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -249,7 +249,7 @@ public class ResultSet
 
         public ResultMetadata copy()
         {
-            return new ResultMetadata(resultMetadataId, EnumSet.copyOf(flags), names, columnCount, pagingState);
+            return new ResultMetadata(resultMetadataId, EnumSet.copyOf(flags), new ArrayList<>(names), columnCount, pagingState);
         }
 
         /**


### PR DESCRIPTION
See for some context https://github.com/stargate/stargate/pull/2760. Essentially, we want to filter out vector columns when they are not selected. This logic will be reverted once we get a fix in stargate.

Note: it was not easy to write a test. I verified the vector tests pass as expected.