### PR TITLE
Use vector view per query and close view when done

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -20,8 +20,8 @@ package org.apache.cassandra.index.sai.disk.v2.hnsw;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
-import java.util.function.Function;
 import java.util.function.IntConsumer;
+import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.slf4j.Logger;
@@ -44,7 +44,9 @@ import org.apache.cassandra.index.sai.disk.vector.NodeScoreToScoredRowIdIterator
 import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.disk.vector.OrdinalsView;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
+import org.apache.cassandra.index.sai.disk.vector.VectorsView;
 import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.lucene.index.VectorEncoding;
@@ -56,7 +58,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
 {
     private static final Logger logger = LoggerFactory.getLogger(CassandraOnDiskHnsw.class);
 
-    private final Function<QueryContext, VectorsWithCache> vectorsSupplier;
+    private final Supplier<VectorsWithCache> vectorsSupplier;
     private final OnDiskOrdinalsMap ordinalsMap;
     private final OnDiskHnswGraph hnsw;
     private final VectorSimilarityFunction similarityFunction;
@@ -73,7 +75,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
 
         vectorsFile = indexFiles.vectors();
         long vectorsSegmentOffset = getComponentMetadata(IndexComponent.VECTOR).offset;
-        vectorsSupplier = (qc) -> new VectorsWithCache(new OnDiskVectors(vectorsFile, vectorsSegmentOffset), qc);
+        vectorsSupplier = () -> new VectorsWithCache(new OnDiskVectors(vectorsFile, vectorsSegmentOffset));
 
         SegmentMetadata.ComponentMetadata postingListsMetadata = getComponentMetadata(IndexComponent.POSTING_LISTS);
         ordinalsMap = new OnDiskOrdinalsMap(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
@@ -111,7 +113,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         CassandraOnHeapGraph.validateIndexable(queryVector, similarityFunction);
 
         NeighborQueue queue;
-        try (var vectors = vectorsSupplier.apply(context); var view = hnsw.getView(context))
+        try (var vectors = vectorsSupplier.get(); var view = hnsw.getView(context))
         {
             queue = HnswGraphSearcher.search(queryVector,
                                              topK,
@@ -192,9 +194,9 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
     }
 
     @Override
-    public float[] getVectorForOrdinal(int ordinal) throws IOException
+    public VectorsView getVectorsView()
     {
-        return vectorCache.get(ordinal);
+        return new HNSWVectorsView(vectorsSupplier.get());
     }
 
     @Override
@@ -207,12 +209,10 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
     class VectorsWithCache implements RandomAccessVectorValues<float[]>, AutoCloseable
     {
         private final OnDiskVectors vectors;
-        private final QueryContext queryContext;
 
-        public VectorsWithCache(OnDiskVectors vectors, QueryContext queryContext)
+        public VectorsWithCache(OnDiskVectors vectors)
         {
             this.vectors = vectors;
-            this.queryContext = queryContext;
         }
 
         @Override
@@ -246,6 +246,35 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         public void close()
         {
             vectors.close();
+        }
+    }
+
+    private static class HNSWVectorsView implements VectorsView
+    {
+        private final VectorsWithCache view;
+
+        private HNSWVectorsView(VectorsWithCache view)
+        {
+            this.view = view;
+        }
+
+        @Override
+        public float[] getVectorForOrdinal(int ordinal)
+        {
+            try
+            {
+                return view.vectorValue(ordinal);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            FileUtils.closeQuietly(view);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -44,7 +44,7 @@ import org.apache.cassandra.index.sai.disk.vector.NodeScoreToScoredRowIdIterator
 import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.disk.vector.OrdinalsView;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
-import org.apache.cassandra.index.sai.disk.vector.VectorsView;
+import org.apache.cassandra.index.sai.disk.vector.VectorSupplier;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tracing.Tracing;
@@ -194,9 +194,9 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
     }
 
     @Override
-    public VectorsView getVectorsView()
+    public VectorSupplier getVectorSupplier()
     {
-        return new HNSWVectorsView(vectorsSupplier.get());
+        return new HNSWVectorSupplier(vectorsSupplier.get());
     }
 
     @Override
@@ -249,11 +249,11 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         }
     }
 
-    private static class HNSWVectorsView implements VectorsView
+    private static class HNSWVectorSupplier implements VectorSupplier
     {
         private final VectorsWithCache view;
 
-        private HNSWVectorsView(VectorsWithCache view)
+        private HNSWVectorSupplier(VectorsWithCache view)
         {
             this.view = view;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -49,7 +49,7 @@ import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.disk.vector.OrdinalsView;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
-import org.apache.cassandra.index.sai.disk.vector.VectorsView;
+import org.apache.cassandra.index.sai.disk.vector.VectorSupplier;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tracing.Tracing;
@@ -204,16 +204,16 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
     }
 
     @Override
-    public VectorsView getVectorsView()
+    public VectorSupplier getVectorSupplier()
     {
-        return new ANNVectorsView(graph.getView());
+        return new ANNVectorSupplier(graph.getView());
     }
 
-    private static class ANNVectorsView implements VectorsView
+    private static class ANNVectorSupplier implements VectorSupplier
     {
         private final GraphIndex.View<float[]> view;
 
-        private ANNVectorsView(GraphIndex.View<float[]> view)
+        private ANNVectorSupplier(GraphIndex.View<float[]> view)
         {
             this.view = view;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -106,7 +106,6 @@ public class AutoResumingNodeScoreIterator implements CloseableIterator<SearchRe
     public void close()
     {
         nodesVisitedConsumer.accept(cumulativeNodesVisited);
-        if (onClose != null)
-            FileUtils.closeQuietly(onClose);
+        FileUtils.closeQuietly(onClose);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -23,8 +23,11 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.IntConsumer;
 
+import javax.annotation.Nullable;
+
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
 
@@ -37,6 +40,7 @@ public class AutoResumingNodeScoreIterator implements CloseableIterator<SearchRe
     private final GraphSearcher<float[]> searcher;
     private final int topK;
     private final boolean inMemory;
+    private final AutoCloseable onClose;
     private final IntConsumer nodesVisitedConsumer;
     private Iterator<SearchResult.NodeScore> nodeScores;
     private int cumulativeNodesVisited;
@@ -50,12 +54,14 @@ public class AutoResumingNodeScoreIterator implements CloseableIterator<SearchRe
      * @param nodesVisitedConsumer a consumer that accepts the total number of nodes visited
      * @param topK the limit to pass to the {@link GraphSearcher} when resuming search
      * @param inMemory whether the graph is in memory or on disk (used for trace logging)
+     * @param onClose an {@link AutoCloseable} object to close when this iterator is closed
      */
     public AutoResumingNodeScoreIterator(GraphSearcher<float[]> searcher,
                                          SearchResult result,
                                          IntConsumer nodesVisitedConsumer,
                                          int topK,
-                                         boolean inMemory)
+                                         boolean inMemory,
+                                         @Nullable AutoCloseable onClose)
     {
         this.searcher = searcher;
         this.nodeScores = Arrays.stream(result.getNodes()).iterator();
@@ -63,6 +69,7 @@ public class AutoResumingNodeScoreIterator implements CloseableIterator<SearchRe
         this.nodesVisitedConsumer = nodesVisitedConsumer;
         this.topK = topK;
         this.inMemory = inMemory;
+        this.onClose = onClose;
     }
 
     @Override
@@ -99,5 +106,7 @@ public class AutoResumingNodeScoreIterator implements CloseableIterator<SearchRe
     public void close()
     {
         nodesVisitedConsumer.accept(cumulativeNodesVisited);
+        if (onClose != null)
+            FileUtils.closeQuietly(onClose);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
@@ -72,24 +72,21 @@ public class BruteForceRowIdIterator implements CloseableIterator<ScoredRowId>
     private final PriorityQueue<RowWithApproximateScore> approximateScoreQueue;
     // Priority queue with full resolution scores
     private final PriorityQueue<ScoredRowId> exactScoreQueue;
-    private final NodeSimilarity.Reranker reranker;
+    private final CloseableReranker reranker;
     private final int topK;
     private final int limit;
     private int rerankedCount;
-    private final AutoCloseable onClose;
 
     /**
      * @param approximateScoreQueue A priority queue of rows and their ordinal ordered by their approximate similarity scores
      * @param reranker A function that takes a graph ordinal and returns the exact similarity score
      * @param limit The query limit
      * @param topK The number of vectors to resolve and score before returning results
-     * @param onClose an {@link AutoCloseable} object to close when this iterator is closed
      */
     public BruteForceRowIdIterator(PriorityQueue<RowWithApproximateScore> approximateScoreQueue,
-                                   NodeSimilarity.Reranker reranker,
+                                   CloseableReranker reranker,
                                    int limit,
-                                   int topK,
-                                   AutoCloseable onClose)
+                                   int topK)
     {
         this.approximateScoreQueue = approximateScoreQueue;
         this.exactScoreQueue = new PriorityQueue<>(topK, (a, b) -> Float.compare(b.score, a.score));
@@ -98,7 +95,6 @@ public class BruteForceRowIdIterator implements CloseableIterator<ScoredRowId>
         this.limit = limit;
         this.topK = topK;
         this.rerankedCount = topK; // placeholder to kick off computeNext
-        this.onClose = onClose;
     }
 
     @Override
@@ -127,6 +123,6 @@ public class BruteForceRowIdIterator implements CloseableIterator<ScoredRowId>
     @Override
     public void close()
     {
-        FileUtils.closeQuietly(onClose);
+        FileUtils.closeQuietly(reranker);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
@@ -94,7 +94,7 @@ public class BruteForceRowIdIterator extends AbstractIterator<ScoredRowId>
     }
 
     @Override
-    public ScoredRowId computeNext() {
+    protected ScoredRowId computeNext() {
         int consumed = rerankedCount - exactScoreQueue.size();
         if (consumed >= limit) {
             // Refill the exactScoreQueue until it reaches topK exact scores, or the approximate score queue is empty

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -311,7 +311,7 @@ public class CassandraOnHeapGraph<T>
         context.addAnnNodesVisited(result.getVisitedCount());
         // Threshold based searches do not support resuming the search.
         return threshold > 0 ? CloseableIterator.wrap(Arrays.stream(result.getNodes()).iterator())
-                             : new AutoResumingNodeScoreIterator(searcher, result, context::addAnnNodesVisited, topK, true);
+                             : new AutoResumingNodeScoreIterator(searcher, result, context::addAnnNodesVisited, topK, true, null);
     }
 
     public SegmentMetadata.ComponentMetadataMap writeData(IndexDescriptor indexDescriptor, IndexContext indexContext, Function<T, Integer> postingTransformer) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CloseableReranker.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CloseableReranker.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.Closeable;
+
+import io.github.jbellis.jvector.graph.NodeSimilarity;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.apache.cassandra.io.util.FileUtils;
+
+/**
+ * A {@link NodeSimilarity.Reranker} that closes the underlying {@link VectorSupplier} when closed.
+ */
+public class CloseableReranker implements NodeSimilarity.Reranker, Closeable
+{
+    private final VectorSimilarityFunction similarityFunction;
+    private final float[] queryVector;
+    private final VectorSupplier vectorSupplier;
+
+    public CloseableReranker(VectorSimilarityFunction similarityFunction, float[] queryVector, VectorSupplier view)
+    {
+        this.similarityFunction = similarityFunction;
+        this.queryVector = queryVector;
+        this.vectorSupplier = view;
+    }
+
+    @Override
+    public float similarityTo(int i)
+    {
+        return similarityFunction.compare(queryVector, vectorSupplier.getVectorForOrdinal(i));
+    }
+
+    @Override
+    public void close()
+    {
+        FileUtils.closeQuietly(vectorSupplier);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
@@ -52,7 +52,7 @@ public abstract class JVectorLuceneOnDiskGraph implements AutoCloseable
     public abstract int size();
 
     public abstract OrdinalsView getOrdinalsView() throws IOException;
-    public abstract VectorsView getVectorsView() throws IOException;
+    public abstract VectorSupplier getVectorSupplier() throws IOException;
 
     /** returns null if no compression was performed */
     public abstract CompressedVectors getCompressedVectors();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
@@ -52,7 +52,7 @@ public abstract class JVectorLuceneOnDiskGraph implements AutoCloseable
     public abstract int size();
 
     public abstract OrdinalsView getOrdinalsView() throws IOException;
-    public abstract float[] getVectorForOrdinal(int ordinal) throws IOException;
+    public abstract VectorsView getVectorsView() throws IOException;
 
     /** returns null if no compression was performed */
     public abstract CompressedVectors getCompressedVectors();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSupplier.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSupplier.java
@@ -18,7 +18,7 @@
 
 package org.apache.cassandra.index.sai.disk.vector;
 
-public interface VectorsView extends AutoCloseable
+public interface VectorSupplier extends AutoCloseable
 {
     /**
      * Returns the vector for the given ordinal.

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorsView.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorsView.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+public interface VectorsView extends AutoCloseable
+{
+    /**
+     * Returns the vector for the given ordinal.
+     * @param ordinal a graph's ordinal
+     * @return the vector for the given ordinal
+     */
+    float[] getVectorForOrdinal(int ordinal);
+
+    /**
+     * Close the vectors view, logging any exceptions.
+     */
+    @Override
+    void close();
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -41,7 +41,7 @@ public class BruteForceRowIdIteratorTest
 
         // Should work for an empty pq
         NodeSimilarity.Reranker reranker = o -> VectorSimilarityFunction.COSINE.compare(queryVector, identityMapper(o));
-        var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK);
+        var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK, () -> {});
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -23,11 +23,11 @@ import java.util.PriorityQueue;
 
 import org.junit.Test;
 
-import io.github.jbellis.jvector.graph.NodeSimilarity;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class BruteForceRowIdIteratorTest
 {
@@ -40,14 +40,28 @@ public class BruteForceRowIdIteratorTest
         var limit = 10;
 
         // Should work for an empty pq
-        NodeSimilarity.Reranker reranker = o -> VectorSimilarityFunction.COSINE.compare(queryVector, identityMapper(o));
-        var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK, () -> {});
+        var view = new TestVectorSupplier();
+        CloseableReranker reranker = new CloseableReranker(VectorSimilarityFunction.COSINE, queryVector, view);
+        var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK);
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
+        assertTrue(view.isClosed);
     }
 
-    private float[] identityMapper(int rowId)
+    private static class TestVectorSupplier implements VectorSupplier
     {
-        return new float[] { rowId };
+        private boolean isClosed = false;
+
+        @Override
+        public float[] getVectorForOrdinal(int ordinal)
+        {
+            return new float[] { ordinal };
+        }
+
+        @Override
+        public void close()
+        {
+            isClosed = true;
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -45,6 +45,8 @@ public class BruteForceRowIdIteratorTest
         var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK);
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
+        assertFalse(view.isClosed);
+        iter.close();
         assertTrue(view.isClosed);
     }
 


### PR DESCRIPTION
Fixes two key issues:
* The `CassandraOnDiskHnsw` implementation's `VectorsWithCache` was incorrectly accessed by multiple threads. It is now created once per query and closed when the query finishes using the object.
* `CassandraDiskAnn` created a vector view per thread without ever closing the view. This leaks random access readers.

Misc. cleanup:
* Removed unused reference to QueryContext in `VectorsWithCache`
* Converted `BruteForceRowIdIterator` to a `CloseableIterator`