### PR TITLE
Tests go zoom

### DIFF
--- a/src/java/org/apache/cassandra/db/SortedLocalRanges.java
+++ b/src/java/org/apache/cassandra/db/SortedLocalRanges.java
@@ -42,7 +42,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 
 /**
- * This class contains the local ranges for a given table, sorted.
+ * This class contains the local ranges for a given table, sorted.  At least one range is always present.
  */
 public class SortedLocalRanges
 {
@@ -63,10 +63,10 @@ public class SortedLocalRanges
         if (ranges == null || ranges.isEmpty())
         {
             IPartitioner partitioner = realm.getPartitioner();
-            this.ranges = new ArrayList<>(1);
-            this.ranges.add(new Splitter.WeightedRange(1.0,
-                                                       new Range<>(partitioner.getMinimumToken(),
-                                                                   partitioner.getMinimumToken())));
+            var range = new Splitter.WeightedRange(1.0,
+                                                   new Range<>(partitioner.getMinimumToken(),
+                                                               partitioner.getMinimumToken()));
+            this.ranges = List.of(range);
         }
         else
         {
@@ -78,6 +78,7 @@ public class SortedLocalRanges
                     sortedRanges.add(new Splitter.WeightedRange(range.weight(), unwrapped));
                 }
             }
+            assert !sortedRanges.isEmpty() : "Got empty ranges unwrapping " + ranges;
             sortedRanges.sort(Comparator.comparing(Splitter.WeightedRange::left));
 
             this.ranges = sortedRanges;

--- a/src/java/org/apache/cassandra/db/SortedLocalRanges.java
+++ b/src/java/org/apache/cassandra/db/SortedLocalRanges.java
@@ -60,7 +60,7 @@ public class SortedLocalRanges
         this.realm = realm;
         this.ringVersion = ringVersion;
 
-        if (ranges == null)
+        if (ranges == null || ranges.isEmpty())
         {
             IPartitioner partitioner = realm.getPartitioner();
             this.ranges = new ArrayList<>(1);

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -196,7 +196,7 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
      */
     protected boolean maybeSwitchLocation(DecoratedKey key)
     {
-        if (diskBoundaries == null)
+        if (key == null || diskBoundaries == null)
         {
             if (locationIndex < 0)
             {

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -287,6 +287,11 @@ public class TrieMemtable extends AbstractAllocatorMemtable
         return total;
     }
 
+    public int getShardCount()
+    {
+        return shards.length;
+    }
+
     public long rowCount(final ColumnFilter columnFilter, final DataRange dataRange)
     {
         int total = 0;

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -142,7 +142,12 @@ public class TrieMemtable extends AbstractAllocatorMemtable
     @VisibleForTesting
     public static final String SHARD_COUNT_PROPERTY = "cassandra.trie.memtable.shard.count";
 
-    public static volatile int SHARD_COUNT = Integer.getInteger(SHARD_COUNT_PROPERTY, FBUtilities.getAvailableProcessors());
+    public static volatile int SHARD_COUNT = Integer.getInteger(SHARD_COUNT_PROPERTY, autoShardCount());
+
+    private static int autoShardCount()
+    {
+        return 4 * FBUtilities.getAvailableProcessors();
+    }
 
     // only to be used by init(), to setup the very first memtable for the cfs
     TrieMemtable(AtomicReference<CommitLogPosition> commitLogLowerBound, TableMetadataRef metadataRef, Owner owner)
@@ -808,7 +813,7 @@ public class TrieMemtable extends AbstractAllocatorMemtable
         {
             if ("auto".equalsIgnoreCase(shardCount))
             {
-                SHARD_COUNT = FBUtilities.getAvailableProcessors();
+                SHARD_COUNT = autoShardCount();
             }
             else
             {
@@ -818,7 +823,8 @@ public class TrieMemtable extends AbstractAllocatorMemtable
                 }
                 catch (NumberFormatException ex)
                 {
-                    logger.warn("Unable to parse {} as valid value for shard count", shardCount);
+                    logger.warn("Unable to parse {} as valid value for shard count; leaving it as {}",
+                                shardCount, SHARD_COUNT);
                     return;
                 }
             }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.index.sai.utils.RangeConcatIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
+import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Reducer;
@@ -117,7 +118,7 @@ public class TrieMemtableIndex implements MemtableIndex
         return Arrays.stream(rangeIndexes)
                      .map(MemoryIndex::getMinTerm)
                      .filter(Objects::nonNull)
-                     .min(Comparator.comparing(identity(), validator))
+                     .reduce((a, b) -> TypeUtil.min(a, b, validator))
                      .orElse(null);
     }
 
@@ -134,7 +135,7 @@ public class TrieMemtableIndex implements MemtableIndex
         return Arrays.stream(rangeIndexes)
                      .map(MemoryIndex::getMaxTerm)
                      .filter(Objects::nonNull)
-                     .max(Comparator.comparing(identity(), validator))
+                     .reduce((a, b) -> TypeUtil.max(a, b, validator))
                      .orElse(null);
     }
 

--- a/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
@@ -49,7 +49,8 @@ public class SlabAllocator extends MemtableBufferAllocator
 {
     private static final Logger logger = LoggerFactory.getLogger(SlabAllocator.class);
 
-    private final static int REGION_SIZE = 1024 * 1024;
+    @VisibleForTesting
+    public final static int REGION_SIZE = 1024 * 1024;
     private final static int MAX_CLONED_SIZE = 128 * 1024; // bigger than this don't go in the region
 
     // globally stash any Regions we allocate but are beaten to using, and use these up before allocating any more

--- a/test/unit/org/apache/cassandra/db/SortedLocalRangesTest.java
+++ b/test/unit/org/apache/cassandra/db/SortedLocalRangesTest.java
@@ -115,13 +115,13 @@ public class SortedLocalRangesTest
         assertEquals(sortedRanges.hashCode(), sortedRanges.hashCode());
 
         assertFalse(sortedRanges.isOutOfDate());
-        assertTrue(sortedRanges.getRanges().isEmpty());
+        assertEquals(1, sortedRanges.getRanges().size());
         assertEquals(ringVersion, sortedRanges.getRingVersion());
 
-        // if there are no ranges, the splitter will return an array with the maximum token regardless of how many splits
+        // split(x) returns 1 range for all x <= 1
         assertEquals(1, sortedRanges.split(0).size());
-        assertEquals(1, sortedRanges.split(1).size());
-        assertEquals(1, sortedRanges.split(2).size());
+        for (int i = 1; i <= 10; i++)
+            assertEquals(i, sortedRanges.split(i).size());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
@@ -182,10 +182,11 @@ public abstract class MemtableSizeTestBase extends CQLTester
             long expectedHeap = deepSizeAfter - deepSizeBefore;
             long max_difference = MAX_DIFFERENCE_PERCENT * expectedHeap / 100;
             long trie_overhead = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).unusedReservedMemory() : 0;
+            int slabCount = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).getShardCount() : 1;
             switch (DatabaseDescriptor.getMemtableAllocationType())
             {
                 case heap_buffers:
-                    max_difference += SLAB_OVERHEAD;
+                    max_difference += (long) SLAB_OVERHEAD * slabCount;
                     actualHeap += trie_overhead;    // adjust trie memory with unused buffer space if on-heap
                     break;
                 case unslabbed_heap_buffers:

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.memory.SlabAllocator;
 import org.github.jamm.MemoryMeter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,8 +73,6 @@ public abstract class MemtableSizeTestBase extends CQLTester
     // Must be within 3% of the real usage. We are actually more precise than this, but the threshold is set higher to
     // avoid flakes. For on-heap allocators we allow for extra overheads below.
     final int MAX_DIFFERENCE_PERCENT = 3;
-    // Slab overhead, added when the memtable uses heap_buffers.
-    final int SLAB_OVERHEAD = 1024 * 1024;
     // Extra leniency for unslabbed buffers. We are not as precise there, and it's not a mode in real use.
     final int UNSLABBED_EXTRA_PERCENT = 2;
 
@@ -168,7 +167,7 @@ public abstract class MemtableSizeTestBase extends CQLTester
                               cfs.getTracker().getView().getCurrentMemtable());
 
             Memtable.MemoryUsage usage = Memtable.getMemoryUsage(memtable);
-            long actualHeap = usage.ownsOnHeap;
+            long calculatedHeap = usage.ownsOnHeap;
             System.out.println(String.format("Memtable in %s mode: %d ops, %s serialized bytes, %s",
                                              DatabaseDescriptor.getMemtableAllocationType(),
                                              memtable.getOperations(),
@@ -179,27 +178,29 @@ public abstract class MemtableSizeTestBase extends CQLTester
             System.out.println("Memtable deep size " +
                                FBUtilities.prettyPrintMemory(deepSizeAfter));
 
-            long expectedHeap = deepSizeAfter - deepSizeBefore;
-            long max_difference = MAX_DIFFERENCE_PERCENT * expectedHeap / 100;
-            long trie_overhead = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).unusedReservedMemory() : 0;
-            int slabCount = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).getShardCount() : 1;
+            long actualHeap = deepSizeAfter - deepSizeBefore;
+            long maxDifference = MAX_DIFFERENCE_PERCENT * actualHeap / 100;
+            long trieOverhead = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).unusedReservedMemory() : 0;
+            calculatedHeap += trieOverhead;    // adjust trie memory with unused buffer space if on-heap
             switch (DatabaseDescriptor.getMemtableAllocationType())
             {
                 case heap_buffers:
-                    max_difference += (long) SLAB_OVERHEAD * slabCount;
-                    actualHeap += trie_overhead;    // adjust trie memory with unused buffer space if on-heap
+                    // MemoryUsage only counts the memory actually used by cells,
+                    // so add in the slab overhead to match what MemoryMeter sees
+                    int slabCount = memtable instanceof TrieMemtable ? ((TrieMemtable) memtable).getShardCount() : 1;
+                    maxDifference += (long) SlabAllocator.REGION_SIZE * slabCount;
                     break;
                 case unslabbed_heap_buffers:
-                    max_difference += expectedHeap * UNSLABBED_EXTRA_PERCENT / 100;   // We are not as precise for this
-                    actualHeap += trie_overhead;    // adjust trie memory with unused buffer space if on-heap
+                    // add a hardcoded slack factor
+                    maxDifference += actualHeap * UNSLABBED_EXTRA_PERCENT / 100;
                     break;
             }
-            String message = String.format("Expected heap usage close to %s, got %s, %s difference.\n",
-                                           FBUtilities.prettyPrintMemory(expectedHeap),
+            String message = String.format("Actual heap usage is %s, got %s, %s difference.\n",
                                            FBUtilities.prettyPrintMemory(actualHeap),
-                                           FBUtilities.prettyPrintMemory(expectedHeap - actualHeap));
+                                           FBUtilities.prettyPrintMemory(calculatedHeap),
+                                           FBUtilities.prettyPrintMemory(actualHeap - calculatedHeap));
             System.out.println(message);
-            Assert.assertTrue(message, Math.abs(actualHeap - expectedHeap) <= max_difference);
+            Assert.assertTrue(message, Math.abs(calculatedHeap - actualHeap) <= maxDifference);
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/db/memtable/TrieMemtableConfigTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/TrieMemtableConfigTest.java
@@ -57,6 +57,6 @@ public class TrieMemtableConfigTest extends CQLTester
     public void testAutoShardCount() throws MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException, IOException, InvalidAttributeValueException
     {
         jmxConnection.setAttribute(new ObjectName(TRIE_MEMTABLE_CONFIG_OBJECT_NAME), new Attribute("ShardCount", "auto"));
-        assertEquals(FBUtilities.getAvailableProcessors(), Integer.parseInt(new TrieMemtable.TrieMemtableConfig().getShardCount()));
+        assertEquals(4 * FBUtilities.getAvailableProcessors(), Integer.parseInt(new TrieMemtable.TrieMemtableConfig().getShardCount()));
     }
 }


### PR DESCRIPTION
Minor change: increase default shard count

Much bigger impact: fix the case where SortedLocalRanges ends up empty, if SLR.ranges is empty then you always only get a single shard