### PR TITLE
Fix IndexViewManager#invalidate race with AtomicRef

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
+++ b/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
@@ -148,16 +148,14 @@ public class IndexViewManager
      */
     public void invalidate(boolean obsolete)
     {
-        View currentView = view.get();
+        View previousView = view.getAndSet(new View(context, Collections.emptyList()));
 
-        for (SSTableIndex index : currentView)
+        for (SSTableIndex index : previousView)
         {
             if (obsolete)
                 index.markObsolete();
             else
                 index.release();
         }
-
-        view.set(new View(context, Collections.emptyList()));
     }
 }


### PR DESCRIPTION
While working on vsearch-14, I came across a potential data race. I'm not sure that it is an issue, but since we're using an `AtomicReference`, it seems like we should make sure to update the reference in an atomic way.