### PR TITLE
VECTOR-SEARCH 10: Add checksums to on-disk vector index components

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
@@ -37,6 +37,11 @@ public interface IndexFeatureSet
      */
     boolean isRowAware();
 
+    default boolean hasVectorIndexChecksum()
+    {
+        return true;
+    }
+
     /**
      * The {@code Accumulator} is used to accumulate the {@code IndexFeatureSet} responses from
      * multiple sources. This will include all the SSTables included in a query and all the indexes
@@ -50,6 +55,7 @@ public interface IndexFeatureSet
     public static class Accumulator
     {
         boolean isRowAware = true;
+        boolean hasVectorIndexChecksum = true;
         boolean complete = false;
 
         /**
@@ -62,6 +68,8 @@ public interface IndexFeatureSet
             assert !complete : "Cannot accumulate after complete has been called";
             if (!indexFeatureSet.isRowAware())
                 isRowAware = false;
+            if (!indexFeatureSet.hasVectorIndexChecksum())
+                hasVectorIndexChecksum = false;
         }
 
         /**
@@ -79,6 +87,11 @@ public interface IndexFeatureSet
                 public boolean isRowAware()
                 {
                     return isRowAware;
+                }
+                @Override
+                public boolean hasVectorIndexChecksum()
+                {
+                    return hasVectorIndexChecksum;
                 }
             };
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -132,11 +132,9 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public boolean validateOneIndexComponent(IndexComponent component, IndexDescriptor descriptor, IndexContext context, boolean checksum)
+    protected boolean isVectorComponent(IndexComponent indexComponent)
     {
-        if (context.isVector())
-            return true;
-        return super.validateOneIndexComponent(component, descriptor, context, checksum);
+        return VECTOR_COMPONENTS_V2.contains(indexComponent);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.utils;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.zip.CRC32;
 
@@ -99,6 +100,21 @@ public class IndexFileUtils
         IncrementalChecksumSequentialWriter(File file)
         {
             super(file, writerOption);
+        }
+
+        @Override
+        public void write(ByteBuffer src) throws IOException
+        {
+            ByteBuffer shallowCopy = src.slice().order(src.order());
+            super.write(src);
+            checksum.update(shallowCopy);
+        }
+
+        @Override
+        public void writeBoolean(boolean v) throws IOException
+        {
+            super.writeBoolean(v);
+            checksum.update(v ? 1 : 0);
         }
 
         @Override


### PR DESCRIPTION
rebase of https://github.com/datastax/cassandra/pull/738 on diskann3 with updates ot the changes in the branch