### PR TITLE
include LIMIT count in the calculation for brute force rows

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.hnsw.CassandraOnDiskHnsw;
+import org.apache.cassandra.index.sai.disk.hnsw.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.disk.v1.postings.ReorderingPostingList;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.ArrayPostingList;
@@ -57,7 +58,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
     private final CassandraOnDiskHnsw graph;
     private final PrimaryKey.Factory keyFactory;
     private final VectorType<float[]> type;
-    private int maxBruteForceRows; // not final so test can inject its own setting
+    private int globalBruteForceRows; // not final so test can inject its own setting
     private final ThreadLocal<SparseFixedBitSet> cachedBitSets;
 
     VectorIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
@@ -72,9 +73,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
         type = (VectorType<float[]>) indexContext.getValidator();
         cachedBitSets = ThreadLocal.withInitial(() -> new SparseFixedBitSet(graph.size()));
 
-        // estimate the number of comparisons that a search would require; use brute force if we have
-        // fewer rows involved than that
-        maxBruteForceRows = (int)(indexContext.getIndexWriterConfig().getMaximumNodeConnections() * Math.log(graph.size()));
+        globalBruteForceRows = Integer.MAX_VALUE;
     }
 
     @Override
@@ -136,7 +135,9 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
 
             // if num of matches are not bigger than limit, skip ANN
             var nRows = maxSSTableRowId - minSSTableRowId + 1;
-            if (nRows <= Math.max(maxBruteForceRows, limit))
+            int mbfr = getMaxBruteForceRows(limit);
+            int maxBruteForceRows = Math.min(globalBruteForceRows, mbfr);
+            if (nRows <= maxBruteForceRows)
             {
                 IntArrayList postings = new IntArrayList(Math.toIntExact(nRows), -1);
                 for (long sstableRowId = minSSTableRowId; sstableRowId <= maxSSTableRowId; sstableRowId++)
@@ -178,6 +179,14 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
         }
     }
 
+    private int getMaxBruteForceRows(int limit)
+    {
+        // VSTODO the memtable calculation assumes that doing a graph comparison is equally as expensive
+        // as a brute force comparison.  This is not correct but I'm not sure by how much.  2x seems like
+        // a reasonable minimum factor to increase it by.  (This will change for DiskANN.)
+        return 2 * VectorMemtableIndex.getMaxBruteForceRows(limit, indexContext.getIndexWriterConfig().getMaximumNodeConnections(), graph.size());
+    }
+
     private SparseFixedBitSet bitSetForSearch()
     {
         var bits = cachedBitSets.get();
@@ -194,7 +203,8 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
             // are from our own token range so we can use row ids to order the results by vector similarity.
             var maxSegmentRowId = metadata.toSegmentRowId(metadata.maxSSTableRowId);
             SparseFixedBitSet bits = bitSetForSearch();
-            int[] bruteForceRows = new int[Math.max(limit, this.maxBruteForceRows)];
+            int mbfr = getMaxBruteForceRows(limit);
+            int[] bruteForceRows = new int[Math.min(globalBruteForceRows, mbfr)];
             int n = 0;
             try (var ordinalsView = graph.getOrdinalsView())
             {


### PR DESCRIPTION
        // constants are computed by Code Interpreter based on observed comparison counts in tests
        // https://chat.openai.com/share/29a25377-786f-4690-b146-12acb6acb75b
