### PR TITLE
VECTOR-SEARCH 32: shadowed rows metrics

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -65,6 +65,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     private final ReadCommand command;
     private final QueryController controller;
     private final QueryContext queryContext;
+    private final ColumnFamilyStore cfs;
 
     public StorageAttachedIndexSearcher(ColumnFamilyStore cfs,
                                         TableQueryMetrics tableQueryMetrics,
@@ -74,6 +75,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                                         long executionQuotaMs)
     {
         this.command = command;
+        this.cfs = cfs;
         this.queryContext = new QueryContext(executionQuotaMs);
         this.controller = new QueryController(cfs, command, filterOperation, indexFeatureSet, queryContext, tableQueryMetrics);
     }
@@ -115,6 +117,8 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
 
         // If there are shadowed primary keys, we have to at least query twice.
         // First time to find out there are shadowed keys, second time to find out there are no more shadow keys.
+        int loopsCount = 0;
+        final long startShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
         while (true)
         {
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
@@ -123,8 +127,14 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
 
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             if (lastShadowedKeysCount == currentShadowedKeysCount)
+            {
+                cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
+                if (loopsCount > 0)
+                    Tracing.trace("Scanned {} shadowed keys, in {} query loops", currentShadowedKeysCount - startShadowedKeysCount, loopsCount + 1);
                 return topK;
-            Tracing.trace("Found {} new shadowed keys, rerunning query", currentShadowedKeysCount - lastShadowedKeysCount);
+            }
+            loopsCount++;
+            Tracing.trace("Found {} new shadowed keys, rerunning query loop {}", currentShadowedKeysCount - lastShadowedKeysCount, loopsCount + 1);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -131,6 +131,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)
                     Tracing.trace("No new shadowed keys after query loop {}", loopsCount);
+                return topK;
             }
             loopsCount++;
             Tracing.trace("Found {} new shadowed keys, rerunning query (loop {})", currentShadowedKeysCount - lastShadowedKeysCount, loopsCount);

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -118,6 +118,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         // If there are shadowed primary keys, we have to at least query twice.
         // First time to find out there are shadowed keys, second time to find out there are no more shadow keys.
         int loopsCount = 1;
+        final long startShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
         while (true)
         {
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
@@ -133,6 +134,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             }
             loopsCount++;
             Tracing.trace("Found {} new shadowed keys, rerunning query (loop {})", currentShadowedKeysCount - lastShadowedKeysCount, loopsCount);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -81,6 +81,10 @@ public class KeyspaceMetrics
     public final Histogram sstablesPerReadHistogram;
     /** Tombstones scanned in queries on this Keyspace */
     public final Histogram tombstoneScannedHistogram;
+
+    /** Shadowed keys scan metrics **/
+    public final Histogram shadowedKeysScannedHistogram;
+    public final Histogram shadowedKeysLoopsHistogram;
     /** Live cells scanned in queries on this Keyspace */
     public final Histogram liveScannedHistogram;
     /** Column update time delta on this Keyspace */
@@ -214,6 +218,8 @@ public class KeyspaceMetrics
         // create histograms for TableMetrics to replicate updates to
         sstablesPerReadHistogram = createKeyspaceHistogram("SSTablesPerReadHistogram", true);
         tombstoneScannedHistogram = createKeyspaceHistogram("TombstoneScannedHistogram", false);
+        shadowedKeysScannedHistogram = createKeyspaceHistogram("ShadowedKeysScannedHistogram", false);
+        shadowedKeysLoopsHistogram = createKeyspaceHistogram("ShadowedKeysLoopsHistogram", false);
         liveScannedHistogram = createKeyspaceHistogram("LiveScannedHistogram", false);
         colUpdateTimeDeltaHistogram = createKeyspaceHistogram("ColUpdateTimeDeltaHistogram", false);
         viewLockAcquireTime = createKeyspaceTimer("ViewLockAcquireTime");

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -250,6 +250,11 @@ public class TableMetrics
     public final Gauge<Long> compressionMetadataOffHeapMemoryUsed;
     /** Key cache hit rate  for this CF */
     public final Gauge<Double> keyCacheHitRate;
+
+    /** Shadowed keys scan metrics **/
+    public final TableHistogram shadowedKeysScannedHistogram;
+    public final TableHistogram shadowedKeysLoopsHistogram;
+
     /** Tombstones scanned in queries on this CF */
     public final TableHistogram tombstoneScannedHistogram;
     public final Counter tombstoneScannedCounter;
@@ -973,6 +978,8 @@ public class TableMetrics
             }
         }, null);
         tombstoneScannedHistogram = createTableHistogram("TombstoneScannedHistogram", cfs.getKeyspaceMetrics().tombstoneScannedHistogram, false);
+        shadowedKeysScannedHistogram = createTableHistogram("ShadowedKeysScannedHistogram", cfs.getKeyspaceMetrics().shadowedKeysScannedHistogram, false);
+        shadowedKeysLoopsHistogram = createTableHistogram("ShadowedKeysLoopsHistogram", cfs.getKeyspaceMetrics().shadowedKeysLoopsHistogram, false);
         tombstoneScannedCounter = createTableCounter("TombstoneScannedCounter");
         liveScannedHistogram = createTableHistogram("LiveScannedHistogram", cfs.getKeyspaceMetrics().liveScannedHistogram, false);
         colUpdateTimeDeltaHistogram = createTableHistogram("ColUpdateTimeDeltaHistogram", cfs.getKeyspaceMetrics().colUpdateTimeDeltaHistogram, false);
@@ -1068,6 +1075,12 @@ public class TableMetrics
     public void incLiveRows(long liveRows)
     {
         liveScannedHistogram.update(liveRows);
+    }
+
+    public void incShadowedKeys(long numLoops, long numShadowedKeys)
+    {
+        shadowedKeysLoopsHistogram.update(numLoops);
+        shadowedKeysScannedHistogram.update(numShadowedKeys);
     }
 
     public void incTombstones(long tombstones, boolean triggerWarning)


### PR DESCRIPTION
https://github.com/riptano/VECTOR-SEARCH/issues/32

I decided on approach 1 ("add a new metric for shadowed rows"), otherwise it will be hard to match metrics for number of loops with number of shadowed rows if they are mixed with tombstones.
