### PR TITLE
V2VectorIndexSearcher: use correct keys list for seq scan

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -418,7 +418,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                         int cmp = 1; // Need to initialize. The value is irrelevant.
                         for ( ; i + keysToSkip < keysInRange.size(); keysToSkip++)
                         {
-                            var nextPrimaryKey = keys.get(i + keysToSkip);
+                            var nextPrimaryKey = keysInRange.get(i + keysToSkip);
                             cmp = nextPrimaryKey.compareTo(ceilingPrimaryKey);
                             if (cmp >= 0)
                                 break;


### PR DESCRIPTION
I attempted to fix this bug with #902. That fix missed the (common) case where an sstable has multiple segments making the `keys` a strict superset of the `keysInRange`.