### PR TITLE
Improve timeout handling; prevent resource leaks

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -120,12 +120,17 @@ public class PostingListRangeIterator extends RangeIterator
         }
         catch (Throwable t)
         {
-            //TODO We aren't tidying up resources here
             if (!(t instanceof AbortedOperationException))
                 logger.error(indexContext.logMessage("Unable to provide next token!"), t);
 
+            closeOnException(t);
             throw Throwables.cleaned(t);
         }
+    }
+
+    private void closeOnException(Throwable t)
+    {
+        FileUtils.closeQuietly(this);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -213,14 +213,7 @@ public class QueryController
 
     public UnfilteredRowIterator executePartitionReadCommand(SinglePartitionReadCommand command, ReadExecutionController executionController)
     {
-        try
-        {
-            return command.queryMemtableAndDisk(cfs, executionController);
-        }
-        finally
-        {
-            queryContext.checkpoint();
-        }
+        return command.queryMemtableAndDisk(cfs, executionController);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -314,7 +314,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             try (UnfilteredRowIterator partition = controller.executePartitionReadCommand(command, executionController))
             {
                 queryContext.addPartitionsRead(1);
-
+                queryContext.checkpoint();
                 return applyIndexFilter(key, partition, filterTree, queryContext);
             }
         }
@@ -506,7 +506,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             try (UnfilteredRowIterator partition = controller.getPartition(key, executionController))
             {
                 queryContext.addPartitionsRead(1);
-
+                queryContext.checkpoint();
                 return applyIndexFilter(key, partition, filterTree, queryContext);
             }
         }


### PR DESCRIPTION
Move checkpoint into try-with-resources block; prevent leak.

We are leaking references after `AbortedOperationException` is thrown by the `query.checkpoint()` in the modified code.

Also, unwrap the exception when it is an `AbortedOperationException` so we catch it later.