### PR TITLE
VECTOR-SEARCH-54: Add VECTOR type support to COPY command

### DIFF
--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -52,7 +52,7 @@ from six.moves.queue import Queue
 from cassandra import OperationTimedOut
 from cassandra.cluster import DefaultConnection
 from cassandra.connection import SniEndPoint
-from cassandra.cqltypes import ReversedType, UserType, BytesType, VarcharType
+from cassandra.cqltypes import ReversedType, UserType, BytesType, VarcharType, VectorType
 from cassandra.metadata import protect_name, protect_names, protect_value
 from cassandra.policies import RetryPolicy, WhiteListRoundRobinPolicy, DCAwareRoundRobinPolicy, FallthroughRetryPolicy
 from cassandra.query import BatchStatement, BatchType, SimpleStatement, tuple_factory
@@ -2101,6 +2101,13 @@ class ImportConversion(object):
             return ImmutableDict(frozenset((convert_mandatory(ct.subtypes[0], v[0]), convert(ct.subtypes[1], v[1]))
                                  for v in [split(split_format_str % vv, sep=sep) for vv in split(val)]))
 
+        def convert_vector(val, ct=cql_type):
+            string_coordinates = val.strip("[]").split(',')
+            if len(string_coordinates) != ct.vector_size:
+                raise ParseError("The length of given vector value '%d' is not equal to the vector size from the type definition '%d'" % (len(string_coordinates), ct.vector_size))
+            float_vector = [float(v) for v in string_coordinates]
+            return float_vector
+
         def convert_user_type(val, ct=cql_type):
             """
             A user type is a dictionary except that we must convert each key into
@@ -2157,6 +2164,7 @@ class ImportConversion(object):
             'map': convert_map,
             'tuple': convert_tuple,
             'frozen': convert_single_subtype,
+            VectorType.typename: convert_vector,
         }
 
         return converters.get(cql_type.typename, convert_unknown)

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -2102,11 +2102,10 @@ class ImportConversion(object):
                                  for v in [split(split_format_str % vv, sep=sep) for vv in split(val)]))
 
         def convert_vector(val, ct=cql_type):
-            string_coordinates = val.strip("[]").split(',')
+            string_coordinates = split(val)
             if len(string_coordinates) != ct.vector_size:
                 raise ParseError("The length of given vector value '%d' is not equal to the vector size from the type definition '%d'" % (len(string_coordinates), ct.vector_size))
-            float_vector = [float(v) for v in string_coordinates]
-            return float_vector
+            return [convert_mandatory(ct.subtype, v) for v in string_coordinates]
 
         def convert_user_type(val, ct=cql_type):
             """


### PR DESCRIPTION
This patch adds a converter that allows parsing vector literals passed via csv files to the COPY command (https://github.com/riptano/VECTOR-SEARCH/issues/54).

The test that covers the change has been implemented as a dtest - https://github.com/datastax/cassandra-dtest/tree/vsearch-54.