### PR TITLE
Make ReversedTrieRangeIterator return correct value when term is not found

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -161,7 +161,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             // If we didn't find the first key, we won't find the last primary key either
             if (minSSTableRowId < 0)
                 return new BitsOrPostingList(PostingList.EMPTY);
-            long maxSSTableRowId = getMaxSSTableRowId(primaryKeyMap, keyRange);
+            long maxSSTableRowId = getMaxSSTableRowId(primaryKeyMap, keyRange.right);
 
             if (minSSTableRowId > maxSSTableRowId)
                 return new BitsOrPostingList(PostingList.EMPTY);
@@ -224,14 +224,14 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         }
     }
 
-    private long getMaxSSTableRowId(PrimaryKeyMap primaryKeyMap, AbstractBounds<PartitionPosition> keyRange)
+    private long getMaxSSTableRowId(PrimaryKeyMap primaryKeyMap, PartitionPosition right)
     {
         // if the right token is the minimum token, there is no upper bound on the keyRange and
         // we can save a lookup by using the maxSSTableRowId
-        if (keyRange.right.isMinimum())
+        if (right.isMinimum())
             return metadata.maxSSTableRowId;
 
-        PrimaryKey lastPrimaryKey = keyFactory.createTokenOnly(keyRange.right.getToken());
+        PrimaryKey lastPrimaryKey = keyFactory.createTokenOnly(right.getToken());
         long max = primaryKeyMap.floor(lastPrimaryKey);
         if (max < 0)
             return metadata.maxSSTableRowId;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -155,14 +155,13 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                 return new BitsOrPostingList(context.bitsetForShadowedPrimaryKeys(metadata, primaryKeyMap, graph));
 
             PrimaryKey firstPrimaryKey = keyFactory.createTokenOnly(keyRange.left.getToken());
-            PrimaryKey lastPrimaryKey = keyFactory.createTokenOnly(keyRange.right.getToken());
 
             // it will return the next row id if given key is not found.
             long minSSTableRowId = primaryKeyMap.ceiling(firstPrimaryKey);
             // If we didn't find the first key, we won't find the last primary key either
             if (minSSTableRowId < 0)
                 return new BitsOrPostingList(PostingList.EMPTY);
-            long maxSSTableRowId = primaryKeyMap.floor(lastPrimaryKey);
+            long maxSSTableRowId = getMaxSSTableRowId(primaryKeyMap, keyRange);
 
             if (minSSTableRowId > maxSSTableRowId)
                 return new BitsOrPostingList(PostingList.EMPTY);
@@ -223,6 +222,20 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             return new BitsOrPostingList(bits, VectorMemtableIndex.expectedNodesVisited(limit, nRows, graph.size()));
         }
+    }
+
+    private long getMaxSSTableRowId(PrimaryKeyMap primaryKeyMap, AbstractBounds<PartitionPosition> keyRange)
+    {
+        // if the right token is the minimum token, there is no upper bound on the keyRange and
+        // we can save a lookup by using the maxSSTableRowId
+        if (keyRange.right.isMinimum())
+            return metadata.maxSSTableRowId;
+
+        PrimaryKey lastPrimaryKey = keyFactory.createTokenOnly(keyRange.right.getToken());
+        long max = primaryKeyMap.floor(lastPrimaryKey);
+        if (max < 0)
+            return metadata.maxSSTableRowId;
+        return max;
     }
 
     private int maxBruteForceRows(int limit, int nPermittedOrdinals, int graphSize)

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/ReversedTrieRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/ReversedTrieRangeIterator.java
@@ -47,7 +47,7 @@ class ReversedTrieRangeIterator extends ReverseValueIterator<ReversedTrieRangeIt
         {
             currentNode = nextPayloadedNode();
             if (currentNode == -1)
-                return Long.MAX_VALUE;
+                return TrieTermsDictionaryReader.NOT_FOUND;
         }
 
         go(currentNode);


### PR DESCRIPTION
This PR fixes two issues. Together, the two issues effectively cancel each other out and work correctly on `vsearch`, however, when we merge the switch proposed in #801, we do not get the cancellation.

The problem is that for range queries the right bound of an AbstractBound can be less than the left bound, and this matters when finding the `floor` for a token, since our definition of floor does not treat numbers as a ring. The current code works because when the PK does not have a floor, ReversedTrieRangeIterator returns Long.MAX_VALUE, and we get the correct range of sstable row ids.

The solution:

* Update ReversedTrieRangeIterator to return -1, and adopt the behavior we will see in #801.
* Update `V2VectorIndexSearcher#bitsOrPostingListForKeyRange` so that it correctly handles the right boundary as the minimum token.

This change is covered by the `VectorTypeTest#rangeSearchTest`, which fails if we only implement the first bullet of the solution.

Additionally, note that we have have the same usage pattern for `isMinimum` on the right bound in the vector `VectorMemtableIndex#search` method.

https://github.com/datastax/cassandra/blob/49a51690caca180fc33bd49c7b95cfc8ee0627f3/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java#L170-L171