### PR TITLE
Fix TrieRangeIterator for certain lower bound edge cases

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
@@ -182,7 +182,6 @@ public class TrieRangeIterator extends Walker<TrieRangeIterator>
 
             childIndex = -1 - childIndex - 1;
 
-            System.out.println("position " + position + " payload node " + payloadedNode);
             stack = new IterationPosition(position, childIndex, limitByte, prev);
 
             // Advancing now gives us first match if we didn't find one already.

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
@@ -125,6 +125,10 @@ public class TrieRangeIterator extends Walker<TrieRangeIterator>
         {
             first = false;
             if (stack == null) return -1;
+            // The top of the stack is behind, which appears to happen when the lower bound is both a prefix of the next
+            // greatest term and a base of the next lesser term (that term is a prefix of the lower bound).
+            if (stack.node < next)
+                return advanceNode();
             return stack.node;
         }
         long toReturn = next;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIterator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.disk.v2.sortedterms;
+package org.apache.cassandra.index.sai.disk.v1.trie;
 
 
 import java.nio.ByteBuffer;
@@ -26,7 +26,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.collect.AbstractIterator;
 
-import org.apache.cassandra.index.sai.disk.v1.trie.TrieTermsDictionaryReader;
 import org.apache.cassandra.io.tries.Walker;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.utils.Pair;
@@ -39,7 +38,7 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
  * The payload may be changed to something else.
  */
 @NotThreadSafe
-class TrieRangeIterator extends Walker<TrieRangeIterator>
+public class TrieRangeIterator extends Walker<TrieRangeIterator>
 {
     private final ByteSource limit;
     private final TrieTermsDictionaryReader.TransitionBytesCollector collector = new TrieTermsDictionaryReader.TransitionBytesCollector();
@@ -179,6 +178,7 @@ class TrieRangeIterator extends Walker<TrieRangeIterator>
 
             childIndex = -1 - childIndex - 1;
 
+            System.out.println("position " + position + " payload node " + payloadedNode);
             stack = new IterationPosition(position, childIndex, limitByte, prev);
 
             // Advancing now gives us first match if we didn't find one already.

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieRangeIteratorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.v1.trie;
+
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.utils.SaiRandomizedTest;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+public class TrieRangeIteratorTest extends SaiRandomizedTest
+{
+    private IndexDescriptor indexDescriptor;
+    private IndexContext indexContext;
+
+    @Before
+    public void setup() throws Throwable
+    {
+        indexDescriptor = newIndexDescriptor();
+        indexContext = SAITester.createIndexContext(newIndex(), UTF8Type.instance);
+    }
+
+    private long makeTrie() throws Exception
+    {
+        try (TrieTermsDictionaryWriter writer = new TrieTermsDictionaryWriter(indexDescriptor, indexContext, false))
+        {
+            writer.add(asByteComparable("bb"), 0);
+            writer.add(asByteComparable("bbbb"), 1);
+            writer.add(asByteComparable("bbbbbb"), 2);
+            return writer.complete(new MutableLong());
+        }
+    }
+
+    @Test
+    public void testExactPrefixMatchWithAdmitPrefix() throws Exception
+    {
+        long fp = makeTrie();
+
+        var prefix = asByteComparable("bb");
+        var suffix = asByteComparable("bbbbbb");
+
+        try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
+             TrieRangeIterator reader = new TrieRangeIterator(input.instantiateRebufferer(), fp, prefix, suffix, true, true))
+        {
+            var iter = reader.iterator();
+            assertEquals(0, iter.next().right.longValue());
+            assertEquals(1, iter.next().right.longValue());
+            assertEquals(2, iter.next().right.longValue());
+        }
+    }
+
+    @Test
+    public void testExactPrefixMatchWithNotAdmitPrefix() throws Exception
+    {
+        long fp = makeTrie();
+
+        var prefix1 = ByteComparable.of("bbb");
+        var suffix1 = asByteComparable("c");
+
+        try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
+             TrieRangeIterator reader = new TrieRangeIterator(input.instantiateRebufferer(), fp, prefix1, suffix1, false, true))
+        {
+            var iter = reader.iterator();
+            assertEquals(1, iter.next().right.longValue());
+            assertEquals(2, iter.next().right.longValue());
+        }
+    }
+    @Test
+    public void testLowerBoundTerminatesAsPrefixMatchNoPayloadWithNotAdmitPrefix() throws Exception
+    {
+        long fp = makeTrie();
+        var prefix2 = ByteComparable.of("bbb");
+        var suffix2 = asByteComparable("c");
+
+        try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
+             TrieRangeIterator reader = new TrieRangeIterator(input.instantiateRebufferer(), fp, prefix2, suffix2, true, true))
+        {
+            var iter = reader.iterator();
+            assertEquals(1, iter.next().right.longValue());
+            assertEquals(2, iter.next().right.longValue());
+        }
+    }
+
+    private ByteComparable asByteComparable(String s)
+    {
+        return ByteComparable.fixedLength(ByteBufferUtil.bytes(s));
+    }
+
+}


### PR DESCRIPTION
There appears to be a bug in the `TrieRangeIterator` implementation.