### PR TITLE
Store sstable row id in PrimaryKey

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 
 /**
  * A bidirectional map of {@link PrimaryKey} to row Id. Implementations of this interface
@@ -51,6 +52,12 @@ public interface PrimaryKeyMap extends Closeable
         {
         }
     }
+
+    /**
+     * Returns the {@link SSTableId} associated with this {@link PrimaryKeyMap}
+     * @return an {@link SSTableId}
+     */
+    SSTableId<?> getSSTableId();
 
     /**
      * Returns a {@link PrimaryKey} for a row Id

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
@@ -21,10 +21,13 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.NotImplementedException;
+
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
@@ -55,6 +58,12 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
         return new PartitionAwarePrimaryKey(partitionKey.getToken(), partitionKey, null);
     }
 
+    @Override
+    public PrimaryKey create(DecoratedKey partitionKey, Clustering clustering, SSTableId ssTableId, long sstableRowId)
+    {
+        throw new NotImplementedException();
+    }
+
     private class PartitionAwarePrimaryKey implements PrimaryKey
     {
         private final Token token;
@@ -83,6 +92,18 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
         public Token token()
         {
             return this.token;
+        }
+
+        @Override
+        public long sstableRowId(SSTableId ssTableId)
+        {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void mergeSSTableMetadata(PrimaryKey other)
+        {
+            throw new NotImplementedException();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.index.sai.disk.v1.bitpack.BlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.MonotonicBlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -64,6 +65,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         private final KeyFetcher keyFetcher;
         private final IPartitioner partitioner;
         private final PrimaryKey.Factory primaryKeyFactory;
+        private final SSTableId ssTableId;
 
         private FileHandle token = null;
         private FileHandle offset = null;
@@ -84,6 +86,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
                 this.partitioner = indexDescriptor.partitioner;
                 this.keyFetcher = new KeyFetcher(sstable);
                 this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
+                this.ssTableId = sstable.getId();
             }
             catch (Throwable t)
             {
@@ -97,7 +100,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
             final LongArray rowIdToToken = new LongArray.DeferredLongArray(() -> tokenReaderFactory.open());
             final LongArray rowIdToOffset = new LongArray.DeferredLongArray(() -> offsetReaderFactory.open());
 
-            return new PartitionAwarePrimaryKeyMap(rowIdToToken, rowIdToOffset, partitioner, keyFetcher, primaryKeyFactory);
+            return new PartitionAwarePrimaryKeyMap(rowIdToToken, rowIdToOffset, partitioner, keyFetcher, primaryKeyFactory, ssTableId);
         }
 
         @Override
@@ -114,12 +117,14 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     private final RandomAccessReader reader;
     private final PrimaryKey.Factory primaryKeyFactory;
     private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
+    private final SSTableId sstableId;
 
     private PartitionAwarePrimaryKeyMap(LongArray rowIdToToken,
                                         LongArray rowIdToOffset,
                                         IPartitioner partitioner,
                                         KeyFetcher keyFetcher,
-                                        PrimaryKey.Factory primaryKeyFactory)
+                                        PrimaryKey.Factory primaryKeyFactory,
+                                        SSTableId sstableId)
     {
         this.rowIdToToken = rowIdToToken;
         this.rowIdToOffset = rowIdToOffset;
@@ -127,6 +132,13 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         this.keyFetcher = keyFetcher;
         this.reader = keyFetcher.createReader();
         this.primaryKeyFactory = primaryKeyFactory;
+        this.sstableId = sstableId;
+    }
+
+    @Override
+    public SSTableId<?> getSSTableId()
+    {
+        return sstableId;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
 import org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsMeta;
 import org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsReader;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -80,6 +81,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         private final IPartitioner partitioner;
         private final ClusteringComparator clusteringComparator;
         private final PrimaryKey.Factory primaryKeyFactory;
+        private final SSTableId<?> sstableId;
 
         public RowAwarePrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable)
         {
@@ -99,6 +101,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                 this.partitioner = sstable.metadata().partitioner;
                 this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
                 this.clusteringComparator = indexDescriptor.clusteringComparator;
+                this.sstableId = sstable.getId();
             }
             catch (Throwable t)
             {
@@ -117,7 +120,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                                                  sortedTermsReader.openCursor(),
                                                  partitioner,
                                                  primaryKeyFactory,
-                                                 clusteringComparator);
+                                                 clusteringComparator,
+                                                 sstableId);
             }
             catch (IOException e)
             {
@@ -139,13 +143,15 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     private final PrimaryKey.Factory primaryKeyFactory;
     private final ClusteringComparator clusteringComparator;
     private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
+    private final SSTableId<?> sstableId;
 
     private RowAwarePrimaryKeyMap(LongArray rowIdToToken,
                                   SortedTermsReader sortedTermsReader,
                                   SortedTermsReader.Cursor cursor,
                                   IPartitioner partitioner,
                                   PrimaryKey.Factory primaryKeyFactory,
-                                  ClusteringComparator clusteringComparator)
+                                  ClusteringComparator clusteringComparator,
+                                  SSTableId<?> sstableId)
     {
         this.rowIdToToken = rowIdToToken;
         this.sortedTermsReader = sortedTermsReader;
@@ -153,6 +159,13 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         this.partitioner = partitioner;
         this.primaryKeyFactory = primaryKeyFactory;
         this.clusteringComparator = clusteringComparator;
+        this.sstableId = sstableId;
+    }
+
+    @Override
+    public SSTableId<?> getSSTableId()
+    {
+        return sstableId;
     }
 
     @Override
@@ -209,7 +222,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                                     : clusteringComparator.clusteringFromByteComparable(ByteBufferAccessor.instance,
                                                                                         v -> ByteSourceInverse.nextComponentSource(peekable));
 
-            return primaryKeyFactory.create(partitionKey, clustering);
+            return primaryKeyFactory.create(partitionKey, clustering, sstableId, sstableRowId);
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -282,7 +282,9 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             {
                 for (PrimaryKey primaryKey : keysInRange)
                 {
-                    long sstableRowId = primaryKeyMap.exactRowIdForPrimaryKey(primaryKey);
+                    long sstableRowId = primaryKey.sstableRowId(primaryKeyMap.getSSTableId());
+                    if (sstableRowId < 0)
+                        sstableRowId = primaryKeyMap.exactRowIdForPrimaryKey(primaryKey);
                     // skip rows that are not in our segment (or more preciesely, have no vectors that were indexed)
                     // or are not in this segment (exactRowIdForPrimaryKey returns a negative value for not found)
                     if (sstableRowId < metadata.minSSTableRowId)

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.v1.PartitionAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
@@ -92,6 +93,16 @@ public interface PrimaryKey extends Comparable<PrimaryKey>
          * @return a {@link PrimaryKey} contain the partition key and clustering
          */
         PrimaryKey create(DecoratedKey partitionKey, Clustering clustering);
+
+        /**
+         * Creates a {@link PrimaryKey} that is fully represented by partition key
+         * and clustering.
+         *
+         * @param partitionKey the {@link DecoratedKey}
+         * @param clustering the {@link Clustering}
+         * @return a {@link PrimaryKey} contain the partition key and clustering
+         */
+        PrimaryKey create(DecoratedKey partitionKey, Clustering clustering, SSTableId ssTableId, long sstableRowId);
     }
 
     /**
@@ -116,6 +127,10 @@ public interface PrimaryKey extends Comparable<PrimaryKey>
      * @return the {@link Token}
      */
     Token token();
+
+    long sstableRowId(SSTableId<?> sstableId);
+
+    void mergeSSTableMetadata(PrimaryKey other);
 
     /**
      * Returns the {@link DecoratedKey} associated with this primary key.

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeIntersectionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeIntersectionIterator.java
@@ -98,6 +98,7 @@ public class RangeIntersectionIterator extends RangeIterator
                     assert nextKey.compareTo(highestKey) == 0:
                     String.format("skipTo skipped to an item smaller than the target; " +
                                   "iterator: %s, target key: %s, returned key: %s", range, highestKey, nextKey);
+                    highestKey.mergeSSTableMetadata(nextKey);
                 }
             }
             // If we reached here, next() has been called at least once on each range iterator and

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
@@ -52,8 +52,13 @@ public class RangeUnionIterator extends RangeIterator
             if (range.hasNext())
             {
                 // Avoid repeated values but only if we have read at least one value
-                while (next != null && range.hasNext() && range.peek().compareTo(getCurrent()) == 0)
+                while (next != null && range.hasNext())
+                {
+                    if (range.peek().compareTo(getCurrent()) != 0)
+                        break;
+                    getCurrent().mergeSSTableMetadata(range.peek());
                     range.next();
+                }
                 if (!range.hasNext())
                     continue;
                 if (candidate == null)
@@ -65,7 +70,10 @@ public class RangeUnionIterator extends RangeIterator
                 {
                     int cmp = candidate.compareTo(range.peek());
                     if (cmp == 0)
+                    {
+                        candidate.mergeSSTableMetadata(range.peek());
                         candidates.add(range);
+                    }
                     else if (cmp > 0)
                     {
                         candidates.clear();

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -56,6 +56,7 @@ import org.apache.cassandra.index.sai.utils.AbstractIterator;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.disk.v1.PartitionAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
@@ -72,6 +73,12 @@ public class KDTreeIndexBuilder
     public static final PrimaryKeyMap TEST_PRIMARY_KEY_MAP = new PrimaryKeyMap()
     {
         private final PrimaryKey.Factory primaryKeyFactory = new PartitionAwarePrimaryKeyFactory();
+
+        @Override
+        public SSTableId<?> getSSTableId()
+        {
+            return null;
+        }
 
         @Override
         public PrimaryKey primaryKeyFromRowId(long sstableRowId)

--- a/test/unit/org/apache/cassandra/index/sai/utils/AbstractRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/AbstractRangeIteratorTest.java
@@ -90,7 +90,7 @@ public class AbstractRangeIteratorTest extends SaiRandomizedTest
 
     protected LongIterator build(long[] tokensA, boolean onErrorA)
     {
-        LongIterator rangeA = new LongIterator(tokensA);
+        LongIterator rangeA = new LongIterator(tokensA, 0);
 
         if (onErrorA)
             rangeA.throwsException();

--- a/test/unit/org/apache/cassandra/index/sai/utils/RangeIntersectionIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/RangeIntersectionIteratorTest.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.index.sai.utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -72,11 +74,14 @@ public class RangeIntersectionIteratorTest extends AbstractRangeIteratorTest
     {
         RangeIterator.Builder builder = RangeIntersectionIterator.builder();
 
-        builder.add(new LongIterator(new long[] { 1L, 4L, 6L, 7L }));
-        builder.add(new LongIterator(new long[] { 2L, 4L, 5L, 6L }));
-        builder.add(new LongIterator(new long[] { 4L, 6L, 8L, 9L, 10L }));
+        builder.add(new LongIterator(new long[] { 1L, 4L, 6L, 7L }, 0));
+        builder.add(new LongIterator(new long[] { 2L, 4L, 5L, 6L }, 1));
+        builder.add(new LongIterator(new long[] { 4L, 6L, 8L, 9L, 10L }, 2));
 
-        Assert.assertEquals(convert(4L, 6L), convert(builder.build()));
+        Map<Long, List<Integer>> expected = new HashMap<>();
+        expected.put(4L, List.of(0, 1, 2));
+        expected.put(6L, List.of(0, 1, 2));
+        LongIterator.assertEqual(expected, builder.build());
     }
 
     @Test
@@ -84,10 +89,15 @@ public class RangeIntersectionIteratorTest extends AbstractRangeIteratorTest
     {
         RangeIterator.Builder builder = RangeIntersectionIterator.builder();
 
-        builder.add(new LongIterator(new long[] { 1L, 2L, 3L, 4L }));
-        builder.add(new LongIterator(new long[] { 1L, 2L, 3L, 4L }));
+        builder.add(new LongIterator(new long[] { 1L, 2L, 3L, 4L }, 0));
+        builder.add(new LongIterator(new long[] { 1L, 2L, 3L, 4L }, 0));
 
-        Assert.assertEquals(convert(1L, 2L, 3L, 4L), convert(builder.build()));
+        Map<Long, List<Integer>> expected = new HashMap<>();
+        expected.put(1L, List.of(0));
+        expected.put(2L, List.of(0));
+        expected.put(3L, List.of(0));
+        expected.put(4L, List.of(0));
+        LongIterator.assertEqual(expected, builder.build());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/utils/RangeUnionIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/RangeUnionIteratorTest.java
@@ -19,7 +19,9 @@ package org.apache.cassandra.index.sai.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Assert;
@@ -39,11 +41,15 @@ public class RangeUnionIteratorTest extends AbstractRangeIteratorTest
     {
         RangeUnionIterator.Builder builder = RangeUnionIterator.builder();
 
-        builder.add(new LongIterator(new long[] { 2L, 3L, 5L, 6L }));
-        builder.add(new LongIterator(new long[] { 1L, 7L }));
-        builder.add(new LongIterator(new long[] { 4L, 8L, 9L, 10L }));
+        builder.add(new LongIterator(new long[] { 2L, 3L, 5L, 6L }, 0));
+        builder.add(new LongIterator(new long[] { 1L, 7L }, 1));
+        builder.add(new LongIterator(new long[] { 4L, 8L, 9L, 10L }, 2));
 
-        Assert.assertEquals(convert(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L), convert(builder.build()));
+        Map<Long, List<Integer>> expected = new HashMap<>();
+        LongIterator.updateExpectedMap(expected, new long[] { 2L, 3L, 5L, 6L }, List.of(0));
+        LongIterator.updateExpectedMap(expected, new long[] { 1L, 7L }, List.of(1));
+        LongIterator.updateExpectedMap(expected, new long[] { 4L, 8L, 9L, 10L }, List.of(2));
+        LongIterator.assertEqual(expected, builder.build());
     }
 
     @Test
@@ -51,9 +57,11 @@ public class RangeUnionIteratorTest extends AbstractRangeIteratorTest
     {
         RangeUnionIterator.Builder builder = RangeUnionIterator.builder();
 
-        builder.add(new LongIterator(new long[] { 1L, 2L, 4L, 9L }));
+        builder.add(new LongIterator(new long[] { 1L, 2L, 4L, 9L }, 1));
 
-        Assert.assertEquals(convert(1L, 2L, 4L, 9L), convert(builder.build()));
+        Map<Long, List<Integer>> expected = new HashMap<>();
+        LongIterator.updateExpectedMap(expected, new long[] { 1L, 2L, 4L, 9L }, List.of(1));
+        LongIterator.assertEqual(expected, builder.build());
     }
 
     @Test
@@ -61,13 +69,19 @@ public class RangeUnionIteratorTest extends AbstractRangeIteratorTest
     {
         RangeUnionIterator.Builder builder = RangeUnionIterator.builder();
 
-        builder.add(new LongIterator(new long[] { 1L, 4L, 6L, 7L }));
-        builder.add(new LongIterator(new long[] { 2L, 3L, 5L, 6L }));
-        builder.add(new LongIterator(new long[] { 4L, 6L, 8L, 9L, 10L }));
+        builder.add(new LongIterator(new long[] { 1L, 4L, 6L, 7L }, 0));
+        builder.add(new LongIterator(new long[] { 2L, 3L, 5L, 6L }, 1));
+        builder.add(new LongIterator(new long[] { 4L, 6L, 8L, 9L, 10L }, 2));
 
-        List<Long> values = convert(builder.build());
 
-        Assert.assertEquals(values.toString(), convert(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L), values);
+        Map<Long, List<Integer>> expected = new HashMap<>();
+        LongIterator.updateExpectedMap(expected, new long[]{ 1L, 7L}, List.of(0));
+        LongIterator.updateExpectedMap(expected, new long[]{ 2L, 3L, 5L }, List.of(1));
+        LongIterator.updateExpectedMap(expected, new long[]{ 8L, 9L, 10L }, List.of(2));
+        LongIterator.updateExpectedMap(expected, new long[]{ 4L }, List.of(0, 2));
+        LongIterator.updateExpectedMap(expected, new long[]{ 6L }, List.of(0, 1, 2));
+
+        LongIterator.assertEqual(expected, builder.build());
     }
 
     @Test


### PR DESCRIPTION
By storing the sstable id and row id in the Primary Key, we can save later look ups.

The logic: add row id info when key is created or loaded. In union and intersection range iterators, merge the metadata to keep it in memory.