### PR TITLE
Only add ANN Ordering to top level of StatementRestrictions

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -433,7 +433,8 @@ public class StatementRestrictions
 
             // ORDER BY clause.
             // Some indexes can be used for ordering.
-            addOrderingRestrictions(orderings, nonPrimaryKeyRestrictionSet);
+            if (nestingLevel == 0)
+                addOrderingRestrictions(orderings, nonPrimaryKeyRestrictionSet);
 
             PartitionKeyRestrictions partitionKeyRestrictions = partitionKeyRestrictionSet.build();
             ClusteringColumnRestrictions clusteringColumnsRestrictions = clusteringColumnsRestrictionSet.build();

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -208,14 +208,16 @@ public class Operation
 
     static RangeIterator buildIterator(QueryController controller)
     {
-        var orderings = controller.filterOperation().expressions()
-                                  .stream().filter(e -> e.operator() == Operator.ANN).collect(Collectors.toList());
-        assert orderings.size() <= 1;
         var filterOperation = controller.filterOperation();
+        var orderings = filterOperation.expressions()
+                                       .stream().filter(e -> e.operator() == Operator.ANN).collect(Collectors.toList());
+        assert orderings.size() <= 1;
         if (filterOperation.expressions().size() == 1 && filterOperation.children().isEmpty() && orderings.size() == 1)
             // If we only have one expression, we just use the ANN index to order and limit.
             return controller.getTopKRows(orderings.get(0));
-        var iter = Node.buildTree(controller.filterOperation()).analyzeTree(controller).rangeIterator(controller);
+        var nonOrderingExpressions = filterOperation.expressions().stream()
+                                                    .filter(e -> e.operator() != Operator.ANN).collect(Collectors.toList());
+        var iter = Node.buildTree(nonOrderingExpressions, filterOperation.children(), filterOperation.isDisjunction()).analyzeTree(controller).rangeIterator(controller);
         if (orderings.isEmpty())
             return iter;
         return controller.getTopKRows(iter, orderings.get(0));
@@ -256,18 +258,19 @@ public class Operation
 
         abstract RangeIterator rangeIterator(QueryController controller);
 
-        static Node buildTree(RowFilter.FilterElement filterOperation)
+        static Node buildTree(List<RowFilter.Expression> expressions, List<RowFilter.FilterElement> children, boolean isDisjunction)
         {
-            OperatorNode node = filterOperation.isDisjunction() ? new OrNode() : new AndNode();
-            for (RowFilter.Expression expression : filterOperation.expressions())
-            {
-                if (expression.operator() == Operator.ANN)
-                    continue;
+            OperatorNode node = isDisjunction ? new OrNode() : new AndNode();
+            for (RowFilter.Expression expression : expressions)
                 node.add(buildExpression(expression));
-            }
-            for (RowFilter.FilterElement child : filterOperation.children())
+            for (RowFilter.FilterElement child : children)
                 node.add(buildTree(child));
             return node;
+        }
+
+        static Node buildTree(RowFilter.FilterElement filterOperation)
+        {
+            return buildTree(filterOperation.expressions(), filterOperation.children(), filterOperation.isDisjunction());
         }
 
         static Node buildExpression(RowFilter.Expression expression)

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -211,7 +211,8 @@ public class Operation
         var orderings = controller.filterOperation().expressions()
                                   .stream().filter(e -> e.operator() == Operator.ANN).collect(Collectors.toList());
         assert orderings.size() <= 1;
-        if (controller.filterOperation().expressions().size() == 1 && orderings.size() == 1)
+        var filterOperation = controller.filterOperation();
+        if (filterOperation.expressions().size() == 1 && filterOperation.children().isEmpty() && orderings.size() == 1)
             // If we only have one expression, we just use the ANN index to order and limit.
             return controller.getTopKRows(orderings.get(0));
         var iter = Node.buildTree(controller.filterOperation()).analyzeTree(controller).rangeIterator(controller);
@@ -259,7 +260,11 @@ public class Operation
         {
             OperatorNode node = filterOperation.isDisjunction() ? new OrNode() : new AndNode();
             for (RowFilter.Expression expression : filterOperation.expressions())
+            {
+                if (expression.operator() == Operator.ANN)
+                    continue;
                 node.add(buildExpression(expression));
+            }
             for (RowFilter.FilterElement child : filterOperation.children())
                 node.add(buildTree(child));
             return node;

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -782,6 +782,21 @@ public class VectorTypeTest extends VectorTester
         execute("INSERT INTO %s (pk, val, vec) VALUES (3, 'match me', [1, 1])");
         execute("INSERT INTO %s (pk, val, vec) VALUES (4, 'match me', [1, 1])");
         assertRowsIgnoringOrder(execute("SELECT pk FROM %s WHERE val = 'match me' ORDER BY vec ANN OF [1,1] LIMIT 5"),
-                   row(1), row(2), row(3), row(4), row(5));
+                                row(1), row(2), row(3), row(4), row(5));
+    }
+
+    @Test
+    public void testNestedANNQuery()
+    {
+        createTable("CREATE TABLE %s (pk int, name text, body text, vals vector<float, 2>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vals) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(name) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        execute("INSERT INTO %s (pk, name, body, vals) VALUES (1, 'Ann', 'A lizard said bad things to the snakes', [0.1, 0.1])");
+        execute("INSERT INTO %s (pk, name, body, vals) VALUES (2, 'Bea', 'Please wear protective gear before operating the machine', [0.2, -0.3])");
+        execute("INSERT INTO %s (pk, name, body, vals) VALUES (3, 'Cal', 'My name is Slim Shady', [0.0, 0.9])");
+        execute("INSERT INTO %s (pk, name, body, vals) VALUES (4, 'Bea', 'I repeat: wear your helmet!', [0.3, -0.2])");
+        var result = execute("SELECT pk FROM %s WHERE name='Bea' OR name='Ann' ORDER BY vals ANN OF [0.3, 0.1] LIMIT 5");
+        assertRowsIgnoringOrder(result, row(1), row(2), row(4));
     }
 }


### PR DESCRIPTION
There is currently a bug where we add the ANN ordering clause to every level of a StatementRestriction. Before #758, that meant we were executing the order by clause for each nested group of clauses. After #758, those queries are actually broken.

The current approach for this PR is to only add the ANN restriction at the top level.