### PR TITLE
Add support for unique query_analyzer on analyzed SAI

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -146,7 +146,9 @@ public class IndexContext
             this.indexWriterConfig = IndexWriterConfig.fromOptions(fullIndexName, validator, config.options);
             this.isAnalyzed = AbstractAnalyzer.isAnalyzed(config.options);
             this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), config.options);
-            this.queryAnalyzerFactory = this.analyzerFactory;
+            this.queryAnalyzerFactory = AbstractAnalyzer.hasQueryAnalyzer(config.options)
+                                        ? AbstractAnalyzer.fromOptionsQueryAnalyzer(getValidator(), config.options)
+                                        : this.analyzerFactory;
             this.segmentCompactionEnabled = Boolean.parseBoolean(config.options.getOrDefault(ENABLE_SEGMENT_COMPACTION_OPTION_NAME, "false"));
         }
         else

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -195,7 +195,8 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS,
                                                                      IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH,
                                                                      IndexWriterConfig.SIMILARITY_FUNCTION,
-                                                                     LuceneAnalyzer.INDEX_ANALYZER);
+                                                                     LuceneAnalyzer.INDEX_ANALYZER,
+                                                                     LuceneAnalyzer.QUERY_ANALYZER);
 
     public static final Set<CQL3Type> SUPPORTED_TYPES = ImmutableSet.of(CQL3Type.Native.ASCII, CQL3Type.Native.BIGINT, CQL3Type.Native.DATE,
                                                                         CQL3Type.Native.DOUBLE, CQL3Type.Native.FLOAT, CQL3Type.Native.INT,

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -88,6 +88,11 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
         resetInternal(input);
     }
 
+    public static boolean hasQueryAnalyzer(Map<String, String> options)
+    {
+       return options.containsKey(LuceneAnalyzer.QUERY_ANALYZER);
+    }
+
     public interface AnalyzerFactory extends Closeable
     {
         AbstractAnalyzer create();
@@ -95,6 +100,12 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
         default void close()
         {
         }
+    }
+
+    public static AnalyzerFactory fromOptionsQueryAnalyzer(final AbstractType<?> type, final Map<String, String> options)
+    {
+        final String json = options.get(LuceneAnalyzer.QUERY_ANALYZER);
+        return toAnalyzerFactory(json, type, options);
     }
 
     public static AnalyzerFactory toAnalyzerFactory(String json, final AbstractType<?> type, final Map<String, String> options) //throws Exception

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -150,6 +150,12 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
             throw new InvalidRequestException("Cannot specify case_insensitive, normalize, or ascii options with" +
                                               " index_analyzer option. options=" + options);
         }
+        boolean containsQueryAnalyzer = options.containsKey(LuceneAnalyzer.QUERY_ANALYZER);
+        if (containsQueryAnalyzer && !containsIndexAnalyzer && !containsNonTokenizingOptions)
+        {
+            throw new InvalidRequestException("Cannot specify query_analyzer without an index_analyzer option or any" +
+                                              " combination of case_sensitive, normalize, or ascii options. options=" + options);
+        }
 
         if (containsIndexAnalyzer)
         {

--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.CharsRefBuilder;
 public class LuceneAnalyzer extends AbstractAnalyzer
 {
     public static final String INDEX_ANALYZER = "index_analyzer";
+    public static final String QUERY_ANALYZER = "query_analyzer";
     private AbstractType<?> type;
     private boolean hasNext = false;
 

--- a/src/java/org/apache/cassandra/index/sai/analyzer/README.md
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/README.md
@@ -69,6 +69,7 @@ The following built-in analyzers are available:
 | `whitespace`  | Analyzer that uses `WhitespaceTokenizer`.                                                                |
 | `stop`        | Filters `LetterTokenizer` output with `LowerCaseFilter` and removes Lucene's default English stop words. |
 | `lowercase`   | Normalizes input by applying `LowerCaseFilter` (no additional tokenization is performed).                |
+| `keyword`     | Analyzer that uses `KeywordTokenizer`, which is an identity function on input values.                    |
 | `<language>`  | Analyzers for specific languages. For example, `english` and `french`.                                   |
 
 ### Standard Analyzer

--- a/src/java/org/apache/cassandra/index/sai/analyzer/filter/BuiltInAnalyzers.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/filter/BuiltInAnalyzers.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.br.BrazilianAnalyzer;
 import org.apache.lucene.analysis.ca.CatalanAnalyzer;
 import org.apache.lucene.analysis.cjk.CJKAnalyzer;
 import org.apache.lucene.analysis.ckb.SoraniAnalyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
@@ -104,6 +105,20 @@ public enum BuiltInAnalyzers
                 builder.withTokenizer("keyword");
                 builder.addTokenFilter("lowercase");
                 return builder.build();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    },
+    KEYWORD
+    {
+        public Analyzer getNewAnalyzer()
+        {
+            try
+            {
+                return new KeywordAnalyzer();
             }
             catch (Exception e)
             {

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -118,7 +118,7 @@ public class Expression
     public Expression(IndexContext indexContext)
     {
         this.context = indexContext;
-        this.analyzerFactory = indexContext.getQueryAnalyzerFactory();
+        this.analyzerFactory = indexContext.getAnalyzerFactory();
         this.validator = indexContext.getValidator();
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -75,6 +75,31 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
+    public void testCreateIndexWithQueryAnalyzerAndNoIndexAnalyzerFails() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, c1 text)");
+        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS = " +
+                    "{'query_analyzer': 'whitespace'}"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasRootCauseMessage("Cannot specify query_analyzer without an index_analyzer option or any combination of " +
+                             "case_sensitive, normalize, or ascii options. options={query_analyzer=whitespace, target=c1}");;
+    }
+
+    @Test
+    public void testCreateIndexWithNormalizersWorks() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, c1 text, c2 text, c3 text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS = " +
+                    "{'query_analyzer': 'whitespace', 'case_sensitive': false}");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(c2) USING 'StorageAttachedIndex' WITH OPTIONS = " +
+                    "{'query_analyzer': 'whitespace', 'normalize': true}");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(c3) USING 'StorageAttachedIndex' WITH OPTIONS = " +
+                    "{'query_analyzer': 'whitespace', 'ascii': true}");
+    }
+
+    @Test
     public void testStandardAnalyzerWithFullConfig() throws Throwable
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -80,11 +80,12 @@ public class LuceneAnalyzerTest extends SAITester
         UntypedResultSet resultSet = execute("SELECT id FROM %s WHERE val : 'QUERY'");
         assertRows(resultSet, row(1), row(2), row(4));
 
-        // add whitespace in front of query and since it isn't filtered, we get no results
+        // add whitespace in front of query term and since it isn't tokenized by whitespace, we get no results
         resultSet = execute("SELECT id FROM %s WHERE val : ' query'");
         assertRows(resultSet);
 
-        // similarly, phrases do not match because index is analyzed with a different analyzer
+        // similarly, phrases do not match because index tokenized by whitespace (among other things) but the query
+        // is not
         resultSet = execute("SELECT id FROM %s WHERE val : 'the query'");
         assertRows(resultSet);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.cql;
 import org.junit.Test;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
-import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.analyzer.filter.BuiltInAnalyzers;
@@ -36,17 +35,24 @@ public class LuceneAnalyzerTest extends SAITester
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
-        assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
-                                             "'index_analyzer': '{\n" +
-                                             "\t\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"3\"}}," +
-                                             "\t\"filters\":[{\"name\":\"lowercase\"}]\n" +
-                                             "}'," +
-                                             "'query_analyzer': '{\n" +
-                                             "\t\"tokenizer\":{\"name\":\"whitespace\"},\n" +
-                                             "\t\"filters\":[{\"name\":\"porterstem\"}]\n" +
-                                             "}'};"))
-        .hasCauseInstanceOf(ConfigurationException.class)
-        .hasRootCauseMessage("Properties specified [query_analyzer] are not understood by StorageAttachedIndex");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"3\"}}," +
+                    "\t\"filters\":[{\"name\":\"lowercase\"}]\n" +
+                    "}'," +
+                    "'query_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"whitespace\"},\n" +
+                    "\t\"filters\":[{\"name\":\"porterstem\"}]\n" +
+                    "}'};");
+
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'the query')");
+
+        // TODO: randomize flushing... not sure how
+        flush();
+
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'query'").size());
     }
 
     @Test


### PR DESCRIPTION
With https://github.com/datastax/cassandra/pull/712, we removed the `query_analyzer` because there were concerns about whether to count an index with a `query_analyzer` but no `index_analyzer` as an "analyzed column". See discussion on https://github.com/datastax/cassandra/pull/709 for additional context. In thinking through the concerns, I realized that we simply need to only allow for a `query_analyzer` to be configured when there is either an `index_analyzer` or one of the non-tokenizing analyzers.

Changes:
* Reject indexes that have invalid analyzer configuration.
* Allow users to configure different query analyzers 
* Use the right analyzer in the `Expression#validateStringValue` method (it's pretty surprising, but I noticed earlier today before knowing I would make this change that the reference was incorrect, but "worked" because the current state requires that the index analyzer is always the query analyzer. This change would have broken that code, as the test in the second commit shows.)
* Add built in analyzer named `keyword`, which is an identity function. This was not possibly useful before, but with unique query and index analyzers, it seems likely to be useful. For example, it could allow a user to verify the query term is used without being analyzed, but we search the analyzed index.