### PR TITLE
Null check before logging in org.apache.cassandra.distributed.impl.Instance

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -296,7 +296,9 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
         MessagingService.instance().outboundSink.add((message, to) -> {
             if (!internodeMessagingStarted)
             {
-                inInstancelogger.debug("Dropping outbound message {} to {} as internode messaging has not been started yet",
+                // to avoid NPE in case this is called before inInstancelogger is created
+                if (inInstancelogger != null)
+                    inInstancelogger.debug("Dropping outbound message {} to {} as internode messaging has not been started yet",
                                        message, to);
                 return false;
             }
@@ -442,7 +444,9 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
     {
         if (!internodeMessagingStarted)
         {
-            inInstancelogger.debug("Dropping inbound message {} to {} as internode messaging has not been started yet",
+            // to avoid NPE in case this is called before inInstancelogger is created
+            if (inInstancelogger != null)
+                inInstancelogger.debug("Dropping inbound message {} to {} as internode messaging has not been started yet",
                                    message, config().broadcastAddress());
             return;
         }


### PR DESCRIPTION
Getting rid of random test failures with the same suppressed NPE in stack, like

```
org.apache.cassandra.distributed.shared.ShutdownException: Uncaught exceptions were thrown during test
	at org.apache.cassandra.distributed.impl.AbstractCluster.checkAndResetUncaughtExceptions(AbstractCluster.java:910)
	at org.apache.cassandra.distributed.impl.AbstractCluster.close(AbstractCluster.java:896)
	at org.apache.cassandra.distributed.test.CasWriteTest.close(CasWriteTest.java:82)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	Suppressed: java.lang.NullPointerException
		at org.apache.cassandra.distributed.impl.Instance.receiveMessageWithInvokingThread(Instance.java:445)
		at org.apache.cassandra.distributed.impl.Instance.lambda$receiveMessage$6(Instance.java:437)
		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:829)
```