### PR TITLE
Flaky test NativeIndexDDLTest / Status of chunk was not EVICTED

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -879,8 +879,8 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                                 .thenRun(() -> {
                                     // when the instance is eventually stopped, we need to release buffer pools manually
                                     // they are assumed to gone along with JVM, but this is not the case in dtests
-                                    BufferPools.forNetworking().unsafeReset();
-                                    BufferPools.forChunkCache().unsafeReset();
+                                    BufferPools.forNetworking().unsafeReset(true);
+                                    BufferPools.forChunkCache().unsafeReset(true);
                                 });
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/NativeIndexDDLTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/NativeIndexDDLTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.distributed.shared.Byteman;
 import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.Throwables;
@@ -91,8 +92,7 @@ public class NativeIndexDDLTest extends TestBaseImpl
     @After
     public void destroyCluster() throws Throwable
     {
-        if (cluster != null)
-            cluster.close();
+        FileUtils.closeQuietly(cluster);
     }
 
     @Test


### PR DESCRIPTION
sometimes test flakes with
```
java.util.concurrent.ExecutionException: java.lang.AssertionError: Status of chunk [slab java.nio.DirectByteBuffer[pos=0 lim=131072 cap=131072], slots bitmap 0, capacity 131072, free 0, owner null, recycler org.apache.cassandra.utils.memory.BufferPool$GlobalPool@3b210747] was not EVICTED
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at org.apache.cassandra.distributed.test.sai.NativeIndexDDLTest.verifyIndexWithDecommission(NativeIndexDDLTest.java:208)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Caused by: java.lang.AssertionError: Status of chunk [slab java.nio.DirectByteBuffer[pos=0 lim=131072 cap=131072], slots bitmap 0, capacity 131072, free 0, owner null, recycler org.apache.cassandra.utils.memory.BufferPool$GlobalPool@3b210747] was not EVICTED
	at org.apache.cassandra.utils.memory.BufferPool$Chunk.recycleFully(BufferPool.java:1272)
	at org.apache.cassandra.utils.memory.BufferPool$Chunk.unsafeRecycle(BufferPool.java:1538)
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.forEach(BufferPool.java:648)
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.clearForEach(BufferPool.java:636)
	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.unsafeRecycle(BufferPool.java:739)
	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.unsafeRecycle(BufferPool.java:1034)
	at org.apache.cassandra.utils.memory.BufferPool.unsafeReset(BufferPool.java:1598)
	at org.apache.cassandra.distributed.impl.Instance.lambda$shutdown$39(Instance.java:882)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:783)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1742)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

As I understood, this is a test harness problem. 
unsafeRecycle (used in tests only) sets owner to null but doesn't mark local pool's chunks as evicted.