### PR TITLE
Map built-in English analyzer to EnglishAnalyzer, not StandardAnalzyer

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/filter/BuiltInAnalyzers.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/filter/BuiltInAnalyzers.java
@@ -207,7 +207,7 @@ public enum BuiltInAnalyzers
      {
          public Analyzer getNewAnalyzer()
          {
-             return new StandardAnalyzer();
+             return new EnglishAnalyzer();
          }
      },
      ESTONIAN


### PR DESCRIPTION
When the built-in analyzers were added, the `english` analyzer incorrectly mapped to the `StandardAnalyzer`. This PR fixes the mapping, but does not address the underlying indexing issues that may have already taken place.