### PR TITLE
CNDB-7471 Rollup READ_BYTES from writers and add it to CQL response message as custom payload

### DIFF
--- a/src/java/org/apache/cassandra/sensors/SensorsQueryTracker.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsQueryTracker.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.PartitionRangeReadCommand;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.sensors.read.SensorsReadTracker;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryInfoTracker;
+
+public class SensorsQueryTracker implements QueryInfoTracker
+{
+    @Override
+    public WriteTracker onWrite(ClientState state, boolean isLogged, Collection<? extends IMutation> mutations, ConsistencyLevel consistencyLevel)
+    {
+        return WriteTracker.NOOP;
+    }
+
+    @Override
+    public ReadTracker onRead(ClientState state, TableMetadata table, List<SinglePartitionReadCommand> commands, ConsistencyLevel consistencyLevel)
+    {
+        return new SensorsReadTracker();
+    }
+
+    @Override
+    public ReadTracker onRangeRead(ClientState state, TableMetadata table, PartitionRangeReadCommand command, ConsistencyLevel consistencyLevel)
+    {
+        return ReadTracker.NOOP;
+    }
+
+    @Override
+    public LWTWriteTracker onLWTWrite(ClientState state, TableMetadata table, DecoratedKey key, ConsistencyLevel serialConsistency, ConsistencyLevel commitConsistency)
+    {
+        return LWTWriteTracker.NOOP;
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/read/SensorsReadTracker.java
+++ b/src/java/org/apache/cassandra/sensors/read/SensorsReadTracker.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors.read;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import com.google.common.util.concurrent.AtomicDouble;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.ReadResponse;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.service.QueryInfoTracker;
+
+public class SensorsReadTracker implements QueryInfoTracker.ReadTracker
+{
+
+    private final AtomicDouble quaryReadBytes = new AtomicDouble();
+
+    @Override
+    public void onDone()
+    {
+    }
+
+    @Override
+    public void onError(Throwable exception)
+    {
+    }
+
+    @Override
+    public void onReplicaPlan(ReplicaPlan.ForRead<?> replicaPlan)
+    {
+    }
+
+    @Override
+    public void onPartition(DecoratedKey partitionKey)
+    {
+    }
+
+    @Override
+    public void onRow(Row row)
+    {
+    }
+
+    @Override
+    public void onResponse(Message<ReadResponse> message)
+    {
+        Map<String, byte[]> customParams = message.header.customParams();
+        if (customParams == null)
+            return;
+
+        byte[] bytes = customParams.get("READ_BYTES");
+        if (bytes == null)
+            return;
+
+        ByteBuffer readBytesBuffer = ByteBuffer.allocate(Double.BYTES);
+        readBytesBuffer.put(bytes);
+        readBytesBuffer.flip();
+        double messageReadBytes = readBytesBuffer.getDouble();
+        this.quaryReadBytes.getAndAdd(messageReadBytes);
+    }
+
+    public ByteBuffer getQueryReadBytesAsByteBuffer() {
+        ByteBuffer readBytesBuffer = ByteBuffer.allocate(Double.BYTES);
+        readBytesBuffer.putDouble(this.quaryReadBytes.get());
+        return readBytesBuffer;
+    }
+}

--- a/src/java/org/apache/cassandra/service/QueryInfoTracker.java
+++ b/src/java/org/apache/cassandra/service/QueryInfoTracker.java
@@ -21,14 +21,11 @@ package org.apache.cassandra.service;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.cassandra.db.ConsistencyLevel;
-import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.IMutation;
-import org.apache.cassandra.db.PartitionRangeReadCommand;
-import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.net.Message;
 import org.apache.cassandra.schema.TableMetadata;
 
 /**
@@ -213,9 +210,19 @@ public interface QueryInfoTracker
         /**
          * Called on every row read.
          *
-         * @param row          the merged row.
+         * @param row the merged row.
          */
         void onRow(Row row);
+
+        /**
+         * Called on every message reponse reveibed from a replica
+         *
+         * @param message the received message
+         */
+        default void onResponse(Message<ReadResponse> message)
+        {
+            // NOOP
+        }
 
         ReadTracker NOOP = new ReadTracker()
         {
@@ -231,6 +238,11 @@ public interface QueryInfoTracker
 
             @Override
             public void onRow(Row row)
+            {
+            }
+
+            @Override
+            public void onResponse(Message<ReadResponse> message)
             {
             }
 
@@ -288,6 +300,11 @@ public interface QueryInfoTracker
             }
 
             @Override
+            public void onResponse(Message<ReadResponse> message)
+            {
+            }
+
+            @Override
             public void onNotApplied()
             {
             }
@@ -307,6 +324,5 @@ public interface QueryInfoTracker
             {
             }
         };
-
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
+++ b/src/java/org/apache/cassandra/service/reads/AbstractReadExecutor.java
@@ -94,7 +94,7 @@ public abstract class AbstractReadExecutor
         // the ReadRepair and DigestResolver both need to see our updated
         this.readRepair = ReadRepair.create(command, this.replicaPlan, queryStartNanoTime);
         this.digestResolver = new DigestResolver<>(command, this.replicaPlan, queryStartNanoTime, readTracker);
-        this.handler = new ReadCallback<>(digestResolver, command, this.replicaPlan, queryStartNanoTime);
+        this.handler = new ReadCallback<>(digestResolver, command, this.replicaPlan, queryStartNanoTime, readTracker);
         this.cfs = cfs;
         this.traceState = Tracing.instance.get();
         this.queryStartNanoTime = queryStartNanoTime;

--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -151,7 +151,7 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
                                queryStartNanoTime,
                                QueryInfoTracker.ReadTracker.NOOP);
 
-        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime);
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime, QueryInfoTracker.ReadTracker.NOOP);
 
         if (source.isSelf())
         {

--- a/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ShortReadPartitionsProtection.java
@@ -198,7 +198,7 @@ public class ShortReadPartitionsProtection extends Transformation<UnfilteredRowI
                                                          (NoopReadRepair<E, P>)NoopReadRepair.instance,
                                                          queryStartNanoTime,
                                                          QueryInfoTracker.ReadTracker.NOOP);
-        ReadCallback<E, P> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime);
+        ReadCallback<E, P> handler = new ReadCallback<>(resolver, cmd, replicaPlan, queryStartNanoTime, QueryInfoTracker.ReadTracker.NOOP);
 
         if (source.isSelf())
         {

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
@@ -49,7 +49,6 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.service.QueryInfoTracker;
-import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.reads.DataResolver;
 import org.apache.cassandra.service.reads.ReadCallback;
 import org.apache.cassandra.service.reads.ShortReadPartitionsProtection;
@@ -176,7 +175,7 @@ public class EndpointGroupingCoordinator
 
         // Create a handler for the range and add it, by replica, to the endpoint contexts.
         ReadCallback<EndpointsForRange, ReplicaPlan.ForRangeRead> handler =
-                new ReadCallback<>(resolver, subrangeCommand, sharedReplicaPlan, queryStartNanoTime);
+                new ReadCallback<>(resolver, subrangeCommand, sharedReplicaPlan, queryStartNanoTime, readTracker);
         
         perRangeHandlers.add(handler);
         for (Replica replica : replicaPlan.contacts())

--- a/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/NonGroupingRangeCommandIterator.java
@@ -113,7 +113,7 @@ public class NonGroupingRangeCommandIterator extends RangeCommandIterator
         DataResolver<EndpointsForRange, ReplicaPlan.ForRangeRead> resolver =
         new DataResolver<>(rangeCommand, sharedReplicaPlan, readRepair, queryStartNanoTime, trackRepairData, readTracker);
         ReadCallback<EndpointsForRange, ReplicaPlan.ForRangeRead> handler =
-        new ReadCallback<>(resolver, rangeCommand, sharedReplicaPlan, queryStartNanoTime);
+        new ReadCallback<>(resolver, rangeCommand, sharedReplicaPlan, queryStartNanoTime, readTracker);
 
         if (replicaPlan.contacts().size() == 1 && replicaPlan.contacts().get(0).isSelf())
         {

--- a/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
@@ -134,7 +134,7 @@ public abstract class AbstractReadRepair<E extends Endpoints<E>, P extends Repli
 
         // Do a full data read to resolve the correct response (and repair node that need be)
         DataResolver<E, P> resolver = new DataResolver<>(command, replicaPlan, this, queryStartNanoTime, trackRepairedStatus, digestResolver.getReadTracker());
-        ReadCallback<E, P> readCallback = new ReadCallback<>(resolver, command, replicaPlan, queryStartNanoTime);
+        ReadCallback<E, P> readCallback = new ReadCallback<>(resolver, command, replicaPlan, queryStartNanoTime, digestResolver.getReadTracker());
 
         digestRepair = new DigestRepair<>(resolver, readCallback, resultConsumer);
 

--- a/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessageFlag;
+import org.apache.cassandra.net.MessageSerializationPropertyTest;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.ParamType;
 import org.apache.cassandra.schema.Schema;

--- a/test/unit/org/apache/cassandra/service/QueryInfoTrackerTest.java
+++ b/test/unit/org/apache/cassandra/service/QueryInfoTrackerTest.java
@@ -38,10 +38,12 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
+import org.apache.cassandra.db.ReadResponse;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.net.Message;
 import org.apache.cassandra.schema.TableMetadata;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -544,6 +546,12 @@ public class QueryInfoTrackerTest extends CQLTester
 
                 readRows.incrementAndGet();
             }
+
+            @Override
+            public void onResponse(Message<ReadResponse> message)
+            {
+                // TODO: unit test
+            }
         }
 
         private class TestRangeReadTracker implements ReadTracker
@@ -576,6 +584,12 @@ public class QueryInfoTrackerTest extends CQLTester
             public void onRow(Row row)
             {
                 readRows.incrementAndGet();
+            }
+
+            @Override
+            public void onResponse(Message<ReadResponse> message)
+            {
+                // TODO: unit test
             }
         }
 
@@ -622,6 +636,12 @@ public class QueryInfoTrackerTest extends CQLTester
             public void onRow(Row row)
             {
                 readRows.incrementAndGet();
+            }
+
+            @Override
+            public void onResponse(Message<ReadResponse> message)
+            {
+                // TODO: unit test
             }
         }
     }

--- a/test/unit/org/apache/cassandra/service/reads/DigestResolverTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/DigestResolverTest.java
@@ -100,7 +100,7 @@ public class DigestResolverTest extends AbstractReadResponseTest
             {
                 final long startNanos = System.nanoTime();
                 final DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = new DigestResolver<>(command, plan, startNanos, noopReadTracker());
-                final ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = new ReadCallback<>(resolver, command, plan, startNanos);
+                final ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = new ReadCallback<>(resolver, command, plan, startNanos, noopReadTracker());
                 
                 final CountDownLatch startlatch = new CountDownLatch(2);
 


### PR DESCRIPTION
Draft implementation to rollup UCU from writers --> coordinating leveraging the `QueryInfoTracker`