### PR TITLE
Allow `StorageProvider` to impact the creation of `FileHandle` builders

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
@@ -84,15 +84,10 @@ public class IndexFileUtils
         return IndexInputReader.create(handle);
     }
 
-    public IndexInput openBlockingInput(File file)
+    public IndexInput openBlockingInput(FileHandle fileHandle)
     {
-        try (final FileHandle.Builder builder = new FileHandle.Builder(file))
-        {
-            final FileHandle fileHandle = builder.complete();
-            final RandomAccessReader randomReader = fileHandle.createReader();
-
-            return IndexInputReader.create(randomReader, fileHandle::close);
-        }
+        final RandomAccessReader randomReader = fileHandle.createReader();
+        return IndexInputReader.create(randomReader, fileHandle::close);
     }
 
     public interface ChecksumWriter

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.sstable.format.big.BigTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.DiskOptimizationStrategy;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
@@ -89,20 +90,14 @@ public abstract class SSTableReaderBuilder
 
     public abstract SSTableReader build();
 
-    @SuppressWarnings("resource")
     public static FileHandle.Builder defaultIndexHandleBuilder(Descriptor descriptor, Component component)
     {
-        return new FileHandle.Builder(descriptor.fileFor(component))
-                .mmapped(DatabaseDescriptor.getIndexAccessMode() == Config.DiskAccessMode.mmap)
-                .withChunkCache(ChunkCache.instance);
+        return StorageProvider.instance.fileHandleBuilderFor(descriptor, component);
     }
 
-    @SuppressWarnings("resource")
     public static FileHandle.Builder defaultDataHandleBuilder(Descriptor descriptor)
     {
-        return new FileHandle.Builder(descriptor.fileFor(Component.DATA))
-                .mmapped(DatabaseDescriptor.getDiskAccessMode() == Config.DiskAccessMode.mmap)
-                .withChunkCache(ChunkCache.instance);
+        return StorageProvider.instance.fileHandleBuilderFor(descriptor, Component.DATA);
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/storage/StorageProvider.java
+++ b/src/java/org/apache/cassandra/io/storage/StorageProvider.java
@@ -24,9 +24,17 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
@@ -118,6 +126,46 @@ public interface StorageProvider
      */
     void invalidateFileSystemCache(File file);
 
+    /**
+     * Creates a new {@link FileHandle.Builder} for the given sstable component.
+     * <p>
+     * The returned builder will be configured with the appropriate "access mode" (mmap or not), and the "chunk cache"
+     * will have been set if appropriate.
+     *
+     * @param descriptor descriptor for the sstable whose handler is built.
+     * @param component sstable component for which to build the handler.
+     * @return a new {@link FileHandle.Builder} for the provided sstable component with access mode and chunk cache
+     *   configured as appropriate.
+     */
+    FileHandle.Builder fileHandleBuilderFor(Descriptor descriptor, Component component);
+
+    /**
+     * Creates a new {@link FileHandle.Builder} for the given SAI component (for index with per-sstable files).
+     * <p>
+     * The returned builder will be configured with the appropriate "access mode" (mmap or not), and the "chunk cache"
+     * will have been set if appropriate.
+     *
+     * @param descriptor descriptor for the index file whose handler is built.
+     * @param component index component for which to build the handler.
+     * @return a new {@link FileHandle.Builder} for the provided SAI component with access mode and chunk cache
+     *   configured as appropriate.
+     */
+    FileHandle.Builder fileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component);
+
+    /**
+     * Creates a new {@link FileHandle.Builder} for the given SAI component and context (for index with per-index files).
+     * <p>
+     * The returned builder will be configured with the appropriate "access mode" (mmap or not), and the "chunk cache"
+     * will have been set if appropriate.
+     *
+     * @param descriptor descriptor for the index file whose handler is built.
+     * @param component index component for which to build the handler.
+     * @param context index context for which to build the handler.
+     * @return a new {@link FileHandle.Builder} for the provided SAI component with access mode and chunk cache
+     *   configured as appropriate.
+     */
+    FileHandle.Builder fileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component, IndexContext context);
+
     class DefaultProvider implements StorageProvider
     {
         @Override
@@ -157,6 +205,54 @@ public interface StorageProvider
         public void invalidateFileSystemCache(File file)
         {
             INativeLibrary.instance.trySkipCache(file, 0, 0);
+        }
+
+        protected Config.DiskAccessMode accessMode(Component component)
+        {
+            switch (component.type)
+            {
+                case PRIMARY_INDEX:
+                case PARTITION_INDEX:
+                case ROW_INDEX:
+                    return DatabaseDescriptor.getIndexAccessMode();
+                default:
+                    return DatabaseDescriptor.getDiskAccessMode();
+            }
+        }
+
+        @Override
+        @SuppressWarnings("resource")
+        public FileHandle.Builder fileHandleBuilderFor(Descriptor descriptor, Component component)
+        {
+            return new FileHandle.Builder(descriptor.fileFor(component))
+                   .mmapped(accessMode(component) == Config.DiskAccessMode.mmap)
+                   .withChunkCache(ChunkCache.instance);
+        }
+
+        @Override
+        @SuppressWarnings("resource")
+        public FileHandle.Builder fileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component)
+        {
+            File file = descriptor.fileFor(component);
+            if (logger.isTraceEnabled())
+            {
+                logger.trace(descriptor.logMessage("Opening {} file handle for {} ({})"),
+                             file, FBUtilities.prettyPrintMemory(file.length()));
+            }
+            return new FileHandle.Builder(file).mmapped(true);
+        }
+
+        @Override
+        @SuppressWarnings("resource")
+        public FileHandle.Builder fileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component, IndexContext context)
+        {
+            File file = descriptor.fileFor(component, context);
+            if (logger.isTraceEnabled())
+            {
+                logger.trace(descriptor.logMessage("Opening {} file handle for {} ({})"),
+                             file, FBUtilities.prettyPrintMemory(file.length()));
+            }
+            return new FileHandle.Builder(file).mmapped(true);
         }
     }
 }


### PR DESCRIPTION
When dealing with remote storage, we need a way to impact what kind of access mode is used for sstable components. For sstable data and "primary" index, this can be somewhat configured, but for SAI index components, this is currently hard-coded.

This patch allows `StorageProvider` to customize the concrete `FileHandle` used for both sstable files and SAI ones.  As `StorageProvider` is about abstracting "storage" in order to potentially allow the use of tiered/remote storage, it feels like it should have a say in how file are acccessed in practice.