### PR TITLE
STAR-1902: Option to disable call to NativeLibrary.trySkipCache

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -384,7 +384,10 @@ public enum CassandraRelevantProperties
     SYSTEM_VIEWS_INCLUDE_INDEXES("cassandra.system_view.include_indexes"),
     VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR("cassandra.sai.validate_max_term_size_at_coordinator"),
     CUSTOM_KEYSPACES_FILTER_PROVIDER("cassandra.custom_keyspaces_filter_provider_class"),
-    CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class");
+    CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class"),
+
+    // Allows skipping advising the OS to free cached pages associated with commitlog flushing
+    COMMITLOG_SKIP_FILE_ADVICE("cassandra.commitlog.skip_file_advice");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
@@ -31,6 +31,8 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.INativeLibrary;
 import org.apache.cassandra.utils.SyncUtil;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_SKIP_FILE_ADVICE;
+
 /*
  * Memory-mapped segment. Maps the destination channel into an appropriately-sized memory-mapped buffer in which the
  * mutation threads write. On sync forces the buffer to disk.
@@ -39,7 +41,7 @@ import org.apache.cassandra.utils.SyncUtil;
 class MemoryMappedSegment extends CommitLogSegment
 {
     @VisibleForTesting
-    static boolean skipFileAdviseToFreePageCache = Boolean.getBoolean("cassandra.commitlog.skip_file_advice");
+    static boolean skipFileAdviseToFreePageCache = COMMITLOG_SKIP_FILE_ADVICE.getBoolean();
 
     /**
      * Constructs a new segment file.

--- a/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
@@ -22,8 +22,11 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.INativeLibrary;
 import org.apache.cassandra.utils.SyncUtil;
@@ -33,12 +36,16 @@ import org.apache.cassandra.utils.SyncUtil;
  * mutation threads write. On sync forces the buffer to disk.
  * If possible, recycles used segment files to avoid reallocating large chunks of disk.
  */
-public class MemoryMappedSegment extends CommitLogSegment
+class MemoryMappedSegment extends CommitLogSegment
 {
+    @VisibleForTesting
+    static boolean skipFileAdviseToFreePageCache = Boolean.getBoolean("cassandra.commitlog.skip_file_advice");
+
     /**
      * Constructs a new segment file.
      *
      * @param commitLog the commit log it will be used with.
+     * @param manager the commit log segment manager that is linked with {@code commitLog}.
      */
     MemoryMappedSegment(CommitLog commitLog, AbstractCommitLogSegmentManager manager)
     {
@@ -90,6 +97,15 @@ public class MemoryMappedSegment extends CommitLogSegment
         {
             throw new FSWriteError(e, getPath());
         }
+
+        if (!skipFileAdviseToFreePageCache)
+        {
+            adviceOnFileToFreePageCache(fd, startMarker, nextMarker, logFile);
+        }
+    }
+
+    void adviceOnFileToFreePageCache(int fd, int startMarker, int nextMarker, File logFile)
+    {
         INativeLibrary.instance.trySkipCache(fd, startMarker, nextMarker, logFile.absolutePath());
     }
 

--- a/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
+++ b/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemoryMappedSegmentStartupTest
+{
+    @After
+    public void tearDown() throws Exception
+    {
+        System.clearProperty("cassandra.commitlog.skip_file_advice");
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceTrueWithParameterTrue() throws IOException
+    {
+        System.setProperty("cassandra.commitlog.skip_file_advice", "true");
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(true, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceFalseWithParameterFalse() throws IOException
+    {
+        System.setProperty("cassandra.commitlog.skip_file_advice", "false");
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(false, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceFalseWithParameterMissing() throws IOException
+    {
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(false, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
+++ b/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_SKIP_FILE_ADVICE;
 import static org.junit.Assert.assertEquals;
 
 public class MemoryMappedSegmentStartupTest
@@ -32,13 +33,13 @@ public class MemoryMappedSegmentStartupTest
     @After
     public void tearDown() throws Exception
     {
-        System.clearProperty("cassandra.commitlog.skip_file_advice");
+        COMMITLOG_SKIP_FILE_ADVICE.reset();
     }
 
     @Test
     public void shouldSetSkipFileAdviceTrueWithParameterTrue() throws IOException
     {
-        System.setProperty("cassandra.commitlog.skip_file_advice", "true");
+        COMMITLOG_SKIP_FILE_ADVICE.setBoolean(true);
         try (Cluster cluster = Cluster.build(1).start())
         {
             assertEquals(true, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
@@ -48,7 +49,7 @@ public class MemoryMappedSegmentStartupTest
     @Test
     public void shouldSetSkipFileAdviceFalseWithParameterFalse() throws IOException
     {
-        System.setProperty("cassandra.commitlog.skip_file_advice", "false");
+        COMMITLOG_SKIP_FILE_ADVICE.setBoolean(false);
         try (Cluster cluster = Cluster.build(1).start())
         {
             assertEquals(false, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));

--- a/test/unit/org/apache/cassandra/db/commitlog/MemoryMappedSegmentTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/MemoryMappedSegmentTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.io.util.File;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class MemoryMappedSegmentTest
+{
+    @BeforeClass
+    public static void beforeClass() throws Exception
+    {
+        SchemaLoader.prepareServer();
+    }
+
+    @Test
+    public void shouldNotSkipFileAdviseToFreeSystemCache()
+    {
+        //given
+        MemoryMappedSegment.skipFileAdviseToFreePageCache = false;
+        MemoryMappedSegment memoryMappedSegment = memoryMappedSegment();
+        int startMarker = 0;
+        int nextMarker = 1024;
+
+        //when
+        memoryMappedSegment.flush(startMarker, nextMarker);
+
+        //then
+        verify(memoryMappedSegment)
+                .adviceOnFileToFreePageCache(eq(memoryMappedSegment.fd), eq(startMarker), eq(nextMarker), eq(memoryMappedSegment.logFile));
+    }
+
+    @Test
+    public void shouldSkipFileAdviseToFreeSystemCache()
+    {
+        //given
+        MemoryMappedSegment.skipFileAdviseToFreePageCache = true;
+        MemoryMappedSegment memoryMappedSegment = memoryMappedSegment();
+
+        //when
+        memoryMappedSegment.flush(0, 1024);
+
+        //then
+        verify(memoryMappedSegment, never())
+                .adviceOnFileToFreePageCache(anyInt(), anyInt(), anyInt(), any(File.class));
+    }
+
+    private MemoryMappedSegment memoryMappedSegment()
+    {
+        return Mockito.spy(new MemoryMappedSegment(CommitLog.instance, CommitLog.instance.getSegmentManager()));
+    }
+}


### PR DESCRIPTION
https://datastax.jira.com/browse/STAR-1902

Introduce system property "cassandra.commitlog.skip_file_advice" that allows to skip the native call to "fadvise" with "FADV_DONTNEED" argument. The native call is not skipped by default.

This patch was originally implemented in DSE 5.1 under DSP-22315.

**Some context for why it's needed**
As DSE7 depends on converged core, in particular on the [vsearch](https://github.com/datastax/cassandra/tree/vsearch) branch we need to merge it to that branch - the related PR https://github.com/datastax/cassandra/pull/933.

This patch aims to merge the same changes to ds-trunk to prevent history divergence.