### PR TITLE
Fix when an index accepts the : operator

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -441,7 +441,7 @@ public class IndexContext
         if (op.isLike() || op == Operator.LIKE) return false;
         // Analyzed columns store the indexed result, so we are unable to compute raw equality.
         // The only supported operator is ANALYZER_MATCHES.
-        if (isAnalyzed) return op == Operator.ANALYZER_MATCHES;
+        if (isAnalyzed || op == Operator.ANALYZER_MATCHES) return isAnalyzed && op == Operator.ANALYZER_MATCHES;
 
         // ANN is only supported against vectors, and vector indexes only support ANN
         if (column.type instanceof VectorType)

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -559,4 +559,18 @@ public class LuceneAnalyzerTest extends SAITester
 
         waitForIndexQueryable();
     }
+
+    @Test
+    public void testInvalidQueryOnNumericColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, some_num tinyint)");
+        createIndex("CREATE CUSTOM INDEX ON %s(some_num) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, some_num) VALUES (1, 1)");
+        flush();
+
+        assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE some_num : 1"))
+        .isInstanceOf(InvalidRequestException.class);
+    }
 }


### PR DESCRIPTION
Fix the logic for determining when an index supports the `:` operator. If the operator is `:` or if the index is analyzed, we must verify that the index is analyzed and the operator is `:`.