### PR TITLE
Replace RangeConcatIterator's PriorityQueue with List

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -161,10 +161,11 @@ public class TrieMemtableIndex implements MemtableIndex
     @Override
     public RangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit)
     {
-        RangeConcatIterator.Builder builder = RangeConcatIterator.builder();
-
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = keyRange.right.isMinimum() ? boundaries.shardCount() - 1 : boundaries.getShardForToken(keyRange.right.getToken());
+
+        RangeConcatIterator.Builder builder = RangeConcatIterator.builder(endShard - startShard + 1);
+
         for (int shard  = startShard; shard <= endShard; ++shard)
         {
             assert rangeIndexes[shard] != null;

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
@@ -45,7 +45,7 @@ public class RangeConcatIterator extends RangeIterator
         super(statistics);
 
         this.ranges = ranges.iterator();
-        this.toRelease = new ArrayList<>(ranges);
+        this.toRelease = ranges;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
@@ -19,8 +19,8 @@ package org.apache.cassandra.index.sai.utils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.PriorityQueue;
 
 import org.apache.cassandra.io.util.FileUtils;
 
@@ -36,14 +36,15 @@ import org.apache.cassandra.io.util.FileUtils;
  */
 public class RangeConcatIterator extends RangeIterator
 {
-    private final PriorityQueue<RangeIterator> ranges;
+    private final Iterator<RangeIterator> ranges;
+    private RangeIterator currentRange;
     private final List<RangeIterator> toRelease;
 
-    protected RangeConcatIterator(RangeIterator.Builder.Statistics statistics, PriorityQueue<RangeIterator> ranges)
+    protected RangeConcatIterator(RangeIterator.Builder.Statistics statistics, List<RangeIterator> ranges)
     {
         super(statistics);
 
-        this.ranges = ranges;
+        this.ranges = ranges.iterator();
         this.toRelease = new ArrayList<>(ranges);
     }
 
@@ -51,18 +52,18 @@ public class RangeConcatIterator extends RangeIterator
     @SuppressWarnings("resource")
     protected void performSkipTo(PrimaryKey primaryKey)
     {
-        while (!ranges.isEmpty())
+        if (currentRange != null && currentRange.getMaximum().compareTo(primaryKey) >= 0)
         {
-            if (ranges.peek().getCurrent().compareTo(primaryKey) >= 0)
-                break;
-
-            var head = ranges.poll();
-
-            if (head.getMaximum().compareTo(primaryKey) >= 0)
+            currentRange.skipTo(primaryKey);
+            return;
+        }
+        while (ranges.hasNext())
+        {
+            currentRange = ranges.next();
+            if (currentRange.getMaximum().compareTo(primaryKey) >= 0)
             {
-                head.skipTo(primaryKey);
-                ranges.add(head);
-                break;
+                currentRange.skipTo(primaryKey);
+                return;
             }
         }
     }
@@ -78,50 +79,80 @@ public class RangeConcatIterator extends RangeIterator
     @SuppressWarnings("resource")
     protected PrimaryKey computeNext()
     {
-        while (!ranges.isEmpty())
+        if (currentRange == null || !currentRange.hasNext())
         {
-            RangeIterator current = ranges.poll();
-            if (current.hasNext())
+            do
             {
-                PrimaryKey next = current.next();
-                // hasNext will update RangeIterator's current which is used to sort in PQ
-                if (current.hasNext())
-                    ranges.add(current);
-
-                return next;
-            }
+                if (!ranges.hasNext())
+                    return endOfData();
+                currentRange = ranges.next();
+            } while (!currentRange.hasNext());
         }
-
-        return endOfData();
+        return currentRange.next();
     }
 
     public static Builder builder()
     {
-        return new Builder();
+        return builder(1);
+    }
+
+    public static Builder builder(int size)
+    {
+        return new Builder(size);
     }
 
     public static RangeIterator build(List<RangeIterator> tokens)
     {
-        return new Builder().add(tokens).build();
+        return new Builder(tokens.size()).add(tokens).build();
     }
 
     public static class Builder extends RangeIterator.Builder
     {
-        public Builder()
+        // We can use a list because the iterators are already in order
+        private final List<RangeIterator> rangeIterators;
+        public Builder(int size)
         {
             super(IteratorType.CONCAT);
+            this.rangeIterators = new ArrayList<>(size);
+        }
+
+        public int rangeCount()
+        {
+            return rangeIterators.size();
+        }
+
+        @Override
+        public Builder add(RangeIterator range)
+        {
+            if (range == null)
+                return this;
+
+            if (range.getCount() > 0)
+            {
+                rangeIterators.add(range);
+                statistics.update(range);
+            }
+            else
+                FileUtils.closeQuietly(range);
+
+            return this;
+        }
+
+        @Override
+        public RangeIterator.Builder add(List<RangeIterator> ranges)
+        {
+            if (ranges == null || ranges.isEmpty())
+                return this;
+
+            ranges.forEach(this::add);
+            return this;
         }
 
         protected RangeIterator buildIterator()
         {
-            switch (rangeCount())
-            {
-                case 1:
-                    return ranges.poll();
-
-                default:
-                    return new RangeConcatIterator(statistics, ranges);
-            }
+            if (rangeCount() == 1)
+                return rangeIterators.get(0);
+            return new RangeConcatIterator(statistics, rangeIterators);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
@@ -81,12 +81,10 @@ public class RangeConcatIterator extends RangeIterator
     {
         if (currentRange == null || !currentRange.hasNext())
         {
-            do
-            {
-                if (!ranges.hasNext())
-                    return endOfData();
-                currentRange = ranges.next();
-            } while (!currentRange.hasNext());
+            if (!ranges.hasNext())
+                return endOfData();
+            currentRange = ranges.next();
+            assert currentRange.hasNext() : "Only non empty range iterators are added. Current range must not be empty.";
         }
         return currentRange.next();
     }

--- a/test/unit/org/apache/cassandra/index/sai/utils/AbstractRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/AbstractRangeIteratorTest.java
@@ -70,7 +70,7 @@ public class AbstractRangeIteratorTest extends SaiRandomizedTest
 
     final RangeIterator buildConcat(RangeIterator... ranges)
     {
-        return RangeConcatIterator.<PrimaryKey>builder().add(Arrays.asList(ranges)).build();
+        return RangeConcatIterator.builder(ranges.length).add(Arrays.asList(ranges)).build();
     }
 
     final RangeIterator buildConcat(long[]... ranges)


### PR DESCRIPTION
The RangeConcatIterator is used to join ordered RangeIterators. As such, we can remove the PQ and replace it with a list/iterator. This change particularly benefits us for intersections because it is common for those to incur many calls to skipTo, which is where we currently remove and subsequently put range iterators.