### PR TITLE
Ensure topKFor limit is at least the limit

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -140,7 +140,8 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         var n = indexContext.getIndexWriterConfig().getOptimizeFor() == OptimizeFor.LATENCY
                 ? 0.979 + 4.021 * pow(limit, -0.761)  // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
                 : 0.509 + 9.491 * pow(limit, -0.402); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
-        return (int) (n * limit);
+        // In some edge cases, n is less than 1.
+        return (int) (Math.max(n, 1) * limit);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -137,10 +137,12 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     private int topKFor(int limit)
     {
         // compute the factor `n` to multiply limit by to increase the number of results from the index.
-        // The functions become less than 1 at the 997.325... and 1583.4 points, respectively.
         var n = indexContext.getIndexWriterConfig().getOptimizeFor() == OptimizeFor.LATENCY
-                ? (limit > 997) ? limit : 0.979 + 4.021 * pow(limit, -0.761)  // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
-                : (limit > 1583) ? limit : 0.509 + 9.491 * pow(limit, -0.402); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
+                ? 0.979 + 4.021 * pow(limit, -0.761)  // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
+                : 0.509 + 9.491 * pow(limit, -0.402); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
+        // The functions become less than 1 at the 997.325... and 1583.4 points, respectively.
+        if (n < 1.0)
+            return limit;
         return (int) (n * limit);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -137,11 +137,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     private int topKFor(int limit)
     {
         // compute the factor `n` to multiply limit by to increase the number of results from the index.
+        // The functions become less than 1 at the 997.325... and 1583.4 points, respectively.
         var n = indexContext.getIndexWriterConfig().getOptimizeFor() == OptimizeFor.LATENCY
-                ? 0.979 + 4.021 * pow(limit, -0.761)  // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
-                : 0.509 + 9.491 * pow(limit, -0.402); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
-        // In some edge cases, n is less than 1.
-        return (int) (Math.max(n, 1) * limit);
+                ? (limit > 997) ? limit : 0.979 + 4.021 * pow(limit, -0.761)  // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
+                : (limit > 1583) ? limit : 0.509 + 9.491 * pow(limit, -0.402); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
+        return (int) (n * limit);
     }
 
     /**


### PR DESCRIPTION
`topKFor` must return at least the `limit` to ensure correct results.