### PR TITLE
build with alpha=1.2 instead of 1.4

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -122,7 +122,7 @@ public class CassandraOnHeapGraph<T>
                                           indexWriterConfig.getMaximumNodeConnections(),
                                           indexWriterConfig.getConstructionBeamWidth(),
                                           1.2f,
-                                          1.4f);
+                                          1.2f);
     }
 
     public int size()


### PR DESCRIPTION
zero impact on large embeddings (they fill up at 1.2 and 1.4 is a no-op) but increases performance for 2D indexes