### PR TITLE
STAR-1903: ConsistencyLevel.THREE means ALL_BUT_ONE (vsearch)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -413,7 +413,11 @@ public enum CassandraRelevantProperties
     PARALLEL_INDEX_READ_NUM_THREADS("cassandra.index_read.parallel_thread_num"),
 
     // Allows skipping advising the OS to free cached pages associated commitlog flushing
-    COMMITLOG_SKIP_FILE_ADVICE("cassandra.commitlog.skip_file_advice");
+    COMMITLOG_SKIP_FILE_ADVICE("cassandra.commitlog.skip_file_advice"),
+
+    // Changes the semantic of the "THREE" consistency level to mean "all but one"
+    // i.e. that all replicas except for at most one in the cluster (across all DCs) must accept the write for it to be successful.
+    THREE_MEANS_ALL_BUT_ONE("dse.consistency_level.three_means_all_but_one", "false");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/test/unit/org/apache/cassandra/db/ConsistencyLevelTest.java
+++ b/test/unit/org/apache/cassandra/db/ConsistencyLevelTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.OrderPreservingPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.locator.AbstractNetworkTopologySnitch;
+import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.locator.EverywhereStrategy;
+import org.apache.cassandra.locator.IEndpointSnitch;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.LocalStrategy;
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.locator.SimpleStrategy;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.utils.Pair;
+
+import static org.junit.Assert.*;
+
+public class ConsistencyLevelTest
+{
+    private static final String KS = "test";
+    private static final Map<String, String> RACK = new HashMap<>(), DATACENTER = new HashMap<>();
+    private static final IEndpointSnitch SNITCH = new AbstractNetworkTopologySnitch()
+    {
+        @Override
+        public String getRack(InetAddressAndPort endpoint)
+        {
+            return RACK.getOrDefault(endpoint.getHostAddress(false), "RC1");
+        }
+
+        @Override
+        public String getDatacenter(InetAddressAndPort endpoint)
+        {
+            return DATACENTER.getOrDefault(endpoint.getHostAddress(false), "DC1");
+        }
+    };
+
+    @BeforeClass
+    public static void setSnitch()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        DatabaseDescriptor.setEndpointSnitch(SNITCH);
+    }
+
+    @AfterClass
+    public static void resetSnitch()
+    {
+        DatabaseDescriptor.setEndpointSnitch(null);
+    }
+
+    @After
+    public void resetSnitchState()
+    {
+        RACK.clear();
+        DATACENTER.clear();
+    }
+
+    @Test
+    public void allButOne_shouldBe_2_forReplicationFactor_3()
+    {
+        testAllButOne(simpleStrategy(3), 2);
+    }
+
+    @Test
+    public void allButOne_shouldBe_1_forReplicationFactor_2()
+    {
+        testAllButOne(simpleStrategy(2), 1);
+    }
+
+    @Test
+    public void allButOne_shouldBe_1_forReplicationFactor_1()
+    {
+        testAllButOne(simpleStrategy(1), 1);
+    }
+
+    @Test
+    public void allButOne_shouldBe_1_forLocalStrategy()
+    {
+        testAllButOne(localStrategy(), 1);
+    }
+
+    @Test
+    public void allButOne_shouldBe_8_forReplicationFactor_3_3_3()
+    {
+        testAllButOne(networkTopologyStrategy(3, 3, 3), 8);
+    }
+
+    @Test
+    public void allButOne_shouldBe_11_forEverywhereStrategyOnClusterOf_12() throws Exception
+    {
+        testAllButOne(everywhereStrategy(
+                        dc(1, Pair.create("192.168.0.1", "A"), Pair.create("192.168.0.2", "E"), Pair.create("192.168.0.3", "H"),
+                                Pair.create("192.168.0.4", "C"), Pair.create("192.168.0.5", "I"), Pair.create("192.168.0.6", "J")),
+                        dc(2, Pair.create("192.168.1.1", "B"), Pair.create("192.168.1.2", "G"), Pair.create("192.168.1.3", "L"),
+                                Pair.create("192.168.1.4", "D"), Pair.create("192.168.1.5", "F"), Pair.create("192.168.1.6", "K"))),
+                11);
+    }
+
+    private void testAllButOne(AbstractReplicationStrategy replicationStrategy, int expected)
+    {
+        // when
+        int blockFor = ConsistencyLevel.allButOneFor(replicationStrategy);
+
+        // then
+        assertEquals("number of nodes to block for", expected, blockFor);
+    }
+
+    private static NetworkTopologyStrategy networkTopologyStrategy(int... dc)
+    {
+        Map<String, String> config = new HashMap<>();
+        for (int i = 0; i < dc.length; i++)
+        {
+            config.put("DC" + i, Integer.toString(dc[i]));
+        }
+        return new NetworkTopologyStrategy(KS, new TokenMetadata(), SNITCH, config);
+    }
+
+    private static AbstractReplicationStrategy simpleStrategy(int replicationFactory)
+    {
+        Map<String, String> config = Collections.singletonMap("replication_factor", Integer.toString(replicationFactory));
+        return new SimpleStrategy(KS, new TokenMetadata(), SNITCH, config);
+    }
+
+    @SafeVarargs
+    private static AbstractReplicationStrategy everywhereStrategy(Multimap<InetAddressAndPort, Token>... dcs)
+    {
+        TokenMetadata metadata = new TokenMetadata();
+        for (Multimap<InetAddressAndPort, Token> dc : dcs)
+        {
+            metadata.updateNormalTokens(dc);
+        }
+        return new EverywhereStrategy(KS, metadata, SNITCH, Collections.emptyMap());
+    }
+
+    private static AbstractReplicationStrategy localStrategy()
+    {
+        return new LocalStrategy(KS, new TokenMetadata(), SNITCH, Collections.emptyMap());
+    }
+
+    private static Multimap<InetAddressAndPort, Token> dc(int id, Pair<String, String>... addressToken) throws UnknownHostException
+    {
+        Multimap<InetAddressAndPort, Token> dc = HashMultimap.create();
+        for (Pair<String, String> pair : addressToken)
+        {
+            DATACENTER.put(pair.left, "DC" + id);
+            dc.put(InetAddressAndPort.getByName(pair.left), new OrderPreservingPartitioner.StringToken(pair.right));
+        }
+        return dc;
+    }
+}


### PR DESCRIPTION
https://datastax.jira.com/browse/STAR-1903

Add a system property (dse.consistency_level.three_means_all_but_one) that changes the behaviour of ConsistencyLevel.THREE to mean ALL_BUT_ONE, i.e. that all replicas except for at most one in the cluster (across all DCs) must accept the write for it to be successful. 

This is a bit disingenuous and hacky but a simple change that introduces a new
ConsistencyLevel, since otherwise that would require client and protocol changes.

https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-pr-gate/view/change-requests/job/PR-936/4/

Related dtest PR: https://github.com/datastax/cassandra-dtest/pull/69
* https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-build/696/testReport/dtest-bti.consistency_test/TestAllButOneAvailabilitySimpleStrategy/
* https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-build/695/testReport/dtest-large-bti.consistency_test/TestAllButOneAvailabilityNts/

The following failures https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-build/695/testReport/ are happening for `ds-trunk` as well - https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-build/697/testReport/.

**Some context for why it's needed**

This patch was originally implemented in DSE under [DSP-22366](https://datastax.jira.com/browse/DSP-22366), the goal of this PR is to port it to CC to ensure DSE7 remains backwards compatible with 5.1 and 6.8.

[DSP-22366]: https://datastax.jira.com/browse/DSP-22366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

