### PR TITLE
VectorMemtableIndex should be able to handle queries when empty

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -203,6 +203,11 @@ public class VectorMemtableIndex implements MemtableIndex
     @Override
     public RangeIterator<PrimaryKey> limitToTopResults(QueryContext context, RangeIterator<PrimaryKey> iterator, Expression exp, int limit)
     {
+        if (minimumKey == null)
+        {
+            assert maximumKey == null : "Minimum key is null but maximum key is not";
+            return RangeIterator.emptyKeys();
+        }
         Set<PrimaryKey> results = new HashSet<>();
         while (iterator.hasNext())
         {

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -330,6 +330,8 @@ public class SAITester extends CQLTester
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
             IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
+            if (indexDescriptor.isIndexEmpty(context))
+                continue;
             if (!indexDescriptor.validatePerSSTableComponentsChecksum() || !indexDescriptor.validatePerIndexComponentsChecksum(context))
                 return false;
         }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -524,19 +524,4 @@ public class VectorLocalTest extends VectorTester
         super.compact();
         verifyChecksum();
     }
-
-    private void verifyChecksum()  {
-        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        cfs.indexManager.listIndexes().stream().forEach(index -> {
-            var indexContext = SAITester.createIndexContext(index.getIndexMetadata().name, VectorType.getInstance(FloatType.instance, 100), cfs);
-            if (!indexContext.getColumnName().matches("table_\\d+_val_idx"))
-            {
-                return;
-            }
-            logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
-            boolean checksumValid = verifyChecksum(indexContext);
-            assertThat(checksumValid).isTrue();
-        });
-    }
-
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -127,6 +127,8 @@ public class VectorTester extends SAITester
                 var indexContext = (IndexContext) FieldUtils
                                                   .getDeclaredField(index.getClass(), "indexContext", true)
                                                   .get(index);
+                if (!indexContext.isVector())
+                    return;
                 logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
                 boolean checksumValid = verifyChecksum(indexContext);
                 assertThat(checksumValid).isTrue();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -24,17 +24,23 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang.reflect.FieldUtils;
 import org.junit.Before;
 
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.vector.VectorEncoding;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.vector.ConcurrentVectorValues;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VectorTester extends SAITester
 {
@@ -111,5 +117,23 @@ public class VectorTester extends SAITester
         }
 
         return (double) matches / topK;
+    }
+
+    protected void verifyChecksum() {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        cfs.indexManager.listIndexes().stream().forEach(index -> {
+            try
+            {
+                var indexContext = (IndexContext) FieldUtils
+                                                  .getDeclaredField(index.getClass(), "indexContext", true)
+                                                  .get(index);
+                logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
+                boolean checksumValid = verifyChecksum(indexContext);
+                assertThat(checksumValid).isTrue();
+            } catch (IllegalAccessException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -25,23 +25,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.reflect.FieldUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.UntypedResultSet;
-import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.index.sai.IndexContext;
-import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.tracing.TracingTestImpl;
@@ -57,24 +50,6 @@ public class VectorTypeTest extends VectorTester
     public static void setupClass()
     {
         System.setProperty("cassandra.custom_tracing_class", "org.apache.cassandra.tracing.TracingTestImpl");
-    }
-
-    private void verifyChecksum() {
-        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        cfs.indexManager.listIndexes().stream().forEach(index -> {
-            try
-            {
-                var indexContext = (IndexContext) FieldUtils
-                                                  .getDeclaredField(index.getClass(), "indexContext", true)
-                                                  .get(index);
-                logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
-                boolean checksumValid = verifyChecksum(indexContext);
-                assertThat(checksumValid).isTrue();
-            } catch (IllegalAccessException e)
-            {
-                throw new RuntimeException(e);
-            }
-        });
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -61,10 +61,6 @@ public class VectorTypeTest extends VectorTester
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
         cfs.indexManager.listIndexes().stream().forEach(index -> {
             var indexContext = SAITester.createIndexContext(index.getIndexMetadata().name, VectorType.getInstance(FloatType.instance, 100), cfs);
-            if (!indexContext.isVector())
-            {
-                return;
-            }
             logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
             boolean checksumValid = verifyChecksum(indexContext);
             assertThat(checksumValid).isTrue();


### PR DESCRIPTION
Without the change to `VectorMemtableIndex`, we get the following error in the test:

```
java.lang.AssertionError: null - null 1
	at org.apache.cassandra.index.sai.utils.RangeIterator.<init>(RangeIterator.java:56)
	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex$ReorderingRangeIterator.<init>(VectorMemtableIndex.java:348)
	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.limitToTopResults(VectorMemtableIndex.java:224)
	at org.apache.cassandra.index.sai.IndexContext.limitToTopResults(IndexContext.java:316)
	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:308)
	at org.apache.cassandra.index.sai.plan.Operation.buildIterator(Operation.java:227)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.analyze(StorageAttachedIndexSearcher.java:138)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.lambda$search$0(StorageAttachedIndexSearcher.java:112)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:121)
	at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:448)
	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:396)
	at org.apache.cassandra.db.ReadCommand.executeInternal(ReadCommand.java:473)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeInternal(SelectStatement.java:546)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:530)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:103)
	at org.apache.cassandra.cql3.QueryProcessor.executeInternal(QueryProcessor.java:483)
	at org.apache.cassandra.cql3.CQLTester.executeFormattedQuery(CQLTester.java:1381)
	at org.apache.cassandra.cql3.CQLTester.execute(CQLTester.java:1369)
	at org.apache.cassandra.index.sai.cql.VectorTypeTest.testMatchingRowWithNullVector(VectorTypeTest.java:764)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
```

Note: we need this logic here because we are determining the result based on brute force and so we don't get to implicitly rely on the graph search implementation to filter out these rows.