### PR TITLE
Return PostingList.EMPTY, not null; fix BKDReaderTest

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
@@ -340,7 +340,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
         if (relation == Relation.CELL_OUTSIDE_QUERY)
         {
             listener.onIntersectionEarlyExit();
-            return null;
+            return PostingList.EMPTY;
         }
 
         listener.onSegmentHit();

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -215,7 +215,7 @@ public class BKDReaderTest extends SaiRandomizedTest
 
         try (PostingList intersection = reader.intersect(NONE_MATCH, (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext()))
         {
-            assertNull(intersection);
+            assertEquals(PostingList.EMPTY, intersection);
         }
 
         try (PostingList collectAllIntersection = reader.intersect(ALL_MATCH, (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
@@ -240,7 +240,6 @@ public class BKDReaderTest extends SaiRandomizedTest
 
         final PostingList intersection = reader.intersect(buildQuery(queryMin, queryMax), (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
 
-        assertThat(intersection, is(instanceOf(MergePostingList.class)));
         long expectedRowID = queryMin;
         for (long id = intersection.nextPosting(); id != PostingList.END_OF_STREAM; id = intersection.nextPosting())
         {
@@ -279,7 +278,7 @@ public class BKDReaderTest extends SaiRandomizedTest
         final BKDReader reader = finishAndOpenReaderOneDim(2, buffer);
 
         PostingList intersection = reader.intersect(NONE_MATCH, (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
-        assertNull(intersection);
+        assertEquals(PostingList.EMPTY, intersection);
 
         intersection = reader.intersect(ALL_MATCH, (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
         assertEquals(numRows, intersection.size());
@@ -318,7 +317,7 @@ public class BKDReaderTest extends SaiRandomizedTest
         final BKDReader reader = finishAndOpenReaderOneDim(50, buffer);
 
         final PostingList intersection = reader.intersect(buildQuery(1017, 1096), (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
-        assertNull(intersection);
+        assertEquals(PostingList.EMPTY, intersection);
     }
 
     private BKDReader.IntersectVisitor buildQuery(int queryMin, int queryMax)


### PR DESCRIPTION
#938 was merged with two test failures. This PR fixes the failures. Note that the test failures are not regressions in production code, so this isn't an urgent PR.