### PR TITLE
Revert "Simplify logic for computeNext"

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
@@ -116,6 +116,7 @@ public class RangeConcatIterator extends RangeIterator
             this.rangeIterators = new ArrayList<>(size);
         }
 
+        @Override
         public int rangeCount()
         {
             return rangeIterators.size();

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeConcatIterator.java
@@ -81,10 +81,12 @@ public class RangeConcatIterator extends RangeIterator
     {
         if (currentRange == null || !currentRange.hasNext())
         {
-            if (!ranges.hasNext())
-                return endOfData();
-            currentRange = ranges.next();
-            assert currentRange.hasNext() : "Only non empty range iterators are added. Current range must not be empty.";
+            do
+            {
+                if (!ranges.hasNext())
+                    return endOfData();
+                currentRange = ranges.next();
+            } while (!currentRange.hasNext());
         }
         return currentRange.next();
     }


### PR DESCRIPTION
This reverts commit e0187ab19c4de00b73d17112343933fb59c2a8b6, which was merged in https://github.com/datastax/cassandra/pull/816.

I incorrectly assumed that the check to `range.getCount() > 0` meant all RangeIterators had PKs.