### PR TITLE
Skip similarity score caching when using brute force

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -74,7 +74,8 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
      */
     public PostingListRangeIterator(IndexContext indexContext,
                                     PrimaryKeyMap primaryKeyMap,
-                                    IndexSearcherContext searcherContext)
+                                    IndexSearcherContext searcherContext,
+                                    boolean isBruteForce)
     {
         super(searcherContext.minimumKey, searcherContext.maximumKey, searcherContext.count());
 
@@ -83,7 +84,8 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
         this.postingList = searcherContext.postingList;
         this.searcherContext = searcherContext;
         this.queryContext = this.searcherContext.context;
-        this.scoreStoreProxy = this.queryContext.getScoreStoreProxyForSSTable(primaryKeyMap.getSSTableId());
+        // When brute force is enabled, we don't yet have scores to store
+        this.scoreStoreProxy = isBruteForce ? ScoreStoreProxy.EMPTY : this.queryContext.getScoreStoreProxyForSSTable(primaryKeyMap.getSSTableId());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/VectorIndexSearcher.java
@@ -253,19 +253,18 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
             if (n < bruteForceRows.length)
             {
                 var results = new ReorderingPostingList(Arrays.stream(bruteForceRows, 0, n).iterator(), n);
-                return toPrimaryKeyIterator(results, context);
+                return toPrimaryKeyIterator(results, context, true);
             }
 
             // else ask hnsw to perform a search limited to the bits we created
             float[] queryVector = exp.lower.value.vector;
             var results = graph.search(queryVector, limit, bits, Integer.MAX_VALUE, context,
                                        context.getScoreRecorder(sstableId, metadata.segmentRowIdOffset));
-            return toPrimaryKeyIterator(results, context);
+            return toPrimaryKeyIterator(results, context, false);
         }
     }
 
-
-    RangeIterator<PrimaryKey> toPrimaryKeyIterator(PostingList postingList, QueryContext queryContext) throws IOException
+    RangeIterator<PrimaryKey> toPrimaryKeyIterator(PostingList postingList, QueryContext queryContext, boolean isBruteForce) throws IOException
     {
         if (postingList == null || postingList.size() == 0)
             return RangeIterator.emptyKeys();
@@ -278,7 +277,7 @@ public class VectorIndexSearcher extends IndexSearcher implements SegmentOrderin
                                                                         queryContext,
                                                                         postingList.peekable());
 
-        return new PostingListRangeIterator(indexContext, primaryKeyMapFactory.newPerSSTablePrimaryKeyMap(), searcherContext);
+        return new PostingListRangeIterator(indexContext, primaryKeyMapFactory.newPerSSTablePrimaryKeyMap(), searcherContext, isBruteForce);
     }
 
     @Override


### PR DESCRIPTION
Cherry picked from 03492e5c9bddc503f74b20b199989fd1ec7597e5. These tests were flaky but are not with the patch: 

Multiple tests fail intermittently at

```
java.lang.AssertionError: null
	at org.apache.cassandra.index.sai.ScoreStoreProxyImpl.mapStoredScoreForRowIdToPrimaryKey(ScoreStoreProxyImpl.java:41)
```

VLT.multiSSTablesTest and multipleNonAnnSegmentsTest fail about 50% of the time, multipleSegmentsMultiplePostingsTest fails about 10% of the time