### PR TITLE
VSEARCH 76: IllegalArgumentException in MergePostingList.nextPosting

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingList.java
@@ -74,6 +74,10 @@ public class MergePostingList implements PostingList
         // lazily create PQ if we haven't already
         if (pq == null)
         {
+            // elements could be removed in advance() even thouh postingLists started as non-empty
+            if (postingLists.isEmpty())
+                return PostingList.END_OF_STREAM;
+
             pq = new PriorityQueue<>(postingLists.size(), COMPARATOR);
             pq.addAll(postingLists);
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.disk.v1.PartitionAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.SSTableId;
+import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
@@ -77,7 +78,7 @@ public class KDTreeIndexBuilder
         @Override
         public SSTableId<?> getSSTableId()
         {
-            return null;
+            return new SequenceBasedSSTableId(0);
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingListTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingListTest.java
@@ -122,6 +122,19 @@ public class MergePostingListTest extends SaiRandomizedTest
     }
 
     @Test
+    public void handleEmptyLists() throws IOException
+    {
+        var lists = listOfLists(
+        new ArrayPostingList(new int[]{ }),
+        new ArrayPostingList(new int[]{ }));
+
+        final PostingList merged = MergePostingList.merge(lists);
+
+        // merged.advance() should not throw
+        assertEquals(PostingList.END_OF_STREAM, merged.advance(-1));
+    }
+
+    @Test
     public void shouldInterleaveNextAndAdvance() throws IOException
     {
         var lists = listOfLists(


### PR DESCRIPTION
Fixes https://github.com/riptano/VECTOR-SEARCH/issues/76