### PR TITLE
CNDB-8201 hint version is optional, also use the correct peer address

### DIFF
--- a/src/java/org/apache/cassandra/hints/HintMessage.java
+++ b/src/java/org/apache/cassandra/hints/HintMessage.java
@@ -111,7 +111,8 @@ public final class HintMessage implements SerializableHintMessage
                 Encoded message = (Encoded) obj;
 
                 if (version != message.version)
-                    throw new IllegalArgumentException("serializedSize() called with non-matching version " + version);
+                    throw new IllegalArgumentException("serializedSize() called with non-matching version " + version +
+                                                       " for message with version " + message.version);
 
                 long size = UUIDSerializer.serializer.serializedSize(message.hostId, version);
                 size += TypeSizes.sizeofUnsignedVInt(message.hint.remaining());

--- a/src/java/org/apache/cassandra/hints/HintsDispatcher.java
+++ b/src/java/org/apache/cassandra/hints/HintsDispatcher.java
@@ -69,10 +69,14 @@ final class HintsDispatcher implements AutoCloseable
         this.abortRequested = abortRequested;
     }
 
-    static HintsDispatcher create(File file, RateLimiter rateLimiter, InetAddressAndPort address, UUID hostId, BooleanSupplier abortRequested)
+    static HintsDispatcher create(File file,
+                                  RateLimiter rateLimiter,
+                                  InetAddressAndPort address,
+                                  UUID hostId,
+                                  int peerMessagingVersion,
+                                  BooleanSupplier abortRequested)
     {
-        int messagingVersion = HintsEndpointProvider.instance.versionForEndpoint(address);
-        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, messagingVersion, abortRequested);
+        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, peerMessagingVersion, abortRequested);
         HintDiagnostics.dispatcherCreated(dispatcher);
         return dispatcher;
     }

--- a/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
+++ b/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
@@ -64,7 +64,7 @@ public class EndpointMessagingVersions
         if (v == null)
         {
             // we don't know the version. assume current. we'll know soon enough if that was incorrect.
-            logger.trace("Assuming current protocol version for {}", endpoint);
+            logger.debug("Assuming current protocol version for {}", endpoint);
             return MessagingService.current_version;
         }
         else

--- a/test/unit/org/apache/cassandra/hints/HintsEndpointProviderTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsEndpointProviderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.hints;
+
+import java.util.Optional;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HintsEndpointProviderTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        SchemaLoader.prepareServer();
+    }
+
+    @Test
+    public void testVersionForUnknownEndpoint()
+    {
+        HintsEndpointProvider.DefaultHintsEndpointProvider provider = new HintsEndpointProvider.DefaultHintsEndpointProvider();
+
+        Optional<Integer> version = provider.versionForEndpoint(FBUtilities.getBroadcastAddressAndPort());
+
+        assertFalse("Version should not be present for unknown endpoint", version.isPresent());
+    }
+
+    @Test
+    public void testVersionForKnownEndpoint()
+    {
+        InetAddressAndPort knownEndpointAddress = FBUtilities.getBroadcastAddressAndPort().withPort(9999);
+        int version = 333;
+        MessagingService.instance().versions.set(knownEndpointAddress, version);
+
+        HintsEndpointProvider.DefaultHintsEndpointProvider provider = new HintsEndpointProvider.DefaultHintsEndpointProvider();
+        Optional<Integer> versionOption = provider.versionForEndpoint(knownEndpointAddress);
+
+        assertTrue("Version should be present for a known endpoint", versionOption.isPresent());
+        assertEquals(version, versionOption.get().intValue());
+    }
+}

--- a/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
@@ -99,6 +99,12 @@ public class HintsServiceTest
         MessagingService.instance().inboundSink.clear();
         MessagingService.instance().outboundSink.clear();
 
+        // Hint service has to know the endpoint version to be able to send the hints. Otherwise,
+        // it wouldn't be able to make a decision whether to decode (rewrap) or not.
+        MessagingService.instance().versions.set(
+            HintsEndpointProvider.instance.endpointForHost(StorageService.instance.getLocalHostUUID()),
+            MessagingService.current_version);
+
         if (!HintsService.instance.isShutDown())
         {
             HintsService.instance.shutdownBlocking();

--- a/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
@@ -105,7 +105,7 @@ public class MessageSerializationPropertyTest implements Serializable
                         FixedMonotonicClock.setNowInNanos(message.createdAtNanos());
 
                         serializer.serialize(message, first, version.value);
-                        Message<Object> read = serializer.deserialize(new DataInputBuffer(first.buffer(), true), FBUtilities.getBroadcastAddressAndPort(), version.value);
+                        Message<Object> read = serializer.deserialize(new DataInputBuffer(first.buffer(), true), message.from(), version.value);
                         serializer.serialize(read, second, version.value);
                         // using hex as byte buffer equality kept failing, and was harder to debug difference
                         // using hex means the specific section of the string that is different will be shown


### PR DESCRIPTION
- Hint version is now optional. If the version is missing, the hint won't be sent. A retry will 
be attempted later.

- Messages pre 4.0 use peer address retrieved from the actual connection. 
Before this patch the messages used the address 
retrieved from message bytes, which didn't work in MR setups (non public address was used).
With the patch, message addressing pre 4.0 is consistent with messages post 4.0.