### PR TITLE
Lazily advanceNode in TrieTermsDictionaryReader#ceiling

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryReader.java
@@ -103,12 +103,12 @@ public class TrieTermsDictionaryReader extends ValueIterator<TrieTermsDictionary
     public long ceiling(ByteComparable key)
     {
         skipTo(key, LeftBoundTreatment.ADMIT_EXACT);
-        return nextAsLong();
+        return peekNextAsLong();
     }
 
-    public long nextAsLong()
+    public long peekNextAsLong()
     {
-        return nextValueAsLong(this::getCurrentPayload, NOT_FOUND);
+        return nextValueAsLong(this::getCurrentPayload, NOT_FOUND, false);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndex.java
@@ -389,7 +389,7 @@ public class PartitionIndex implements Closeable
          */
         protected long nextIndexPos()
         {
-            return nextValueAsLong(this::getCurrentIndexPos, NOT_FOUND);
+            return nextValueAsLong(this::getCurrentIndexPos, NOT_FOUND, true);
         }
 
         private long getCurrentIndexPos()

--- a/src/java/org/apache/cassandra/io/tries/ValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ValueIterator.java
@@ -173,13 +173,14 @@ public class ValueIterator<CONCRETE extends ValueIterator<CONCRETE>> extends Wal
         return result;
     }
 
-    protected long nextValueAsLong(LongSupplier supplier, long valueIfNone)
+    protected long nextValueAsLong(LongSupplier supplier, long valueIfNone, boolean advanceNode)
     {
         if (next == NONE)
             return valueIfNone;
         go(next);
         long result = supplier.getAsLong();
-        next = advanceNode();
+        if (advanceNode)
+            next = advanceNode();
         return result;
     }
 


### PR DESCRIPTION
In my testing, this change reduced the cost of `PostingListRangeIterator#getNextRowId` from about 67% of my profile to between 60% and 62%. While `advanceNode` is still necessary in most logical branches, it is definitely not necessary the final time that we call `ceiling` for the `PostingListRangeIterator`, and therefore, lazily advancing should save us some reads from disk.

Here is a profile at the first commit using the workload from https://github.com/jbellis/latlon-sim

[d3309cfb2e-2-min.zip](https://github.com/datastax/cassandra/files/13496662/d3309cfb2e-2-min.zip)
