### PR TITLE
add PrimaryKeyWithSource to accelerate same-sstable comparisons

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 
 /**
  * A bidirectional map of {@link PrimaryKey} to row Id. Implementations of this interface
@@ -51,6 +52,12 @@ public interface PrimaryKeyMap extends Closeable
         {
         }
     }
+
+    /**
+     * Returns the {@link SSTableId} associated with this {@link PrimaryKeyMap}
+     * @return an {@link SSTableId}
+     */
+    SSTableId<?> getSSTableId();
 
     /**
      * Returns a {@link PrimaryKey} for a row Id

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyWithSource.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyWithSource.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk;
+
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+
+public class PrimaryKeyWithSource implements PrimaryKey
+{
+    private final PrimaryKey primaryKey;
+    private final SSTableId<?> sourceSstableId;
+    private final long sourceRowId;
+
+    public PrimaryKeyWithSource(PrimaryKey primaryKey, SSTableId<?> sstableId, long sstableRowId)
+    {
+        assert primaryKey != null : "Cannot construct a PrimaryKeyWithSource with a null primaryKey";
+        this.primaryKey = primaryKey;
+        this.sourceSstableId = sstableId;
+        this.sourceRowId = sstableRowId;
+    }
+
+    public long getSourceRowId()
+    {
+        return sourceRowId;
+    }
+
+    public SSTableId<?> getSourceSstableId()
+    {
+        return sourceSstableId;
+    }
+
+    @Override
+    public Token token()
+    {
+        return primaryKey.token();
+    }
+
+    @Override
+    public DecoratedKey partitionKey()
+    {
+        return primaryKey.partitionKey();
+    }
+
+    @Override
+    public Clustering clustering()
+    {
+        return primaryKey.clustering();
+    }
+
+    @Override
+    public PrimaryKey loadDeferred()
+    {
+        return primaryKey.loadDeferred();
+    }
+
+    @Override
+    public ByteSource asComparableBytes(ByteComparable.Version version)
+    {
+        return primaryKey.asComparableBytes(version);
+    }
+
+    @Override
+    public ByteSource asComparableBytesMinPrefix(ByteComparable.Version version)
+    {
+        return primaryKey.asComparableBytesMinPrefix(version);
+    }
+
+    @Override
+    public ByteSource asComparableBytesMaxPrefix(ByteComparable.Version version)
+    {
+        return primaryKey.asComparableBytesMaxPrefix(version);
+    }
+
+    @Override
+    public int compareTo(PrimaryKey o)
+    {
+        if (o instanceof PrimaryKeyWithSource)
+        {
+            var other = (PrimaryKeyWithSource) o;
+            if (sourceSstableId.equals(other.sourceSstableId))
+                return Long.compare(sourceRowId, other.sourceRowId);
+        }
+        return primaryKey.compareTo(o);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.index.sai.disk.v1.bitpack.BlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.MonotonicBlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -64,6 +65,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         private final KeyFetcher keyFetcher;
         private final IPartitioner partitioner;
         private final PrimaryKey.Factory primaryKeyFactory;
+        private final SSTableId<?> sstableId;
 
         private FileHandle token = null;
         private FileHandle offset = null;
@@ -84,6 +86,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
                 this.partitioner = indexDescriptor.partitioner;
                 this.keyFetcher = new KeyFetcher(sstable);
                 this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
+                this.sstableId = sstable.getId();
             }
             catch (Throwable t)
             {
@@ -97,7 +100,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
             final LongArray rowIdToToken = new LongArray.DeferredLongArray(() -> tokenReaderFactory.open());
             final LongArray rowIdToOffset = new LongArray.DeferredLongArray(() -> offsetReaderFactory.open());
 
-            return new PartitionAwarePrimaryKeyMap(rowIdToToken, rowIdToOffset, partitioner, keyFetcher, primaryKeyFactory);
+            return new PartitionAwarePrimaryKeyMap(rowIdToToken, rowIdToOffset, partitioner, keyFetcher, primaryKeyFactory, sstableId);
         }
 
         @Override
@@ -113,13 +116,15 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     private final KeyFetcher keyFetcher;
     private final RandomAccessReader reader;
     private final PrimaryKey.Factory primaryKeyFactory;
+    private final SSTableId<?> sstableId;
     private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private PartitionAwarePrimaryKeyMap(LongArray rowIdToToken,
                                         LongArray rowIdToOffset,
                                         IPartitioner partitioner,
                                         KeyFetcher keyFetcher,
-                                        PrimaryKey.Factory primaryKeyFactory)
+                                        PrimaryKey.Factory primaryKeyFactory,
+                                        SSTableId<?> sstableId)
     {
         this.rowIdToToken = rowIdToToken;
         this.rowIdToOffset = rowIdToOffset;
@@ -127,6 +132,13 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         this.keyFetcher = keyFetcher;
         this.reader = keyFetcher.createReader();
         this.primaryKeyFactory = primaryKeyFactory;
+        this.sstableId = sstableId;
+    }
+
+    @Override
+    public SSTableId<?> getSSTableId()
+    {
+        return sstableId;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
 import org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsMeta;
 import org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsReader;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -80,6 +81,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         private final IPartitioner partitioner;
         private final ClusteringComparator clusteringComparator;
         private final PrimaryKey.Factory primaryKeyFactory;
+        private final SSTableId<?> sstableId;
 
         public RowAwarePrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable)
         {
@@ -99,6 +101,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                 this.partitioner = sstable.metadata().partitioner;
                 this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
                 this.clusteringComparator = indexDescriptor.clusteringComparator;
+                this.sstableId = sstable.getId();
             }
             catch (Throwable t)
             {
@@ -117,7 +120,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                                                  sortedTermsReader.openCursor(),
                                                  partitioner,
                                                  primaryKeyFactory,
-                                                 clusteringComparator);
+                                                 clusteringComparator,
+                                                 sstableId);
             }
             catch (IOException e)
             {
@@ -138,6 +142,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     private final IPartitioner partitioner;
     private final PrimaryKey.Factory primaryKeyFactory;
     private final ClusteringComparator clusteringComparator;
+    private final SSTableId<?> sstableId;
     private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private RowAwarePrimaryKeyMap(LongArray rowIdToToken,
@@ -145,7 +150,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                                   SortedTermsReader.Cursor cursor,
                                   IPartitioner partitioner,
                                   PrimaryKey.Factory primaryKeyFactory,
-                                  ClusteringComparator clusteringComparator)
+                                  ClusteringComparator clusteringComparator,
+                                  SSTableId<?> sstableId)
     {
         this.rowIdToToken = rowIdToToken;
         this.sortedTermsReader = sortedTermsReader;
@@ -153,6 +159,13 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         this.partitioner = partitioner;
         this.primaryKeyFactory = primaryKeyFactory;
         this.clusteringComparator = clusteringComparator;
+        this.sstableId = sstableId;
+    }
+
+    @Override
+    public SSTableId<?> getSSTableId()
+    {
+        return sstableId;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.disk.PrimaryKeyWithSource;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
@@ -368,8 +369,13 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             for (int i = 0; i < keysInRange.size(); i++)
             {
+                // turn the pk back into a row id, with a fast path for the case where the pk is from this sstable
+                long sstableRowId = -1;
                 var primaryKey = keysInRange.get(i);
-                long sstableRowId = primaryKeyMap.exactRowIdOrInvertedCeiling(primaryKey);
+                assert primaryKey instanceof PrimaryKeyWithSource : "Expected PrimaryKeyWithSource, got " + primaryKey;
+                var pkws = (PrimaryKeyWithSource) primaryKey;
+                if (pkws.getSourceSstableId().equals(primaryKeyMap.getSSTableId()))
+                    sstableRowId = pkws.getSourceRowId();
 
                 // The current primary key is not in this sstable. Use ceiling to search for the row id
                 // of the next closest primary key in this sstable and skip to that primary key.

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -56,6 +56,7 @@ import org.apache.cassandra.index.sai.utils.AbstractIterator;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.disk.v1.PartitionAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
@@ -72,6 +73,12 @@ public class KDTreeIndexBuilder
     public static final PrimaryKeyMap TEST_PRIMARY_KEY_MAP = new PrimaryKeyMap()
     {
         private final PrimaryKey.Factory primaryKeyFactory = new PartitionAwarePrimaryKeyFactory();
+
+        @Override
+        public SSTableId<?> getSSTableId()
+        {
+            return null;
+        }
 
         @Override
         public PrimaryKey primaryKeyFromRowId(long sstableRowId)


### PR DESCRIPTION
Rebooting https://github.com/datastax/cassandra/pull/889, didn't realize I'd need a new PR after force-pushing