### PR TITLE
Improve accuracy of softLimit estimation

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -49,7 +49,6 @@ public class QueryContext
     private final LongAdder segmentsHit = new LongAdder();
     private final LongAdder partitionsRead = new LongAdder();
     private final LongAdder rowsFiltered = new LongAdder();
-    private final LongAdder rowsMatched = new LongAdder();
     private final LongAdder trieSegmentsHit = new LongAdder();
 
     private final LongAdder bkdPostingListsHit = new LongAdder();
@@ -79,7 +78,7 @@ public class QueryContext
     private float postFilterSelectivityEstimate = 1.0f;
 
     // Last used soft limit for vector search.
-    private int softLimit = -1;
+    private int softLimit = 0;
 
     @VisibleForTesting
     public QueryContext()
@@ -113,14 +112,6 @@ public class QueryContext
     public void addRowsFiltered(long val)
     {
         rowsFiltered.add(val);
-    }
-    public void addRowsMatched(long val)
-    {
-        rowsMatched.add(val);
-    }
-    public void resetRowsMatched()
-    {
-        rowsMatched.reset();
     }
     public void addTrieSegmentsHit(long val)
     {
@@ -200,10 +191,6 @@ public class QueryContext
     public long rowsFiltered()
     {
         return rowsFiltered.longValue();
-    }
-    public long rowsMatched()
-    {
-        return rowsMatched.longValue();
     }
     public long trieSegmentsHit()
     {

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -134,25 +134,21 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             queryContext.addShadowedKeysLoopCount(1L);
             long lastShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             ResultRetriever result = queryIndexes.get();
-            queryContext.resetRowsMatched();
             UnfilteredPartitionIterator topK = (UnfilteredPartitionIterator) new VectorTopKProcessor(command).filter(result);
             long currentShadowedKeysCount = queryContext.getShadowedPrimaryKeys().size();
             long newShadowedKeysCount = currentShadowedKeysCount - lastShadowedKeysCount;
             logger.debug("Shadow loop iteration {}: rows matched: {}, keys shadowed: {}",
                          queryContext.shadowedKeysLoopCount(),
-                         queryContext.rowsMatched(),
+                         Math.max(0, queryContext.softLimit() - currentShadowedKeysCount),
                          currentShadowedKeysCount);
-            // Stop if no new shadowed keys found or if we already got enough rows
-            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.rowsMatched())
+            // Stop if we already got enough rows (In this case, we're basically
+            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows to
+            // guarantee we have a valid result.)
+            if (exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)
-                {
-                    if (newShadowedKeysCount == 0)
-                        Tracing.trace("No new shadowed keys after query loop {}", loopsCount);
-                    else if (exactLimit <= queryContext.rowsMatched())
-                        Tracing.trace("Got enough rows after query loop {}", loopsCount);
-                }
+                    Tracing.trace("Got enough rows after query loop {}", loopsCount);
                 return topK;
             }
             loopsCount++;
@@ -535,7 +531,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), row, staticRow))
                 {
-                    queryContext.addRowsMatched(1);
                     clusters.add(row);
                 }
             }
@@ -545,7 +540,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 queryContext.addRowsFiltered(1);
                 if (tree.isSatisfiedBy(key.partitionKey(), staticRow, staticRow))
                 {
-                    queryContext.addRowsMatched(1);
                     clusters.add(staticRow);
                 }
             }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -141,10 +141,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                          queryContext.shadowedKeysLoopCount(),
                          Math.max(0, queryContext.softLimit() - currentShadowedKeysCount),
                          currentShadowedKeysCount);
-            // Stop if we already got enough rows (In this case, we're basically
-            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows to
-            // guarantee we have a valid result.)
-            if (exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
+            // Stop if no new shadowed keys found or if we already got enough rows (In this case, we're basically
+            // checking that if all the shadowed keys came from one index, we still got enough non-shadowed rows from
+            // that index to still guarantee we have a valid result.)
+            if (newShadowedKeysCount == 0 || exactLimit <= queryContext.softLimit() - currentShadowedKeysCount)
             {
                 cfs.metric.incShadowedKeys(loopsCount, currentShadowedKeysCount - startShadowedKeysCount);
                 if (loopsCount > 1)


### PR DESCRIPTION
When reverting #927 in https://github.com/datastax/cassandra/pull/935, we also reverted an improvement to the `currentSoftLimitEstimate` method. I am pretty sure we want those fixes, so this PR cherry picks two commits from #927 without re-introducing the performance regression.