### PR TITLE
Replace assert with trace to prevent unnecessary errors

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/ScoreStoreProxyImpl.java
+++ b/src/java/org/apache/cassandra/index/sai/ScoreStoreProxyImpl.java
@@ -34,11 +34,10 @@ class ScoreStoreProxyImpl implements ScoreStoreProxy
 
     @Override
     public void mapStoredScoreForRowIdToPrimaryKey(long sstableRowId, PrimaryKey pk) {
-        float score = scoreMap.getOrDefault(sstableRowId, -1);
         // The score should always be present in the cache because we just put it there in the previous iterator.
         // A better solution would be to pass the score through the iterator's as metadata associated with a row.
         // However, we cannot do that yet, so we use a map to store and retrieve the score.
-        assert score >= 0;
+        float score = scoreMap.getOrDefault(sstableRowId, -1);
         queryContext.recordScore(pk, score);
     }
 }


### PR DESCRIPTION
We have seen two different errors related to the removed asserts. When a -1 is stored, we just have to recompute vector similarity later, so the consequence is minimal and it is disproportionate to throw an exception here.