### PR TITLE
Fix exceptions when executing complex queries

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/hnsw/VectorMemtableIndex.java
@@ -312,14 +312,10 @@ public class VectorMemtableIndex implements MemtableIndex
         }
 
         @Override
-        // VSTODO maybe we can abuse "current" to avoid having to pop and re-add the last skipped key
         protected void performSkipTo(PrimaryKey nextKey)
         {
-            PrimaryKey lastSkipped = null;
             while (!keyQueue.isEmpty() && keyQueue.peek().compareTo(nextKey) < 0)
-                lastSkipped = keyQueue.poll();
-            if (lastSkipped != null)
-                keyQueue.add(lastSkipped);
+                keyQueue.poll();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -235,6 +235,7 @@ public class QueryController
         {
             List<RangeIterator<PrimaryKey>> sstableIntersections = queryView.view.entrySet()
                                                                                  .stream()
+                                                                                 .filter(e -> !isAnnHybridSearch || annQueryViewInHybridSearch.view.containsKey(e.getKey()))
                                                                                  .map(e -> {
                                                                                      RangeIterator<Long> it = createRowIdIterator(op, e.getValue(), defer, isAnnHybridSearch);
                                                                                      if (isAnnHybridSearch)


### PR DESCRIPTION
These are part of vector 14, but the fixes are just for exceptions while executing the queries incorrectly. Fixing the execution design will come later but in the meantime it's good to make query processing not crash, since we handle that poorly (eventually becomes a timed out query but no error as such makes its way back to the client).

Since I can't just push a fix (yay branch protection) I've included the failing tests, but commented them out because CI is dumb. What I would commit is just the two "fix" changes.
