### PR TITLE
Fix SAIS#search to correctly count shadowed keys in termination logic

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -49,7 +49,6 @@ public class QueryContext
     private final LongAdder segmentsHit = new LongAdder();
     private final LongAdder partitionsRead = new LongAdder();
     private final LongAdder rowsFiltered = new LongAdder();
-    private final LongAdder rowsMatched = new LongAdder();
     private final LongAdder trieSegmentsHit = new LongAdder();
 
     private final LongAdder bkdPostingListsHit = new LongAdder();
@@ -79,7 +78,7 @@ public class QueryContext
     private float postFilterSelectivityEstimate = 1.0f;
 
     // Last used soft limit for vector search.
-    private int softLimit = -1;
+    private int softLimit = 0;
 
     @VisibleForTesting
     public QueryContext()
@@ -113,14 +112,6 @@ public class QueryContext
     public void addRowsFiltered(long val)
     {
         rowsFiltered.add(val);
-    }
-    public void addRowsMatched(long val)
-    {
-        rowsMatched.add(val);
-    }
-    public void resetRowsMatched()
-    {
-        rowsMatched.reset();
     }
     public void addTrieSegmentsHit(long val)
     {
@@ -200,10 +191,6 @@ public class QueryContext
     public long rowsFiltered()
     {
         return rowsFiltered.longValue();
-    }
-    public long rowsMatched()
-    {
-        return rowsMatched.longValue();
     }
     public long trieSegmentsHit()
     {

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -134,27 +134,21 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             queryContext.addShadowedKeysLoopCount(1L);
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             ResultRetriever result = queryIndexes.get();
-            queryContext.resetRowsMatched();
             UnfilteredPartitionIterator topK = (UnfilteredPartitionIterator) new VectorTopKProcessor(command).filter(result);
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             long newShadowedKeysCount = currentShadowedKeysCount - lastShadowedKeysCount;
             logger.debug("Shadow loop iteration {}: rows matched: {}, keys shadowed: {}",
                          queryContext.shadowedKeysLoopCount(),
-                         queryContext.rowsMatched(),
+                         Math.max(0, queryContext.softLimit() - currentShadowedKeysCount),
                          currentShadowedKeysCount);
-            // Stop if no new shadowed keys found or if we already got enough rows (In this case, we're basically
+            // Stop if we already got enough rows (In this case, we're basically
             // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows to
             // guarantee we have a valid result.)
-            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
+            if (exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)
-                {
-                    if (newShadowedKeysCount == 0)
-                        Tracing.trace("No new shadowed keys after query loop {}", loopsCount);
-                    else if (exactLimit <= queryContext.rowsMatched())
-                        Tracing.trace("Got enough rows after query loop {}", loopsCount);
-                }
+                    Tracing.trace("Got enough rows after query loop {}", loopsCount);
                 return topK;
             }
             loopsCount++;
@@ -537,7 +531,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), row, staticRow))
                 {
-                    queryContext.addRowsMatched(1);
                     clusters.add(row);
                 }
             }
@@ -547,7 +540,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), staticRow, staticRow))
                 {
-                    queryContext.addRowsMatched(1);
                     clusters.add(staticRow);
                 }
             }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -142,7 +142,9 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                          queryContext.shadowedKeysLoopCount(),
                          queryContext.rowsMatched(),
                          currentShadowedKeysCount);
-            // Stop if no new shadowed keys found or if we already got enough rows
+            // Stop if no new shadowed keys found or if we already got enough rows (In this case, we're basically
+            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows to
+            // guarantee we have a valid result.)
             if (newShadowedKeysCount == 0 || exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -143,7 +143,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                          queryContext.rowsMatched(),
                          currentShadowedKeysCount);
             // Stop if no new shadowed keys found or if we already got enough rows
-            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.rowsMatched())
+            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -141,10 +141,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                          queryContext.shadowedKeysLoopCount(),
                          Math.max(0, queryContext.softLimit() - currentShadowedKeysCount),
                          currentShadowedKeysCount);
-            // Stop if we already got enough rows (In this case, we're basically
-            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows to
-            // guarantee we have a valid result.)
-            if (exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
+            // Stop if no new shadowed keys found or if we already got enough rows (In this case, we're basically
+            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows from
+            // that index to still guarantee we have a valid result.)
+            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -780,6 +780,39 @@ public class VectorUpdateDeleteTest extends VectorTester
         }
     }
 
+    @Test
+    public void shadowedPrimaryKeysRequireDeeperSearch() throws Throwable
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // Create 100 rows so that each row has a slightly less similar score.
+        for (int i = 0; i < 100; i++)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'A', ?)", i, vector(1, i));
+
+        flush();
+
+        // Create 10 rows with the worst scores, but they won't be shadowed.
+        for (int i = 100; i < 110; i++)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'A', [1,1000])", i);
+
+        // Delete first 90 rows
+        for (int i = 0; i < 90; i++)
+            execute("DELETE FROM %s WHERE pk = ?", i);
+
+        beforeAndAfterFlush(() -> {
+            // ANN Only
+            assertRows(execute("SELECT pk FROM %s ORDER BY val ann of [1.0, 1.0] LIMIT 4"),
+                       row(90), row(91), row(92), row(93));
+            // Hyrbid
+            assertRows(execute("SELECT pk FROM %s WHERE str_val = 'A' ORDER BY val ann of [1.0, 1.0] LIMIT 4"),
+                       row(90), row(91), row(92), row(93));
+        });
+    }
+
     private static void setChunkSize(final int selectivityLimit) throws Exception
     {
         Field selectivity = QueryController.class.getDeclaredField("ORDER_CHUNK_SIZE");


### PR DESCRIPTION
I missed the change on this line: https://github.com/datastax/cassandra/pull/915/files#r1445373254.

After writing a worst case scenario test, it looks like the logic before #915 was wrong too.