### PR TITLE
CNDB-7789: Support schemas with embedded non-frozen UDTs

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1777,7 +1777,7 @@ comparatorType returns [CQL3Type.Raw t]
     | s=STRING_LITERAL
       {
         try {
-            $t = CQL3Type.Raw.from(new CQL3Type.Custom($s.text));
+            $t = CQL3Type.Raw.custom($s.text);
         } catch (SyntaxException e) {
             addRecognitionError("Cannot parse type " + $s.text + ": " + e.getMessage());
         } catch (ConfigurationException e) {

--- a/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
@@ -67,7 +67,7 @@ public abstract class AbstractFunction implements Function
     {
         return argTypes().stream()
                          .map(AbstractType::asCQL3Type)
-                         .map(CQL3Type::toString)
+                         .map(CQL3Type::toSchemaString)
                          .collect(toList());
     }
 
@@ -104,7 +104,7 @@ public abstract class AbstractFunction implements Function
         // We should ignore the fact that the receiver type is frozen in our comparison as functions do not support
         // frozen types for return type
         AbstractType<?> returnType = returnType();
-        if (receiver.type.isFreezable() && !receiver.type.isMultiCell())
+        if (!receiver.type.isMultiCell())
             returnType = returnType.freeze();
 
         if (receiver.type.equals(returnType))
@@ -158,8 +158,7 @@ public abstract class AbstractFunction implements Function
      */
     protected String toCqlString(AbstractType<?> type)
     {
-        return type.isTuple() ? ((Tuple) type.asCQL3Type()).toString(false)
-                              : type.asCQL3Type().toString();
+        return type.asCQL3Type().toString();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/selection/ElementsSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ElementsSelector.java
@@ -313,7 +313,7 @@ abstract class ElementsSelector extends Selector
 
         protected ByteBuffer extractSelection(ByteBuffer collection)
         {
-            return type.getSerializer().getSliceFromSerialized(collection, from, to, type.nameComparator(), type.isFrozenCollection());
+            return type.getSerializer().getSliceFromSerialized(collection, from, to, type.nameComparator(), !type.isMultiCell());
         }
 
         public AbstractType<?> getType()

--- a/src/java/org/apache/cassandra/cql3/selection/Selectable.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selectable.java
@@ -648,7 +648,7 @@ public interface Selectable extends AssignmentTestable
                                                 VariableSpecifications boundNames)
         {
             SelectorFactories factories = createFactoriesAndCollectColumnDefinitions(selectables,
-                                                                                     tupleType.allTypes(),
+                                                                                     tupleType.subTypes(),
                                                                                      cfm,
                                                                                      defs,
                                                                                      boundNames);
@@ -1191,9 +1191,7 @@ public interface Selectable extends AssignmentTestable
             public Selectable prepare(TableMetadata cfm)
             {
                 Selectable selectable = raw.prepare(cfm);
-                AbstractType<?> type = this.typeRaw.prepare(cfm.keyspace).getType();
-                if (type.isFreezable())
-                    type = type.freeze();
+                AbstractType<?> type = this.typeRaw.prepare(cfm.keyspace).getType().freeze();
                 return new WithTypeHint(typeRaw.toString(), type, selectable);
             }
         }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
@@ -91,14 +91,12 @@ public final class AlterKeyspaceStatement extends AlterSchemaStatement implement
         if (newKeyspace.params.replication.klass.equals(LocalStrategy.class))
             throw ire("Unable to use given strategy class: LocalStrategy is reserved for internal use.");
 
-        newKeyspace.params.validate(keyspaceName);
+        newKeyspace.validate();
 
         validateNoRangeMovements();
         validateTransientReplication(keyspace.createReplicationStrategy(), newKeyspace.createReplicationStrategy());
 
-        Keyspaces res = schema.withAddedOrUpdated(newKeyspace);
-
-        return res;
+        return schema.withAddedOrUpdated(newKeyspace);
     }
 
     SchemaChange schemaChangeEvent(KeyspacesDiff diff)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -231,7 +231,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                     throw ire("Cannot re-add previously dropped column '%s' of type %s, incompatible with previous type %s",
                               name,
                               type.asCQL3Type(),
-                              droppedColumn.type.asCQL3Type());
+                              droppedColumn.type.asCQL3Type().toSchemaString());
                 }
 
                 if (droppedColumn.isStatic() != isStatic)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -81,7 +81,13 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
         if (null == type)
             throw ire("Type %s.%s doesn't exist", keyspaceName, typeName);
 
-        return schema.withAddedOrUpdated(keyspace.withUpdatedUserType(apply(keyspace, type)));
+        UserType updated = apply(keyspace, type);
+        CreateTypeStatement.validate(updated);
+
+        KeyspaceMetadata newKeyspace = keyspace.withUpdatedUserType(updated);
+        newKeyspace.validate();
+
+        return schema.withAddedOrUpdated(newKeyspace);
     }
 
     abstract UserType apply(KeyspaceMetadata keyspace, UserType type);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.statements.RawKeyspaceAwareStatement;
@@ -255,11 +254,11 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (column.isPartitionKey() && table.partitionKeyColumns().size() == 1)
             throw ire("Cannot create secondary index on the only partition key column %s", column);
 
-        if (column.type.isFrozenCollection() && target.type != Type.FULL)
+        if (column.type.isCollection() && !column.type.isMultiCell() && target.type != Type.FULL)
             throw ire("Cannot create %s() index on frozen column %s. Frozen collections are immutable and must be fully " +
                       "indexed by using the 'full(%s)' modifier", target.type, column, column);
 
-        if (!column.type.isFrozenCollection() && target.type == Type.FULL)
+        if ((!column.type.isCollection() || column.type.isMultiCell()) && target.type == Type.FULL)
             throw ire("full() indexes can only be created on frozen collections");
 
         if (!column.type.isCollection() && target.type != Type.SIMPLE)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
@@ -93,11 +93,11 @@ public final class CreateKeyspaceStatement extends AlterSchemaStatement implemen
         }
 
         KeyspaceMetadata keyspace = KeyspaceMetadata.create(keyspaceName, attrs.asNewKeyspaceParams());
+        keyspace.validate();
 
         if (keyspace.params.replication.klass.equals(LocalStrategy.class))
             throw ire("Unable to use given strategy class: LocalStrategy is reserved for internal use.");
 
-        keyspace.params.validate(keyspaceName);
         return schema.withAddedOrUpdated(keyspace);
     }
 

--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -74,8 +74,6 @@ public class ClusteringComparator implements Comparator<Clusterable>
         this.indexReverseComparator = (o1, o2) -> ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.firstName,
                                                                                     (ClusteringPrefix<?>) o2.firstName);
         this.reverseComparator = (c1, c2) -> ClusteringComparator.this.compare(c2, c1);
-        for (AbstractType<?> type : clusteringTypes)
-            type.checkComparable(); // this should already be enforced by TableMetadata.Builder.addColumn, but we check again for other constructors
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.filter.*;
@@ -320,8 +319,8 @@ public class DataRange
         {
             CompositeType ct = (CompositeType)type;
             ByteBuffer[] values = ct.split(key);
-            for (int i = 0; i < ct.types.size(); i++)
-                sb.append(i == 0 ? "" : ", ").append(ct.types.get(i).getString(values[i]));
+            for (int i = 0; i < ct.subTypes().size(); i++)
+                sb.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).getString(values[i]));
         }
         else
         {

--- a/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
+++ b/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
@@ -31,7 +31,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
     public TombstoneOverwhelmingException(long numTombstones, String query, TableMetadata metadata, DecoratedKey lastPartitionKey, ClusteringPrefix<?> lastClustering)
     {
         super(RequestFailureReason.READ_TOO_MANY_TOMBSTONES,
-              String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partion key was (%s)); query aborted", 
+              String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partition key was (%s)); query aborted",
                             numTombstones, query, lastPartitionKey.getToken(), makePKString(metadata, lastPartitionKey.getKey(), lastClustering)));
     }
 
@@ -40,7 +40,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
         StringBuilder sb = new StringBuilder();
 
         if (clustering.size() > 0)
-            sb.append("(");
+            sb.append('(');
 
         // TODO: We should probably make that a lot easier/transparent for partition keys
         AbstractType<?> pkType = metadata.partitionKeyType;
@@ -52,7 +52,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
             {
                 if (i > 0)
                     sb.append(", ");
-                sb.append(ct.types.get(i).getString(values[i]));
+                sb.append(ct.subTypes().get(i).getString(values[i]));
             }
         }
         else
@@ -61,7 +61,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
         }
 
         if (clustering.size() > 0)
-            sb.append(")");
+            sb.append(')');
 
         for (int i = 0; i < clustering.size(); i++)
             sb.append(", ").append(clustering.stringAt(i, metadata.comparator));

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import com.google.common.collect.ImmutableList;
+
 import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.serializers.BytesSerializer;
@@ -38,9 +40,9 @@ import org.apache.cassandra.utils.ByteBufferUtil;
  */
 public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
 {
-    protected AbstractCompositeType()
+    protected AbstractCompositeType(ImmutableList<AbstractType<?>> subTypes)
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, false, subTypes);
     }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
@@ -102,7 +104,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
      */
     public ByteBuffer[] split(ByteBuffer bb)
     {
-        List<ByteBuffer> l = new ArrayList<ByteBuffer>();
+        List<ByteBuffer> l = new ArrayList<>();
         boolean isStatic = readIsStatic(bb, ByteBufferAccessor.instance);
         int offset = startingOffset(isStatic);
 

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -347,7 +347,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * method goes since it only impacts sorting), this method is final and subclasses should override the
      * {@link #isValueCompatibleWithInternal} method instead.
      */
-    public boolean isValueCompatibleWith(AbstractType<?> otherType)
+    public final boolean isValueCompatibleWith(AbstractType<?> otherType)
     {
         return unwrap().isValueCompatibleWithInternal(otherType.unwrap());
     }
@@ -355,7 +355,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     /**
      * Needed to handle {@link ReversedType} in value-compatibility checks. Subclasses should override this instead of
      * {@link #isValueCompatibleWith}. However, if said override has subtypes on which they need to check value
-     * compatibility recursively, they should call {@link #isValueCompatibleWith} insteas of this method
+     * compatibility recursively, they should call {@link #isValueCompatibleWith} instead of this method
      * so that reversed types are ignored even if nested.
      */
     protected boolean isValueCompatibleWithInternal(AbstractType<?> otherType)

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -21,21 +21,27 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -45,11 +51,12 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.github.jamm.Unmetered;
 
+import static com.google.common.collect.Iterables.transform;
 import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM;
 
 /**
  * Specifies a Comparator for a specific type of ByteBuffer.
- *
+ * <p>
  * Note that empty ByteBuffer are used to represent "start at the beginning"
  * or "stop at the end" arguments to get_slice, so the Comparator
  * should always handle those values even if they normally do not
@@ -58,9 +65,9 @@ import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM
 @Unmetered
 public abstract class AbstractType<T> implements Comparator<ByteBuffer>, AssignmentTestable
 {
-    private final static int VARIABLE_LENGTH = -1;
+    private static final Logger logger = LoggerFactory.getLogger(AbstractType.class);
 
-    public final Comparator<ByteBuffer> reverseComparator;
+    private final static int VARIABLE_LENGTH = -1;
 
     public enum ComparisonType
     {
@@ -83,19 +90,25 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     public final ComparisonType comparisonType;
     public final boolean isByteOrderComparable;
     public final ValueComparators comparatorSet;
+    private final boolean isMultiCell;
+    protected final ImmutableList<AbstractType<?>> subTypes;
 
     protected AbstractType(ComparisonType comparisonType)
     {
+        this(comparisonType, false, ImmutableList.of());
+    }
+
+    protected AbstractType(ComparisonType comparisonType, boolean isMultiCell, List<AbstractType<?>> subTypes)
+    {
         this.comparisonType = comparisonType;
         this.isByteOrderComparable = comparisonType == ComparisonType.BYTE_ORDER;
-        reverseComparator = (o1, o2) -> AbstractType.this.compare(o2, o1);
         try
         {
             Method custom = getClass().getMethod("compareCustom", Object.class, ValueAccessor.class, Object.class, ValueAccessor.class);
             if ((custom.getDeclaringClass() == AbstractType.class) == (comparisonType == CUSTOM))
                 throw new IllegalStateException((comparisonType == CUSTOM ? "compareCustom must be overridden if ComparisonType is CUSTOM"
                                                                          : "compareCustom should not be overridden if ComparisonType is not CUSTOM")
-                                                + " (" + getClass().getSimpleName() + ")");
+                                                + " (" + getClass().getSimpleName() + ')');
         }
         catch (NoSuchMethodException e)
         {
@@ -104,6 +117,23 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
         comparatorSet = new ValueComparators((l, r) -> compare(l, ByteArrayAccessor.instance, r, ByteArrayAccessor.instance),
                                              (l, r) -> compare(l, ByteBufferAccessor.instance, r, ByteBufferAccessor.instance));
+
+        this.isMultiCell = isMultiCell;
+
+        // A frozen type can only have frozen subtypes, basically by definition. So make sure we don't mess it up
+        // when constructing types by forgetting to set some multi-cell flag. Note that because we have had a lot of
+        // frozen-related errors in the past, we log an error if this happens, but continue with the type frozen as this
+        // is almost surely the right thing to do.
+        ImmutableList<AbstractType<?>> cleanedSubtypes = ImmutableList.copyOf(subTypes);
+        if (!isMultiCell && subTypes.stream().anyMatch(AbstractType::isMultiCell))
+        {
+            logger.error("Detected corrupted type: creating a frozen {} but with some non-frozen sub-types. " +
+                         "This is likely a bug and should be reported, but continuing with the " +
+                         "sub-types frozen as this almost surely the right thing to do.", getClass());
+            cleanedSubtypes = freeze(subTypes);
+        }
+        this.subTypes = cleanedSubtypes;
+
     }
 
     static <VL, VR, T extends Comparable<T>> int compareComposed(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR, AbstractType<T> type)
@@ -258,30 +288,19 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     public abstract TypeSerializer<T> getSerializer();
 
-    /* convenience method */
-    public String getString(Collection<ByteBuffer> names)
-    {
-        StringBuilder builder = new StringBuilder();
-        for (ByteBuffer name : names)
-        {
-            builder.append(getString(name)).append(",");
-        }
-        return builder.toString();
-    }
-
     public boolean isCounter()
     {
         return false;
     }
 
-    public boolean isFrozenCollection()
-    {
-        return isCollection() && !isMultiCell();
-    }
-
     public boolean isReversed()
     {
         return false;
+    }
+
+    public AbstractType<T> unwrap()
+    {
+        return isReversed() ? ((ReversedType<T>) this).baseType.unwrap() : this;
     }
 
     public static AbstractType<?> parseDefaultParameters(AbstractType<?> baseType, TypeParser parser) throws SyntaxException
@@ -314,24 +333,30 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * Returns true if values of the other AbstractType can be read and "reasonably" interpreted by the this
+     * Returns true if values of the other AbstractType can be read and "reasonably" interpreted by this
      * AbstractType. Note that this is a weaker version of isCompatibleWith, as it does not require that both type
      * compare values the same way.
-     *
+     * <p>
      * The restriction on the other type being "reasonably" interpreted is to prevent, for example, IntegerType from
      * being compatible with all other types.  Even though any byte string is a valid IntegerType value, it doesn't
      * necessarily make sense to interpret a UUID or a UTF8 string as an integer.
-     *
+     * <p>
      * Note that a type should be compatible with at least itself.
+     * <p>
+     * Also note that to ensure consistent handling of the {@link ReversedType} (which should be ignored as far as this
+     * method goes since it only impacts sorting), this method is final and subclasses should override the
+     * {@link #isValueCompatibleWithInternal} method instead.
      */
     public boolean isValueCompatibleWith(AbstractType<?> otherType)
     {
-        return isValueCompatibleWithInternal((otherType instanceof ReversedType) ? ((ReversedType) otherType).baseType : otherType);
+        return unwrap().isValueCompatibleWithInternal(otherType.unwrap());
     }
 
     /**
-     * Needed to handle ReversedType in value-compatibility checks.  Subclasses should implement this instead of
-     * isValueCompatibleWith().
+     * Needed to handle {@link ReversedType} in value-compatibility checks. Subclasses should override this instead of
+     * {@link #isValueCompatibleWith}. However, if said override has subtypes on which they need to check value
+     * compatibility recursively, they should call {@link #isValueCompatibleWith} insteas of this method
+     * so that reversed types are ignored even if nested.
      */
     protected boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
@@ -371,37 +396,100 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return false;
     }
 
-    public boolean isMultiCell()
+    /**
+     * Whether the type is multi-cell, that is whether its value is encoded using multiple cells internally.
+     * <p>
+     * Only "complex" types, whose values are somewhat composite, can be multi-cell (and so multi-cell types will
+     * have non-empty {@link #subTypes}, corresponding to the type(s) of the decomposed values). Further, all
+     * multi-cell types have a so-called <b>frozen</b> counterpart: a non-multi-cell version that fundamentally
+     * represents the same type but where the decomposed values are all packed into a single cell value (rather than
+     * split into multiple cells).
+     * <p>
+     * Note that by definition, if a type is frozen (non-multi-cell) and "complex" (has non-empty {@link #subTypes()}),
+     * then all its subtypes must also be frozen.
+     */
+    public final boolean isMultiCell()
     {
-        return false;
-    }
-
-    public boolean isFreezable()
-    {
-        return false;
-    }
-
-    public AbstractType<?> freeze()
-    {
-        return this;
-    }
-
-    public List<AbstractType<?>> subTypes()
-    {
-        return Collections.emptyList();
+        return isMultiCell;
     }
 
     /**
-     * Returns an AbstractType instance that is equivalent to this one, but with all nested UDTs and collections
-     * explicitly frozen.
+     * If the type is a multi-cell one ({@link #isMultiCell()} is true), returns a frozen copy of this type (one
+     * for which {@link #isMultiCell()} returns false).
+     * <p>
+     * Note that as mentioned on {@link #isMultiCell()}, a frozen type necessarily has all its subtypes frozen, so
+     * this method also ensures that no subtypes (recursively) are marked as multi-cell.
      *
-     * This is only necessary for {@code 2.x -> 3.x} schema migrations, and can be removed in Cassandra 4.0.
-     *
-     * See CASSANDRA-11609 and CASSANDRA-11613.
+     * @return a frozen version of this type. If this type is not multi-cell (whether because it is not a "complex"
+     * type, or because it is already a frozen one), this should return {@code this}.
      */
-    public AbstractType<?> freezeNestedMulticellTypes()
+    public AbstractType<?> freeze()
     {
+        if (!isMultiCell())
+            return this;
+
+        return with(freeze(subTypes()), false);
+    }
+
+    /**
+     * Utility method that freezes a list of types.
+     *
+     * @param types the list of types to freeze.
+     * @return a new (unmodifiable) list containing the result of applying {@link #freeze()} on every type of
+     * {@code types}.
+     */
+    public static ImmutableList<AbstractType<?>> freeze(List<AbstractType<?>> types)
+    {
+        if (types.isEmpty())
+            return ImmutableList.of();
+
+        ImmutableList.Builder<AbstractType<?>> builder = ImmutableList.builder();
+        for (AbstractType<?> type : types)
+            builder.add(type.freeze());
+        return builder.build();
+    }
+
+    /**
+     * Creates an instance of this type (the concrete type extending this class) with the provided updated multi-cell
+     * flag and subtypes.
+     * <p>
+     * Any other information (other than multi-cellness and subtypes) the type may have is expected to be left unchanged
+     * in the created type.
+     *
+     * @param isMultiCell whether the returned type must be a multi-cell one or not.
+     * @param subTypes the subtypes to use for the returned type as a list. The list will have subtypes in the exact
+     * same order as returned by {@link #subTypes()}, and exactly as many as the concrete class expects.
+     * @return the created type, which can be {@code this} if the provided subTypes and multi-cell flag are the same
+     * as that of this type.
+     */
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        // Default implementation for types that can neither be multi-cell, nor have subtypes (and thus where this
+        // is basically a no-op). Any other type must override this.
+
+        assert this.subTypes.isEmpty() && subTypes.isEmpty() :
+        String.format("Invalid call to copyWith on %s with subTypes %s (provided subTypes: %s)",
+                      this, this.subTypes, subTypes);
+
+        assert !this.isMultiCell() && !isMultiCell:
+        String.format("Invalid call to copyWith on %s with isMultiCell %b (provided isMultiCell: %b)",
+                      this, this.isMultiCell(), isMultiCell);
+
         return this;
+    }
+
+    /**
+     * If the type has "complex" values that depend on subtypes, return those (direct) subtypes (in undefined order),
+     * and an empty list otherwise.
+     * <p>
+     * Note that most "complex" types (type for which this return a non-empty iterable) are subclasses of
+     * {@link MultiCellCapableType} and thus can be multi-cell or frozen. However, a few legacy types (namely
+     * {@link CompositeType} and {@link DynamicCompositeType}) are "complex" (have subtypes) but are only even supported
+     * as "frozen" (and so don't extend {@link MultiCellCapableType}).
+     */
+    public final ImmutableList<AbstractType<?>> subTypes()
+    {
+        return subTypes;
     }
 
     /**
@@ -413,28 +501,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * @param ignoreFreezing if true, the type string will not be wrapped with FrozenType(...), even if this type is frozen.
-     */
-    public String toString(boolean ignoreFreezing)
-    {
-        return this.toString();
-    }
-
-    /**
      * To override keyspace name in {@link UserType}
      */
     public AbstractType<T> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        return this;
-    }
-
-    /**
-     * Return a list of the "subcomponents" this type has.
-     * This always return a singleton list with the type itself except for CompositeType.
-     */
-    public List<AbstractType<?>> getComponents()
-    {
-        return Collections.<AbstractType<?>>singletonList(this);
+        return this; // TODO: can we have a better default implementation?
     }
 
     /**
@@ -553,7 +624,9 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
     {
-        return false;
+        // Note that non-complex types have no subtypes, so will return false, and UserType overrides this to return
+        // true if the provided name matches.
+        return subTypes().stream().anyMatch(t -> t.referencesUserType(name, accessor));
     }
 
     /**
@@ -570,7 +643,14 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      */
     public AbstractType<?> withUpdatedUserType(UserType udt)
     {
-        return this;
+        if (!referencesUserType(udt.name))
+            return this;
+
+        ImmutableList.Builder<AbstractType<?>> builder = ImmutableList.builder();
+        for (AbstractType<?> subType : subTypes)
+            builder.add(subType.withUpdatedUserType(udt));
+
+        return with(builder.build(), isMultiCell());
     }
 
     /**
@@ -591,18 +671,27 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     /**
      * Replace any instances of UserType with equivalent TupleType-s.
-     *
+     * <p>
      * We need it for dropped_columns, to allow safely dropping unused user types later without retaining any references
      * to them in system_schema.dropped_columns.
      */
     public AbstractType<?> expandUserTypes()
     {
-        return this;
+        return referencesUserTypes()
+               ? with(ImmutableList.copyOf(transform(subTypes, AbstractType::expandUserTypes)), isMultiCell())
+               : this;
     }
 
     public boolean referencesDuration()
     {
-        return false;
+        // Note that non-complex types have no subtypes, so will return false, and DurationType overrides this to return
+        // true.
+        return subTypes().stream().anyMatch(AbstractType::referencesDuration);
+    }
+
+    public final boolean referencesCounter()
+    {
+        return isCounter() || subTypes().stream().anyMatch(AbstractType::referencesCounter);
     }
 
     /**
@@ -613,7 +702,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         // testAssignement is for CQL literals and native protocol values, none of which make a meaningful
         // difference between frozen or not and reversed or not.
 
-        if (isFreezable() && !isMultiCell())
+        if (!isMultiCell())
             receiverType = receiverType.freeze();
 
         if (isReversed() && !receiverType.isReversed())
@@ -626,6 +715,125 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
             return AssignmentTestable.TestResult.WEAKLY_ASSIGNABLE;
 
         return AssignmentTestable.TestResult.NOT_ASSIGNABLE;
+    }
+
+    /**
+     * Validates whether this type is valid as a column type for a column of the provided kind.
+     * <p>
+     * A number of limits must be respected by column types (possibly depending on the type of columns). For
+     * instance, primary key columns must always be frozen, cannot use counters, etc. And for regular columns, amongst
+     * other things, we currently only support non-frozen types at top-level, so any type with a non-frozen subtype
+     * is invalid (note that it's valid to <b>create</b> a type with non-frozen subtypes, with a {@code CREATE TYPE}
+     * for instance, but they cannot be used as column types without being frozen).
+     *
+     * @param columnName the name of the column whose type is checked.
+     * @param isPrimaryKeyColumn whether {@code columnName} is a primary key column or not.
+     * @param isCounterTable whether the table the {@code columnName} is part of is a counter table.
+     *
+     * @throws InvalidColumnTypeException if this type is not a valid column type for {@code columnName}.
+     */
+    public void validateForColumn(ByteBuffer columnName, boolean isPrimaryKeyColumn, boolean isCounterTable)
+    {
+        if (isPrimaryKeyColumn)
+        {
+            if (isMultiCell())
+                throw columnException(columnName, true, isCounterTable,
+                                      "non-frozen %s are not supported for PRIMARY KEY columns", category());
+            if (referencesCounter())
+                throw columnException(columnName, true, isCounterTable,
+                                      "counters are not supported within PRIMARY KEY columns");
+            // We don't allow durations in anything sorted (primary key here, or in the "name-comparator" part of
+            // collections below). This isn't really a technical limitation, but duration sorts in a somewhat random
+            // way, so CASSANDRA-11873 decided to reject them when sorting was involved.
+            if (referencesDuration())
+                throw columnException(columnName, true, isCounterTable,
+                                      "duration types are not supported within PRIMARY KEY columns");
+
+            if (comparisonType == ComparisonType.NOT_COMPARABLE)
+                throw columnException(columnName, true, isCounterTable,
+                                      "type %s is not comparable and cannot be used for PRIMARY KEY columns", asCQL3Type());
+        }
+        else
+        {
+            if (isMultiCell())
+            {
+                for (AbstractType<?> subType : subTypes())
+                {
+                    if (subType.isMultiCell())
+                    {
+                        throw columnException(columnName, false, isCounterTable,
+                                              "non-frozen %s are only supported at top-level: subtype %s of %s must be frozen",
+                                              subType.category(), subType.asCQL3Type(), asCQL3Type());
+                    }
+                }
+
+                if (this instanceof MultiCellCapableType)
+                {
+                    AbstractType<?> nameComparator = ((MultiCellCapableType<?>) this).nameComparator();
+                    // As mentioned above, CASSANDRA-11873 decided to reject durations when sorting was involved.
+                    if (nameComparator.referencesDuration())
+                    {
+                        // Trying to profile a more precise error message
+                        String what = this instanceof MapType
+                                      ? "map keys"
+                                      : (this instanceof SetType ? "sets" : category());
+                        throw columnException(columnName, false, isCounterTable,
+                                              "duration types are not supported within non-frozen %s", what);
+                    }
+                }
+            }
+
+            if (isCounterTable)
+            {
+                // Everything within a counter table must be a counter, and we don't allow nesting (collections of
+                // counters), except for legacy backward-compatibility, in the super-column map used to support old
+                // super columns.
+                if (!isCounter() && !TableMetadata.isSuperColumnMapColumnName(columnName))
+                {
+                    // We don't allow counter inside collections, but to be fair, at least for map, it's a bit of an
+                    // arbitrary limitation (it works internally, we don't expose it mostly because counters have
+                    // their limitations, and we want to restrict how user can use them to hopefully make user think
+                    // twice about their usage). In any case, a slightly more user-friendly message is probably nice.
+                    if (referencesCounter())
+                        throw columnException(columnName, false, true, "counters are not allowed within %s", category());
+
+                    throw columnException(columnName, false, true, "Cannot mix counter and non counter columns in the same table");
+                }
+            }
+            else
+            {
+                if (isCounter())
+                    throw columnException(columnName, false, false, "Cannot mix counter and non counter columns in the same table");
+
+                // For nested counters, we prefer complaining about the nested-ness rather than this not being a counter
+                // table, because the table won't be marked as a counter one even if it has only nested counters, and so
+                // that's overall a more intuitive message.
+                if (referencesCounter())
+                    throw columnException(columnName, false, false, "counters are not allowed within %s", category());
+            }
+        }
+    }
+
+    private InvalidColumnTypeException columnException(ByteBuffer columnName,
+                                                       boolean isPrimaryKeyColumn,
+                                                       boolean isCounterTable,
+                                                       String reason,
+                                                       Object... args)
+    {
+        String msg = args.length == 0 ? reason : String.format(reason, args);
+        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, msg);
+    }
+
+    private String category()
+    {
+        if (isCollection())
+            return "collections";
+        else if (isTuple())
+            return "tuples";
+        else if (isUDT())
+            return "user types";
+        else
+            return "types";
     }
 
     /**
@@ -692,25 +900,21 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * This must be overriden by subclasses if necessary so that for any
-     * AbstractType, this == TypeParser.parse(toString()).
+     * This must be overriden by subclasses if necessary so that for any type,
+     * {@code toString(x) == TypeParser.parse(toString(x))}.
      *
-     * Note that for backwards compatibility this includes the full classname.
-     * For CQL purposes the short name is fine.
+     * @param ignoreFreezing if true, the type string will not be wrapped with FrozenType(...), even if this type is
+     * frozen.
      */
-    @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
         return getClass().getName();
     }
 
-    public void checkComparable()
+    @Override
+    public final String toString()
     {
-        switch (comparisonType)
-        {
-            case NOT_COMPARABLE:
-                throw new IllegalArgumentException(this + " cannot be used in comparisons, so cannot be used as a clustering column");
-        }
+        return toString(false);
     }
 
     public final AssignmentTestable.TestResult testAssignment(String keyspace, ColumnSpecification receiver)
@@ -722,5 +926,17 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     public AbstractType<?> getCompatibleTypeIfKnown(String keyspace)
     {
         return this;
+    }
+
+    protected static <K, V extends AbstractType<?>> V getInstance(ConcurrentMap<K, V> instances, K key, Supplier<V> value)
+    {
+        V cached = instances.get(key);
+        if (cached != null)
+            return cached;
+
+        // We avoid constructor calls in Map#computeIfAbsent to avoid recursive update exceptions because the automatic
+        // fixing of subtypes done by the top-level constructor might attempt a recursive update to the instances map.
+        V instance = value.get();
+        return instances.computeIfAbsent(key, k -> instance);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/CompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CompositeType.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
@@ -70,10 +69,8 @@ public class CompositeType extends AbstractCompositeType
 {
     private static final int STATIC_MARKER = 0xFFFF;
 
-    public final List<AbstractType<?>> types;
-
     // interning instances
-    private static final ConcurrentMap<List<AbstractType<?>>, CompositeType> instances = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<ImmutableList<AbstractType<?>>, CompositeType> instances = new ConcurrentHashMap<>();
 
     public static CompositeType getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -82,10 +79,10 @@ public class CompositeType extends AbstractCompositeType
 
     public static CompositeType getInstance(Iterable<AbstractType<?>> types)
     {
-        return getInstance(Lists.newArrayList(types));
+        return getInstance(ImmutableList.copyOf(types));
     }
 
-    public static CompositeType getInstance(AbstractType... types)
+    public static CompositeType getInstance(AbstractType<?>... types)
     {
         return getInstance(Arrays.asList(types));
     }
@@ -93,7 +90,7 @@ public class CompositeType extends AbstractCompositeType
     @Override
     public CompositeType overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        return getInstance(types.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()));
+        return getInstance(subTypes.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()));
     }
 
     protected static int startingOffsetInternal(boolean isStatic)
@@ -136,25 +133,31 @@ public class CompositeType extends AbstractCompositeType
         return true;
     }
 
-    public static CompositeType getInstance(List<AbstractType<?>> types)
+    public static CompositeType getInstance(ImmutableList<AbstractType<?>> types)
     {
         assert types != null && !types.isEmpty();
-        CompositeType t = instances.get(types);
-        return null == t
-             ? instances.computeIfAbsent(types, CompositeType::new)
-             : t;
+        return getInstance(instances, types, () -> new CompositeType(types));
     }
 
-    protected CompositeType(List<AbstractType<?>> types)
+    protected CompositeType(ImmutableList<AbstractType<?>> types)
     {
-        this.types = ImmutableList.copyOf(types);
+        super(types);
+    }
+
+    @Override
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        if (isMultiCell)
+            throw new IllegalArgumentException("Cannot create a multi-cell CompositeType");
+
+        return getInstance(subTypes);
     }
 
     protected <V> AbstractType<?> getComparator(int i, V value, ValueAccessor<V> accessor, int offset)
     {
         try
         {
-            return types.get(i);
+            return subTypes.get(i);
         }
         catch (IndexOutOfBoundsException e)
         {
@@ -174,7 +177,7 @@ public class CompositeType extends AbstractCompositeType
 
     protected <V> AbstractType<?> getAndAppendComparator(int i, V value, ValueAccessor<V> accessor, StringBuilder sb, int offset)
     {
-        return types.get(i);
+        return subTypes.get(i);
     }
 
     @Override
@@ -183,7 +186,7 @@ public class CompositeType extends AbstractCompositeType
         if (data == null || accessor.isEmpty(data))
             return null;
 
-        ByteSource[] srcs = new ByteSource[types.size() * 2 + 1];
+        ByteSource[] srcs = new ByteSource[subTypes.size() * 2 + 1];
         int length = accessor.size(data);
 
         // statics go first
@@ -201,7 +204,7 @@ public class CompositeType extends AbstractCompositeType
 
             int componentLength = accessor.getUnsignedShort(data, offset);
             offset += 2;
-            srcs[i * 2 + 1] = types.get(i).asComparableBytes(accessor, accessor.slice(data, offset, componentLength), version);
+            srcs[i * 2 + 1] = subTypes.get(i).asComparableBytes(accessor, accessor.slice(data, offset, componentLength), version);
             offset += componentLength;
             lastEoc = accessor.getByte(data, offset);
             offset += 1;
@@ -234,17 +237,17 @@ public class CompositeType extends AbstractCompositeType
         int separator = comparableBytes.next();
         boolean isStatic = ByteSourceInverse.nextComponentNull(separator);
         int i = 0;
-        V[] buffers = accessor.createArray(types.size());
+        V[] buffers = accessor.createArray(subTypes.size());
         byte lastEoc = 0;
 
-        while ((separator = comparableBytes.next()) != ByteSource.TERMINATOR && i < types.size())
+        while ((separator = comparableBytes.next()) != ByteSource.TERMINATOR && i < subTypes.size())
         {
             // Only the end-of-component byte of the last component of this composite can be non-zero, so the
             // component before can't have a non-zero end-of-component byte.
             assert lastEoc == 0 : lastEoc;
 
             // Get the next type and decode its payload.
-            AbstractType<?> type = types.get(i);
+            AbstractType<?> type = subTypes.get(i);
             V decoded = type.fromComparableBytes(accessor,
                                                  ByteSourceInverse.nextComponentSource(comparableBytes, separator),
                                                  version);
@@ -257,14 +260,14 @@ public class CompositeType extends AbstractCompositeType
 
     protected ParsedComparator parseComparator(int i, String part)
     {
-        return new StaticParsedComparator(types.get(i), part);
+        return new StaticParsedComparator(subTypes.get(i), part);
     }
 
     protected <V> AbstractType<?> validateComparator(int i, V value, ValueAccessor<V> accessor, int offset) throws MarshalException
     {
-        if (i >= types.size())
+        if (i >= subTypes.size())
             throw new MarshalException("Too many bytes for comparator");
-        return types.get(i);
+        return subTypes.get(i);
     }
 
     protected <V> int getComparatorSize(V value, ValueAccessor<V> accessor, int offset)
@@ -272,14 +275,15 @@ public class CompositeType extends AbstractCompositeType
         return 0;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public ByteBuffer decompose(Object... objects)
     {
-        assert objects.length == types.size();
+        assert objects.length == subTypes.size();
 
         ByteBuffer[] serialized = new ByteBuffer[objects.length];
         for (int i = 0; i < objects.length; i++)
         {
-            ByteBuffer buffer = ((AbstractType) types.get(i)).decompose(objects[i]);
+            ByteBuffer buffer = ((AbstractType) subTypes.get(i)).decompose(objects[i]);
             serialized[i] = buffer;
         }
         return build(ByteBufferAccessor.instance, serialized);
@@ -290,7 +294,7 @@ public class CompositeType extends AbstractCompositeType
     {
         // Assume all components, we'll trunk the array afterwards if need be, but
         // most names will be complete.
-        ByteBuffer[] l = new ByteBuffer[types.size()];
+        ByteBuffer[] l = new ByteBuffer[subTypes.size()];
         ByteBuffer bb = name.duplicate();
         readStatic(bb);
         int i = 0;
@@ -341,12 +345,6 @@ public class CompositeType extends AbstractCompositeType
     }
 
     @Override
-    public List<AbstractType<?>> getComponents()
-    {
-        return types;
-    }
-
-    @Override
     public boolean isCompatibleWith(AbstractType<?> previous)
     {
         if (this == previous)
@@ -357,13 +355,13 @@ public class CompositeType extends AbstractCompositeType
 
         // Extending with new components is fine
         CompositeType cp = (CompositeType)previous;
-        if (types.size() < cp.types.size())
+        if (subTypes.size() < cp.subTypes.size())
             return false;
 
-        for (int i = 0; i < cp.types.size(); i++)
+        for (int i = 0; i < cp.subTypes.size(); i++)
         {
-            AbstractType tprev = cp.types.get(i);
-            AbstractType tnew = types.get(i);
+            AbstractType<?> tprev = cp.subTypes.get(i);
+            AbstractType<?> tnew = subTypes.get(i);
             if (!tnew.isCompatibleWith(tprev))
                 return false;
         }
@@ -381,13 +379,13 @@ public class CompositeType extends AbstractCompositeType
 
         // Extending with new components is fine
         CompositeType cp = (CompositeType) otherType;
-        if (types.size() < cp.types.size())
+        if (subTypes.size() < cp.subTypes.size())
             return false;
 
-        for (int i = 0; i < cp.types.size(); i++)
+        for (int i = 0; i < cp.subTypes.size(); i++)
         {
-            AbstractType tprev = cp.types.get(i);
-            AbstractType tnew = types.get(i);
+            AbstractType<?> tprev = cp.subTypes.get(i);
+            AbstractType<?> tnew = subTypes.get(i);
             if (!tnew.isValueCompatibleWith(tprev))
                 return false;
         }
@@ -397,7 +395,7 @@ public class CompositeType extends AbstractCompositeType
     @Override
     public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
     {
-        return any(types, t -> t.referencesUserType(name, accessor));
+        return any(subTypes, t -> t.referencesUserType(name, accessor));
     }
 
     @Override
@@ -406,15 +404,9 @@ public class CompositeType extends AbstractCompositeType
         if (!referencesUserType(udt.name))
             return this;
 
-        instances.remove(types);
+        instances.remove(subTypes);
 
-        return getInstance(transform(types, t -> t.withUpdatedUserType(udt)));
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(transform(types, AbstractType::expandUserTypes));
+        return getInstance(transform(subTypes, t -> t.withUpdatedUserType(udt)));
     }
 
     private static class StaticParsedComparator implements ParsedComparator
@@ -447,9 +439,11 @@ public class CompositeType extends AbstractCompositeType
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
-        return getClass().getName() + TypeParser.stringifyTypeParameters(types);
+        // Subtypes will always be frozen (since CompositeType always is), but we don't include it in the string
+        // representation (so that we ignore our parameter).
+        return getClass().getName() + TypeParser.stringifyTypeParameters(subTypes, true);
     }
 
     @SafeVarargs

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -133,6 +133,7 @@ public class ListType<T> extends CollectionType<List<T>>
         return serializer;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return compareListOrSet(getElementsType(), left, accessorL, right, accessorR);

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -19,12 +19,14 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Lists;
@@ -47,9 +49,7 @@ public class ListType<T> extends CollectionType<List<T>>
     private static final ConcurrentHashMap<AbstractType<?>, ListType> instances = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<AbstractType<?>, ListType> frozenInstances = new ConcurrentHashMap<>();
 
-    private final AbstractType<T> elements;
     public final ListSerializer<T> serializer;
-    private final boolean isMultiCell;
 
     public static ListType<?> getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -60,20 +60,21 @@ public class ListType<T> extends CollectionType<List<T>>
         return getInstance(l.get(0), true);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> ListType<T> getInstance(AbstractType<T> elements, boolean isMultiCell)
     {
-        ConcurrentHashMap<AbstractType<?>, ListType> internMap = isMultiCell ? instances : frozenInstances;
-        ListType<T> t = internMap.get(elements);
-        return null == t
-             ? internMap.computeIfAbsent(elements, k -> new ListType<>(k, isMultiCell))
-             : t;
+        return getInstance(isMultiCell ? instances : frozenInstances,
+                           elements,
+                           () -> new ListType<>(elements, isMultiCell));
     }
 
     @Override
     public ListType<T> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        AbstractType<T> newType = elements.overrideKeyspace(overrideKeyspace);
-        if (newType == elements)
+        AbstractType<T> oldType = getElementsType();
+        AbstractType<T> newType = oldType.overrideKeyspace(overrideKeyspace);
+
+        if (newType == oldType)
             return this;
 
         return getInstance(newType, isMultiCell());
@@ -81,33 +82,28 @@ public class ListType<T> extends CollectionType<List<T>>
 
     private ListType(AbstractType<T> elements, boolean isMultiCell)
     {
-        super(ComparisonType.CUSTOM, Kind.LIST);
-        this.elements = elements;
+        super(Kind.LIST, ImmutableList.of(elements), isMultiCell);
         this.serializer = ListSerializer.getInstance(elements.getSerializer());
-        this.isMultiCell = isMultiCell;
     }
 
     @Override
-    public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
+    @SuppressWarnings("unchecked")
+    public ListType<T> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
     {
-        return elements.referencesUserType(name, accessor);
+        Preconditions.checkArgument(subTypes.size() == 1,
+                                    "Invalid number of subTypes for ListType (got %s)", subTypes.size());
+        return getInstance((AbstractType<T>) subTypes.get(0), isMultiCell);
     }
 
     @Override
     public ListType<?> withUpdatedUserType(UserType udt)
     {
-        if (!referencesUserType(udt.name))
-            return this;
+        // If our subtypes do contain the UDT and this is requested, there is a fair chance we won't be re-using an
+        // instance with our own exact subtypes, so clean up the interned instance.
+        if (referencesUserType(udt.name))
+            (isMultiCell() ? instances : frozenInstances).remove(getElementsType());
 
-        (isMultiCell ? instances : frozenInstances).remove(elements);
-
-        return getInstance(elements.withUpdatedUserType(udt), isMultiCell);
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(elements.expandUserTypes(), isMultiCell);
+        return (ListType<?>) super.withUpdatedUserType(udt);
     }
 
     @Override
@@ -116,9 +112,10 @@ public class ListType<T> extends CollectionType<List<T>>
         return getElementsType().referencesDuration();
     }
 
+    @SuppressWarnings("unchecked")
     public AbstractType<T> getElementsType()
     {
-        return elements;
+        return (AbstractType<T>) subTypes.get(0);
     }
 
     public AbstractType<UUID> nameComparator()
@@ -128,7 +125,7 @@ public class ListType<T> extends CollectionType<List<T>>
 
     public AbstractType<T> valueComparator()
     {
-        return elements;
+        return getElementsType();
     }
 
     public ListSerializer<T> getSerializer()
@@ -136,56 +133,9 @@ public class ListType<T> extends CollectionType<List<T>>
         return serializer;
     }
 
-    @Override
-    public AbstractType<?> freeze()
-    {
-        if (isMultiCell)
-            return getInstance(this.elements, false);
-        else
-            return this;
-    }
-
-    @Override
-    public AbstractType<?> freezeNestedMulticellTypes()
-    {
-        if (!isMultiCell())
-            return this;
-
-        if (elements.isFreezable() && elements.isMultiCell())
-            return getInstance(elements.freeze(), isMultiCell);
-
-        return getInstance(elements.freezeNestedMulticellTypes(), isMultiCell);
-    }
-
-    @Override
-    public List<AbstractType<?>> subTypes()
-    {
-        return Collections.singletonList(elements);
-    }
-
-    @Override
-    public boolean isMultiCell()
-    {
-        return isMultiCell;
-    }
-
-    @Override
-    public boolean isCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        return this.elements.isCompatibleWith(((ListType) previous).elements);
-    }
-
-    @Override
-    public boolean isValueCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        return this.elements.isValueCompatibleWithInternal(((ListType) previous).elements);
-    }
-
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        return compareListOrSet(elements, left, accessorL, right, accessorR);
+        return compareListOrSet(getElementsType(), left, accessorL, right, accessorR);
     }
 
     static <VL, VR> int compareListOrSet(AbstractType<?> elementsComparator, VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
@@ -277,18 +227,18 @@ public class ListType<T> extends CollectionType<List<T>>
 
         StringBuilder sb = new StringBuilder();
         if (includeFrozenType)
-            sb.append(FrozenType.class.getName()).append("(");
+            sb.append(FrozenType.class.getName()).append('(');
         sb.append(getClass().getName());
-        sb.append(TypeParser.stringifyTypeParameters(Collections.<AbstractType<?>>singletonList(elements), ignoreFreezing || !isMultiCell));
+        sb.append(TypeParser.stringifyTypeParameters(subTypes, ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
-            sb.append(")");
+            sb.append(')');
         return sb.toString();
     }
 
     public List<ByteBuffer> serializedValues(Iterator<Cell<?>> cells)
     {
-        assert isMultiCell;
-        List<ByteBuffer> bbs = new ArrayList<ByteBuffer>();
+        assert isMultiCell();
+        List<ByteBuffer> bbs = new ArrayList<>();
         while (cells.hasNext())
             bbs.add(cells.next().buffer());
         return bbs;
@@ -304,19 +254,19 @@ public class ListType<T> extends CollectionType<List<T>>
             throw new MarshalException(String.format(
                     "Expected a list, but got a %s: %s", parsed.getClass().getSimpleName(), parsed));
 
-        List list = (List) parsed;
+        List<?> list = (List<?>) parsed;
         List<Term> terms = new ArrayList<>(list.size());
         for (Object element : list)
         {
             if (element == null)
                 throw new MarshalException("Invalid null element in list");
-            terms.add(elements.fromJSONObject(element));
+            terms.add(getElementsType().fromJSONObject(element));
         }
 
         return new Lists.DelayedValue(terms);
     }
 
-    public static String setOrListToJsonString(ByteBuffer buffer, AbstractType elementsType, ProtocolVersion protocolVersion)
+    public static String setOrListToJsonString(ByteBuffer buffer, AbstractType<?> elementsType, ProtocolVersion protocolVersion)
     {
         ByteBuffer value = buffer.duplicate();
         StringBuilder sb = new StringBuilder("[");
@@ -330,18 +280,12 @@ public class ListType<T> extends CollectionType<List<T>>
             offset += CollectionSerializer.sizeOfValue(element, ByteBufferAccessor.instance, protocolVersion);
             sb.append(elementsType.toJSONString(element, protocolVersion));
         }
-        return sb.append("]").toString();
-    }
-
-    public ByteBuffer getSliceFromSerialized(ByteBuffer collection, ByteBuffer from, ByteBuffer to)
-    {
-        // We don't support slicing on lists so we don't need that function
-        throw new UnsupportedOperationException();
+        return sb.append(']').toString();
     }
 
     @Override
     public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
     {
-        return setOrListToJsonString(buffer, elements, protocolVersion);
+        return setOrListToJsonString(buffer, getElementsType(), protocolVersion);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -139,6 +139,7 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
         return getValuesType();
     }
 
+    @Override
     public <RL, TR> int compareCustom(RL left, ValueAccessor<RL> accessorL, TR right, ValueAccessor<TR> accessorR)
     {
         return compareMaps(getKeysType(), getValuesType(), left, accessorL, right, accessorR);
@@ -257,6 +258,7 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
         return values.size() / 2;
     }
 
+    @Override
     public String toString(boolean ignoreFreezing)
     {
         boolean includeFrozenType = !ignoreFreezing && !isMultiCell();

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -22,6 +22,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Maps;
 import org.apache.cassandra.cql3.Term;
@@ -43,10 +46,7 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
     private static final ConcurrentHashMap<Pair<AbstractType<?>, AbstractType<?>>, MapType> instances = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<Pair<AbstractType<?>, AbstractType<?>>, MapType> frozenInstances = new ConcurrentHashMap<>();
 
-    private final AbstractType<K> keys;
-    private final AbstractType<V> values;
     private final MapSerializer<K, V> serializer;
-    private final boolean isMultiCell;
 
     public static MapType<?, ?> getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -57,23 +57,24 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
         return getInstance(l.get(0), l.get(1), true);
     }
 
+    @SuppressWarnings("unchecked")
     public static <K, V> MapType<K, V> getInstance(AbstractType<K> keys, AbstractType<V> values, boolean isMultiCell)
     {
-        ConcurrentHashMap<Pair<AbstractType<?>, AbstractType<?>>, MapType> internMap = isMultiCell ? instances : frozenInstances;
-        Pair<AbstractType<?>, AbstractType<?>> p = Pair.create(keys, values);
-        MapType<K, V> t = internMap.get(p);
-        return null == t
-             ? internMap.computeIfAbsent(p, k -> new MapType<>(k.left, k.right, isMultiCell))
-             : t;
+        return getInstance(isMultiCell ? instances : frozenInstances,
+                           Pair.create(keys, values),
+                           () -> new MapType<>(keys, values, isMultiCell));
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public MapType<K,V> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        AbstractType<K> newKeyType = keys.overrideKeyspace(overrideKeyspace);
-        AbstractType<V> newValueType = values.overrideKeyspace(overrideKeyspace);
-        if (newKeyType == keys && newValueType == values)
+        AbstractType<K> oldKeyType = getKeysType();
+        AbstractType<V> oldValueType = getValuesType();
+
+        AbstractType<K> newKeyType = oldKeyType.overrideKeyspace(overrideKeyspace);
+        AbstractType<V> newValueType = oldValueType.overrideKeyspace(overrideKeyspace);
+
+        if (newKeyType == oldKeyType && newValueType == oldValueType)
             return this;
 
         return getInstance(newKeyType, newValueType, isMultiCell());
@@ -81,36 +82,30 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
 
     private MapType(AbstractType<K> keys, AbstractType<V> values, boolean isMultiCell)
     {
-        super(ComparisonType.CUSTOM, Kind.MAP);
-        this.keys = keys;
-        this.values = values;
+        super(Kind.MAP, ImmutableList.of(keys, values), isMultiCell);
         this.serializer = MapSerializer.getInstance(keys.getSerializer(),
                                                     values.getSerializer(),
                                                     keys.comparatorSet);
-        this.isMultiCell = isMultiCell;
     }
 
     @Override
-    public <T> boolean referencesUserType(T name, ValueAccessor<T> accessor)
+    @SuppressWarnings("unchecked")
+    public MapType<K, V> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
     {
-        return keys.referencesUserType(name, accessor) || values.referencesUserType(name, accessor);
+        Preconditions.checkArgument(subTypes.size() == 2,
+                                    "Invalid number of subTypes for MapType (got %s)", subTypes.size());
+        return getInstance((AbstractType<K>)subTypes.get(0), (AbstractType<V>)subTypes.get(1), isMultiCell);
     }
 
     @Override
     public MapType<?,?> withUpdatedUserType(UserType udt)
     {
-        if (!referencesUserType(udt.name))
-            return this;
+        // If our subtypes do contain the UDT and this is requested, there is a fair chance we won't be re-using an
+        // instance with our own exact subtypes, so clean up the interned instance.
+        if (referencesUserType(udt.name))
+            (isMultiCell() ? instances : frozenInstances).remove(Pair.create(getKeysType(), getValuesType()));
 
-        (isMultiCell ? instances : frozenInstances).remove(Pair.create(keys, values));
-
-        return getInstance(keys.withUpdatedUserType(udt), values.withUpdatedUserType(udt), isMultiCell);
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(keys.expandUserTypes(), values.expandUserTypes(), isMultiCell);
+        return (MapType<?, ?>) super.withUpdatedUserType(udt);
     }
 
     @Override
@@ -120,83 +115,33 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
         return getValuesType().referencesDuration();
     }
 
+    @SuppressWarnings("unchecked")
     public AbstractType<K> getKeysType()
     {
-        return keys;
+        return (AbstractType<K>) subTypes.get(0);
     }
 
+    @SuppressWarnings("unchecked")
     public AbstractType<V> getValuesType()
     {
-        return values;
+        return (AbstractType<V>) subTypes.get(1);
     }
 
+    @Override
     public AbstractType<K> nameComparator()
     {
-        return keys;
+        return getKeysType();
     }
 
+    @Override
     public AbstractType<V> valueComparator()
     {
-        return values;
-    }
-
-    @Override
-    public boolean isMultiCell()
-    {
-        return isMultiCell;
-    }
-
-    @Override
-    public List<AbstractType<?>> subTypes()
-    {
-        return Arrays.asList(keys, values);
-    }
-
-    @Override
-    public AbstractType<?> freeze()
-    {
-        if (isMultiCell)
-            return getInstance(this.keys, this.values, false);
-        else
-            return this;
-    }
-
-    @Override
-    public AbstractType<?> freezeNestedMulticellTypes()
-    {
-        if (!isMultiCell())
-            return this;
-
-        AbstractType<?> keyType = (keys.isFreezable() && keys.isMultiCell())
-                                ? keys.freeze()
-                                : keys.freezeNestedMulticellTypes();
-
-        AbstractType<?> valueType = (values.isFreezable() && values.isMultiCell())
-                                  ? values.freeze()
-                                  : values.freezeNestedMulticellTypes();
-
-        return getInstance(keyType, valueType, isMultiCell);
-    }
-
-    @Override
-    public boolean isCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        MapType tprev = (MapType) previous;
-        return keys.isCompatibleWith(tprev.keys) && values.isCompatibleWith(tprev.values);
-    }
-
-    @Override
-    public boolean isValueCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        MapType tprev = (MapType) previous;
-        return keys.isCompatibleWith(tprev.keys) && values.isValueCompatibleWith(tprev.values);
+        return getValuesType();
     }
 
     public <RL, TR> int compareCustom(RL left, ValueAccessor<RL> accessorL, TR right, ValueAccessor<TR> accessorR)
     {
-        return compareMaps(keys, values, left, accessorL, right, accessorR);
+        return compareMaps(getKeysType(), getValuesType(), left, accessorL, right, accessorR);
     }
 
     public static <TL, TR> int compareMaps(AbstractType<?> keysComparator, AbstractType<?> valuesComparator, TL left, ValueAccessor<TL> accessorL, TR right, ValueAccessor<TR> accessorR)
@@ -235,13 +180,13 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
     }
 
     @Override
-    public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, Version version)
+    public <T> ByteSource asComparableBytes(ValueAccessor<T> accessor, T data, Version version)
     {
         return asComparableBytesMap(getKeysType(), getValuesType(), accessor, data, version);
     }
 
     @Override
-    public <V> V fromComparableBytes(ValueAccessor<V> accessor, ByteSource.Peekable comparableBytes, Version version)
+    public <T> T fromComparableBytes(ValueAccessor<T> accessor, ByteSource.Peekable comparableBytes, Version version)
     {
         return fromComparableBytesMap(accessor, comparableBytes, version, getKeysType(), getValuesType());
     }
@@ -318,17 +263,18 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
 
         StringBuilder sb = new StringBuilder();
         if (includeFrozenType)
-            sb.append(FrozenType.class.getName()).append("(");
-        sb.append(getClass().getName()).append(TypeParser.stringifyTypeParameters(Arrays.asList(keys, values), ignoreFreezing || !isMultiCell));
+            sb.append(FrozenType.class.getName()).append('(');
+        sb.append(getClass().getName())
+          .append(TypeParser.stringifyTypeParameters(subTypes, ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
-            sb.append(")");
+            sb.append(')');
         return sb.toString();
     }
 
     public List<ByteBuffer> serializedValues(Iterator<Cell<?>> cells)
     {
-        assert isMultiCell;
-        List<ByteBuffer> bbs = new ArrayList<ByteBuffer>();
+        assert isMultiCell();
+        List<ByteBuffer> bbs = new ArrayList<>();
         while (cells.hasNext())
         {
             Cell<?> c = cells.next();
@@ -348,9 +294,11 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
             throw new MarshalException(String.format(
                     "Expected a map, but got a %s: %s", parsed.getClass().getSimpleName(), parsed));
 
-        Map<Object, Object> map = (Map<Object, Object>) parsed;
+        Map<?, ?> map = (Map<?, ?>) parsed;
         Map<Term, Term> terms = new HashMap<>(map.size());
-        for (Map.Entry<Object, Object> entry : map.entrySet())
+        AbstractType<K> keys = getKeysType();
+        AbstractType<V> values = getValuesType();
+        for (Map.Entry<?, ?> entry : map.entrySet())
         {
             if (entry.getKey() == null)
                 throw new MarshalException("Invalid null key in map");
@@ -370,6 +318,8 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
         StringBuilder sb = new StringBuilder("{");
         int size = CollectionSerializer.readCollectionSize(value, ByteBufferAccessor.instance, protocolVersion);
         int offset = CollectionSerializer.sizeOfCollectionSize(size, protocolVersion);
+        AbstractType<K> keys = getKeysType();
+        AbstractType<V> values = getValuesType();
         for (int i = 0; i < size; i++)
         {
             if (i > 0)
@@ -389,6 +339,6 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
             offset += CollectionSerializer.sizeOfValue(vv, ByteBufferAccessor.instance, protocolVersion);
             sb.append(values.toJSONString(vv, protocolVersion));
         }
-        return sb.append("}").toString();
+        return sb.append('}').toString();
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellPath;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+/**
+ * Base class for all types that have the capacity of being multi-cell (when not frozen).
+ *
+ * <p>A multi-cell type is one whose value is composed of multiple sub-values that are layout on multiple {@link Cell}
+ * (one for each sub-value), typically collections. Being layout on multiple cell allows partial update (of only some
+ * of the sub-values) without read-before write.
+ *
+ * <p>All multi-cell capable types can either be used as truly multi-cell types, or can be used frozen. In the later
+ * case, the values are not layout in multiple cells, but instead the whole value (with all its sub-values) is packed
+ * within a single cell value (which imply no partial update without read-before-write in particular).
+ * {@link #isMultiCell()} allows to know if a given type is a multi-cell variant or a frozen one (both are technically
+ * 2 different types, that have the same values from a user point of view, just with different capability).
+ *
+ * @param <T> the type of the values of this type.
+ */
+public abstract class MultiCellCapableType<T> extends AbstractType<T>
+{
+
+    protected MultiCellCapableType(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        super(ComparisonType.CUSTOM, isMultiCell, subTypes);
+    }
+
+    // Overriding as abstract to make subclass don't rely on the default implementation, as it's not appropriate.
+    @Override
+    public abstract AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell);
+
+    /**
+     * The subtype/comparator to use for the {@link CellPath} part of cells forming values for this type when used in
+     * its multi-cell variant.
+     *
+     * <p>Note: in theory, we shouldn't have to access this on frozen instances (where {@code isMultiCell() == false}),
+     * but for convenience, it is expected that this method always returns a proper value "as if" the type was a
+     * multi-cell variant, even if it is not.
+     *
+     * @return the comparator for the {@link CellPath} component of cells of this type.
+     */
+    public abstract AbstractType<?> nameComparator();
+
+    public abstract ByteBuffer serializeForNativeProtocol(Iterator<Cell<?>> cells, ProtocolVersion version);
+
+    /**
+     * Whether {@code this} type is compatible (including for sorting) with {@code previous}, assuming both are
+     * of the same class (so {@code previous} can be safely cast to whichever class implements this) and both are
+     * frozen.
+     */
+    protected abstract boolean isCompatibleWhenFrozenWith(AbstractType<?> previous);
+
+    /**
+     * Whether {@code this} type is compatible (including for sorting) with {@code previous}, assuming both are
+     * of the same class (so {@code previous} can be safely cast to whichever class implements this) but neither
+     * are frozen.
+     */
+    protected abstract boolean isCompatibleWhenNonFrozenWith(AbstractType<?> previous);
+
+    /**
+     * Whether {@code this} type is value-compatible with {@code previous}, assuming both are of the same class (so
+     * {@code previous} can be safely cast to whichever class implements this) and both are are frozen.
+     */
+    protected abstract boolean isValueCompatibleWhenFrozenWith(AbstractType<?> previous);
+
+    /**
+     *  Whether {@code this} type is equal to {@code that} type, assuming both are of the same class (so
+     * {@code that} can be safely cast to whichever class implements this), that
+     * {@code this.isMultiCell() == that.isMultiCell()} and that {@code this.subTypes().equals(that.subTypes())}.
+     */
+    protected abstract boolean equalsNoFrozenNoSubtypes(AbstractType<?> that);
+
+    @Override
+    public final boolean isCompatibleWith(AbstractType<?> previous)
+    {
+        if (this == previous)
+            return true;
+
+        if (!getClass().equals(previous.getClass()))
+            return false;
+
+        if (isMultiCell() != previous.isMultiCell())
+            return false;
+
+        return isMultiCell() ? isCompatibleWhenNonFrozenWith(previous) : isCompatibleWhenFrozenWith(previous);
+    }
+
+    @Override
+    protected final boolean isValueCompatibleWithInternal(AbstractType<?> previous)
+    {
+        if (this == previous)
+            return true;
+
+        if (!getClass().equals(previous.getClass()))
+            return false;
+
+        if (isMultiCell() != previous.isMultiCell())
+            return false;
+
+        // For multi-cell, there is no difference between compatible and value-compatible: multi-cell types can only be
+        // used as non-primary key column values, and so in a way are always checked for "value compatibility". Though
+        // even when compared as values, they have sub-parts that end up in a CellPath, which are sorted, and may thus
+        // require sorted compatibility. It would almost make sense to reject isCompatibleWith when types are
+        // multi-cell, but that could be a tad error prone/inconvenient, so instead we just make both versions do the
+        // same thing (hence the call to isCompatibleWhenNonFrozenWith like in isCompatibleWith).
+        return isMultiCell() ? isCompatibleWhenNonFrozenWith(previous) : isValueCompatibleWhenFrozenWith(previous);
+    }
+
+    @Override
+    public final boolean equals(Object that)
+    {
+        if (this == that)
+            return true;
+
+        if (!getClass().equals(that.getClass()))
+            return false;
+
+        AbstractType<?> other = (AbstractType<?>) that;
+        return isMultiCell() == other.isMultiCell()
+               && subTypes.equals(other.subTypes)
+               && equalsNoFrozenNoSubtypes(other);
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
@@ -50,7 +50,7 @@ public abstract class MultiCellCapableType<T> extends AbstractType<T>
         super(ComparisonType.CUSTOM, isMultiCell, subTypes);
     }
 
-    // Overriding as abstract to make subclass don't rely on the default implementation, as it's not appropriate.
+    // Overriding as abstract to prevent subclasses from relying on the default implementation, as it's not appropriate.
     @Override
     public abstract AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell);
 

--- a/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
+++ b/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
@@ -136,7 +136,7 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
         return String.format("%s(%s)", getClass().getName(), partitioner.getClass().getName());
     }

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -23,6 +23,11 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -34,25 +39,49 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class ReversedType<T> extends AbstractType<T>
 {
+    private static final Logger logger = LoggerFactory.getLogger(ReversedType.class);
+
     // interning instances
     private static final Map<AbstractType<?>, ReversedType> instances = new ConcurrentHashMap<>();
 
     public final AbstractType<T> baseType;
 
-    public static <T> ReversedType<T> getInstance(TypeParser parser)
+    public static AbstractType<?> getInstance(TypeParser parser)
     {
         List<AbstractType<?>> types = parser.getTypeParameters();
         if (types.size() != 1)
             throw new ConfigurationException("ReversedType takes exactly one argument, " + types.size() + " given");
-        return getInstance((AbstractType<T>) types.get(0));
+        return getInstance(types.get(0));
     }
 
-    public static <T> ReversedType<T> getInstance(AbstractType<T> baseType)
+    @SuppressWarnings("unchecked")
+    public static <T> AbstractType<T> getInstance(AbstractType<T> baseType)
     {
-        ReversedType<T> t = instances.get(baseType);
-        return null == t
-             ? instances.computeIfAbsent(baseType, ReversedType::new)
-             : t;
+        ReversedType<T> type = instances.get(baseType);
+        if (type != null)
+            return type;
+
+        // Stacking ReversedType is really useless and would actually break some of the code (typically,
+        // AbstractType#isValueCompatibleWith would end up hitting the exception thrown by
+        // ReversedType#isValueCompatibleWithInternal). So we should throw if we find such stacking. But at the
+        // same time, we can't be 100% no-one ever made that mistake somewhere, and it went un-noticed and it's
+        // probably not worth risking breaking them. So we log an error but otherwise "cancel-out" the double
+        // reverse.
+        if (baseType instanceof ReversedType)
+        {
+            // Note: users have no way to input ReversedType outside custom types (which are pretty
+            // confidential in the first place), so if this is ever triggered, this will likely be an internal but.
+            // So shipping an exception in the logger output to get a stack trace and make debugging easier.
+            logger.error("Detected a type with 2 ReversedType() back-to-back, which is not allowed. This should "
+                         + "be looked at as this is likely unintended, but cancelling out the double reversion in "
+                         + "the meantime", new RuntimeException("Invalid double-reversion"));
+            return ((ReversedType<T>)baseType).baseType;
+        }
+
+        // We avoid constructor calls in Map#computeIfAbsent to avoid recursive update exceptions because the automatic
+        // fixing of subtypes done by the top-level constructor might attempt a recursive update to the instances map.
+        ReversedType<T> instance = new ReversedType<>(baseType);
+        return instances.computeIfAbsent(baseType, k -> instance);
     }
 
     @Override
@@ -67,8 +96,17 @@ public class ReversedType<T> extends AbstractType<T>
 
     private ReversedType(AbstractType<T> baseType)
     {
-        super(ComparisonType.CUSTOM);
+
+        super(ComparisonType.CUSTOM, baseType.isMultiCell(), ImmutableList.of(baseType));
         this.baseType = baseType;
+    }
+
+    @Override
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        Preconditions.checkArgument(subTypes.size() == 1,
+                                    "Invalid number of subTypes for ReversedType (got %s)", subTypes.size());
+        return getInstance(subTypes.get(0));
     }
 
     public boolean isEmptyValueMeaningless()
@@ -145,9 +183,9 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public boolean isValueCompatibleWith(AbstractType<?> otherType)
+    protected boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
-        return this.baseType.isValueCompatibleWith(otherType);
+        throw new AssertionError("This should never have been called on the ReversedType");
     }
 
     @Override
@@ -162,19 +200,7 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
-    {
-        return baseType.referencesUserType(name, accessor);
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(baseType.expandUserTypes());
-    }
-
-    @Override
-    public ReversedType<?> withUpdatedUserType(UserType udt)
+    public AbstractType<?> withUpdatedUserType(UserType udt)
     {
         if (!referencesUserType(udt.name))
             return this;
@@ -197,9 +223,9 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
-        return getClass().getName() + "(" + baseType + ")";
+        return getClass().getName() + '(' + baseType + ')';
     }
 
     private static final class ReversedPeekableByteSource extends ByteSource.Peekable

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -22,6 +22,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Sets;
 import org.apache.cassandra.cql3.Term;
@@ -40,9 +43,7 @@ public class SetType<T> extends CollectionType<Set<T>>
     private static final ConcurrentHashMap<AbstractType<?>, SetType> instances = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<AbstractType<?>, SetType> frozenInstances = new ConcurrentHashMap<>();
 
-    private final AbstractType<T> elements;
     private final SetSerializer<T> serializer;
-    private final boolean isMultiCell;
 
     public static SetType<?> getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -53,64 +54,61 @@ public class SetType<T> extends CollectionType<Set<T>>
         return getInstance(l.get(0), true);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> SetType<T> getInstance(AbstractType<T> elements, boolean isMultiCell)
     {
-        ConcurrentHashMap<AbstractType<?>, SetType> internMap = isMultiCell ? instances : frozenInstances;
-        SetType<T> t = internMap.get(elements);
-        return null == t
-             ? internMap.computeIfAbsent(elements, k -> new SetType<>(k, isMultiCell))
-             : t;
+        return getInstance(isMultiCell ? instances : frozenInstances,
+                           elements,
+                           () -> new SetType<>(elements, isMultiCell));
     }
 
     @Override
     public SetType<T> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        AbstractType<T> newType = elements.overrideKeyspace(overrideKeyspace);
-        if (newType == elements)
+        AbstractType<T> oldType = getElementsType();
+        AbstractType<T> newType = oldType.overrideKeyspace(overrideKeyspace);
+
+        if (newType == oldType)
             return this;
 
         return getInstance(newType, isMultiCell());
     }
 
-    public SetType(AbstractType<T> elements, boolean isMultiCell)
+    private SetType(AbstractType<T> elements, boolean isMultiCell)
     {
-        super(ComparisonType.CUSTOM, Kind.SET);
-        this.elements = elements;
+        super(Kind.SET, ImmutableList.of(elements), isMultiCell);
         this.serializer = SetSerializer.getInstance(elements.getSerializer(), elements.comparatorSet);
-        this.isMultiCell = isMultiCell;
     }
 
     @Override
-    public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
+    @SuppressWarnings("unchecked")
+    public SetType<T> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
     {
-        return elements.referencesUserType(name, accessor);
+        Preconditions.checkArgument(subTypes.size() == 1,
+                                    "Invalid number of subTypes for SetType (got %s)", subTypes.size());
+        return getInstance((AbstractType<T>) subTypes.get(0), isMultiCell);
     }
 
     @Override
     public SetType<?> withUpdatedUserType(UserType udt)
     {
-        if (!referencesUserType(udt.name))
-            return this;
+        // If our subtypes do contain the UDT and this is requested, there is a fair chance we won't be re-using an
+        // instance with our own exact subtypes, so clean up the interned instance.
+        if (referencesUserType(udt.name))
+            (isMultiCell() ? instances : frozenInstances).remove(getElementsType());
 
-        (isMultiCell ? instances : frozenInstances).remove(elements);
-
-        return getInstance(elements.withUpdatedUserType(udt), isMultiCell);
+        return (SetType<?>) super.withUpdatedUserType(udt);
     }
 
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(elements.expandUserTypes(), isMultiCell);
-    }
-
+    @SuppressWarnings("unchecked")
     public AbstractType<T> getElementsType()
     {
-        return elements;
+        return (AbstractType<T>) subTypes.get(0);
     }
 
     public AbstractType<T> nameComparator()
     {
-        return elements;
+        return getElementsType();
     }
 
     public AbstractType<?> valueComparator()
@@ -118,56 +116,9 @@ public class SetType<T> extends CollectionType<Set<T>>
         return EmptyType.instance;
     }
 
-    @Override
-    public boolean isMultiCell()
-    {
-        return isMultiCell;
-    }
-
-    @Override
-    public AbstractType<?> freeze()
-    {
-        if (isMultiCell)
-            return getInstance(this.elements, false);
-        else
-            return this;
-    }
-
-    @Override
-    public List<AbstractType<?>> subTypes()
-    {
-        return Collections.singletonList(elements);
-    }
-
-    @Override
-    public AbstractType<?> freezeNestedMulticellTypes()
-    {
-        if (!isMultiCell())
-            return this;
-
-        if (elements.isFreezable() && elements.isMultiCell())
-            return getInstance(elements.freeze(), isMultiCell);
-
-        return getInstance(elements.freezeNestedMulticellTypes(), isMultiCell);
-    }
-
-    @Override
-    public boolean isCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        return this.elements.isCompatibleWith(((SetType) previous).elements);
-    }
-
-    @Override
-    public boolean isValueCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        // because sets are ordered, any changes to the type must maintain the ordering
-        return isCompatibleWithFrozen(previous);
-    }
-
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        return ListType.compareListOrSet(elements, left, accessorL, right, accessorR);
+        return ListType.compareListOrSet(getElementsType(), left, accessorL, right, accessorR);
     }
 
     @Override
@@ -194,17 +145,17 @@ public class SetType<T> extends CollectionType<Set<T>>
 
         StringBuilder sb = new StringBuilder();
         if (includeFrozenType)
-            sb.append(FrozenType.class.getName()).append("(");
+            sb.append(FrozenType.class.getName()).append('(');
         sb.append(getClass().getName());
-        sb.append(TypeParser.stringifyTypeParameters(Collections.<AbstractType<?>>singletonList(elements), ignoreFreezing || !isMultiCell));
+        sb.append(TypeParser.stringifyTypeParameters(subTypes, ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
-            sb.append(")");
+            sb.append(')');
         return sb.toString();
     }
 
     public List<ByteBuffer> serializedValues(Iterator<Cell<?>> cells)
     {
-        List<ByteBuffer> bbs = new ArrayList<ByteBuffer>();
+        List<ByteBuffer> bbs = new ArrayList<>();
         while (cells.hasNext())
             bbs.add(cells.next().path().get(0));
         return bbs;
@@ -220,8 +171,9 @@ public class SetType<T> extends CollectionType<Set<T>>
             throw new MarshalException(String.format(
                     "Expected a list (representing a set), but got a %s: %s", parsed.getClass().getSimpleName(), parsed));
 
-        List list = (List) parsed;
+        List<?> list = (List<?>) parsed;
         Set<Term> terms = new HashSet<>(list.size());
+        AbstractType<T> elements = getElementsType();
         for (Object element : list)
         {
             if (element == null)
@@ -235,6 +187,6 @@ public class SetType<T> extends CollectionType<Set<T>>
     @Override
     public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
     {
-        return ListType.setOrListToJsonString(buffer, elements, protocolVersion);
+        return ListType.setOrListToJsonString(buffer, getElementsType(), protocolVersion);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -116,6 +116,7 @@ public class SetType<T> extends CollectionType<Set<T>>
         return EmptyType.instance;
     }
 
+    @Override
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         return ListType.compareListOrSet(getElementsType(), left, accessorL, right, accessorR);

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +45,7 @@ import static org.apache.cassandra.cql3.ColumnIdentifier.maybeQuote;
 
 /**
  * A user defined type.
- *
+ * <p>
  * A user type is really just a tuple type on steroids.
  */
 public class UserType extends TupleType implements SchemaElement
@@ -58,18 +58,29 @@ public class UserType extends TupleType implements SchemaElement
     public final ByteBuffer name;
     private final List<FieldIdentifier> fieldNames;
     private final List<String> stringFieldNames;
-    private final boolean isMultiCell;
     private final UserTypeSerializer serializer;
 
-    public UserType(String keyspace, ByteBuffer name, List<FieldIdentifier> fieldNames, List<AbstractType<?>> fieldTypes, boolean isMultiCell)
+    public UserType(String keyspace,
+                    ByteBuffer name,
+                    List<FieldIdentifier> fieldNames,
+                    List<AbstractType<?>> fieldTypes,
+                    boolean isMultiCell)
     {
-        super(fieldTypes, false);
+        this(keyspace, name, fieldNames, ImmutableList.copyOf(fieldTypes), isMultiCell);
+    }
+
+    public UserType(String keyspace,
+                    ByteBuffer name,
+                    List<FieldIdentifier> fieldNames,
+                    ImmutableList<AbstractType<?>> fieldTypes,
+                    boolean isMultiCell)
+    {
+        super(fieldTypes, isMultiCell);
         assert fieldNames.size() == fieldTypes.size();
         this.keyspace = keyspace;
         this.name = name;
         this.fieldNames = fieldNames;
         this.stringFieldNames = new ArrayList<>(fieldNames.size());
-        this.isMultiCell = isMultiCell;
 
         LinkedHashMap<String , TypeSerializer<?>> fieldSerializers = new LinkedHashMap<>(fieldTypes.size());
         for (int i = 0, m = fieldNames.size(); i < m; i++)
@@ -85,12 +96,12 @@ public class UserType extends TupleType implements SchemaElement
 
     public static UserType getInstance(TypeParser parser)
     {
-        Pair<Pair<String, ByteBuffer>, List<Pair<ByteBuffer, AbstractType>>> params = parser.getUserTypeParameters();
+        Pair<Pair<String, ByteBuffer>, List<Pair<ByteBuffer, AbstractType<?>>>> params = parser.getUserTypeParameters();
         String keyspace = params.left.left;
         ByteBuffer name = params.left.right;
         List<FieldIdentifier> columnNames = new ArrayList<>(params.right.size());
         List<AbstractType<?>> columnTypes = new ArrayList<>(params.right.size());
-        for (Pair<ByteBuffer, AbstractType> p : params.right)
+        for (Pair<ByteBuffer, AbstractType<?>> p : params.right)
         {
             columnNames.add(new FieldIdentifier(p.left));
             columnTypes.add(p.right);
@@ -100,13 +111,23 @@ public class UserType extends TupleType implements SchemaElement
     }
 
     @Override
+    public UserType with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        return new UserType(keyspace, name, fieldNames, subTypes, isMultiCell);
+    }
+
+    @Override
     public UserType overrideKeyspace(Function<String, String> overrideKeyspace)
     {
         String newKeyspace = overrideKeyspace.apply(keyspace);
         if (newKeyspace.equals(keyspace))
             return this;
 
-        return new UserType(newKeyspace, name, fieldNames, types.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()), isMultiCell());
+        return new UserType(newKeyspace,
+                            name,
+                            fieldNames,
+                            subTypes.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()),
+                            isMultiCell());
     }
 
     @Override
@@ -120,18 +141,6 @@ public class UserType extends TupleType implements SchemaElement
         return false;
     }
 
-    @Override
-    public boolean isMultiCell()
-    {
-        return isMultiCell;
-    }
-
-    @Override
-    public boolean isFreezable()
-    {
-        return true;
-    }
-
     public AbstractType<?> fieldType(int i)
     {
         return type(i);
@@ -139,7 +148,7 @@ public class UserType extends TupleType implements SchemaElement
 
     public List<AbstractType<?>> fieldTypes()
     {
-        return types;
+        return subTypes;
     }
 
     public FieldIdentifier fieldName(int i)
@@ -173,39 +182,9 @@ public class UserType extends TupleType implements SchemaElement
         return CellPath.create(ByteBufferUtil.bytes((short)fieldPosition(fieldName)));
     }
 
-    public ShortType nameComparator()
-    {
-        return ShortType.instance;
-    }
-
-    public ByteBuffer serializeForNativeProtocol(Iterator<Cell<?>> cells, ProtocolVersion protocolVersion)
-    {
-        assert isMultiCell;
-
-        ByteBuffer[] components = new ByteBuffer[size()];
-        short fieldPosition = 0;
-        while (cells.hasNext())
-        {
-            Cell<?> cell = cells.next();
-
-            // handle null fields that aren't at the end
-            short fieldPositionOfCell = ByteBufferUtil.toShort(cell.path().get(0));
-            while (fieldPosition < fieldPositionOfCell)
-                components[fieldPosition++] = null;
-
-            components[fieldPosition++] = cell.buffer();
-        }
-
-        // append trailing nulls for missing cells
-        while (fieldPosition < size())
-            components[fieldPosition++] = null;
-
-        return TupleType.buildValue(components);
-    }
-
     public <V> void validateCell(Cell<V> cell) throws MarshalException
     {
-        if (isMultiCell)
+        if (isMultiCell())
         {
             ByteBuffer path = cell.path().get(0);
             nameComparator().validate(path);
@@ -232,13 +211,13 @@ public class UserType extends TupleType implements SchemaElement
 
         Json.handleCaseSensitivity(map);
 
-        List<Term> terms = new ArrayList<>(types.size());
+        List<Term> terms = new ArrayList<>(size());
 
-        Set keys = map.keySet();
-        assert keys.isEmpty() || keys.iterator().next() instanceof String;
+        Set<String> keys = map.keySet();
+        assert keys.isEmpty() || keys.iterator().next() != null;
 
         int foundValues = 0;
-        for (int i = 0; i < types.size(); i++)
+        for (int i = 0; i < size(); i++)
         {
             Object value = map.get(stringFieldNames.get(i));
             if (value == null)
@@ -247,7 +226,7 @@ public class UserType extends TupleType implements SchemaElement
             }
             else
             {
-                terms.add(types.get(i).fromJSONObject(value));
+                terms.add(subTypes.get(i).fromJSONObject(value));
                 foundValues += 1;
             }
         }
@@ -255,7 +234,7 @@ public class UserType extends TupleType implements SchemaElement
         // check for extra, unrecognized fields
         if (foundValues != map.size())
         {
-            for (Object fieldName : keys)
+            for (String fieldName : keys)
             {
                 if (!stringFieldNames.contains(fieldName))
                     throw new MarshalException(String.format(
@@ -271,14 +250,14 @@ public class UserType extends TupleType implements SchemaElement
     {
         ByteBuffer[] buffers = split(ByteBufferAccessor.instance, buffer);
         StringBuilder sb = new StringBuilder("{");
-        for (int i = 0; i < types.size(); i++)
+        for (int i = 0; i < size(); i++)
         {
             if (i > 0)
                 sb.append(", ");
 
             String name = stringFieldNames.get(i);
             if (!name.equals(name.toLowerCase(Locale.US)))
-                name = "\"" + name + "\"";
+                name = '"' + name + '"';
 
             sb.append('"');
             sb.append(Json.quoteAsJsonString(name));
@@ -288,38 +267,21 @@ public class UserType extends TupleType implements SchemaElement
             if (valueBuffer == null)
                 sb.append("null");
             else
-                sb.append(types.get(i).toJSONString(valueBuffer, protocolVersion));
+                sb.append(subTypes.get(i).toJSONString(valueBuffer, protocolVersion));
         }
-        return sb.append("}").toString();
+        return sb.append('}').toString();
     }
 
     @Override
     public UserType freeze()
     {
-        if (isMultiCell)
-            return new UserType(keyspace, name, fieldNames, fieldTypes(), false);
-        else
-            return this;
-    }
-
-    @Override
-    public AbstractType<?> freezeNestedMulticellTypes()
-    {
-        if (!isMultiCell())
-            return this;
-
-        // the behavior here doesn't exactly match the method name: we want to freeze everything inside of UDTs
-        List<AbstractType<?>> newTypes = fieldTypes().stream()
-                .map(subtype -> (subtype.isFreezable() && subtype.isMultiCell() ? subtype.freeze() : subtype))
-                .collect(Collectors.toList());
-
-        return new UserType(keyspace, name, fieldNames, newTypes, isMultiCell);
+        return (UserType) super.freeze();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hashCode(keyspace, name, fieldNames, types, isMultiCell);
+        return Objects.hashCode(keyspace, name, fieldNames, subTypes, isMultiCell());
     }
 
     @Override
@@ -332,14 +294,14 @@ public class UserType extends TupleType implements SchemaElement
             return false;
 
         UserType other = (UserType) previous;
-        if (isMultiCell != other.isMultiCell())
+        if (isMultiCell() != other.isMultiCell())
             return false;
 
         if (!keyspace.equals(other.keyspace))
             return false;
 
-        Iterator<AbstractType<?>> thisTypeIter = types.iterator();
-        Iterator<AbstractType<?>> previousTypeIter = other.types.iterator();
+        Iterator<AbstractType<?>> thisTypeIter = subTypes.iterator();
+        Iterator<AbstractType<?>> previousTypeIter = other.subTypes.iterator();
         while (thisTypeIter.hasNext() && previousTypeIter.hasNext())
         {
             if (!thisTypeIter.next().isCompatibleWith(previousTypeIter.next()))
@@ -351,27 +313,36 @@ public class UserType extends TupleType implements SchemaElement
     }
 
     @Override
-    public boolean equals(Object o)
+    protected boolean isCompatibleWhenFrozenWith(AbstractType<?> previous)
     {
-        if(!(o instanceof UserType))
-            return false;
-
-        UserType that = (UserType)o;
-
-        return equalsWithoutTypes(that) && types.equals(that.types);
+        return super.isCompatibleWhenFrozenWith(previous) && keyspace.equals(((UserType)previous).keyspace);
     }
 
-    private boolean equalsWithoutTypes(UserType other)
+    @Override
+    protected boolean isCompatibleWhenNonFrozenWith(AbstractType<?> previous)
     {
-        return name.equals(other.name)
-            && fieldNames.equals(other.fieldNames)
-            && keyspace.equals(other.keyspace)
-            && isMultiCell == other.isMultiCell;
+        return super.isCompatibleWhenNonFrozenWith(previous) && keyspace.equals(((UserType)previous).keyspace);
+    }
+
+    @Override
+    protected boolean isValueCompatibleWhenFrozenWith(AbstractType<?> previous)
+    {
+        return super.isValueCompatibleWhenFrozenWith(previous) && keyspace.equals(((UserType)previous).keyspace);
+    }
+
+    @Override
+    protected boolean equalsNoFrozenNoSubtypes(AbstractType<?> other)
+    {
+        UserType that = (UserType)other;
+        return super.equalsNoFrozenNoSubtypes(other)
+               && this.name.equals(that.name)
+               && this.fieldNames.equals(that.fieldNames)
+               && this.keyspace.equals(that.keyspace);
     }
 
     public Optional<Difference> compare(UserType other)
     {
-        if (!equalsWithoutTypes(other))
+        if (!equalsNoFrozenNoSubtypes(other) || isMultiCell() != other.isMultiCell())
             return Optional.of(Difference.SHALLOW);
 
         boolean differsDeeply = false;
@@ -406,51 +377,34 @@ public class UserType extends TupleType implements SchemaElement
     }
 
     @Override
+    public AbstractType<?> expandUserTypes()
+    {
+        return new TupleType(ImmutableList.copyOf(transform(subTypes, AbstractType::expandUserTypes)), isMultiCell());
+    }
+
+    @Override
     public UserType withUpdatedUserType(UserType udt)
     {
-        if (!referencesUserType(udt.name))
-            return this;
+        // If we're not the UDT to update, we can rely on the default implementation
+        if (!name.equals(udt.name))
+            return (UserType) super.withUpdatedUserType(udt);
 
-        // preserve frozen/non-frozen status of the updated UDT
-        if (name.equals(udt.name))
-        {
-            return isMultiCell == udt.isMultiCell
-                 ? udt
-                 : new UserType(udt.keyspace, name, udt.fieldNames(), udt.fieldTypes(), isMultiCell);
-        }
-
-        return new UserType(udt.keyspace,
-                            name,
-                            fieldNames,
-                            Lists.newArrayList(transform(fieldTypes(), t -> t.withUpdatedUserType(udt))),
-                            isMultiCell());
+        assert udt.isMultiCell();
+        // The type we're updating may be frozen, why the updated user type will never be (a UDT is never frozen in
+        // its definition, only in its use). So if we are frozen, we should froze the UDT we switch to.
+        return isMultiCell() ? udt : udt.freeze();
     }
 
     @Override
     public boolean referencesDuration()
     {
-        return fieldTypes().stream().anyMatch(f -> f.referencesDuration());
+        return fieldTypes().stream().anyMatch(AbstractType::referencesDuration);
     }
 
     @Override
-    public String toString()
+    protected String stringifyTypeParameters(boolean ignoreFreezing)
     {
-        return this.toString(false);
-    }
-
-    @Override
-    public String toString(boolean ignoreFreezing)
-    {
-        boolean includeFrozenType = !ignoreFreezing && !isMultiCell();
-
-        StringBuilder sb = new StringBuilder();
-        if (includeFrozenType)
-            sb.append(FrozenType.class.getName()).append("(");
-        sb.append(getClass().getName());
-        sb.append(TypeParser.stringifyUserTypeParameters(keyspace, name, fieldNames, types, ignoreFreezing || !isMultiCell));
-        if (includeFrozenType)
-            sb.append(")");
-        return sb.toString();
+        return TypeParser.stringifyUserTypeParameters(keyspace, name, fieldNames, subTypes, ignoreFreezing || !isMultiCell());
     }
 
     public String getCqlTypeName()

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -285,34 +285,6 @@ public class UserType extends TupleType implements SchemaElement
     }
 
     @Override
-    public boolean isValueCompatibleWith(AbstractType<?> previous)
-    {
-        if (this == previous)
-            return true;
-
-        if (!(previous instanceof UserType))
-            return false;
-
-        UserType other = (UserType) previous;
-        if (isMultiCell() != other.isMultiCell())
-            return false;
-
-        if (!keyspace.equals(other.keyspace))
-            return false;
-
-        Iterator<AbstractType<?>> thisTypeIter = subTypes.iterator();
-        Iterator<AbstractType<?>> previousTypeIter = other.subTypes.iterator();
-        while (thisTypeIter.hasNext() && previousTypeIter.hasNext())
-        {
-            if (!thisTypeIter.next().isCompatibleWith(previousTypeIter.next()))
-                return false;
-        }
-
-        // it's okay for the new type to have additional fields, but not for the old type to have additional fields
-        return !previousTypeIter.hasNext();
-    }
-
-    @Override
     protected boolean isCompatibleWhenFrozenWith(AbstractType<?> previous)
     {
         return super.isCompatibleWhenFrozenWith(previous) && keyspace.equals(((UserType)previous).keyspace);

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
@@ -146,8 +146,9 @@ public class CassandraStreamReader implements IStreamReader
 
     protected SerializationHeader getHeader(TableMetadata metadata) throws UnknownColumnException
     {
-        return header != null? header.toHeader(metadata) : null; //pre-3.0 sstable have no SerializationHeader
+        return header != null? header.toHeader("stream from " + session.peer, metadata) : null; //pre-3.0 sstable have no SerializationHeader
     }
+
     @SuppressWarnings("resource")
     protected SSTableMultiWriter createWriter(ColumnFamilyStore cfs, long totalSize, long repairedAt, UUID pendingRepair, SSTableFormat.Type format) throws IOException
     {

--- a/src/java/org/apache/cassandra/exceptions/InvalidColumnTypeException.java
+++ b/src/java/org/apache/cassandra/exceptions/InvalidColumnTypeException.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.db.marshal.AbstractType;
+
+/**
+ * Exception thrown when a configured column type is invalid.
+ */
+public class InvalidColumnTypeException extends ConfigurationException
+{
+    private final ByteBuffer name;
+    private final AbstractType<?> invalidType;
+    private final boolean isPrimaryKeyColumn;
+    private final boolean isCounterTable;
+
+    public InvalidColumnTypeException(ByteBuffer name,
+                                      AbstractType<?> invalidType,
+                                      boolean isPrimaryKeyColumn,
+                                      boolean isCounterTable,
+                                      String reason)
+    {
+        super(msg(name, invalidType, reason));
+        this.name = name;
+        this.invalidType = invalidType;
+        this.isPrimaryKeyColumn = isPrimaryKeyColumn;
+        this.isCounterTable = isCounterTable;
+    }
+
+    private static String msg(ByteBuffer name,
+                              AbstractType<?> invalidType,
+                              String reason)
+    {
+        return String.format("Invalid type %s for column %s: %s",
+                             invalidType.asCQL3Type(),
+                             ColumnIdentifier.toCQLString(name),
+                             reason);
+    }
+
+    /**
+     * Attempts to return a "fixed" (and thus valid) version of the type. Doing is so is only possible in restrained
+     * case where we know why the type is invalid and are confident we know what it should be.
+     *
+     * @return if we know how to auto-magically fix the invalid type that triggered this exception, the hopefully
+     * fixed version of said type. Otherwise, {@code null}.
+     */
+    public AbstractType<?> tryFix()
+    {
+        AbstractType<?> fixed = tryFixInternal();
+        if (fixed != null)
+        {
+            try
+            {
+                // Make doubly sure the fixed type is valid before returning it.
+                fixed.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+                return fixed;
+            }
+            catch (InvalidColumnTypeException e2)
+            {
+                // Continue as if we hadn't been able to fix, since we haven't
+            }
+        }
+        return null;
+    }
+
+    private AbstractType<?> tryFixInternal()
+    {
+        if (isPrimaryKeyColumn)
+        {
+            // The only issue we have a fix to in that case if the type is not frozen; we can then just freeze it.
+            if (invalidType.isMultiCell())
+                return invalidType.freeze();
+        }
+        else
+        {
+            // Here again, it's mainly issues of frozen-ness that are fixable, namely if a multi-cell type has
+            // non-frozen subtypes. In which case, we just freeze all sub-types.
+            if (invalidType.isMultiCell())
+                return invalidType.with(AbstractType.freeze(invalidType.subTypes()), true);
+
+        }
+        // In other case, we don't know how to fix (at least somewhat auto-magically) and will have to fail.
+        return null;
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
@@ -396,8 +396,8 @@ public abstract class SSTableHeaderFix
         {
             // Note, the logic is similar as just calling 'fixType()' using the composite partition key,
             // but the log messages should use the composite partition key column names.
-            List<AbstractType<?>> headerKeyComponents = ((CompositeType) headerKeyType).types;
-            List<AbstractType<?>> schemaKeyComponents = ((CompositeType) schemaKeyType).types;
+            List<AbstractType<?>> headerKeyComponents = headerKeyType.subTypes();
+            List<AbstractType<?>> schemaKeyComponents = schemaKeyType.subTypes();
             if (headerKeyComponents.size() != schemaKeyComponents.size())
             {
                 // different number of components in composite partition keys - very suspicious
@@ -738,15 +738,15 @@ public abstract class SSTableHeaderFix
 
     private AbstractType<?> fixTypeInnerComposite(CompositeType cHeader, CompositeType cSchema, boolean droppedColumnMode)
     {
-        if (cHeader.types.size() != cSchema.types.size())
+        if (cHeader.subTypes().size() != cSchema.subTypes().size())
             // different number of components - bummer...
             return null;
-        List<AbstractType<?>> cHeaderFixed = new ArrayList<>(cHeader.types.size());
+        List<AbstractType<?>> cHeaderFixed = new ArrayList<>(cHeader.subTypes().size());
         boolean anyChanged = false;
-        for (int i = 0; i < cHeader.types.size(); i++)
+        for (int i = 0; i < cHeader.subTypes().size(); i++)
         {
-            AbstractType<?> cHeaderComp = cHeader.types.get(i);
-            AbstractType<?> cHeaderCompFixed = fixTypeInner(cHeaderComp, cSchema.types.get(i), droppedColumnMode);
+            AbstractType<?> cHeaderComp = cHeader.subTypes().get(i);
+            AbstractType<?> cHeaderCompFixed = fixTypeInner(cHeaderComp, cSchema.subTypes().get(i), droppedColumnMode);
             if (cHeaderCompFixed == null)
                 // incompatible, bummer...
                 return null;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -526,7 +526,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
         try
         {
-            return new SSTableReaderBuilder.ForBatch(descriptor, metadata, components, statsMetadata, header.toHeader(metadata.get())).build();
+            return new SSTableReaderBuilder.ForBatch(descriptor, metadata, components, statsMetadata, header.toHeader(descriptor.toString(), metadata.get())).build();
         }
         catch (UnknownColumnException e)
         {
@@ -599,7 +599,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
                                                        isOffline,
                                                        components,
                                                        statsMetadata,
-                                                       header.toHeader(metadata.get())).build();
+                                                       header.toHeader(descriptor.toString(), metadata.get())).build();
         }
         catch (UnknownColumnException e)
         {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -172,7 +172,7 @@ public class BigFormat implements SSTableFormat
                 SerializationHeader.Component headerComponent = (SerializationHeader.Component)
                                                                 descriptor.getMetadataSerializer()
                                                                           .deserialize(descriptor, MetadataType.HEADER);
-                SerializationHeader header = headerComponent.toHeader(metadata);
+                SerializationHeader header = headerComponent.toHeader(descriptor.toString(), metadata);
                 BigTableRowIndexEntry.Serializer serializer = new BigTableRowIndexEntry.Serializer(descriptor.version, header);
                 return BigTablePartitionIndexIterator.create(iFile, serializer);
             }

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -1042,7 +1042,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                                   System.currentTimeMillis(),
                                                                   statsMetadata,
                                                                   OpenReason.NORMAL,
-                                                                  header.toHeader(metadata.get()));
+                                                                  header.toHeader(descriptor.toString(), metadata.get()));
                 }
             }
             else
@@ -1055,7 +1055,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                               System.currentTimeMillis(),
                                                               statsMetadata,
                                                               OpenReason.NORMAL,
-                                                              header.toHeader(metadata.get()));
+                                                              header.toHeader(descriptor.toString(), metadata.get()));
             }
             if (validate)
                 sstable.validate();

--- a/src/java/org/apache/cassandra/schema/CQLTypeParser.java
+++ b/src/java/org/apache/cassandra/schema/CQLTypeParser.java
@@ -50,7 +50,7 @@ public final class CQLTypeParser
         if (udt != null)
             return udt;
 
-        return parseRaw(unparsed).prepareInternal(keyspace, userTypes).getType();
+        return parseRaw(unparsed).prepare(keyspace, userTypes).getType();
     }
 
     static CQL3Type.Raw parseRaw(String type)

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -217,9 +217,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         if (kind.isPrimaryKeyKind() || !type.isMultiCell())
             return null;
 
-        AbstractType<?> nameComparator = type.isCollection()
-                                       ? ((CollectionType) type).nameComparator()
-                                       : ((UserType) type).nameComparator();
+        AbstractType<?> nameComparator = ((MultiCellCapableType<?>) type).nameComparator();
 
 
         return (path1, path2) ->
@@ -566,5 +564,15 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
     public AbstractType<?> getExactTypeIfKnown(String keyspace)
     {
         return type;
+    }
+
+    /**
+     * Validate whether the column definition is valid (mostly, that the type is valid for the type of column this is).
+     *
+     * @param isCounterTable whether the table the column is part of is a counter table.
+     */
+    public void validate(boolean isCounterTable)
+    {
+        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable);
     }
 }

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -73,7 +73,7 @@ public final class DroppedColumn
     {
         return String.format("DROPPED COLUMN RECORD %s %s%s USING TIMESTAMP %d",
                              column.name.toCQLString(),
-                             column.type.asCQL3Type(),
+                             column.type.asCQL3Type().toSchemaString(),
                              column.isStatic() ? " static" : "",
                              droppedTime);
     }

--- a/src/java/org/apache/cassandra/schema/Keyspaces.java
+++ b/src/java/org/apache/cassandra/schema/Keyspaces.java
@@ -161,11 +161,6 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
                         .build();
     }
 
-    public void validate()
-    {
-        keyspaces.values().forEach(KeyspaceMetadata::validate);
-    }
-
     @Override
     public boolean equals(Object o)
     {

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -75,6 +75,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.db.rows.RowIterators;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.ColumnMetadata.ClusteringOrder;
 import org.apache.cassandra.schema.Keyspaces.KeyspacesDiff;
@@ -540,7 +541,7 @@ public final class SchemaKeyspace
         mutation.update(Types)
                 .row(type.getNameAsString())
                 .add("field_names", type.fieldNames().stream().map(FieldIdentifier::toString).collect(toList()))
-                .add("field_types", type.fieldTypes().stream().map(AbstractType::asCQL3Type).map(CQL3Type::toString).collect(toList()));
+                .add("field_types", type.fieldTypes().stream().map(AbstractType::asCQL3Type).map(CQL3Type::toSchemaString).collect(toList()));
     }
 
     private static void addDropTypeToSchemaMutation(UserType type, Mutation.SimpleBuilder builder)
@@ -726,7 +727,7 @@ public final class SchemaKeyspace
                .add("kind", column.kind.toString().toLowerCase())
                .add("position", column.position())
                .add("clustering_order", column.clusteringOrder().toString().toLowerCase())
-               .add("type", type.asCQL3Type().toString());
+               .add("type", type.asCQL3Type().toSchemaString());
     }
 
     private static void dropColumnFromSchemaMutation(TableMetadata table, ColumnMetadata column, Mutation.SimpleBuilder builder)
@@ -740,7 +741,7 @@ public final class SchemaKeyspace
         builder.update(DroppedColumns)
                .row(table.name, column.column.name.toString())
                .add("dropped_time", new Date(TimeUnit.MICROSECONDS.toMillis(column.droppedTime)))
-               .add("type", column.column.type.asCQL3Type().toString())
+               .add("type", column.column.type.asCQL3Type().toSchemaString())
                .add("kind", column.column.kind.toString().toLowerCase());
     }
 
@@ -985,10 +986,11 @@ public final class SchemaKeyspace
         UntypedResultSet.Row row = rows.one();
 
         Set<TableMetadata.Flag> flags = TableMetadata.Flag.fromStringSet(row.getFrozenSet("flags", UTF8Type.instance));
+        boolean isCounter = flags.contains(TableMetadata.Flag.COUNTER);
         return TableMetadata.builder(keyspaceName, tableName, TableId.fromUUID(row.getUUID("id")))
                             .flags(flags)
                             .params(createTableParamsFromRow(row))
-                            .addColumns(fetchColumns(keyspaceName, tableName, types))
+                            .addColumns(fetchColumns(keyspaceName, tableName, types, isCounter))
                             .droppedColumns(fetchDroppedColumns(keyspaceName, tableName))
                             .indexes(fetchIndexes(keyspaceName, tableName))
                             .triggers(fetchTriggers(keyspaceName, tableName))
@@ -1021,7 +1023,7 @@ public final class SchemaKeyspace
                           .build();
     }
 
-    private static List<ColumnMetadata> fetchColumns(String keyspace, String table, Types types)
+    private static List<ColumnMetadata> fetchColumns(String keyspace, String table, Types types, boolean isCounterTable)
     {
         String query = format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ?", SchemaConstants.SCHEMA_KEYSPACE_NAME, COLUMNS);
         UntypedResultSet columnRows = query(query, keyspace, table);
@@ -1029,7 +1031,7 @@ public final class SchemaKeyspace
             throw new MissingColumns("Columns not found in schema table for " + keyspace + '.' + table);
 
         List<ColumnMetadata> columns = new ArrayList<>();
-        columnRows.forEach(row -> columns.add(createColumnFromRow(row, types)));
+        columnRows.forEach(row -> columns.add(createColumnFromRow(row, types, isCounterTable)));
 
         if (columns.stream().noneMatch(ColumnMetadata::isPartitionKey))
             throw new MissingColumns("No partition key columns found in schema table for " + keyspace + "." + table);
@@ -1037,8 +1039,35 @@ public final class SchemaKeyspace
         return columns;
     }
 
+    private static AbstractType<?> validate(String keyspace,
+                                            String table,
+                                            ByteBuffer name,
+                                            AbstractType<?> type,
+                                            boolean isPrimaryKeyColumn,
+                                            boolean isCounterTable)
+    {
+        try
+        {
+            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+            return type;
+        }
+        catch (InvalidColumnTypeException e)
+        {
+            AbstractType<?> fixed = e.tryFix();
+            if (fixed == null)
+                throw e;
+
+            logger.error("Error reading schema for table {}.{}, column {} had invalid type {} (invalid because: {}). "
+                         + "This was likely the result of a previous bug and the type was automatically converted to "
+                         + "valid type {}. If this is incorrect, or this message repeats itself, please contact "
+                         + "DataStax support", keyspace, table, ColumnIdentifier.toCQLString(name), type.asCQL3Type(),
+                         e.getMessage(), fixed.asCQL3Type());
+            return fixed;
+        }
+    }
+
     @VisibleForTesting
-    static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types)
+    static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types, boolean isCounterTable)
     {
         String keyspace = row.getString("keyspace_name");
         String table = row.getString("table_name");
@@ -1052,7 +1081,10 @@ public final class SchemaKeyspace
         if (order == ClusteringOrder.DESC)
             type = ReversedType.getInstance(type);
 
-        ColumnIdentifier name = new ColumnIdentifier(row.getBytes("column_name_bytes"), row.getString("column_name"));
+        ByteBuffer columnNameBytes = row.getBytes("column_name_bytes");
+        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable);
+
+        ColumnIdentifier name = new ColumnIdentifier(columnNameBytes, row.getString("column_name"));
 
         return new ColumnMetadata(keyspace, table, name, type, position, kind);
     }
@@ -1145,7 +1177,7 @@ public final class SchemaKeyspace
         boolean includeAll = row.getBoolean("include_all_columns");
         String whereClauseString = row.getString("where_clause");
 
-        List<ColumnMetadata> columns = fetchColumns(keyspaceName, viewName, types);
+        List<ColumnMetadata> columns = fetchColumns(keyspaceName, viewName, types, false);
 
         TableMetadata metadata =
             TableMetadata.builder(keyspaceName, viewName, TableId.fromUUID(row.getUUID("id")))

--- a/src/java/org/apache/cassandra/schema/Types.java
+++ b/src/java/org/apache/cassandra/schema/Types.java
@@ -459,7 +459,7 @@ public final class Types implements Iterable<UserType>
 
                 List<AbstractType<?>> preparedFieldTypes =
                     fieldTypes.stream()
-                              .map(t -> t.prepareInternal(keyspace, types).getType())
+                              .map(t -> t.prepare(keyspace, types).getType())
                               .collect(toList());
 
                 return new UserType(keyspace, bytes(name), preparedFieldNames, preparedFieldTypes, true);

--- a/src/java/org/apache/cassandra/tools/JsonTransformer.java
+++ b/src/java/org/apache/cassandra/tools/JsonTransformer.java
@@ -163,9 +163,9 @@ public final class JsonTransformer
                 }
 
                 int i = 0;
-                while (keyBytes.remaining() > 0 && i < compositeType.getComponents().size())
+                while (keyBytes.remaining() > 0 && i < compositeType.subTypes().size())
                 {
-                    AbstractType<?> colType = compositeType.getComponents().get(i);
+                    AbstractType<?> colType = compositeType.subTypes().get(i);
 
                     ByteBuffer value = ByteBufferUtil.readBytesWithShortLength(keyBytes);
                     String colValue = colType.getString(value);

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -924,4 +924,23 @@ public class ByteBufferUtil
 
         return n;
     }
+
+    /**
+     * Essentially the same as {@link #bytesToHex(ByteBuffer)} (though it prepends "0x" for clarity) but takes care of
+     * not output a string too long if the value is too big. This is to be used for error/debug message where we don't
+     * want to blow things up.
+     *
+     * @param bytes the bytes to convert to hexadecimal string.
+     * @return a string representation of {@code bytes} that may be only partial if {@code bytes} is too big.
+     */
+    public static String toDebugHexString(ByteBuffer bytes)
+    {
+        int maxSize = 50; // kind of arbitrary tbh but that's not hugely important
+        if (bytes.remaining() > maxSize)
+        {
+            bytes = bytes.duplicate();
+            bytes.limit(bytes.position() + maxSize);
+        }
+        return "0x" + bytesToHex(bytes);
+    }
 }

--- a/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
@@ -191,10 +191,10 @@ public class TermSelectionTest extends CQLTester
                             tuple(tuple("three", "three"), tuple("three", "three", 3L, "three")))));
 
         // single element tuple: tuple(t) incompatible with tuple(long, long)
-        assertInvalidMessage("(t) is not of the expected type: frozen<tuple<bigint, bigint>>",
+        assertInvalidMessage("(t) is not of the expected type: tuple<bigint, bigint>",
                              "SELECT [(CAST(pk AS BIGINT), CAST(ck AS BIGINT)), (t)] FROM %s");
 
-        assertInvalidMessage("(cast(ck as bigint)) is not of the expected type: frozen<tuple<text, text>>",
+        assertInvalidMessage("(cast(ck as bigint)) is not of the expected type: tuple<text, text>",
                              "SELECT [(t, t), (CAST(ck AS BIGINT))] FROM %s");
 
         // single element tuple: tuple(long) compatible with tuple(long, long)
@@ -308,7 +308,7 @@ public class TermSelectionTest extends CQLTester
                            tuple(tuple("three", "three"), tuple("three", "three", 3L, "three")))));
 
         // getExactType for (t) is null
-        assertInvalidMessage("(t) is not of the expected type: frozen<tuple<bigint, bigint>>",
+        assertInvalidMessage("(t) is not of the expected type: tuple<bigint, bigint>",
                              "SELECT {(CAST(pk AS BIGINT), CAST(ck AS BIGINT)), (t), (CAST(pk AS BIGINT), CAST(ck AS BIGINT))} FROM %s");
 
         // Test UDTs nested within Sets
@@ -465,7 +465,7 @@ public class TermSelectionTest extends CQLTester
 
 
         // Test Litteral Set with Duration elements
-        assertInvalidMessage("Durations are not allowed inside sets: set<duration>",
+        assertInvalidMessage("Durations are not allowed inside sets: frozen<set<duration>>",
                              "SELECT pk, ck, (set<duration>){2d, 1mo} FROM %s");
 
         assertInvalidMessage("Invalid field selection: system.min(ck) of type int is not a user type",
@@ -494,7 +494,7 @@ public class TermSelectionTest extends CQLTester
                    row(map(2, Duration.from("10h"))),
                    row(map(3, Duration.from("11h"))));
 
-        assertInvalidMessage("Durations are not allowed as map keys: map<duration, int>",
+        assertInvalidMessage("Durations are not allowed as map keys: frozen<map<duration, int>>",
                              "SELECT (map<duration, int>){d1 : ck, d2 :ck} FROM %s");
     }
 
@@ -502,7 +502,7 @@ public class TermSelectionTest extends CQLTester
     public void testSelectUDTLiteral() throws Throwable
     {
         String type = createType("CREATE TYPE %s(a int, b text)");
-        createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ")");
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ')');
 
         execute("INSERT INTO %s(k, v) VALUES (?, ?)", 0, userType("a", 3, "b", "foo"));
 

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -221,8 +221,8 @@ public class DescribeStatementTest extends CQLTester
             assertRowsNet(executeDescribeNet("DESCRIBE FUNCTION " + function),
                           row(KEYSPACE_PER_TEST,
                               "function",
-                              shortFunctionName(function) + "(tuple<int>, list<frozen<tuple<int, text>>>, tuple<frozen<tuple<int, text>>, text>)",
-                              "CREATE FUNCTION " + function + "(t tuple<int>, l list<frozen<tuple<int, text>>>, nt tuple<frozen<tuple<int, text>>, text>)\n" +
+                              shortFunctionName(function) + "(tuple<int>, list<tuple<int, text>>, tuple<tuple<int, text>, text>)",
+                              "CREATE FUNCTION " + function + "(t tuple<int>, l list<tuple<int, text>>, nt tuple<tuple<int, text>, text>)\n" +
                               "    CALLED ON NULL INPUT\n" +
                               "    RETURNS tuple<int, text>\n" +
                               "    LANGUAGE java\n" +
@@ -954,7 +954,7 @@ public class DescribeStatementTest extends CQLTester
                "    textcol text,\n" +
                "    timestampcol timestamp,\n" +
                "    tinyintcol tinyint,\n" +
-               "    tuplecol frozen<tuple<text, int, frozen<tuple<timestamp>>>>,\n" +
+               "    tuplecol tuple<text, int, tuple<timestamp>>,\n" +
                "    uuidcol uuid,\n" +
                "    varcharcol text,\n" +
                "    varintcol varint,\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
@@ -1762,15 +1762,15 @@ public class CollectionsTest extends CQLTester
     {
         String type = createType("CREATE TYPE %s (s set<int>, m map<text, text>)");
 
-        assertInvalidMessage("Non-frozen UDTs are not allowed inside collections",
+        assertInvalidMessage("non-frozen user types are only supported at top-level",
                              "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v map<text, " + type + ">)");
 
         String mapType = "map<text, frozen<" + type + ">>";
         for (boolean frozen : new boolean[]{false, true})
         {
-            mapType = frozen ? "frozen<" + mapType + ">" : mapType;
+            mapType = frozen ? "frozen<" + mapType + '>' : mapType;
 
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + mapType + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + mapType + ')');
 
             execute("INSERT INTO %s(k, v) VALUES (0, ?)", map("abc", userType("s", set(2, 4, 6), "m", map("a", "v1", "d", "v2"))));
 
@@ -1782,16 +1782,16 @@ public class CollectionsTest extends CQLTester
             });
         }
 
-        assertInvalidMessage("Non-frozen UDTs with nested non-frozen collections are not supported",
-                             "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v " + type + ")");
+        assertInvalidMessage("non-frozen collections are only supported at top-level",
+                             "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v " + type + ')');
 
         type = createType("CREATE TYPE %s (s frozen<set<int>>, m frozen<map<text, text>>)");
 
         for (boolean frozen : new boolean[]{false, true})
         {
-            type = frozen ? "frozen<" + type + ">" : type;
+            type = frozen ? "frozen<" + type + '>' : type;
 
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ')');
 
             execute("INSERT INTO %s(k, v) VALUES (0, ?)", userType("s", set(2, 4, 6), "m", map("a", "v1", "d", "v2")));
 
@@ -1889,7 +1889,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, s) VALUES (0, ?)",
                              set(tuple(1, "1", 1.0, 1), tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid set literal for s: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid set literal for s: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, s) VALUES (0, {(1, '1', 1.0, 1)})");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, l frozen<list<tuple<int, text, double>>>)");
@@ -1897,7 +1897,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, l) VALUES (0, ?)",
                              list(tuple(1, "1", 1.0, 1), tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid list literal for l: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid list literal for l: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, l) VALUES (0, [(1, '1', 1.0, 1)])");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, m frozen<map<tuple<int, text, double>, int>>)");
@@ -1905,7 +1905,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, m) VALUES (0, ?)",
                              map(tuple(1, "1", 1.0, 1), 1, tuple(2, "2", 2.0, 2), 2));
 
-        assertInvalidMessage("Invalid map literal for m: key (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid map literal for m: key (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, m) VALUES (0, {(1, '1', 1.0, 1) : 1})");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, m frozen<map<int, tuple<int, text, double>>>)");
@@ -1913,7 +1913,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, m) VALUES (0, ?)",
                              map(1, tuple(1, "1", 1.0, 1), 2, tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid map literal for m: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid map literal for m: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, m) VALUES (0, {1 : (1, '1', 1.0, 1)})");
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.cassandra.cql3.validation.entities;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -803,10 +803,10 @@ public class FrozenCollectionsTest extends CQLTester
         assertInvalid("DELETE m[?] FROM %s WHERE k=?", 0, 0);
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t set<set<int>>)",
-                "Non-frozen collections are not allowed inside collections");
+                                       "non-frozen collections are only supported at top-level");
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t frozen<set<counter>>)",
-                                       "Counters are not allowed inside collections");
+                                       "counters are not allowed within collections");
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t frozen<text>)",
                 "frozen<> is only allowed on collections, tuples, and user-defined types");
@@ -1373,10 +1373,9 @@ public class FrozenCollectionsTest extends CQLTester
         assertEquals("MapType(ListType(Int32Type),Int32Type)", clean(m.toString(true)));
 
         // tuple<set<int>>
-        List<AbstractType<?>> types = new ArrayList<>();
-        types.add(SetType.getInstance(Int32Type.instance, true));
+        List<AbstractType<?>> types = Collections.singletonList(SetType.getInstance(Int32Type.instance, true));
         TupleType tuple = new TupleType(types);
-        assertEquals("TupleType(SetType(Int32Type))", clean(tuple.toString()));
+        assertEquals("FrozenType(TupleType(SetType(Int32Type)))", clean(tuple.toString()));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
@@ -55,7 +55,7 @@ public class TupleTypeTest extends CQLTester
         String[] valueTypes = {"frozen<tuple<int, text, double>>", "tuple<int, text, double>"};
         for (String valueType : valueTypes)
         {
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, t " + valueType + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, t " + valueType + ')');
 
             execute("INSERT INTO %s (k, t) VALUES (?, ?)", 0, tuple(3, "foo", 3.4));
             execute("INSERT INTO %s (k, t) VALUES (?, ?)", 1, tuple(8, "bar", 0.2));
@@ -136,7 +136,7 @@ public class TupleTypeTest extends CQLTester
             row(0, 4, tuple(null, "1"))
         );
 
-        assertInvalidMessage("Invalid tuple literal: too many elements. Type frozen<tuple<int, text>> expects 2 but got 3",
+        assertInvalidMessage("Invalid tuple literal: too many elements. Type tuple<int, text> expects 2 but got 3",
                              "INSERT INTO %s(k, t) VALUES (1,'1:2:3')");
     }
 
@@ -147,7 +147,7 @@ public class TupleTypeTest extends CQLTester
 
         assertInvalidSyntax("INSERT INTO %s (k, t) VALUES (0, ())");
 
-        assertInvalidMessage("Invalid tuple literal for t: too many elements. Type frozen<tuple<int, text, double>> expects 3 but got 4",
+        assertInvalidMessage("Invalid tuple literal for t: too many elements. Type tuple<int, text, double> expects 3 but got 4",
                              "INSERT INTO %s (k, t) VALUES (0, (2, 'foo', 3.1, 'bar'))");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, t frozen<tuple<int, tuple<int, text, double>>>)");
@@ -155,7 +155,7 @@ public class TupleTypeTest extends CQLTester
                              "INSERT INTO %s (k, t) VALUES (0, ?)",
                              tuple(1, tuple(1, "1", 1.0, 1)));
 
-        assertInvalidMessage("Invalid tuple literal for t: component 1 is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid tuple literal for t: component 1 is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, t) VALUES (0, (1, (1, '1', 1.0, 1)))");
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -122,13 +122,13 @@ public class CreateTest extends CQLTester
     @Test
     public void testCreateTableWithDurationColumns() throws Throwable
     {
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'a'",
+        assertInvalidMessage("Invalid type duration for column a: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a duration PRIMARY KEY, b int);");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'b'",
+        assertInvalidMessage("Invalid type duration for column b: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a text, b duration, c duration, primary key (a, b));");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'b'",
+        assertInvalidMessage("Invalid type duration for column b: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a text, b duration, c duration, primary key (a, b)) with clustering order by (b DESC);");
 
         createTable("CREATE TABLE %s (a int, b int, c duration, primary key (a, b));");
@@ -208,7 +208,7 @@ public class CreateTest extends CQLTester
         createTable("CREATE TABLE %s (a text PRIMARY KEY, duration duration);");
 
         // Test duration within Map
-        assertInvalidMessage("Durations are not allowed as map keys: map<duration, text>",
+        assertInvalidMessage("Invalid type map<duration, text> for column m: duration types are not supported within non-frozen map keys",
                              "CREATE TABLE cql_test_keyspace.table0(pk int PRIMARY KEY, m map<duration, text>)");
 
         createTable("CREATE TABLE %s(pk int PRIMARY KEY, m map<text, duration>)");
@@ -216,17 +216,17 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, map("one month", Duration.from("1mo"), "60 days", Duration.from("60d"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
-                "CREATE TABLE cql_test_keyspace.table0(m frozen<map<text, duration>> PRIMARY KEY, v int)");
+        assertInvalidMessage("Invalid type frozen<map<text, duration>> for column m: duration types are not supported within PRIMARY KEY columns",
+                             "CREATE TABLE cql_test_keyspace.table0(m frozen<map<text, duration>> PRIMARY KEY, v int)");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
+        assertInvalidMessage("Invalid type frozen<map<text, duration>> for column m: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, duration>>, v int, PRIMARY KEY (pk, m))");
 
         // Test duration within Set
-        assertInvalidMessage("Durations are not allowed inside sets: set<duration>",
+        assertInvalidMessage("Invalid type set<duration> for column s: duration types are not supported within non-frozen",
                              "CREATE TABLE cql_test_keyspace.table0(pk int PRIMARY KEY, s set<duration>)");
 
-        assertInvalidMessage("Durations are not allowed inside sets: frozen<set<duration>>",
+        assertInvalidMessage("Invalid type frozen<set<duration>> for column s: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(s frozen<set<duration>> PRIMARY KEY, v int)");
 
         // Test duration within List
@@ -235,7 +235,7 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, list(Duration.from("1mo"), Duration.from("60d"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'l'",
+        assertInvalidMessage("Invalid type frozen<list<duration>> for column l: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(l frozen<list<duration>> PRIMARY KEY, v int)");
 
         // Test duration within Tuple
@@ -244,23 +244,23 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, tuple(1, Duration.from("1mo"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 't'",
+        assertInvalidMessage("Invalid type tuple<int, duration> for column t: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(t frozen<tuple<int, duration>> PRIMARY KEY, v int)");
 
         // Test duration within UDT
         String typename = createType("CREATE TYPE %s (a duration)");
         String myType = KEYSPACE + '.' + typename;
-        createTable("CREATE TABLE %s(pk int PRIMARY KEY, u " + myType + ")");
+        createTable("CREATE TABLE %s(pk int PRIMARY KEY, u " + myType + ')');
         execute("INSERT INTO %s (pk, u) VALUES (1, {a : 1mo})");
         assertRows(execute("SELECT * FROM %s"),
                    row(1, userType("a", Duration.from("1mo"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'u'",
+        assertInvalidMessage("Invalid type frozen<" + typename + "> for column u: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(pk int, u frozen<" + myType + ">, v int, PRIMARY KEY(pk, u))");
 
         // Test duration with several level of depth
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
-                "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, list<tuple<int, duration>>>>, v int, PRIMARY KEY (pk, m))");
+        assertInvalidMessage("Invalid type frozen<map<text, list<tuple<int, duration>>>> for column m: duration types are not supported within PRIMARY KEY columns",
+                             "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, list<tuple<int, duration>>>>, v int, PRIMARY KEY (pk, m))");
     }
 
     private ByteBuffer duration(long months, long days, long nanoseconds) throws IOException

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -116,7 +116,7 @@ public class NativeCellTest
         return new ColumnMetadata("",
                                   "",
                                   ColumnIdentifier.getInterned(uuid.toString(), false),
-                                    isComplex ? new SetType<>(BytesType.instance, true) : BytesType.instance,
+                                    isComplex ? SetType.getInstance(BytesType.instance, true) : BytesType.instance,
                                   -1,
                                   ColumnMetadata.Kind.REGULAR);
     }

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -133,6 +134,6 @@ public class CompositeAndTupleTypesTest
     @Test
     public void composite()
     {
-        testSerializationDeserialization(CompositeType::new, CompositeType::build);
+        testSerializationDeserialization(types -> new CompositeType(ImmutableList.copyOf(types)), CompositeType::build);
     }
 }

--- a/test/unit/org/apache/cassandra/db/marshal/ReversedTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ReversedTypeTest.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.db.marshal;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQL3Type;
+import org.assertj.core.api.Assertions;
+
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
 
@@ -28,7 +31,7 @@ public class ReversedTypeTest
     @Test
     public void testReverseComparison()
     {
-        ReversedType<Long> t = ReversedType.getInstance(LongType.instance);
+        AbstractType<Long> t = ReversedType.getInstance(LongType.instance);
 
         assert t.compare(bytes(2L), bytes(4L)) > 0;
         assert t.compare(bytes(4L), bytes(2L)) < 0;
@@ -36,5 +39,18 @@ public class ReversedTypeTest
         // the empty byte buffer is always the smaller
         assert t.compare(EMPTY_BYTE_BUFFER, bytes(2L)) > 0;
         assert t.compare(bytes(2L), EMPTY_BYTE_BUFFER) < 0;
+    }
+
+    @Test
+    public void testReverseOfReversed()
+    {
+        for (CQL3Type.Native cql3Type : CQL3Type.Native.values())
+        {
+            AbstractType<?> type = cql3Type.getType();
+            AbstractType<?> reversed = ReversedType.getInstance(type);
+            Assertions.assertThat(type)
+                      .isNotEqualTo(reversed)
+                      .isEqualTo(ReversedType.getInstance(reversed));
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/TypeUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/TypeUtilTest.java
@@ -106,8 +106,8 @@ public class TypeUtilTest extends SaiRandomizedTest
         {
             TupleType type = new TupleType(Arrays.asList(elementType.getType(), elementType.getType()), true);
             assertFalse(TypeUtil.isFrozenCollection(type));
-            assertTrue(TypeUtil.isFrozen(type));
-            assertTrue(TypeUtil.isLiteral(type));
+            assertFalse(TypeUtil.isFrozen(type));
+            assertFalse(TypeUtil.isLiteral(type));
 
             type = new TupleType(Arrays.asList(elementType.getType(), elementType.getType()), false);
             assertFalse(TypeUtil.isFrozenCollection(type));

--- a/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
@@ -254,7 +254,7 @@ public class SchemaKeyspaceTest
                                                                 UnfilteredRowIterators.filter(serializedCD.unfilteredIterator(), FBUtilities.nowInSeconds()));
         Set<ColumnMetadata> columns = new HashSet<>();
         for (UntypedResultSet.Row row : columnsRows)
-            columns.add(SchemaKeyspace.createColumnFromRow(row, Types.none()));
+            columns.add(SchemaKeyspace.createColumnFromRow(row, Types.none(), metadata.isCounter()));
 
         assertEquals(metadata.params, params);
         assertEquals(new HashSet<>(metadata.columns()), columns);

--- a/test/unit/org/apache/cassandra/schema/SchemaStatementWarningsTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaStatementWarningsTest.java
@@ -52,7 +52,7 @@ public class SchemaStatementWarningsTest extends CQLTester
     @BMRules(rules = { @BMRule(name = "client warning 1",
                                targetClass = "CreateKeyspaceStatement",
                                targetMethod = "apply",
-                               targetLocation = "AT INVOKE KeyspaceParams.validate",
+                               targetLocation = "AT INVOKE KeyspaceMetadata.validate",
                                action = "org.apache.cassandra.schema.SchemaStatementWarningsTest.addWarn()"),
                        @BMRule(name = "client warning 2",
                                targetClass = "CreateKeyspaceStatement",

--- a/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
+++ b/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
@@ -40,9 +40,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies that the string representations of {@link AbstractType} and {@link CQL3Type} are as expected and compatible.
- *
+ * </p>
  * C* 3.0 is known to <em>not</em> enclose a frozen UDT in a "frozen bracket" in the {@link AbstractType}.
- * The string representation of a frozuen UDT using the {@link CQL3Type} type hierarchy is correct in C* 3.0.
+ * The string representation of a frozen UDT using the {@link CQL3Type} type hierarchy is correct in C* 3.0.
  */
 public class TupleTypesRepresentationTest
 {
@@ -129,7 +129,7 @@ public class TupleTypesRepresentationTest
                    ", cqlType=" + cqlType + '\n' +
                    ", droppedType=" + droppedType + '\n' +
                    ", droppedCqlTypeString='" + droppedCqlTypeString + "'\n" +
-                   ", droppedCqlType=" + droppedCqlType + '\n' +
+                   ", droppedCqlType=" + droppedCqlType.toSchemaString() + '\n' +
                    '}';
         }
     }
@@ -142,7 +142,7 @@ public class TupleTypesRepresentationTest
             "'foobar'");
 
     private static final TypeDef tuple_text__text_ = new TypeDef(
-            "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)",
+            "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
             "tuple<text, text>",
             "frozen<tuple<text, text>>",
             false,
@@ -206,9 +206,7 @@ public class TupleTypesRepresentationTest
             "{'foo':'bar'}");
 
     private static final TypeDef list_frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "list<frozen<tuple<text, text>>>",
             "list<frozen<tuple<text, text>>>",
             true,
@@ -216,15 +214,13 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_list_tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<list<frozen<tuple<text, text>>>>",
+            "frozen<list<tuple<text, text>>>",
             "frozen<list<frozen<tuple<text, text>>>>",
             true,
             "[('foo','bar')]");
 
     private static final TypeDef set_frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "set<frozen<tuple<text, text>>>",
             "set<frozen<tuple<text, text>>>",
             true,
@@ -232,15 +228,13 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_set_tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<set<frozen<tuple<text, text>>>>",
+            "frozen<set<tuple<text, text>>>",
             "frozen<set<frozen<tuple<text, text>>>>",
             true,
             "{('foo','bar')}");
 
     private static final TypeDef map_text__frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "map<text, frozen<tuple<text, text>>>",
             "map<text, frozen<tuple<text, text>>>",
             true,
@@ -248,7 +242,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_map_text__tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<map<text, frozen<tuple<text, text>>>>",
+            "frozen<map<text, tuple<text, text>>>",
             "frozen<map<text, frozen<tuple<text, text>>>>",
             true,
             "{'foobar':('foo','bar')}");
@@ -262,7 +256,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_list_i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<list<frozen<i_udt>>>",
+            "frozen<list<i_udt>>",
             "frozen<list<frozen<tuple<text, text>>>>",
             true,
             "[{a:'foo',b:'bar'}]");
@@ -276,7 +270,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_set_i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<set<frozen<i_udt>>>",
+            "frozen<set<i_udt>>",
             "frozen<set<frozen<tuple<text, text>>>>",
             true,
             "{{a:'foo',b:'bar'}}");
@@ -290,7 +284,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_map_text__i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<map<text, frozen<i_udt>>>",
+            "frozen<map<text, i_udt>>",
             "frozen<map<text, frozen<tuple<text, text>>>>",
             true,
             "{'foobar':{a:'foo',b:'bar'}}");
@@ -375,16 +369,13 @@ public class TupleTypesRepresentationTest
         {
             try
             {
-                assertEquals(typeDef.toString() + "\n typeString vs type\n", typeDef.typeString, typeDef.type.toString());
-                assertEquals(typeDef.toString() + "\n typeString vs cqlType.getType()\n", typeDef.typeString, typeDef.cqlType.getType().toString());
+                assertEquals(typeDef + "\n typeString vs type\n", typeDef.typeString, typeDef.type.toString());
+                assertEquals(typeDef + "\n typeString vs cqlType.getType()\n", typeDef.typeString, typeDef.cqlType.getType().toString());
                 AbstractType<?> expanded = typeDef.type.expandUserTypes();
                 CQL3Type expandedCQL = expanded.asCQL3Type();
-                // Note: cannot include this commented-out assertion, because the parsed CQL3Type instance for
-                // 'frozen<list<tuple<text, text>>>' returns 'frozen<list<frozen<tuple<text, text>>>>' via it's CQL3Type.toString()
-                // implementation.
-                assertEquals(typeDef.toString() + "\n droppedCqlType\n", typeDef.droppedCqlType, expandedCQL);
-                assertEquals(typeDef.toString() + "\n droppedCqlTypeString\n", typeDef.droppedCqlTypeString, expandedCQL.toString());
-                assertEquals(typeDef.toString() + "\n multiCell\n", typeDef.type.isMultiCell(), typeDef.droppedType.isMultiCell());
+                assertEquals(typeDef + "\n droppedCqlType\n", typeDef.droppedCqlType, expandedCQL);
+                assertEquals(typeDef + "\n droppedCqlTypeString\n", typeDef.droppedCqlTypeString, expandedCQL.toSchemaString());
+                assertEquals(typeDef + "\n multiCell\n", typeDef.type.isMultiCell(), typeDef.droppedType.isMultiCell());
 
                 AbstractType<?> parsedType = TypeParser.parse(typeDef.typeString);
                 assertEquals(typeDef.toString(), typeDef.typeString, parsedType.toString());

--- a/test/unit/org/apache/cassandra/transport/messages/ResultMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/messages/ResultMessageTest.java
@@ -124,7 +124,7 @@ public class ResultMessageTest
         TupleType tt = new TupleType(asList(Int32Type.instance, udt));
         allTypes.add(tt);
         allTypes.add(Int32Type.instance);
-        ReversedType rt = ReversedType.getInstance(udt);
+        AbstractType<?> rt = ReversedType.getInstance(udt);
         allTypes.add(rt);
 
         ColumnSpecification cs1 = new ColumnSpecification("ks1", "cf1", new ColumnIdentifier("a", true), Int32Type.instance);


### PR DESCRIPTION
This is a port of [DB-3084](https://datastax.jira.com/browse/DB-3084) and some bits of [DB-3434](https://datastax.jira.com/browse/DB-3434).

The patch allows creating nested UDTs without the need to use frozen in the nested types:
```
cqlsh> CREATE TYPE inner (a int, b int);
cqlsh> CREATE TYPE outer (a inner, b inner);
```
These nested types cannot be used on tables without the frozen keyword:
```
cqlsh> CREATE TABLE t (k int PRIMARY KEY, t outer);
ConfigurationException: Invalid type outer for column t: non-frozen user types are only supported at top-level: subtype inner of outer must be frozen
cqlsh> CREATE TABLE t (k int PRIMARY KEY, l list<outer>);
ConfigurationException: Invalid type list<outer> for column l: non-frozen user types are only supported at top-level: subtype outer of list<outer> must be frozen
```
However they can be used with the frozen keyword:
```
cqlsh> CREATE TABLE t (k int PRIMARY KEY, t frozen<outer>);
```
They can also be used nested into other frozen types, without the need to explictely add the nested keyword into the nested types:
```
cqlsh> CREATE TABLE t2 (k int PRIMARY KEY, l frozen<list<outer>>);
cqlsh> CREATE TABLE t3 (k int PRIMARY KEY, l frozen<list<frozen<outer>>>);
```
Independently of whether the frozen keyword has been used, they are presented to users in their most simple form:
```
cqlsh> DESCRIBE TABLE t3;

CREATE TABLE k.t3 (
    k int PRIMARY KEY,
    l frozen<list<outer>>
)
```
In the special case of tuples, which are always single-cell, the frozen keyword is still optional, but it's never presented when displaying the schema:
```
cqlsh> CREATE TABLE t4 (k int PRIMARY KEY, t tuple<int,int>, ft frozen<tuple<int,int>>);
cqlsh> DESCRIBE t4;

CREATE TABLE k.t4 (
    k int PRIMARY KEY,
    ft tuple<int, int>,
    t tuple<int, int>
)
```
However, the internal schema tables are still always explicit about whether a type is frozen:
```
cqlsh> SELECT table_name,column_name,type FROM system_schema.columns WHERE keyspace_name = 'k';

 table_name | column_name | type
------------+-------------+-----------------------------
         t2 |           k |                         int
         t2 |           l | frozen<list<frozen<outer>>>
         t3 |           k |                         int
         t3 |           l | frozen<list<frozen<outer>>>
         t4 |          ft |     frozen<tuple<int, int>>
         t4 |           k |                         int
         t4 |           t |     frozen<tuple<int, int>>
```

[DB-3084]: https://datastax.jira.com/browse/DB-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DB-3434]: https://datastax.jira.com/browse/DB-3434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ