### PR TITLE
Accept lucene file configs as json values in SAI OPTIONS

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/analyzer/ArgsStringLoader.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/ArgsStringLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.analyzer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.lucene.util.ResourceLoader;
+
+/**
+ * A resource loader that considers each passed string as the resource. This class allows us to configure stop words
+ * and synonyms as arguments in the 'args' parameter of the filter's configuration.
+ * Example: WITH OPTIONS = {'index_analyzer':'{"tokenizer":{"name" : "whitespace"}, "filters":[{"name":"stop", "args": {"words": "the, test"}}]}'}
+ * The above configuration will create a stop filter with the words "the" and "test". The args key name, e.g. words,
+ * is specific to the lucene component being configured. The delimiter can vary based on the filter, but appears to
+ * be comma delimited for most lucene components. Note that commas can be escaped with a backslash.
+ */
+public class ArgsStringLoader implements ResourceLoader
+{
+    @Override
+    public InputStream openResource(String s) throws IOException
+    {
+        return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public <T> Class<? extends T> findClass(String cname, Class<T> expectedType) {
+        try {
+            return Class.forName(cname).asSubclass(expectedType);
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot load class: " + cname, e);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
@@ -19,9 +19,6 @@
 package org.apache.cassandra.index.sai.analyzer;
 
 import java.io.IOException;
-import java.util.Set;
-
-import com.google.common.collect.Sets;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -32,15 +29,6 @@ import org.apache.lucene.analysis.custom.CustomAnalyzer;
 public class JSONAnalyzerParser
 {
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
-    // unsupported because these filters open external files such as stop words
-    public static final Set<String> unsupportedFilters =
-    Sets.newHashSet("synonymgraph", // same as synonym
-                    "synonym", // replaces words, loads external file, could be implemented
-                    "commongrams", // loads external file terms, search feature
-                    "stop", // the stop words opens an arbitrary file and reads as stop words, so we don't yet support
-                    // arbitrary stop words. We do allow Lucene's built-in stop words, though.
-                    "snowballporter"); // bug in reflection instantiation
 
     public static Analyzer parse(String json) throws IOException
     {
@@ -53,7 +41,7 @@ public class JSONAnalyzerParser
         // Don't have built in analyzer, parse JSON
         LuceneCustomAnalyzerConfig analyzerModel = JSON_MAPPER.readValue(json, LuceneCustomAnalyzerConfig.class);
 
-        CustomAnalyzer.Builder builder = CustomAnalyzer.builder();
+        CustomAnalyzer.Builder builder = CustomAnalyzer.builder(new ArgsStringLoader());
         // An ommitted tokenizer maps directly to the keyword tokenizer, which is an identity map on input terms
         if (analyzerModel.getTokenizer() == null)
         {
@@ -72,10 +60,6 @@ public class JSONAnalyzerParser
             if (filter.getName() == null)
             {
                 throw new InvalidRequestException("filter 'name' field is required for options=" + json);
-            }
-            if (unsupportedFilters.contains(filter.getName()))
-            {
-                throw new InvalidRequestException("filter=" + filter.getName() + " is unsupported.");
             }
             builder.addTokenFilter(filter.getName(), filter.getArgs());
         }

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -152,11 +153,22 @@ public class LuceneAnalyzerTest
         // acceptable. Note that in CQL, it'll just need 2 backslashes.
         String json = "{\"tokenizer\":{\"name\" : \"keyword\"}," +
                       "\"filters\":[{\"name\":\"synonym\", \"args\": " +
-                      "{\"synonyms\": \"as => like\"}}]}";
+                      "{\"synonyms\": \"as => like\", \"analyzer\":\"" + WhitespaceAnalyzer.class.getName() + "\"}}]}";
         String testString = "as";
         String[] expected = new String[]{ "like" };
         List<String> list = tokenize(testString, json);
         assertArrayEquals(expected, list.toArray(new String[0]));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testMissingClassException() throws Exception
+    {
+        // Need 4 backslashes to get through all of the parsing... this is an unlikely scenario, so it seems
+        // acceptable. Note that in CQL, it'll just need 2 backslashes.
+        String json = "{\"tokenizer\":{\"name\" : \"keyword\"}," +
+                      "\"filters\":[{\"name\":\"synonym\", \"args\": " +
+                      "{\"synonyms\": \"as => like\", \"analyzer\":\"not-a-class\"}}]}";
+        tokenize("irrelevant text", json);
     }
 
     public static List<String> tokenize(String testString, String json) throws Exception

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -284,15 +284,55 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStopFilter() throws Throwable
+    public void testStopFilterNoFormat() throws Throwable
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
-        assertThatThrownBy(() -> executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
+        executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
                                             "\t{\"tokenizer\":{\"name\" : \"whitespace\"},\n" +
-                                            "\t \"filters\":[{\"name\":\"stop\"}]}'}"))
-        .isInstanceOf(InvalidQueryException.class)
-        .hasMessageContaining("filter=stop is unsupported.");
+                                            "\t \"filters\":[{\"name\":\"stop\", \"args\": {\"words\": \"the,test\"}}]}'}");
+        verifyStopWordsLoadedCorrectly();
+    }
+
+    @Test
+    public void testStopFilterWordSet() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
+                   "\t{\"tokenizer\":{\"name\" : \"whitespace\"},\n" +
+                   "\t \"filters\":[{\"name\":\"stop\", \"args\": {\"words\": \"the, test\", \"format\": \"wordset\"}}]}'}");
+        verifyStopWordsLoadedCorrectly();
+    }
+
+    @Test
+    public void testStopFilterSnowball() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        // snowball allows multiple words on the same line--they are broken up by whitespace
+        executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
+                   "\t{\"tokenizer\":{\"name\" : \"whitespace\"},\n" +
+                   "\t \"filters\":[{\"name\":\"stop\", \"args\": {\"words\": \"the test\", \"format\": \"snowball\"}}]}'}");
+        verifyStopWordsLoadedCorrectly();
+
+    }
+
+    private void verifyStopWordsLoadedCorrectly() throws Throwable
+    {
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'the big test')");
+
+        flush();
+
+        assertRows(execute("SELECT id FROM %s WHERE val : 'the'"));
+        assertRows(execute("SELECT id FROM %s WHERE val : 'the test'"));
+        assertRows(execute("SELECT id FROM %s WHERE val : 'test'"));
+        assertRows(execute("SELECT id FROM %s WHERE val : 'the big'"), row("1"));
+        assertRows(execute("SELECT id FROM %s WHERE val : 'big'"), row("1"));
+        // the extra words shouldn't change the outcome because tokenizer is whitespace and tokens are matched then unioned
+        assertRows(execute("SELECT id FROM %s WHERE val : 'test some other words'"));
     }
 
     @Test


### PR DESCRIPTION
The current analyzer implementation rejects certain stop word and synonym filters because they open files. We can instead allow for these parameters to be passed as part of the `args` block, as you can see in the tests.