### PR TITLE
CNDB-8464 Propagate UCUs (READ_BYTES) from Writer to Coordinator

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -88,8 +88,8 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         Message.Builder<ReadResponse> reply = message.responseWithBuilder(response);
         readRequestSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> reply.withCustomParam(SensorsCustomParams.READ_BYTES_REQUEST, bytes));
 
-        Optional<Sensor> aggregareReadBytes = SensorsRegistry.instance.getSensor(Context.from(command), Type.READ_BYTES);
-        aggregareReadBytes.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> reply.withCustomParam(SensorsCustomParams.READ_BYTES_TABLE, bytes));
+        Optional<Sensor> readTableSensor = SensorsRegistry.instance.getSensor(Context.from(command), Type.READ_BYTES);
+        readTableSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> reply.withCustomParam(SensorsCustomParams.READ_BYTES_TABLE, bytes));
 
         MessagingService.instance().send(reply.build(), message.from());
     }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.net;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.IVersionedAsymmetricSerializer;
 import org.apache.cassandra.io.IVersionedSerializer;
@@ -50,7 +48,6 @@ import org.apache.cassandra.utils.NoSpamLogger;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 import static org.apache.cassandra.db.TypeSizes.sizeof;
 import static org.apache.cassandra.db.TypeSizes.sizeofUnsignedVInt;
 import static org.apache.cassandra.locator.InetAddressAndPort.Serializer.inetAddressAndPortSerializer;
@@ -244,21 +241,6 @@ public class Message<T>
                                .withCreatedAt(createdAtNanos)
                                .withFlags(flags)
                                .withParams(buildParams(paramType, paramValue));
-    }
-
-    private static <T> Message<T> outWithCustomParam(long id, Verb verb, long expiresAtNanos, T payload, int flags, String paramName, byte[] paramValue)
-    {
-        if (payload == null || paramName == null || paramValue == null)
-            throw new IllegalArgumentException();
-
-        InetAddressAndPort from = FBUtilities.getBroadcastAddressAndPort();
-        long createdAtNanos = approxTime.now();
-        if (expiresAtNanos == 0)
-            expiresAtNanos = verb.expiresAtNanos(createdAtNanos);
-        Map<String,byte[]> customParams  = new HashMap<>();
-
-        customParams.put(paramName, paramValue);
-        return new Message<>(new Header(id, verb, from, createdAtNanos, expiresAtNanos, flags, buildParams(ParamType.CUSTOM_MAP, customParams)), payload);
     }
 
     public static <T> Message<T> internalResponse(Verb verb, T payload)

--- a/src/java/org/apache/cassandra/net/SensorsCustomParams.java
+++ b/src/java/org/apache/cassandra/net/SensorsCustomParams.java
@@ -21,22 +21,21 @@ package org.apache.cassandra.net;
 import java.nio.ByteBuffer;
 
 import org.apache.cassandra.sensors.Sensor;
-import org.apache.cassandra.sensors.Type;
 
 /**
- * A utility class that contians the defintion of custom params added to the {@link Message} header to prpagate {@link Sensor} values from
- * writer to cooridnater and necessary methods to encode sensor values as appropriate for the internode mesage format.
+ * A utility class that contains the definition of custom params added to the {@link Message} header to propagate {@link Sensor} values from
+ * writer to coordinator and necessary methods to encode sensor values as appropriate for the internode message format.
  */
 public final class SensorsCustomParams
 {
     /**
-     * The per-request read bytes value for a given keyspace.
+     * The per-request read bytes value for a given keyspace and table.
      */
-    public static final String READ_BYTES = Type.READ_BYTES.name();
+    public static final String READ_BYTES_REQUEST = "READ_BYTES_REQUEST";
     /**
-     * The aggregated read bytes value for a given keyspace, across all requests.
+     * The total read bytes value for a given keyspace and table, across all requests. This is a monotonically increasing value.
      */
-    public static final String READ_BYTES_TOTAL = String.format("%s_TOTAL", READ_BYTES);
+    public static final String READ_BYTES_TABLE = "READ_BYTES_TABLE";
 
     private SensorsCustomParams()
     {
@@ -45,11 +44,11 @@ public final class SensorsCustomParams
     /**
      * Utility method to encode senors value as byte buffer in the big endian order.
      */
-    public static byte[] doubleAsBytes(double value)
+    public static byte[] sensorValueAsBytes(double value)
     {
-        ByteBuffer readBytesBuffer = ByteBuffer.allocate(Double.BYTES);
-        readBytesBuffer.putDouble(value);
+        ByteBuffer buffer = ByteBuffer.allocate(Double.BYTES);
+        buffer.putDouble(value);
 
-        return readBytesBuffer.array();
+        return buffer.array();
     }
 }

--- a/src/java/org/apache/cassandra/net/SensorsCustomParams.java
+++ b/src/java/org/apache/cassandra/net/SensorsCustomParams.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.sensors.Sensor;
+import org.apache.cassandra.sensors.Type;
+
+/**
+ * A utility class that contians the defintion of custom params added to the {@link Message} header to prpagate {@link Sensor} values from
+ * writer to cooridnater and necessary methods to encode sensor values as appropriate for the internode mesage format.
+ */
+public final class SensorsCustomParams
+{
+    /**
+     * The per-request read bytes value for a given keyspace.
+     */
+    public static final String READ_BYTES = Type.READ_BYTES.name();
+    /**
+     * The aggregated read bytes value for a given keyspace, across all requests.
+     */
+    public static final String READ_BYTES_TOTAL = String.format("%s_TOTAL", READ_BYTES);
+
+    private SensorsCustomParams()
+    {
+    }
+
+    /**
+     * Utility method to encode senors value as byte buffer in the big endian order.
+     */
+    public static byte[] doubleAsBytes(double value)
+    {
+        ByteBuffer readBytesBuffer = ByteBuffer.allocate(Double.BYTES);
+        readBytesBuffer.putDouble(value);
+
+        return readBytesBuffer.array();
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/Sensor.java
+++ b/src/java/org/apache/cassandra/sensors/Sensor.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.sensors;
 
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/src/java/org/apache/cassandra/sensors/Sensor.java
+++ b/src/java/org/apache/cassandra/sensors/Sensor.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.sensors;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.sensors;
 
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -157,6 +158,16 @@ public class SensorsRegistry implements SchemaChangeListener
     public Set<Sensor> getSensorsByKeyspace(String keyspace)
     {
         return Optional.ofNullable(byKeyspace.get(keyspace)).orElseGet(() -> ImmutableSet.of());
+    }
+
+    public Optional<Double> aggregateSensorValueBy(String keyspace, Type type)
+    {
+        return Optional.ofNullable(byKeyspace.get(keyspace))
+                .orElseGet(() -> ImmutableSet.of())
+                .stream()
+                .filter(s -> s.getType().equals(type))
+                .map(Sensor::getValue)
+                .reduce(Double::sum);
     }
 
     public Set<Sensor> getSensorsByTableId(String tableId)

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -163,14 +163,6 @@ public class SensorsRegistry implements SchemaChangeListener
         return Optional.ofNullable(byKeyspace.get(keyspace)).orElseGet(() -> ImmutableSet.of());
     }
 
-    public Optional<Sensor> getSensorsByKeyspaceAndType(String keyspace, Type type)
-    {
-        return getSensorsByKeyspace(keyspace)
-                .stream()
-                .filter(s -> s.getType().equals(type))
-                .findFirst();
-    }
-
     public Set<Sensor> getSensorsByTableId(String tableId)
     {
         return Optional.ofNullable(byTableId.get(tableId)).orElseGet(() -> ImmutableSet.of());

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.sensors;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -37,7 +36,6 @@ import java.util.function.Predicate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,6 +109,11 @@ public class SensorsRegistry implements SchemaChangeListener
         logger.debug("Listener {} unregistered", listener);
     }
 
+    public Optional<Sensor> getSensor(Context context, Type type)
+    {
+        return Optional.ofNullable(identity.get(Pair.create(context, type)));
+    }
+
     public Optional<Sensor> getOrCreateSensor(Context context, Type type)
     {
         updateLock.readLock().lock();
@@ -160,14 +163,12 @@ public class SensorsRegistry implements SchemaChangeListener
         return Optional.ofNullable(byKeyspace.get(keyspace)).orElseGet(() -> ImmutableSet.of());
     }
 
-    public Optional<Double> aggregateSensorValueBy(String keyspace, Type type)
+    public Optional<Sensor> getSensorsByKeyspaceAndType(String keyspace, Type type)
     {
-        return Optional.ofNullable(byKeyspace.get(keyspace))
-                .orElseGet(() -> ImmutableSet.of())
+        return getSensorsByKeyspace(keyspace)
                 .stream()
                 .filter(s -> s.getType().equals(type))
-                .map(Sensor::getValue)
-                .reduce(Double::sum);
+                .findFirst();
     }
 
     public Set<Sensor> getSensorsByTableId(String tableId)

--- a/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
+++ b/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
@@ -30,7 +30,7 @@ public class SensorsCustomParamsTest
     public void testDoubleAsBytes()
     {
         double d = Double.MAX_VALUE;
-        byte[] bytes = SensorsCustomParams.doubleAsBytes(d);
+        byte[] bytes = SensorsCustomParams.sensorValueAsBytes(d);
         ByteBuffer bb = ByteBuffer.wrap(bytes);
         assertEquals(Double.MAX_VALUE, bb.getDouble(), 0.0);
     }

--- a/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
+++ b/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SensorsCustomParamsTest
+{
+    @Test
+    public void testDoubleAsBytes()
+    {
+        double d = Double.MAX_VALUE;
+        byte[] bytes = SensorsCustomParams.doubleAsBytes(d);
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        assertEquals(Double.MAX_VALUE, bb.getDouble(), 0.0);
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/SensorsReadTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsReadTest.java
@@ -297,7 +297,7 @@ public class SensorsReadTest
         double requestReadBytes = bytesToDouble(message.header.customParams().get(READ_BYTES_REQUEST));
         double tableReadBytes = bytesToDouble(message.header.customParams().get(READ_BYTES_TABLE));
         assertThat(requestReadBytes).isEqualTo(requestValue);
-        assertThat(tableReadBytes).isEqualTo(tableReadBytes);
+        assertThat(tableReadBytes).isEqualTo(registryValue);
     }
 
     private static double bytesToDouble(byte[] bytes)


### PR DESCRIPTION
Addresses: #https://github.com/riptano/cndb/issues/8464

Add `READ_BYTES` and `READ_BYTES_TOTAL` sensor values to the ReadCommandVerbHandler outbound messages as a custom map header