### PR TITLE
Flaky tests caused by exceptions in test teardown

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/RepairCoordinatorBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/RepairCoordinatorBase.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.NodeToolResult;
 import org.apache.cassandra.distributed.test.DistributedRepairUtils.RepairParallelism;
 import org.apache.cassandra.distributed.test.DistributedRepairUtils.RepairType;
+import org.apache.cassandra.io.util.FileUtils;
 
 public class RepairCoordinatorBase extends TestBaseImpl
 {
@@ -83,8 +84,7 @@ public class RepairCoordinatorBase extends TestBaseImpl
     @AfterClass
     public static void teardownCluster()
     {
-        if (CLUSTER != null)
-            CLUSTER.close();
+        FileUtils.closeQuietly(CLUSTER);
     }
 
     protected String tableName(String prefix) {


### PR DESCRIPTION
Tests occasionally fail with stack like
```
org.apache.cassandra.distributed.shared.ShutdownException: Uncaught exceptions were thrown during test
	at org.apache.cassandra.distributed.impl.AbstractCluster.checkAndResetUncaughtExceptions(AbstractCluster.java:910)
	at org.apache.cassandra.distributed.impl.AbstractCluster.close(AbstractCluster.java:896)
	at org.apache.cassandra.distributed.test.RepairCoordinatorBase.teardownCluster(RepairCoordinatorBase.java:87)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	Suppressed: java.lang.RuntimeException: Could not create snapshot at /127.0.0.2:7012
		at org.apache.cassandra.repair.SnapshotTask$SnapshotCallback.onFailure(SnapshotTask.java:86)
		at org.apache.cassandra.net.ResponseVerbHandler.doVerb(ResponseVerbHandler.java:53)
		at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:79)
		at org.apache.cassandra.net.InboundSink$Filtered.accept(InboundSink.java:65)
		at org.apache.cassandra.net.InboundSink$Filtered.accept(InboundSink.java:51)
		at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:98)
		at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)
		at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)
		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
		at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
		at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
		at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:829)
```

As I understand, shutdown can cause snapshotting failures and can result in exception.
This only happens occasionally and AFAICT only in test. 
In case of the test teardown this is just noise IMO.
