### PR TITLE
Fix ignored nodetool stop ANTICOMPACTION

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1704,18 +1704,23 @@ public class CompactionManager implements CompactionManagerMBean
                         pendingRepair);
             return fullSSTables.size() + transSSTables.size() + unrepairedSSTables.size();
         }
-        catch (Throwable e)
+        catch (CompactionInterruptedException e)
         {
-            if (e instanceof CompactionInterruptedException && isCancelled.getAsBoolean())
+            if (isCancelled.getAsBoolean())
             {
                 logger.info("Anticompaction has been canceled for session {}", pendingRepair);
                 logger.trace(e.getMessage(), e);
             }
             else
             {
-                JVMStabilityInspector.inspectThrowable(e);
-                logger.error("Error anticompacting " + txn + " for " + pendingRepair, e);
+                logger.info("Anticompaction for session {} has been stopped by request.", pendingRepair);
             }
+            throw e;
+        }
+        catch (Throwable e)
+        {
+            JVMStabilityInspector.inspectThrowable(e);
+            logger.error("Error anticompacting " + txn + " for " + pendingRepair, e);
             throw e;
         }
     }
@@ -1747,6 +1752,12 @@ public class CompactionManager implements CompactionManagerMBean
             public OperationProgress getProgress()
             {
                 return compaction.getProgress();
+            }
+
+            @Override
+            public void stop()
+            {
+                compaction.stop();
             }
 
             @Override

--- a/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionBytemanTest.java
@@ -20,26 +20,46 @@ package org.apache.cassandra.db.repair;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.streaming.PreviewKind;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.UUIDGen;
+import org.assertj.core.api.Assertions;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 
+import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -96,5 +116,59 @@ public class PendingAntiCompactionBytemanTest extends AbstractPendingAntiCompact
             builder.add(new Replica(local, range, false));
 
         return builder.build();
+    }
+
+    @BMRules(rules = { @BMRule(name = "Abort anti-compaction after first call to onOperationStart",
+            targetClass = "CompactionManager",
+            targetMethod = "antiCompactGroup",
+            condition = "not flagged(\"done\")",
+            targetLocation = "AFTER INVOKE compactionRateLimiterAcquire",
+            action = "org.apache.cassandra.db.compaction.CompactionManager.instance.stopCompaction(\"ANTICOMPACTION\");") } )
+    @Test
+    public void testStopAntiCompaction()
+    {
+        Assert.assertSame(ByteOrderedPartitioner.class, DatabaseDescriptor.getPartitioner().getClass());
+        cfs.disableAutoCompaction();
+
+        // create 2 sstables, one that will be split, and another that will be moved
+        for (int i = 0; i < 10; i++)
+        {
+            QueryProcessor.executeInternal(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", ks, tbl), i, i);
+        }
+        cfs.forceBlockingFlush(UNIT_TESTS);
+        for (int i = 10; i < 20; i++)
+        {
+            QueryProcessor.executeInternal(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", ks, tbl), i, i);
+        }
+        cfs.forceBlockingFlush(UNIT_TESTS);
+
+        assertEquals(2, cfs.getLiveSSTables().size());
+        assertEquals(0, cfs.getLiveSSTables().stream().filter(SSTableReader::isPendingRepair).count());
+
+        Token left = ByteOrderedPartitioner.instance.getToken(ByteBufferUtil.bytes(5));
+        Token right = ByteOrderedPartitioner.instance.getToken(ByteBufferUtil.bytes(15));
+        List<Range<Token>> ranges = Collections.singletonList(new Range<>(left, right));
+        List<ColumnFamilyStore> tables = Collections.singletonList(cfs);
+
+        // create a repair session so the anti-compaction job can find it
+        UUID sessionID = UUIDGen.getTimeUUID();
+        ActiveRepairService.instance.registerParentRepairSession(sessionID, InetAddressAndPort.getLocalHost(), tables, ranges, true, 1, true, PreviewKind.NONE);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try
+        {
+            PendingAntiCompaction pac = new PendingAntiCompaction(sessionID, tables, atEndpoint(ranges, NO_RANGES), executor, () -> false);
+            Future<?> future = pac.run();
+            Assertions.assertThatThrownBy(future::get)
+                      .hasCauseInstanceOf(CompactionInterruptedException.class)
+                      .hasMessageContaining("Compaction interrupted");
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+
+        assertEquals(2, cfs.getLiveSSTables().size());
+        assertEquals(0, cfs.getLiveSSTables().stream().filter(SSTableReader::isPendingRepair).count());
     }
 }


### PR DESCRIPTION
As reported by [DSP-23936](https://datastax.jira.com/browse/DSP-23936), it seems that `nodetool stop ANTICOMPACTION` doesn't have any effect.

I think this bug was introduced by [STAR-410](https://datastax.jira.com/browse/STAR-410), and it doesn't affect OSS. 

`CompactionManager#getAntiCompactionIterator` used to return an anonymous class extending `CompactionIterator` and overriding the `isStopRequested` method. OSS still has this behaviour: https://github.com/apache/cassandra/blob/43eb2a4bdee169e0f9338afab4f70009604997b2/src/java/org/apache/cassandra/db/compaction/CompactionManager.java#L1895-L1904

However, [STAR-410](https://datastax.jira.com/browse/STAR-410) modified that method so the anonymous `CompactionIterator` overrides the `CompactionIterator#createOperation` method to return an anonymous `TableOperation` that wraps the base `TableOperation` changing some methods.

Since wrapping is trickier than extending, the `TableOperation#stop` method was forgotten, so the wrapper object doesn't propagate the call to the wrapped object. That way, when a user runs `nodetool stop ANTICOMPACTION`, it's the wrapping object that receives the stop signal with no effect, whereas we want to stop the wrapped object.

The proposed PR simply adds the needed override of `TableOperation#stop` so the wrapped object receives the stop signal. I have added a very simple test that reproduces the issue without the fix.

I'm also including the simple fix contributed to OSS by [CASSANDRA-17841](https://issues.apache.org/jira/browse/CASSANDRA-17841), so manually aborting anticompaction doesn't produce a log error but an INFO message, as it is a normal part of operations.

[DSP-23936]: https://datastax.jira.com/browse/DSP-23936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STAR-410]: https://datastax.jira.com/browse/STAR-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STAR-410]: https://datastax.jira.com/browse/STAR-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ