### PR TITLE
Refactored TableMetadata.validateCompatibility() method and added a slightly modified version

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1777,7 +1777,7 @@ comparatorType returns [CQL3Type.Raw t]
     | s=STRING_LITERAL
       {
         try {
-            $t = CQL3Type.Raw.from(new CQL3Type.Custom($s.text));
+            $t = CQL3Type.Raw.custom($s.text);
         } catch (SyntaxException e) {
             addRecognitionError("Cannot parse type " + $s.text + ": " + e.getMessage());
         } catch (ConfigurationException e) {

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -811,7 +811,7 @@ tableProperty[CreateTableStatement.Raw stmt]
              K_TO noncol_ident '(' mockVertex ')'
              {stmt.attrs.addProperty("dse_edge_label_property", "edge");}
     | K_DROPPED K_COLUMN K_RECORD
-          k=ident v=comparatorType (K_STATIC {isStatic = true;})?
+          k=ident v=comparatorTypeWithMultiCellTuple (K_STATIC {isStatic = true;})?
           K_USING K_TIMESTAMP t=INTEGER
       {
           stmt.attrs.addDroppedColumnRecord(k, v, isStatic, Long.parseLong($t.text));
@@ -1761,10 +1761,9 @@ inMarkerForTuple returns [Tuples.INRaw marker]
     | ':' name=noncol_ident { $marker = newTupleINBindVariables(name); }
     ;
 
-comparatorType returns [CQL3Type.Raw t]
+comparatorTypeWithoutTuples returns [CQL3Type.Raw t]
     : n=native_type     { $t = CQL3Type.Raw.from(n); }
     | c=collection_type { $t = c; }
-    | tt=tuple_type     { $t = tt; }
     | id=userTypeName   { $t = CQL3Type.Raw.userType(id); }
     | K_FROZEN '<' f=comparatorType '>'
       {
@@ -1784,6 +1783,16 @@ comparatorType returns [CQL3Type.Raw t]
             addRecognitionError("Error setting type " + $s.text + ": " + e.getMessage());
         }
       }
+    ;
+
+// Force frozen tuples.
+comparatorType returns [CQL3Type.Raw t]
+    : ct=comparatorTypeWithoutTuples     { $t = ct; }
+    | tt=tuple_types                     { $t = CQL3Type.Raw.tuple(tt, true); }
+    ;
+comparatorTypeWithMultiCellTuple returns [CQL3Type.Raw t]
+    : ct=comparatorTypeWithoutTuples     { $t = ct; }
+    | tt=tuple_types                     { $t = CQL3Type.Raw.tuple(tt, false); }
     ;
 
 native_type returns [CQL3Type t]
@@ -1823,10 +1832,8 @@ collection_type returns [CQL3Type.Raw pt]
         { if (t != null) $pt = CQL3Type.Raw.set(t); }
     ;
 
-tuple_type returns [CQL3Type.Raw t]
-    @init {List<CQL3Type.Raw> types = new ArrayList<>();}
-    @after {$t = CQL3Type.Raw.tuple(types);}
-    : K_TUPLE '<' t1=comparatorType { types.add(t1); } (',' tn=comparatorType { types.add(tn); })* '>'
+tuple_types returns [List<CQL3Type.Raw> types]
+    : K_TUPLE '<' t1=comparatorType { $types = new ArrayList<>(); $types.add(t1); } (',' tn=comparatorType { $types.add(tn); })* '>'
     ;
 
 username

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -383,6 +383,7 @@ public enum CassandraRelevantProperties
     //This only applies if include all is false
     SYSTEM_VIEWS_INCLUDE_INDEXES("cassandra.system_view.include_indexes"),
     VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR("cassandra.sai.validate_max_term_size_at_coordinator"),
+    CUSTOM_KEYSPACES_FILTER_PROVIDER("cassandra.custom_keyspaces_filter_provider_class"),
     CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class");
 
     CassandraRelevantProperties(String key, String defaultVal)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -384,7 +384,10 @@ public enum CassandraRelevantProperties
     SYSTEM_VIEWS_INCLUDE_INDEXES("cassandra.system_view.include_indexes"),
     VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR("cassandra.sai.validate_max_term_size_at_coordinator"),
     CUSTOM_KEYSPACES_FILTER_PROVIDER("cassandra.custom_keyspaces_filter_provider_class"),
-    CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class");
+    CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class"),
+
+    // Allows skipping advising the OS to free cached pages associated with commitlog flushing
+    COMMITLOG_SKIP_FILE_ADVICE("cassandra.commitlog.skip_file_advice");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -381,7 +381,9 @@ public enum CassandraRelevantProperties
     //This only applies if include all is false
     SYSTEM_VIEWS_INCLUDE_LOCAL_AND_PEERS("cassandra.system_view.include_local_and_peers"),
     //This only applies if include all is false
-    SYSTEM_VIEWS_INCLUDE_INDEXES("cassandra.system_view.include_indexes");
+    SYSTEM_VIEWS_INCLUDE_INDEXES("cassandra.system_view.include_indexes"),
+    VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR("cassandra.sai.validate_max_term_size_at_coordinator"),
+    CUSTOM_READ_OBSERVER_FACTORY("cassandra.custom_read_observer_factory_class");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
@@ -67,7 +67,7 @@ public abstract class AbstractFunction implements Function
     {
         return argTypes().stream()
                          .map(AbstractType::asCQL3Type)
-                         .map(CQL3Type::toString)
+                         .map(CQL3Type::toSchemaString)
                          .collect(toList());
     }
 
@@ -104,7 +104,7 @@ public abstract class AbstractFunction implements Function
         // We should ignore the fact that the receiver type is frozen in our comparison as functions do not support
         // frozen types for return type
         AbstractType<?> returnType = returnType();
-        if (receiver.type.isFreezable() && !receiver.type.isMultiCell())
+        if (!receiver.type.isMultiCell())
             returnType = returnType.freeze();
 
         if (receiver.type.equals(returnType))
@@ -158,8 +158,7 @@ public abstract class AbstractFunction implements Function
      */
     protected String toCqlString(AbstractType<?> type)
     {
-        return type.isTuple() ? ((Tuple) type.asCQL3Type()).toString(false)
-                              : type.asCQL3Type().toString();
+        return type.asCQL3Type().toString();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/selection/ElementsSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ElementsSelector.java
@@ -313,7 +313,7 @@ abstract class ElementsSelector extends Selector
 
         protected ByteBuffer extractSelection(ByteBuffer collection)
         {
-            return type.getSerializer().getSliceFromSerialized(collection, from, to, type.nameComparator(), type.isFrozenCollection());
+            return type.getSerializer().getSliceFromSerialized(collection, from, to, type.nameComparator(), !type.isMultiCell());
         }
 
         public AbstractType<?> getType()

--- a/src/java/org/apache/cassandra/cql3/selection/Selectable.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selectable.java
@@ -648,7 +648,7 @@ public interface Selectable extends AssignmentTestable
                                                 VariableSpecifications boundNames)
         {
             SelectorFactories factories = createFactoriesAndCollectColumnDefinitions(selectables,
-                                                                                     tupleType.allTypes(),
+                                                                                     tupleType.subTypes(),
                                                                                      cfm,
                                                                                      defs,
                                                                                      boundNames);
@@ -1191,9 +1191,7 @@ public interface Selectable extends AssignmentTestable
             public Selectable prepare(TableMetadata cfm)
             {
                 Selectable selectable = raw.prepare(cfm);
-                AbstractType<?> type = this.typeRaw.prepare(cfm.keyspace).getType();
-                if (type.isFreezable())
-                    type = type.freeze();
+                AbstractType<?> type = this.typeRaw.prepare(cfm.keyspace).getType().freeze();
                 return new WithTypeHint(typeRaw.toString(), type, selectable);
             }
         }

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -34,10 +34,10 @@ import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.restrictions.ExternalRestriction;
 import org.apache.cassandra.cql3.restrictions.Restrictions;
+import org.apache.cassandra.db.marshal.MultiCellCapableType;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.Schema;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.cql3.*;
@@ -52,10 +52,8 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.aggregation.AggregationSpecification;
 import org.apache.cassandra.db.aggregation.GroupMaker;
 import org.apache.cassandra.db.filter.*;
-import org.apache.cassandra.db.marshal.CollectionType;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.db.rows.Row;
@@ -1010,10 +1008,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             ComplexColumnData complexData = row.getComplexColumnData(def);
             if (complexData == null)
                 result.add(null);
-            else if (def.type.isCollection())
-                result.add(((CollectionType) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
             else
-                result.add(((UserType) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
+                result.add(((MultiCellCapableType<?>) def.type).serializeForNativeProtocol(complexData.iterator(), protocolVersion));
         }
         else
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterKeyspaceStatement.java
@@ -91,14 +91,12 @@ public final class AlterKeyspaceStatement extends AlterSchemaStatement implement
         if (newKeyspace.params.replication.klass.equals(LocalStrategy.class))
             throw ire("Unable to use given strategy class: LocalStrategy is reserved for internal use.");
 
-        newKeyspace.params.validate(keyspaceName);
+        newKeyspace.validate();
 
         validateNoRangeMovements();
         validateTransientReplication(keyspace.createReplicationStrategy(), newKeyspace.createReplicationStrategy());
 
-        Keyspaces res = schema.withAddedOrUpdated(newKeyspace);
-
-        return res;
+        return schema.withAddedOrUpdated(newKeyspace);
     }
 
     SchemaChange schemaChangeEvent(KeyspacesDiff diff)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQL3Type;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.QualifiedName;
@@ -298,14 +297,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
             if (currentColumn.isPrimaryKeyColumn())
                 throw ire("Cannot drop PRIMARY KEY column %s", column);
-
-            /*
-             * Cannot allow dropping top-level columns of user defined types that aren't frozen because we cannot convert
-             * the type into an equivalent tuple: we only support frozen tuples currently. And as such we cannot persist
-             * the correct type in system_schema.dropped_columns.
-             */
-            if (currentColumn.type.isUDT() && currentColumn.type.isMultiCell())
-                throw ire("Cannot drop non-frozen column %s of user type %s", column, currentColumn.type.asCQL3Type());
 
             // TODO: some day try and find a way to not rely on Keyspace/IndexManager/Index to find dependent indexes
             Set<IndexMetadata> dependentIndexes = Keyspace.openAndGetStore(table).indexManager.getDependentIndexes(currentColumn);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -231,7 +231,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                     throw ire("Cannot re-add previously dropped column '%s' of type %s, incompatible with previous type %s",
                               name,
                               type.asCQL3Type(),
-                              droppedColumn.type.asCQL3Type());
+                              droppedColumn.type.asCQL3Type().toSchemaString());
                 }
 
                 if (droppedColumn.isStatic() != isStatic)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -81,7 +81,13 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
         if (null == type)
             throw ire("Type %s.%s doesn't exist", keyspaceName, typeName);
 
-        return schema.withAddedOrUpdated(keyspace.withUpdatedUserType(apply(keyspace, type)));
+        UserType updated = apply(keyspace, type);
+        CreateTypeStatement.validate(updated);
+
+        KeyspaceMetadata newKeyspace = keyspace.withUpdatedUserType(updated);
+        newKeyspace.validate();
+
+        return schema.withAddedOrUpdated(newKeyspace);
     }
 
     abstract UserType apply(KeyspaceMetadata keyspace, UserType type);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.statements.RawKeyspaceAwareStatement;
@@ -255,11 +254,11 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (column.isPartitionKey() && table.partitionKeyColumns().size() == 1)
             throw ire("Cannot create secondary index on the only partition key column %s", column);
 
-        if (column.type.isFrozenCollection() && target.type != Type.FULL)
+        if (column.type.isCollection() && !column.type.isMultiCell() && target.type != Type.FULL)
             throw ire("Cannot create %s() index on frozen column %s. Frozen collections are immutable and must be fully " +
                       "indexed by using the 'full(%s)' modifier", target.type, column, column);
 
-        if (!column.type.isFrozenCollection() && target.type == Type.FULL)
+        if ((!column.type.isCollection() || column.type.isMultiCell()) && target.type == Type.FULL)
             throw ire("full() indexes can only be created on frozen collections");
 
         if (!column.type.isCollection() && target.type != Type.SIMPLE)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateKeyspaceStatement.java
@@ -93,11 +93,11 @@ public final class CreateKeyspaceStatement extends AlterSchemaStatement implemen
         }
 
         KeyspaceMetadata keyspace = KeyspaceMetadata.create(keyspaceName, attrs.asNewKeyspaceParams());
+        keyspace.validate();
 
         if (keyspace.params.replication.klass.equals(LocalStrategy.class))
             throw ire("Unable to use given strategy class: LocalStrategy is reserved for internal use.");
 
-        keyspace.params.validate(keyspaceName);
         return schema.withAddedOrUpdated(keyspace);
     }
 

--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -74,8 +74,6 @@ public class ClusteringComparator implements Comparator<Clusterable>
         this.indexReverseComparator = (o1, o2) -> ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.firstName,
                                                                                     (ClusteringPrefix<?>) o2.firstName);
         this.reverseComparator = (c1, c2) -> ClusteringComparator.this.compare(c2, c1);
-        for (AbstractType<?> type : clusteringTypes)
-            type.checkComparable(); // this should already be enforced by TableMetadata.Builder.addColumn, but we check again for other constructors
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3319,6 +3319,15 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return Objects.requireNonNull(getIfExists(tableId)).metric;
     }
 
+    // Used by CNDB
+    public long getMemtablesLiveSize()
+    {
+        long liveSize = 0L;
+        for (Memtable memtable : data.getView().getAllMemtables())
+            liveSize += memtable.getLiveDataSize();
+        return liveSize;
+    }
+
     public DiskBoundaries getDiskBoundaries()
     {
         return diskBoundaryManager.getDiskBoundaries(this);

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -74,6 +74,11 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
     private final Object[] columns;
     private final int complexIdx; // Index of the first complex column
 
+    /**
+     * The columns passed to this constructor MUST BE SORTED with natural order - this is not checked in the constructor!
+     * The constructor remains private to ensure that this invariant is maintained - all the methods that call it
+     * ensure that the columns are properly sorted.
+     */
     private Columns(Object[] columns, int complexIdx)
     {
         assert complexIdx <= BTree.size(columns);
@@ -705,7 +710,18 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                     int skipped = 0;
                     while (true)
                     {
-                        int nextMissingIndex = skipped < delta ? (int)in.readUnsignedVInt() : supersetCount;
+                        int nextMissingIndex;
+                        if (skipped < delta)
+                        {
+                            nextMissingIndex = (int) in.readUnsignedVInt();
+                            if (nextMissingIndex >= supersetCount)
+                                throw new IOException("Invalid Columns subset bytes; encoded not existing column: " + nextMissingIndex);
+                        }
+                        else
+                        {
+                            nextMissingIndex = supersetCount;
+                        }
+
                         while (idx < nextMissingIndex)
                         {
                             ColumnMetadata def = iter.next();

--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.filter.*;
@@ -320,8 +319,8 @@ public class DataRange
         {
             CompositeType ct = (CompositeType)type;
             ByteBuffer[] values = ct.split(key);
-            for (int i = 0; i < ct.types.size(); i++)
-                sb.append(i == 0 ? "" : ", ").append(ct.types.get(i).getString(values[i]));
+            for (int i = 0; i < ct.subTypes().size(); i++)
+                sb.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).getString(values[i]));
         }
         else
         {

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -18,12 +18,16 @@
 package org.apache.cassandra.db;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.function.LongPredicate;
 import java.util.function.Function;
-
+import java.util.function.LongPredicate;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -33,22 +37,30 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.db.filter.*;
-import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.guardrails.DefaultGuardrail;
-import org.apache.cassandra.guardrails.Guardrail;
-import org.apache.cassandra.guardrails.Guardrails;
-import org.apache.cassandra.guardrails.Threshold;
-import org.apache.cassandra.net.MessageFlag;
-import org.apache.cassandra.net.Verb;
-import org.apache.cassandra.db.partitions.*;
-import org.apache.cassandra.db.rows.*;
+import org.apache.cassandra.db.filter.ClusteringIndexFilter;
+import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.partitions.PurgeFunction;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.RangeTombstoneMarker;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.db.rows.UnfilteredRowIterators;
 import org.apache.cassandra.db.transform.RTBoundCloser;
 import org.apache.cassandra.db.transform.RTBoundValidator;
 import org.apache.cassandra.db.transform.RTBoundValidator.Stage;
 import org.apache.cassandra.db.transform.StoppingTransformation;
 import org.apache.cassandra.db.transform.Transformation;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.UnknownIndexException;
+import org.apache.cassandra.guardrails.DefaultGuardrail;
+import org.apache.cassandra.guardrails.Guardrails;
+import org.apache.cassandra.guardrails.Threshold;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -57,20 +69,22 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.MessageFlag;
+import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.SchemaProvider;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.schema.SchemaProvider;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.filter;
-import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 import static org.apache.cassandra.db.partitions.UnfilteredPartitionIterators.MergeListener.NOOP;
+import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 
 /**
  * General interface for storage-engine read commands (common to both range and
@@ -393,6 +407,7 @@ public abstract class ReadCommand extends AbstractReadQuery
         try
         {
             iterator = withStateTracking(iterator);
+            iterator = withReadObserver(iterator);
             iterator = RTBoundValidator.validate(withoutPurgeableTombstones(iterator, cfs, executionController), Stage.PURGED, false);
             iterator = withMetricsRecording(iterator, cfs.metric, startTimeNanos);
 
@@ -435,6 +450,55 @@ public abstract class ReadCommand extends AbstractReadQuery
             iterator.close();
             throw e;
         }
+    }
+
+    public UnfilteredPartitionIterator withReadObserver(UnfilteredPartitionIterator partitions)
+    {
+        ReadObserver observer = ReadObserverFactory.instance.create(this.metadata());
+
+        // skip if observer is disabled
+        if (observer == ReadObserver.NO_OP)
+            return partitions;
+
+        class ReadObserverTransformation extends Transformation<UnfilteredRowIterator>
+        {
+            @Override
+            protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
+            {
+                observer.onPartition(partition.partitionKey(), partition.partitionLevelDeletion());
+                return Transformation.apply(partition, this);
+            }
+
+            @Override
+            protected Row applyToStatic(Row row)
+            {
+                if (!row.isEmpty())
+                    observer.onStaticRow(row);
+                return row;
+            }
+
+            @Override
+            protected Row applyToRow(Row row)
+            {
+                observer.onUnfiltered(row);
+                return row;
+            }
+
+            @Override
+            protected RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
+            {
+                observer.onUnfiltered(marker);
+                return marker;
+            }
+
+            @Override
+            protected void onClose()
+            {
+                observer.onComplete();
+            }
+        }
+
+        return Transformation.apply(partitions, new ReadObserverTransformation());
     }
 
     public UnfilteredPartitionIterator searchStorage(Index.Searcher searcher, ReadExecutionController executionController)

--- a/src/java/org/apache/cassandra/db/ReadObserver.java
+++ b/src/java/org/apache/cassandra/db/ReadObserver.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+
+/**
+ * An interface that allows to capture what local data has been read
+ * <p>
+ * This is used by CNDB remote file cache warmup strategy to track access pattern
+ */
+public interface ReadObserver
+{
+    ReadObserver NO_OP = new ReadObserver() {};
+
+    /**
+     * Called on every partition read
+     *
+     * @param partitionKey the partition key
+     * @param deletionTime partition deletion time
+     */
+    default void onPartition(DecoratedKey partitionKey, DeletionTime deletionTime) {}
+
+    /**
+     * Called on every static row read.
+     *
+     * @param staticRow static row of the partition
+     */
+    default void onStaticRow(Row staticRow) {}
+
+    /**
+     * Called on every unfiltered read.
+     *
+     * @param unfiltered either row or range tombstone.
+     */
+    default void onUnfiltered(Unfiltered unfiltered) {}
+
+    /**
+     * Called on read request completion
+     */
+    default void onComplete() {}
+}

--- a/src/java/org/apache/cassandra/db/ReadObserverFactory.java
+++ b/src/java/org/apache/cassandra/db/ReadObserverFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_READ_OBSERVER_FACTORY;
+
+
+/**
+ * Provides custom factory that creates a {@link ReadObserver} instance per read request
+ */
+public interface ReadObserverFactory
+{
+    ReadObserverFactory instance = CUSTOM_READ_OBSERVER_FACTORY.getString() == null ?
+                                   new ReadObserverFactory() {} :
+                                   FBUtilities.construct(CassandraRelevantProperties.CUSTOM_READ_OBSERVER_FACTORY.getString(), "custom read observer factory");
+
+    default ReadObserver create(TableMetadata table)
+    {
+        return ReadObserver.NO_OP;
+    }
+}

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
@@ -215,8 +215,9 @@ public class CommitLogDescriptor
             case VERSION_30:
                 return MessagingService.VERSION_30;
             case VERSION_40:
-            case VERSION_DSE_68:
                 return MessagingService.VERSION_40;
+            case VERSION_DSE_68:
+                return MessagingService.VERSION_DSE_68;
             case VERSION_SG_10:
                 return MessagingService.VERSION_SG_10;
             default:

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -197,10 +197,13 @@ public class CompactionManager implements CompactionManagerMBean
     {
         for (String keyspace : Schema.instance.getKeyspaces())
         {
-            for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+            if (Schema.instance.getKeyspaceInstance(keyspace) != null)
             {
-                CompactionStrategy strat = cfs.getCompactionStrategy();
-                strat.periodicReport();
+                for (ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+                {
+                    CompactionStrategy strat = cfs.getCompactionStrategy();
+                    strat.periodicReport();
+                }
             }
         }
     }
@@ -211,15 +214,16 @@ public class CompactionManager implements CompactionManagerMBean
         for (String keyspace : Schema.instance.getKeyspaces())
         {
             //don't store config files for system tables
-            if (SchemaConstants.isSystemKeyspace(keyspace))
-                continue;
-            for ( ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
+            if (Schema.instance.getKeyspaceInstance(keyspace) != null && !SchemaConstants.isSystemKeyspace(keyspace))
             {
-                CompactionStrategy strat = cfs.getCompactionStrategy();
-                if (strat instanceof UnifiedCompactionContainer)
+                for (ColumnFamilyStore cfs : Schema.instance.getKeyspaceInstance(keyspace).getColumnFamilyStores())
                 {
-                    UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) ((UnifiedCompactionContainer) strat).getStrategies().get(0);
-                    ucs.storeControllerConfig();
+                    CompactionStrategy strat = cfs.getCompactionStrategy();
+                    if (strat instanceof UnifiedCompactionContainer)
+                    {
+                        UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) ((UnifiedCompactionContainer) strat).getStrategies().get(0);
+                        ucs.storeControllerConfig();
+                    }
                 }
             }
         }

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
@@ -464,8 +464,8 @@ UCS accepts these compaction strategy parameters:
   The default value is 1 GiB.
 * `base_shard_count` The minimum number of shards $b$, used for levels with the smallest density. This gives the
   minimum compaction concurrency for the lowest levels. A low number would result in larger L0 sstables but may limit
-  the overall maximum write throughput (as every piece of data has to go through L0).  
-  The default value is 4 (1 for system tables, or when multiple data locations are defined).
+  the overall maximum write throughput (as every piece of data has to go through L0). The base shard count only applies after `min_sstable_size` is reached.  
+  The default value is 4 for all tables.
 * `sstable_growth` The sstable growth component $\lambda$, applied as a factor in the shard exponent calculation.
   This is a number between 0 and 1 that controls what part of the density growth should apply to individual sstable
   size and what part should increase the number of shards. Using a value of 1 has the effect of fixing the shard
@@ -479,12 +479,11 @@ UCS accepts these compaction strategy parameters:
   manageable both as memory overhead and individual compaction duration and space overhead. The balance between the
   two can be further tweaked by increasing $\lambda$ to get fewer but bigger sstables on the top level, and decreasing
   it to favour a higher count of smaller sstables.  
-  The default value is 0, corresponding to a fixed sstable target size.
-* `sstable_size_min` The minimum sstable size $m$, applicable when the base shard count will result is sstables
+  The default value is 0.333 meaning the sstable size grows with the square root of the growth of the shard count.
+* `min_sstable_size` The minimum sstable size $m$, applicable when the base shard count will result is sstables
   that are considered too small. If set, the strategy will split the space into fewer than the base count shards, to
-  make the estimated sstables size at least as large as this value.  
-  The default value is 0, which disables this feature. A value of `auto` sets the minimum sstable size to the size
-  of sstables resulting from flushes.
+  make the estimated sstables size at least as large as this value. A value of 0 disables this feature. A value of `auto` sets the minimum sstable size to the size
+  of sstables resulting from flushes. The default value is 100MiB.
 * `reserved_threads` Specifies the number of threads to reserve per level. Any remaining threads will take
   work according to the prioritization mechanism (i.e. higher overlap first). Higher reservations mean better
   responsiveness of the compaction strategy to new work, or smoother performance, at the expense of reducing the

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -342,7 +342,7 @@ public abstract class Controller
         this.maxSpaceOverhead = maxSpaceOverhead;
 
         if (maxSSTablesToCompact <= 0)  // use half the maximum permitted compaction size as upper bound by default
-            maxSSTablesToCompact = (int) (dataSetSize * this.maxSpaceOverhead * 0.5 / minSSTableSize);
+            maxSSTablesToCompact = (int) (dataSetSize * this.maxSpaceOverhead * 0.5 / getMinSstableSizeBytes());
 
         this.maxSSTablesToCompact = maxSSTablesToCompact;
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -118,7 +118,7 @@ public abstract class Controller
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
-    static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + MIN_SSTABLE_SIZE_OPTION, "0B"));
+    static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + MIN_SSTABLE_SIZE_OPTION, "100MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */
@@ -173,21 +173,23 @@ public abstract class Controller
      * applied as an exponent in the number of split points. In other words, the given value applies as a negative
      * exponent in the calculation of the number of split points.
      * <p>
-     * Using 0 (the default) applies no correction to the number of split points, resulting in SSTables close to the
+     * Using 0 applies no correction to the number of split points, resulting in SSTables close to the
      * target size. Setting this number to 1 will make UCS never split beyong the base shard count. Using 0.5 will
      * make the number of split points a square root of the required number for the target SSTable size, making
-     * the number of split points and the size of SSTables grow in lockstep as the density grows.
+     * the number of split points and the size of SSTables grow in lockstep as the density grows. Using
+     * 0.333 (the default) makes the sstable growth the cubic root of the density growth, i.e. the sstable size
+     * grows with the square root of the growth of the shard count.
      * <p>
      * For example, given a data size of 1TiB on the top density level and 1GiB target size with base shard count of 1,
-     * growth 0 would result in 1024 SSTables of ~1GiB each, 0.5 would yield 32 SSTables of ~32GiB each, and 1 would
-     * yield 1 SSTable of 1TiB.
+     * growth 0 would result in 1024 SSTables of ~1GiB each, 0.333 would result in 128 SSTables of ~8 GiB each,
+     * 0.5 would yield 32 SSTables of ~32GiB each, and 1 would yield 1 SSTable of 1TiB.
      * <p>
      * Note that this correction only applies after the base shard count is reached, so for the above example with
-     * base count of 4, the number of SSTables will be 4 (~256GiB each) for a growth value of 1, and 64 (~16GiB each)
-     * for 0.5.
+     * base count of 4, the number of SSTables will be 4 (~256GiB each) for a growth value of 1, 128 (~8GiB each) for
+     * a growth value of 0.333, and 64 (~16GiB each) for a growth value of 0.5.
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
-    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + SSTABLE_GROWTH_OPTION, "0"));
+    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + SSTABLE_GROWTH_OPTION, "0.333"));
 
     /**
      * Number of reserved threads to keep for each compaction level. This is used to ensure that there are always
@@ -275,6 +277,7 @@ public abstract class Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     static final String SCALING_PARAMETERS_OPTION = "scaling_parameters";
+    @Deprecated
     static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
 
     protected final MonotonicClock clock;
@@ -442,13 +445,15 @@ public abstract class Controller
         if (minSize > 0)
         {
             double count = localDensity / minSize;
-            // Minimum size only applies if it is smaller than the base count.
+            // Minimum size only applies if the base count would result in smaller sstables.
+            // We also want to use the min size if we don't yet know the flush size (density is NaN).
             // Note: the minimum size cannot be larger than the target size's minimum.
-            if (count < baseShardCount)
+            if (!(count >= baseShardCount)) // also true for count == NaN
             {
                 // Make it a power of two, rounding down so that sstables are greater in size than the min.
                 // Setting the bottom bit to 1 ensures the result is at least 1.
-                shards = Integer.highestOneBit((int) count | 1);
+                // If baseShardCount is not a power of 2, split only to powers of two that are divisors of baseShardCount so boundaries match higher levels
+                shards = Math.min(Integer.highestOneBit((int) count | 1), baseShardCount & -baseShardCount);
                 if (logger.isDebugEnabled())
                     logger.debug("Shard count {} for density {}, {} times min size {}",
                                  shards,
@@ -842,10 +847,7 @@ public abstract class Controller
         }
         else
         {
-            if (SchemaConstants.isSystemKeyspace(realm.getKeyspaceName()) || realm.getDiskBoundaries().getNumBoundaries() > 1)
-                baseShardCount = 1;
-            else
-                baseShardCount = DEFAULT_BASE_SHARD_COUNT;
+            baseShardCount = DEFAULT_BASE_SHARD_COUNT;
         }
 
         long targetSStableSize = options.containsKey(TARGET_SSTABLE_SIZE_OPTION)
@@ -1246,7 +1248,7 @@ public abstract class Controller
                                                  e);
         }
 
-        if (sizeInBytes <= 0)
+        if (sizeInBytes < 0)
             throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
                                                            opt,
                                                            s));

--- a/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_1.svg
+++ b/src/java/org/apache/cassandra/db/compaction/unified/shards_graph_lambda_1.svg
@@ -1,12 +1,103 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- 
+Generated using the following python script:
+
+import math
+import numpy
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+
+
+m = 100000000
+t = 1000000000
+b = 10
+l = 1
+
+def f(d):
+    if (d < m):
+        return 1;
+    elif d < m * b:
+        return min(2**math.floor(math.log2(d/m)), b & -b)
+    elif d < t * b:
+        return b
+    else:
+        return b*2**math.floor((1 - l) * math.log2(d/(t*b)) + 0.5)
+
+
+e_values = list(range(1250, 2200))
+x_values = [2**(x/50) for x in e_values]
+fx_values = [f(x) for x in x_values]
+x_f_ratio_values = [x / fx if fx > 0 else 0 for x, fx in zip(x_values, fx_values)]
+
+
+# plt.plot(x_values, fx_values, 'b', label='shards')
+# plt.plot(x_values, x_f_ratio_values, 'r', label='SSTable size MiB')
+# plt.xscale('log')
+# plt.yscale('log')
+# plt.xlabel('density MiB')
+# plt.ylabel('shards / MiB')
+# plt.legend()
+# plt.title('SSTable size and shard count')
+# plt.grid()
+# plt.show()
+
+
+fig, (ax0, ax1) = plt.subplots(nrows=2)
+
+formatter0 = ticker.EngFormatter(unit='B')
+formatter1 = ticker.ScalarFormatter(useMathText=True)
+#ax1.axis('equal')
+ax0.set_xscale('log')
+ax0.set_yscale('log', base=2)
+ax1.set_xscale('log')
+ax1.set_yscale('log')
+ax0.xaxis.set_major_formatter(formatter0)
+ax0.yaxis.set_major_locator(ticker.FixedLocator([1, 2, 4, 10]))
+ax0.yaxis.set_major_formatter(formatter1)
+ax1.xaxis.set_major_formatter(formatter0)
+ax1.yaxis.set_major_formatter(formatter0)
+
+ax0.plot(x_values, fx_values, 'b', label='shards')
+ax0.set_xlabel('density')
+ax0.set_ylabel('shards')
+ax0.set_title('Shard count')
+ax0.grid()
+
+ax1.plot(x_values, x_f_ratio_values, 'r', label='SSTable size')
+ax1.set_xlabel('density')
+ax1.set_ylabel('SSTable size')
+ax1.set_title('SSTable size')
+ax1.grid()
+
+plt.tight_layout()
+plt.show()
+-->
+
 <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-06-14T10:06:53.579133</dc:date>
+    <dc:date>2023-10-26T11:50:35.670645</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,16 +133,16 @@ z
      <g id="line2d_1">
       <path d="M 115.586572 136.24 
 L 115.586572 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m99b41d0da3" d="M 0 0 
+       <path id="m9d2bb9098e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m99b41d0da3" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="115.586572" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -156,11 +247,11 @@ z
      <g id="line2d_3">
       <path d="M 176.114145 136.24 
 L 176.114145 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m99b41d0da3" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="176.114145" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -204,11 +295,11 @@ z
      <g id="line2d_5">
       <path d="M 236.641717 136.24 
 L 236.641717 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m99b41d0da3" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="236.641717" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -226,11 +317,11 @@ L 236.641717 26.88
      <g id="line2d_7">
       <path d="M 297.16929 136.24 
 L 297.16929 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m99b41d0da3" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="297.16929" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -249,11 +340,11 @@ L 297.16929 26.88
      <g id="line2d_9">
       <path d="M 357.696863 136.24 
 L 357.696863 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m99b41d0da3" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="357.696863" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -283,11 +374,11 @@ z
      <g id="line2d_11">
       <path d="M 418.224436 136.24 
 L 418.224436 26.88 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m99b41d0da3" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="418.224436" y="136.24" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -304,355 +395,355 @@ L 418.224436 26.88
     <g id="xtick_7">
      <g id="line2d_13">
       <defs>
-       <path id="mc50d4081ef" d="M 0 0 
+       <path id="m1f1a006c09" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc50d4081ef" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="73.279614" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc50d4081ef" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="83.93799" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc50d4081ef" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="91.500229" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc50d4081ef" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="97.365957" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc50d4081ef" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="102.158605" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc50d4081ef" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="106.210732" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc50d4081ef" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="109.720844" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc50d4081ef" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="112.816982" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mc50d4081ef" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="133.807187" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc50d4081ef" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="144.465563" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc50d4081ef" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="152.027802" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc50d4081ef" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="157.89353" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc50d4081ef" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="162.686178" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc50d4081ef" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="166.738305" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc50d4081ef" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="170.248417" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc50d4081ef" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="173.344555" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mc50d4081ef" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="194.33476" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc50d4081ef" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="204.993136" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_25">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mc50d4081ef" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="212.555375" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_26">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc50d4081ef" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="218.421102" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_27">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#mc50d4081ef" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="223.213751" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_28">
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc50d4081ef" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="227.265878" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_29">
      <g id="line2d_35">
       <g>
-       <use xlink:href="#mc50d4081ef" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="230.77599" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_30">
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc50d4081ef" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="233.872128" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_31">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#mc50d4081ef" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="254.862332" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_32">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc50d4081ef" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="265.520709" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_33">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#mc50d4081ef" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="273.082947" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_34">
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc50d4081ef" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="278.948675" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_35">
      <g id="line2d_41">
       <g>
-       <use xlink:href="#mc50d4081ef" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="283.741324" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_36">
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc50d4081ef" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="287.793451" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_37">
      <g id="line2d_43">
       <g>
-       <use xlink:href="#mc50d4081ef" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="291.303562" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_38">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc50d4081ef" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="294.3997" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#mc50d4081ef" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="315.389905" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc50d4081ef" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="326.048282" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mc50d4081ef" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="333.61052" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc50d4081ef" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="339.476248" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mc50d4081ef" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="344.268897" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc50d4081ef" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="348.321023" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mc50d4081ef" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="351.831135" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc50d4081ef" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="354.927273" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_47">
      <g id="line2d_53">
       <g>
-       <use xlink:href="#mc50d4081ef" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="375.917478" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_48">
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mc50d4081ef" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="386.575855" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_49">
      <g id="line2d_55">
       <g>
-       <use xlink:href="#mc50d4081ef" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="394.138093" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_50">
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mc50d4081ef" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="400.003821" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_51">
      <g id="line2d_57">
       <g>
-       <use xlink:href="#mc50d4081ef" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="404.79647" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_52">
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mc50d4081ef" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="408.848596" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_53">
      <g id="line2d_59">
       <g>
-       <use xlink:href="#mc50d4081ef" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="412.358708" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_54">
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mc50d4081ef" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="415.454846" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_55">
      <g id="line2d_61">
       <g>
-       <use xlink:href="#mc50d4081ef" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="436.445051" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_56">
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mc50d4081ef" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="447.103428" y="136.24" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -828,16 +919,16 @@ z
      <g id="line2d_63">
       <path d="M 69.59 131.269091 
 L 450 131.269091 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <defs>
-       <path id="mee738894df" d="M 0 0 
+       <path id="m0ce4e003d6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="131.269091" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -851,11 +942,11 @@ L -3.5 0
      <g id="line2d_65">
       <path d="M 69.59 101.341236 
 L 450 101.341236 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="101.341236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="101.341236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +986,11 @@ z
      <g id="line2d_67">
       <path d="M 69.59 71.413381 
 L 450 71.413381 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="71.413381" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="71.413381" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -934,11 +1025,11 @@ z
      <g id="line2d_69">
       <path d="M 69.59 31.850909 
 L 450 31.850909 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="31.850909" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1036,15 +1127,11 @@ z
     <path d="M 86.881364 131.269091 
 L 133.526138 131.269091 
 L 133.89055 101.341236 
-L 151.746753 101.341236 
-L 152.111165 71.413381 
-L 169.967368 71.413381 
-L 170.33178 41.485526 
-L 175.797965 41.485526 
+L 175.797965 101.341236 
 L 176.162377 31.850909 
 L 432.708636 31.850909 
 L 432.708636 31.850909 
-" clip-path="url(#p77222f8fef)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p2459403182)" style="fill: none; stroke: #0000ff; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="patch_3">
     <path d="M 69.59 136.24 
@@ -1194,11 +1281,11 @@ z
      <g id="line2d_72">
       <path d="M 115.586572 303.64 
 L 115.586572 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m99b41d0da3" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="115.586572" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1217,11 +1304,11 @@ L 115.586572 194.28
      <g id="line2d_74">
       <path d="M 176.114145 303.64 
 L 176.114145 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m99b41d0da3" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="176.114145" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1238,11 +1325,11 @@ L 176.114145 194.28
      <g id="line2d_76">
       <path d="M 236.641717 303.64 
 L 236.641717 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m99b41d0da3" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="236.641717" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1260,11 +1347,11 @@ L 236.641717 194.28
      <g id="line2d_78">
       <path d="M 297.16929 303.64 
 L 297.16929 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m99b41d0da3" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="297.16929" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1283,11 +1370,11 @@ L 297.16929 194.28
      <g id="line2d_80">
       <path d="M 357.696863 303.64 
 L 357.696863 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#m99b41d0da3" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="357.696863" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1304,11 +1391,11 @@ L 357.696863 194.28
      <g id="line2d_82">
       <path d="M 418.224436 303.64 
 L 418.224436 194.28 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#m99b41d0da3" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d2bb9098e" x="418.224436" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1325,350 +1412,350 @@ L 418.224436 194.28
     <g id="xtick_63">
      <g id="line2d_84">
       <g>
-       <use xlink:href="#mc50d4081ef" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="73.279614" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_64">
      <g id="line2d_85">
       <g>
-       <use xlink:href="#mc50d4081ef" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="83.93799" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_65">
      <g id="line2d_86">
       <g>
-       <use xlink:href="#mc50d4081ef" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="91.500229" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_66">
      <g id="line2d_87">
       <g>
-       <use xlink:href="#mc50d4081ef" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="97.365957" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_67">
      <g id="line2d_88">
       <g>
-       <use xlink:href="#mc50d4081ef" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="102.158605" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_68">
      <g id="line2d_89">
       <g>
-       <use xlink:href="#mc50d4081ef" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="106.210732" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_69">
      <g id="line2d_90">
       <g>
-       <use xlink:href="#mc50d4081ef" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="109.720844" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_70">
      <g id="line2d_91">
       <g>
-       <use xlink:href="#mc50d4081ef" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="112.816982" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_71">
      <g id="line2d_92">
       <g>
-       <use xlink:href="#mc50d4081ef" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="133.807187" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_72">
      <g id="line2d_93">
       <g>
-       <use xlink:href="#mc50d4081ef" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="144.465563" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_73">
      <g id="line2d_94">
       <g>
-       <use xlink:href="#mc50d4081ef" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="152.027802" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_74">
      <g id="line2d_95">
       <g>
-       <use xlink:href="#mc50d4081ef" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="157.89353" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_75">
      <g id="line2d_96">
       <g>
-       <use xlink:href="#mc50d4081ef" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="162.686178" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_76">
      <g id="line2d_97">
       <g>
-       <use xlink:href="#mc50d4081ef" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="166.738305" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_77">
      <g id="line2d_98">
       <g>
-       <use xlink:href="#mc50d4081ef" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="170.248417" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_78">
      <g id="line2d_99">
       <g>
-       <use xlink:href="#mc50d4081ef" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="173.344555" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_79">
      <g id="line2d_100">
       <g>
-       <use xlink:href="#mc50d4081ef" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="194.33476" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_80">
      <g id="line2d_101">
       <g>
-       <use xlink:href="#mc50d4081ef" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="204.993136" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_81">
      <g id="line2d_102">
       <g>
-       <use xlink:href="#mc50d4081ef" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="212.555375" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_82">
      <g id="line2d_103">
       <g>
-       <use xlink:href="#mc50d4081ef" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="218.421102" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_83">
      <g id="line2d_104">
       <g>
-       <use xlink:href="#mc50d4081ef" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="223.213751" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_84">
      <g id="line2d_105">
       <g>
-       <use xlink:href="#mc50d4081ef" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="227.265878" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_85">
      <g id="line2d_106">
       <g>
-       <use xlink:href="#mc50d4081ef" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="230.77599" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_86">
      <g id="line2d_107">
       <g>
-       <use xlink:href="#mc50d4081ef" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="233.872128" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_87">
      <g id="line2d_108">
       <g>
-       <use xlink:href="#mc50d4081ef" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="254.862332" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_88">
      <g id="line2d_109">
       <g>
-       <use xlink:href="#mc50d4081ef" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="265.520709" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_89">
      <g id="line2d_110">
       <g>
-       <use xlink:href="#mc50d4081ef" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="273.082947" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_90">
      <g id="line2d_111">
       <g>
-       <use xlink:href="#mc50d4081ef" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="278.948675" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_91">
      <g id="line2d_112">
       <g>
-       <use xlink:href="#mc50d4081ef" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="283.741324" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_92">
      <g id="line2d_113">
       <g>
-       <use xlink:href="#mc50d4081ef" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="287.793451" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_93">
      <g id="line2d_114">
       <g>
-       <use xlink:href="#mc50d4081ef" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="291.303562" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_94">
      <g id="line2d_115">
       <g>
-       <use xlink:href="#mc50d4081ef" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="294.3997" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_95">
      <g id="line2d_116">
       <g>
-       <use xlink:href="#mc50d4081ef" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="315.389905" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_96">
      <g id="line2d_117">
       <g>
-       <use xlink:href="#mc50d4081ef" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="326.048282" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_97">
      <g id="line2d_118">
       <g>
-       <use xlink:href="#mc50d4081ef" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="333.61052" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_98">
      <g id="line2d_119">
       <g>
-       <use xlink:href="#mc50d4081ef" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="339.476248" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_99">
      <g id="line2d_120">
       <g>
-       <use xlink:href="#mc50d4081ef" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="344.268897" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_100">
      <g id="line2d_121">
       <g>
-       <use xlink:href="#mc50d4081ef" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="348.321023" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_101">
      <g id="line2d_122">
       <g>
-       <use xlink:href="#mc50d4081ef" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="351.831135" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_102">
      <g id="line2d_123">
       <g>
-       <use xlink:href="#mc50d4081ef" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="354.927273" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_103">
      <g id="line2d_124">
       <g>
-       <use xlink:href="#mc50d4081ef" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="375.917478" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_104">
      <g id="line2d_125">
       <g>
-       <use xlink:href="#mc50d4081ef" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="386.575855" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_105">
      <g id="line2d_126">
       <g>
-       <use xlink:href="#mc50d4081ef" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="394.138093" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_106">
      <g id="line2d_127">
       <g>
-       <use xlink:href="#mc50d4081ef" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="400.003821" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_107">
      <g id="line2d_128">
       <g>
-       <use xlink:href="#mc50d4081ef" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="404.79647" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_108">
      <g id="line2d_129">
       <g>
-       <use xlink:href="#mc50d4081ef" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="408.848596" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_109">
      <g id="line2d_130">
       <g>
-       <use xlink:href="#mc50d4081ef" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="412.358708" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_110">
      <g id="line2d_131">
       <g>
-       <use xlink:href="#mc50d4081ef" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="415.454846" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_111">
      <g id="line2d_132">
       <g>
-       <use xlink:href="#mc50d4081ef" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="436.445051" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_112">
      <g id="line2d_133">
       <g>
-       <use xlink:href="#mc50d4081ef" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1f1a006c09" x="447.103428" y="303.64" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1690,11 +1777,11 @@ L 418.224436 194.28
      <g id="line2d_134">
       <path d="M 69.59 267.574208 
 L 450 267.574208 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_135">
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="267.574208" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="267.574208" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -1711,11 +1798,11 @@ L 450 267.574208
      <g id="line2d_136">
       <path d="M 69.59 225.390208 
 L 450 225.390208 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_137">
       <g>
-       <use xlink:href="#mee738894df" x="69.59" y="225.390208" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ce4e003d6" x="69.59" y="225.390208" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
@@ -1800,15 +1887,11 @@ z
     <path d="M 86.881364 298.669091 
 L 133.526138 282.41482 
 L 133.89055 288.637158 
-L 151.746753 282.41482 
-L 152.111165 288.637158 
-L 169.967368 282.41482 
-L 170.33178 288.637158 
-L 175.797965 286.732361 
+L 175.797965 274.033711 
 L 176.162377 288.6494 
 L 432.708636 199.250909 
 L 432.708636 199.250909 
-" clip-path="url(#pf633062729)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p018d99a91a)" style="fill: none; stroke: #ff0000; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="patch_8">
     <path d="M 69.59 303.64 
@@ -1850,10 +1933,10 @@ L 450 194.28
   </g>
  </g>
  <defs>
-  <clipPath id="p77222f8fef">
+  <clipPath id="p2459403182">
    <rect x="69.59" y="26.88" width="380.41" height="109.36"/>
   </clipPath>
-  <clipPath id="pf633062729">
+  <clipPath id="p018d99a91a">
    <rect x="69.59" y="194.28" width="380.41" height="109.36"/>
   </clipPath>
  </defs>

--- a/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
+++ b/src/java/org/apache/cassandra/db/filter/TombstoneOverwhelmingException.java
@@ -31,7 +31,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
     public TombstoneOverwhelmingException(long numTombstones, String query, TableMetadata metadata, DecoratedKey lastPartitionKey, ClusteringPrefix<?> lastClustering)
     {
         super(RequestFailureReason.READ_TOO_MANY_TOMBSTONES,
-              String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partion key was (%s)); query aborted", 
+              String.format("Scanned over %d tombstones during query '%s' (last scanned row token was %s and partition key was (%s)); query aborted",
                             numTombstones, query, lastPartitionKey.getToken(), makePKString(metadata, lastPartitionKey.getKey(), lastClustering)));
     }
 
@@ -40,7 +40,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
         StringBuilder sb = new StringBuilder();
 
         if (clustering.size() > 0)
-            sb.append("(");
+            sb.append('(');
 
         // TODO: We should probably make that a lot easier/transparent for partition keys
         AbstractType<?> pkType = metadata.partitionKeyType;
@@ -52,7 +52,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
             {
                 if (i > 0)
                     sb.append(", ");
-                sb.append(ct.types.get(i).getString(values[i]));
+                sb.append(ct.subTypes().get(i).getString(values[i]));
             }
         }
         else
@@ -61,7 +61,7 @@ public class TombstoneOverwhelmingException extends UncheckedInternalRequestExec
         }
 
         if (clustering.size() > 0)
-            sb.append(")");
+            sb.append(')');
 
         for (int i = 0; i < clustering.size(); i++)
             sb.append(", ").append(clustering.stringAt(i, metadata.comparator));

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import com.google.common.collect.ImmutableList;
+
 import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.serializers.BytesSerializer;
@@ -38,9 +40,9 @@ import org.apache.cassandra.utils.ByteBufferUtil;
  */
 public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
 {
-    protected AbstractCompositeType()
+    protected AbstractCompositeType(ImmutableList<AbstractType<?>> subTypes)
     {
-        super(ComparisonType.CUSTOM);
+        super(ComparisonType.CUSTOM, false, subTypes);
     }
 
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
@@ -102,7 +104,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
      */
     public ByteBuffer[] split(ByteBuffer bb)
     {
-        List<ByteBuffer> l = new ArrayList<ByteBuffer>();
+        List<ByteBuffer> l = new ArrayList<>();
         boolean isStatic = readIsStatic(bb, ByteBufferAccessor.instance);
         int offset = startingOffset(isStatic);
 

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.CQLTypeParser;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
@@ -729,39 +730,50 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * @param columnName the name of the column whose type is checked.
      * @param isPrimaryKeyColumn whether {@code columnName} is a primary key column or not.
      * @param isCounterTable whether the table the {@code columnName} is part of is a counter table.
+     * @param isDroppedColumn whether the type is that of a dropped column. This has an impact on tuple validation,
+     *                        which can be multi-cell only for dropped columns (for reasons detailed in
+     *                        {@link CQLTypeParser#parseDroppedType(String, String)}).
      *
      * @throws InvalidColumnTypeException if this type is not a valid column type for {@code columnName}.
      */
-    public void validateForColumn(ByteBuffer columnName, boolean isPrimaryKeyColumn, boolean isCounterTable)
+    public void validateForColumn(ByteBuffer columnName,
+                                  boolean isPrimaryKeyColumn,
+                                  boolean isCounterTable,
+                                  boolean isDroppedColumn)
     {
         if (isPrimaryKeyColumn)
         {
             if (isMultiCell())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "non-frozen %s are not supported for PRIMARY KEY columns", category());
             if (referencesCounter())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "counters are not supported within PRIMARY KEY columns");
             // We don't allow durations in anything sorted (primary key here, or in the "name-comparator" part of
             // collections below). This isn't really a technical limitation, but duration sorts in a somewhat random
             // way, so CASSANDRA-11873 decided to reject them when sorting was involved.
             if (referencesDuration())
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "duration types are not supported within PRIMARY KEY columns");
 
             if (comparisonType == ComparisonType.NOT_COMPARABLE)
-                throw columnException(columnName, true, isCounterTable,
+                throw columnException(columnName, true, isCounterTable, isDroppedColumn,
                                       "type %s is not comparable and cannot be used for PRIMARY KEY columns", asCQL3Type());
         }
         else
         {
             if (isMultiCell())
             {
+                if (isTuple() && !isDroppedColumn)
+                    throw columnException(columnName, false, isCounterTable, false,
+                                          "tuple type %s is not frozen, which should not have happened",
+                                          asCQL3Type());
+
                 for (AbstractType<?> subType : subTypes())
                 {
                     if (subType.isMultiCell())
                     {
-                        throw columnException(columnName, false, isCounterTable,
+                        throw columnException(columnName, false, isCounterTable, isDroppedColumn,
                                               "non-frozen %s are only supported at top-level: subtype %s of %s must be frozen",
                                               subType.category(), subType.asCQL3Type(), asCQL3Type());
                     }
@@ -777,7 +789,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
                         String what = this instanceof MapType
                                       ? "map keys"
                                       : (this instanceof SetType ? "sets" : category());
-                        throw columnException(columnName, false, isCounterTable,
+                        throw columnException(columnName, false, isCounterTable, isDroppedColumn,
                                               "duration types are not supported within non-frozen %s", what);
                     }
                 }
@@ -795,21 +807,21 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
                     // their limitations, and we want to restrict how user can use them to hopefully make user think
                     // twice about their usage). In any case, a slightly more user-friendly message is probably nice.
                     if (referencesCounter())
-                        throw columnException(columnName, false, true, "counters are not allowed within %s", category());
+                        throw columnException(columnName, false, true, isDroppedColumn, "counters are not allowed within %s", category());
 
-                    throw columnException(columnName, false, true, "Cannot mix counter and non counter columns in the same table");
+                    throw columnException(columnName, false, true, isDroppedColumn, "Cannot mix counter and non counter columns in the same table");
                 }
             }
             else
             {
                 if (isCounter())
-                    throw columnException(columnName, false, false, "Cannot mix counter and non counter columns in the same table");
+                    throw columnException(columnName, false, false, isDroppedColumn, "Cannot mix counter and non counter columns in the same table");
 
                 // For nested counters, we prefer complaining about the nested-ness rather than this not being a counter
                 // table, because the table won't be marked as a counter one even if it has only nested counters, and so
                 // that's overall a more intuitive message.
                 if (referencesCounter())
-                    throw columnException(columnName, false, false, "counters are not allowed within %s", category());
+                    throw columnException(columnName, false, false, isDroppedColumn, "counters are not allowed within %s", category());
             }
         }
     }
@@ -817,11 +829,12 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     private InvalidColumnTypeException columnException(ByteBuffer columnName,
                                                        boolean isPrimaryKeyColumn,
                                                        boolean isCounterTable,
+                                                       boolean isDroppedColumn,
                                                        String reason,
                                                        Object... args)
     {
         String msg = args.length == 0 ? reason : String.format(reason, args);
-        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, msg);
+        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, msg);
     }
 
     private String category()

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -21,21 +21,27 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -45,11 +51,12 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.github.jamm.Unmetered;
 
+import static com.google.common.collect.Iterables.transform;
 import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM;
 
 /**
  * Specifies a Comparator for a specific type of ByteBuffer.
- *
+ * <p>
  * Note that empty ByteBuffer are used to represent "start at the beginning"
  * or "stop at the end" arguments to get_slice, so the Comparator
  * should always handle those values even if they normally do not
@@ -58,9 +65,9 @@ import static org.apache.cassandra.db.marshal.AbstractType.ComparisonType.CUSTOM
 @Unmetered
 public abstract class AbstractType<T> implements Comparator<ByteBuffer>, AssignmentTestable
 {
-    private final static int VARIABLE_LENGTH = -1;
+    private static final Logger logger = LoggerFactory.getLogger(AbstractType.class);
 
-    public final Comparator<ByteBuffer> reverseComparator;
+    private final static int VARIABLE_LENGTH = -1;
 
     public enum ComparisonType
     {
@@ -83,19 +90,25 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     public final ComparisonType comparisonType;
     public final boolean isByteOrderComparable;
     public final ValueComparators comparatorSet;
+    private final boolean isMultiCell;
+    protected final ImmutableList<AbstractType<?>> subTypes;
 
     protected AbstractType(ComparisonType comparisonType)
     {
+        this(comparisonType, false, ImmutableList.of());
+    }
+
+    protected AbstractType(ComparisonType comparisonType, boolean isMultiCell, List<AbstractType<?>> subTypes)
+    {
         this.comparisonType = comparisonType;
         this.isByteOrderComparable = comparisonType == ComparisonType.BYTE_ORDER;
-        reverseComparator = (o1, o2) -> AbstractType.this.compare(o2, o1);
         try
         {
             Method custom = getClass().getMethod("compareCustom", Object.class, ValueAccessor.class, Object.class, ValueAccessor.class);
             if ((custom.getDeclaringClass() == AbstractType.class) == (comparisonType == CUSTOM))
                 throw new IllegalStateException((comparisonType == CUSTOM ? "compareCustom must be overridden if ComparisonType is CUSTOM"
                                                                          : "compareCustom should not be overridden if ComparisonType is not CUSTOM")
-                                                + " (" + getClass().getSimpleName() + ")");
+                                                + " (" + getClass().getSimpleName() + ')');
         }
         catch (NoSuchMethodException e)
         {
@@ -104,6 +117,23 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
         comparatorSet = new ValueComparators((l, r) -> compare(l, ByteArrayAccessor.instance, r, ByteArrayAccessor.instance),
                                              (l, r) -> compare(l, ByteBufferAccessor.instance, r, ByteBufferAccessor.instance));
+
+        this.isMultiCell = isMultiCell;
+
+        // A frozen type can only have frozen subtypes, basically by definition. So make sure we don't mess it up
+        // when constructing types by forgetting to set some multi-cell flag. Note that because we have had a lot of
+        // frozen-related errors in the past, we log an error if this happens, but continue with the type frozen as this
+        // is almost surely the right thing to do.
+        ImmutableList<AbstractType<?>> cleanedSubtypes = ImmutableList.copyOf(subTypes);
+        if (!isMultiCell && subTypes.stream().anyMatch(AbstractType::isMultiCell))
+        {
+            logger.error("Detected corrupted type: creating a frozen {} but with some non-frozen sub-types. " +
+                         "This is likely a bug and should be reported, but continuing with the " +
+                         "sub-types frozen as this almost surely the right thing to do.", getClass());
+            cleanedSubtypes = freeze(subTypes);
+        }
+        this.subTypes = cleanedSubtypes;
+
     }
 
     static <VL, VR, T extends Comparable<T>> int compareComposed(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR, AbstractType<T> type)
@@ -258,30 +288,19 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     public abstract TypeSerializer<T> getSerializer();
 
-    /* convenience method */
-    public String getString(Collection<ByteBuffer> names)
-    {
-        StringBuilder builder = new StringBuilder();
-        for (ByteBuffer name : names)
-        {
-            builder.append(getString(name)).append(",");
-        }
-        return builder.toString();
-    }
-
     public boolean isCounter()
     {
         return false;
     }
 
-    public boolean isFrozenCollection()
-    {
-        return isCollection() && !isMultiCell();
-    }
-
     public boolean isReversed()
     {
         return false;
+    }
+
+    public AbstractType<T> unwrap()
+    {
+        return isReversed() ? ((ReversedType<T>) this).baseType.unwrap() : this;
     }
 
     public static AbstractType<?> parseDefaultParameters(AbstractType<?> baseType, TypeParser parser) throws SyntaxException
@@ -314,24 +333,30 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * Returns true if values of the other AbstractType can be read and "reasonably" interpreted by the this
+     * Returns true if values of the other AbstractType can be read and "reasonably" interpreted by this
      * AbstractType. Note that this is a weaker version of isCompatibleWith, as it does not require that both type
      * compare values the same way.
-     *
+     * <p>
      * The restriction on the other type being "reasonably" interpreted is to prevent, for example, IntegerType from
      * being compatible with all other types.  Even though any byte string is a valid IntegerType value, it doesn't
      * necessarily make sense to interpret a UUID or a UTF8 string as an integer.
-     *
+     * <p>
      * Note that a type should be compatible with at least itself.
+     * <p>
+     * Also note that to ensure consistent handling of the {@link ReversedType} (which should be ignored as far as this
+     * method goes since it only impacts sorting), this method is final and subclasses should override the
+     * {@link #isValueCompatibleWithInternal} method instead.
      */
-    public boolean isValueCompatibleWith(AbstractType<?> otherType)
+    public final boolean isValueCompatibleWith(AbstractType<?> otherType)
     {
-        return isValueCompatibleWithInternal((otherType instanceof ReversedType) ? ((ReversedType) otherType).baseType : otherType);
+        return unwrap().isValueCompatibleWithInternal(otherType.unwrap());
     }
 
     /**
-     * Needed to handle ReversedType in value-compatibility checks.  Subclasses should implement this instead of
-     * isValueCompatibleWith().
+     * Needed to handle {@link ReversedType} in value-compatibility checks. Subclasses should override this instead of
+     * {@link #isValueCompatibleWith}. However, if said override has subtypes on which they need to check value
+     * compatibility recursively, they should call {@link #isValueCompatibleWith} instead of this method
+     * so that reversed types are ignored even if nested.
      */
     protected boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
@@ -371,37 +396,100 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return false;
     }
 
-    public boolean isMultiCell()
+    /**
+     * Whether the type is multi-cell, that is whether its value is encoded using multiple cells internally.
+     * <p>
+     * Only "complex" types, whose values are somewhat composite, can be multi-cell (and so multi-cell types will
+     * have non-empty {@link #subTypes}, corresponding to the type(s) of the decomposed values). Further, all
+     * multi-cell types have a so-called <b>frozen</b> counterpart: a non-multi-cell version that fundamentally
+     * represents the same type but where the decomposed values are all packed into a single cell value (rather than
+     * split into multiple cells).
+     * <p>
+     * Note that by definition, if a type is frozen (non-multi-cell) and "complex" (has non-empty {@link #subTypes()}),
+     * then all its subtypes must also be frozen.
+     */
+    public final boolean isMultiCell()
     {
-        return false;
-    }
-
-    public boolean isFreezable()
-    {
-        return false;
-    }
-
-    public AbstractType<?> freeze()
-    {
-        return this;
-    }
-
-    public List<AbstractType<?>> subTypes()
-    {
-        return Collections.emptyList();
+        return isMultiCell;
     }
 
     /**
-     * Returns an AbstractType instance that is equivalent to this one, but with all nested UDTs and collections
-     * explicitly frozen.
+     * If the type is a multi-cell one ({@link #isMultiCell()} is true), returns a frozen copy of this type (one
+     * for which {@link #isMultiCell()} returns false).
+     * <p>
+     * Note that as mentioned on {@link #isMultiCell()}, a frozen type necessarily has all its subtypes frozen, so
+     * this method also ensures that no subtypes (recursively) are marked as multi-cell.
      *
-     * This is only necessary for {@code 2.x -> 3.x} schema migrations, and can be removed in Cassandra 4.0.
-     *
-     * See CASSANDRA-11609 and CASSANDRA-11613.
+     * @return a frozen version of this type. If this type is not multi-cell (whether because it is not a "complex"
+     * type, or because it is already a frozen one), this should return {@code this}.
      */
-    public AbstractType<?> freezeNestedMulticellTypes()
+    public AbstractType<?> freeze()
     {
+        if (!isMultiCell())
+            return this;
+
+        return with(freeze(subTypes()), false);
+    }
+
+    /**
+     * Utility method that freezes a list of types.
+     *
+     * @param types the list of types to freeze.
+     * @return a new (unmodifiable) list containing the result of applying {@link #freeze()} on every type of
+     * {@code types}.
+     */
+    public static ImmutableList<AbstractType<?>> freeze(List<AbstractType<?>> types)
+    {
+        if (types.isEmpty())
+            return ImmutableList.of();
+
+        ImmutableList.Builder<AbstractType<?>> builder = ImmutableList.builder();
+        for (AbstractType<?> type : types)
+            builder.add(type.freeze());
+        return builder.build();
+    }
+
+    /**
+     * Creates an instance of this type (the concrete type extending this class) with the provided updated multi-cell
+     * flag and subtypes.
+     * <p>
+     * Any other information (other than multi-cellness and subtypes) the type may have is expected to be left unchanged
+     * in the created type.
+     *
+     * @param isMultiCell whether the returned type must be a multi-cell one or not.
+     * @param subTypes the subtypes to use for the returned type as a list. The list will have subtypes in the exact
+     * same order as returned by {@link #subTypes()}, and exactly as many as the concrete class expects.
+     * @return the created type, which can be {@code this} if the provided subTypes and multi-cell flag are the same
+     * as that of this type.
+     */
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        // Default implementation for types that can neither be multi-cell, nor have subtypes (and thus where this
+        // is basically a no-op). Any other type must override this.
+
+        assert this.subTypes.isEmpty() && subTypes.isEmpty() :
+        String.format("Invalid call to copyWith on %s with subTypes %s (provided subTypes: %s)",
+                      this, this.subTypes, subTypes);
+
+        assert !this.isMultiCell() && !isMultiCell:
+        String.format("Invalid call to copyWith on %s with isMultiCell %b (provided isMultiCell: %b)",
+                      this, this.isMultiCell(), isMultiCell);
+
         return this;
+    }
+
+    /**
+     * If the type has "complex" values that depend on subtypes, return those (direct) subtypes (in undefined order),
+     * and an empty list otherwise.
+     * <p>
+     * Note that most "complex" types (type for which this return a non-empty iterable) are subclasses of
+     * {@link MultiCellCapableType} and thus can be multi-cell or frozen. However, a few legacy types (namely
+     * {@link CompositeType} and {@link DynamicCompositeType}) are "complex" (have subtypes) but are only even supported
+     * as "frozen" (and so don't extend {@link MultiCellCapableType}).
+     */
+    public final ImmutableList<AbstractType<?>> subTypes()
+    {
+        return subTypes;
     }
 
     /**
@@ -413,28 +501,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * @param ignoreFreezing if true, the type string will not be wrapped with FrozenType(...), even if this type is frozen.
-     */
-    public String toString(boolean ignoreFreezing)
-    {
-        return this.toString();
-    }
-
-    /**
      * To override keyspace name in {@link UserType}
      */
     public AbstractType<T> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        return this;
-    }
-
-    /**
-     * Return a list of the "subcomponents" this type has.
-     * This always return a singleton list with the type itself except for CompositeType.
-     */
-    public List<AbstractType<?>> getComponents()
-    {
-        return Collections.<AbstractType<?>>singletonList(this);
+        return this; // TODO: can we have a better default implementation?
     }
 
     /**
@@ -553,7 +624,9 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
     {
-        return false;
+        // Note that non-complex types have no subtypes, so will return false, and UserType overrides this to return
+        // true if the provided name matches.
+        return subTypes().stream().anyMatch(t -> t.referencesUserType(name, accessor));
     }
 
     /**
@@ -570,7 +643,14 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      */
     public AbstractType<?> withUpdatedUserType(UserType udt)
     {
-        return this;
+        if (!referencesUserType(udt.name))
+            return this;
+
+        ImmutableList.Builder<AbstractType<?>> builder = ImmutableList.builder();
+        for (AbstractType<?> subType : subTypes)
+            builder.add(subType.withUpdatedUserType(udt));
+
+        return with(builder.build(), isMultiCell());
     }
 
     /**
@@ -591,18 +671,27 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     /**
      * Replace any instances of UserType with equivalent TupleType-s.
-     *
+     * <p>
      * We need it for dropped_columns, to allow safely dropping unused user types later without retaining any references
      * to them in system_schema.dropped_columns.
      */
     public AbstractType<?> expandUserTypes()
     {
-        return this;
+        return referencesUserTypes()
+               ? with(ImmutableList.copyOf(transform(subTypes, AbstractType::expandUserTypes)), isMultiCell())
+               : this;
     }
 
     public boolean referencesDuration()
     {
-        return false;
+        // Note that non-complex types have no subtypes, so will return false, and DurationType overrides this to return
+        // true.
+        return subTypes().stream().anyMatch(AbstractType::referencesDuration);
+    }
+
+    public final boolean referencesCounter()
+    {
+        return isCounter() || subTypes().stream().anyMatch(AbstractType::referencesCounter);
     }
 
     /**
@@ -613,7 +702,7 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         // testAssignement is for CQL literals and native protocol values, none of which make a meaningful
         // difference between frozen or not and reversed or not.
 
-        if (isFreezable() && !isMultiCell())
+        if (!isMultiCell())
             receiverType = receiverType.freeze();
 
         if (isReversed() && !receiverType.isReversed())
@@ -626,6 +715,125 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
             return AssignmentTestable.TestResult.WEAKLY_ASSIGNABLE;
 
         return AssignmentTestable.TestResult.NOT_ASSIGNABLE;
+    }
+
+    /**
+     * Validates whether this type is valid as a column type for a column of the provided kind.
+     * <p>
+     * A number of limits must be respected by column types (possibly depending on the type of columns). For
+     * instance, primary key columns must always be frozen, cannot use counters, etc. And for regular columns, amongst
+     * other things, we currently only support non-frozen types at top-level, so any type with a non-frozen subtype
+     * is invalid (note that it's valid to <b>create</b> a type with non-frozen subtypes, with a {@code CREATE TYPE}
+     * for instance, but they cannot be used as column types without being frozen).
+     *
+     * @param columnName the name of the column whose type is checked.
+     * @param isPrimaryKeyColumn whether {@code columnName} is a primary key column or not.
+     * @param isCounterTable whether the table the {@code columnName} is part of is a counter table.
+     *
+     * @throws InvalidColumnTypeException if this type is not a valid column type for {@code columnName}.
+     */
+    public void validateForColumn(ByteBuffer columnName, boolean isPrimaryKeyColumn, boolean isCounterTable)
+    {
+        if (isPrimaryKeyColumn)
+        {
+            if (isMultiCell())
+                throw columnException(columnName, true, isCounterTable,
+                                      "non-frozen %s are not supported for PRIMARY KEY columns", category());
+            if (referencesCounter())
+                throw columnException(columnName, true, isCounterTable,
+                                      "counters are not supported within PRIMARY KEY columns");
+            // We don't allow durations in anything sorted (primary key here, or in the "name-comparator" part of
+            // collections below). This isn't really a technical limitation, but duration sorts in a somewhat random
+            // way, so CASSANDRA-11873 decided to reject them when sorting was involved.
+            if (referencesDuration())
+                throw columnException(columnName, true, isCounterTable,
+                                      "duration types are not supported within PRIMARY KEY columns");
+
+            if (comparisonType == ComparisonType.NOT_COMPARABLE)
+                throw columnException(columnName, true, isCounterTable,
+                                      "type %s is not comparable and cannot be used for PRIMARY KEY columns", asCQL3Type());
+        }
+        else
+        {
+            if (isMultiCell())
+            {
+                for (AbstractType<?> subType : subTypes())
+                {
+                    if (subType.isMultiCell())
+                    {
+                        throw columnException(columnName, false, isCounterTable,
+                                              "non-frozen %s are only supported at top-level: subtype %s of %s must be frozen",
+                                              subType.category(), subType.asCQL3Type(), asCQL3Type());
+                    }
+                }
+
+                if (this instanceof MultiCellCapableType)
+                {
+                    AbstractType<?> nameComparator = ((MultiCellCapableType<?>) this).nameComparator();
+                    // As mentioned above, CASSANDRA-11873 decided to reject durations when sorting was involved.
+                    if (nameComparator.referencesDuration())
+                    {
+                        // Trying to profile a more precise error message
+                        String what = this instanceof MapType
+                                      ? "map keys"
+                                      : (this instanceof SetType ? "sets" : category());
+                        throw columnException(columnName, false, isCounterTable,
+                                              "duration types are not supported within non-frozen %s", what);
+                    }
+                }
+            }
+
+            if (isCounterTable)
+            {
+                // Everything within a counter table must be a counter, and we don't allow nesting (collections of
+                // counters), except for legacy backward-compatibility, in the super-column map used to support old
+                // super columns.
+                if (!isCounter() && !TableMetadata.isSuperColumnMapColumnName(columnName))
+                {
+                    // We don't allow counter inside collections, but to be fair, at least for map, it's a bit of an
+                    // arbitrary limitation (it works internally, we don't expose it mostly because counters have
+                    // their limitations, and we want to restrict how user can use them to hopefully make user think
+                    // twice about their usage). In any case, a slightly more user-friendly message is probably nice.
+                    if (referencesCounter())
+                        throw columnException(columnName, false, true, "counters are not allowed within %s", category());
+
+                    throw columnException(columnName, false, true, "Cannot mix counter and non counter columns in the same table");
+                }
+            }
+            else
+            {
+                if (isCounter())
+                    throw columnException(columnName, false, false, "Cannot mix counter and non counter columns in the same table");
+
+                // For nested counters, we prefer complaining about the nested-ness rather than this not being a counter
+                // table, because the table won't be marked as a counter one even if it has only nested counters, and so
+                // that's overall a more intuitive message.
+                if (referencesCounter())
+                    throw columnException(columnName, false, false, "counters are not allowed within %s", category());
+            }
+        }
+    }
+
+    private InvalidColumnTypeException columnException(ByteBuffer columnName,
+                                                       boolean isPrimaryKeyColumn,
+                                                       boolean isCounterTable,
+                                                       String reason,
+                                                       Object... args)
+    {
+        String msg = args.length == 0 ? reason : String.format(reason, args);
+        return new InvalidColumnTypeException(columnName, this, isPrimaryKeyColumn, isCounterTable, msg);
+    }
+
+    private String category()
+    {
+        if (isCollection())
+            return "collections";
+        else if (isTuple())
+            return "tuples";
+        else if (isUDT())
+            return "user types";
+        else
+            return "types";
     }
 
     /**
@@ -692,25 +900,21 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     }
 
     /**
-     * This must be overriden by subclasses if necessary so that for any
-     * AbstractType, this == TypeParser.parse(toString()).
+     * This must be overriden by subclasses if necessary so that for any type,
+     * {@code toString(x) == TypeParser.parse(toString(x))}.
      *
-     * Note that for backwards compatibility this includes the full classname.
-     * For CQL purposes the short name is fine.
+     * @param ignoreFreezing if true, the type string will not be wrapped with FrozenType(...), even if this type is
+     * frozen.
      */
-    @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
         return getClass().getName();
     }
 
-    public void checkComparable()
+    @Override
+    public final String toString()
     {
-        switch (comparisonType)
-        {
-            case NOT_COMPARABLE:
-                throw new IllegalArgumentException(this + " cannot be used in comparisons, so cannot be used as a clustering column");
-        }
+        return toString(false);
     }
 
     public final AssignmentTestable.TestResult testAssignment(String keyspace, ColumnSpecification receiver)
@@ -722,5 +926,17 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
     public AbstractType<?> getCompatibleTypeIfKnown(String keyspace)
     {
         return this;
+    }
+
+    protected static <K, V extends AbstractType<?>> V getInstance(ConcurrentMap<K, V> instances, K key, Supplier<V> value)
+    {
+        V cached = instances.get(key);
+        if (cached != null)
+            return cached;
+
+        // We avoid constructor calls in Map#computeIfAbsent to avoid recursive update exceptions because the automatic
+        // fixing of subtypes done by the top-level constructor might attempt a recursive update to the instances map.
+        V instance = value.get();
+        return instances.computeIfAbsent(key, k -> instance);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/CompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CompositeType.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
@@ -70,10 +69,8 @@ public class CompositeType extends AbstractCompositeType
 {
     private static final int STATIC_MARKER = 0xFFFF;
 
-    public final List<AbstractType<?>> types;
-
     // interning instances
-    private static final ConcurrentMap<List<AbstractType<?>>, CompositeType> instances = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<ImmutableList<AbstractType<?>>, CompositeType> instances = new ConcurrentHashMap<>();
 
     public static CompositeType getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -82,10 +79,10 @@ public class CompositeType extends AbstractCompositeType
 
     public static CompositeType getInstance(Iterable<AbstractType<?>> types)
     {
-        return getInstance(Lists.newArrayList(types));
+        return getInstance(ImmutableList.copyOf(types));
     }
 
-    public static CompositeType getInstance(AbstractType... types)
+    public static CompositeType getInstance(AbstractType<?>... types)
     {
         return getInstance(Arrays.asList(types));
     }
@@ -93,7 +90,7 @@ public class CompositeType extends AbstractCompositeType
     @Override
     public CompositeType overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        return getInstance(types.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()));
+        return getInstance(subTypes.stream().map(t -> t.overrideKeyspace(overrideKeyspace)).collect(Collectors.toList()));
     }
 
     protected static int startingOffsetInternal(boolean isStatic)
@@ -136,25 +133,31 @@ public class CompositeType extends AbstractCompositeType
         return true;
     }
 
-    public static CompositeType getInstance(List<AbstractType<?>> types)
+    public static CompositeType getInstance(ImmutableList<AbstractType<?>> types)
     {
         assert types != null && !types.isEmpty();
-        CompositeType t = instances.get(types);
-        return null == t
-             ? instances.computeIfAbsent(types, CompositeType::new)
-             : t;
+        return getInstance(instances, types, () -> new CompositeType(types));
     }
 
-    protected CompositeType(List<AbstractType<?>> types)
+    protected CompositeType(ImmutableList<AbstractType<?>> types)
     {
-        this.types = ImmutableList.copyOf(types);
+        super(types);
+    }
+
+    @Override
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        if (isMultiCell)
+            throw new IllegalArgumentException("Cannot create a multi-cell CompositeType");
+
+        return getInstance(subTypes);
     }
 
     protected <V> AbstractType<?> getComparator(int i, V value, ValueAccessor<V> accessor, int offset)
     {
         try
         {
-            return types.get(i);
+            return subTypes.get(i);
         }
         catch (IndexOutOfBoundsException e)
         {
@@ -174,7 +177,7 @@ public class CompositeType extends AbstractCompositeType
 
     protected <V> AbstractType<?> getAndAppendComparator(int i, V value, ValueAccessor<V> accessor, StringBuilder sb, int offset)
     {
-        return types.get(i);
+        return subTypes.get(i);
     }
 
     @Override
@@ -183,7 +186,7 @@ public class CompositeType extends AbstractCompositeType
         if (data == null || accessor.isEmpty(data))
             return null;
 
-        ByteSource[] srcs = new ByteSource[types.size() * 2 + 1];
+        ByteSource[] srcs = new ByteSource[subTypes.size() * 2 + 1];
         int length = accessor.size(data);
 
         // statics go first
@@ -201,7 +204,7 @@ public class CompositeType extends AbstractCompositeType
 
             int componentLength = accessor.getUnsignedShort(data, offset);
             offset += 2;
-            srcs[i * 2 + 1] = types.get(i).asComparableBytes(accessor, accessor.slice(data, offset, componentLength), version);
+            srcs[i * 2 + 1] = subTypes.get(i).asComparableBytes(accessor, accessor.slice(data, offset, componentLength), version);
             offset += componentLength;
             lastEoc = accessor.getByte(data, offset);
             offset += 1;
@@ -234,17 +237,17 @@ public class CompositeType extends AbstractCompositeType
         int separator = comparableBytes.next();
         boolean isStatic = ByteSourceInverse.nextComponentNull(separator);
         int i = 0;
-        V[] buffers = accessor.createArray(types.size());
+        V[] buffers = accessor.createArray(subTypes.size());
         byte lastEoc = 0;
 
-        while ((separator = comparableBytes.next()) != ByteSource.TERMINATOR && i < types.size())
+        while ((separator = comparableBytes.next()) != ByteSource.TERMINATOR && i < subTypes.size())
         {
             // Only the end-of-component byte of the last component of this composite can be non-zero, so the
             // component before can't have a non-zero end-of-component byte.
             assert lastEoc == 0 : lastEoc;
 
             // Get the next type and decode its payload.
-            AbstractType<?> type = types.get(i);
+            AbstractType<?> type = subTypes.get(i);
             V decoded = type.fromComparableBytes(accessor,
                                                  ByteSourceInverse.nextComponentSource(comparableBytes, separator),
                                                  version);
@@ -257,14 +260,14 @@ public class CompositeType extends AbstractCompositeType
 
     protected ParsedComparator parseComparator(int i, String part)
     {
-        return new StaticParsedComparator(types.get(i), part);
+        return new StaticParsedComparator(subTypes.get(i), part);
     }
 
     protected <V> AbstractType<?> validateComparator(int i, V value, ValueAccessor<V> accessor, int offset) throws MarshalException
     {
-        if (i >= types.size())
+        if (i >= subTypes.size())
             throw new MarshalException("Too many bytes for comparator");
-        return types.get(i);
+        return subTypes.get(i);
     }
 
     protected <V> int getComparatorSize(V value, ValueAccessor<V> accessor, int offset)
@@ -272,14 +275,15 @@ public class CompositeType extends AbstractCompositeType
         return 0;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public ByteBuffer decompose(Object... objects)
     {
-        assert objects.length == types.size();
+        assert objects.length == subTypes.size();
 
         ByteBuffer[] serialized = new ByteBuffer[objects.length];
         for (int i = 0; i < objects.length; i++)
         {
-            ByteBuffer buffer = ((AbstractType) types.get(i)).decompose(objects[i]);
+            ByteBuffer buffer = ((AbstractType) subTypes.get(i)).decompose(objects[i]);
             serialized[i] = buffer;
         }
         return build(ByteBufferAccessor.instance, serialized);
@@ -290,7 +294,7 @@ public class CompositeType extends AbstractCompositeType
     {
         // Assume all components, we'll trunk the array afterwards if need be, but
         // most names will be complete.
-        ByteBuffer[] l = new ByteBuffer[types.size()];
+        ByteBuffer[] l = new ByteBuffer[subTypes.size()];
         ByteBuffer bb = name.duplicate();
         readStatic(bb);
         int i = 0;
@@ -341,12 +345,6 @@ public class CompositeType extends AbstractCompositeType
     }
 
     @Override
-    public List<AbstractType<?>> getComponents()
-    {
-        return types;
-    }
-
-    @Override
     public boolean isCompatibleWith(AbstractType<?> previous)
     {
         if (this == previous)
@@ -357,13 +355,13 @@ public class CompositeType extends AbstractCompositeType
 
         // Extending with new components is fine
         CompositeType cp = (CompositeType)previous;
-        if (types.size() < cp.types.size())
+        if (subTypes.size() < cp.subTypes.size())
             return false;
 
-        for (int i = 0; i < cp.types.size(); i++)
+        for (int i = 0; i < cp.subTypes.size(); i++)
         {
-            AbstractType tprev = cp.types.get(i);
-            AbstractType tnew = types.get(i);
+            AbstractType<?> tprev = cp.subTypes.get(i);
+            AbstractType<?> tnew = subTypes.get(i);
             if (!tnew.isCompatibleWith(tprev))
                 return false;
         }
@@ -381,13 +379,13 @@ public class CompositeType extends AbstractCompositeType
 
         // Extending with new components is fine
         CompositeType cp = (CompositeType) otherType;
-        if (types.size() < cp.types.size())
+        if (subTypes.size() < cp.subTypes.size())
             return false;
 
-        for (int i = 0; i < cp.types.size(); i++)
+        for (int i = 0; i < cp.subTypes.size(); i++)
         {
-            AbstractType tprev = cp.types.get(i);
-            AbstractType tnew = types.get(i);
+            AbstractType<?> tprev = cp.subTypes.get(i);
+            AbstractType<?> tnew = subTypes.get(i);
             if (!tnew.isValueCompatibleWith(tprev))
                 return false;
         }
@@ -397,7 +395,7 @@ public class CompositeType extends AbstractCompositeType
     @Override
     public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
     {
-        return any(types, t -> t.referencesUserType(name, accessor));
+        return any(subTypes, t -> t.referencesUserType(name, accessor));
     }
 
     @Override
@@ -406,15 +404,9 @@ public class CompositeType extends AbstractCompositeType
         if (!referencesUserType(udt.name))
             return this;
 
-        instances.remove(types);
+        instances.remove(subTypes);
 
-        return getInstance(transform(types, t -> t.withUpdatedUserType(udt)));
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(transform(types, AbstractType::expandUserTypes));
+        return getInstance(transform(subTypes, t -> t.withUpdatedUserType(udt)));
     }
 
     private static class StaticParsedComparator implements ParsedComparator
@@ -447,9 +439,11 @@ public class CompositeType extends AbstractCompositeType
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
-        return getClass().getName() + TypeParser.stringifyTypeParameters(types);
+        // Subtypes will always be frozen (since CompositeType always is), but we don't include it in the string
+        // representation (so that we ignore our parameter).
+        return getClass().getName() + TypeParser.stringifyTypeParameters(subTypes, true);
     }
 
     @SafeVarargs

--- a/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MultiCellCapableType.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.CellPath;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+/**
+ * Base class for all types that have the capacity of being multi-cell (when not frozen).
+ *
+ * <p>A multi-cell type is one whose value is composed of multiple sub-values that are layout on multiple {@link Cell}
+ * (one for each sub-value), typically collections. Being layout on multiple cell allows partial update (of only some
+ * of the sub-values) without read-before write.
+ *
+ * <p>All multi-cell capable types can either be used as truly multi-cell types, or can be used frozen. In the later
+ * case, the values are not layout in multiple cells, but instead the whole value (with all its sub-values) is packed
+ * within a single cell value (which imply no partial update without read-before-write in particular).
+ * {@link #isMultiCell()} allows to know if a given type is a multi-cell variant or a frozen one (both are technically
+ * 2 different types, that have the same values from a user point of view, just with different capability).
+ *
+ * @param <T> the type of the values of this type.
+ */
+public abstract class MultiCellCapableType<T> extends AbstractType<T>
+{
+
+    protected MultiCellCapableType(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        super(ComparisonType.CUSTOM, isMultiCell, subTypes);
+    }
+
+    // Overriding as abstract to prevent subclasses from relying on the default implementation, as it's not appropriate.
+    @Override
+    public abstract AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell);
+
+    /**
+     * The subtype/comparator to use for the {@link CellPath} part of cells forming values for this type when used in
+     * its multi-cell variant.
+     *
+     * <p>Note: in theory, we shouldn't have to access this on frozen instances (where {@code isMultiCell() == false}),
+     * but for convenience, it is expected that this method always returns a proper value "as if" the type was a
+     * multi-cell variant, even if it is not.
+     *
+     * @return the comparator for the {@link CellPath} component of cells of this type.
+     */
+    public abstract AbstractType<?> nameComparator();
+
+    public abstract ByteBuffer serializeForNativeProtocol(Iterator<Cell<?>> cells, ProtocolVersion version);
+
+    /**
+     * Whether {@code this} type is compatible (including for sorting) with {@code previous}, assuming both are
+     * of the same class (so {@code previous} can be safely cast to whichever class implements this) and both are
+     * frozen.
+     */
+    protected abstract boolean isCompatibleWhenFrozenWith(AbstractType<?> previous);
+
+    /**
+     * Whether {@code this} type is compatible (including for sorting) with {@code previous}, assuming both are
+     * of the same class (so {@code previous} can be safely cast to whichever class implements this) but neither
+     * are frozen.
+     */
+    protected abstract boolean isCompatibleWhenNonFrozenWith(AbstractType<?> previous);
+
+    /**
+     * Whether {@code this} type is value-compatible with {@code previous}, assuming both are of the same class (so
+     * {@code previous} can be safely cast to whichever class implements this) and both are are frozen.
+     */
+    protected abstract boolean isValueCompatibleWhenFrozenWith(AbstractType<?> previous);
+
+    /**
+     *  Whether {@code this} type is equal to {@code that} type, assuming both are of the same class (so
+     * {@code that} can be safely cast to whichever class implements this), that
+     * {@code this.isMultiCell() == that.isMultiCell()} and that {@code this.subTypes().equals(that.subTypes())}.
+     */
+    protected abstract boolean equalsNoFrozenNoSubtypes(AbstractType<?> that);
+
+    @Override
+    public final boolean isCompatibleWith(AbstractType<?> previous)
+    {
+        if (this == previous)
+            return true;
+
+        if (!getClass().equals(previous.getClass()))
+            return false;
+
+        if (isMultiCell() != previous.isMultiCell())
+            return false;
+
+        return isMultiCell() ? isCompatibleWhenNonFrozenWith(previous) : isCompatibleWhenFrozenWith(previous);
+    }
+
+    @Override
+    protected final boolean isValueCompatibleWithInternal(AbstractType<?> previous)
+    {
+        if (this == previous)
+            return true;
+
+        if (!getClass().equals(previous.getClass()))
+            return false;
+
+        if (isMultiCell() != previous.isMultiCell())
+            return false;
+
+        // For multi-cell, there is no difference between compatible and value-compatible: multi-cell types can only be
+        // used as non-primary key column values, and so in a way are always checked for "value compatibility". Though
+        // even when compared as values, they have sub-parts that end up in a CellPath, which are sorted, and may thus
+        // require sorted compatibility. It would almost make sense to reject isCompatibleWith when types are
+        // multi-cell, but that could be a tad error prone/inconvenient, so instead we just make both versions do the
+        // same thing (hence the call to isCompatibleWhenNonFrozenWith like in isCompatibleWith).
+        return isMultiCell() ? isCompatibleWhenNonFrozenWith(previous) : isValueCompatibleWhenFrozenWith(previous);
+    }
+
+    @Override
+    public final boolean equals(Object that)
+    {
+        if (this == that)
+            return true;
+
+        if (!getClass().equals(that.getClass()))
+            return false;
+
+        AbstractType<?> other = (AbstractType<?>) that;
+        return isMultiCell() == other.isMultiCell()
+               && subTypes.equals(other.subTypes)
+               && equalsNoFrozenNoSubtypes(other);
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
+++ b/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
@@ -136,7 +136,7 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
         return String.format("%s(%s)", getClass().getName(), partitioner.getClass().getName());
     }

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -23,6 +23,11 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -34,25 +39,49 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 public class ReversedType<T> extends AbstractType<T>
 {
+    private static final Logger logger = LoggerFactory.getLogger(ReversedType.class);
+
     // interning instances
     private static final Map<AbstractType<?>, ReversedType> instances = new ConcurrentHashMap<>();
 
     public final AbstractType<T> baseType;
 
-    public static <T> ReversedType<T> getInstance(TypeParser parser)
+    public static AbstractType<?> getInstance(TypeParser parser)
     {
         List<AbstractType<?>> types = parser.getTypeParameters();
         if (types.size() != 1)
             throw new ConfigurationException("ReversedType takes exactly one argument, " + types.size() + " given");
-        return getInstance((AbstractType<T>) types.get(0));
+        return getInstance(types.get(0));
     }
 
-    public static <T> ReversedType<T> getInstance(AbstractType<T> baseType)
+    @SuppressWarnings("unchecked")
+    public static <T> AbstractType<T> getInstance(AbstractType<T> baseType)
     {
-        ReversedType<T> t = instances.get(baseType);
-        return null == t
-             ? instances.computeIfAbsent(baseType, ReversedType::new)
-             : t;
+        ReversedType<T> type = instances.get(baseType);
+        if (type != null)
+            return type;
+
+        // Stacking ReversedType is really useless and would actually break some of the code (typically,
+        // AbstractType#isValueCompatibleWith would end up hitting the exception thrown by
+        // ReversedType#isValueCompatibleWithInternal). So we should throw if we find such stacking. But at the
+        // same time, we can't be 100% no-one ever made that mistake somewhere, and it went un-noticed and it's
+        // probably not worth risking breaking them. So we log an error but otherwise "cancel-out" the double
+        // reverse.
+        if (baseType instanceof ReversedType)
+        {
+            // Note: users have no way to input ReversedType outside custom types (which are pretty
+            // confidential in the first place), so if this is ever triggered, this will likely be an internal but.
+            // So shipping an exception in the logger output to get a stack trace and make debugging easier.
+            logger.error("Detected a type with 2 ReversedType() back-to-back, which is not allowed. This should "
+                         + "be looked at as this is likely unintended, but cancelling out the double reversion in "
+                         + "the meantime", new RuntimeException("Invalid double-reversion"));
+            return ((ReversedType<T>)baseType).baseType;
+        }
+
+        // We avoid constructor calls in Map#computeIfAbsent to avoid recursive update exceptions because the automatic
+        // fixing of subtypes done by the top-level constructor might attempt a recursive update to the instances map.
+        ReversedType<T> instance = new ReversedType<>(baseType);
+        return instances.computeIfAbsent(baseType, k -> instance);
     }
 
     @Override
@@ -67,8 +96,17 @@ public class ReversedType<T> extends AbstractType<T>
 
     private ReversedType(AbstractType<T> baseType)
     {
-        super(ComparisonType.CUSTOM);
+
+        super(ComparisonType.CUSTOM, baseType.isMultiCell(), ImmutableList.of(baseType));
         this.baseType = baseType;
+    }
+
+    @Override
+    public AbstractType<?> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
+    {
+        Preconditions.checkArgument(subTypes.size() == 1,
+                                    "Invalid number of subTypes for ReversedType (got %s)", subTypes.size());
+        return getInstance(subTypes.get(0));
     }
 
     public boolean isEmptyValueMeaningless()
@@ -145,9 +183,9 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public boolean isValueCompatibleWith(AbstractType<?> otherType)
+    protected boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
-        return this.baseType.isValueCompatibleWith(otherType);
+        throw new AssertionError("This should never have been called on the ReversedType");
     }
 
     @Override
@@ -162,19 +200,7 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
-    {
-        return baseType.referencesUserType(name, accessor);
-    }
-
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(baseType.expandUserTypes());
-    }
-
-    @Override
-    public ReversedType<?> withUpdatedUserType(UserType udt)
+    public AbstractType<?> withUpdatedUserType(UserType udt)
     {
         if (!referencesUserType(udt.name))
             return this;
@@ -197,9 +223,9 @@ public class ReversedType<T> extends AbstractType<T>
     }
 
     @Override
-    public String toString()
+    public String toString(boolean ignoreFreezing)
     {
-        return getClass().getName() + "(" + baseType + ")";
+        return getClass().getName() + '(' + baseType + ')';
     }
 
     private static final class ReversedPeekableByteSource extends ByteSource.Peekable

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -22,6 +22,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Sets;
 import org.apache.cassandra.cql3.Term;
@@ -40,9 +43,7 @@ public class SetType<T> extends CollectionType<Set<T>>
     private static final ConcurrentHashMap<AbstractType<?>, SetType> instances = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<AbstractType<?>, SetType> frozenInstances = new ConcurrentHashMap<>();
 
-    private final AbstractType<T> elements;
     private final SetSerializer<T> serializer;
-    private final boolean isMultiCell;
 
     public static SetType<?> getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
@@ -53,64 +54,61 @@ public class SetType<T> extends CollectionType<Set<T>>
         return getInstance(l.get(0), true);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> SetType<T> getInstance(AbstractType<T> elements, boolean isMultiCell)
     {
-        ConcurrentHashMap<AbstractType<?>, SetType> internMap = isMultiCell ? instances : frozenInstances;
-        SetType<T> t = internMap.get(elements);
-        return null == t
-             ? internMap.computeIfAbsent(elements, k -> new SetType<>(k, isMultiCell))
-             : t;
+        return getInstance(isMultiCell ? instances : frozenInstances,
+                           elements,
+                           () -> new SetType<>(elements, isMultiCell));
     }
 
     @Override
     public SetType<T> overrideKeyspace(Function<String, String> overrideKeyspace)
     {
-        AbstractType<T> newType = elements.overrideKeyspace(overrideKeyspace);
-        if (newType == elements)
+        AbstractType<T> oldType = getElementsType();
+        AbstractType<T> newType = oldType.overrideKeyspace(overrideKeyspace);
+
+        if (newType == oldType)
             return this;
 
         return getInstance(newType, isMultiCell());
     }
 
-    public SetType(AbstractType<T> elements, boolean isMultiCell)
+    private SetType(AbstractType<T> elements, boolean isMultiCell)
     {
-        super(ComparisonType.CUSTOM, Kind.SET);
-        this.elements = elements;
+        super(Kind.SET, ImmutableList.of(elements), isMultiCell);
         this.serializer = SetSerializer.getInstance(elements.getSerializer(), elements.comparatorSet);
-        this.isMultiCell = isMultiCell;
     }
 
     @Override
-    public <V> boolean referencesUserType(V name, ValueAccessor<V> accessor)
+    @SuppressWarnings("unchecked")
+    public SetType<T> with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
     {
-        return elements.referencesUserType(name, accessor);
+        Preconditions.checkArgument(subTypes.size() == 1,
+                                    "Invalid number of subTypes for SetType (got %s)", subTypes.size());
+        return getInstance((AbstractType<T>) subTypes.get(0), isMultiCell);
     }
 
     @Override
     public SetType<?> withUpdatedUserType(UserType udt)
     {
-        if (!referencesUserType(udt.name))
-            return this;
+        // If our subtypes do contain the UDT and this is requested, there is a fair chance we won't be re-using an
+        // instance with our own exact subtypes, so clean up the interned instance.
+        if (referencesUserType(udt.name))
+            (isMultiCell() ? instances : frozenInstances).remove(getElementsType());
 
-        (isMultiCell ? instances : frozenInstances).remove(elements);
-
-        return getInstance(elements.withUpdatedUserType(udt), isMultiCell);
+        return (SetType<?>) super.withUpdatedUserType(udt);
     }
 
-    @Override
-    public AbstractType<?> expandUserTypes()
-    {
-        return getInstance(elements.expandUserTypes(), isMultiCell);
-    }
-
+    @SuppressWarnings("unchecked")
     public AbstractType<T> getElementsType()
     {
-        return elements;
+        return (AbstractType<T>) subTypes.get(0);
     }
 
     public AbstractType<T> nameComparator()
     {
-        return elements;
+        return getElementsType();
     }
 
     public AbstractType<?> valueComparator()
@@ -119,55 +117,9 @@ public class SetType<T> extends CollectionType<Set<T>>
     }
 
     @Override
-    public boolean isMultiCell()
-    {
-        return isMultiCell;
-    }
-
-    @Override
-    public AbstractType<?> freeze()
-    {
-        if (isMultiCell)
-            return getInstance(this.elements, false);
-        else
-            return this;
-    }
-
-    @Override
-    public List<AbstractType<?>> subTypes()
-    {
-        return Collections.singletonList(elements);
-    }
-
-    @Override
-    public AbstractType<?> freezeNestedMulticellTypes()
-    {
-        if (!isMultiCell())
-            return this;
-
-        if (elements.isFreezable() && elements.isMultiCell())
-            return getInstance(elements.freeze(), isMultiCell);
-
-        return getInstance(elements.freezeNestedMulticellTypes(), isMultiCell);
-    }
-
-    @Override
-    public boolean isCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        assert !isMultiCell;
-        return this.elements.isCompatibleWith(((SetType) previous).elements);
-    }
-
-    @Override
-    public boolean isValueCompatibleWithFrozen(CollectionType<?> previous)
-    {
-        // because sets are ordered, any changes to the type must maintain the ordering
-        return isCompatibleWithFrozen(previous);
-    }
-
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
-        return ListType.compareListOrSet(elements, left, accessorL, right, accessorR);
+        return ListType.compareListOrSet(getElementsType(), left, accessorL, right, accessorR);
     }
 
     @Override
@@ -194,17 +146,17 @@ public class SetType<T> extends CollectionType<Set<T>>
 
         StringBuilder sb = new StringBuilder();
         if (includeFrozenType)
-            sb.append(FrozenType.class.getName()).append("(");
+            sb.append(FrozenType.class.getName()).append('(');
         sb.append(getClass().getName());
-        sb.append(TypeParser.stringifyTypeParameters(Collections.<AbstractType<?>>singletonList(elements), ignoreFreezing || !isMultiCell));
+        sb.append(TypeParser.stringifyTypeParameters(subTypes, ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
-            sb.append(")");
+            sb.append(')');
         return sb.toString();
     }
 
     public List<ByteBuffer> serializedValues(Iterator<Cell<?>> cells)
     {
-        List<ByteBuffer> bbs = new ArrayList<ByteBuffer>();
+        List<ByteBuffer> bbs = new ArrayList<>();
         while (cells.hasNext())
             bbs.add(cells.next().path().get(0));
         return bbs;
@@ -220,8 +172,9 @@ public class SetType<T> extends CollectionType<Set<T>>
             throw new MarshalException(String.format(
                     "Expected a list (representing a set), but got a %s: %s", parsed.getClass().getSimpleName(), parsed));
 
-        List list = (List) parsed;
+        List<?> list = (List<?>) parsed;
         Set<Term> terms = new HashSet<>(list.size());
+        AbstractType<T> elements = getElementsType();
         for (Object element : list)
         {
             if (element == null)
@@ -235,6 +188,6 @@ public class SetType<T> extends CollectionType<Set<T>>
     @Override
     public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
     {
-        return ListType.setOrListToJsonString(buffer, elements, protocolVersion);
+        return ListType.setOrListToJsonString(buffer, getElementsType(), protocolVersion);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -99,8 +99,7 @@ public class TupleType extends MultiCellCapableType<ByteBuffer>
     public static TupleType getInstance(TypeParser parser) throws ConfigurationException, SyntaxException
     {
         List<AbstractType<?>> types = parser.getTypeParameters();
-        types.replaceAll(AbstractType::freeze);
-        return new TupleType(types);
+        return new TupleType(types, true);
     }
 
     @Override
@@ -514,7 +513,7 @@ public class TupleType extends MultiCellCapableType<ByteBuffer>
         sb.append(getClass().getName());
         // FrozenType applies to anything nested (it wouldn't make sense otherwise) and so we only put once at the
         // highest level. So we can ignore freezing in the subtypes if either we're already within a frozen type
-        // (we're a sub-type ourselves and frozenType has been included at the outer level), or we're frozen.
+        // (we're a subtype ourselves and frozenType has been included at the outer level), or we're frozen.
         sb.append(stringifyTypeParameters(ignoreFreezing || !isMultiCell()));
         if (includeFrozenType)
             sb.append(')');

--- a/src/java/org/apache/cassandra/db/marshal/TypeParser.java
+++ b/src/java/org/apache/cassandra/db/marshal/TypeParser.java
@@ -57,7 +57,7 @@ public class TypeParser
     }
 
     /**
-     * Parse a string containing an type definition.
+     * Creates a new TypeParser and uses it to parse the given type definition string.
      *
      * @param str the string to parse.
      */
@@ -303,9 +303,13 @@ public class TypeParser
         throw new SyntaxException(String.format("Syntax error parsing '%s' at char %d: unexpected end of string", str, idx));
     }
 
-    private static AbstractType<?> getAbstractType(String compareWith) throws ConfigurationException
+    /**
+     * Parse a type string and return the corresponding {@link AbstractType}. It is used for the type definition which
+     * is not followed by an opening parenthesis, e.g. "org.apache.cassandra.db.marshal.UTF8Type".
+     */
+    private static AbstractType<?> getAbstractType(String typeName) throws ConfigurationException
     {
-        String className = compareWith.contains(".") ? compareWith : "org.apache.cassandra.db.marshal." + compareWith;
+        String className = typeName.contains(".") ? typeName : "org.apache.cassandra.db.marshal." + typeName;
         Class<? extends AbstractType<?>> typeClass = FBUtilities.classForName(className, "abstract-type");
         try
         {
@@ -319,10 +323,16 @@ public class TypeParser
         }
     }
 
+    /**
+     * Parse a type string and return the corresponding {@link AbstractType}. It is used for the type definition
+     * which is followed by an opening parenthesis, e.g.
+     * "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)".
+     */
     private static AbstractType<?> getAbstractType(String compareWith, TypeParser parser) throws SyntaxException, ConfigurationException
     {
         String className = compareWith.contains(".") ? compareWith : "org.apache.cassandra.db.marshal." + compareWith;
         Class<? extends AbstractType<?>> typeClass = FBUtilities.classForName(className, "abstract-type");
+
         try
         {
             Method method = typeClass.getDeclaredMethod("getInstance", TypeParser.class);
@@ -341,6 +351,11 @@ public class TypeParser
         }
     }
 
+    /**
+     * Parse a type string and return the corresponding AbstractType. It is used for the type definition which is not
+     * followed by an opening parenthesis, e.g. "org.apache.cassandra.db.marshal.UTF8Type", but does not have static
+     * {@code instance} field.
+     */
     private static AbstractType<?> getRawAbstractType(Class<? extends AbstractType<?>> typeClass) throws ConfigurationException
     {
         try

--- a/src/java/org/apache/cassandra/db/rows/AbstractCell.java
+++ b/src/java/org/apache/cassandra/db/rows/AbstractCell.java
@@ -163,6 +163,11 @@ public abstract class AbstractCell<V> extends Cell<V>
         return timestamp();
     }
 
+    public long minTimestamp()
+    {
+        return timestamp();
+    }
+
     public static <V1, V2> boolean equals(Cell<V1> left, Cell<V2> right)
     {
         return left.column().equals(right.column())

--- a/src/java/org/apache/cassandra/db/rows/ColumnData.java
+++ b/src/java/org/apache/cassandra/db/rows/ColumnData.java
@@ -287,4 +287,6 @@ public abstract class ColumnData
     public abstract ColumnData purge(DeletionPurger purger, int nowInSec);
 
     public abstract long maxTimestamp();
+
+    public abstract long minTimestamp();
 }

--- a/src/java/org/apache/cassandra/db/rows/ComplexColumnData.java
+++ b/src/java/org/apache/cassandra/db/rows/ComplexColumnData.java
@@ -266,6 +266,16 @@ public class ComplexColumnData extends ColumnData implements Iterable<Cell<?>>
         return timestamp;
     }
 
+    public long minTimestamp()
+    {
+        long timestamp = complexDeletion.isLive()
+                         ? Long.MAX_VALUE
+                         : complexDeletion.markedForDeleteAt();
+        for (Cell cell : this)
+            timestamp = Math.min(timestamp, cell.timestamp());
+        return timestamp;
+    }
+
     // This is the partner in crime of ArrayBackedRow.setValue. The exact warning apply. The short
     // version is: "don't use that method".
     void setValue(CellPath path, ByteBuffer value)

--- a/src/java/org/apache/cassandra/db/rows/RangeTombstoneBoundMarker.java
+++ b/src/java/org/apache/cassandra/db/rows/RangeTombstoneBoundMarker.java
@@ -157,6 +157,18 @@ public class RangeTombstoneBoundMarker extends AbstractRangeTombstoneMarker<Clus
         deletion.digest(digest);
     }
 
+    @Override
+    public long minTimestamp()
+    {
+        return deletion.markedForDeleteAt();
+    }
+
+    @Override
+    public long maxTimestamp()
+    {
+        return deletion.markedForDeleteAt();
+    }
+
     public String toString(TableMetadata metadata)
     {
         return String.format("Marker %s@%d/%d", bound.toString(metadata), deletion.markedForDeleteAt(), deletion.localDeletionTime());

--- a/src/java/org/apache/cassandra/db/rows/RangeTombstoneBoundaryMarker.java
+++ b/src/java/org/apache/cassandra/db/rows/RangeTombstoneBoundaryMarker.java
@@ -188,6 +188,18 @@ public class RangeTombstoneBoundaryMarker extends AbstractRangeTombstoneMarker<C
         startDeletion.digest(digest);
     }
 
+    @Override
+    public long minTimestamp()
+    {
+        return Math.min(startDeletion.markedForDeleteAt(), endDeletion.markedForDeleteAt());
+    }
+
+    @Override
+    public long maxTimestamp()
+    {
+        return Math.max(startDeletion.markedForDeleteAt(), endDeletion.markedForDeleteAt());
+    }
+
     public String toString(TableMetadata metadata)
     {
         return String.format("Marker %s@%d/%d-%d/%d",

--- a/src/java/org/apache/cassandra/db/rows/Unfiltered.java
+++ b/src/java/org/apache/cassandra/db/rows/Unfiltered.java
@@ -83,4 +83,16 @@ public interface Unfiltered extends Clusterable
     {
         return kind() == Kind.RANGE_TOMBSTONE_MARKER;
     }
+
+    /**
+     * Minimum the timestamps of all data in the row or marker.
+     * Note: deletion times are timestamps too, e.g. the min and max timestamp of a range marker is its deletion time.
+     */
+    public long minTimestamp();
+
+    /**
+     * Maximum the timestamps of all data in the row or marker.
+     * Note: deletion times are timestamps too, e.g. the min and max timestamp of a range marker is its deletion time.
+     */
+    public long maxTimestamp();
 }

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
@@ -146,8 +146,9 @@ public class CassandraStreamReader implements IStreamReader
 
     protected SerializationHeader getHeader(TableMetadata metadata) throws UnknownColumnException
     {
-        return header != null? header.toHeader(metadata) : null; //pre-3.0 sstable have no SerializationHeader
+        return header != null? header.toHeader("stream from " + session.peer, metadata) : null; //pre-3.0 sstable have no SerializationHeader
     }
+
     @SuppressWarnings("resource")
     protected SSTableMultiWriter createWriter(ColumnFamilyStore cfs, long totalSize, long repairedAt, UUID pendingRepair, SSTableFormat.Type format) throws IOException
     {

--- a/src/java/org/apache/cassandra/dht/Range.java
+++ b/src/java/org/apache/cassandra/dht/Range.java
@@ -70,7 +70,7 @@ public class Range<T extends RingPosition<T>> extends AbstractBounds<T> implemen
         }
     }
 
-    public boolean contains(Range<T> that)
+    public boolean contains(AbstractBounds<T> that)
     {
         if (this.left.equals(this.right))
         {

--- a/src/java/org/apache/cassandra/dht/Splitter.java
+++ b/src/java/org/apache/cassandra/dht/Splitter.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -318,28 +319,26 @@ public abstract class Splitter
     }
 
     /**
-     * Splits the specified token range in at least {@code minParts} subranges, unless the range has not enough tokens
-     * in which case the range will be returned without splitting.
+     * Splits the specified token range in {@code parts} subranges, unless the range has not enough tokens in which case
+     * the range will be returned without splitting.
      *
      * @param range a token range
      * @param parts the number of subranges
-     * @return {@code parts} even subranges of {@code range}
+     * @return {@code parts} even subranges of {@code range}, or {@code range} if it is too small to be splitted
      */
     private Set<Range<Token>> split(Range<Token> range, int parts)
     {
-        // the range might not have enough tokens to split
-        BigInteger numTokens = tokensInRange(range);
-        if (BigInteger.valueOf(parts).compareTo(numTokens) > 0)
-            return Collections.singleton(range);
-
         Token left = range.left;
-        Set<Range<Token>> subranges = new HashSet<>(parts);
-        for (double i = 1; i <= parts; i++)
+        Set<Range<Token>> subranges = new LinkedHashSet<>(parts);
+
+        for (double i = 1; i < parts; i++)
         {
             Token right = partitioner.split(range.left, range.right, i / parts);
-            subranges.add(new Range<>(left, right));
+            if (!left.equals(right))
+                subranges.add(new Range<>(left, right));
             left = right;
         }
+        subranges.add(new Range<>(left, range.right));
         return subranges;
     }
 

--- a/src/java/org/apache/cassandra/exceptions/InvalidColumnTypeException.java
+++ b/src/java/org/apache/cassandra/exceptions/InvalidColumnTypeException.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.db.marshal.AbstractType;
+
+/**
+ * Exception thrown when a configured column type is invalid.
+ */
+public class InvalidColumnTypeException extends ConfigurationException
+{
+    private final ByteBuffer name;
+    private final AbstractType<?> invalidType;
+    private final boolean isPrimaryKeyColumn;
+    private final boolean isCounterTable;
+
+    public InvalidColumnTypeException(ByteBuffer name,
+                                      AbstractType<?> invalidType,
+                                      boolean isPrimaryKeyColumn,
+                                      boolean isCounterTable,
+                                      String reason)
+    {
+        super(msg(name, invalidType, reason));
+        this.name = name;
+        this.invalidType = invalidType;
+        this.isPrimaryKeyColumn = isPrimaryKeyColumn;
+        this.isCounterTable = isCounterTable;
+    }
+
+    private static String msg(ByteBuffer name,
+                              AbstractType<?> invalidType,
+                              String reason)
+    {
+        return String.format("Invalid type %s for column %s: %s",
+                             invalidType.asCQL3Type(),
+                             ColumnIdentifier.toCQLString(name),
+                             reason);
+    }
+
+    /**
+     * Attempts to return a "fixed" (and thus valid) version of the type. Doing is so is only possible in restrained
+     * case where we know why the type is invalid and are confident we know what it should be.
+     *
+     * @return if we know how to auto-magically fix the invalid type that triggered this exception, the hopefully
+     * fixed version of said type. Otherwise, {@code null}.
+     */
+    public AbstractType<?> tryFix()
+    {
+        AbstractType<?> fixed = tryFixInternal();
+        if (fixed != null)
+        {
+            try
+            {
+                // Make doubly sure the fixed type is valid before returning it.
+                fixed.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+                return fixed;
+            }
+            catch (InvalidColumnTypeException e2)
+            {
+                // Continue as if we hadn't been able to fix, since we haven't
+            }
+        }
+        return null;
+    }
+
+    private AbstractType<?> tryFixInternal()
+    {
+        if (isPrimaryKeyColumn)
+        {
+            // The only issue we have a fix to in that case if the type is not frozen; we can then just freeze it.
+            if (invalidType.isMultiCell())
+                return invalidType.freeze();
+        }
+        else
+        {
+            // Here again, it's mainly issues of frozen-ness that are fixable, namely if a multi-cell type has
+            // non-frozen subtypes. In which case, we just freeze all sub-types.
+            if (invalidType.isMultiCell())
+                return invalidType.with(AbstractType.freeze(invalidType.subTypes()), true);
+
+        }
+        // In other case, we don't know how to fix (at least somewhat auto-magically) and will have to fail.
+        return null;
+    }
+}

--- a/src/java/org/apache/cassandra/guardrails/CustomUserKeyspaceFilterProvider.java
+++ b/src/java/org/apache/cassandra/guardrails/CustomUserKeyspaceFilterProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+public class CustomUserKeyspaceFilterProvider
+{
+    public static UserKeyspaceFilterProvider make(String customImpl)
+    {
+        try
+        {
+            return (UserKeyspaceFilterProvider) Class.forName(customImpl).getDeclaredConstructor().newInstance();
+        }
+        catch (Throwable ex)
+        {
+            throw new IllegalStateException("Unknown user keyspace filter provider: " + customImpl, ex);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/guardrails/DefaultUserKeyspaceFilter.java
+++ b/src/java/org/apache/cassandra/guardrails/DefaultUserKeyspaceFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+import org.apache.cassandra.db.Keyspace;
+
+/**
+ * A default implementation of the UserKeyspaceFilter, which just includes all keyspaces automatically.
+ * This is done so that "max table count" guardrails will still work in C* databases that don't have
+ * keyspaces prefixed by tenant values.
+ */
+public class DefaultUserKeyspaceFilter implements UserKeyspaceFilter
+{
+    public boolean filter(Keyspace keyspace)
+    {
+        return true;
+    }
+}

--- a/src/java/org/apache/cassandra/guardrails/DefaultUserKeyspaceFilterProvider.java
+++ b/src/java/org/apache/cassandra/guardrails/DefaultUserKeyspaceFilterProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+import org.apache.cassandra.service.QueryState;
+
+public class DefaultUserKeyspaceFilterProvider implements UserKeyspaceFilterProvider
+{
+    @Override
+    public UserKeyspaceFilter get(QueryState queryState)
+    {
+        return new DefaultUserKeyspaceFilter();
+    }
+}

--- a/src/java/org/apache/cassandra/guardrails/UserKeyspaceFilter.java
+++ b/src/java/org/apache/cassandra/guardrails/UserKeyspaceFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+import org.apache.cassandra.db.Keyspace;
+
+public interface UserKeyspaceFilter
+{
+    /**
+     * Returns true if the keyspace should be included.
+     */
+    boolean filter(Keyspace keyspaceName);
+}

--- a/src/java/org/apache/cassandra/guardrails/UserKeyspaceFilterProvider.java
+++ b/src/java/org/apache/cassandra/guardrails/UserKeyspaceFilterProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.service.QueryState;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_KEYSPACES_FILTER_PROVIDER;
+
+public interface UserKeyspaceFilterProvider
+{
+    UserKeyspaceFilterProvider instance = getCustomProviderClass() == null ?
+                                          new DefaultUserKeyspaceFilterProvider() :
+                                          CustomUserKeyspaceFilterProvider.make(getCustomProviderClass());
+
+    UserKeyspaceFilter get(QueryState queryState);
+
+    @Nullable
+    static String getCustomProviderClass()
+    {
+        return CUSTOM_KEYSPACES_FILTER_PROVIDER.getString();
+    }
+}

--- a/src/java/org/apache/cassandra/hints/HintMessage.java
+++ b/src/java/org/apache/cassandra/hints/HintMessage.java
@@ -111,7 +111,8 @@ public final class HintMessage implements SerializableHintMessage
                 Encoded message = (Encoded) obj;
 
                 if (version != message.version)
-                    throw new IllegalArgumentException("serializedSize() called with non-matching version " + version);
+                    throw new IllegalArgumentException("serializedSize() called with non-matching version " + version +
+                                                       " for message with version " + message.version);
 
                 long size = UUIDSerializer.serializer.serializedSize(message.hostId, version);
                 size += TypeSizes.sizeofUnsignedVInt(message.hint.remaining());

--- a/src/java/org/apache/cassandra/hints/HintsDispatcher.java
+++ b/src/java/org/apache/cassandra/hints/HintsDispatcher.java
@@ -69,10 +69,14 @@ final class HintsDispatcher implements AutoCloseable
         this.abortRequested = abortRequested;
     }
 
-    static HintsDispatcher create(File file, RateLimiter rateLimiter, InetAddressAndPort address, UUID hostId, BooleanSupplier abortRequested)
+    static HintsDispatcher create(File file,
+                                  RateLimiter rateLimiter,
+                                  InetAddressAndPort address,
+                                  UUID hostId,
+                                  int peerMessagingVersion,
+                                  BooleanSupplier abortRequested)
     {
-        int messagingVersion = HintsEndpointProvider.instance.versionForEndpoint(address);
-        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, messagingVersion, abortRequested);
+        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, peerMessagingVersion, abortRequested);
         HintDiagnostics.dispatcherCreated(dispatcher);
         return dispatcher;
     }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -242,6 +242,16 @@ public interface Index
     }
 
     /**
+     * Returns true if index initialization should be skipped, false if it should run
+     * (via {@link #getInitializationTask()}); defaults to skipping based on {@link IndexBuildDecider#onInitialBuild()}
+     * decision.
+     */
+    default boolean shouldSkipInitialization()
+    {
+        return IndexBuildDecider.instance.onInitialBuild().skipped();
+    }
+
+    /**
      * Return a task to perform any initialization work when a new index instance is created.
      * This may involve costly operations such as (re)building the index, and is performed asynchronously
      * by SecondaryIndexManager

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -192,8 +192,8 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
     // store per-endpoint index status: the key of inner map is identifier "keyspace.index"
     public static final Map<InetAddressAndPort, Map<String, Index.Status>> peerIndexStatus = new ConcurrentHashMap<>();
-    // executes index status propagation task asynchronously to avoid potential deadlock on SIM
-    private static final ExecutorService statusPropagationExecutor = Executors.newSingleThreadExecutor();
+    // executes index status propagation task asynchronously to avoid potential deadlock on SIM. Used NamedThreadFactory to create daemon thread
+    private static final ExecutorService statusPropagationExecutor = Executors.newSingleThreadExecutor(new NamedThreadFactory("IndexStatusPropagationExecutor"));
 
     /**
      * All registered indexes.
@@ -1939,8 +1939,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
         return delta;
     }
 
-    @VisibleForTesting
-    public synchronized static void propagateLocalIndexStatus(String keyspace, String index, Index.Status status)
+    private synchronized static void propagateLocalIndexStatus(String keyspace, String index, Index.Status status)
     {
         try
         {

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -70,7 +71,9 @@ import org.apache.cassandra.index.sai.view.View;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
@@ -80,6 +83,12 @@ import org.apache.cassandra.utils.concurrent.OpOrder;
 public class IndexContext
 {
     private static final Logger logger = LoggerFactory.getLogger(IndexContext.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
+
+    private static final int MAX_STRING_TERM_SIZE = Integer.getInteger("cassandra.sai.max_string_term_size_kb", 1) * 1024;
+    private static final int MAX_FROZEN_TERM_SIZE = Integer.getInteger("cassandra.sai.max_frozen_term_size_kb", 5) * 1024;
+    private static final String TERM_OVERSIZE_MESSAGE = "Can't add term of column %s to index for key: %s, term size %s " +
+                                                        "max allowed size %s, use analyzed = true (if not yet set) for that column.";
 
     private static final Set<AbstractType<?>> EQ_ONLY_TYPES =
             ImmutableSet.of(UTF8Type.instance, AsciiType.instance, BooleanType.instance, UUIDType.instance);
@@ -109,6 +118,8 @@ public class IndexContext
     private final AbstractAnalyzer.AnalyzerFactory queryAnalyzerFactory;
     private final PrimaryKey.Factory primaryKeyFactory;
 
+    private final int maxTermSize;
+
     public IndexContext(@Nonnull String keyspace,
                         @Nonnull String table,
                         @Nonnull AbstractType<?> partitionKeyType,
@@ -128,6 +139,7 @@ public class IndexContext
         this.viewManager = new IndexViewManager(this);
         this.indexMetrics = new IndexMetrics(this);
         this.validator = TypeUtil.cellValueType(column, indexType);
+        this.maxTermSize = isFrozen() ? MAX_FROZEN_TERM_SIZE : MAX_STRING_TERM_SIZE;
         this.owner = owner;
 
         this.columnQueryMetrics = isLiteral() ? new ColumnQueryMetrics.TrieIndexMetrics(keyspace, table, getIndexName())
@@ -224,6 +236,63 @@ public class IndexContext
             target.index(key, row.clustering(), value, memtable, opGroup);
         }
         indexMetrics.memtableIndexWriteLatency.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Validate maximum term size for given row
+     */
+    public void validateMaxTermSizeForRow(DecoratedKey key, Row row, boolean sendClientWarning)
+    {
+        AbstractAnalyzer analyzer = analyzerFactory.create();
+        if (isNonFrozenCollection())
+        {
+            Iterator<ByteBuffer> bufferIterator = getValuesOf(row, FBUtilities.nowInSeconds());
+            while (bufferIterator != null && bufferIterator.hasNext())
+                validateMaxTermSizeForCell(analyzer, key, bufferIterator.next(), sendClientWarning);
+        }
+        else
+        {
+            ByteBuffer value = getValueOf(key, row, FBUtilities.nowInSeconds());
+            validateMaxTermSizeForCell(analyzer, key, value, sendClientWarning);
+        }
+    }
+
+    private void validateMaxTermSizeForCell(AbstractAnalyzer analyzer, DecoratedKey key, @Nullable ByteBuffer cellBuffer, boolean sendClientWarning)
+    {
+        if (cellBuffer == null || cellBuffer.remaining() == 0)
+            return;
+
+        // analyzer should not return terms that are larger than the origin value.
+        if (cellBuffer.remaining() <= maxTermSize)
+            return;
+
+        analyzer.reset(cellBuffer.duplicate());
+        while (analyzer.hasNext())
+            validateMaxTermSize(key, analyzer.next(), sendClientWarning);
+    }
+
+    /**
+     * Validate maximum term size for given term
+     * @return true if given term is valid; otherwise false.
+     */
+    public boolean validateMaxTermSize(DecoratedKey key, ByteBuffer term, boolean sendClientWarning)
+    {
+        if (term.remaining() > maxTermSize)
+        {
+            String message = logMessage(String.format(TERM_OVERSIZE_MESSAGE,
+                                                      getColumnName(),
+                                                      keyValidator().getString(key.getKey()),
+                                                      FBUtilities.prettyPrintMemory(term.remaining()),
+                                                      FBUtilities.prettyPrintMemory(maxTermSize)));
+
+            if (sendClientWarning)
+                ClientWarn.instance.warn(message);
+
+            noSpamLogger.warn(message);
+            return false;
+        }
+
+        return true;
     }
 
     public void renewMemtable(Memtable renewed)

--- a/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
@@ -128,6 +128,12 @@ public class SSTableContextManager
     }
 
     @VisibleForTesting
+    public boolean contains(SSTableReader sstable)
+    {
+        return sstableContexts.containsKey(sstable);
+    }
+
+    @VisibleForTesting
     public int size()
     {
         return sstableContexts.size();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -52,18 +52,11 @@ public class SSTableIndexWriter implements PerIndexWriter
     private static final Logger logger = LoggerFactory.getLogger(SSTableIndexWriter.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
-    public static final int MAX_STRING_TERM_SIZE = Integer.getInteger("cassandra.sai.max_string_term_size_kb", 1) * 1024;
-    public static final int MAX_FROZEN_TERM_SIZE = Integer.getInteger("cassandra.sai.max_frozen_term_size_kb", 5) * 1024;
-    public static final String TERM_OVERSIZE_MESSAGE =
-            "Can't add term of column {} to index for key: {}, term size {} " +
-                    "max allowed size {}, use analyzed = true (if not yet set) for that column.";
-
     private final IndexDescriptor indexDescriptor;
     private final IndexContext indexContext;
     private final int nowInSec = FBUtilities.nowInSeconds();
     private final AbstractAnalyzer analyzer;
     private final NamedMemoryLimiter limiter;
-    private final int maxTermSize;
     private final BooleanSupplier isIndexValid;
 
     private boolean aborted = false;
@@ -80,7 +73,6 @@ public class SSTableIndexWriter implements PerIndexWriter
         this.analyzer = indexContext.getAnalyzerFactory().create();
         this.limiter = limiter;
         this.isIndexValid = isIndexValid;
-        this.maxTermSize = indexContext.isFrozen() ? MAX_FROZEN_TERM_SIZE : MAX_STRING_TERM_SIZE;
     }
 
     @Override
@@ -205,15 +197,8 @@ public class SSTableIndexWriter implements PerIndexWriter
 
     private void addTerm(ByteBuffer term, PrimaryKey key, long sstableRowId, AbstractType<?> type) throws IOException
     {
-        if (term.remaining() >= maxTermSize)
-        {
-            noSpamLogger.warn(indexContext.logMessage(TERM_OVERSIZE_MESSAGE),
-                              indexContext.getColumnName(),
-                              indexContext.keyValidator().getString(key.partitionKey().getKey()),
-                              FBUtilities.prettyPrintMemory(term.remaining()),
-                              FBUtilities.prettyPrintMemory(maxTermSize));
+        if (!indexContext.validateMaxTermSize(key.partitionKey(), term, false))
             return;
-        }
 
         if (currentBuilder == null)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -166,7 +166,7 @@ public class V1OnDiskFormat implements OnDiskFormat
                                             RowMapping rowMapping)
     {
         // If we're not flushing or we haven't yet started the initialization build, flush from SSTable contents.
-        if (tracker.opType() != OperationType.FLUSH || !index.isInitBuildStarted())
+        if (tracker.opType() != OperationType.FLUSH || !index.canFlushFromMemtableIndex())
         {
             NamedMemoryLimiter limiter = SEGMENT_BUILD_MEMORY_LIMITER;
             logger.info(index.getIndexContext().logMessage("Starting a compaction index build. Global segment memory usage: {}"),

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -102,6 +102,8 @@ public class TrieMemoryIndex extends MemoryIndex
             while (analyzer.hasNext())
             {
                 final ByteBuffer term = analyzer.next();
+                if (!indexContext.validateMaxTermSize(key, term, false))
+                    continue;
 
                 setMinMaxTerm(term.duplicate());
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
@@ -396,8 +396,8 @@ public abstract class SSTableHeaderFix
         {
             // Note, the logic is similar as just calling 'fixType()' using the composite partition key,
             // but the log messages should use the composite partition key column names.
-            List<AbstractType<?>> headerKeyComponents = ((CompositeType) headerKeyType).types;
-            List<AbstractType<?>> schemaKeyComponents = ((CompositeType) schemaKeyType).types;
+            List<AbstractType<?>> headerKeyComponents = headerKeyType.subTypes();
+            List<AbstractType<?>> schemaKeyComponents = schemaKeyType.subTypes();
             if (headerKeyComponents.size() != schemaKeyComponents.size())
             {
                 // different number of components in composite partition keys - very suspicious
@@ -738,15 +738,15 @@ public abstract class SSTableHeaderFix
 
     private AbstractType<?> fixTypeInnerComposite(CompositeType cHeader, CompositeType cSchema, boolean droppedColumnMode)
     {
-        if (cHeader.types.size() != cSchema.types.size())
+        if (cHeader.subTypes().size() != cSchema.subTypes().size())
             // different number of components - bummer...
             return null;
-        List<AbstractType<?>> cHeaderFixed = new ArrayList<>(cHeader.types.size());
+        List<AbstractType<?>> cHeaderFixed = new ArrayList<>(cHeader.subTypes().size());
         boolean anyChanged = false;
-        for (int i = 0; i < cHeader.types.size(); i++)
+        for (int i = 0; i < cHeader.subTypes().size(); i++)
         {
-            AbstractType<?> cHeaderComp = cHeader.types.get(i);
-            AbstractType<?> cHeaderCompFixed = fixTypeInner(cHeaderComp, cSchema.types.get(i), droppedColumnMode);
+            AbstractType<?> cHeaderComp = cHeader.subTypes().get(i);
+            AbstractType<?> cHeaderCompFixed = fixTypeInner(cHeaderComp, cSchema.subTypes().get(i), droppedColumnMode);
             if (cHeaderCompFixed == null)
                 // incompatible, bummer...
                 return null;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -526,7 +526,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
         try
         {
-            return new SSTableReaderBuilder.ForBatch(descriptor, metadata, components, statsMetadata, header.toHeader(metadata.get())).build();
+            return new SSTableReaderBuilder.ForBatch(descriptor, metadata, components, statsMetadata, header.toHeader(descriptor.toString(), metadata.get())).build();
         }
         catch (UnknownColumnException e)
         {
@@ -599,7 +599,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
                                                        isOffline,
                                                        components,
                                                        statsMetadata,
-                                                       header.toHeader(metadata.get())).build();
+                                                       header.toHeader(descriptor.toString(), metadata.get())).build();
         }
         catch (UnknownColumnException e)
         {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -172,7 +172,7 @@ public class BigFormat implements SSTableFormat
                 SerializationHeader.Component headerComponent = (SerializationHeader.Component)
                                                                 descriptor.getMetadataSerializer()
                                                                           .deserialize(descriptor, MetadataType.HEADER);
-                SerializationHeader header = headerComponent.toHeader(metadata);
+                SerializationHeader header = headerComponent.toHeader(descriptor.toString(), metadata);
                 BigTableRowIndexEntry.Serializer serializer = new BigTableRowIndexEntry.Serializer(descriptor.version, header);
                 return BigTablePartitionIndexIterator.create(iFile, serializer);
             }

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -1042,7 +1042,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                                   System.currentTimeMillis(),
                                                                   statsMetadata,
                                                                   OpenReason.NORMAL,
-                                                                  header.toHeader(metadata.get()));
+                                                                  header.toHeader(descriptor.toString(), metadata.get()));
                 }
             }
             else
@@ -1055,7 +1055,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                               System.currentTimeMillis(),
                                                               statsMetadata,
                                                               OpenReason.NORMAL,
-                                                              header.toHeader(metadata.get()));
+                                                              header.toHeader(descriptor.toString(), metadata.get()));
             }
             if (validate)
                 sstable.validate();

--- a/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.ArrayUtils;
@@ -49,6 +50,7 @@ import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.serializers.AbstractTypeSerializer;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.EstimatedHistogram;
+import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.UUIDSerializer;
 import org.apache.cassandra.utils.streamhist.TombstoneHistogram;
 
@@ -302,6 +304,7 @@ public class StatsMetadata extends MetadataComponent
     public static class StatsMetadataSerializer implements IMetadataComponentSerializer<StatsMetadata>
     {
         private static final Logger logger = LoggerFactory.getLogger(StatsMetadataSerializer.class);
+        private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1L, TimeUnit.MINUTES);
 
         private final AbstractTypeSerializer typeSerializer = new AbstractTypeSerializer();
 
@@ -602,7 +605,7 @@ public class StatsMetadata extends MetadataComponent
 
             if (version.hasIncrementalNodeSyncMetadata())
             {
-                logger.warn("Ignoring incremental node sync metadata from {} as it is not supported", in);
+                noSpamLogger.warn("Ignoring incremental node sync metadata from {} as it is not supported", in);
                 in.readLong();
             }
 

--- a/src/java/org/apache/cassandra/net/AcceptVersions.java
+++ b/src/java/org/apache/cassandra/net/AcceptVersions.java
@@ -22,12 +22,23 @@ package org.apache.cassandra.net;
  */
 class AcceptVersions
 {
-    final int min, max;
+    final int min, max, dse;
 
     AcceptVersions(int min, int max)
     {
+        this(min, max, -1);
+    }
+
+    AcceptVersions(int min, int max, int dse)
+    {
         this.min = min;
         this.max = max;
+        this.dse = dse;
+    }
+
+    public boolean acceptsDse()
+    {
+        return dse > 0;
     }
 
     @Override
@@ -37,6 +48,7 @@ class AcceptVersions
             return false;
 
         return min == ((AcceptVersions) that).min
-            && max == ((AcceptVersions) that).max;
+               && max == ((AcceptVersions) that).max
+               && dse == ((AcceptVersions) that).dse;
     }
 }

--- a/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
+++ b/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
@@ -64,7 +64,7 @@ public class EndpointMessagingVersions
         if (v == null)
         {
             // we don't know the version. assume current. we'll know soon enough if that was incorrect.
-            logger.trace("Assuming current protocol version for {}", endpoint);
+            logger.debug("Assuming current protocol version for {}", endpoint);
             return MessagingService.current_version;
         }
         else

--- a/src/java/org/apache/cassandra/net/HandshakeProtocol.java
+++ b/src/java/org/apache/cassandra/net/HandshakeProtocol.java
@@ -125,7 +125,8 @@ class HandshakeProtocol
             flags |= ((framing.id & 1) << 2) | ((framing.id & 2) << 3);
             flags |= (requestMessagingVersion << 8);
 
-            if (requestMessagingVersion < VERSION_40 || acceptVersions.max < VERSION_40)
+            if ((requestMessagingVersion < VERSION_40 || acceptVersions.max < VERSION_40) &&
+                !(requestMessagingVersion == 255 && acceptVersions.acceptsDse()))
                 return flags; // for testing, permit serializing as though we are pre40
 
             flags |= (acceptVersions.min << 16);

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -52,11 +52,13 @@ import org.apache.cassandra.security.SSLFactory;
 import org.apache.cassandra.streaming.async.StreamingInboundHandler;
 import org.apache.cassandra.utils.memory.BufferPools;
 
-import static java.lang.Math.*;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.cassandra.net.MessagingService.*;
+import static org.apache.cassandra.net.MessagingService.VERSION_30;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.MessagingService.current_version;
+import static org.apache.cassandra.net.MessagingService.instance;
 import static org.apache.cassandra.net.MessagingService.minimum_version;
 import static org.apache.cassandra.net.SocketFactory.WIRETRACE;
 import static org.apache.cassandra.net.SocketFactory.newSslHandler;
@@ -232,9 +234,13 @@ public class InboundConnectionInitiator
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
         {
-            if (initiate == null) initiate(ctx, in);
-            else if (initiate.acceptVersions == null && confirmOutboundPre40 == null) confirmPre40(ctx, in);
-            else throw new IllegalStateException("Should no longer be on pipeline");
+            if (initiate == null)
+                initiate(ctx, in);
+            else if ((initiate.acceptVersions == null || initiate.acceptVersions.max == settings.acceptMessaging.dse)
+                     && confirmOutboundPre40 == null)
+                confirmPre40(ctx, in);
+            else
+                throw new IllegalStateException("Should no longer be on pipeline");
         }
 
         void initiate(ChannelHandlerContext ctx, ByteBuf in) throws IOException
@@ -263,36 +269,62 @@ public class InboundConnectionInitiator
                 else
                     accept = settings.acceptMessaging;
 
-                int useMessagingVersion = max(accept.min, min(accept.max, initiate.acceptVersions.max));
-                ByteBuf flush = new HandshakeProtocol.Accept(useMessagingVersion, accept.max).encode(ctx.alloc());
-
-                AsyncChannelPromise.writeAndFlush(ctx, flush, (ChannelFutureListener) future -> {
-                    if (!future.isSuccess())
-                        exceptionCaught(future.channel(), future.cause());
-                });
-
-                if (initiate.acceptVersions.min > accept.max)
+                boolean failed = false;
+                boolean isDse = false;
+                if (accept.dse > 0 && initiate.acceptVersions.max == accept.dse)
+                {
+                    logger.info("peer {} has DSE messaging versions ({}) ", ctx.channel().remoteAddress(), accept.dse);
+                    isDse = true;
+                }
+                else if (initiate.acceptVersions.min > accept.max)
                 {
                     logger.info("peer {} only supports messaging versions higher ({}) than this node supports ({})", ctx.channel().remoteAddress(), initiate.acceptVersions.min, current_version);
-                    failHandshake(ctx);
+                    failed = true;
                 }
                 else if (initiate.acceptVersions.max < accept.min)
                 {
                     logger.info("peer {} only supports messaging versions lower ({}) than this node supports ({})", ctx.channel().remoteAddress(), initiate.acceptVersions.max, minimum_version);
-                    failHandshake(ctx);
+                    failed = true;
+                }
+                if (isDse)
+                {
+                    assert initiate.type.isMessaging();
+
+                    // Second message to DSE is sent with version 10 (oss 3.0)
+                    ByteBuf response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.min, ctx.alloc());
+                    AsyncChannelPromise.writeAndFlush(ctx, response,
+                                                      (ChannelFutureListener) future -> {
+                                                          if (!future.isSuccess())
+                                                              exceptionCaught(future.channel(), future.cause());
+                                                      });
                 }
                 else
                 {
-                    if (initiate.type.isStreaming())
+                    int useMessagingVersion = max(accept.min, min(accept.max, initiate.acceptVersions.max));
+                    ByteBuf flush = new HandshakeProtocol.Accept(useMessagingVersion, accept.max).encode(ctx.alloc());
+                    AsyncChannelPromise.writeAndFlush(ctx, flush, (ChannelFutureListener) future -> {
+                        if (!future.isSuccess())
+                            exceptionCaught(future.channel(), future.cause());
+                    });
+                    if (failed)
+                    {
+                        failHandshake(ctx);
+                    }
+                    else if (initiate.type.isStreaming())
+                    {
                         setupStreamingPipeline(initiate.from, ctx);
+                    }
                     else
+                    {
                         setupMessagingPipeline(initiate.from, useMessagingVersion, initiate.acceptVersions.max, ctx.pipeline());
+                    }
                 }
             }
             else
             {
                 int version = initiate.requestMessagingVersion;
-                assert version < VERSION_40 && version >= settings.acceptMessaging.min;
+                assert (version < VERSION_40 && version >= settings.acceptMessaging.min) ||
+                       (version == settings.acceptMessaging.min && settings.acceptMessaging.acceptsDse());
                 logger.trace("Connection version {} from {}", version, ctx.channel().remoteAddress());
 
                 if (initiate.type.isStreaming())
@@ -309,7 +341,17 @@ public class InboundConnectionInitiator
                 {
                     // if this version is < the MS version the other node is trying
                     // to connect with, the other node will disconnect
-                    ByteBuf response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.max, ctx.alloc());
+                    ByteBuf response;
+                    if (version == settings.acceptMessaging.min && settings.acceptMessaging.acceptsDse())
+                    {
+                        // Min protocol is used for DSE CNDB compatibility
+                        response = HandshakeProtocol.Accept.respondPre40(version, ctx.alloc());
+                    }
+                    else
+                    {
+                        response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.max, ctx.alloc());
+                    }
+
                     AsyncChannelPromise.writeAndFlush(ctx, response,
                           (ChannelFutureListener) future -> {
                                if (!future.isSuccess())

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -202,6 +202,8 @@ public class MessagingService extends MessagingServiceMBeanImpl
 {
     private static final Logger logger = LoggerFactory.getLogger(MessagingService.class);
 
+    private static final int SUPPORTED_DSE_VERSION = Integer.getInteger("cassandra.dse.messaging.version", 4);
+
     // 8 bits version, so don't waste versions
     public static final int VERSION_30 = 10;
     public static final int VERSION_3014 = 11;
@@ -215,7 +217,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
     // DSE 6.8 version for backward compatibility
     public static final int VERSION_DSE_68 = 168;
 
-    static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version);
+    static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version, SUPPORTED_DSE_VERSION);
     static AcceptVersions accept_streaming = new AcceptVersions(current_version, current_version);
     static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, v -> v.ordinal()));
 

--- a/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
@@ -127,7 +127,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
     private Future<Result<SuccessType>> initiate(EventLoop eventLoop)
     {
         if (logger.isTraceEnabled())
-            logger.trace("creating outbound bootstrap to {}, requestVersion: {}", settings, requestMessagingVersion);
+                logger.trace("creating outbound bootstrap to {}, requestVersion: {}", settings, requestMessagingVersion);
 
         if (!settings.authenticate())
         {
@@ -147,8 +147,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
                                          {
                                              if (future.isCancelled() && !timedout.get())
                                                  resultPromise.cancel(true);
-                                             else if (future.isCancelled())
-                                                 resultPromise.tryFailure(new IOException("Timeout handshaking with " + settings.connectToId()));
+                                             else if (future.isCancelled()) resultPromise.tryFailure(new IOException("Timeout handshaking with " + settings.connectToId()));
                                              else
                                                  resultPromise.tryFailure(future.cause());
                                          }
@@ -332,7 +331,9 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
 
                     if (result.isSuccess())
                     {
-                        ConfirmOutboundPre40 message = new ConfirmOutboundPre40(settings.acceptVersions.max, settings.from);
+                        // Third handshake message carries PV 10 rather than PV 100.
+                        // Note that CC -> CC handshake doesn't use thrid message at all.
+                        ConfirmOutboundPre40 message = new ConfirmOutboundPre40(settings.acceptVersions.min, settings.from);
                         AsyncChannelPromise.writeAndFlush(ctx, message.encode());
                     }
                 }

--- a/src/java/org/apache/cassandra/notifications/SSTableAddingNotification.java
+++ b/src/java/org/apache/cassandra/notifications/SSTableAddingNotification.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.notifications;
+
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+/**
+ * Notification sent before SSTables are added to their {@link org.apache.cassandra.db.ColumnFamilyStore}.
+ */
+public class SSTableAddingNotification implements INotification
+{
+    /** The SSTables to be added*/
+    public final Iterable<SSTableReader> adding;
+
+    /** The memtable from which the sstables come when they need to be added due to a flush, {@code null} otherwise. */
+    @Nullable
+    private final Memtable memtable;
+
+    /** The type of operation that created the sstables */
+    public final OperationType operationType;
+
+    /** The id of the operation that created the sstables, if available */
+    public final Optional<UUID> operationId;
+
+    /**
+     * Creates a new {@code SSTableAddingNotification} for the specified SSTables and optional memtable.
+     *
+     * @param adding    the SSTables to be added
+     * @param memtable the memtable from which the sstables come when they need to be added due to a memtable flush,
+     *                 or {@code null} if they don't come from a flush
+     * @param operationType the type of operation that created the sstables
+     * @param operationId the id of the operation (transaction) that created the sstables, or empty if no id is available
+     */
+    public SSTableAddingNotification(Iterable<SSTableReader> adding, @Nullable Memtable memtable, OperationType operationType, Optional<UUID> operationId)
+    {
+        this.adding = adding;
+        this.memtable = memtable;
+        this.operationType = operationType;
+        this.operationId = operationId;
+    }
+
+    /**
+     * Returns the memtable from which the sstables come when they need to be addeddue to a memtable flush. If not, an
+     * empty Optional should be returned.
+     *
+     * @return the origin memtable in case of a flush, {@link Optional#empty()} otherwise
+     */
+    public Optional<Memtable> memtable()
+    {
+        return Optional.ofNullable(memtable);
+    }
+}

--- a/src/java/org/apache/cassandra/schema/CQLTypeParser.java
+++ b/src/java/org/apache/cassandra/schema/CQLTypeParser.java
@@ -50,7 +50,7 @@ public final class CQLTypeParser
         if (udt != null)
             return udt;
 
-        return parseRaw(unparsed).prepareInternal(keyspace, userTypes).getType();
+        return parseRaw(unparsed).prepare(keyspace, userTypes).getType();
     }
 
     static CQL3Type.Raw parseRaw(String type)

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -573,6 +573,6 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
      */
     public void validate(boolean isCounterTable)
     {
-        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable);
+        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable, isDropped);
     }
 }

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -217,9 +217,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         if (kind.isPrimaryKeyKind() || !type.isMultiCell())
             return null;
 
-        AbstractType<?> nameComparator = type.isCollection()
-                                       ? ((CollectionType) type).nameComparator()
-                                       : ((UserType) type).nameComparator();
+        AbstractType<?> nameComparator = ((MultiCellCapableType<?>) type).nameComparator();
 
 
         return (path1, path2) ->
@@ -566,5 +564,15 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
     public AbstractType<?> getExactTypeIfKnown(String keyspace)
     {
         return type;
+    }
+
+    /**
+     * Validate whether the column definition is valid (mostly, that the type is valid for the type of column this is).
+     *
+     * @param isCounterTable whether the table the column is part of is a counter table.
+     */
+    public void validate(boolean isCounterTable)
+    {
+        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable);
     }
 }

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -40,6 +40,7 @@ public final class DroppedColumn
      */
     public DroppedColumn(ColumnMetadata column, long droppedTime)
     {
+        assert column.isDropped() : column.debugString() + " should be dropped";
         this.column = column;
         this.droppedTime = droppedTime;
     }

--- a/src/java/org/apache/cassandra/schema/DroppedColumn.java
+++ b/src/java/org/apache/cassandra/schema/DroppedColumn.java
@@ -73,7 +73,7 @@ public final class DroppedColumn
     {
         return String.format("DROPPED COLUMN RECORD %s %s%s USING TIMESTAMP %d",
                              column.name.toCQLString(),
-                             column.type.asCQL3Type(),
+                             column.type.asCQL3Type().toSchemaString(),
                              column.isStatic() ? " static" : "",
                              droppedTime);
     }

--- a/src/java/org/apache/cassandra/schema/Keyspaces.java
+++ b/src/java/org/apache/cassandra/schema/Keyspaces.java
@@ -161,11 +161,6 @@ public final class Keyspaces implements Iterable<KeyspaceMetadata>
                         .build();
     }
 
-    public void validate()
-    {
-        keyspaces.values().forEach(KeyspaceMetadata::validate);
-    }
-
     @Override
     public boolean equals(Object o)
     {

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -75,6 +75,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.db.rows.RowIterators;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.exceptions.InvalidColumnTypeException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.ColumnMetadata.ClusteringOrder;
 import org.apache.cassandra.schema.Keyspaces.KeyspacesDiff;
@@ -540,7 +541,7 @@ public final class SchemaKeyspace
         mutation.update(Types)
                 .row(type.getNameAsString())
                 .add("field_names", type.fieldNames().stream().map(FieldIdentifier::toString).collect(toList()))
-                .add("field_types", type.fieldTypes().stream().map(AbstractType::asCQL3Type).map(CQL3Type::toString).collect(toList()));
+                .add("field_types", type.fieldTypes().stream().map(AbstractType::asCQL3Type).map(CQL3Type::toSchemaString).collect(toList()));
     }
 
     private static void addDropTypeToSchemaMutation(UserType type, Mutation.SimpleBuilder builder)
@@ -726,7 +727,7 @@ public final class SchemaKeyspace
                .add("kind", column.kind.toString().toLowerCase())
                .add("position", column.position())
                .add("clustering_order", column.clusteringOrder().toString().toLowerCase())
-               .add("type", type.asCQL3Type().toString());
+               .add("type", type.asCQL3Type().toSchemaString());
     }
 
     private static void dropColumnFromSchemaMutation(TableMetadata table, ColumnMetadata column, Mutation.SimpleBuilder builder)
@@ -740,7 +741,7 @@ public final class SchemaKeyspace
         builder.update(DroppedColumns)
                .row(table.name, column.column.name.toString())
                .add("dropped_time", new Date(TimeUnit.MICROSECONDS.toMillis(column.droppedTime)))
-               .add("type", column.column.type.asCQL3Type().toString())
+               .add("type", column.column.type.asCQL3Type().toSchemaString())
                .add("kind", column.column.kind.toString().toLowerCase());
     }
 
@@ -985,10 +986,11 @@ public final class SchemaKeyspace
         UntypedResultSet.Row row = rows.one();
 
         Set<TableMetadata.Flag> flags = TableMetadata.Flag.fromStringSet(row.getFrozenSet("flags", UTF8Type.instance));
+        boolean isCounter = flags.contains(TableMetadata.Flag.COUNTER);
         return TableMetadata.builder(keyspaceName, tableName, TableId.fromUUID(row.getUUID("id")))
                             .flags(flags)
                             .params(createTableParamsFromRow(row))
-                            .addColumns(fetchColumns(keyspaceName, tableName, types))
+                            .addColumns(fetchColumns(keyspaceName, tableName, types, isCounter))
                             .droppedColumns(fetchDroppedColumns(keyspaceName, tableName))
                             .indexes(fetchIndexes(keyspaceName, tableName))
                             .triggers(fetchTriggers(keyspaceName, tableName))
@@ -1021,7 +1023,7 @@ public final class SchemaKeyspace
                           .build();
     }
 
-    private static List<ColumnMetadata> fetchColumns(String keyspace, String table, Types types)
+    private static List<ColumnMetadata> fetchColumns(String keyspace, String table, Types types, boolean isCounterTable)
     {
         String query = format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ?", SchemaConstants.SCHEMA_KEYSPACE_NAME, COLUMNS);
         UntypedResultSet columnRows = query(query, keyspace, table);
@@ -1029,7 +1031,7 @@ public final class SchemaKeyspace
             throw new MissingColumns("Columns not found in schema table for " + keyspace + '.' + table);
 
         List<ColumnMetadata> columns = new ArrayList<>();
-        columnRows.forEach(row -> columns.add(createColumnFromRow(row, types)));
+        columnRows.forEach(row -> columns.add(createColumnFromRow(row, types, isCounterTable)));
 
         if (columns.stream().noneMatch(ColumnMetadata::isPartitionKey))
             throw new MissingColumns("No partition key columns found in schema table for " + keyspace + "." + table);
@@ -1037,8 +1039,35 @@ public final class SchemaKeyspace
         return columns;
     }
 
+    private static AbstractType<?> validate(String keyspace,
+                                            String table,
+                                            ByteBuffer name,
+                                            AbstractType<?> type,
+                                            boolean isPrimaryKeyColumn,
+                                            boolean isCounterTable)
+    {
+        try
+        {
+            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+            return type;
+        }
+        catch (InvalidColumnTypeException e)
+        {
+            AbstractType<?> fixed = e.tryFix();
+            if (fixed == null)
+                throw e;
+
+            logger.error("Error reading schema for table {}.{}, column {} had invalid type {} (invalid because: {}). "
+                         + "This was likely the result of a previous bug and the type was automatically converted to "
+                         + "valid type {}. If this is incorrect, or this message repeats itself, please contact "
+                         + "DataStax support", keyspace, table, ColumnIdentifier.toCQLString(name), type.asCQL3Type(),
+                         e.getMessage(), fixed.asCQL3Type());
+            return fixed;
+        }
+    }
+
     @VisibleForTesting
-    static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types)
+    static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types, boolean isCounterTable)
     {
         String keyspace = row.getString("keyspace_name");
         String table = row.getString("table_name");
@@ -1052,7 +1081,10 @@ public final class SchemaKeyspace
         if (order == ClusteringOrder.DESC)
             type = ReversedType.getInstance(type);
 
-        ColumnIdentifier name = new ColumnIdentifier(row.getBytes("column_name_bytes"), row.getString("column_name"));
+        ByteBuffer columnNameBytes = row.getBytes("column_name_bytes");
+        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable);
+
+        ColumnIdentifier name = new ColumnIdentifier(columnNameBytes, row.getString("column_name"));
 
         return new ColumnMetadata(keyspace, table, name, type, position, kind);
     }
@@ -1145,7 +1177,7 @@ public final class SchemaKeyspace
         boolean includeAll = row.getBoolean("include_all_columns");
         String whereClauseString = row.getString("where_clause");
 
-        List<ColumnMetadata> columns = fetchColumns(keyspaceName, viewName, types);
+        List<ColumnMetadata> columns = fetchColumns(keyspaceName, viewName, types, false);
 
         TableMetadata metadata =
             TableMetadata.builder(keyspaceName, viewName, TableId.fromUUID(row.getUUID("id")))

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -991,7 +991,7 @@ public final class SchemaKeyspace
                             .flags(flags)
                             .params(createTableParamsFromRow(row))
                             .addColumns(fetchColumns(keyspaceName, tableName, types, isCounter))
-                            .droppedColumns(fetchDroppedColumns(keyspaceName, tableName))
+                            .droppedColumns(fetchDroppedColumns(keyspaceName, tableName, isCounter))
                             .indexes(fetchIndexes(keyspaceName, tableName))
                             .triggers(fetchTriggers(keyspaceName, tableName))
                             .build();
@@ -1044,11 +1044,12 @@ public final class SchemaKeyspace
                                             ByteBuffer name,
                                             AbstractType<?> type,
                                             boolean isPrimaryKeyColumn,
-                                            boolean isCounterTable)
+                                            boolean isCounterTable,
+                                            boolean isDroppedColumn)
     {
         try
         {
-            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable);
+            type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn);
             return type;
         }
         catch (InvalidColumnTypeException e)
@@ -1082,43 +1083,42 @@ public final class SchemaKeyspace
             type = ReversedType.getInstance(type);
 
         ByteBuffer columnNameBytes = row.getBytes("column_name_bytes");
-        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable);
+        type = validate(keyspace, table, columnNameBytes, type, kind.isPrimaryKeyKind(), isCounterTable, false);
 
         ColumnIdentifier name = new ColumnIdentifier(columnNameBytes, row.getString("column_name"));
 
         return new ColumnMetadata(keyspace, table, name, type, position, kind);
     }
 
-    private static Map<ByteBuffer, DroppedColumn> fetchDroppedColumns(String keyspace, String table)
+    private static Map<ByteBuffer, DroppedColumn> fetchDroppedColumns(String keyspace, String table, boolean isCounterTable)
     {
         String query = format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ?", SchemaConstants.SCHEMA_KEYSPACE_NAME, DROPPED_COLUMNS);
         Map<ByteBuffer, DroppedColumn> columns = new HashMap<>();
         for (UntypedResultSet.Row row : query(query, keyspace, table))
         {
-            DroppedColumn column = createDroppedColumnFromRow(row);
+            DroppedColumn column = createDroppedColumnFromRow(row, isCounterTable);
             columns.put(column.column.name.bytes, column);
         }
         return columns;
     }
 
-    private static DroppedColumn createDroppedColumnFromRow(UntypedResultSet.Row row)
+    private static DroppedColumn createDroppedColumnFromRow(UntypedResultSet.Row row, boolean isCounterTable)
     {
         String keyspace = row.getString("keyspace_name");
         String table = row.getString("table_name");
         String name = row.getString("column_name");
-        /*
-         * we never store actual UDT names in dropped column types (so that we can safely drop types if nothing refers to
-         * them anymore), so before storing dropped columns in schema we expand UDTs to tuples. See expandUserTypes method.
-         * Because of that, we can safely pass Types.none() to parse()
-         */
-        AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), org.apache.cassandra.schema.Types.none());
+
+        // Note that it's important we call parseDroppedType, not parse, see the method javadoc for details.
+        AbstractType<?> type = CQLTypeParser.parseDroppedType(keyspace, row.getString("type"));
         ColumnMetadata.Kind kind = row.has("kind")
                                  ? ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase())
                                  : ColumnMetadata.Kind.REGULAR;
         assert kind == ColumnMetadata.Kind.REGULAR || kind == ColumnMetadata.Kind.STATIC
             : "Unexpected dropped column kind: " + kind;
 
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        type = validate(keyspace, table, UTF8Type.instance.decompose(name), type, false, isCounterTable, true);
+
+        ColumnMetadata column = ColumnMetadata.droppedColumn(keyspace, table, ColumnIdentifier.getInterned(name, true), type, kind);
         long droppedTime = TimeUnit.MILLISECONDS.toMicros(row.getLong("dropped_time"));
         return new DroppedColumn(column, droppedTime);
     }
@@ -1183,7 +1183,7 @@ public final class SchemaKeyspace
             TableMetadata.builder(keyspaceName, viewName, TableId.fromUUID(row.getUUID("id")))
                          .kind(TableMetadata.Kind.VIEW)
                          .addColumns(columns)
-                         .droppedColumns(fetchDroppedColumns(keyspaceName, viewName))
+                         .droppedColumns(fetchDroppedColumns(keyspaceName, viewName, false))
                          .params(createTableParamsFromRow(row))
                          .build();
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.schema;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -178,6 +179,12 @@ public class TableMetadata implements SchemaElement
         clusteringColumns = ImmutableList.copyOf(builder.clusteringColumns);
         regularAndStaticColumns = RegularAndStaticColumns.builder().addAll(builder.regularAndStaticColumns).build();
         columns = ImmutableMap.copyOf(builder.columns);
+
+        assert columns.values().stream().noneMatch(ColumnMetadata::isDropped) :
+                "Invalid columns (contains dropped): " + columns.values()
+                                                                .stream()
+                                                                .map(ColumnMetadata::debugString)
+                                                                .collect(Collectors.joining(", "));
 
         indexes = builder.indexes;
         triggers = builder.triggers;

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -469,23 +469,58 @@ public class TableMetadata implements SchemaElement
         return !columnName.bytes.hasRemaining();
     }
 
+    /*
+    Method that runs the same checks as validateCompatibility, but does not check the keyspace name and table id.
+    */
+    public void validateTableStructureCompatibility(TableMetadata previous)
+    {
+        if (isIndex())
+            return;
+
+        validateTableName(previous);
+        validateTableType(previous);
+        validateTableColumns(previous);
+    }
+
     void validateCompatibility(TableMetadata previous)
     {
         if (isIndex())
             return;
 
+        validateKeyspaceName(previous);
+        validateTableName(previous);
+        validateTableId(previous);
+        validateTableType(previous);
+        validateTableColumns(previous);
+
+    }
+
+    private void validateKeyspaceName(TableMetadata previous)
+    {
         if (!previous.keyspace.equals(keyspace))
             except("Keyspace mismatch (found %s; expected %s)", keyspace, previous.keyspace);
+    }
 
+    private void validateTableName(TableMetadata previous)
+    {
         if (!previous.name.equals(name))
             except("Table mismatch (found %s; expected %s)", name, previous.name);
+    }
 
+    private void validateTableId(TableMetadata previous)
+    {
         if (!previous.id.equals(id))
             except("Table ID mismatch (found %s; expected %s)", id, previous.id);
+    }
 
+    private void validateTableType(TableMetadata previous)
+    {
         if (!previous.flags.equals(flags) && (!Flag.isCQLTable(flags) || Flag.isCQLTable(previous.flags)))
             except("Table type mismatch (found %s; expected %s)", flags, previous.flags);
+    }
 
+    private void validateTableColumns(TableMetadata previous)
+    {
         if (previous.partitionKeyColumns.size() != partitionKeyColumns.size())
         {
             except("Partition keys of different length (found %s; expected %s)",

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -424,22 +424,7 @@ public class TableMetadata implements SchemaElement
 
         params.validate();
 
-        if (partitionKeyColumns.stream().anyMatch(c -> c.type.isCounter()))
-            except("PRIMARY KEY columns cannot contain counters");
-
-        // Mixing counter with non counter columns is not supported (#2614)
-        if (isCounter())
-        {
-            for (ColumnMetadata column : regularAndStaticColumns)
-                if (!(column.type.isCounter()) && !isSuperColumnMapColumnName(column.name))
-                    except("Cannot have a non counter column (\"%s\") in a counter table", column.name);
-        }
-        else
-        {
-            for (ColumnMetadata column : regularAndStaticColumns)
-                if (column.type.isCounter())
-                    except("Cannot have a counter column (\"%s\") in a non counter table", column.name);
-        }
+        columns().forEach(c -> c.validate(isCounter()));
 
         // All tables should have a partition key
         if (partitionKeyColumns.isEmpty())
@@ -464,9 +449,9 @@ public class TableMetadata implements SchemaElement
      *   table with counters to rename that weirdly name map to something more meaningful (it's not possible today
      *   as after renaming the validation in {@link #validate)} would trigger).
      */
-    private static boolean isSuperColumnMapColumnName(ColumnIdentifier columnName)
+    public static boolean isSuperColumnMapColumnName(ByteBuffer columnName)
     {
-        return !columnName.bytes.hasRemaining();
+        return !columnName.hasRemaining();
     }
     
     public void validateTableStructureCompatibility(TableMetadata previous)
@@ -826,11 +811,11 @@ public class TableMetadata implements SchemaElement
         if (partitionKeyType instanceof CompositeType)
         {
             ByteBuffer[] values = ((CompositeType) partitionKeyType).split(partitionKey);
-            int size = ((CompositeType) partitionKeyType).types.size();
+            int size = partitionKeyType.subTypes().size();
             literals = new String[size + clusteringSize];
             for (i = 0; i < size; i++)
             {
-                literals[i] = asCQLLiteral(((CompositeType) partitionKeyType).types.get(i), values[i]);
+                literals[i] = asCQLLiteral(partitionKeyType.subTypes().get(i), values[i]);
             }
         }
         else
@@ -844,7 +829,7 @@ public class TableMetadata implements SchemaElement
             literals[i++] = asCQLLiteral(clusteringColumns().get(j).type, clustering.bufferAt(j));
         }
 
-        return i == 1 ? literals[0] : "(" + String.join(", ", literals) + ")";
+        return i == 1 ? literals[0] : '(' + String.join(", ", literals) + ')';
     }
 
     private static String asCQLLiteral(AbstractType<?> type, ByteBuffer value)
@@ -1097,7 +1082,6 @@ public class TableMetadata implements SchemaElement
                     Collections.sort(partitionKeyColumns);
                     break;
                 case CLUSTERING:
-                    column.type.checkComparable();
                     clusteringColumns.add(column);
                     Collections.sort(clusteringColumns);
                     break;

--- a/src/java/org/apache/cassandra/schema/Types.java
+++ b/src/java/org/apache/cassandra/schema/Types.java
@@ -459,7 +459,7 @@ public final class Types implements Iterable<UserType>
 
                 List<AbstractType<?>> preparedFieldTypes =
                     fieldTypes.stream()
-                              .map(t -> t.prepareInternal(keyspace, types).getType())
+                              .map(t -> t.prepare(keyspace, types).getType())
                               .collect(toList());
 
                 return new UserType(keyspace, bytes(name), preparedFieldNames, preparedFieldTypes, true);

--- a/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/AbstractTypeSerializer.java
@@ -45,6 +45,8 @@ public class AbstractTypeSerializer
             serialize(type, out);
     }
 
+    // Used only in serialization header, when deserializing a type from the sstable header,
+    // not used in commit log or internode transport.
     public AbstractType<?> deserialize(DataInputPlus in) throws IOException
     {
         ByteBuffer raw = ByteBufferUtil.readWithVIntLength(in);

--- a/src/java/org/apache/cassandra/tools/JsonTransformer.java
+++ b/src/java/org/apache/cassandra/tools/JsonTransformer.java
@@ -163,9 +163,9 @@ public final class JsonTransformer
                 }
 
                 int i = 0;
-                while (keyBytes.remaining() > 0 && i < compositeType.getComponents().size())
+                while (keyBytes.remaining() > 0 && i < compositeType.subTypes().size())
                 {
-                    AbstractType<?> colType = compositeType.getComponents().get(i);
+                    AbstractType<?> colType = compositeType.subTypes().get(i);
 
                     ByteBuffer value = ByteBufferUtil.readBytesWithShortLength(keyBytes);
                     String colValue = colType.getString(value);

--- a/src/java/org/apache/cassandra/tools/Util.java
+++ b/src/java/org/apache/cassandra/tools/Util.java
@@ -308,8 +308,22 @@ public final class Util
      * @param desc SSTable's descriptor
      * @return Restored CFMetaData
      * @throws IOException when Stats.db cannot be read
+     *
+     * Hardcodes the keyspace and table name to default values to preserve the existing behavior.
      */
     public static TableMetadata metadataFromSSTable(Descriptor desc) throws IOException
+    {
+        return metadataFromSSTable(desc, "keyspace", "table");
+    }
+
+    /**
+     * Construct table schema from info stored in SSTable's Stats.db, using the specified keyspace and table names.
+     *
+     * @param desc SSTable's descriptor
+     * @return Restored CFMetaData
+     * @throws IOException when Stats.db cannot be read
+     */
+    public static TableMetadata metadataFromSSTable(Descriptor desc, String keyspaceName, String tableName) throws IOException
     {
         if (desc.getFormat().getType() == SSTableFormat.Type.BIG)
         {
@@ -323,7 +337,7 @@ public final class Util
 
         IPartitioner partitioner = FBUtilities.newPartitioner(desc);
 
-        TableMetadata.Builder builder = TableMetadata.builder("keyspace", "table").partitioner(partitioner);
+        TableMetadata.Builder builder = TableMetadata.builder(keyspaceName, tableName).partitioner(partitioner);
         header.getStaticColumns().entrySet().stream()
                 .forEach(entry -> {
                     ColumnIdentifier ident = ColumnIdentifier.getInterned(UTF8Type.instance.getString(entry.getKey()), true);

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -924,4 +924,23 @@ public class ByteBufferUtil
 
         return n;
     }
+
+    /**
+     * Essentially the same as {@link #bytesToHex(ByteBuffer)} (though it prepends "0x" for clarity) but takes care of
+     * not output a string too long if the value is too big. This is to be used for error/debug message where we don't
+     * want to blow things up.
+     *
+     * @param bytes the bytes to convert to hexadecimal string.
+     * @return a string representation of {@code bytes} that may be only partial if {@code bytes} is too big.
+     */
+    public static String toDebugHexString(ByteBuffer bytes)
+    {
+        int maxSize = 50; // kind of arbitrary tbh but that's not hugely important
+        if (bytes.remaining() > maxSize)
+        {
+            bytes = bytes.duplicate();
+            bytes.limit(bytes.position() + maxSize);
+        }
+        return "0x" + bytesToHex(bytes);
+    }
 }

--- a/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
+++ b/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
@@ -220,7 +220,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
         String name = row.getString("column_name");
         AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), Types.none());
         ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        ColumnMetadata column = ColumnMetadata.droppedColumn(keyspace, table, ColumnIdentifier.getInterned(name, true), type, kind);
         long droppedTime = row.getTimestamp("dropped_time").getTime();
         return new DroppedColumn(column, droppedTime);
     }

--- a/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
+++ b/test/distributed/org/apache/cassandra/db/commitlog/MemoryMappedSegmentStartupTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_SKIP_FILE_ADVICE;
+import static org.junit.Assert.assertEquals;
+
+public class MemoryMappedSegmentStartupTest
+{
+    @After
+    public void tearDown() throws Exception
+    {
+        COMMITLOG_SKIP_FILE_ADVICE.reset();
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceTrueWithParameterTrue() throws IOException
+    {
+        COMMITLOG_SKIP_FILE_ADVICE.setBoolean(true);
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(true, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceFalseWithParameterFalse() throws IOException
+    {
+        COMMITLOG_SKIP_FILE_ADVICE.setBoolean(false);
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(false, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+
+    @Test
+    public void shouldSetSkipFileAdviceFalseWithParameterMissing() throws IOException
+    {
+        try (Cluster cluster = Cluster.build(1).start())
+        {
+            assertEquals(false, cluster.get(1).callOnInstance(() -> MemoryMappedSegment.skipFileAdviseToFreePageCache));
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/DropUDTWithRestartTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/DropUDTWithRestartTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.tools.SSTableExport;
+import org.apache.cassandra.tools.ToolRunner;
+import org.assertj.core.api.Assertions;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+public class DropUDTWithRestartTest extends TestBaseImpl
+{
+    @Test
+    public void testReadingValuesOfDroppedColumns() throws Throwable
+    {
+        // given there is a table with a UDT column and some additional non-UDT columns, and there are rows with
+        // different combinations of values and nulls for all columns
+        try (Cluster cluster = Cluster.build(1).withConfig(c -> c.with(GOSSIP, NATIVE_PROTOCOL)).start())
+        {
+            IInvokableInstance node = cluster.get(1);
+            node.executeInternal("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            node.executeInternal("CREATE TYPE ks.udt (foo text, bar text)");
+            node.executeInternal("CREATE TABLE ks.tab (pk int PRIMARY KEY, a_udt udt, b text, c text)");
+            node.executeInternal("INSERT INTO ks.tab (pk, c) VALUES (1, 'c_value')");
+            node.executeInternal("INSERT INTO ks.tab (pk, b) VALUES (2, 'b_value')");
+            node.executeInternal("INSERT INTO ks.tab (pk, a_udt) VALUES (3, {foo: 'a_foo', bar: 'a_bar'})");
+
+            File dataDir = new File(node.callOnInstance(() -> Keyspace.open("ks")
+                                                                      .getColumnFamilyStore("tab")
+                                                                      .getDirectories()
+                                                                      .getDirectoryForNewSSTables()
+                                                                      .absolutePath()));
+            checkData(cluster);
+
+            // when the UDT columns is dropped while the data cannot be flushed before drop and must remain in the commitlog
+
+            // prevent flushing the data
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(dataDir.toPath());
+            permissions.remove(PosixFilePermission.OWNER_WRITE);
+            permissions.remove(PosixFilePermission.GROUP_WRITE);
+            permissions.remove(PosixFilePermission.OTHERS_WRITE);
+            Files.setPosixFilePermissions(dataDir.toPath(), permissions);
+
+            node.executeInternal("ALTER TABLE ks.tab DROP a_udt");
+
+            // and the node is restarted
+            // restart is needed because this way we can simulate the situation where the commit log contains the data
+            // of the dropped cell, while the schema is already altered (the column moved to dropped columns and transformed)
+            node.shutdown(false).get();
+
+            // unlock the ability to flush data
+            permissions = Files.getPosixFilePermissions(dataDir.toPath());
+            permissions.add(PosixFilePermission.OWNER_WRITE);
+            Files.setPosixFilePermissions(dataDir.toPath(), permissions);
+            node.startup();
+
+            // then, we should still be able to read the data of the remaining columns correctly
+            checkData(cluster);
+
+            // and even after flushing and restarting the node again
+            // the next restart is needed to make sure that the sstable header is read from disk
+            node.flush("ks");
+            node.shutdown(false).get();
+            node.startup();
+
+            checkData(cluster);
+
+            // verify that the sstable can be read with sstabledump
+            String sstable = node.callOnInstance(() -> Keyspace.open("ks").getColumnFamilyStore("tab")
+                                                               .getDirectories().getCFDirectories()
+                                                               .get(0).tryList()[0].toString());
+            ToolRunner.ToolResult tool = ToolRunner.invokeClass(SSTableExport.class, sstable);
+            tool.assertCleanStdErr();
+            tool.assertOnExitCode();
+            Assertions.assertThat(tool.getStdout())
+                      .contains("\"key\" : [ \"1\" ],")
+                      .contains("\"key\" : [ \"2\" ],")
+                      .contains("{ \"name\" : \"c\", \"value\" : \"c_value\" }")
+                      .contains("{ \"name\" : \"b\", \"value\" : \"b_value\" }");
+        }
+    }
+
+    private void checkData(Cluster cluster)
+    {
+        ICoordinator coordinator = cluster.coordinator(1);
+        String query = "SELECT b, c FROM ks.tab WHERE pk = ?";
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 1), row(null, "c_value"));
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 2), row("b_value", null));
+        assertRows(coordinator.execute(query, ConsistencyLevel.QUORUM, 3), row(null, null));
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/UnifiedCompactionDensitiesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/UnifiedCompactionDensitiesTest.java
@@ -70,7 +70,10 @@ public class UnifiedCompactionDensitiesTest extends TestBaseImpl
                                              .start()))
         {
             cluster.schemaChange(withKeyspace("alter keyspace %s with replication = {'class': 'SimpleStrategy', 'replication_factor':1}"));
-            cluster.schemaChange(withKeyspace("create table %s.tbl (id bigint primary key, value text) with compaction = {'class':'UnifiedCompactionStrategy', 'target_sstable_size' : '1MiB'}"));
+            cluster.schemaChange(withKeyspace("create table %s.tbl (id bigint primary key, value text) with compaction = {'class':'UnifiedCompactionStrategy', " +
+                                              "'target_sstable_size' : '1MiB', " +
+                                              "'min_sstable_size' : '0B', " +
+                                              "'sstable_growth': '0'}"));
             long targetSize = 1L<<20;
             long targetMin = targetSize * 10 / 16;  // Size must be within sqrt(0.5), sqrt(2) of target, use 1.6 to account for estimations
             long targetMax = targetSize * 16 / 10;

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -63,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.FieldIdentifier;
 import org.apache.cassandra.db.AbstractReadCommandBuilder;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ClusteringComparator;
@@ -88,6 +90,8 @@ import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
 import org.apache.cassandra.db.partitions.ImmutableBTreePartition;
 import org.apache.cassandra.db.partitions.Partition;
@@ -1280,6 +1284,7 @@ public class Util
                     ApplicationState.STATUS_WITH_PORT,
                     new VersionedValue.VersionedValueFactory(partitioner).normal(Collections.singleton(token)));
     }
+
     public static boolean isListeningOn(InetSocketAddress address)
     {
         try (ServerSocket socket = new ServerSocket())
@@ -1291,5 +1296,22 @@ public class Util
         {
             return true;
         }
+    }
+
+    public static UserType makeUDT(String name, Map<String, AbstractType<?>> fields, boolean multicell)
+    {
+        return makeUDT("ks", name, fields, multicell);
+    }
+
+    public static UserType makeUDT(String ks, String name, Map<String, AbstractType<?>> fields, boolean multicell)
+    {
+        List<FieldIdentifier> fieldNames = new ArrayList<>(fields.size());
+        List<AbstractType<?>> fieldTypes = new ArrayList<>(fields.size());
+        for (Map.Entry<String, AbstractType<?>> entry : fields.entrySet())
+        {
+            fieldNames.add(FieldIdentifier.forUnquoted(entry.getKey()));
+            fieldTypes.add(entry.getValue());
+        }
+        return new UserType(ks, UTF8Type.instance.decompose(name), fieldNames, fieldTypes, multicell);
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
+++ b/test/unit/org/apache/cassandra/cql3/CQL3TypeLiteralTest.java
@@ -388,7 +388,7 @@ public class CQL3TypeLiteralTest
         checkForEachUserType(CQL3Type.Raw.list(CQL3Type.Raw.userType(name1)), name1);
         checkForEachUserType(CQL3Type.Raw.set(CQL3Type.Raw.userType(name1)), name1);
         checkForEachUserType(CQL3Type.Raw.map(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2)), name1, name2);
-        checkForEachUserType(CQL3Type.Raw.tuple(Arrays.asList(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2))), name1, name2);
+        checkForEachUserType(CQL3Type.Raw.tuple(Arrays.asList(CQL3Type.Raw.userType(name1), CQL3Type.Raw.userType(name2)), true), name1, name2);
     }
 
     private void checkForEachUserType(CQL3Type.Raw t, UTName... expectedNames)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -139,6 +139,7 @@ import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.nodes.Nodes;
+import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
@@ -634,6 +635,16 @@ public abstract class CQLTester
     public ColumnFamilyStore getColumnFamilyStore(String keyspace, String table)
     {
         return Keyspace.open(keyspace).getColumnFamilyStore(table);
+    }
+
+    public ColumnMetadata getColumn(String name)
+    {
+        return getCurrentColumnFamilyStore().metadata.get().getColumn(ColumnIdentifier.getInterned(name, true));
+    }
+
+    public ColumnMetadata getDroppedColumn(String name)
+    {
+        return getCurrentColumnFamilyStore().metadata.get().getDroppedColumn(ColumnIdentifier.getInterned(name, true).bytes);
     }
 
     public void flush(boolean forceFlush)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -63,7 +63,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -85,8 +84,6 @@ import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.NettyOptions;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.ResultSet;
-
-import com.datastax.shaded.netty.channel.EventLoopGroup;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
@@ -1796,6 +1793,13 @@ public abstract class CQLTester
                 assertMessageContains(errorMessage, e);
             }
         }
+    }
+
+    public static List<String> warningsFromResultSet(List<String> ignoredWarnings, ResultSet rs)
+    {
+        return rs.getExecutionInfo().getWarnings()
+                 .stream().filter(w -> ignoredWarnings.stream().noneMatch(w::contains))
+                 .collect(Collectors.toList());
     }
 
     private static String queryInfo(String query, Object[] values)

--- a/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
@@ -579,7 +579,7 @@ public class TermSelectionTest extends CQLTester
         assertColumnSpec(boundNames.get(0), "[selection]", Int32Type.instance);
         assertColumnSpec(boundNames.get(1), "adecimal", DecimalType.instance);
         assertColumnSpec(boundNames.get(2), "[selection]", UTF8Type.instance);
-        assertColumnSpec(boundNames.get(3), "atuple", TypeParser.parse("TupleType(Int32Type,UTF8Type)"));
+        assertColumnSpec(boundNames.get(3), "atuple", TypeParser.parse("TupleType(Int32Type,UTF8Type)").freeze());
         assertColumnSpec(boundNames.get(4), "pk", Int32Type.instance);
 
 
@@ -590,7 +590,7 @@ public class TermSelectionTest extends CQLTester
         assertColumnSpec(resultNames.get(0), "(int)?", Int32Type.instance);
         assertColumnSpec(resultNames.get(1), "(decimal)?", DecimalType.instance);
         assertColumnSpec(resultNames.get(2), "(text)?", UTF8Type.instance);
-        assertColumnSpec(resultNames.get(3), "(tuple<int, text>)?", TypeParser.parse("TupleType(Int32Type,UTF8Type)"));
+        assertColumnSpec(resultNames.get(3), "(tuple<int, text>)?", TypeParser.parse("TupleType(Int32Type,UTF8Type)").freeze());
         assertColumnSpec(resultNames.get(4), "pk", Int32Type.instance);
         assertColumnSpec(resultNames.get(5), "ck", Int32Type.instance);
         assertColumnSpec(resultNames.get(6), "t", UTF8Type.instance);

--- a/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/TermSelectionTest.java
@@ -191,10 +191,10 @@ public class TermSelectionTest extends CQLTester
                             tuple(tuple("three", "three"), tuple("three", "three", 3L, "three")))));
 
         // single element tuple: tuple(t) incompatible with tuple(long, long)
-        assertInvalidMessage("(t) is not of the expected type: frozen<tuple<bigint, bigint>>",
+        assertInvalidMessage("(t) is not of the expected type: tuple<bigint, bigint>",
                              "SELECT [(CAST(pk AS BIGINT), CAST(ck AS BIGINT)), (t)] FROM %s");
 
-        assertInvalidMessage("(cast(ck as bigint)) is not of the expected type: frozen<tuple<text, text>>",
+        assertInvalidMessage("(cast(ck as bigint)) is not of the expected type: tuple<text, text>",
                              "SELECT [(t, t), (CAST(ck AS BIGINT))] FROM %s");
 
         // single element tuple: tuple(long) compatible with tuple(long, long)
@@ -308,7 +308,7 @@ public class TermSelectionTest extends CQLTester
                            tuple(tuple("three", "three"), tuple("three", "three", 3L, "three")))));
 
         // getExactType for (t) is null
-        assertInvalidMessage("(t) is not of the expected type: frozen<tuple<bigint, bigint>>",
+        assertInvalidMessage("(t) is not of the expected type: tuple<bigint, bigint>",
                              "SELECT {(CAST(pk AS BIGINT), CAST(ck AS BIGINT)), (t), (CAST(pk AS BIGINT), CAST(ck AS BIGINT))} FROM %s");
 
         // Test UDTs nested within Sets
@@ -465,7 +465,7 @@ public class TermSelectionTest extends CQLTester
 
 
         // Test Litteral Set with Duration elements
-        assertInvalidMessage("Durations are not allowed inside sets: set<duration>",
+        assertInvalidMessage("Durations are not allowed inside sets: frozen<set<duration>>",
                              "SELECT pk, ck, (set<duration>){2d, 1mo} FROM %s");
 
         assertInvalidMessage("Invalid field selection: system.min(ck) of type int is not a user type",
@@ -494,7 +494,7 @@ public class TermSelectionTest extends CQLTester
                    row(map(2, Duration.from("10h"))),
                    row(map(3, Duration.from("11h"))));
 
-        assertInvalidMessage("Durations are not allowed as map keys: map<duration, int>",
+        assertInvalidMessage("Durations are not allowed as map keys: frozen<map<duration, int>>",
                              "SELECT (map<duration, int>){d1 : ck, d2 :ck} FROM %s");
     }
 
@@ -502,7 +502,7 @@ public class TermSelectionTest extends CQLTester
     public void testSelectUDTLiteral() throws Throwable
     {
         String type = createType("CREATE TYPE %s(a int, b text)");
-        createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ")");
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ')');
 
         execute("INSERT INTO %s(k, v) VALUES (?, ?)", 0, userType("a", 3, "b", "foo"));
 

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -221,8 +221,8 @@ public class DescribeStatementTest extends CQLTester
             assertRowsNet(executeDescribeNet("DESCRIBE FUNCTION " + function),
                           row(KEYSPACE_PER_TEST,
                               "function",
-                              shortFunctionName(function) + "(tuple<int>, list<frozen<tuple<int, text>>>, tuple<frozen<tuple<int, text>>, text>)",
-                              "CREATE FUNCTION " + function + "(t tuple<int>, l list<frozen<tuple<int, text>>>, nt tuple<frozen<tuple<int, text>>, text>)\n" +
+                              shortFunctionName(function) + "(tuple<int>, list<tuple<int, text>>, tuple<tuple<int, text>, text>)",
+                              "CREATE FUNCTION " + function + "(t tuple<int>, l list<tuple<int, text>>, nt tuple<tuple<int, text>, text>)\n" +
                               "    CALLED ON NULL INPUT\n" +
                               "    RETURNS tuple<int, text>\n" +
                               "    LANGUAGE java\n" +
@@ -954,7 +954,7 @@ public class DescribeStatementTest extends CQLTester
                "    textcol text,\n" +
                "    timestampcol timestamp,\n" +
                "    tinyintcol tinyint,\n" +
-               "    tuplecol frozen<tuple<text, int, frozen<tuple<timestamp>>>>,\n" +
+               "    tuplecol tuple<text, int, tuple<timestamp>>,\n" +
                "    uuidcol uuid,\n" +
                "    varcharcol text,\n" +
                "    varintcol varint,\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
@@ -1762,15 +1762,15 @@ public class CollectionsTest extends CQLTester
     {
         String type = createType("CREATE TYPE %s (s set<int>, m map<text, text>)");
 
-        assertInvalidMessage("Non-frozen UDTs are not allowed inside collections",
+        assertInvalidMessage("non-frozen user types are only supported at top-level",
                              "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v map<text, " + type + ">)");
 
         String mapType = "map<text, frozen<" + type + ">>";
         for (boolean frozen : new boolean[]{false, true})
         {
-            mapType = frozen ? "frozen<" + mapType + ">" : mapType;
+            mapType = frozen ? "frozen<" + mapType + '>' : mapType;
 
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + mapType + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + mapType + ')');
 
             execute("INSERT INTO %s(k, v) VALUES (0, ?)", map("abc", userType("s", set(2, 4, 6), "m", map("a", "v1", "d", "v2"))));
 
@@ -1782,16 +1782,16 @@ public class CollectionsTest extends CQLTester
             });
         }
 
-        assertInvalidMessage("Non-frozen UDTs with nested non-frozen collections are not supported",
-                             "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v " + type + ")");
+        assertInvalidMessage("non-frozen collections are only supported at top-level",
+                             "CREATE TABLE " + KEYSPACE + ".t (k int PRIMARY KEY, v " + type + ')');
 
         type = createType("CREATE TYPE %s (s frozen<set<int>>, m frozen<map<text, text>>)");
 
         for (boolean frozen : new boolean[]{false, true})
         {
-            type = frozen ? "frozen<" + type + ">" : type;
+            type = frozen ? "frozen<" + type + '>' : type;
 
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, v " + type + ')');
 
             execute("INSERT INTO %s(k, v) VALUES (0, ?)", userType("s", set(2, 4, 6), "m", map("a", "v1", "d", "v2")));
 
@@ -1889,7 +1889,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, s) VALUES (0, ?)",
                              set(tuple(1, "1", 1.0, 1), tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid set literal for s: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid set literal for s: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, s) VALUES (0, {(1, '1', 1.0, 1)})");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, l frozen<list<tuple<int, text, double>>>)");
@@ -1897,7 +1897,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, l) VALUES (0, ?)",
                              list(tuple(1, "1", 1.0, 1), tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid list literal for l: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid list literal for l: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, l) VALUES (0, [(1, '1', 1.0, 1)])");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, m frozen<map<tuple<int, text, double>, int>>)");
@@ -1905,7 +1905,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, m) VALUES (0, ?)",
                              map(tuple(1, "1", 1.0, 1), 1, tuple(2, "2", 2.0, 2), 2));
 
-        assertInvalidMessage("Invalid map literal for m: key (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid map literal for m: key (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, m) VALUES (0, {(1, '1', 1.0, 1) : 1})");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, m frozen<map<int, tuple<int, text, double>>>)");
@@ -1913,7 +1913,7 @@ public class CollectionsTest extends CQLTester
                              "INSERT INTO %s (k, m) VALUES (0, ?)",
                              map(1, tuple(1, "1", 1.0, 1), 2, tuple(2, "2", 2.0, 2)));
 
-        assertInvalidMessage("Invalid map literal for m: value (1, '1', 1.0, 1) is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid map literal for m: value (1, '1', 1.0, 1) is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, m) VALUES (0, {1 : (1, '1', 1.0, 1)})");
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.cassandra.cql3.validation.entities;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -803,10 +803,10 @@ public class FrozenCollectionsTest extends CQLTester
         assertInvalid("DELETE m[?] FROM %s WHERE k=?", 0, 0);
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t set<set<int>>)",
-                "Non-frozen collections are not allowed inside collections");
+                                       "non-frozen collections are only supported at top-level");
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t frozen<set<counter>>)",
-                                       "Counters are not allowed inside collections");
+                                       "counters are not allowed within collections");
 
         assertInvalidCreateWithMessage("CREATE TABLE %s (k int PRIMARY KEY, t frozen<text>)",
                 "frozen<> is only allowed on collections, tuples, and user-defined types");
@@ -1373,10 +1373,9 @@ public class FrozenCollectionsTest extends CQLTester
         assertEquals("MapType(ListType(Int32Type),Int32Type)", clean(m.toString(true)));
 
         // tuple<set<int>>
-        List<AbstractType<?>> types = new ArrayList<>();
-        types.add(SetType.getInstance(Int32Type.instance, true));
+        List<AbstractType<?>> types = Collections.singletonList(SetType.getInstance(Int32Type.instance, true));
         TupleType tuple = new TupleType(types);
-        assertEquals("TupleType(SetType(Int32Type))", clean(tuple.toString()));
+        assertEquals("FrozenType(TupleType(SetType(Int32Type)))", clean(tuple.toString()));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/TupleTypeTest.java
@@ -55,7 +55,7 @@ public class TupleTypeTest extends CQLTester
         String[] valueTypes = {"frozen<tuple<int, text, double>>", "tuple<int, text, double>"};
         for (String valueType : valueTypes)
         {
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, t " + valueType + ")");
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, t " + valueType + ')');
 
             execute("INSERT INTO %s (k, t) VALUES (?, ?)", 0, tuple(3, "foo", 3.4));
             execute("INSERT INTO %s (k, t) VALUES (?, ?)", 1, tuple(8, "bar", 0.2));
@@ -136,7 +136,7 @@ public class TupleTypeTest extends CQLTester
             row(0, 4, tuple(null, "1"))
         );
 
-        assertInvalidMessage("Invalid tuple literal: too many elements. Type frozen<tuple<int, text>> expects 2 but got 3",
+        assertInvalidMessage("Invalid tuple literal: too many elements. Type tuple<int, text> expects 2 but got 3",
                              "INSERT INTO %s(k, t) VALUES (1,'1:2:3')");
     }
 
@@ -147,7 +147,7 @@ public class TupleTypeTest extends CQLTester
 
         assertInvalidSyntax("INSERT INTO %s (k, t) VALUES (0, ())");
 
-        assertInvalidMessage("Invalid tuple literal for t: too many elements. Type frozen<tuple<int, text, double>> expects 3 but got 4",
+        assertInvalidMessage("Invalid tuple literal for t: too many elements. Type tuple<int, text, double> expects 3 but got 4",
                              "INSERT INTO %s (k, t) VALUES (0, (2, 'foo', 3.1, 'bar'))");
 
         createTable("CREATE TABLE %s (k int PRIMARY KEY, t frozen<tuple<int, tuple<int, text, double>>>)");
@@ -155,7 +155,7 @@ public class TupleTypeTest extends CQLTester
                              "INSERT INTO %s (k, t) VALUES (0, ?)",
                              tuple(1, tuple(1, "1", 1.0, 1)));
 
-        assertInvalidMessage("Invalid tuple literal for t: component 1 is not of type frozen<tuple<int, text, double>>",
+        assertInvalidMessage("Invalid tuple literal for t: component 1 is not of type tuple<int, text, double>",
                              "INSERT INTO %s (k, t) VALUES (0, (1, (1, '1', 1.0, 1)))");
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -122,13 +122,13 @@ public class CreateTest extends CQLTester
     @Test
     public void testCreateTableWithDurationColumns() throws Throwable
     {
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'a'",
+        assertInvalidMessage("Invalid type duration for column a: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a duration PRIMARY KEY, b int);");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'b'",
+        assertInvalidMessage("Invalid type duration for column b: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a text, b duration, c duration, primary key (a, b));");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'b'",
+        assertInvalidMessage("Invalid type duration for column b: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0 (a text, b duration, c duration, primary key (a, b)) with clustering order by (b DESC);");
 
         createTable("CREATE TABLE %s (a int, b int, c duration, primary key (a, b));");
@@ -208,7 +208,7 @@ public class CreateTest extends CQLTester
         createTable("CREATE TABLE %s (a text PRIMARY KEY, duration duration);");
 
         // Test duration within Map
-        assertInvalidMessage("Durations are not allowed as map keys: map<duration, text>",
+        assertInvalidMessage("Invalid type map<duration, text> for column m: duration types are not supported within non-frozen map keys",
                              "CREATE TABLE cql_test_keyspace.table0(pk int PRIMARY KEY, m map<duration, text>)");
 
         createTable("CREATE TABLE %s(pk int PRIMARY KEY, m map<text, duration>)");
@@ -216,17 +216,17 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, map("one month", Duration.from("1mo"), "60 days", Duration.from("60d"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
-                "CREATE TABLE cql_test_keyspace.table0(m frozen<map<text, duration>> PRIMARY KEY, v int)");
+        assertInvalidMessage("Invalid type frozen<map<text, duration>> for column m: duration types are not supported within PRIMARY KEY columns",
+                             "CREATE TABLE cql_test_keyspace.table0(m frozen<map<text, duration>> PRIMARY KEY, v int)");
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
+        assertInvalidMessage("Invalid type frozen<map<text, duration>> for column m: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, duration>>, v int, PRIMARY KEY (pk, m))");
 
         // Test duration within Set
-        assertInvalidMessage("Durations are not allowed inside sets: set<duration>",
+        assertInvalidMessage("Invalid type set<duration> for column s: duration types are not supported within non-frozen",
                              "CREATE TABLE cql_test_keyspace.table0(pk int PRIMARY KEY, s set<duration>)");
 
-        assertInvalidMessage("Durations are not allowed inside sets: frozen<set<duration>>",
+        assertInvalidMessage("Invalid type frozen<set<duration>> for column s: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(s frozen<set<duration>> PRIMARY KEY, v int)");
 
         // Test duration within List
@@ -235,7 +235,7 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, list(Duration.from("1mo"), Duration.from("60d"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'l'",
+        assertInvalidMessage("Invalid type frozen<list<duration>> for column l: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(l frozen<list<duration>> PRIMARY KEY, v int)");
 
         // Test duration within Tuple
@@ -244,23 +244,23 @@ public class CreateTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"),
                    row(1, tuple(1, Duration.from("1mo"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 't'",
+        assertInvalidMessage("Invalid type tuple<int, duration> for column t: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(t frozen<tuple<int, duration>> PRIMARY KEY, v int)");
 
         // Test duration within UDT
         String typename = createType("CREATE TYPE %s (a duration)");
         String myType = KEYSPACE + '.' + typename;
-        createTable("CREATE TABLE %s(pk int PRIMARY KEY, u " + myType + ")");
+        createTable("CREATE TABLE %s(pk int PRIMARY KEY, u " + myType + ')');
         execute("INSERT INTO %s (pk, u) VALUES (1, {a : 1mo})");
         assertRows(execute("SELECT * FROM %s"),
                    row(1, userType("a", Duration.from("1mo"))));
 
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'u'",
+        assertInvalidMessage("Invalid type frozen<" + typename + "> for column u: duration types are not supported within PRIMARY KEY columns",
                              "CREATE TABLE cql_test_keyspace.table0(pk int, u frozen<" + myType + ">, v int, PRIMARY KEY(pk, u))");
 
         // Test duration with several level of depth
-        assertInvalidMessage("duration type is not supported for PRIMARY KEY column 'm'",
-                "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, list<tuple<int, duration>>>>, v int, PRIMARY KEY (pk, m))");
+        assertInvalidMessage("Invalid type frozen<map<text, list<tuple<int, duration>>>> for column m: duration types are not supported within PRIMARY KEY columns",
+                             "CREATE TABLE cql_test_keyspace.table0(pk int, m frozen<map<text, list<tuple<int, duration>>>>, v int, PRIMARY KEY (pk, m))");
     }
 
     private ByteBuffer duration(long months, long days, long nanoseconds) throws IOException

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -116,7 +116,7 @@ public class NativeCellTest
         return new ColumnMetadata("",
                                   "",
                                   ColumnIdentifier.getInterned(uuid.toString(), false),
-                                    isComplex ? new SetType<>(BytesType.instance, true) : BytesType.instance,
+                                    isComplex ? SetType.getInstance(BytesType.instance, true) : BytesType.instance,
                                   -1,
                                   ColumnMetadata.Kind.REGULAR);
     }

--- a/test/unit/org/apache/cassandra/db/ReadObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadObserverTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.repair.consistent.LocalSessionAccessor;
+import org.apache.cassandra.schema.CachingParams;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Pair;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ReadObserverTest
+{
+    public static class TestReadObserverFactory implements ReadObserverFactory
+    {
+        static List<Pair<TableMetadata, ReadObserver>> issuedObservers = new CopyOnWriteArrayList<>();
+
+        @Override
+        public ReadObserver create(TableMetadata table)
+        {
+            ReadObserver observer = mock(ReadObserver.class);
+            issuedObservers.add(Pair.create(table, observer));
+            return observer;
+        }
+    }
+
+    private static final String CF = "Standard";
+    private static final String KEYSPACE = "ReadObserverTest";
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        CassandraRelevantProperties.CUSTOM_READ_OBSERVER_FACTORY.setString(TestReadObserverFactory.class.getName());
+
+        DatabaseDescriptor.daemonInitialization();
+
+        TableMetadata.Builder metadata =
+        TableMetadata.builder(KEYSPACE, CF)
+                     .addPartitionKeyColumn("key", BytesType.instance)
+                     .addStaticColumn("s", AsciiType.instance)
+                     .addClusteringColumn("col", AsciiType.instance)
+                     .addRegularColumn("a", AsciiType.instance)
+                     .addRegularColumn("b", AsciiType.instance)
+                     .caching(CachingParams.CACHE_EVERYTHING);
+
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE,
+                                    KeyspaceParams.simple(1),
+                                    metadata);
+
+        LocalSessionAccessor.startup();
+    }
+
+    @Test
+    public void testObserverCallbacks()
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(CF);
+
+        new RowUpdateBuilder(cfs.metadata(), 0, ByteBufferUtil.bytes("key"))
+        .clustering("cc")
+        .add("a", ByteBufferUtil.bytes("regular"))
+        .build()
+        .apply();
+
+        new RowUpdateBuilder(cfs.metadata(), 0, ByteBufferUtil.bytes("key"))
+        .add("s", ByteBufferUtil.bytes("static"))
+        .build()
+        .apply();
+
+        ReadCommand readCommand = Util.cmd(cfs, Util.dk("key")).build();
+        assertFalse(Util.getAll(readCommand).isEmpty());
+
+        List<Pair<TableMetadata, ReadObserver>> observers = TestReadObserverFactory.issuedObservers.stream()
+                                                                                                   .filter(p -> p.left.name.equals(CF))
+                                                                                                   .collect(Collectors.toList());
+        assertEquals(1, observers.size());
+        ReadObserver observer = observers.get(0).right;
+
+        verify(observer).onPartition(eq(Util.dk("key")), eq(DeletionTime.LIVE));
+        verify(observer).onUnfiltered(argThat(Unfiltered::isRow));
+        verify(observer).onStaticRow(argThat(row -> row.columns().stream().allMatch(col -> col.name.toCQLString().equals("s"))));
+        verify(observer).onComplete();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogDescriptorTest.java
@@ -310,4 +310,11 @@ public class CommitLogDescriptorTest
         CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, enabledEncryption);
         Assert.assertEquals(desc1, desc2);
     }
+
+    @Test
+    public void testDSE68MessagingVersion()
+    {
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(680, 1, null, null);
+        Assert.assertEquals(MessagingService.VERSION_DSE_68, descriptor.getMessagingVersion());
+    }
 }

--- a/test/unit/org/apache/cassandra/db/commitlog/MemoryMappedSegmentTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/MemoryMappedSegmentTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.io.util.File;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class MemoryMappedSegmentTest
+{
+    @BeforeClass
+    public static void beforeClass() throws Exception
+    {
+        SchemaLoader.prepareServer();
+    }
+
+    @Test
+    public void shouldNotSkipFileAdviseToFreeSystemCache()
+    {
+        //given
+        MemoryMappedSegment.skipFileAdviseToFreePageCache = false;
+        MemoryMappedSegment memoryMappedSegment = memoryMappedSegment();
+        int startMarker = 0;
+        int nextMarker = 1024;
+
+        //when
+        memoryMappedSegment.flush(startMarker, nextMarker);
+
+        //then
+        verify(memoryMappedSegment)
+                .adviceOnFileToFreePageCache(eq(memoryMappedSegment.fd), eq(startMarker), eq(nextMarker), eq(memoryMappedSegment.logFile));
+    }
+
+    @Test
+    public void shouldSkipFileAdviseToFreeSystemCache()
+    {
+        //given
+        MemoryMappedSegment.skipFileAdviseToFreePageCache = true;
+        MemoryMappedSegment memoryMappedSegment = memoryMappedSegment();
+
+        //when
+        memoryMappedSegment.flush(0, 1024);
+
+        //then
+        verify(memoryMappedSegment, never())
+                .adviceOnFileToFreePageCache(anyInt(), anyInt(), anyInt(), any(File.class));
+    }
+
+    private MemoryMappedSegment memoryMappedSegment()
+    {
+        return Mockito.spy(new MemoryMappedSegment(CommitLog.instance, CommitLog.instance.getSegmentManager()));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
@@ -309,7 +309,7 @@ public class CQLUnifiedCompactionTest extends CQLTester
 
         createTable("create table %s (id int primary key, val blob) with compression = { 'enabled' : false } AND " +
                     "compaction = {'class':'UnifiedCompactionStrategy', 'adaptive' : 'false', " +
-                    String.format("'scaling_parameters' : '%s', 'min_sstable_size_in_mb' : '1', 'base_shard_count': '%d', 'log_all' : 'true'}",
+                    String.format("'scaling_parameters' : '%s', 'min_sstable_size' : '0B', 'base_shard_count': '%d', 'log_all' : 'true'}",
                                   scalingParamsStr, numShards));
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -149,8 +149,8 @@ public abstract class ControllerTest
         assertNull(controller.getCalculator());
         if (!options.containsKey(Controller.NUM_SHARDS_OPTION))
         {
-            assertEquals(2, controller.getNumShards(0));
-            assertEquals(16, controller.getNumShards(16 * 100 << 20));
+            assertEquals(1, controller.getNumShards(0));
+            assertEquals(4, controller.getNumShards(16 * 100 << 20));
             assertEquals(Overlaps.InclusionMethod.SINGLE, controller.overlapInclusionMethod());
         }
         else
@@ -197,8 +197,8 @@ public abstract class ControllerTest
 
         if (!options.containsKey(Controller.NUM_SHARDS_OPTION))
         {
-            options.putIfAbsent(Controller.BASE_SHARD_COUNT_OPTION, Integer.toString(2));
-            options.putIfAbsent(Controller.TARGET_SSTABLE_SIZE_OPTION, FBUtilities.prettyPrintMemory(100 << 20));
+            options.putIfAbsent(Controller.BASE_SHARD_COUNT_OPTION, Integer.toString(4));
+            options.putIfAbsent(Controller.TARGET_SSTABLE_SIZE_OPTION, FBUtilities.prettyPrintMemory(1 << 30));
         }
         options.putIfAbsent(Controller.OVERLAP_INCLUSION_METHOD_OPTION, Overlaps.InclusionMethod.SINGLE.toString().toLowerCase());
     }
@@ -306,6 +306,7 @@ public abstract class ControllerTest
         options.put(Controller.BASE_SHARD_COUNT_OPTION, Integer.toString(3));
         options.put(Controller.TARGET_SSTABLE_SIZE_OPTION, "100MiB");
         options.put(Controller.MIN_SSTABLE_SIZE_OPTION, "10MiB");
+        options.put(Controller.SSTABLE_GROWTH_OPTION, "0");
         Controller controller = Controller.fromOptions(cfs, options);
         assertEquals(0.0, controller.sstableGrowthModifier, 0.0);
 
@@ -325,8 +326,8 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(50, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(30, 20)));
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(29, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(20, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(29, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(20, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(19, 20)));
         assertEquals(1, controller.getNumShards(5));
         assertEquals(1, controller.getNumShards(0));
@@ -335,7 +336,7 @@ public abstract class ControllerTest
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Math.scalb(10, 60)));
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Double.POSITIVE_INFINITY));
         // Check NaN
-        assertEquals(3, controller.getNumShards(Double.NaN));
+        assertEquals(1, controller.getNumShards(Double.NaN));
     }
 
     @Test
@@ -364,8 +365,8 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(50, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(30, 20)));
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(29, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(20, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(29, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(20, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(19, 20)));
         assertEquals(1, controller.getNumShards(5));
         assertEquals(1, controller.getNumShards(0));
@@ -374,7 +375,7 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(10, 60)));
         assertEquals(3, controller.getNumShards(Double.POSITIVE_INFINITY));
         // Check NaN
-        assertEquals(3, controller.getNumShards(Double.NaN));
+        assertEquals(1, controller.getNumShards(Double.NaN));
     }
 
     @Test
@@ -401,8 +402,8 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(400, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(300, 20)));
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(290, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(200, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(290, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(200, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(190, 20)));
         assertEquals(1, controller.getNumShards(5));
         assertEquals(1, controller.getNumShards(0));
@@ -411,7 +412,7 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(10, 60)));
         assertEquals(3, controller.getNumShards(Double.POSITIVE_INFINITY));
         // Check NaN
-        assertEquals(3, controller.getNumShards(Double.NaN));
+        assertEquals(1, controller.getNumShards(Double.NaN));
 
         assertEquals(Integer.MAX_VALUE, controller.getReservedThreads());
     }
@@ -425,8 +426,8 @@ public abstract class ControllerTest
         Controller controller = Controller.fromOptions(cfs, options);
 
         // The number of shards grows with local density, the controller works as if number of shards was not defined
-        assertEquals(4, controller.getNumShards(Math.scalb(200, 20)));
-        assertEquals(8, controller.getNumShards(Math.scalb(200, 25)));
+        assertEquals(2, controller.getNumShards(Math.scalb(200, 20)));
+        assertEquals(4, controller.getNumShards(Math.scalb(200, 25)));
     }
 
     @Test
@@ -440,6 +441,7 @@ public abstract class ControllerTest
         options = new HashMap<>();
         options.put(Controller.NUM_SHARDS_OPTION, Integer.toString(-1));
         options.put(Controller.TARGET_SSTABLE_SIZE_OPTION, "128MB");
+        options.put(Controller.MIN_SSTABLE_SIZE_OPTION, "0B");
         validatedOptions = Controller.validateOptions(options);
         assertTrue("-1 num of shards should be acceptable with V2 params: " + validatedOptions, validatedOptions.isEmpty());
 
@@ -476,8 +478,8 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(50, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(30, 20)));
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(29, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(20, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(29, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(20, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(19, 20)));
         assertEquals(1, controller.getNumShards(5));
         assertEquals(1, controller.getNumShards(0));
@@ -486,7 +488,7 @@ public abstract class ControllerTest
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Math.scalb(10, 80)));
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Double.POSITIVE_INFINITY));
         // Check NaN
-        assertEquals(3, controller.getNumShards(Double.NaN));
+        assertEquals(1, controller.getNumShards(Double.NaN));
     }
 
     @Test
@@ -515,8 +517,8 @@ public abstract class ControllerTest
         assertEquals(3, controller.getNumShards(Math.scalb(50, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(30, 20)));
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(29, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(20, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(29, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(20, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(19, 20)));
         assertEquals(1, controller.getNumShards(5));
         assertEquals(1, controller.getNumShards(0));
@@ -524,7 +526,7 @@ public abstract class ControllerTest
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Math.scalb(600, 50)));
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Math.scalb(10, 60)));
         assertEquals(3 * (int) Controller.MAX_SHARD_SPLIT, controller.getNumShards(Double.POSITIVE_INFINITY));
-        assertEquals(3, controller.getNumShards(Double.NaN));
+        assertEquals(1, controller.getNumShards(Double.NaN));
     }
 
     @Test
@@ -538,8 +540,8 @@ public abstract class ControllerTest
         Controller controller = Controller.fromOptions(cfs, options);
 
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(149, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(100, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(149, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(100, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(99, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(50, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(49, 20)));
@@ -547,7 +549,7 @@ public abstract class ControllerTest
 
         // sanity check
         assertEquals(3, controller.getNumShards(Math.scalb(600, 20)));
-        assertEquals(12, controller.getNumShards(Math.scalb(2400, 20)));
+        assertEquals(6, controller.getNumShards(Math.scalb(2400, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(400, 20)));
         assertEquals(3, controller.getNumShards(Math.scalb(200, 20)));
     }
@@ -572,13 +574,13 @@ public abstract class ControllerTest
         Controller controller = Controller.fromOptions(cfs, options);
 
         // Check min size
-        assertEquals(2, controller.getNumShards(Math.scalb(400, 20)));
-        assertEquals(2, controller.getNumShards(Math.scalb(300, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(400, 20)));
+        assertEquals(1, controller.getNumShards(Math.scalb(300, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(200, 20)));
         assertEquals(1, controller.getNumShards(Math.scalb(100, 20)));
         // sanity check
         assertEquals(3, controller.getNumShards(Math.scalb(600, 20)));
-        assertEquals(12, controller.getNumShards(Math.scalb(2400, 20)));
+        assertEquals(6, controller.getNumShards(Math.scalb(2400, 20)));
     }
 
     void testValidateCompactionStrategyOptions(boolean testLogType)

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ShardedMultiWriterTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ShardedMultiWriterTest.java
@@ -76,7 +76,7 @@ public class ShardedMultiWriterTest extends CQLTester
     private void testShardedCompactionWriter(int numShards, long totSizeBytes, int numOutputSSTables) throws Throwable
     {
         createTable(String.format("CREATE TABLE %%s (k int, t int, v blob, PRIMARY KEY (k, t)) with compaction = " +
-                                  "{'class':'UnifiedCompactionStrategy', 'base_shard_count' : '%d'} ", numShards));
+                                  "{'class':'UnifiedCompactionStrategy', 'base_shard_count' : '%d', 'min_sstable_size' : '0B'} ", numShards));
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         cfs.disableAutoCompaction();

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -353,7 +353,7 @@ public class StaticControllerTest extends ControllerTest
         {
             keyspaceName = SchemaConstants.SYSTEM_KEYSPACE_NAME;
             controller = controller.fromOptions(cfs, options);
-            assertEquals(1, controller.baseShardCount);
+            assertEquals(4, controller.baseShardCount);
         }
         finally
         {
@@ -362,7 +362,7 @@ public class StaticControllerTest extends ControllerTest
 
         numDirectories = 3;
         controller = controller.fromOptions(cfs, options);
-        assertEquals(1, controller.baseShardCount);
+        assertEquals(4, controller.baseShardCount);
 
         numDirectories = 1;
         controller = controller.fromOptions(cfs, options);

--- a/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.lifecycle;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -162,9 +163,11 @@ public class TrackerTest
         tracker.addInitialSSTables(copyOf(readers));
 
         Assert.assertEquals(3, tracker.view.get().sstables.size());
-        Assert.assertEquals(1, listener.senders.size());
-        Assert.assertEquals(1, listener.received.size());
-        Assert.assertTrue(listener.received.get(0) instanceof InitialSSTableAddedNotification);
+        Assert.assertEquals(2, listener.senders.size()); // one sender sent two notifications
+        Assert.assertEquals(listener.senders.get(0), listener.senders.get(1));
+        Assert.assertEquals(2, listener.received.size());
+        Assert.assertTrue(listener.received.get(0) instanceof SSTableAddingNotification);
+        Assert.assertTrue(listener.received.get(1) instanceof InitialSSTableAddedNotification);
 
         for (SSTableReader reader : readers)
             Assert.assertTrue(reader.isKeyCacheEnabled());
@@ -192,10 +195,12 @@ public class TrackerTest
             Assert.assertTrue(reader.isKeyCacheEnabled());
 
         Assert.assertEquals(17 + 121 + 9, cfs.metric.liveDiskSpaceUsed.getCount());
-        Assert.assertEquals(1, listener.senders.size());
-        Assert.assertEquals(1, listener.received.size());
+        Assert.assertEquals(2, listener.senders.size()); // one tracker issued two notifications
+        Assert.assertEquals(2, listener.received.size()); // 'adding' and 'added' notifications
         Assert.assertEquals(tracker, listener.senders.get(0));
-        Assert.assertTrue(listener.received.get(0) instanceof SSTableAddedNotification);
+        Assert.assertEquals(tracker, listener.senders.get(1));
+        Assert.assertTrue(listener.received.get(0) instanceof SSTableAddingNotification);
+        Assert.assertTrue(listener.received.get(1) instanceof SSTableAddedNotification);
         DatabaseDescriptor.setIncrementalBackupsEnabled(backups);
     }
 
@@ -249,16 +254,17 @@ public class TrackerTest
             Assert.assertNull(tracker.dropSSTables(reader -> reader != readers.get(0), OperationType.UNKNOWN, null));
 
             Assert.assertEquals(1, tracker.getView().sstables.size());
-            Assert.assertEquals(4, listener.received.size());
+            Assert.assertEquals(5, listener.received.size());
             Assert.assertEquals(tracker, listener.senders.get(0));
-            Assert.assertTrue(listener.received.get(0) instanceof InitialSSTableAddedNotification);
-            Assert.assertTrue(listener.received.get(1) instanceof SSTableDeletingNotification);
-            Assert.assertTrue(listener.received.get(2) instanceof  SSTableDeletingNotification);
-            Assert.assertTrue(listener.received.get(3) instanceof SSTableListChangedNotification);
-            Assert.assertEquals(readers.get(1), ((SSTableDeletingNotification) listener.received.get(1)).deleting);
-            Assert.assertEquals(readers.get(2), ((SSTableDeletingNotification)listener.received.get(2)).deleting);
-            Assert.assertEquals(2, ((SSTableListChangedNotification) listener.received.get(3)).removed.size());
-            Assert.assertEquals(0, ((SSTableListChangedNotification) listener.received.get(3)).added.size());
+            Assert.assertTrue(listener.received.get(0) instanceof SSTableAddingNotification);
+            Assert.assertTrue(listener.received.get(1) instanceof InitialSSTableAddedNotification);
+            Assert.assertTrue(listener.received.get(2) instanceof SSTableDeletingNotification);
+            Assert.assertTrue(listener.received.get(3) instanceof  SSTableDeletingNotification);
+            Assert.assertTrue(listener.received.get(4) instanceof SSTableListChangedNotification);
+            Assert.assertEquals(readers.get(1), ((SSTableDeletingNotification) listener.received.get(2)).deleting);
+            Assert.assertEquals(readers.get(2), ((SSTableDeletingNotification)listener.received.get(3)).deleting);
+            Assert.assertEquals(2, ((SSTableListChangedNotification) listener.received.get(4)).removed.size());
+            Assert.assertEquals(0, ((SSTableListChangedNotification) listener.received.get(4)).added.size());
             Assert.assertEquals(9, cfs.metric.liveDiskSpaceUsed.getCount());
             readers.get(0).selfRef().release();
         }
@@ -374,10 +380,10 @@ public class TrackerTest
         SSTableReader reader = MockSchema.sstable(0, 10, false, cfs);
         tracker.replaceFlushed(prev2, singleton(reader), Optional.empty());
         Assert.assertEquals(1, tracker.getView().sstables.size());
-        Assert.assertEquals(2, listener.received.size());
-        Assert.assertEquals(prev2, ((MemtableDiscardedNotification) listener.received.get(0)).memtable);
-        Assert.assertEquals(singleton(reader), ((SSTableAddedNotification) listener.received.get(1)).added);
-        Assert.assertEquals(Optional.of(prev2), ((SSTableAddedNotification) listener.received.get(1)).memtable());
+        Assert.assertEquals(3, listener.received.size());
+        Assert.assertEquals(prev2, ((MemtableDiscardedNotification) listener.received.get(1)).memtable);
+        Assert.assertEquals(singleton(reader), ((SSTableAddedNotification) listener.received.get(2)).added);
+        Assert.assertEquals(Optional.of(prev2), ((SSTableAddedNotification) listener.received.get(2)).memtable());
         listener.received.clear();
         Assert.assertTrue(reader.isKeyCacheEnabled());
         Assert.assertEquals(10, cfs.metric.liveDiskSpaceUsed.getCount());
@@ -395,13 +401,13 @@ public class TrackerTest
         Assert.assertEquals(0, tracker.getView().sstables.size());
         Assert.assertEquals(0, tracker.getView().flushingMemtables.size());
         Assert.assertEquals(0, cfs.metric.liveDiskSpaceUsed.getCount());
-        Assert.assertEquals(5, listener.received.size());
+        Assert.assertEquals(6, listener.received.size());
         Assert.assertEquals(prev1, ((MemtableSwitchedNotification) listener.received.get(0)).memtable);
-        Assert.assertEquals(prev1, ((MemtableDiscardedNotification) listener.received.get(1)).memtable);
-        Assert.assertEquals(singleton(reader), ((SSTableAddedNotification) listener.received.get(2)).added);
-        Assert.assertEquals(Optional.of(prev1), ((SSTableAddedNotification) listener.received.get(2)).memtable());
-        Assert.assertTrue(listener.received.get(3) instanceof SSTableDeletingNotification);
-        Assert.assertEquals(1, ((SSTableListChangedNotification) listener.received.get(4)).removed.size());
+        Assert.assertEquals(prev1, ((MemtableDiscardedNotification) listener.received.get(2)).memtable);
+        Assert.assertEquals(singleton(reader), ((SSTableAddedNotification) listener.received.get(3)).added);
+        Assert.assertEquals(Optional.of(prev1), ((SSTableAddedNotification) listener.received.get(3)).memtable());
+        Assert.assertTrue(listener.received.get(4) instanceof SSTableDeletingNotification);
+        Assert.assertEquals(1, ((SSTableListChangedNotification) listener.received.get(5)).removed.size());
         DatabaseDescriptor.setIncrementalBackupsEnabled(backups);
     }
 

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -133,6 +134,6 @@ public class CompositeAndTupleTypesTest
     @Test
     public void composite()
     {
-        testSerializationDeserialization(CompositeType::new, CompositeType::build);
+        testSerializationDeserialization(types -> new CompositeType(ImmutableList.copyOf(types)), CompositeType::build);
     }
 }

--- a/test/unit/org/apache/cassandra/db/marshal/ReversedTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ReversedTypeTest.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.db.marshal;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQL3Type;
+import org.assertj.core.api.Assertions;
+
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
 
@@ -28,7 +31,7 @@ public class ReversedTypeTest
     @Test
     public void testReverseComparison()
     {
-        ReversedType<Long> t = ReversedType.getInstance(LongType.instance);
+        AbstractType<Long> t = ReversedType.getInstance(LongType.instance);
 
         assert t.compare(bytes(2L), bytes(4L)) > 0;
         assert t.compare(bytes(4L), bytes(2L)) < 0;
@@ -36,5 +39,18 @@ public class ReversedTypeTest
         // the empty byte buffer is always the smaller
         assert t.compare(EMPTY_BYTE_BUFFER, bytes(2L)) > 0;
         assert t.compare(bytes(2L), EMPTY_BYTE_BUFFER) < 0;
+    }
+
+    @Test
+    public void testReverseOfReversed()
+    {
+        for (CQL3Type.Native cql3Type : CQL3Type.Native.values())
+        {
+            AbstractType<?> type = cql3Type.getType();
+            AbstractType<?> reversed = ReversedType.getInstance(type);
+            Assertions.assertThat(type)
+                      .isNotEqualTo(reversed)
+                      .isEqualTo(ReversedType.getInstance(reversed));
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionBytemanTest.java
@@ -20,26 +20,46 @@ package org.apache.cassandra.db.repair;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.streaming.PreviewKind;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.UUIDGen;
+import org.assertj.core.api.Assertions;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 
+import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -96,5 +116,59 @@ public class PendingAntiCompactionBytemanTest extends AbstractPendingAntiCompact
             builder.add(new Replica(local, range, false));
 
         return builder.build();
+    }
+
+    @BMRules(rules = { @BMRule(name = "Abort anti-compaction after first call to onOperationStart",
+            targetClass = "CompactionManager",
+            targetMethod = "antiCompactGroup",
+            condition = "not flagged(\"done\")",
+            targetLocation = "AFTER INVOKE compactionRateLimiterAcquire",
+            action = "org.apache.cassandra.db.compaction.CompactionManager.instance.stopCompaction(\"ANTICOMPACTION\");") } )
+    @Test
+    public void testStopAntiCompaction()
+    {
+        Assert.assertSame(ByteOrderedPartitioner.class, DatabaseDescriptor.getPartitioner().getClass());
+        cfs.disableAutoCompaction();
+
+        // create 2 sstables, one that will be split, and another that will be moved
+        for (int i = 0; i < 10; i++)
+        {
+            QueryProcessor.executeInternal(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", ks, tbl), i, i);
+        }
+        cfs.forceBlockingFlush(UNIT_TESTS);
+        for (int i = 10; i < 20; i++)
+        {
+            QueryProcessor.executeInternal(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", ks, tbl), i, i);
+        }
+        cfs.forceBlockingFlush(UNIT_TESTS);
+
+        assertEquals(2, cfs.getLiveSSTables().size());
+        assertEquals(0, cfs.getLiveSSTables().stream().filter(SSTableReader::isPendingRepair).count());
+
+        Token left = ByteOrderedPartitioner.instance.getToken(ByteBufferUtil.bytes(5));
+        Token right = ByteOrderedPartitioner.instance.getToken(ByteBufferUtil.bytes(15));
+        List<Range<Token>> ranges = Collections.singletonList(new Range<>(left, right));
+        List<ColumnFamilyStore> tables = Collections.singletonList(cfs);
+
+        // create a repair session so the anti-compaction job can find it
+        UUID sessionID = UUIDGen.getTimeUUID();
+        ActiveRepairService.instance.registerParentRepairSession(sessionID, InetAddressAndPort.getLocalHost(), tables, ranges, true, 1, true, PreviewKind.NONE);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try
+        {
+            PendingAntiCompaction pac = new PendingAntiCompaction(sessionID, tables, atEndpoint(ranges, NO_RANGES), executor, () -> false);
+            Future<?> future = pac.run();
+            Assertions.assertThatThrownBy(future::get)
+                      .hasCauseInstanceOf(CompactionInterruptedException.class)
+                      .hasMessageContaining("Compaction interrupted");
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+
+        assertEquals(2, cfs.getLiveSSTables().size());
+        assertEquals(0, cfs.getLiveSSTables().stream().filter(SSTableReader::isPendingRepair).count());
     }
 }

--- a/test/unit/org/apache/cassandra/db/rows/BTreeRowTest.java
+++ b/test/unit/org/apache/cassandra/db/rows/BTreeRowTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.rows;
+
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.LivenessInfo;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+
+public class BTreeRowTest
+{
+    private final TableMetadata metadata = TableMetadata.builder("", "")
+                                                        .addPartitionKeyColumn("pk", Int32Type.instance)
+                                                        .addClusteringColumn("ck", Int32Type.instance)
+                                                        .addRegularColumn("v1", Int32Type.instance)
+                                                        .addRegularColumn("v2", Int32Type.instance)
+                                                        .build();
+    private final ColumnMetadata v2Metadata = metadata.regularAndStaticColumns().columns(false).getSimple(1);
+    private final ColumnMetadata v1Metadata = metadata.regularAndStaticColumns().columns(false).getSimple(0);
+
+    private BTreeRow.Builder row(int ck, Cell<?>... columns)
+    {
+        BTreeRow.Builder builder = new BTreeRow.Builder(true);
+        builder.newRow(Util.clustering(metadata.comparator, ck));
+        for (Cell<?> cell : columns)
+            builder.addCell(cell);
+        return builder;
+    }
+
+    private Cell<?> cell(ColumnMetadata metadata, int v, long timestamp)
+    {
+        return new BufferCell(metadata,
+                              timestamp,
+                              BufferCell.NO_TTL,
+                              BufferCell.NO_DELETION_TIME,
+                              ByteBufferUtil.bytes(v),
+                              null);
+    }
+
+    @Test
+    public void testRowMinTimespampFromCells()
+    {
+        int v1CellTimestamp = 1000;
+        int v2CellTimestamp = 500;
+        int primaryKeyTimestamp = 2000;
+        BTreeRow.Builder builder = row(1, cell(v1Metadata, 1, v1CellTimestamp), cell(v2Metadata, 1, v2CellTimestamp));
+        builder.addPrimaryKeyLivenessInfo(LivenessInfo.create(primaryKeyTimestamp, FBUtilities.nowInSeconds()));
+        Row row = builder.build();
+        assertEquals(v2CellTimestamp, row.minTimestamp());
+    }
+
+    @Test
+    public void testRowMinTimespampFromPrimaryKeyListener()
+    {
+        int v1CellTimestamp = 1000;
+        int v2CellTimestamp = 500;
+        int primaryKeyTimestamp = 100;
+        BTreeRow.Builder builder = row(2, cell(v1Metadata, 1, v1CellTimestamp), cell(v2Metadata, 1, v2CellTimestamp));
+        builder.addPrimaryKeyLivenessInfo(LivenessInfo.create(primaryKeyTimestamp, FBUtilities.nowInSeconds()));
+        Row row = builder.build();
+        assertEquals(primaryKeyTimestamp, row.minTimestamp());
+    }
+
+    @Test
+    public void testRowMinTimespampFromDeletion()
+    {
+        int v1CellTimestamp = 1000;
+        int v2CellTimestamp = 500;
+        int primaryKeyTimestamp = 100;
+        int localDeletionTime = 50;
+        BTreeRow.Builder builder = row(3, cell(v1Metadata, 1, v1CellTimestamp), cell(v2Metadata, 1, v2CellTimestamp));
+        builder.addPrimaryKeyLivenessInfo(LivenessInfo.create(primaryKeyTimestamp, FBUtilities.nowInSeconds()));
+        builder.addRowDeletion(new Row.Deletion(new DeletionTime(localDeletionTime, FBUtilities.nowInSeconds()), true));
+        Row row = builder.build();
+        assertEquals(primaryKeyTimestamp, row.minTimestamp());
+    }
+}

--- a/test/unit/org/apache/cassandra/dht/SplitterTest.java
+++ b/test/unit/org/apache/cassandra/dht/SplitterTest.java
@@ -301,7 +301,6 @@ public class SplitterTest
         // single range too small to be partitioned
         testSplit(partitioner, 1, newHashSet(Pair.create(1, 2)), newHashSet(Pair.create(1, 2)));
         testSplit(partitioner, 2, newHashSet(Pair.create(1, 2)), newHashSet(Pair.create(1, 2)));
-        testSplit(partitioner, 4, newHashSet(Pair.create(1, 4)), newHashSet(Pair.create(1, 4)));
         testSplit(partitioner, 8, newHashSet(Pair.create(1, 2)), newHashSet(Pair.create(1, 2)));
 
         // single wrapping range
@@ -314,7 +313,7 @@ public class SplitterTest
         testSplit(partitioner, 2,
                   newHashSet(Pair.create(max.subtract(BigInteger.valueOf(8)), min)),
                   newHashSet(Pair.create(max.subtract(BigInteger.valueOf(8)), max.subtract(BigInteger.valueOf(4))),
-                             Pair.create(max.subtract(BigInteger.valueOf(4)), isRandom ? first : max)));
+                             Pair.create(max.subtract(BigInteger.valueOf(4)), min)));
         testSplit(partitioner, 2,
                   newHashSet(Pair.create(max.subtract(BigInteger.valueOf(8)), max)),
                   newHashSet(Pair.create(max.subtract(BigInteger.valueOf(8)), max.subtract(BigInteger.valueOf(4))),

--- a/test/unit/org/apache/cassandra/guardrails/CustomUserKeyspaceFilterProviderTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/CustomUserKeyspaceFilterProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.guardrails;
+
+
+import org.junit.Test;
+
+import org.apache.cassandra.service.QueryState;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class CustomUserKeyspaceFilterProviderTest
+{
+    public static class TestUserKeyspaceFilterProvider implements UserKeyspaceFilterProvider
+    {
+        @Override
+        public UserKeyspaceFilter get(QueryState queryState)
+        {
+            return null;
+        }
+    }
+
+    @Test
+    public void testMakeWithValidClass()
+    {
+        String validClassName = "org.apache.cassandra.guardrails.CustomUserKeyspaceFilterProviderTest$TestUserKeyspaceFilterProvider";
+        UserKeyspaceFilterProvider provider = CustomUserKeyspaceFilterProvider.make(validClassName);
+        assertTrue(provider instanceof TestUserKeyspaceFilterProvider);
+    }
+
+    @Test
+    public void testMakeWithInvalidClass()
+    {
+        String invalidClassName = "com.example.NonExistingClass";
+        assertThrows(IllegalStateException.class, () -> CustomUserKeyspaceFilterProvider.make(invalidClassName));
+    }
+}

--- a/test/unit/org/apache/cassandra/hints/HintsEndpointProviderTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsEndpointProviderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.hints;
+
+import java.util.Optional;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HintsEndpointProviderTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        SchemaLoader.prepareServer();
+    }
+
+    @Test
+    public void testVersionForUnknownEndpoint()
+    {
+        HintsEndpointProvider.DefaultHintsEndpointProvider provider = new HintsEndpointProvider.DefaultHintsEndpointProvider();
+
+        Optional<Integer> version = provider.versionForEndpoint(FBUtilities.getBroadcastAddressAndPort());
+
+        assertFalse("Version should not be present for unknown endpoint", version.isPresent());
+    }
+
+    @Test
+    public void testVersionForKnownEndpoint()
+    {
+        InetAddressAndPort knownEndpointAddress = FBUtilities.getBroadcastAddressAndPort().withPort(9999);
+        int version = 333;
+        MessagingService.instance().versions.set(knownEndpointAddress, version);
+
+        HintsEndpointProvider.DefaultHintsEndpointProvider provider = new HintsEndpointProvider.DefaultHintsEndpointProvider();
+        Optional<Integer> versionOption = provider.versionForEndpoint(knownEndpointAddress);
+
+        assertTrue("Version should be present for a known endpoint", versionOption.isPresent());
+        assertEquals(version, versionOption.get().intValue());
+    }
+}

--- a/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
@@ -99,6 +99,12 @@ public class HintsServiceTest
         MessagingService.instance().inboundSink.clear();
         MessagingService.instance().outboundSink.clear();
 
+        // Hint service has to know the endpoint version to be able to send the hints. Otherwise,
+        // it wouldn't be able to make a decision whether to decode (rewrap) or not.
+        MessagingService.instance().versions.set(
+            HintsEndpointProvider.instance.endpointForHost(StorageService.instance.getLocalHostUUID()),
+            MessagingService.current_version);
+
         if (!HintsService.instance.isShutDown())
         {
             HintsService.instance.shutdownBlocking();

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -91,6 +91,21 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
+    public void testIndexStatusPropagationThread() throws Throwable
+    {
+        // create index to submit index status propagation task
+        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        String indexName = createIndex("CREATE INDEX ON %s(c)");
+        waitForIndex(KEYSPACE, tableName, indexName);
+
+        Thread statusPropagationThread  = Thread.getAllStackTraces().keySet()
+                                                .stream()
+                                                .filter(t -> t.getName().contains("IndexStatusPropagationExecutor"))
+                                                .findFirst().get();
+        assertTrue(statusPropagationThread.isDaemon());
+    }
+
+    @Test
     public void rebuilOrRecoveringIndexMarksTheIndexAsBuilt() throws Throwable
     {
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");

--- a/test/unit/org/apache/cassandra/index/sai/disk/TypeUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/TypeUtilTest.java
@@ -106,8 +106,8 @@ public class TypeUtilTest extends SaiRandomizedTest
         {
             TupleType type = new TupleType(Arrays.asList(elementType.getType(), elementType.getType()), true);
             assertFalse(TypeUtil.isFrozenCollection(type));
-            assertTrue(TypeUtil.isFrozen(type));
-            assertTrue(TypeUtil.isLiteral(type));
+            assertFalse(TypeUtil.isFrozen(type));
+            assertFalse(TypeUtil.isLiteral(type));
 
             type = new TupleType(Arrays.asList(elementType.getType(), elementType.getType()), false);
             assertFalse(TypeUtil.isFrozenCollection(type));

--- a/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
@@ -1,0 +1,171 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.cassandra.index.sai.functional;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Iterables;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.exceptions.ReadFailureException;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.index.IndexBuildDecider;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SSTableContextManager;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.v1.MemtableIndexWriter;
+import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.FileUtils;
+import org.awaitility.Awaitility;
+
+import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IndexBuildDeciderTest extends SAITester
+{
+    static final Injections.Counter flushWithMemtableIndexWriterCount =
+    Injections.newCounter("flushWithMemtableIndexWriterCount")
+              .add(newInvokePoint().onClass(MemtableIndexWriter.class).onMethod("<init>"))
+              .build();
+
+    @BeforeClass
+    public static void init()
+    {
+        System.setProperty("cassandra.custom_index_build_decider", IndexBuildDeciderWithoutInitialBuild.class.getName());
+    }
+
+    @AfterClass
+    public static void teardown()
+    {
+        System.clearProperty("cassandra.custom_index_build_decider");
+    }
+
+    @Before
+    public void before() throws Throwable
+    {
+        Injections.inject(flushWithMemtableIndexWriterCount);
+    }
+
+    @After
+    public void after()
+    {
+        flushWithMemtableIndexWriterCount.reset();
+        Injections.deleteAll();
+    }
+
+    @Test
+    public void testNoInitialBuildWithSAI() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE);
+
+        // populate one sstable
+        int rowCount = 10;
+        for (int j = 0; j < rowCount / 2; j++)
+            execute("INSERT INTO %s (id1, v1) VALUES (?, ?)", String.valueOf(j), j);
+        flush();
+
+        SSTableReader initialSSTable = Iterables.getOnlyElement(getCurrentColumnFamilyStore().getLiveSSTables());
+        int initialSSTableFileCount = sstableFileCount(initialSSTable);
+
+        // populate memtable
+        for (int j = rowCount / 2; j < rowCount; j++)
+            execute("INSERT INTO %s (id1, v1) VALUES (?, ?)", String.valueOf(j), j);
+
+        // create index: it's not queryable because IndexBuildDeciderWithoutInitialBuild skipped the initial build and
+        // didn't consider the index queryable because there was already one sstable
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        Awaitility.await("Index is not queryable")
+                  .pollDelay(5, TimeUnit.SECONDS)
+                  .until(() -> !isIndexQueryable());
+        assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE v1>=0")).isInstanceOf(ReadFailureException.class);
+
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore());
+        SSTableContextManager sstableContext = group.sstableContextManager();
+
+        // given there was no index build, the initial sstable has no index files
+        assertEquals(initialSSTableFileCount, sstableFileCount(initialSSTable));
+        assertFalse(sstableContext.contains(initialSSTable));
+
+        // creating the index caused the memtable to be flushed: any existing memtables before the index is created are
+        // flushed with the SSTableIndexWriter
+        assertEquals(2, getCurrentColumnFamilyStore().getLiveSSTables().size());
+        assertEquals(0, flushWithMemtableIndexWriterCount.get());
+
+        // check the second sstable flushed at index creation is now indexed:
+        SSTableReader secondSSTable = getCurrentColumnFamilyStore().getLiveSSTables().stream().filter(s -> s != initialSSTable).findFirst().get();
+        assertEquals(initialSSTableFileCount + numericIndexFileCount(), sstableFileCount(secondSSTable));
+        assertTrue(sstableContext.contains(secondSSTable));
+
+        // SAI#canFlushFromMemtableIndex should be true
+        StorageAttachedIndex sai = (StorageAttachedIndex) group.getIndexes().iterator().next();
+        assertTrue(sai.canFlushFromMemtableIndex());
+
+        // flush another memtable: it should be flushed with MemtableIndexWriter
+        execute("INSERT INTO %s (id1, v1) VALUES (?, ?)", String.valueOf(0), 0);
+        flush();
+        assertEquals(1, flushWithMemtableIndexWriterCount.get());
+        SSTableReader thirdSStable = getCurrentColumnFamilyStore().getLiveSSTables().stream().filter(s -> s != initialSSTable && s != secondSSTable).findFirst().get();
+        assertEquals(initialSSTableFileCount + numericIndexFileCount(), sstableFileCount(thirdSStable));
+        assertTrue(sstableContext.contains(thirdSStable));
+    }
+
+    private int sstableFileCount(SSTableReader secondSSTable)
+    {
+        Path sstableDir = secondSSTable.descriptor.directory.toPath();
+        String prefix = sstableDir + "/" + secondSSTable.descriptor.filenamePart();
+        return FileUtils.listPaths(sstableDir, path -> path.toString().startsWith(prefix)).size();
+    }
+
+    private int numericIndexFileCount()
+    {
+        IndexContext context = createIndexContext("v1", Int32Type.instance);
+        return V2OnDiskFormat.instance.perIndexComponents(context).size()
+               + V2OnDiskFormat.instance.perSSTableComponents().size();
+    }
+
+    public static class IndexBuildDeciderWithoutInitialBuild implements IndexBuildDecider
+    {
+        @Override
+        public Decision onInitialBuild()
+        {
+            return Decision.NONE;
+        }
+
+        @Override
+        public boolean isIndexQueryableAfterInitialBuild(ColumnFamilyStore cfs)
+        {
+            return cfs.getLiveSSTables().isEmpty();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -189,7 +189,8 @@ public class ConnectionTest
             .withRequireClientAuth(false)
             .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA");
 
-    static final AcceptVersions legacy = new AcceptVersions(VERSION_30, VERSION_30);
+    // 30 is used for CNDB compatibility
+    static final AcceptVersions legacy = new AcceptVersions(VERSION_3014, VERSION_3014);
 
     static final List<Function<Settings, Settings>> MODIFIERS = ImmutableList.of(
         settings -> settings.outbound(outbound -> outbound.withAcceptVersions(legacy))
@@ -546,7 +547,7 @@ public class ConnectionTest
     public void testPre40() throws Throwable
     {
         MessagingService.instance().versions.set(FBUtilities.getBroadcastAddressAndPort(),
-                                                 MessagingService.VERSION_30);
+                                                 MessagingService.VERSION_3014);
 
         try
         {

--- a/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
@@ -105,7 +105,7 @@ public class MessageSerializationPropertyTest implements Serializable
                         FixedMonotonicClock.setNowInNanos(message.createdAtNanos());
 
                         serializer.serialize(message, first, version.value);
-                        Message<Object> read = serializer.deserialize(new DataInputBuffer(first.buffer(), true), FBUtilities.getBroadcastAddressAndPort(), version.value);
+                        Message<Object> read = serializer.deserialize(new DataInputBuffer(first.buffer(), true), message.from(), version.value);
                         serializer.serialize(read, second, version.value);
                         // using hex as byte buffer equality kept failing, and was harder to debug difference
                         // using hex means the specific section of the string that is different will be shown

--- a/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
@@ -254,7 +254,7 @@ public class SchemaKeyspaceTest
                                                                 UnfilteredRowIterators.filter(serializedCD.unfilteredIterator(), FBUtilities.nowInSeconds()));
         Set<ColumnMetadata> columns = new HashSet<>();
         for (UntypedResultSet.Row row : columnsRows)
-            columns.add(SchemaKeyspace.createColumnFromRow(row, Types.none()));
+            columns.add(SchemaKeyspace.createColumnFromRow(row, Types.none(), metadata.isCounter()));
 
         assertEquals(metadata.params, params);
         assertEquals(new HashSet<>(metadata.columns()), columns);

--- a/test/unit/org/apache/cassandra/schema/SchemaStatementWarningsTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaStatementWarningsTest.java
@@ -52,7 +52,7 @@ public class SchemaStatementWarningsTest extends CQLTester
     @BMRules(rules = { @BMRule(name = "client warning 1",
                                targetClass = "CreateKeyspaceStatement",
                                targetMethod = "apply",
-                               targetLocation = "AT INVOKE KeyspaceParams.validate",
+                               targetLocation = "AT INVOKE KeyspaceMetadata.validate",
                                action = "org.apache.cassandra.schema.SchemaStatementWarningsTest.addWarn()"),
                        @BMRule(name = "client warning 2",
                                targetClass = "CreateKeyspaceStatement",

--- a/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
+++ b/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
@@ -113,7 +113,7 @@ public class TupleTypesRepresentationTest
                                        .prepare(keyspace, types);
             type = cqlType.getType();
 
-            droppedCqlType = CQLFragmentParser.parseAny(CqlParser::comparatorType, droppedCqlTypeString, "dropped type")
+            droppedCqlType = CQLFragmentParser.parseAny(CqlParser::comparatorTypeWithMultiCellTuple, droppedCqlTypeString, "dropped type")
                                               .prepare(keyspace, types);
             // NOTE: TupleType is *always* parsed as frozen, but never toString()'d with the surrounding FrozenType
             droppedType = droppedCqlType.getType();
@@ -148,13 +148,12 @@ public class TupleTypesRepresentationTest
             false,
             "('foo','bar')");
 
-    // Currently, dropped non-frozen-UDT columns are recorded as frozen<tuple<...>>, which is technically wrong
-    //private static final TypeDef mc_udt = new TypeDef(
-    //        "org.apache.cassandra.db.marshal.UserType(ks,6d635f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)",
-    //        "mc_udt",
-    //        "tuple<text, text>",
-    //        true,
-    //        "{a:'foo',b:'bar'}");
+    private static final TypeDef mc_udt = new TypeDef(
+            "org.apache.cassandra.db.marshal.UserType(ks,6d635f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)",
+            "mc_udt",
+            "tuple<text, text>",
+            true,
+            "{a:'foo',b:'bar'}");
 
     private static final TypeDef frozen_f_udt_ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,665f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type))",
@@ -292,6 +291,7 @@ public class TupleTypesRepresentationTest
     private static final TypeDef[] allTypes = {
             text,
             tuple_text__text_,
+            mc_udt,
             frozen_f_udt_,
             list_text_,
             frozen_list_text__,

--- a/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
+++ b/test/unit/org/apache/cassandra/schema/TupleTypesRepresentationTest.java
@@ -40,9 +40,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies that the string representations of {@link AbstractType} and {@link CQL3Type} are as expected and compatible.
- *
+ * </p>
  * C* 3.0 is known to <em>not</em> enclose a frozen UDT in a "frozen bracket" in the {@link AbstractType}.
- * The string representation of a frozuen UDT using the {@link CQL3Type} type hierarchy is correct in C* 3.0.
+ * The string representation of a frozen UDT using the {@link CQL3Type} type hierarchy is correct in C* 3.0.
  */
 public class TupleTypesRepresentationTest
 {
@@ -129,7 +129,7 @@ public class TupleTypesRepresentationTest
                    ", cqlType=" + cqlType + '\n' +
                    ", droppedType=" + droppedType + '\n' +
                    ", droppedCqlTypeString='" + droppedCqlTypeString + "'\n" +
-                   ", droppedCqlType=" + droppedCqlType + '\n' +
+                   ", droppedCqlType=" + droppedCqlType.toSchemaString() + '\n' +
                    '}';
         }
     }
@@ -142,7 +142,7 @@ public class TupleTypesRepresentationTest
             "'foobar'");
 
     private static final TypeDef tuple_text__text_ = new TypeDef(
-            "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)",
+            "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
             "tuple<text, text>",
             "frozen<tuple<text, text>>",
             false,
@@ -206,9 +206,7 @@ public class TupleTypesRepresentationTest
             "{'foo':'bar'}");
 
     private static final TypeDef list_frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "list<frozen<tuple<text, text>>>",
             "list<frozen<tuple<text, text>>>",
             true,
@@ -216,15 +214,13 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_list_tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<list<frozen<tuple<text, text>>>>",
+            "frozen<list<tuple<text, text>>>",
             "frozen<list<frozen<tuple<text, text>>>>",
             true,
             "[('foo','bar')]");
 
     private static final TypeDef set_frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "set<frozen<tuple<text, text>>>",
             "set<frozen<tuple<text, text>>>",
             true,
@@ -232,15 +228,13 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_set_tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<set<frozen<tuple<text, text>>>>",
+            "frozen<set<tuple<text, text>>>",
             "frozen<set<frozen<tuple<text, text>>>>",
             true,
             "{('foo','bar')}");
 
     private static final TypeDef map_text__frozen_tuple_text__text___ = new TypeDef(
-            // in consequence, this should be:
-            // "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))",
+            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
             "map<text, frozen<tuple<text, text>>>",
             "map<text, frozen<tuple<text, text>>>",
             true,
@@ -248,7 +242,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_map_text__tuple_text__text___ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<map<text, frozen<tuple<text, text>>>>",
+            "frozen<map<text, tuple<text, text>>>",
             "frozen<map<text, frozen<tuple<text, text>>>>",
             true,
             "{'foobar':('foo','bar')}");
@@ -262,7 +256,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_list_i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<list<frozen<i_udt>>>",
+            "frozen<list<i_udt>>",
             "frozen<list<frozen<tuple<text, text>>>>",
             true,
             "[{a:'foo',b:'bar'}]");
@@ -276,7 +270,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_set_i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<set<frozen<i_udt>>>",
+            "frozen<set<i_udt>>",
             "frozen<set<frozen<tuple<text, text>>>>",
             true,
             "{{a:'foo',b:'bar'}}");
@@ -290,7 +284,7 @@ public class TupleTypesRepresentationTest
 
     private static final TypeDef frozen_map_text__i_udt__ = new TypeDef(
             "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UserType(ks,695f756474,61:org.apache.cassandra.db.marshal.UTF8Type,62:org.apache.cassandra.db.marshal.UTF8Type)))",
-            "frozen<map<text, frozen<i_udt>>>",
+            "frozen<map<text, i_udt>>",
             "frozen<map<text, frozen<tuple<text, text>>>>",
             true,
             "{'foobar':{a:'foo',b:'bar'}}");
@@ -375,16 +369,13 @@ public class TupleTypesRepresentationTest
         {
             try
             {
-                assertEquals(typeDef.toString() + "\n typeString vs type\n", typeDef.typeString, typeDef.type.toString());
-                assertEquals(typeDef.toString() + "\n typeString vs cqlType.getType()\n", typeDef.typeString, typeDef.cqlType.getType().toString());
+                assertEquals(typeDef + "\n typeString vs type\n", typeDef.typeString, typeDef.type.toString());
+                assertEquals(typeDef + "\n typeString vs cqlType.getType()\n", typeDef.typeString, typeDef.cqlType.getType().toString());
                 AbstractType<?> expanded = typeDef.type.expandUserTypes();
                 CQL3Type expandedCQL = expanded.asCQL3Type();
-                // Note: cannot include this commented-out assertion, because the parsed CQL3Type instance for
-                // 'frozen<list<tuple<text, text>>>' returns 'frozen<list<frozen<tuple<text, text>>>>' via it's CQL3Type.toString()
-                // implementation.
-                assertEquals(typeDef.toString() + "\n droppedCqlType\n", typeDef.droppedCqlType, expandedCQL);
-                assertEquals(typeDef.toString() + "\n droppedCqlTypeString\n", typeDef.droppedCqlTypeString, expandedCQL.toString());
-                assertEquals(typeDef.toString() + "\n multiCell\n", typeDef.type.isMultiCell(), typeDef.droppedType.isMultiCell());
+                assertEquals(typeDef + "\n droppedCqlType\n", typeDef.droppedCqlType, expandedCQL);
+                assertEquals(typeDef + "\n droppedCqlTypeString\n", typeDef.droppedCqlTypeString, expandedCQL.toSchemaString());
+                assertEquals(typeDef + "\n multiCell\n", typeDef.type.isMultiCell(), typeDef.droppedType.isMultiCell());
 
                 AbstractType<?> parsedType = TypeParser.parse(typeDef.typeString);
                 assertEquals(typeDef.toString(), typeDef.typeString, parsedType.toString());

--- a/test/unit/org/apache/cassandra/transport/messages/ResultMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/messages/ResultMessageTest.java
@@ -124,7 +124,7 @@ public class ResultMessageTest
         TupleType tt = new TupleType(asList(Int32Type.instance, udt));
         allTypes.add(tt);
         allTypes.add(Int32Type.instance);
-        ReversedType rt = ReversedType.getInstance(udt);
+        AbstractType<?> rt = ReversedType.getInstance(udt);
         allTypes.add(rt);
 
         ColumnSpecification cs1 = new ColumnSpecification("ks1", "cf1", new ColumnIdentifier("a", true), Int32Type.instance);


### PR DESCRIPTION
The method `validateCompatibility()` in TableMetadata checks whether two schemas are compatible with each other. I broke down the sequence of checks into individual methods, and called them in the same sequence from `validateCompatibility()`: as a result, this method is performing the exact same operations as before.

Additionally, I also created a modified version of this method called `validateTableStructureCompatibility()`. This is a new method that performs a subset of these checks by calling the corresponding individual methods. This method is only used externally and does not affect anything in this codebase.