### PR TITLE
Fix RowID lookup from PK for shadowed key ignore bits

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -157,7 +157,7 @@ public class QueryContext
                     continue;
 
                 long sstableRowId = primaryKeyMap.exactRowIdForPrimaryKey(primaryKey);
-                if (sstableRowId == Long.MAX_VALUE) // not found
+                if (primaryKeyMap.isNotFound(sstableRowId)) // not found
                     continue;
 
                 int segmentRowId = metadata.toSegmentRowId(sstableRowId);

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -156,7 +156,7 @@ public class QueryContext
                 if (primaryKey.compareTo(metadata.minKey) < 0 || primaryKey.compareTo(metadata.maxKey) > 0)
                     continue;
 
-                long sstableRowId = primaryKeyMap.rowIdFromPrimaryKey(primaryKey);
+                long sstableRowId = primaryKeyMap.exactRowIdForPrimaryKey(primaryKey);
                 if (sstableRowId == Long.MAX_VALUE) // not found
                     continue;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -146,7 +146,7 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
         long segmentRowId;
         if (needsSkipping)
         {
-            long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
+            long targetRowID = primaryKeyMap.ceiling(skipToToken);
             // skipToToken is larger than max token in token file
             if (primaryKeyMap.isNotFound(targetRowID))
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -148,7 +148,7 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
         {
             long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
             // skipToToken is larger than max token in token file
-            if (targetRowID == Long.MAX_VALUE)
+            if (primaryKeyMap.isNotFound(targetRowID))
             {
                 return PostingList.END_OF_STREAM;
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -146,9 +146,9 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
         long segmentRowId;
         if (needsSkipping)
         {
-            long targetRowID = primaryKeyMap.rowIdFromPrimaryKey(skipToToken);
+            long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
             // skipToToken is larger than max token in token file
-            if (targetRowID < 0)
+            if (targetRowID == Long.MAX_VALUE)
             {
                 return PostingList.END_OF_STREAM;
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -69,20 +69,22 @@ public interface PrimaryKeyMap extends Closeable
     long exactRowIdForPrimaryKey(PrimaryKey key);
 
     /**
-     * Returns the first row Id for a given {@link PrimaryKey}
+     * Returns the sstable row id associated with the least {@link PrimaryKey} greater than or equal to the given
+     * {@link PrimaryKey}, or <code>Long.MAX_VALUE</code> if there is no such row id.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the first row Id associated with the {@link PrimaryKey}
      */
-    long firstRowIdFromPrimaryKey(PrimaryKey key);
+    long ceiling(PrimaryKey key);
 
     /**
-     * Returns the last row Id for a given {@link PrimaryKey}
+     * Returns the sstable row id associated with the greatest {@link PrimaryKey} less than or equal to the given
+     * {@link PrimaryKey}, or <code>Long.MAX_VALUE</code> if there is no such term.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the last row Id associated with the {@link PrimaryKey}
      */
-    long lastRowIdFromPrimaryKey(PrimaryKey key);
+    long floor(PrimaryKey key);
 
     /**
      * This method is necessary because the two implementations have varying definitions of end of stream.

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -61,7 +61,7 @@ public interface PrimaryKeyMap extends Closeable
     PrimaryKey primaryKeyFromRowId(long sstableRowId);
 
     /**
-     * Returns a row Id for a {@link PrimaryKey}
+     * Returns a row Id for a {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the row Id associated with the {@link PrimaryKey}
@@ -70,7 +70,7 @@ public interface PrimaryKeyMap extends Closeable
 
     /**
      * Returns the sstable row id associated with the least {@link PrimaryKey} greater than or equal to the given
-     * {@link PrimaryKey}, or <code>Long.MAX_VALUE</code> if there is no such row id.
+     * {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the first row Id associated with the {@link PrimaryKey}
@@ -79,17 +79,18 @@ public interface PrimaryKeyMap extends Closeable
 
     /**
      * Returns the sstable row id associated with the greatest {@link PrimaryKey} less than or equal to the given
-     * {@link PrimaryKey}, or <code>Long.MAX_VALUE</code> if there is no such term.
+     * {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
      *
      * @param key the {@link PrimaryKey} to lookup
-     * @return the last row Id associated with the {@link PrimaryKey}
+     * @return an sstable row id
      */
     long floor(PrimaryKey key);
 
     /**
-     * This method is necessary because the two implementations have varying definitions of end of stream.
+     * This method is necessary because the two implementations for this interface have divergent behavior for
+     * indicating that a {@link PrimaryKey} was not found.
      * @param sstableRowId
-     * @return true if the row Id is a terminal value for the stream
+     * @return true if the passed row id is not found by the {@link PrimaryKeyMap}
      */
     boolean isNotFound(long sstableRowId);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -84,6 +84,13 @@ public interface PrimaryKeyMap extends Closeable
      */
     long lastRowIdFromPrimaryKey(PrimaryKey key);
 
+    /**
+     * This method is necessary because the two implementations have varying definitions of end of stream.
+     * @param sstableRowId
+     * @return true if the row Id is a terminal value for the stream
+     */
+    boolean isNotFound(long sstableRowId);
+
     @Override
     default void close() throws IOException
     {

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -66,7 +66,7 @@ public interface PrimaryKeyMap extends Closeable
      * @param key the {@link PrimaryKey} to lookup
      * @return the row Id associated with the {@link PrimaryKey}
      */
-    long rowIdFromPrimaryKey(PrimaryKey key);
+    long exactRowIdForPrimaryKey(PrimaryKey key);
 
     /**
      * Returns the first row Id for a given {@link PrimaryKey}

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
@@ -143,7 +143,7 @@ public class SSTableRowIdKeyRangeIterator extends RangeIterator<PrimaryKey>
         long sstableRowId;
         if (needsSkipping)
         {
-            long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
+            long targetRowID = primaryKeyMap.ceiling(skipToToken);
             // skipToToken is larger than max token in token file
             if (primaryKeyMap.isNotFound(targetRowID))
                 return PostingList.END_OF_STREAM;

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
@@ -145,7 +145,7 @@ public class SSTableRowIdKeyRangeIterator extends RangeIterator<PrimaryKey>
         {
             long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
             // skipToToken is larger than max token in token file
-            if (targetRowID == Long.MAX_VALUE)
+            if (primaryKeyMap.isNotFound(targetRowID))
                 return PostingList.END_OF_STREAM;
 
             sstableRowIdIterator.skipTo(targetRowID);

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
@@ -143,9 +143,9 @@ public class SSTableRowIdKeyRangeIterator extends RangeIterator<PrimaryKey>
         long sstableRowId;
         if (needsSkipping)
         {
-            long targetRowID = primaryKeyMap.rowIdFromPrimaryKey(skipToToken);
+            long targetRowID = primaryKeyMap.firstRowIdFromPrimaryKey(skipToToken);
             // skipToToken is larger than max token in token file
-            if (targetRowID < 0)
+            if (targetRowID == Long.MAX_VALUE)
                 return PostingList.END_OF_STREAM;
 
             sstableRowIdIterator.skipTo(targetRowID);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -144,13 +144,13 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
-    public long firstRowIdFromPrimaryKey(PrimaryKey key)
+    public long ceiling(PrimaryKey key)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long lastRowIdFromPrimaryKey(PrimaryKey key)
+    public long floor(PrimaryKey key)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -156,6 +156,12 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
+    public boolean isNotFound(long sstableRowId)
+    {
+        return sstableRowId < 0;
+    }
+
+    @Override
     public void close() throws IOException
     {
         FileUtils.closeQuietly(rowIdToToken, rowIdToOffset, reader);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -138,7 +138,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
-    public long rowIdFromPrimaryKey(PrimaryKey key)
+    public long exactRowIdForPrimaryKey(PrimaryKey key)
     {
         return rowIdToToken.findTokenRowID(key.token().getLongValue());
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -170,13 +170,13 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
-    public long firstRowIdFromPrimaryKey(PrimaryKey key)
+    public long ceiling(PrimaryKey key)
     {
         return sortedTermsReader.ceiling(v -> key.asComparableBytesMinPrefix(v));
     }
 
     @Override
-    public long lastRowIdFromPrimaryKey(PrimaryKey key)
+    public long floor(PrimaryKey key)
     {
         return sortedTermsReader.floor(v -> key.asComparableBytesMaxPrefix(v));
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -164,7 +164,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
-    public long rowIdFromPrimaryKey(PrimaryKey key)
+    public long exactRowIdForPrimaryKey(PrimaryKey key)
     {
         return sortedTermsReader.getExactPointId(v -> key.asComparableBytes(v));
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -181,6 +181,12 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         return sortedTermsReader.getLastPointId(v -> key.asComparableBytesMaxPrefix(v));
     }
 
+    @Override
+    public boolean isNotFound(long sstableRowId)
+    {
+        return sstableRowId == Long.MAX_VALUE;
+    }
+
 
     @Override
     public void close() throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -172,13 +172,13 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public long firstRowIdFromPrimaryKey(PrimaryKey key)
     {
-        return sortedTermsReader.getNextPointId(v -> key.asComparableBytesMinPrefix(v));
+        return sortedTermsReader.ceiling(v -> key.asComparableBytesMinPrefix(v));
     }
 
     @Override
     public long lastRowIdFromPrimaryKey(PrimaryKey key)
     {
-        return sortedTermsReader.getLastPointId(v -> key.asComparableBytesMaxPrefix(v));
+        return sortedTermsReader.floor(v -> key.asComparableBytesMaxPrefix(v));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -166,13 +166,13 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public long rowIdFromPrimaryKey(PrimaryKey key)
     {
-        return sortedTermsReader.getPointId(v -> key.asComparableBytes(v));
+        return sortedTermsReader.getExactPointId(v -> key.asComparableBytes(v));
     }
 
     @Override
     public long firstRowIdFromPrimaryKey(PrimaryKey key)
     {
-        return sortedTermsReader.getPointId(v -> key.asComparableBytesMinPrefix(v));
+        return sortedTermsReader.getNextPointId(v -> key.asComparableBytesMinPrefix(v));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -158,6 +158,9 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             // it will return the next row id if given key is not found.
             long minSSTableRowId = primaryKeyMap.firstRowIdFromPrimaryKey(firstPrimaryKey);
+            // If we didn't find the first key, we won't find the last primary key either
+            if (primaryKeyMap.isNotFound(minSSTableRowId))
+                return new BitsOrPostingList(PostingList.EMPTY);
             long maxSSTableRowId = primaryKeyMap.lastRowIdFromPrimaryKey(lastPrimaryKey);
 
             if (minSSTableRowId > maxSSTableRowId)

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -157,11 +157,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             PrimaryKey lastPrimaryKey = keyFactory.createTokenOnly(keyRange.right.getToken());
 
             // it will return the next row id if given key is not found.
-            long minSSTableRowId = primaryKeyMap.firstRowIdFromPrimaryKey(firstPrimaryKey);
+            long minSSTableRowId = primaryKeyMap.ceiling(firstPrimaryKey);
             // If we didn't find the first key, we won't find the last primary key either
             if (primaryKeyMap.isNotFound(minSSTableRowId))
                 return new BitsOrPostingList(PostingList.EMPTY);
-            long maxSSTableRowId = primaryKeyMap.lastRowIdFromPrimaryKey(lastPrimaryKey);
+            long maxSSTableRowId = primaryKeyMap.floor(lastPrimaryKey);
 
             if (minSSTableRowId > maxSSTableRowId)
                 return new BitsOrPostingList(PostingList.EMPTY);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -105,8 +105,8 @@ public class SortedTermsReader
     }
 
     /**
-     * Returns the point id (ordinal) associated with the greatest term less than or equal to the given term, or
-     * <code>Long.MAX_VALUE</code> if there is no such term.
+     * Returns the point id (ordinal) associated with the least term greater than or equal to the given term, or
+     * <code>Long.MAX_VALUE</code> if there is no such point id.
      * @param term
      * @return
      */
@@ -143,7 +143,7 @@ public class SortedTermsReader
     }
 
     /**
-     * Returns the point id (ordinal) associated with the least term greater than or equal to the given term, or
+     * Returns the point id (ordinal) associated with the greatest term less than or equal to the given term, or
      * <code>Long.MAX_VALUE</code> if there is no such term.
      * Complexity of this operation is O(log n).
      *

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -104,18 +104,18 @@ public class SortedTermsReader
     }
 
     /**
-     * Returns the point id (ordinal) of the target term or the next greater if no exact match found.
+     * Returns the point id (ordinal) associated with the greatest term less than or equal to the given term, or
+     * <code>Long.MAX_VALUE</code> if there is no such term.
      * @param term
      * @return
      */
-    public long getNextPointId(@Nonnull ByteComparable term)
+    public long ceiling(@Nonnull ByteComparable term)
     {
         return getPointId(term, false);
     }
 
     /**
-     * Returns the point id (ordinal) of the target term.
-     * If reached the end of the terms file, returns <code>Long.MAX_VALUE</code>.
+     * Returns the point id (ordinal) of the target term or <code>Long.MAX_VALUE</code> if there is no such term.
      * Complexity of this operation is O(log n).
      *
      * @param term target term to lookup
@@ -142,13 +142,13 @@ public class SortedTermsReader
     }
 
     /**
-     * Returns the last point id (ordinal) of the target term or the next smaller if no exact match found.
-     * If reached the end of the terms file, returns <code>Long.MAX_VALUE</code>.
+     * Returns the point id (ordinal) associated with the least term greater than or equal to the given term, or
+     * <code>Long.MAX_VALUE</code> if there is no such term.
      * Complexity of this operation is O(log n).
      *
      * @param term target term to lookup
      */
-    public long getLastPointId(@Nonnull ByteComparable term)
+    public long floor(@Nonnull ByteComparable term)
     {
         Preconditions.checkNotNull(term, "term null");
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -105,19 +105,34 @@ public class SortedTermsReader
 
     /**
      * Returns the point id (ordinal) of the target term or the next greater if no exact match found.
+     * @param term
+     * @return
+     */
+    public long getNextPointId(@Nonnull ByteComparable term)
+    {
+        return getPointId(term, false);
+    }
+
+    /**
+     * Returns the point id (ordinal) of the target term.
      * If reached the end of the terms file, returns <code>Long.MAX_VALUE</code>.
      * Complexity of this operation is O(log n).
      *
      * @param term target term to lookup
      */
-    public long getPointId(@Nonnull ByteComparable term)
+    public long getExactPointId(@Nonnull ByteComparable term)
+    {
+        return getPointId(term, true);
+    }
+
+    private long getPointId(@Nonnull ByteComparable term, boolean exactMatch)
     {
         Preconditions.checkNotNull(term, "term null");
 
         try (TrieRangeIterator reader = new TrieRangeIterator(termsTrie.instantiateRebufferer(),
                                                               meta.trieFP,
                                                               term,
-                                                              null,
+                                                              exactMatch ? term : null,
                                                               true,
                                                               true))
         {

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
@@ -253,7 +253,7 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
     {
         for (int i = 0; i < NUM_INVOCATIONS; i++)
         {
-            bh.consume(sortedTermsReader.getNextPointId(ByteComparable.fixedLength(this.bcIntBytes[i * skippingDistance])));
+            bh.consume(sortedTermsReader.ceiling(ByteComparable.fixedLength(this.bcIntBytes[i * skippingDistance])));
         }
     }
 

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
@@ -253,7 +253,7 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
     {
         for (int i = 0; i < NUM_INVOCATIONS; i++)
         {
-            bh.consume(sortedTermsReader.getPointId(ByteComparable.fixedLength(this.bcIntBytes[i * skippingDistance])));
+            bh.consume(sortedTermsReader.getNextPointId(ByteComparable.fixedLength(this.bcIntBytes[i * skippingDistance])));
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -472,4 +472,36 @@ public class VectorUpdateDeleteTest extends VectorTester
         var result = execute("SELECT * FROM %s ORDER BY val ann of [1.0, 2.0, 3.0] LIMIT 1");
         assertThat(result).hasSize(1);
     }
+
+    // This test intentionally has extra rows with primary keys that are above and below the
+    // deleted primary key so that we do not short circuit certain parts of the shadowed key logic.
+    @Test
+    public void shadowedPrimaryKeyInDifferentSSTableEachWithMultipleRows() throws Throwable
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // flush a sstable with one vector
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'A', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'A', [1.0, 2.0, 3.0])");
+        flush();
+
+        // flush another sstable to shadow the vector row
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [1.0, 2.0, 3.0])");
+        execute("DELETE FROM %s where pk = 2");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'A', [1.0, 2.0, 3.0])");
+        flush();
+
+        // flush another sstable with one new vector row
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'B', [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'B', [2.0, 3.0, 4.0])");
+        flush();
+
+        // the shadow vector has the highest score
+        var result = execute("SELECT * FROM %s ORDER BY val ann of [1.0, 2.0, 3.0] LIMIT 4");
+        assertThat(result).hasSize(4);
+    }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -57,7 +57,9 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static org.apache.cassandra.index.sai.disk.v1.kdtree.BKDQueries.bkdQueryFrom;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Note: The sstables and SAI indexes used in this test were written with DSE 6.8
@@ -140,6 +142,20 @@ public class LegacyOnDiskFormatTest
         PrimaryKey primaryKey = primaryKeyMap.primaryKeyFromRowId(0);
 
         assertEquals(expected, primaryKey);
+    }
+
+    // This test should pass, but I am not able to run it yet due to the class being Ignored.
+    @Test
+    public void endOfStreamForLegacyPrimaryKeyMap() throws Throwable
+    {
+        try (PrimaryKeyMap.Factory primaryKeyMapFactory = indexDescriptor.newPrimaryKeyMapFactory(sstable);
+             PrimaryKeyMap primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap())
+        {
+            assertTrue(primaryKeyMap.isNotFound(-1));
+            assertFalse(primaryKeyMap.isNotFound(0));
+            assertFalse(primaryKeyMap.isNotFound(1));
+        }
+
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -86,13 +86,13 @@ public class KDTreeIndexBuilder
         }
 
         @Override
-        public long firstRowIdFromPrimaryKey(PrimaryKey key)
+        public long ceiling(PrimaryKey key)
         {
             return key.token().getLongValue();
         }
 
         @Override
-        public long lastRowIdFromPrimaryKey(PrimaryKey key)
+        public long floor(PrimaryKey key)
         {
             return key.token().getLongValue();
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -80,7 +80,7 @@ public class KDTreeIndexBuilder
         }
 
         @Override
-        public long rowIdFromPrimaryKey(PrimaryKey key)
+        public long exactRowIdForPrimaryKey(PrimaryKey key)
         {
             return key.token().getLongValue();
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -96,6 +96,12 @@ public class KDTreeIndexBuilder
         {
             return key.token().getLongValue();
         }
+
+        @Override
+        public boolean isNotFound(long sstableRowId)
+        {
+            return false;
+        }
     };
     public static final PrimaryKeyMap.Factory TEST_PRIMARY_KEY_MAP_FACTORY = () -> TEST_PRIMARY_KEY_MAP;
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
@@ -144,7 +144,7 @@ public class SortedTermsTest extends SaiRandomizedTest
         {
             for (int x = 0; x < terms.size(); x++)
             {
-                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(x)));
+                long pointId = reader.ceiling(ByteComparable.fixedLength(terms.get(x)));
                 assertEquals(x, pointId);
             }
         });
@@ -154,7 +154,7 @@ public class SortedTermsTest extends SaiRandomizedTest
         {
             for (int x = terms.size() - 1; x >= 0; x--)
             {
-                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(x)));
+                long pointId = reader.ceiling(ByteComparable.fixedLength(terms.get(x)));
                 assertEquals(x, pointId);
             }
         });
@@ -166,7 +166,7 @@ public class SortedTermsTest extends SaiRandomizedTest
             {
                 int target = nextInt(0, terms.size());
 
-                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(target)));
+                long pointId = reader.ceiling(ByteComparable.fixedLength(terms.get(target)));
                 assertEquals(target, pointId);
             }
         });
@@ -188,8 +188,8 @@ public class SortedTermsTest extends SaiRandomizedTest
             for (int x = 0; x < termsMaxPrefixNoMatch.size(); x++)
             {
                 int index = x;
-                long pointIdStart = reader.getNextPointId(v -> termsMinPrefixNoMatch.get(index));
-                long pointIdEnd = reader.getLastPointId(v -> termsMaxPrefixNoMatch.get(index));
+                long pointIdStart = reader.ceiling(v -> termsMinPrefixNoMatch.get(index));
+                long pointIdEnd = reader.floor(v -> termsMaxPrefixNoMatch.get(index));
                 assertTrue(pointIdStart > pointIdEnd);
             }
         });
@@ -211,8 +211,8 @@ public class SortedTermsTest extends SaiRandomizedTest
             for (int x = 0; x < termsMaxPrefix.size(); x++)
             {
                 int index = x;
-                long pointIdStart = reader.getNextPointId(v -> termsMinPrefix.get(index));
-                long pointIdEnd = reader.getLastPointId(v -> termsMaxPrefix.get(index));
+                long pointIdStart = reader.ceiling(v -> termsMinPrefix.get(index));
+                long pointIdEnd = reader.floor(v -> termsMaxPrefix.get(index));
                 assertEquals(pointIdStart, x / valuesPerPrefix * valuesPerPrefix);
                 assertEquals(pointIdStart + valuesPerPrefix - 1, pointIdEnd);
             }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
@@ -144,7 +144,7 @@ public class SortedTermsTest extends SaiRandomizedTest
         {
             for (int x = 0; x < terms.size(); x++)
             {
-                long pointId = reader.getPointId(ByteComparable.fixedLength(terms.get(x)));
+                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(x)));
                 assertEquals(x, pointId);
             }
         });
@@ -154,7 +154,7 @@ public class SortedTermsTest extends SaiRandomizedTest
         {
             for (int x = terms.size() - 1; x >= 0; x--)
             {
-                long pointId = reader.getPointId(ByteComparable.fixedLength(terms.get(x)));
+                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(x)));
                 assertEquals(x, pointId);
             }
         });
@@ -166,7 +166,7 @@ public class SortedTermsTest extends SaiRandomizedTest
             {
                 int target = nextInt(0, terms.size());
 
-                long pointId = reader.getPointId(ByteComparable.fixedLength(terms.get(target)));
+                long pointId = reader.getNextPointId(ByteComparable.fixedLength(terms.get(target)));
                 assertEquals(target, pointId);
             }
         });
@@ -188,7 +188,7 @@ public class SortedTermsTest extends SaiRandomizedTest
             for (int x = 0; x < termsMaxPrefixNoMatch.size(); x++)
             {
                 int index = x;
-                long pointIdStart = reader.getPointId(v -> termsMinPrefixNoMatch.get(index));
+                long pointIdStart = reader.getNextPointId(v -> termsMinPrefixNoMatch.get(index));
                 long pointIdEnd = reader.getLastPointId(v -> termsMaxPrefixNoMatch.get(index));
                 assertTrue(pointIdStart > pointIdEnd);
             }
@@ -211,7 +211,7 @@ public class SortedTermsTest extends SaiRandomizedTest
             for (int x = 0; x < termsMaxPrefix.size(); x++)
             {
                 int index = x;
-                long pointIdStart = reader.getPointId(v -> termsMinPrefix.get(index));
+                long pointIdStart = reader.getNextPointId(v -> termsMinPrefix.get(index));
                 long pointIdEnd = reader.getLastPointId(v -> termsMaxPrefix.get(index));
                 assertEquals(pointIdStart, x / valuesPerPrefix * valuesPerPrefix);
                 assertEquals(pointIdStart + valuesPerPrefix - 1, pointIdEnd);


### PR DESCRIPTION
The `rowIdFromPrimaryKey` method is implemented as a `ceiling` method--it returns the row id for the least Primary Key greater than or equal to the passed PK. The name and the interface's javadoc imply a more straightforward definition: return the row id for the PK or return a `long` indicating there is no such row for the given PK.

The implementation's `ceiling` semantics cause a problem when we build the ignore bits for a pure ANN search becaus we do a reverse lookup from PK to sstable row id and assume that those row ids ought to be ignored.

Another minor detail: the two implementations of `PrimaryKeyMap` return different values to indicate a row was not found. In `PartitionAwarePrimaryKeyMap`, it returns a negative number but in `RowAwarePrimaryKeyMap`, it returns `Long.MAX_VALUE`. This is a problem in `PostingListRangeIterator` and `SSTableRowIdKeyRangeIterator` where we assume that a negative value from the `PrimaryKeyMap` indicates a missing value. The impact is negligible, but I fixed this in the PR.

In this PR, I propose we fix `RowAwarePrimaryKeyMap#rowIdFromPrimaryKey` by first renaming it to `exactRowIdForPrimaryKey` and then making it return an exact row id or a number indicating the row is not found. We also rename methods that mean `ceiling` and `floor` to improve the API.

For test coverage, I have a test that fails for the first case. I am generally assuming that the logic in the `TrieTermsDictionaryReader` class is sufficient.