### PR TITLE
Fix early component reading

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
@@ -179,12 +179,11 @@ public class ShardedMultiWriter implements SSTableMultiWriter
     }
 
     @Override
-    public SSTableMultiWriter setOpenResult(boolean openResult)
+    public void openResult()
     {
         for (SSTableWriter writer : writers)
             if (writer != null)
-                writer.setOpenResult(openResult);
-        return this;
+                writer.openResult();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -376,6 +376,22 @@ public class IndexDescriptor
         }
     }
 
+    /**
+     * Opens a file handle for the provided index component similarly to {@link #createPerIndexFileHandle(IndexComponent, IndexContext)},
+     * but this method shoud be called instead of the aforemented one if the access is done "as part of flushing", that is
+     * before the full index that this is a part of has been finalized.
+     * <p>
+     * The use of this method can allow specific storage providers, typically tiered storage ones, to distinguish accesses
+     * that happen "at flush time" from other accesses, as the related file may be in different tier of storage.
+     */
+    public FileHandle createFlushTimePerIndexFileHandle(IndexComponent indexComponent, IndexContext indexContext)
+    {
+        try (final FileHandle.Builder builder = StorageProvider.instance.flushTimeFileHandleBuilderFor(this, indexComponent, indexContext))
+        {
+            return builder.complete();
+        }
+    }
+
     @Override
     public int hashCode()
     {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
@@ -175,7 +175,7 @@ public class NumericIndexWriter implements Closeable
             components.put(IndexComponent.KD_TREE, bkdPosition, bkdOffset, bkdLength, attributes);
         }
 
-        try (TraversingBKDReader reader = new TraversingBKDReader(indexDescriptor.createPerIndexFileHandle(IndexComponent.KD_TREE, indexContext), bkdPosition);
+        try (TraversingBKDReader reader = new TraversingBKDReader(indexDescriptor.createFlushTimePerIndexFileHandle(IndexComponent.KD_TREE, indexContext), bkdPosition);
              IndexOutput postingsOutput = indexDescriptor.openPerIndexOutput(IndexComponent.KD_TREE_POSTING_LISTS, indexContext, true))
         {
             final long postingsOffset = postingsOutput.getFilePointer();

--- a/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
@@ -40,7 +40,13 @@ public interface SSTableMultiWriter extends Transactional
     Collection<SSTableReader> finish(boolean openResult);
     Collection<SSTableReader> finished();
 
-    SSTableMultiWriter setOpenResult(boolean openResult);
+    /**
+     * Opens the resulting sstables after writing has finished. If those readers need to be accessed, then this must
+     * be called after `prepareToCommit` (so the writing is complete) but before `commit` (because committing closes
+     * some of the resources used to create the underlying readers). When used, the readers can then be accessed by
+     * calling `finished()`.
+     */
+    void openResult();
 
     String getFilename();
     long getBytesWritten();

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -348,7 +348,8 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
         for (SSTableWriter writer : writers)
         {
             assert writer.getFilePointer() > 0;
-            writer.setRepairedAt(repairedAt).setOpenResult(true).prepareToCommit();
+            writer.setRepairedAt(repairedAt).prepareToCommit();
+            writer.openResult();
             SSTableReader reader = writer.finished();
             transaction.update(reader, false);
             preparedForCommit.add(reader);

--- a/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
@@ -88,8 +88,10 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
 
     public Collection<SSTableReader> finish(boolean openResult)
     {
-        writer.setOpenResult(openResult);
-        finish();
+        prepareToCommit();
+        if (openResult)
+            writer.openResult();
+        commit();
         return writer.finished();
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
@@ -64,10 +64,9 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
         return Collections.singleton(writer.finished());
     }
 
-    public SSTableMultiWriter setOpenResult(boolean openResult)
+    public void openResult()
     {
-        writer.setOpenResult(openResult);
-        return this;
+        writer.openResult();
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
@@ -150,11 +150,10 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
     }
 
     @Override
-    public SSTableMultiWriter setOpenResult(boolean openResult)
+    public void openResult()
     {
-        finishedWriters.forEach((w) -> w.setOpenResult(openResult));
-        currentWriter.setOpenResult(openResult);
-        return this;
+        finishedWriters.forEach(SSTableMultiWriter::openResult);
+        currentWriter.openResult();
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -284,7 +284,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         return this;
     }
 
-    public abstract SSTableWriter setOpenResult(boolean openResult);
+    public abstract void openResult();
 
     /**
      * Open the resultant SSTableReader before it has been fully written
@@ -307,8 +307,10 @@ public abstract class SSTableWriter extends SSTable implements Transactional
 
     public SSTableReader finish(boolean openResult)
     {
-        setOpenResult(openResult);
-        txnProxy().finish();
+        txnProxy().prepareToCommit();
+        if (openResult)
+            openResult();
+        txnProxy().commit();
         observers.forEach(SSTableFlushObserver::complete);
         return finished();
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
@@ -124,8 +124,6 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     @Override
     public Collection<SSTableReader> finish(boolean openResult)
     {
-        setOpenResult(openResult);
-
         for (SequentialWriter writer : componentWriters.values())
             writer.finish();
 
@@ -142,9 +140,8 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     }
 
     @Override
-    public SSTableMultiWriter setOpenResult(boolean openResult)
+    public void openResult()
     {
-        return null;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -319,10 +319,9 @@ public abstract class SortedTableWriter extends SSTableWriter
         }
     }
 
-    public SSTableWriter setOpenResult(boolean openResult)
+    public void openResult()
     {
-        txnProxy().openResult = openResult;
-        return this;
+        txnProxy().openResult();
     }
 
     public SSTableReader finished()
@@ -341,7 +340,6 @@ public abstract class SortedTableWriter extends SSTableWriter
         // should be set during doPrepare()
         private SSTableReader finalReader;
         protected boolean finalReaderAccessed;
-        private boolean openResult;
 
         // finalise our state on disk, including renaming
         protected void doPrepare()
@@ -352,12 +350,12 @@ public abstract class SortedTableWriter extends SSTableWriter
 
             // save the table of components
             SSTable.appendTOC(descriptor, components);
+        }
 
-            if (openResult)
-            {
-                finalReader = openFinal(SSTableReader.OpenReason.NORMAL);
-                finalReaderAccessed = false;
-            }
+        private void openResult()
+        {
+            finalReader = openFinal(SSTableReader.OpenReason.NORMAL);
+            finalReaderAccessed = false;
         }
 
         protected Throwable doCommit(Throwable accumulate)

--- a/src/java/org/apache/cassandra/io/storage/StorageProvider.java
+++ b/src/java/org/apache/cassandra/io/storage/StorageProvider.java
@@ -166,6 +166,22 @@ public interface StorageProvider
      */
     FileHandle.Builder fileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component, IndexContext context);
 
+    /**
+     * Creates a new {@link FileHandle.Builder} for the given SAI component and context (for index with per-index files),
+     * that is suitable for reading the component "at flush time", that is typcally for when we need to access the
+     * component to complete the writing of another related component.
+     * <p>
+     * Other the fact that this method will be called a different time, it's requirements are the same than for
+     * {@link #fileHandleBuilderFor(IndexDescriptor, IndexComponent, IndexContext)}.
+     *
+     * @param descriptor descriptor for the index file whose handler is built.
+     * @param component index component for which to build the handler.
+     * @param context index context for which to build the handler.
+     * @return a new {@link FileHandle.Builder} for the provided SAI component with access mode and chunk cache
+     *   configured as appropriate.
+     */
+    FileHandle.Builder flushTimeFileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component, IndexContext context);
+
     class DefaultProvider implements StorageProvider
     {
         @Override
@@ -253,6 +269,14 @@ public interface StorageProvider
                              file, FBUtilities.prettyPrintMemory(file.length()));
             }
             return new FileHandle.Builder(file).mmapped(true);
+        }
+
+        @Override
+        public FileHandle.Builder flushTimeFileHandleBuilderFor(IndexDescriptor descriptor, IndexComponent component, IndexContext context)
+        {
+            // By default, no difference between accesses "at flush time" and "at query time", but subclasses may need
+            // to differenciate both.
+            return fileHandleBuilderFor(descriptor, component, context);
         }
     }
 }


### PR DESCRIPTION
There is currently 2 places where an sstable component is accessed during the flush of that sstable before the enclosing [`LifecycleTransation.prepareToCommit`](https://github.com/datastax/cassandra/blob/ds-trunk/src/java/org/apache/cassandra/db/ColumnFamilyStore.java#L1413) method has been called:
- for SAI numeric indexes, the `NumericIndexWriter` class does a reading of the `KD_TREE` component to finalize the `KD_TREE_POSTING_LISTS` one.
- the `SSTableReader` objects are opened in the `SSTableMultiWriter.prepareToCommit`, which happens before the `LifecycleTransaction` own `prepareToCommit`, and this opening also triggers some reads (of the partition index, at least with trie sstables).

That `LifecycleTransation.prepareToCommit` call is where sstable contents are uploaded to remote storage with tiered storage, and it is important for tiered storage implementations that reads only happens after this call (or at least to be able to distinguish between reads that comes before that call and those coming after it), so the implementation knows, when a reads come, if the content is in remote storage or not.

This PR has 2 commits for the 2 cases above. Note that for the SAI numeric index problem, the patch here is more akin to a work-around: It isn't immediately clear to me how to refactor things to delay the read that occurs, since that read is use to finish another component, so instead, the patch introduces a new hook to `StorageProvider` to distinguish this read (that happens during the flush) from other future "query time" reads.