### PR TITLE
Minor optimization for limitToTopResults; add test covering #902 patch

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -431,8 +431,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                         }
                         comparisonsSavedByBsearch.update(keysToSkip - (int) ceil(logBase2(keysInRange.size() - i)));
                         i += keysToSkip;
-                        if (cmp == 0)
-                            ceilingPrimaryKeyMatchesKeyInRange = true;
+                        ceilingPrimaryKeyMatchesKeyInRange = cmp == 0;
                     }
                     else
                     {

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -454,8 +454,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                     if (ceilingPrimaryKeyMatchesKeyInRange)
                         sstableRowId = ceilingRowId;
                     else
-                        // without incrementing i further. ceilingPrimaryKey is less than the current key at index i.
-                        continue;
+                        continue; // without incrementing i further. ceilingPrimaryKey is less than the PK at index i.
                 }
                 // Increment here to simplify the sstableRowId < 0 logic.
                 i++;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -415,7 +415,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                     }
                     var ceilingPrimaryKey = primaryKeyMap.primaryKeyFromRowId(ceilingRowId);
 
-                    boolean ceilingPrimaryKeyMatchedKeyInRange = false;
+                    boolean ceilingPrimaryKeyMatchesKeyInRange = false;
                     // adaptively choose either seq scan or bsearch to skip ahead in keysInRange until
                     // we find one at least as large as the ceiling key
                     if (preferSeqScanToBsearch)
@@ -432,7 +432,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                         comparisonsSavedByBsearch.update(keysToSkip - (int) ceil(logBase2(keysInRange.size() - i)));
                         i += keysToSkip;
                         if (cmp == 0)
-                            ceilingPrimaryKeyMatchedKeyInRange = true;
+                            ceilingPrimaryKeyMatchesKeyInRange = true;
                     }
                     else
                     {
@@ -443,7 +443,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                             // We got: -(insertion point) - 1. Invert it so we get the insertion point.
                             nextIndexForCeiling = -nextIndexForCeiling - 1;
                         else
-                            ceilingPrimaryKeyMatchedKeyInRange = true;
+                            ceilingPrimaryKeyMatchesKeyInRange = true;
 
                         comparisonsSavedByBsearch.update(nextIndexForCeiling - (int) ceil(logBase2(keysRemaining.size())));
                         i += nextIndexForCeiling;
@@ -452,7 +452,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                     // update our estimate
                     preferSeqScanToBsearch = comparisonsSavedByBsearch.getCount() >= 10
                                              && comparisonsSavedByBsearch.getSnapshot().getMean() < 0;
-                    if (ceilingPrimaryKeyMatchedKeyInRange)
+                    if (ceilingPrimaryKeyMatchesKeyInRange)
                         sstableRowId = ceilingRowId;
                     else
                         continue;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -454,6 +454,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                     if (ceilingPrimaryKeyMatchesKeyInRange)
                         sstableRowId = ceilingRowId;
                     else
+                        // without incrementing i further. ceilingPrimaryKey is less than the current key at index i.
                         continue;
                 }
                 // Increment here to simplify the sstableRowId < 0 logic.

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -392,7 +392,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             var comparisonsSavedByBsearch = new Histogram(new SlidingWindowReservoir(10));
             boolean preferSeqScanToBsearch = false;
 
-            for (int i = 0; i < keysInRange.size(); i++)
+            for (int i = 0; i < keysInRange.size();)
             {
                 // turn the pk back into a row id, with a fast path for the case where the pk is from this sstable
                 var primaryKey = keysInRange.get(i);
@@ -410,24 +410,29 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                     long ceilingRowId = - sstableRowId - 1;
                     if (ceilingRowId > metadata.maxSSTableRowId)
                     {
-                        // The next greatest primary key is greater than all the primary keys in this sstable
+                        // The next greatest primary key is greater than all the primary keys in this segment
                         break;
                     }
                     var ceilingPrimaryKey = primaryKeyMap.primaryKeyFromRowId(ceilingRowId);
 
+                    boolean ceilingPrimaryKeyMatchedKeyInRange = false;
                     // adaptively choose either seq scan or bsearch to skip ahead in keysInRange until
                     // we find one at least as large as the ceiling key
                     if (preferSeqScanToBsearch)
                     {
-                        int j = 0;
-                        for ( ; i + j < keysInRange.size(); j++)
+                        int keysToSkip = 1; // We already know that the PK at index i is not equal to the ceiling PK.
+                        int cmp = 1; // Need to initialize. The value is irrelevant.
+                        for ( ; i + keysToSkip < keysInRange.size(); keysToSkip++)
                         {
-                            var nextPrimaryKey = keys.get(i + j);
-                            if (nextPrimaryKey.compareTo(ceilingPrimaryKey) >= 0)
+                            var nextPrimaryKey = keys.get(i + keysToSkip);
+                            cmp = nextPrimaryKey.compareTo(ceilingPrimaryKey);
+                            if (cmp >= 0)
                                 break;
                         }
-                        comparisonsSavedByBsearch.update(j - (int) ceil(logBase2(keysInRange.size() - i)));
-                        i += j - 1; // -1 because loop will increment next
+                        comparisonsSavedByBsearch.update(keysToSkip - (int) ceil(logBase2(keysInRange.size() - i)));
+                        i += keysToSkip;
+                        if (cmp == 0)
+                            ceilingPrimaryKeyMatchedKeyInRange = true;
                     }
                     else
                     {
@@ -437,16 +442,23 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                         if (nextIndexForCeiling < 0)
                             // We got: -(insertion point) - 1. Invert it so we get the insertion point.
                             nextIndexForCeiling = -nextIndexForCeiling - 1;
+                        else
+                            ceilingPrimaryKeyMatchedKeyInRange = true;
 
                         comparisonsSavedByBsearch.update(nextIndexForCeiling - (int) ceil(logBase2(keysRemaining.size())));
-                        i += nextIndexForCeiling - 1; // -1 because loop will increment next
+                        i += nextIndexForCeiling;
                     }
 
                     // update our estimate
                     preferSeqScanToBsearch = comparisonsSavedByBsearch.getCount() >= 10
                                              && comparisonsSavedByBsearch.getSnapshot().getMean() < 0;
-                    continue;
+                    if (ceilingPrimaryKeyMatchedKeyInRange)
+                        sstableRowId = ceilingRowId;
+                    else
+                        continue;
                 }
+                // Increment here to simplify the sstableRowId < 0 logic.
+                i++;
 
                 // these should still be true based on our computation of keysInRange
                 assert sstableRowId >= metadata.minSSTableRowId : String.format("sstableRowId %d < minSSTableRowId %d", sstableRowId, metadata.minSSTableRowId);


### PR DESCRIPTION
* In limit to top results, we can skip a call to `primaryKeyMap.exactRowIdOrInvertedCeiling(primaryKey);` when we know the `ceilingPrimaryKey` is equal to a primary key in the `keysInRange` list.
* Add a test to verify the fix from #902