### PR TITLE
CNDB-8229: Allow dropping non-frozen UDT columns

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -811,7 +811,7 @@ tableProperty[CreateTableStatement.Raw stmt]
              K_TO noncol_ident '(' mockVertex ')'
              {stmt.attrs.addProperty("dse_edge_label_property", "edge");}
     | K_DROPPED K_COLUMN K_RECORD
-          k=ident v=comparatorType (K_STATIC {isStatic = true;})?
+          k=ident v=comparatorTypeWithMultiCellTuple (K_STATIC {isStatic = true;})?
           K_USING K_TIMESTAMP t=INTEGER
       {
           stmt.attrs.addDroppedColumnRecord(k, v, isStatic, Long.parseLong($t.text));
@@ -1761,10 +1761,9 @@ inMarkerForTuple returns [Tuples.INRaw marker]
     | ':' name=noncol_ident { $marker = newTupleINBindVariables(name); }
     ;
 
-comparatorType returns [CQL3Type.Raw t]
+comparatorTypeWithoutTuples returns [CQL3Type.Raw t]
     : n=native_type     { $t = CQL3Type.Raw.from(n); }
     | c=collection_type { $t = c; }
-    | tt=tuple_type     { $t = tt; }
     | id=userTypeName   { $t = CQL3Type.Raw.userType(id); }
     | K_FROZEN '<' f=comparatorType '>'
       {
@@ -1784,6 +1783,16 @@ comparatorType returns [CQL3Type.Raw t]
             addRecognitionError("Error setting type " + $s.text + ": " + e.getMessage());
         }
       }
+    ;
+
+// Force frozen tuples.
+comparatorType returns [CQL3Type.Raw t]
+    : ct=comparatorTypeWithoutTuples     { $t = ct; }
+    | tt=tuple_types                     { $t = CQL3Type.Raw.tuple(tt, true); }
+    ;
+comparatorTypeWithMultiCellTuple returns [CQL3Type.Raw t]
+    : ct=comparatorTypeWithoutTuples     { $t = ct; }
+    | tt=tuple_types                     { $t = CQL3Type.Raw.tuple(tt, false); }
     ;
 
 native_type returns [CQL3Type t]
@@ -1823,10 +1832,8 @@ collection_type returns [CQL3Type.Raw pt]
         { if (t != null) $pt = CQL3Type.Raw.set(t); }
     ;
 
-tuple_type returns [CQL3Type.Raw t]
-    @init {List<CQL3Type.Raw> types = new ArrayList<>();}
-    @after {$t = CQL3Type.Raw.tuple(types);}
-    : K_TUPLE '<' t1=comparatorType { types.add(t1); } (',' tn=comparatorType { types.add(tn); })* '>'
+tuple_types returns [List<CQL3Type.Raw> types]
+    : K_TUPLE '<' t1=comparatorType { $types = new ArrayList<>(); $types.add(t1); } (',' tn=comparatorType { $types.add(tn); })* '>'
     ;
 
 username

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -34,10 +34,10 @@ import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.restrictions.ExternalRestriction;
 import org.apache.cassandra.cql3.restrictions.Restrictions;
+import org.apache.cassandra.db.marshal.MultiCellCapableType;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.Schema;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.cql3.*;
@@ -52,10 +52,8 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.aggregation.AggregationSpecification;
 import org.apache.cassandra.db.aggregation.GroupMaker;
 import org.apache.cassandra.db.filter.*;
-import org.apache.cassandra.db.marshal.CollectionType;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.db.rows.Row;
@@ -1010,10 +1008,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             ComplexColumnData complexData = row.getComplexColumnData(def);
             if (complexData == null)
                 result.add(null);
-            else if (def.type.isCollection())
-                result.add(((CollectionType) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
             else
-                result.add(((UserType) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
+                result.add(((MultiCellCapableType<?>) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
         }
         else
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQL3Type;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.QualifiedName;
@@ -298,14 +297,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
             if (currentColumn.isPrimaryKeyColumn())
                 throw ire("Cannot drop PRIMARY KEY column %s", column);
-
-            /*
-             * Cannot allow dropping top-level columns of user defined types that aren't frozen because we cannot convert
-             * the type into an equivalent tuple: we only support frozen tuples currently. And as such we cannot persist
-             * the correct type in system_schema.dropped_columns.
-             */
-            if (currentColumn.type.isUDT() && currentColumn.type.isMultiCell())
-                throw ire("Cannot drop non-frozen column %s of user type %s", column, currentColumn.type.asCQL3Type());
 
             // TODO: some day try and find a way to not rely on Keyspace/IndexManager/Index to find dependent indexes
             Set<IndexMetadata> dependentIndexes = Keyspace.openAndGetStore(table).indexManager.getDependentIndexes(currentColumn);

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -74,6 +74,11 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
     private final Object[] columns;
     private final int complexIdx; // Index of the first complex column
 
+    /**
+     * The columns passed to this constructor MUST BE SORTED with natural order - this is not checked in the constructor!
+     * The constructor remains private to ensure that this invariant is maintained - all the methods that call it
+     * ensure that the columns are properly sorted.
+     */
     private Columns(Object[] columns, int complexIdx)
     {
         assert complexIdx <= BTree.size(columns);
@@ -705,7 +710,18 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                     int skipped = 0;
                     while (true)
                     {
-                        int nextMissingIndex = skipped < delta ? (int)in.readUnsignedVInt() : supersetCount;
+                        int nextMissingIndex;
+                        if (skipped < delta)
+                        {
+                            nextMissingIndex = (int) in.readUnsignedVInt();
+                            if (nextMissingIndex >= supersetCount)
+                                throw new IOException("Invalid Columns subset bytes; encoded not existing column: " + nextMissingIndex);
+                        }
+                        else
+                        {
+                            nextMissingIndex = supersetCount;
+                        }
+
                         while (idx < nextMissingIndex)
                         {
                             ColumnMetadata def = iter.next();

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.CQLTypeParser;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
@@ -729,39 +730,50 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * @param columnName the name of the column whose type is checked.
      * @param isPrimaryKeyColumn whether {@code columnName} is a primary key column or not.
      * @param isCounterTable whether the table the {@code columnName} is part of is a counter table.
+     * @param isDroppedColumn whether the type is that of a dropped column. This has an impact on tuple validation,
+     *                        which can be multi-cell only for dropped columns (for reasons detailed in
+     *                        {@link CQLTypeParser#parseDroppedType(String, String)}).
      *
      * @throws InvalidColumnTypeException if this type is not a valid column type for {@code columnName}.
      */
-    public void validateForColumn(ByteBuffer columnName, boolean isPrimaryKeyColumn, boolean isCounterTable)
+    public void validateForColumn(ByteBuffer columnName,
+                                  boolean isPrimaryKeyColumn,
+                                  boolean isCounterTable,
+                                  boolean isDroppedColumn)
     {
         if (isPrimaryKeyColumn)
         {
             if (isMultiCell())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "non-frozen %s are not supported for PRIMARY KEY columns", category());
             if (referencesCounter())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "counters are not supported within PRIMARY KEY columns");
             // We don't allow durations in anything sorted (primary key here, or in the "name-comparator" part of
             // collections below). This isn't really a technical limitation, but duration sorts in a somewhat random
             // way, so CASSANDRA-11873 decided to reject them when sorting was involved.
             if (referencesDuration())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "duration types are not supported within PRIMARY KEY columns");
 
             if (comparisonType == ComparisonType.NOT_COMPARABLE)
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "type %s is not comparable and cannot be used for PRIMARY KEY columns", asCQL3Type());
         }
         else
         {
             if (isMultiCell())
             {
+                if (isTuple() && !isDroppedColumn)
+                    throw columnException(columnName, false, isCounterTable, false,
+                                          "tuple type %s is not frozen, which should not have happened",
+                                          asCQL3Type());
+
                 for (AbstractType<?> subType : subTypes())
                 {
                     if (subType.isMultiCell())
                     {
-                        throw columnException(columnName, false, isCounterTable,
+                        throw columnException(columnName, false, isCounterTable, isDroppedColumn,
                                               "non-frozen %s are only supported at top-level: subtype %s of %s must be frozen",
                                               subType.category(), subType.asCQL3Type(), asCQL3Type());
                     }
@@ -777,7 +789,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
                         String what = this instanceof MapType
                                       ? "map keys"
                                       : (this instanceof SetType ? "sets" : category());
-                        throw columnException(columnName, false, isCounterTable,
+                        throw columnException(columnName, false, isCounterTable, isDroppedColumn,
                                               "duration types are not supported within non-frozen %s", what);
                     }
                 }
@@ -795,21 +807,21 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
                     // their limitations, and we want to restrict how user can use them to hopefully make user think
                     // twice about their usage). In any case, a slightly more user-friendly message is probably nice.
                     if (referencesCounter())
-                        throw columnException(columnName, false, true, "counters are not allowed within %s", category());
+                        throw columnException(columnName, false, true, isDroppedColumn, "counters are not allowed within %s", category());
 
-                    throw columnException(columnName, false, true, "Cannot mix counter and non counter columns in the same table");
+                    throw columnException(columnName, false, true, isDroppedColumn, "Cannot mix counter and non counter columns in the same table");
                 }
             }
             else
             {
                 if (isCounter())
-                    throw columnException(columnName, false, false, "Cannot mix counter and non counter columns in the same table");
+                    throw columnException(columnName, false, false, isDroppedColumn, "Cannot mix counter and non counter columns in the same table");
 
                 // For nested counters, we prefer complaining about the nested-ness rather than this not being a counter
                 // table, because the table won't be marked as a counter one even if it has only nested counters, and so
                 // that's overall a more intuitive message.
                 if (referencesCounter())
-                    throw columnException(columnName, false, false, "counters are not allowed within %s", category());
+                    throw columnException(columnName, false, false, isDroppedColumn, "counters are not allowed within %s", category());
             }
         }
     }
@@ -817,11 +829,12 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     private InvalidColumnTypeException columnException(ByteBuffer columnName,
                                                        boolean isPrimaryKeyColumn,
                                                        boolean isCounterTable,
+                                                       boolean isDroppedColumn,
                                                        String reason,
                                                        Object... args)
     {
         String msg = args.length == 0 ? reason : String.format(reason, args);
-        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, msg);
+        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, msg);
     }
 
     private String category()

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -99,8 +99,7 @@ public class TupleType extends MultiCellCapableType<ByteBuffer>
     public static TupleType getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
         List<AbstractType<?>> types = parser.getTypeParameters();
-        types.replaceAll(AbstractType::freeze);
-        return new TupleType(types);
+        return new TupleType(types, true);
     }
 
     @Override
@@ -514,7 +513,7 @@ public class TupleType extends MultiCellCapableType<ByteBuffer>
         sb.append(getClass().getName());
         // FrozenType applies to anything nested (it wouldn't make sense otherwise) and so we only put once at the
         // highest level. So we can ignore freezing in the subtypes if either we're already within a frozen type
-        // (we're a sub-type ourselves and frozenType has been included at the outer level), or we're frozen.
+        // (we're a subtype ourselves and frozenType has been included at the outer level), or we're frozen.
         sb.append(stringifyTypeParameters(ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
             sb.append(')');

--- a/src/java/org/apache/cassandra/db/marshal/TypeParser.java
+++ b/src/java/org/apache/cassandra/db/marshal/TypeParser.java
@@ -57,7 +57,7 @@ public class TypeParser
     }
 
     /**
-     * Parse a string containing an type definition.
+     * Creates a new TypeParser and uses it to parse the given type definition string.
      *
      * @param str the string to parse.
      */
@@ -303,9 +303,13 @@ public class TypeParser
         throw new SyntaxException(String.format("Syntax error parsing '%s' at char %d: unexpected end of string", str, idx));
     }
 
-    private static AbstractType<?> getAbstractType(String compareWith) throws ConfigurationException
+    /**
+     * Parse a type string and return the corresponding {@link AbstractType}. It is used for the type definition which
+     * is not followed by an opening parenthesis, e.g. "org.apache.cassandra.db.marshal.UTF8Type".
+     */
+    private static AbstractType<?> getAbstractType(String typeName) throws ConfigurationException
     {
-        String className = compareWith.contains(".") ? compareWith : "org.apache.cassandra.db.marshal." + compareWith;
+        String className = typeName.contains(".") ? typeName : "org.apache.cassandra.db.marshal." + typeName;
         Class<? extends AbstractType<?>> typeClass = FBUtilities.classForName(className, "abstract-type");
         try
         {
@@ -319,10 +323,16 @@ public class TypeParser
         }
     }
 
+    /**
+     * Parse a type string and return the corresponding {@link AbstractType}. It is used for the type definition
+     * which is followed by an opening parenthesis, e.g.
+     * "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)".
+     */
     private static AbstractType<?> getAbstractType(String compareWith, TypeParser parser) throws SyntaxException, ConfigurationException
     {
         String className = compareWith.contains(".") ? compareWith : "org.apache.cassandra.db.marshal." + compareWith;
         Class<? extends AbstractType<?>> typeClass = FBUtilities.classForName(className, "abstract-type");
+
         try
         {
             Method method = typeClass.getDeclaredMethod("getInstance", TypeParser.class);
@@ -341,6 +351,11 @@ public class TypeParser
         }
     }
 
+    /**
+     * Parse a type string and return the corresponding AbstractType. It is used for the type definition which is not
+     * followed by an opening parenthesis, e.g. "org.apache.cassandra.db.marshal.UTF8Type", but does not have static
+     * {@code instance} field.
+     */
     private static AbstractType<?> getRawAbstractType(Class<? extends AbstractType<?>> typeClass) throws ConfigurationException
     {
         try

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -573,6 +573,6 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
      */
     public void validate(boolean isCounterTable)
     {
-        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable);
+        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable, isDropped);
     }
 }

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -40,6 +40,7 @@ public final class DroppedColumn
      */
     public DroppedColumn(ColumnMetadata column, long droppedTime)
     {
+        assert column.isDropped() : column.debugString() + " should be dropped";
         this.column = column;
         this.droppedTime = droppedTime;
     }

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -991,7 +991,7 @@ public final class SchemaKeyspace
                             .flags(flags)
                             .params(createTableParamsFromRow(row))
                             .addColumns(fetchColumns(keyspaceName, tableName, types, isCounter))
-                            .droppedColumns(fetchDroppedColumns(keyspaceName, tableName))
+                            .droppedColumns(fetchDroppedColumns(keyspaceName, tableName, isCounter))
                             .indexes(fetchIndexes(keyspaceName, tableName))
                             .triggers(fetchTriggers(keyspaceName, tableName))
                             .build();
@@ -1044,11 +1044,12 @@ public final class SchemaKeyspace
                                             ByteBuffer name,
                                             AbstractType<?> type,
                                             boolean isPrimaryKeyColumn,
-                                            boolean isCounterTable)
+                                            boolean isCounterTable,
+                                            boolean isDroppedColumn)
     {
         try
         {
-            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn);
             return type;
         }
         catch (InvalidColumnTypeException e)
@@ -1082,43 +1083,42 @@ public final class SchemaKeyspace
             type = ReversedType.getInstance(type);
 
         ByteBuffer columnNameBytes = row.getBytes("column_name_bytes");
-        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable);
+        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable, false);
 
         ColumnIdentifier name = new ColumnIdentifier(columnNameBytes, row.getString("column_name"));
 
         return new ColumnMetadata(keyspace, table, name, type, position, kind);
     }
 
-    private static Map<ByteBuffer, DroppedColumn> fetchDroppedColumns(String keyspace, String table)
+    private static Map<ByteBuffer, DroppedColumn> fetchDroppedColumns(String keyspace, String table, boolean isCounterTable)
     {
         String query = format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ?", SchemaConstants.SCHEMA_KEYSPACE_NAME, DROPPED_COLUMNS);
         Map<ByteBuffer, DroppedColumn> columns = new HashMap<>();
         for (UntypedResultSet.Row row : query(query, keyspace, table))
         {
-            DroppedColumn column = createDroppedColumnFromRow(row);
+            DroppedColumn column = createDroppedColumnFromRow(row, isCounterTable);
             columns.put(column.column.name.bytes, column);
         }
         return columns;
     }
 
-    private static DroppedColumn createDroppedColumnFromRow(UntypedResultSet.Row row)
+    private static DroppedColumn createDroppedColumnFromRow(UntypedResultSet.Row row, boolean isCounterTable)
     {
         String keyspace = row.getString("keyspace_name");
         String table = row.getString("table_name");
         String name = row.getString("column_name");
-        /*
-         * we never store actual UDT names in dropped column types (so that we can safely drop types if nothing refers to
-         * them anymore), so before storing dropped columns in schema we expand UDTs to tuples. See expandUserTypes method.
-         * Because of that, we can safely pass Types.none() to parse()
-         */
-        AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), org.apache.cassandra.schema.Types.none());
+
+        // Note that it's important we call parseDroppedType, not parse, see the method javadoc for details.
+        AbstractType<?> type = CQLTypeParser.parseDroppedType(keyspace, row.getString("type"));
         ColumnMetadata.Kind kind = row.has("kind")
                                  ? ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase())
                                  : ColumnMetadata.Kind.REGULAR;
         assert kind == ColumnMetadata.Kind.REGULAR || kind == ColumnMetadata.Kind.STATIC
             : "Unexpected dropped column kind: " + kind;
 
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        type = validate(keyspace, table, UTF8Type.instance.decompose(name), type, false, isCounterTable, true);
+
+        ColumnMetadata column = ColumnMetadata.droppedColumn(keyspace, table, ColumnIdentifier.getInterned(name, true), type, kind);
         long droppedTime = TimeUnit.MILLISECONDS.toMicros(row.getLong("dropped_time"));
         return new DroppedColumn(column, droppedTime);
     }
@@ -1183,7 +1183,7 @@ public final class SchemaKeyspace
             TableMetadata.builder(keyspaceName, viewName, TableId.fromUUID(row.getUUID("id")))
                          .kind(TableMetadata.Kind.VIEW)
                          .addColumns(columns)
-                         .droppedColumns(fetchDroppedColumns(keyspaceName, viewName))
+                         .droppedColumns(fetchDroppedColumns(keyspaceName, viewName, false))
                          .params(createTableParamsFromRow(row))
                          .build();
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.schema;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -178,6 +179,12 @@ public class TableMetadata implements SchemaElement
         clusteringColumns = ImmutableList.copyOf(builder.clusteringColumns);
         regularAndStaticColumns = RegularAndStaticColumns.builder().addAll(builder.regularAndStaticColumns).build();
         columns = ImmutableMap.copyOf(builder.columns);
+
+        assert columns.values().stream().noneMatch(ColumnMetadata::isDropped) :
+                "Invalid columns (contains dropped): " + columns.values()
+                                                                .stream()
+                                                                .map(ColumnMetadata::debugString)
+                                                                .collect(Collectors.joining(", "));
 
         indexes = builder.indexes;
         triggers = builder.triggers;

--- a/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
@@ -45,6 +45,8 @@ public class AbstractTypeSerializer
             serialize(type, out);
     }
 
+    // Used only in serialization header, when deserializing a type from the sstable header,
+    // not used in commit log or internode transport.
     public AbstractType<?> deserialize(DataInputPlus in) throws IOException
     {
         ByteBuffer raw = ByteBufferUtil.readWithVIntLength(in);

--- a/src/java/org/apache/cassandra/tools/JsonTransformer.java
+++ b/src/java/org/apache/cassandra/tools/JsonTransformer.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CollectionType;
 import org.apache.cassandra.db.marshal.CompositeType;
-import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ColumnData;
@@ -466,24 +465,6 @@ public final class JsonTransformer
                 // cellType of udt
                 Short fieldPosition = ((UserType) type).nameComparator().compose(cell.path().get(0));
                 cellType = ((UserType) type).fieldType(fieldPosition);
-            }
-            else if (type.isTuple() && type.isMultiCell()) // non-frozen tuple
-            {
-                TupleType tt = (TupleType) type;
-                json.writeFieldName("path");
-                arrayIndenter.setCompact(true);
-                json.writeStartArray();
-                for (int i = 0; i < cell.path().size(); i++)
-                {
-                    Short elementIndex = tt.nameComparator().compose(cell.path().get(i));
-                    json.writeString(elementIndex.toString());
-                }
-                json.writeEndArray();
-                arrayIndenter.setCompact(false);
-
-                // cellType of tuple
-                Short elementIndex = ((TupleType) type).nameComparator().compose(cell.path().get(0));
-                cellType = tt.type(elementIndex);
             }
             else
             {

--- a/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
+++ b/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
@@ -220,7 +220,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
         String name = row.getString("column_name");
         AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), Types.none());
         ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        ColumnMetadata column = ColumnMetadata.droppedColumn(keyspace, table, ColumnIdentifier.getInterned(name, true), type, kind);
         long droppedTime = row.getTimestamp("dropped_time").getTime();
         return new DroppedColumn(column, droppedTime);
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/DropUDTWithRestartTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/DropUDTWithRestartTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.io.util.File;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+public class DropUDTWithRestartTest extends TestBaseImpl
+{
+    @Test
+    public void testReadingValuesOfDroppedColumns() throws Throwable
+    {
+        // given there is a table with a UDT column and some additional non-UDT columns, and there are rows with
+        // different combinations of values and nulls for all columns
+        try (Cluster cluster = Cluster.build(1).withConfig(c -> c.with(GOSSIP, NATIVE_PROTOCOL)).start())
+        {
+            IInvokableInstance node = cluster.get(1);
+            node.executeInternal("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            node.executeInternal("CREATE TYPE ks.udt (foo text, bar text)");
+            node.executeInternal("CREATE TABLE ks.tab (pk int PRIMARY KEY, a_udt udt, b text, c text)");
+            node.executeInternal("INSERT INTO ks.tab (pk, c) VALUES (1, 'c_value')");
+            node.executeInternal("INSERT INTO ks.tab (pk, b) VALUES (2, 'b_value')");
+            node.executeInternal("INSERT INTO ks.tab (pk, a_udt) VALUES (3, {foo: 'a_foo', bar: 'a_bar'})");
+
+            File dataDir = new File(node.callOnInstance(() -> Keyspace.open("ks")
+                                                                      .getColumnFamilyStore("tab")
+                                                                      .getDirectories()
+                                                                      .getDirectoryForNewSSTables()
+                                                                      .absolutePath()));
+            checkData(cluster);
+
+            // when the UDT columns is dropped while the data cannot be flushed before drop and must remain in the commitlog
+
+            // prevent flushing the data
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(dataDir.toPath());
+            permissions.remove(PosixFilePermission.OWNER_WRITE);
+            permissions.remove(PosixFilePermission.GROUP_WRITE);
+            permissions.remove(PosixFilePermission.OTHERS_WRITE);
+            Files.setPosixFilePermissions(dataDir.toPath(), permissions);
+
+            node.executeInternal("ALTER TABLE ks.tab DROP a_udt");
+
+            // and the node is restarted
+            // restart is needed because this way we can simulate the situation where the commit log contains the data
+            // of the dropped cell, while the schema is already altered (the column moved to dropped columns and transformed)
+            node.shutdown(false).get();
+
+            // unlock the ability to flush data
+            permissions = Files.getPosixFilePermissions(dataDir.toPath());
+            permissions.add(PosixFilePermission.OWNER_WRITE);
+            Files.setPosixFilePermissions(dataDir.toPath(), permissions);
+            node.startup();
+
+            // then, we should still be able to read the data of the remaining columns correctly
+            checkData(cluster);
+
+            // and even after flushing and restarting the node again
+            // the next restart is needed to make sure that the sstable header is read from disk
+            node.flush("ks");
+            node.shutdown(false).get();
+            node.startup();
+
+            checkData(cluster);
+        }
+    }
+
+    private void checkData(Cluster cluster)
+    {
+        ICoordinator coordinator = cluster.coordinator(1);
+        String query = "SELECT b, c FROM ks.tab WHERE pk = ?";
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 1), row(null, "c_value"));
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 2), row("b_value", null));
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 3), row(null, null));
+    }
+}

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -63,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.FieldIdentifier;
 import org.apache.cassandra.db.AbstractReadCommandBuilder;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ClusteringComparator;
@@ -88,6 +90,8 @@ import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
 import org.apache.cassandra.db.partitions.ImmutableBTreePartition;
 import org.apache.cassandra.db.partitions.Partition;
@@ -1280,6 +1284,7 @@ public class Util
                     ApplicationState.STATUS_WITH_PORT,
                     new VersionedValue.VersionedValueFactory(partitioner).normal(Collections.singleton(token)));
     }
+
     public static boolean isListeningOn(InetSocketAddress address)
     {
         try (ServerSocket socket = new ServerSocket())
@@ -1291,5 +1296,22 @@ public class Util
         {
             return true;
         }
+    }
+
+    public static UserType makeUDT(String name, Map<String, AbstractType<?>> fields, boolean multicell)
+    {
+        return makeUDT("ks", name, fields, multicell);
+    }
+
+    public static UserType makeUDT(String ks, String name, Map<String, AbstractType<?>> fields, boolean multicell)
+    {
+        List<FieldIdentifier> fieldNames = new ArrayList<>(fields.size());
+        List<AbstractType<?>> fieldTypes = new ArrayList<>(fields.size());
+        for (Map.Entry<String, AbstractType<?>> entry : fields.entrySet())
+        {
+            fieldNames.add(FieldIdentifier.forUnquoted(entry.getKey()));
+            fieldTypes.add(entry.getValue());
+        }
+        return new UserType(ks, UTF8Type.instance.decompose(name), fieldNames, fieldTypes, multicell);
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
+++ b/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
@@ -388,7 +388,7 @@ public class CQL3TypeLiteralTest
         checkForEachUserType(CQL3Type.Raw.list(CQL3Type.Raw.userType(name1)), name1);
         checkForEachUserType(CQL3Type.Raw.set(CQL3Type.Raw.userType(name1)), name1);
         checkForEachUserType(CQL3Type.Raw.map(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2)), name1, name2);
-        checkForEachUserType(CQL3Type.Raw.tuple(Arrays.asList(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2))), name1, name2);
+        checkForEachUserType(CQL3Type.Raw.tuple(Arrays.asList(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2)), true), name1, name2);
     }
 
     private void checkForEachUserType(CQL3Type.Raw t, UTName... expectedNames)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -139,6 +139,7 @@ import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.nodes.Nodes;
+import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
@@ -634,6 +635,16 @@ public abstract class CQLTester
     public ColumnFamilyStore getColumnFamilyStore(String keyspace, String table)
     {
         return Keyspace.open(keyspace).getColumnFamilyStore(table);
+    }
+
+    public ColumnMetadata getColumn(String name)
+    {
+        return getCurrentColumnFamilyStore().metadata.get().getColumn(ColumnIdentifier.getInterned(name, true));
+    }
+
+    public ColumnMetadata getDroppedColumn(String name)
+    {
+        return getCurrentColumnFamilyStore().metadata.get().getDroppedColumn(ColumnIdentifier.getInterned(name, true).bytes);
     }
 
     public void flush(boolean forceFlush)

--- a/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
@@ -579,7 +579,7 @@ public class TermSelectionTest extends CQLTester
         assertColumnSpec(boundNames.get(0), "[selection]", Int32Type.instance);
         assertColumnSpec(boundNames.get(1), "adecimal", DecimalType.instance);
         assertColumnSpec(boundNames.get(2), "[selection]", UTF8Type.instance);
-        assertColumnSpec(boundNames.get(3), "atuple", TypeParser.parse("TupleType(Int32Type,UTF8Type)"));
+        assertColumnSpec(boundNames.get(3), "atuple", TypeParser.parse("TupleType(Int32Type,UTF8Type)").freeze());
         assertColumnSpec(boundNames.get(4), "pk", Int32Type.instance);
 
 
@@ -590,7 +590,7 @@ public class TermSelectionTest extends CQLTester
         assertColumnSpec(resultNames.get(0), "(int)?", Int32Type.instance);
         assertColumnSpec(resultNames.get(1), "(decimal)?", DecimalType.instance);
         assertColumnSpec(resultNames.get(2), "(text)?", UTF8Type.instance);
-        assertColumnSpec(resultNames.get(3), "(tuple<int, text>)?", TypeParser.parse("TupleType(Int32Type,UTF8Type)"));
+        assertColumnSpec(resultNames.get(3), "(tuple<int, text>)?", TypeParser.parse("TupleType(Int32Type,UTF8Type)").freeze());
         assertColumnSpec(resultNames.get(4), "pk", Int32Type.instance);
         assertColumnSpec(resultNames.get(5), "ck", Int32Type.instance);
         assertColumnSpec(resultNames.get(6), "t", UTF8Type.instance);

--- a/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
+++ b/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
@@ -113,7 +113,7 @@ public class TupleTypesRepresentationTest
                                        .prepare(keyspace, types);
             type = cqlType.getType();
 
-            droppedCqlType = CQLFragmentParser.parseAny(CqlParser::comparatorType, droppedCqlTypeString, "dropped type")
+            droppedCqlType = CQLFragmentParser.parseAny(CqlParser::comparatorTypeWithMultiCellTuple, droppedCqlTypeString, "dropped type")
                                               .prepare(keyspace, types);
             // NOTE: TupleType is *always* parsed as frozen, but never toString()'d with the surrounding FrozenType
             droppedType = droppedCqlType.getType();
@@ -148,13 +148,12 @@ public class TupleTypesRepresentationTest
             false,
             "('foo','bar')");
 
-    // Currently, dropped non-frozen-UDT columns are recorded as frozen<tuple<...>>, which is technically wrong
-    //private static final TypeDef mc_udt = new TypeDef(
-    //        "org.apache.cassandra.db.marshal.UserType(ks,6d635f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)",
-    //        "mc_udt",
-    //        "tuple<text, text>",
-    //        true,
-    //        "{a:'foo',b:'bar'}");
+    private static final TypeDef mc_udt = new TypeDef(
+            "org.apache.cassandra.db.marshal.UserType(ks,6d635f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)",
+            "mc_udt",
+            "tuple<text, text>",
+            true,
+            "{a:'foo',b:'bar'}");
 
     private static final TypeDef frozen_f_udt_ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,665f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type))",
@@ -292,6 +291,7 @@ public class TupleTypesRepresentationTest
     private static final TypeDef[] allTypes = {
             text,
             tuple_text__text_,
+            mc_udt,
             frozen_f_udt_,
             list_text_,
             frozen_list_text__,


### PR DESCRIPTION
Allow dropping non-frozen/multi-cell UDTs. This is done by adding partial support for non-frozen/multi-cell tuples, so dropped UDT columns are transformed into an equivalent tuple type. The support for non-frozen tuples is not user-facing, so users can't create non-frozen tuples. At the CQL level all tuples are considered frozen, so `tuple<>` and `frozen<tuple>` are still considered equivalent.

This PR is based on the PR for CNDB-7789, which is still to be reviewed.