### PR TITLE
wip: Alternate query path: search vector index first and post-filter

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/Memtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/Memtable.java
@@ -212,6 +212,9 @@ public interface Memtable extends Comparable<Memtable>
     /** Number of partitions stored in the memtable */
     long partitionCount();
 
+    /** Number of rows stored in the memtable */
+    long rowCount();
+
     /** Size of the data not accounting for any metadata / mapping overheads */
     long getLiveDataSize();
 

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.db.partitions.BTreePartitionData;
 import org.apache.cassandra.db.partitions.BTreePartitionUpdater;
 import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
@@ -168,6 +169,30 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
     public long partitionCount()
     {
         return partitions.size();
+    }
+
+    @Override
+    public long rowCount()
+    {
+        DataRange range = DataRange.allData(metadata().partitioner);
+        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(metadata(), true).build();
+        return rowCount(columnFilter, range);
+    }
+
+    public long rowCount(final ColumnFilter columnFilter, final DataRange dataRange)
+    {
+        int total = 0;
+        for (var iter = makePartitionIterator(columnFilter, dataRange); iter.hasNext(); )
+        {
+            for (UnfilteredRowIterator it = iter.next(); it.hasNext(); )
+            {
+                Unfiltered uRow = it.next();
+                if (uRow.isRow())
+                    total++;
+            }
+        }
+
+        return total;
     }
 
     public MemtableUnfilteredPartitionIterator makePartitionIterator(final ColumnFilter columnFilter,

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -292,6 +292,14 @@ public class TrieMemtable extends AbstractAllocatorMemtable
         return shards.length;
     }
 
+    @Override
+    public long rowCount()
+    {
+        DataRange range = DataRange.allData(metadata().partitioner);
+        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(metadata(), true).build();
+        return rowCount(columnFilter, range);
+    }
+
     public long rowCount(final ColumnFilter columnFilter, final DataRange dataRange)
     {
         int total = 0;

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -118,7 +118,7 @@ public class QueryContext
     {
         rowsFiltered.add(val);
     }
-    public void addRowsReturned(long val)
+    public void addRowsMatched(long val)
     {
         rowsMatched.add(val);
     }

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -18,10 +18,7 @@
 
 package org.apache.cassandra.index.sai;
 
-import java.io.IOException;
-import java.util.HashSet;
 import java.util.NavigableSet;
-import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -32,9 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.github.jbellis.jvector.util.Bits;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
-import org.apache.cassandra.index.sai.disk.vector.JVectorLuceneOnDiskGraph;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 
@@ -85,8 +80,7 @@ public class QueryContext
     private FilterSortOrder filterSortOrder = null;
 
     // Estimates the probability of a row picked by the index to be accepted by the post filter.
-    // Null means uknown.
-    private Float postFilterSelectivityEstimate = null;
+    private float postFilterSelectivityEstimate = 1.0f;
 
     // Last used soft limit for vector search.
     private int softLimit = -1;
@@ -363,7 +357,7 @@ public class QueryContext
     public enum FilterSortOrder
     {
         /** First get the matching keys from the non-vector indexes, then use vector index to sort them */
-        FILTER_THAN_SORT,
+        FILTER_THEN_SORT,
 
         /** First get the candidates in ANN order from the vector index, then fetch the rows and post-filter them */
         SORT_THEN_FILTER

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -49,7 +49,7 @@ public class QueryContext
     private final LongAdder segmentsHit = new LongAdder();
     private final LongAdder partitionsRead = new LongAdder();
     private final LongAdder rowsFiltered = new LongAdder();
-    private final LongAdder rowsReturned = new LongAdder();
+    private final LongAdder rowsMatched = new LongAdder();
     private final LongAdder trieSegmentsHit = new LongAdder();
 
     private final LongAdder bkdPostingListsHit = new LongAdder();
@@ -120,11 +120,11 @@ public class QueryContext
     }
     public void addRowsReturned(long val)
     {
-        rowsReturned.add(val);
+        rowsMatched.add(val);
     }
-    public void resetRowsReturned()
+    public void resetRowsMatched()
     {
-        rowsReturned.reset();
+        rowsMatched.reset();
     }
     public void addTrieSegmentsHit(long val)
     {
@@ -217,9 +217,9 @@ public class QueryContext
     {
         return rowsFiltered.longValue();
     }
-    public long rowsReturned()
+    public long rowsMatched()
     {
-        return rowsReturned.longValue();
+        return rowsMatched.longValue();
     }
     public long trieSegmentsHit()
     {

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -49,7 +49,7 @@ public class QueryContext
     private final LongAdder segmentsHit = new LongAdder();
     private final LongAdder partitionsRead = new LongAdder();
     private final LongAdder rowsFiltered = new LongAdder();
-
+    private final LongAdder rowsReturned = new LongAdder();
     private final LongAdder trieSegmentsHit = new LongAdder();
 
     private final LongAdder bkdPostingListsHit = new LongAdder();
@@ -117,6 +117,14 @@ public class QueryContext
     public void addRowsFiltered(long val)
     {
         rowsFiltered.add(val);
+    }
+    public void addRowsReturned(long val)
+    {
+        rowsReturned.add(val);
+    }
+    public void resetRowsReturned()
+    {
+        rowsReturned.reset();
     }
     public void addTrieSegmentsHit(long val)
     {
@@ -208,6 +216,10 @@ public class QueryContext
     public long rowsFiltered()
     {
         return rowsFiltered.longValue();
+    }
+    public long rowsReturned()
+    {
+        return rowsReturned.longValue();
     }
     public long trieSegmentsHit()
     {

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -245,28 +245,6 @@ public class Operation
         }
     }
 
-    static RangeIterator buildIterator(QueryController controller)
-    {
-        var filterOperation = controller.filterOperation();
-        var orderings = filterOperation.expressions()
-                                       .stream().filter(e -> e.operator() == Operator.ANN).collect(Collectors.toList());
-        assert orderings.size() <= 1;
-        if (filterOperation.expressions().size() == 1 && filterOperation.children().isEmpty() && orderings.size() == 1)
-            // If we only have one expression, we just use the ANN index to order and limit.
-            return controller.getTopKRows(orderings.get(0));
-        var nonOrderingExpressions = filterOperation.expressions().stream()
-                                                    .filter(e -> e.operator() != Operator.ANN).collect(Collectors.toList());
-        var iter = Node.buildTree(nonOrderingExpressions, filterOperation.children(), filterOperation.isDisjunction()).analyzeTree(controller).rangeIterator(controller);
-        if (orderings.isEmpty())
-            return iter;
-        return controller.getTopKRows(iter, orderings.get(0));
-    }
-
-    static FilterTree buildFilter(QueryController controller)
-    {
-        return Node.buildTree(controller.filterOperation()).buildFilter(controller);
-    }
-
     public static abstract class Node
     {
         ListMultimap<ColumnMetadata, Expression> expressionMap;

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -241,7 +241,6 @@ public class QueryController
                                                     .filter(e -> e.operator() != Operator.ANN)
                                                     .collect(Collectors.toList());
         var iter = Operation.Node.buildTree(nonOrderingExpressions, filterOperation.children(), filterOperation.isDisjunction()).analyzeTree(this).rangeIterator(this);
-        queryContext.setPostFilterSelectivityEstimate(estimateSelectivity(iter));
 
         if (orderings.isEmpty())
             return iter;
@@ -251,11 +250,12 @@ public class QueryController
         {
             // If there are too many keys returned form the index, use postfiltering:
             queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SORT_THEN_FILTER);
+            queryContext.setPostFilterSelectivityEstimate(estimateSelectivity(iter));
             FileUtils.closeQuietly(iter);
             return getTopKRows(orderings.get(0));
         }
 
-        queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.FILTER_THAN_SORT);
+        queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.FILTER_THEN_SORT);
         return getTopKRows(iter, orderings.get(0));
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -491,7 +491,7 @@ public class QueryController
         int target = getExactLimit();
         // shadowedCount includes also the keys filtered out by the post-filter
         long shadowedCount = queryContext.getShadowedPrimaryKeys().size();
-        long fetchedCount = queryContext.rowsReturned() + shadowedCount;
+        long fetchedCount = queryContext.rowsMatched() + shadowedCount;
         int prevSoftLimit = Math.max(target, queryContext.softLimit());
         float postFilterSelectivity = queryContext.postFilterSelectivityEstimate();
 
@@ -502,7 +502,7 @@ public class QueryController
         // For any subsequent iterations we can do better by looking how many keys were rejected in the previous run.
         float keyAcceptanceProbability = (firstShadowKeysLoopIteration && sortBeforeFilter)
             ? postFilterSelectivity
-            : (float) queryContext.rowsReturned() / Math.max(fetchedCount, 1);
+            : (float) queryContext.rowsMatched() / Math.max(fetchedCount, 1);
 
         // TODO: extract the targetProbability to a constant / param?
         int uncappedLimit = SoftLimitUtil.softLimit(target, SOFT_LIMIT_CONFIDENCE, keyAcceptanceProbability);
@@ -747,7 +747,7 @@ public class QueryController
      */
     float estimateSelectivity(RangeIterator iterator)
     {
-        float selectivity = (float) iterator.getMaxKeys() / estimateTotalAvailableRows();
+        float selectivity = Math.min((float) iterator.getMaxKeys() / estimateTotalAvailableRows(), 1.0f);
         queryContext.setPostFilterSelectivityEstimate(selectivity);
         return selectivity;
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -129,13 +129,13 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             queryContext.addShadowedKeysLoopCount(1L);
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             ResultRetriever result = queryIndexes.get();
-            queryContext.resetRowsReturned();
+            queryContext.resetRowsMatched();
             UnfilteredPartitionIterator topK = (UnfilteredPartitionIterator)new VectorTopKProcessor(command).filter(result);
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             long newShadowedKeysCount = currentShadowedKeysCount - lastShadowedKeysCount;
             // Stop if no new shadowed keys found
             // or if we already tried to search beyond the limit for more than the limit + count of new shadowed keys
-            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.rowsReturned())
+            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.rowsMatched())
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -535,7 +535,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), row, staticRow))
                 {
-                    queryContext.addRowsReturned(1);
+                    queryContext.addRowsMatched(1);
                     clusters.add(row);
                 }
             }
@@ -545,7 +545,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), staticRow, staticRow))
                 {
-                    queryContext.addRowsReturned(1);
+                    queryContext.addRowsMatched(1);
                     clusters.add(staticRow);
                 }
             }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -129,14 +129,13 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             queryContext.addShadowedKeysLoopCount(1L);
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             ResultRetriever result = queryIndexes.get();
-            final var softLimit = queryContext.softLimit();
+            queryContext.resetRowsReturned();
             UnfilteredPartitionIterator topK = (UnfilteredPartitionIterator)new VectorTopKProcessor(command).filter(result);
-
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             long newShadowedKeysCount = currentShadowedKeysCount - lastShadowedKeysCount;
             // Stop if no new shadowed keys found
             // or if we already tried to search beyond the limit for more than the limit + count of new shadowed keys
-            if (newShadowedKeysCount == 0 || exactLimit <= softLimit - newShadowedKeysCount)
+            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.rowsReturned())
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)
@@ -523,6 +522,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), row, staticRow))
                 {
+                    queryContext.addRowsReturned(1);
                     clusters.add(row);
                 }
             }
@@ -532,6 +532,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), staticRow, staticRow))
                 {
+                    queryContext.addRowsReturned(1);
                     clusters.add(staticRow);
                 }
             }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -128,8 +128,8 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         {
             queryContext.addShadowedKeysLoopCount(1L);
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
-            final var softLimit = controller.currentSoftLimitEstimate();
             ResultRetriever result = queryIndexes.get();
+            final var softLimit = queryContext.softLimit();
             UnfilteredPartitionIterator topK = (UnfilteredPartitionIterator)new VectorTopKProcessor(command).filter(result);
 
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
@@ -155,7 +155,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
      */
     private RangeIterator analyze()
     {
-        return Operation.buildIterator(controller);
+        return controller.buildIterator();
     }
 
     /**
@@ -169,7 +169,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
      */
     private FilterTree analyzeFilter()
     {
-        return Operation.buildFilter(controller);
+        return controller.buildFilter();
     }
 
     private static class ResultRetriever extends AbstractIterator<UnfilteredRowIterator>

--- a/src/java/org/apache/cassandra/index/sai/utils/SoftLimitUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SoftLimitUtil.java
@@ -41,8 +41,12 @@ public class SoftLimitUtil
      */
     public static int softLimit(int targetLimit, double confidenceLevel, double perItemSuccessRate)
     {
+        if (Double.isNaN(confidenceLevel))
+            throw new IllegalArgumentException("confidenceLevel must not be NaN");
         if (confidenceLevel < 0.0 || confidenceLevel >= 1.0)
             throw new IllegalArgumentException("confidenceLevel out of range [0.0, 1.0): " + confidenceLevel);
+        if (Double.isNaN(perItemSuccessRate))
+            throw new IllegalArgumentException("perItemSuccessRate must not be NaN");
         if (perItemSuccessRate < 0.0 || perItemSuccessRate > 1.0)
             throw new IllegalArgumentException("perItemSuccessRate out of range [0.0, 1.0]: " + perItemSuccessRate);
         if (targetLimit < 0)

--- a/src/java/org/apache/cassandra/index/sai/utils/SoftLimitUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SoftLimitUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.math3.distribution.PascalDistribution;
+
+public class SoftLimitUtil
+{
+    /**
+     * Computes the number of items (e.g. keys, rows) that should be requested from a lower-layer of the system
+     * (e.g. storage) so that we obtain at least targetLimit number of items with given probability.
+     * It assumes that each item may randomly fail, in which case it is not delivered, thus the number of items
+     * delivered may be smaller than the number of items requested. Items are assumed to fail independently.
+     * <p>
+     * For example, if we want to deliver 100 rows to the user, but we know 20% of rows are tombstoned and would
+     * be rejected, then we should request `softLimit(100, 0.95, 0.8)` rows from the storage, and that would deliver
+     * in 95% of cases a sufficient number of rows, without having to query again for more.
+     *
+     * @param targetLimit the number of items that should be delivered to the user or upper layer in the system
+     * @param confidenceLevel the desired probability we obtain enough items in range, given in range [0.0, 1.0),
+     *                        typically you want to set it close to 1.0.
+     * @param perItemSuccessRate the probability of obtaining an item, given in range [0.0, 1.0]
+     * @return the number of items that should be requested from the lower layer of the system; >= 0;
+     *    if the true result is greater than Integer.MAX_VALUE it is clamped to Integer.MAX_VALUE
+     */
+    public static int softLimit(int targetLimit, double confidenceLevel, double perItemSuccessRate)
+    {
+        if (confidenceLevel < 0.0 || confidenceLevel >= 1.0)
+            throw new IllegalArgumentException("confidenceLevel out of range [0.0, 1.0): " + confidenceLevel);
+        if (perItemSuccessRate < 0.0 || perItemSuccessRate > 1.0)
+            throw new IllegalArgumentException("perItemSuccessRate out of range [0.0, 1.0]: " + perItemSuccessRate);
+        if (targetLimit < 0)
+            throw new IllegalArgumentException("targetLimit must not be < 0: " + targetLimit);
+
+        // Consider we perform attempts until we get R successes (=targetLimit), where the probability of success is
+        // P (=perItemSuccessRate). In this case the number of failures is described by a negative binomial
+        // distribution NB(R, P). We use PascalDistribution, which is an optimized special case
+        // of NB for dealing with integers.
+        final var failureDistrib = new PascalDistribution(targetLimit, perItemSuccessRate);
+        long maxExpectedFailures = failureDistrib.inverseCumulativeProbability(confidenceLevel);
+
+        long softLimit = (long) targetLimit + maxExpectedFailures;
+        return (int) Math.min(softLimit, Integer.MAX_VALUE);
+    }
+
+}

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -691,6 +691,12 @@ public class ColumnFamilyStoreTest
             }
 
             @Override
+            public long rowCount()
+            {
+                return 0;
+            }
+
+            @Override
             public long getLiveDataSize()
             {
                 return 0;

--- a/test/unit/org/apache/cassandra/index/sai/utils/SoftLimitUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SoftLimitUtilTest.java
@@ -18,22 +18,153 @@
 
 package org.apache.cassandra.index.sai.utils;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.Random;
 
+import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
+import static org.apache.cassandra.index.sai.utils.SoftLimitUtil.softLimit;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SoftLimitUtilTest
 {
+    private final Random random = new Random();
 
     @Test
-    public void testPerItemProbabilityOne()
+    public void perItemProbabilityOne()
     {
-
+        assertEquals(0, softLimit(0, 0.999, 1.0));
+        assertEquals(1, softLimit(1, 0.999, 1.0));
+        assertEquals(100, softLimit(100, 0.999, 1.0));
+        assertEquals(1000000, softLimit(1000000, 0.999, 1.0));
+        assertEquals(Integer.MAX_VALUE, softLimit(Integer.MAX_VALUE, 0.999, 1.0));
     }
 
+    @Test
+    public void perItemProbabilityZero()
+    {
+        assertEquals(0, softLimit(0, 0.999, 0.0), 0);
+        assertEquals(Integer.MAX_VALUE, softLimit(1, 0.999, 0.0));
+        assertEquals(Integer.MAX_VALUE, softLimit(100, 0.999, 0.0));
+        assertEquals(Integer.MAX_VALUE, softLimit(1000000, 0.999, 0.0));
+        assertEquals(Integer.MAX_VALUE, softLimit(Integer.MAX_VALUE, 0.999, 0.0));
+    }
+
+    @Test
+    public void confidenceLevelZero()
+    {
+        // By setting confidenceLevel to 0.0 we say we don't care about failures
+        assertEquals(0, softLimit(0, 0.0, 0.5));
+        assertEquals(1, softLimit(1, 0.0, 0.5));
+        assertEquals(100, softLimit(100, 0.0, 0.5));
+        assertEquals(1000000, softLimit(1000000, 0.0, 0.5));
+        assertEquals(Integer.MAX_VALUE, softLimit(Integer.MAX_VALUE, 0.0, 0.5));
+    }
+
+    @Test
+    public void confidenceLevelHalf()
+    {
+        assertEquals(0, softLimit(0, 0.5, 0.5));
+        assertEquals(1, softLimit(1, 0.5, 0.5));
+        // For large enough numbers, the number of items we need to query should be very close to targetLimit / perItemProbability.
+        assertEquals(2000000, softLimit(1000000, 0.5, 0.5), 2);
+        assertEquals(5000000, softLimit(1000000, 0.5, 0.2), 5);
+        assertEquals(10000000, softLimit(1000000, 0.5, 0.1), 10);
+        assertEquals(100000000, softLimit(1000000, 0.5, 0.01), 100);
+        assertEquals(1000000000, softLimit(1000000, 0.5, 0.001), 1000);
+        assertEquals(Integer.MAX_VALUE, softLimit(Integer.MAX_VALUE, 0.5, 0.5));
+    }
+
+    @Test
+    public void confidenceLevelNearOne()
+    {
+        assertEquals(0, softLimit(0, 0.999, 0.5));
+        assertEquals(10, softLimit(1, 0.999, 0.5)); // 1.0 - 0.5 ^ 10 is a tad more than 0.999
+
+        // Intuition-driven tests.
+        // We need to query a bit more than targetLimit / perItemProbability to get good confidence.
+        // The higher the targetLimit, the relatively closer to targetLimit / perItemProbability the softLimit is.
+
+        assertTrue(softLimit(10, 0.999, 0.5) >= 30);
+        assertTrue(softLimit(10, 0.999, 0.5) <= 50);
+
+        assertTrue(softLimit(10, 0.999, 0.1) >= 200);
+        assertTrue(softLimit(10, 0.999, 0.1) <= 300);
+
+        assertTrue(softLimit(100, 0.999, 0.5) >= 220);
+        assertTrue(softLimit(100, 0.999, 0.5) <= 250);
+
+        assertTrue(softLimit(100, 0.999, 0.1) >= 1300);
+        assertTrue(softLimit(100, 0.999, 0.1) <= 1500);
+
+        assertTrue(softLimit(100, 0.999, 0.001) >= 130000);
+        assertTrue(softLimit(100, 0.999, 0.001) <= 150000);
+
+        assertTrue(softLimit(1000, 0.999, 0.1) >= 10500);
+        assertTrue(softLimit(1000, 0.999, 0.1) <= 11500);
+
+        assertTrue(softLimit(1000, 0.999, 0.001) >= 1100000);
+        assertTrue(softLimit(1000, 0.999, 0.001) <= 1150000);
+    }
+
+    @Test
+    public void resultIsNonDecreasingWithConfidence()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            int n = (int) Math.pow(10.0, 6 * random.nextDouble());
+            double c1 = random.nextDouble();
+            double c2 = random.nextDouble();
+            double p = random.nextDouble();
+            int l1 = softLimit(n, c1, p);
+            int l2 = softLimit(n, c2, p);
+            assertTrue("n: " + n + ", p: " + p + ", l1: " + l1 + ", l2: " + l2 + ", c1: " + c1 + ", c2: " + c2,
+                       (l1 > l2) == (c1 > c2) || l1 == l2);
+        }
+    }
+
+    @Test
+    public void resultIsNonIncreasingWithPerItemProbability()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            int n = (int) Math.pow(10.0, 6 * random.nextDouble());
+            double c = random.nextDouble();         // [0.0, 1.0)
+            double p1 = 1.0 - random.nextDouble();  // (0.0, 1.0]
+            double p2 = 1.0 - random.nextDouble();  // (0.0, 1.0]
+            int l1 = softLimit(n, c, p1);
+            int l2 = softLimit(n, c, p2);
+            assertTrue("n: " + n + ", c: " + c + ", l1: " + l1 + ", l2: " + l2 + ", p1: " + p1 + ", p2: " + p2,
+                       (l1 > l2) == (p1 < p2) || l1 == l2);
+        }
+    }
+
+    @Test
+    public void randomized()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            int n = (int) Math.pow(10.0, 6 * random.nextDouble());
+            double c = random.nextDouble();         // [0.0, 1.0)
+            double p = 1.0 - random.nextDouble();   // (0.0, 1.0]
+            int softLimit = softLimit(n, c, p);
+            assertTrue(softLimit >= n);
+
+            // Estimate the probability we get at least n successes after softLimit tries with probability p.
+            // Make sure we have enough confidence we get at least n, but not enough we get n + 1.
+            BinomialDistribution successDistribution = new BinomialDistribution(softLimit, p);
+            double confidenceLowerBound = probabilityOfAtLeastNSuccesses(successDistribution, n + 1);
+            double confidenceUpperBound = probabilityOfAtLeastNSuccesses(successDistribution, n);
+            assertTrue(c + " lower than required lower bound " + confidenceLowerBound,c >= confidenceLowerBound);
+            assertTrue(c + " higher than required upper bound " + confidenceLowerBound, c < confidenceUpperBound);
+        }
+    }
+
+    private double probabilityOfAtLeastNSuccesses(BinomialDistribution distribution, int n)
+    {
+        return n > 0
+               ? 1.0 - distribution.cumulativeProbability(n - 1)
+               : 1.0;
+    }
 }

--- a/test/unit/org/apache/cassandra/index/sai/utils/SoftLimitUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SoftLimitUtilTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertTrue;
+
+public class SoftLimitUtilTest
+{
+
+    @Test
+    public void testPerItemProbabilityOne()
+    {
+
+    }
+
+}


### PR DESCRIPTION
If there are too many rows matching the `WHERE` clause, do `ORDER BY column ANN OF ...` first and then post-filter.
