### PR TITLE
Reduce per query tracing, trace in SAISearcher instead of ResultRetriever

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -441,6 +441,11 @@ public abstract class ReadCommand extends AbstractReadQuery
             iterator.close();
             throw e;
         }
+        finally
+        {
+            if (null != searcher)
+                searcher.close();
+        }
     }
 
     public UnfilteredPartitionIterator searchStorage(Index.Searcher searcher, ReadExecutionController executionController)

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -657,7 +657,7 @@ public interface Index
      * An instance performs its query according to the RowFilter.Expression it was created for (see searcherFor)
      * An Expression is a predicate of the form [column] [operator] [value].
      */
-    public interface Searcher
+    public interface Searcher extends AutoCloseable
     {
         /**
          * Returns the {@link ReadCommand} for which this searcher has been created.
@@ -683,6 +683,8 @@ public interface Index
         {
             return command().rowFilter().filter(fullResponse, command().metadata(), command().nowInSec());
         }
+
+        default void close() {}
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -172,6 +172,12 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         return Operation.buildFilter(controller);
     }
 
+    @Override
+    public void close()
+    {
+        controller.finish();
+    }
+
     private static class ResultRetriever extends AbstractIterator<UnfilteredRowIterator>
                 implements UnfilteredPartitionIterator, ParallelCommandProcessor
     {
@@ -581,7 +587,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         public void close()
         {
             FileUtils.closeQuietly(operation);
-            controller.finish();
         }
     }
 


### PR DESCRIPTION
https://github.com/riptano/VECTOR-SEARCH/issues/16

Part 1: "Index query accessed memtable indexes" is logged multiple times per query
This happened because the tracing happened in ResultRetriever.close() and SAISearcher.search() could create multiple RRs in case of shadowed row.