### PR TITLE
add cassandra.sai.delete_corrupt_components, true by default

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -405,6 +405,9 @@ public enum CassandraRelevantProperties
     // if true, allow BQ and writing optimized ordinal maps
     VSEARCH_11_9_UPGRADES("cassandra.vsearch_11_9_upgrades", "true"),
 
+    // Allow disabling deletions of corrupt index components for troubleshooting
+    DELETE_CORRUPT_SAI_COMPONENTS("cassandra.sai.delete_corrupt_components", "true"),
+
     // Enables parallel index read.
     USE_PARALLEL_INDEX_READ("cassandra.index_read.parallel", "true"),
     PARALLEL_INDEX_READ_NUM_THREADS("cassandra.index_read.parallel_thread_num");

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -32,11 +32,10 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.RegularAndStaticColumns;
@@ -348,9 +347,13 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
                 // Column indexes are invalid if their SSTable-level components are corrupted so delete
                 // their associated index files and mark them non-queryable.
                 indices.forEach(index -> {
-                    indexDescriptor.deleteColumnIndex(index.getIndexContext());
+                    if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                        indexDescriptor.deleteColumnIndex(index.getIndexContext());
                     index.makeIndexNonQueryable();
                 });
+
+                if (!CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                    logger.debug("Leaving believed-corrupt files for SSTable {} in place after failure loading per-sstable components", sstable);
             });
             return indices;
         }
@@ -365,7 +368,11 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             {
                 // Delete the index files and mark the index non-queryable, as its view may be compromised,
                 // and incomplete, for our callers:
-                invalid.forEach(context -> context.indexDescriptor.deleteColumnIndex(index.getIndexContext()));
+                if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                    invalid.forEach(context -> context.indexDescriptor.deleteColumnIndex(index.getIndexContext()));
+                else
+                    logger.debug("Leaving believed-corrupt files for {} in place after failure loading per-column components",
+                                 invalid.stream().map(SSTableContext::toString).collect(Collectors.joining(", ")));
                 index.makeIndexNonQueryable();
                 incomplete.add(index);
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -30,6 +30,7 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -42,7 +43,6 @@ import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.NoSpamLogger;
 
 /**
  * Column index writer that accumulates (on-heap) indexed data from a compacted SSTable as it's being flushed to disk.
@@ -175,7 +175,10 @@ public class SSTableIndexWriter implements PerIndexWriter
                          indexDescriptor.descriptor, FBUtilities.prettyPrintMemory(allocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
         }
 
-        indexDescriptor.deleteColumnIndex(indexContext);
+        if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+            indexDescriptor.deleteColumnIndex(indexContext);
+        else
+            logger.debug("Skipping delete of index components after failure on index build of {}.{}", indexDescriptor, indexContext);
     }
 
     /**


### PR DESCRIPTION
Goal is to allow testing the versioning code without your test case vanishing out from under you if you make a mistake.

Needed to update the logic in three places.  Possibly more, but these three solve the problem of files vanishing immediately after startup.