### PR TITLE
VECTOR-SEARCH-27: Summarize sstable merging results for index queries

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -22,8 +22,11 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.codahale.metrics.Histogram;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.index.Index;
+import org.apache.cassandra.metrics.ClearableHistogram;
+import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.MonotonicClock;
@@ -50,6 +53,8 @@ public class ReadExecutionController implements AutoCloseable
     private final RepairedDataInfo repairedDataInfo;
     private int oldestUnrepairedTombstone = Integer.MAX_VALUE;
 
+    public final Histogram sstablesScannedPerRowRead;
+
     ReadExecutionController(ReadCommand command,
                             OpOrder.Group baseOp,
                             TableMetadata baseMetadata,
@@ -67,6 +72,8 @@ public class ReadExecutionController implements AutoCloseable
         this.writeContext = writeContext;
         this.command = command;
         this.createdAtNanos = createdAtNanos;
+
+        this.sstablesScannedPerRowRead = new ClearableHistogram(new DecayingEstimatedHistogramReservoir(false));
 
         if (trackRepairedStatus)
         {
@@ -213,7 +220,17 @@ public class ReadExecutionController implements AutoCloseable
 
         if (createdAtNanos != NO_SAMPLING)
             addSample();
-    }
+
+        if (Tracing.traceSinglePartitions())
+        {
+            var sstablesHistogram = sstablesScannedPerRowRead.getSnapshot();
+            Tracing.trace("Scanned {} rows; average {} sstables scanned per row with stdev {} and max {}",
+                          sstablesScannedPerRowRead.getCount(),
+                          sstablesHistogram.getMean(),
+                          sstablesHistogram.getStdDev(),
+                          sstablesHistogram.getMax());
+        }
+}
 
     public boolean isTrackingRepairedStatus()
     {
@@ -244,5 +261,10 @@ public class ReadExecutionController implements AutoCloseable
         ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(baseMetadata.id);
         if (cfs != null)
             cfs.metric.topLocalReadQueryTime.addSample(cql, timeMicros);
+    }
+
+    public void updateSstablesIteratedPerRow(int mergedSSTablesIterated)
+    {
+        sstablesScannedPerRowRead.update(mergedSSTablesIterated);
     }
 }

--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.codahale.metrics.Histogram;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.index.Index;
-import org.apache.cassandra.metrics.ClearableHistogram;
 import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tracing.Tracing;
@@ -73,7 +72,7 @@ public class ReadExecutionController implements AutoCloseable
         this.command = command;
         this.createdAtNanos = createdAtNanos;
 
-        this.sstablesScannedPerRowRead = new ClearableHistogram(new DecayingEstimatedHistogramReservoir(true));
+        this.sstablesScannedPerRowRead = new Histogram(new DecayingEstimatedHistogramReservoir(true));
 
         if (trackRepairedStatus)
         {

--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -73,7 +73,7 @@ public class ReadExecutionController implements AutoCloseable
         this.command = command;
         this.createdAtNanos = createdAtNanos;
 
-        this.sstablesScannedPerRowRead = new ClearableHistogram(new DecayingEstimatedHistogramReservoir(false));
+        this.sstablesScannedPerRowRead = new ClearableHistogram(new DecayingEstimatedHistogramReservoir(true));
 
         if (trackRepairedStatus)
         {


### PR DESCRIPTION
Fixes https://github.com/riptano/VECTOR-SEARCH/issues/27

Also fixes SinglePartitionReadCommand.queryMemtableAndSSTablesInTimestampOrder didn't update metrics.updateSSTableIterated()