### PR TITLE
Fix failing tests that relied on InvalidRequestException as cause of caught exception

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UFTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UFTest.java
@@ -1024,8 +1024,8 @@ public class UFTest extends CQLTester
                                        "RETURNS int " +
                                        "LANGUAGE JAVA\n" +
                                        "AS 'return val;'");
-            }).hasRootCauseInstanceOf(InvalidRequestException.class)
-              .hasRootCauseMessage("Function name '%s' is invalid", funcName);
+            }).isInstanceOf(InvalidRequestException.class)
+              .hasMessageContaining("Function name '%s' is invalid", funcName);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -2245,8 +2245,8 @@ public class AggregationTest extends CQLTester
                                         " SFUNC func\n" +
                                         " STYPE map<text,bigint>\n" +
                                         " INITCOND { };");
-            }).hasRootCauseInstanceOf(InvalidRequestException.class)
-              .hasRootCauseMessage("Aggregate name '%s' is invalid", funcName);
+            }).isInstanceOf(InvalidRequestException.class)
+              .hasMessageContaining("Aggregate name '%s' is invalid", funcName);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/SchemaCQLHelperTest.java
+++ b/test/unit/org/apache/cassandra/db/SchemaCQLHelperTest.java
@@ -63,7 +63,7 @@ import org.json.simple.parser.JSONParser;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -559,8 +559,8 @@ public class SchemaCQLHelperTest extends CQLTester
         }
         catch (RuntimeException e)
         {
-            assertThat(e.getCause(), notNullValue());
-            assertThat(e.getCause().getMessage(),
+            assertThat(e, instanceOf(org.apache.cassandra.exceptions.InvalidRequestException.class));
+            assertThat(e.getMessage(),
                        containsString("Cannot have multiple dropped column record for column"));
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -218,7 +218,7 @@ public class LuceneAnalyzerTest extends SAITester
                                              "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                                              "WITH OPTIONS = { 'index_analyzer': '{}'}"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasRootCauseMessage("Analzyer config requires at least a tokenizer, a filter, or a charFilter, but none found. config={}");
+        .hasMessageContaining("Analzyer config requires at least a tokenizer, a filter, or a charFilter, but none found. config={}");
     }
 
 // FIXME re-enable exception detection once incompatible options have been purged from prod DBs

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -139,7 +139,7 @@ public class LuceneAnalyzerTest extends SAITester
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS = " +
                     "{'query_analyzer': 'whitespace'}"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasRootCauseMessage("Cannot specify query_analyzer without an index_analyzer option or any combination of " +
+        .hasMessageContaining("Cannot specify query_analyzer without an index_analyzer option or any combination of " +
                              "case_sensitive, normalize, or ascii options. options={query_analyzer=whitespace, target=c1}");;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
@@ -45,7 +45,7 @@ public class MultipleColumnIndexTest extends SAITester
         createTable("CREATE TABLE %s (pk int, ck int, value text, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : true }");
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : false }"))
-                .isInstanceOf(RuntimeException.class).hasCauseInstanceOf(InvalidRequestException.class);
+                .isInstanceOf(InvalidRequestException.class);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sasi/SASICQLTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASICQLTest.java
@@ -118,10 +118,8 @@ public class SASICQLTest extends CQLTester
         }
         catch (RuntimeException e)
         {
-            Throwable cause = e.getCause();
-            Assert.assertNotNull(cause);
-            Assert.assertTrue(cause instanceof InvalidRequestException);
-            Assert.assertTrue(cause.getMessage().contains("SASI indexes are disabled"));
+            Assert.assertTrue(e instanceof InvalidRequestException);
+            Assert.assertTrue(e.getMessage().contains("SASI indexes are disabled"));
         }
         finally
         {


### PR DESCRIPTION
https://github.com/datastax/cassandra/pull/826 removed a wrapper for an exception, which broke several (brittle) tests.