### PR TITLE
Standardize not found logic for PrimaryKeyMap

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -157,7 +157,7 @@ public class QueryContext
                     continue;
 
                 long sstableRowId = primaryKeyMap.exactRowIdForPrimaryKey(primaryKey);
-                if (primaryKeyMap.isNotFound(sstableRowId)) // not found
+                if (sstableRowId < 0) // not found
                     continue;
 
                 int segmentRowId = metadata.toSegmentRowId(sstableRowId);

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -148,7 +148,7 @@ public class PostingListRangeIterator extends RangeIterator<PrimaryKey>
         {
             long targetRowID = primaryKeyMap.ceiling(skipToToken);
             // skipToToken is larger than max token in token file
-            if (primaryKeyMap.isNotFound(targetRowID))
+            if (targetRowID < 0)
             {
                 return PostingList.END_OF_STREAM;
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -61,7 +61,7 @@ public interface PrimaryKeyMap extends Closeable
     PrimaryKey primaryKeyFromRowId(long sstableRowId);
 
     /**
-     * Returns a row Id for a {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
+     * Returns a row Id for a {@link PrimaryKey}. If there is no such term, returns a negative value.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the row Id associated with the {@link PrimaryKey}
@@ -70,7 +70,7 @@ public interface PrimaryKeyMap extends Closeable
 
     /**
      * Returns the sstable row id associated with the least {@link PrimaryKey} greater than or equal to the given
-     * {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
+     * {@link PrimaryKey}. If there is no such term, returns a negative value.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return the first row Id associated with the {@link PrimaryKey}
@@ -79,20 +79,12 @@ public interface PrimaryKeyMap extends Closeable
 
     /**
      * Returns the sstable row id associated with the greatest {@link PrimaryKey} less than or equal to the given
-     * {@link PrimaryKey}. If there is no such term, {@link #isNotFound(long)} will return true.
+     * {@link PrimaryKey}. If there is no such term, returns a negative value.
      *
      * @param key the {@link PrimaryKey} to lookup
      * @return an sstable row id
      */
     long floor(PrimaryKey key);
-
-    /**
-     * This method is necessary because the two implementations for this interface have divergent behavior for
-     * indicating that a {@link PrimaryKey} was not found.
-     * @param sstableRowId
-     * @return true if the passed row id is not found by the {@link PrimaryKeyMap}
-     */
-    boolean isNotFound(long sstableRowId);
 
     @Override
     default void close() throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableRowIdKeyRangeIterator.java
@@ -145,7 +145,7 @@ public class SSTableRowIdKeyRangeIterator extends RangeIterator<PrimaryKey>
         {
             long targetRowID = primaryKeyMap.ceiling(skipToToken);
             // skipToToken is larger than max token in token file
-            if (primaryKeyMap.isNotFound(targetRowID))
+            if (targetRowID < 0)
                 return PostingList.END_OF_STREAM;
 
             sstableRowIdIterator.skipTo(targetRowID);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -156,12 +156,6 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     }
 
     @Override
-    public boolean isNotFound(long sstableRowId)
-    {
-        return sstableRowId < 0;
-    }
-
-    @Override
     public void close() throws IOException
     {
         FileUtils.closeQuietly(rowIdToToken, rowIdToOffset, reader);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -181,12 +181,6 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         return sortedTermsReader.floor(v -> key.asComparableBytesMaxPrefix(v));
     }
 
-    @Override
-    public boolean isNotFound(long sstableRowId)
-    {
-        return sstableRowId == Long.MAX_VALUE;
-    }
-
 
     @Override
     public void close() throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -159,7 +159,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             // it will return the next row id if given key is not found.
             long minSSTableRowId = primaryKeyMap.ceiling(firstPrimaryKey);
             // If we didn't find the first key, we won't find the last primary key either
-            if (primaryKeyMap.isNotFound(minSSTableRowId))
+            if (minSSTableRowId < 0)
                 return new BitsOrPostingList(PostingList.EMPTY);
             long maxSSTableRowId = primaryKeyMap.floor(lastPrimaryKey);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -72,6 +72,7 @@ import static org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsWrit
 @ThreadSafe
 public class SortedTermsReader
 {
+    private static final long NOT_FOUND = -1;
     private final FileHandle termsData;
     private final SortedTermsMeta meta;
     private final FileHandle termsTrie;
@@ -106,7 +107,7 @@ public class SortedTermsReader
 
     /**
      * Returns the point id (ordinal) associated with the least term greater than or equal to the given term, or
-     * <code>Long.MAX_VALUE</code> if there is no such point id.
+     * a negative value if there is no such term.
      * @param term
      * @return
      */
@@ -122,12 +123,12 @@ public class SortedTermsReader
                                                               true))
         {
             final Iterator<Pair<ByteSource, Long>> iterator = reader.iterator();
-            return iterator.hasNext() ? iterator.next().right : Long.MAX_VALUE;
+            return iterator.hasNext() ? iterator.next().right : NOT_FOUND;
         }
     }
 
     /**
-     * Returns the point id (ordinal) of the target term or <code>Long.MAX_VALUE</code> if there is no such term.
+     * Returns the point id (ordinal) of the target term or a negative value if there is no such term.
      * Complexity of this operation is O(log n).
      *
      * @param term target term to lookup
@@ -138,13 +139,13 @@ public class SortedTermsReader
         try (TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(termsTrie.instantiateRebufferer(), meta.trieFP))
         {
             long result = reader.exactMatch(term);
-            return result < 0 ? Long.MAX_VALUE : result;
+            return result < 0 ? NOT_FOUND : result;
         }
     }
 
     /**
      * Returns the point id (ordinal) associated with the greatest term less than or equal to the given term, or
-     * <code>Long.MAX_VALUE</code> if there is no such term.
+     * a negative value if there is no such term.
      * Complexity of this operation is O(log n).
      *
      * @param term target term to lookup

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -144,20 +144,6 @@ public class LegacyOnDiskFormatTest
         assertEquals(expected, primaryKey);
     }
 
-    // This test should pass, but I am not able to run it yet due to the class being Ignored.
-    @Test
-    public void endOfStreamForLegacyPrimaryKeyMap() throws Throwable
-    {
-        try (PrimaryKeyMap.Factory primaryKeyMapFactory = indexDescriptor.newPrimaryKeyMapFactory(sstable);
-             PrimaryKeyMap primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap())
-        {
-            assertTrue(primaryKeyMap.isNotFound(-1));
-            assertFalse(primaryKeyMap.isNotFound(0));
-            assertFalse(primaryKeyMap.isNotFound(1));
-        }
-
-    }
-
     @Test
     public void canSearchBDKIndex() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -97,11 +97,6 @@ public class KDTreeIndexBuilder
             return key.token().getLongValue();
         }
 
-        @Override
-        public boolean isNotFound(long sstableRowId)
-        {
-            return false;
-        }
     };
     public static final PrimaryKeyMap.Factory TEST_PRIMARY_KEY_MAP_FACTORY = () -> TEST_PRIMARY_KEY_MAP;
 


### PR DESCRIPTION
Standardize the "not found" result for all `PrimaryKeyMap` implementations and return a negative value to indicate a row is not found. Remove the `isNotFound` method.

Context: `PartitionAwarePrimaryKeyMap` returns `-1` when there is no such value. `RowAwarePrimaryKeyMap` returns `Long.MAX_VALUE` when there is no such value for `#ceiling` and for `#exactRowIdForPrimaryKey`, but returns `-1` for `#floor`.