### PR TITLE
Remove assumption that PK is PrimaryKeyWithSource in limitToTopResults

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -371,11 +371,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             {
                 // turn the pk back into a row id, with a fast path for the case where the pk is from this sstable
                 var primaryKey = keysInRange.get(i);
-                assert primaryKey instanceof PrimaryKeyWithSource : "Expected PrimaryKeyWithSource, got " + primaryKey;
-                var pkws = (PrimaryKeyWithSource) primaryKey;
                 long sstableRowId;
-                if (pkws.getSourceSstableId().equals(primaryKeyMap.getSSTableId()))
-                    sstableRowId = pkws.getSourceRowId();
+                if (primaryKey instanceof PrimaryKeyWithSource
+                    && ((PrimaryKeyWithSource) primaryKey).getSourceSstableId().equals(primaryKeyMap.getSSTableId()))
+                    sstableRowId = ((PrimaryKeyWithSource) primaryKey).getSourceRowId();
                 else
                     sstableRowId = primaryKeyMap.exactRowIdOrInvertedCeiling(primaryKey);
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -187,6 +187,47 @@ public class VectorTypeTest extends VectorTester
 
         result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
         assertThat(result).hasSize(2);
+
+        // Add another row to query memtable and sstable together
+        execute("INSERT INTO %s (pk, b, v) VALUES (3, true, [4.0, 5.0, 6.0])");
+
+        result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void testTwoPredicatesWithBruteForce() throws Throwable
+    {
+        // Note: the PKs in this test are chosen intentionally to ensure their tokens overlap so that
+        // we can test the brute force path.
+        setMaxBruteForceRows(0);
+        createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, b, v) VALUES (1, true, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, b, v) VALUES (2, true, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, b, v) VALUES (3, false, [3.0, 4.0, 5.0])");
+
+        // the vector given is closest to row 2, but we exclude that row because b=false
+        var result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
+        // VSTODO assert specific row keys
+        assertThat(result).hasSize(2);
+
+        flush();
+        compact();
+
+        result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
+        assertThat(result).hasSize(2);
+
+        // Add 3 rows to memtable. Need number of rows to be greater than both maxBruteForceRows and the LIMIT
+        execute("INSERT INTO %s (pk, b, v) VALUES (4, true, [4.0, 5.0, 6.0])");
+        execute("INSERT INTO %s (pk, b, v) VALUES (5, true, [5.0, 6.0, 7.0])");
+        execute("INSERT INTO %s (pk, b, v) VALUES (6, true, [6.0, 7.0, 8.0])");
+
+        result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
+        assertThat(result).hasSize(2);
     }
 
     @Test
@@ -868,12 +909,13 @@ public class VectorTypeTest extends VectorTester
         execute("INSERT INTO %s (pk, val, vec) VALUES (5, 'A', [1, 5])"); // -7509452495886106294
         execute("INSERT INTO %s (pk, val, vec) VALUES (4, 'A', [1, 4])"); // -2729420104000364805
         execute("INSERT INTO %s (pk, val, vec) VALUES (6, 'A', [1, 6])"); // 2705480034054113608
-        flush();
 
         // Get all rows using first predicate, then filter to get top 1
         // Use a small limit to ensure we do not use brute force
-        assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
-                   row(3));
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
+                       row(3));
+        });
     }
 
     // Clustering columns hit a different code path, we need both sets of tests, even though queries
@@ -896,11 +938,12 @@ public class VectorTypeTest extends VectorTester
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (5, 1, 'A', [1, 5])"); // -7509452495886106294
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (4, 1, 'A', [1, 4])"); // -2729420104000364805
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (6, 1, 'A', [1, 6])"); // 2705480034054113608
-        flush();
 
         // Get all rows using first predicate, then filter to get top 1
         // Use a small limit to ensure we do not use brute force
-        assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
-                   row(3));
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
+                       row(3));
+        });
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -187,12 +187,6 @@ public class VectorTypeTest extends VectorTester
 
         result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
         assertThat(result).hasSize(2);
-
-        // Add another row to query memtable and sstable together
-        execute("INSERT INTO %s (pk, b, v) VALUES (3, true, [4.0, 5.0, 6.0])");
-
-        result = execute("SELECT * FROM %s WHERE b=true ORDER BY v ANN OF [3.1, 4.1, 5.1] LIMIT 2");
-        assertThat(result).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
When a hybrid ANN query gets PKs in the hybrid query, we search all sstables and memtables with those PKs to get the topk. As such, we cannot assume that the source of a PK is an sstbale, even when we're searching an sstable.