### PR TITLE
Optimize VTKP#filter: only store LIMIT of rows; use PQ iterator

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/VectorTopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/VectorTopKProcessor.java
@@ -206,8 +206,12 @@ public class VectorTopKProcessor
 
         // reorder rows in partition/clustering order
         assert topK.size() == limit : "topK size must be equal to limit";
-        for (int i = 0; i < topK.size(); i++) {
-            var triple = topK.poll();
+        // Use an iterator to prevent unnecessary ordering of the final elements. We know we have the topK. The next
+        // step puts the in PrimaryKey order, anyway.
+        var results = topK.iterator();
+        while (results.hasNext())
+        {
+            var triple = results.next();
             addUnfiltered(unfilteredByPartition, triple.getLeft(), triple.getMiddle());
         }
 


### PR DESCRIPTION
A few minor optimizations for `VectorTopKProcessor#filter`.

1. By only keeping references to the `LIMIT` of rows, we minimize the number of rows kept in memory and we decrease the cost of adding and polling elements from the PQ. In my testing, I saw a LIMIT 5 test with many sstables/segments collect 1000 rows in the PQ.
2. When we have the final PQ, we do not care about the ordering, so it is more efficient to use the PQ#iterator since that iterates over the backing array of rows without returning in a specific order.

Additional motivation: we are discussing the value of passing the kth vector score upstream to the vector graph search to improve efficiency of results. That work depends on knowing the kth score efficiently, and this does just that.