### PR TITLE
Validate vector at coordinator

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -681,7 +681,8 @@ public class IndexContext
         if (isVector())
         {
             float[] value = TypeUtil.decomposeVector(getValidator(), getValueOf(key, row, FBUtilities.nowInSeconds()));
-            CassandraOnHeapGraph.validateIndexable(value, vectorSimilarityFunction);
+            if (value != null)
+                CassandraOnHeapGraph.validateIndexable(value, vectorSimilarityFunction);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -692,7 +692,7 @@ public class IndexContext
             return;
         // Only iterate over the top level expressions because that is where the ANN expression is located.
         for (RowFilter.Expression expression : rowFilter.root().expressions())
-            if (expression.operator() == Operator.ANN)
+            if (expression.operator() == Operator.ANN && expression.column().equals(column))
             {
                 float[] value = TypeUtil.decomposeVector(getValidator(), expression.getIndexValue());
                 CassandraOnHeapGraph.validateIndexable(value, vectorSimilarityFunction);

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -172,9 +172,7 @@ public class IndexContext
             this.queryAnalyzerFactory = AbstractAnalyzer.hasQueryAnalyzer(config.options)
                                         ? AbstractAnalyzer.fromOptionsQueryAnalyzer(getValidator(), config.options)
                                         : this.analyzerFactory;
-            String vsf = config.options.get(IndexWriterConfig.SIMILARITY_FUNCTION);
-            // We already validated it's a valid config, so no need to confirm that it is a valid enum value
-            this.vectorSimilarityFunction = vsf != null ? VectorSimilarityFunction.valueOf(vsf.toUpperCase()) : null;
+            this.vectorSimilarityFunction = indexWriterConfig.getSimilarityFunction();
             this.hasEuclideanSimilarityFunc = vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN;
         }
         else

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -689,7 +689,7 @@ public class IndexContext
 
     public void validate(RowFilter rowFilter)
     {
-        // Only vector row filters are validated by the index right now.
+        // Only vector indexes have requirements to validate right now.
         if (!isVector())
             return;
         // Only iterate over the top level expressions because that is where the ANN expression is located.

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -645,7 +645,11 @@ public class StorageAttachedIndex implements Index
 
     @Override
     public void validate(PartitionUpdate update) throws InvalidRequestException
-    {}
+    {
+        DecoratedKey key = update.partitionKey();
+        for (Row row : update)
+            indexContext.validate(key, row);
+    }
 
     /**
      * This method is called by the startup tasks to find SSTables that don't have indexes. The method is

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -629,6 +629,8 @@ public class StorageAttachedIndex implements Index
         if (command.limits().isUnlimited() || command.limits().count() > MAX_TOP_K)
             throw new InvalidRequestException(String.format("Use of ANN OF in an ORDER BY clause requires a LIMIT that is not greater than %s. LIMIT was %s",
                                                             MAX_TOP_K, command.limits().isUnlimited() ? "NO LIMIT" : command.limits().count()));
+
+        indexContext.validate(command.rowFilter());
     }
 
     @Override

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -355,6 +355,25 @@ public class VectorDistributedTest extends TestBaseImpl
         }
     }
 
+    @Test
+    public void testInvalidVectorQueries()
+    {
+        dimensionCount = 2;
+        cluster.schemaChange(formatQuery(String.format(CREATE_TABLE, dimensionCount)));
+        // geo requries euclidean similarity function
+        cluster.schemaChange(formatQuery(String.format(CREATE_INDEX, "val") + " WITH OPTIONS = {'similarity_function' : 'cosine'}"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [0.0, 0.0])")).hasMessage("Zero vectors cannot be indexed or queried with cosine similarity");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [1, NaN])")).hasMessage("non-finite value at vector[1]=NaN");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [1, Infinity])")).hasMessage("non-finite value at vector[1]=Infinity");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [-Infinity, 1])")).hasMessage("non-finite value at vector[0]=-Infinity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [0.0, 0.0] LIMIT 2")).hasMessage("Zero vectors cannot be indexed or queried with cosine similarity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [1, NaN] LIMIT 2")).hasMessage("non-finite value at vector[1]=NaN");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [1, Infinity] LIMIT 2")).hasMessage("non-finite value at vector[1]=Infinity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [-Infinity, 1] LIMIT 2")).hasMessage("non-finite value at vector[0]=-Infinity");
+    }
+
     private List<float[]> searchWithRange(float[] queryVector, long minToken, long maxToken, int expectedSize) throws Throwable
     {
         Object[][] result = execute("SELECT val FROM %s WHERE token(pk) <= " + maxToken + " AND token(pk) >= " + minToken + " ORDER BY val ann of " + Arrays.toString(queryVector) + " LIMIT 1000");

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/VectorDistributedTest.java
@@ -361,12 +361,31 @@ public class VectorDistributedTest extends TestBaseImpl
     }
 
     @Test
-    public void testInvalidVectorQueries()
+    public void testInvalidVectorQueriesWithCosineSimilarity()
     {
         dimensionCount = 2;
         cluster.schemaChange(formatQuery(String.format(CREATE_TABLE, dimensionCount)));
         // geo requries euclidean similarity function
         cluster.schemaChange(formatQuery(String.format(CREATE_INDEX, "val") + " WITH OPTIONS = {'similarity_function' : 'cosine'}"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [0.0, 0.0])")).hasMessage("Zero vectors cannot be indexed or queried with cosine similarity");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [1, NaN])")).hasMessage("non-finite value at vector[1]=NaN");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [1, Infinity])")).hasMessage("non-finite value at vector[1]=Infinity");
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [-Infinity, 1])")).hasMessage("non-finite value at vector[0]=-Infinity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [0.0, 0.0] LIMIT 2")).hasMessage("Zero vectors cannot be indexed or queried with cosine similarity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [1, NaN] LIMIT 2")).hasMessage("non-finite value at vector[1]=NaN");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [1, Infinity] LIMIT 2")).hasMessage("non-finite value at vector[1]=Infinity");
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [-Infinity, 1] LIMIT 2")).hasMessage("non-finite value at vector[0]=-Infinity");
+    }
+
+    @Test
+    public void testInvalidVectorQueriesWithDefaultSimilarity()
+    {
+        dimensionCount = 2;
+        cluster.schemaChange(formatQuery(String.format(CREATE_TABLE, dimensionCount)));
+        // geo requries euclidean similarity function
+        cluster.schemaChange(formatQuery(String.format(CREATE_INDEX, "val")));
         SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
 
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, val) VALUES (0, [0.0, 0.0])")).hasMessage("Zero vectors cannot be indexed or queried with cosine similarity");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
@@ -195,6 +195,9 @@ public class VectorInvalidQueryTest extends SAITester
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.NaN))).isInstanceOf(InvalidRequestException.class);
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(Float.NEGATIVE_INFINITY, 1))).isInstanceOf(InvalidRequestException.class);
+        // TODO the ANN read query no longer fails without writing to the index... this is likely because the other
+        // inserts created the index and then failed afterwards.
+        execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, 1));
         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
@@ -203,6 +203,24 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
+    public void disallowZeroVectorsWithDefaultSimilarity() throws Throwable
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
+
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, [0.0, 0.0])")).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(0, 0))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.NaN))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(Float.NEGATIVE_INFINITY, 1))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(0, 0))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(1, Float.NaN))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(1, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(Float.NEGATIVE_INFINITY, 1))).isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
     public void disallowClusteringColumnPredicateWithoutSupportingIndex() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk, num))");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
@@ -195,10 +195,11 @@ public class VectorInvalidQueryTest extends SAITester
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.NaN))).isInstanceOf(InvalidRequestException.class);
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(Float.NEGATIVE_INFINITY, 1))).isInstanceOf(InvalidRequestException.class);
-        // TODO the ANN read query no longer fails without writing to the index... this is likely because the other
-        // inserts created the index and then failed afterwards.
-        execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, 1));
         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(0, 0))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(1, Float.NaN))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(1, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of ? LIMIT 2", vector(Float.NEGATIVE_INFINITY, 1))).isInstanceOf(InvalidRequestException.class);
     }
 
     @Test


### PR DESCRIPTION
Previous errors looked like `Operation failed - received 0 responses and 2 failures: UNKNOWN from /127.0.0.2:7012, UNKNOWN from /127.0.0.1:7012` because the operation failed at the replica. This adds a coordinator check to provide a meaningful exception to the client.