### PR TITLE
Fix getTokenBound for Bound.END: return maximum token when unbounded

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -1100,7 +1100,7 @@ public class StatementRestrictions
     private Token getTokenBound(Bound b, QueryOptions options, IPartitioner p)
     {
         if (!partitionKeyRestrictions.hasBound(b))
-            return b == Bound.START ? p.getMinimumToken() : p.getMaximumToken();
+            return b.isStart() ? p.getMinimumToken() : p.getMaximumToken();
 
         ByteBuffer value = partitionKeyRestrictions.bounds(b, options).get(0);
         checkNotNull(value, "Invalid null token value");

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -1100,7 +1100,7 @@ public class StatementRestrictions
     private Token getTokenBound(Bound b, QueryOptions options, IPartitioner p)
     {
         if (!partitionKeyRestrictions.hasBound(b))
-            return p.getMinimumToken();
+            return b == Bound.START ? p.getMinimumToken() : p.getMaximumToken();
 
         ByteBuffer value = partitionKeyRestrictions.bounds(b, options).get(0);
         checkNotNull(value, "Invalid null token value");

--- a/src/java/org/apache/cassandra/dht/AbstractBounds.java
+++ b/src/java/org/apache/cassandra/dht/AbstractBounds.java
@@ -51,7 +51,6 @@ public abstract class AbstractBounds<T extends RingPosition<T>> implements Seria
     public AbstractBounds(T left, T right)
     {
         assert left.getPartitioner() == right.getPartitioner();
-        assert left.compareTo(right) <= 0 : "left " + left + " > right " + right;
         this.left = left;
         this.right = right;
     }

--- a/src/java/org/apache/cassandra/dht/AbstractBounds.java
+++ b/src/java/org/apache/cassandra/dht/AbstractBounds.java
@@ -51,6 +51,7 @@ public abstract class AbstractBounds<T extends RingPosition<T>> implements Seria
     public AbstractBounds(T left, T right)
     {
         assert left.getPartitioner() == right.getPartitioner();
+        assert left.compareTo(right) <= 0 : "left" + left + " > right " + right;
         this.left = left;
         this.right = right;
     }

--- a/src/java/org/apache/cassandra/dht/AbstractBounds.java
+++ b/src/java/org/apache/cassandra/dht/AbstractBounds.java
@@ -51,7 +51,7 @@ public abstract class AbstractBounds<T extends RingPosition<T>> implements Seria
     public AbstractBounds(T left, T right)
     {
         assert left.getPartitioner() == right.getPartitioner();
-        assert left.compareTo(right) <= 0 : "left" + left + " > right " + right;
+        assert left.compareTo(right) <= 0 : "left " + left + " > right " + right;
         this.left = left;
         this.right = right;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/ReversedTrieRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/ReversedTrieRangeIterator.java
@@ -47,7 +47,7 @@ class ReversedTrieRangeIterator extends ReverseValueIterator<ReversedTrieRangeIt
         {
             currentNode = nextPayloadedNode();
             if (currentNode == -1)
-                return Long.MAX_VALUE;
+                return TrieTermsDictionaryReader.NOT_FOUND;
         }
 
         go(currentNode);


### PR DESCRIPTION
While working on https://github.com/datastax/cassandra/pull/801, I noticed that the change made `VectorTypeTest.rangeSearchTest` fail in an unexpected way. Notably, the `AbstractBounds` class was built with left > right. The root cause appears to be an incorrect token boundary.

The current code has been working due to the use of `Long.MAX_VALUE` in the `ReversedTrieRangeIterator` to indicate a missing value. With the change to a negative value indicating "not found" we found this incorrect bounding.

I am not familiar with all of the consequences of this change; please review carefully.