### PR TITLE
CNDB-7820 Added CreateTableStatement#isCompactStorage to externally observe if the statement is meant to create a compact storage table

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.statements.RawKeyspaceAwareStatement;
 import org.apache.cassandra.db.Keyspace;
@@ -96,6 +95,11 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         this.ifNotExists = ifNotExists;
         this.useCompactStorage = useCompactStorage;
+    }
+
+    public boolean isCompactStorage()
+    {
+        return useCompactStorage;
     }
 
     @Override


### PR DESCRIPTION
This is required to fix the schema issue observed in https://github.com/riptano/cndb/issues/7820