### PR TITLE
Fix text search queries filtered to empty string due to stop words

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
@@ -45,6 +45,7 @@ public class LuceneAnalyzer extends AbstractAnalyzer
     public static final String QUERY_ANALYZER = "query_analyzer";
     private AbstractType<?> type;
     private boolean hasNext = false;
+    private boolean isReset = true;
 
     private final Analyzer analyzer;
     private TokenStream tokenStream;
@@ -79,6 +80,12 @@ public class LuceneAnalyzer extends AbstractAnalyzer
                 //       getting the max term from the mem trie is best
                 next = ByteBuffer.wrap(BytesRef.deepCopyOf(br).bytes);
             }
+            if (isReset && !hasNext)
+            {
+                next = ByteBuffer.allocate(0);
+                hasNext = true;
+            }
+            isReset = false;
             return hasNext;
         }
         catch (IOException ex)
@@ -143,6 +150,7 @@ public class LuceneAnalyzer extends AbstractAnalyzer
             termAttr = tokenStream.getAttribute(TermToBytesRefAttribute.class);
 
             this.hasNext = true;
+            this.isReset = true;
         }
         catch (Exception ex)
         {
@@ -156,6 +164,7 @@ public class LuceneAnalyzer extends AbstractAnalyzer
         return MoreObjects.toStringHelper(this)
                           .add("type", type)
                           .add("hasNext", hasNext)
+                          .add("isReset", isReset)
                           .add("analyzer", analyzer)
                           .add("tokenStream", tokenStream)
                           .add("termAttr", termAttr)

--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzer.java
@@ -45,7 +45,6 @@ public class LuceneAnalyzer extends AbstractAnalyzer
     public static final String QUERY_ANALYZER = "query_analyzer";
     private AbstractType<?> type;
     private boolean hasNext = false;
-    private boolean isReset = true;
 
     private final Analyzer analyzer;
     private TokenStream tokenStream;
@@ -80,12 +79,6 @@ public class LuceneAnalyzer extends AbstractAnalyzer
                 //       getting the max term from the mem trie is best
                 next = ByteBuffer.wrap(BytesRef.deepCopyOf(br).bytes);
             }
-            if (isReset && !hasNext)
-            {
-                next = ByteBuffer.allocate(0);
-                hasNext = true;
-            }
-            isReset = false;
             return hasNext;
         }
         catch (IOException ex)
@@ -150,7 +143,6 @@ public class LuceneAnalyzer extends AbstractAnalyzer
             termAttr = tokenStream.getAttribute(TermToBytesRefAttribute.class);
 
             this.hasNext = true;
-            this.isReset = true;
         }
         catch (Exception ex)
         {
@@ -164,7 +156,6 @@ public class LuceneAnalyzer extends AbstractAnalyzer
         return MoreObjects.toStringHelper(this)
                           .add("type", type)
                           .add("hasNext", hasNext)
-                          .add("isReset", isReset)
                           .add("analyzer", analyzer)
                           .add("tokenStream", tokenStream)
                           .add("termAttr", termAttr)

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -111,6 +111,7 @@ public class Operation
                     case CONTAINS_KEY:
                     case LIKE_PREFIX:
                     case LIKE_MATCHES:
+                    case ANALYZER_MATCHES:
                         isMultiExpression = true;
                         break;
 

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -122,10 +122,19 @@ public class Operation
                 }
                 if (isMultiExpression)
                 {
-                    while (analyzer.hasNext())
+                    if (!analyzer.hasNext())
                     {
-                        final ByteBuffer token = analyzer.next();
-                        perColumn.add(new Expression(indexContext).add(e.operator(), token.duplicate()));
+                        perColumn.add(new Expression(indexContext).add(e.operator(), ByteBuffer.allocate(0)));
+                    }
+                    else
+                    {
+                        // The hasNext implementation has a side effect, so we need to call next before calling hasNext
+                        do
+                        {
+                            final ByteBuffer token = analyzer.next();
+                            perColumn.add(new Expression(indexContext).add(e.operator(), token.duplicate()));
+                        }
+                        while (analyzer.hasNext());
                     }
                 }
                 else

--- a/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
@@ -49,6 +49,16 @@ public class CollectionIndexingTest extends SAITester
     }
 
     @Test
+    public void indexQueryEmpty() throws Throwable
+    {
+        createPopulatedMap();
+        createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        assertEquals(0, execute("SELECT * FROM %s WHERE value CONTAINS ''").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE value CONTAINS '' AND value CONTAINS 'v1'").size());
+    }
+
+    @Test
     public void indexMapKeys() throws Throwable
     {
         createPopulatedMap();

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -306,6 +306,11 @@ public class LuceneAnalyzerTest extends SAITester
         waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the test')");
+        // When indexing a document with only stop words, the document should not be indexed.
+        // Note: from looking at the collections implementation, these rows are filtered out before getting
+        // to the NoOpAnalyzer, which would otherwise return an empty buffer, which would lead to incorrectly
+        // indexing documents at the base of the trie.
+        execute("INSERT INTO %s (id, val) VALUES ('2', 'the')");
 
         flush();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -295,6 +295,26 @@ public class LuceneAnalyzerTest extends SAITester
         .hasMessageContaining("filter=stop is unsupported.");
     }
 
+    // The english analyzer has a default set of stop words. This test relies on "the" being one of those stop words.
+    @Test
+    public void testEnglishStopWordTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' " +
+                   "WITH OPTIONS = {'index_analyzer':'english'}");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'the test')");
+
+        flush();
+
+        // Ensure row is there
+        assertRows(execute("SELECT id FROM %s WHERE val : 'test'"), row("1"));
+        // Ensure we do not get a result
+        assertRows(execute("SELECT id FROM %s WHERE val : 'the'"));
+    }
+
     @Test
     public void testCharfilter() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -311,8 +311,10 @@ public class LuceneAnalyzerTest extends SAITester
 
         // Ensure row is there
         assertRows(execute("SELECT id FROM %s WHERE val : 'test'"), row("1"));
-        // Ensure we do not get a result
+        // Ensure a query with only stop words results in no rows
         assertRows(execute("SELECT id FROM %s WHERE val : 'the'"));
+        // Ensure that the AND is correctly applied so that we get no results
+        assertRows(execute("SELECT id FROM %s WHERE val : 'the' AND val : 'test'"));
     }
 
     @Test


### PR DESCRIPTION
The current text search feature fails on the final line of this test:

```java
    @Test
    public void testEnglishStopWordTest() throws Throwable
    {
        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

        executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' " +
                   "WITH OPTIONS = {'index_analyzer':'english'}");
        waitForIndexQueryable();

        execute("INSERT INTO %s (id, val) VALUES ('1', 'the test')");

        flush();

        assertRows(execute("SELECT id FROM %s WHERE val : 'test'"), row("1"));
        assertRows(execute("SELECT id FROM %s WHERE val : 'the'"));
    }
```

The problem is how we are building the query.

Changes:
* Update the `Operation#analyzeGroup` method to map an empty analyzer result to an empty byte buffer. This solution feels a bit like a hack, but it makes sense for a couple reasons. First, we only want to change the query analyzer logic right now, and that cannot easily be done in the `LuceneAnalzyer` class. Second, while the `NoOpAnalyzer`, which is the analyzer everything gets when it isn't analyzed, maps empty `''` query strings to an empty byte buffer, it doesn't appear to get indexed, however, it does get indexed when using the `LuceneAnalyzer`. This is likely due to the way rows are filtered before getting analyzed. I am open to changing this if there is a better way to do it, but this seems correct for now.
* Add test that shows maps work similarly for empty queries
* Add test that fails in multiple relevant ways