### PR TITLE
VECTOR-SEARCH-73: Increase SAI max_string_term_size_kb and max_frozen_term_size_kb to 8KiB

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -97,7 +97,7 @@ public class IndexContext
     public static final int MAX_STRING_TERM_SIZE = Integer.getInteger("cassandra.sai.max_string_term_size_kb", 8) * 1024;
     public static final int MAX_FROZEN_TERM_SIZE = Integer.getInteger("cassandra.sai.max_frozen_term_size_kb", 8) * 1024;
     public static final int MAX_VECTOR_TERM_SIZE = Integer.getInteger("cassandra.sai.max_vector_term_size_kb", 16) * 1024;
-    public static final int MAX_ANALYZED_SIZE = Integer.getInteger("cassandra.sai.max_analyzed_size_kb", 5) * 1024;
+    public static final int MAX_ANALYZED_SIZE = Integer.getInteger("cassandra.sai.max_analyzed_size_kb", 8) * 1024;
     private static final String TERM_OVERSIZE_LOG_MESSAGE =
     "Can't add term of column {} to index for key: {}, term size {} max allowed size {}.";
     private static final String TERM_OVERSIZE_ERROR_MESSAGE =
@@ -361,7 +361,7 @@ public class IndexContext
         {
             final ByteBuffer token = analyzer.next();
             bytesCount += token.remaining();
-            if (bytesCount >= maxTermSize)
+            if (bytesCount > maxTermSize)
             {
                 noSpamLogger.warn(logMessage(ANALYZED_TERM_OVERSIZE_LOG_MESSAGE),
                                   getColumnName(),

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -94,8 +94,8 @@ public class IndexContext
     private static final Logger logger = LoggerFactory.getLogger(IndexContext.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
-    public static final int MAX_STRING_TERM_SIZE = Integer.getInteger("cassandra.sai.max_string_term_size_kb", 1) * 1024;
-    public static final int MAX_FROZEN_TERM_SIZE = Integer.getInteger("cassandra.sai.max_frozen_term_size_kb", 5) * 1024;
+    public static final int MAX_STRING_TERM_SIZE = Integer.getInteger("cassandra.sai.max_string_term_size_kb", 8) * 1024;
+    public static final int MAX_FROZEN_TERM_SIZE = Integer.getInteger("cassandra.sai.max_frozen_term_size_kb", 8) * 1024;
     public static final int MAX_VECTOR_TERM_SIZE = Integer.getInteger("cassandra.sai.max_vector_term_size_kb", 16) * 1024;
     public static final int MAX_ANALYZED_SIZE = Integer.getInteger("cassandra.sai.max_analyzed_size_kb", 5) * 1024;
     private static final String TERM_OVERSIZE_LOG_MESSAGE =

--- a/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
@@ -67,6 +67,7 @@ public class CollectionIndexingTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int primary key, value map<int, text>)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
 
         // Test memtable index:
         execute("INSERT INTO %s (pk, value) VALUES (?, ?)", 1, new HashMap<Integer, String>() {{

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -575,7 +575,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testAnalyzerThatProducesTooManyBytesIsRejectedAtWriteTime() throws Throwable
+    public void testAnalyzerThatProducesTooManyBytesIsRejectedAtWriteTime()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
@@ -586,7 +586,7 @@ public class LuceneAnalyzerTest extends SAITester
         waitForIndexQueryable();
 
         assertThatThrownBy(() -> execute("INSERT INTO %s (id, val) VALUES (0, 'abcdedfghijklmnopqrstuvwxyz abcdedfghijklmnopqrstuvwxyz')"))
-        .hasMessage("Term's analyzed size for column val exceeds the cumulative limit for index. Max allowed size 5.000KiB.")
+        .hasMessage("Term's analyzed size for column val exceeds the cumulative limit for index. Max allowed size 8.000KiB.")
         .isInstanceOf(InvalidRequestException.class);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -660,7 +660,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void testMaxTermSizeRejectionsAtWrite() throws Throwable
+    public void testMaxTermSizeRejectionsAtWrite()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (k int PRIMARY KEY, v text, m map<text, text>, frozen_m frozen<map<text, text>>)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
@@ -670,15 +670,18 @@ public class NativeIndexDDLTest extends SAITester
 
         String largeTerm = UTF8Type.instance.compose(ByteBuffer.allocate(FBUtilities.MAX_UNSIGNED_SHORT / 2 + 1));
         assertThatThrownBy(() -> executeNet("INSERT INTO %s (k, v) VALUES (0, ?)", largeTerm))
-        .hasMessage("Term of column v exceeds the byte limit for index. Term size 32.000KiB. Max allowed size 1.000KiB.")
+        .hasMessage(String.format("Term of column v exceeds the byte limit for index. Term size 32.000KiB. Max allowed size %s.",
+                                  FBUtilities.prettyPrintMemory(IndexContext.MAX_STRING_TERM_SIZE)))
         .isInstanceOf(InvalidQueryException.class);
 
         assertThatThrownBy(() -> executeNet("INSERT INTO %s (k, m) VALUES (0, {'key': '" + largeTerm + "'})"))
-        .hasMessage("Term of column m exceeds the byte limit for index. Term size 32.000KiB. Max allowed size 1.000KiB.")
+        .hasMessage(String.format("Term of column m exceeds the byte limit for index. Term size 32.000KiB. Max allowed size %s.",
+                                  FBUtilities.prettyPrintMemory(IndexContext.MAX_STRING_TERM_SIZE)))
         .isInstanceOf(InvalidQueryException.class);
 
         assertThatThrownBy(() -> executeNet("INSERT INTO %s (k, frozen_m) VALUES (0, {'key': '" + largeTerm + "'})"))
-        .hasMessage("Term of column frozen_m exceeds the byte limit for index. Term size 32.015KiB. Max allowed size 5.000KiB.")
+        .hasMessage(String.format("Term of column frozen_m exceeds the byte limit for index. Term size 32.015KiB. Max allowed size %s.",
+                                  FBUtilities.prettyPrintMemory(IndexContext.MAX_FROZEN_TERM_SIZE)))
         .isInstanceOf(InvalidQueryException.class);
     }
 
@@ -1407,5 +1410,61 @@ public class NativeIndexDDLTest extends SAITester
         assertEquals(singletonList(4L), toSize.apply(iterator.next()));
         assertEquals(singletonList(3L), toSize.apply(iterator.next()));
         assertEquals(Arrays.asList(2L, 1L), toSize.apply(iterator.next()));
+    }
+
+    @Test
+    public void shouldRejectLargeStringTerms()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        String insert = "INSERT INTO %s (k, v) VALUES (0, ?)";
+
+        // insert a text term with the max possible size
+        execute(insert, ByteBuffer.allocate(IndexContext.MAX_STRING_TERM_SIZE));
+
+        // insert a text term over the max possible size
+        assertThatThrownBy(() -> execute(insert, ByteBuffer.allocate(IndexContext.MAX_STRING_TERM_SIZE + 1)))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Term of column v exceeds the byte limit for index");
+    }
+
+    @Test
+    public void shouldRejectLargeFrozenTerms()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v frozen<list<text>>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(full(v)) USING 'StorageAttachedIndex'");
+        String insert = "INSERT INTO %s (k, v) VALUES (0, ?)";
+
+        // insert a frozen term with the max possible size
+        // list serialization uses 4 bytes for the collection size, and then 4 bytes per each item size
+        String value1 = UTF8Type.instance.compose(ByteBuffer.allocate(IndexContext.MAX_FROZEN_TERM_SIZE / 2 - 8));
+        String value2 = UTF8Type.instance.compose(ByteBuffer.allocate(IndexContext.MAX_FROZEN_TERM_SIZE / 2 - 4));
+        execute(insert, Arrays.asList(value1, value2));
+
+        // insert a frozen term over the max possible size
+        assertThatThrownBy(() -> execute(insert, Arrays.asList(value1, value2, "x")))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Term of column v exceeds the byte limit for index");
+    }
+
+    @Test
+    public void shouldRejectLargeVector()
+    {
+        String table = "CREATE TABLE %%s (k int PRIMARY KEY, v vector<float, %d>)";
+        String index = "CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}";
+        String insert = "INSERT INTO %s (k, v) VALUES (0, ?)";
+
+        // insert a vector term with the max possible size
+        int dimensions = IndexContext.MAX_VECTOR_TERM_SIZE / Float.BYTES;
+        createTable(String.format(table, dimensions));
+        createIndex(index);
+        execute(insert, vector(new float[dimensions]));
+
+        // insert a vector term over the max possible size
+        createTable(String.format(table, dimensions + 1));
+        createIndex(index);
+        assertThatThrownBy(() -> execute(insert, vector(new float[dimensions + 1])))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessageContaining("Term of column v exceeds the byte limit for index");
     }
 }


### PR DESCRIPTION
This PR sets 8KiB as the default for `cassandra.sai.max_string_term_size_kb`, instead of 1KiB.

It also increases the value of `cassandra.sai.max_frozen_term_size_kb` from 5KiB to the same 8KiB, because I think that the max term size for frozen collections should be at least as large as the one for individual items. I wonder if we should use an even larger value for frozen collections.

There are some additional tests, particularly for `cassandra.sai.max_vector_term_size_kb`. We aren't modifying that default here, but it seemed not covered by tests similar to the ones for the other term size limits.

By the way, `cassandra.sai.max_vector_term_size_kb` implictily sets a limit on the number of dimensions that an indexed vector column can have, if the vector subtype has fixed width. The default max term size of 16KiB sets a limit of 4096 dimensions. So maybe we could reject `CREATE INDEX` on vectors with a number of dimensions that is going to trigger `cassandra.sai.max_vector_term_size_kb` on all writes?
