### PR TITLE
Replace CloseableIterator with AbstractIterator

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.index.sai.disk.v2.hnsw;
 
 import java.io.IOException;
-import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -46,6 +45,7 @@ import org.apache.cassandra.index.sai.disk.vector.OrdinalsView;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
@@ -136,7 +136,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
     /**
      * An iterator that reorders the results from HNSW to descending score order.
      */
-    static class ReorderingNodeScoresIterator implements CloseableIterator<SearchResult.NodeScore>
+    static class ReorderingNodeScoresIterator extends AbstractIterator<SearchResult.NodeScore>
     {
         private final SearchResult.NodeScore[] scores;
         private int index;
@@ -156,25 +156,15 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         }
 
         @Override
-        public boolean hasNext()
+        public SearchResult.NodeScore computeNext()
         {
             if (index < 0)
             {
                 logger.warn("HNSW queue is empty, returning false, but the search might not have been exhaustive");
-                return false;
+                return endOfData();
             }
-            return true;
-        }
-
-        @Override
-        public SearchResult.NodeScore next() {
-            if (!hasNext())
-                throw new NoSuchElementException();
             return scores[index--];
         }
-
-        @Override
-        public void close() {}
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -156,7 +156,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         }
 
         @Override
-        public SearchResult.NodeScore computeNext()
+        protected SearchResult.NodeScore computeNext()
         {
             if (index < 0)
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -65,7 +65,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
     }
 
     @Override
-    public SearchResult.NodeScore computeNext()
+    protected SearchResult.NodeScore computeNext()
     {
         if (nodeScores.hasNext())
             return nodeScores.next();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/NodeScoreToScoredRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/NodeScoreToScoredRowIdIterator.java
@@ -45,7 +45,7 @@ public class NodeScoreToScoredRowIdIterator extends AbstractIterator<ScoredRowId
     }
 
     @Override
-    public ScoredRowId computeNext()
+    protected ScoredRowId computeNext()
     {
         try
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/NodeScoreToScoredRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/NodeScoreToScoredRowIdIterator.java
@@ -19,18 +19,18 @@
 package org.apache.cassandra.index.sai.disk.vector;
 
 import java.io.IOException;
-import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
 import java.util.stream.IntStream;
 
 import io.github.jbellis.jvector.graph.SearchResult;
+import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 
 /**
  * An iterator over {@link ScoredRowId} sorted by score descending. The iterator converts ordinals (node ids) to
  * segment row ids and pairs them with the score given by the index.
  */
-public class NodeScoreToScoredRowIdIterator implements CloseableIterator<ScoredRowId>
+public class NodeScoreToScoredRowIdIterator extends AbstractIterator<ScoredRowId>
 {
     private final CloseableIterator<SearchResult.NodeScore> nodeScores;
     private final RowIdsView rowIdsView;
@@ -45,12 +45,12 @@ public class NodeScoreToScoredRowIdIterator implements CloseableIterator<ScoredR
     }
 
     @Override
-    public boolean hasNext()
+    public ScoredRowId computeNext()
     {
         try
         {
             if (segmentRowIdIterator.hasNext())
-                return true;
+                return new ScoredRowId(segmentRowIdIterator.nextInt(), currentScore);
 
             while (nodeScores.hasNext())
             {
@@ -59,22 +59,14 @@ public class NodeScoreToScoredRowIdIterator implements CloseableIterator<ScoredR
                 var ordinal = result.node;
                 segmentRowIdIterator = rowIdsView.getSegmentRowIdsMatching(ordinal);
                 if (segmentRowIdIterator.hasNext())
-                    return true;
+                    return new ScoredRowId(segmentRowIdIterator.nextInt(), currentScore);
             }
-            return false;
+            return endOfData();
         }
         catch (IOException e)
         {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public ScoredRowId next()
-    {
-        if (!hasNext())
-            throw new NoSuchElementException();
-        return new ScoredRowId(segmentRowIdIterator.nextInt(), currentScore);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -506,7 +506,7 @@ public class VectorMemtableIndex implements MemtableIndex
         }
 
         @Override
-        public ScoredPrimaryKey computeNext()
+        protected ScoredPrimaryKey computeNext()
         {
             if (primaryKeysForNode.hasNext())
                 return primaryKeysForNode.next();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
-import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -59,6 +58,7 @@ import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.index.sai.utils.ScoredPrimaryKey;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -495,7 +495,7 @@ public class VectorMemtableIndex implements MemtableIndex
      * An iterator over {@link ScoredPrimaryKey} sorted by score descending. The iterator converts ordinals (node ids)
      * to {@link PrimaryKey}s and pairs them with the score given by the index.
      */
-    private class NodeScoreToScoredPrimaryKeyIterator implements CloseableIterator<ScoredPrimaryKey>
+    private class NodeScoreToScoredPrimaryKeyIterator extends AbstractIterator<ScoredPrimaryKey>
     {
         private final Iterator<SearchResult.NodeScore> nodeScores;
         private Iterator<ScoredPrimaryKey> primaryKeysForNode = Collections.emptyIterator();
@@ -506,10 +506,10 @@ public class VectorMemtableIndex implements MemtableIndex
         }
 
         @Override
-        public boolean hasNext()
+        public ScoredPrimaryKey computeNext()
         {
             if (primaryKeysForNode.hasNext())
-                return true;
+                return primaryKeysForNode.next();
 
             while (nodeScores.hasNext())
             {
@@ -519,23 +519,10 @@ public class VectorMemtableIndex implements MemtableIndex
                                           .map(pk -> new ScoredPrimaryKey(pk, nodeScore.score))
                                           .iterator();
                 if (primaryKeysForNode.hasNext())
-                    return true;
+                    return primaryKeysForNode.next();
             }
 
-            return false;
-        }
-
-        @Override
-        public ScoredPrimaryKey next()
-        {
-            if (!hasNext())
-                throw new NoSuchElementException();
-            return primaryKeysForNode.next();
-        }
-
-        @Override
-        public void close()
-        {
+            return endOfData();
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/utils/MergeScoredPrimaryKeyIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/MergeScoredPrimaryKeyIterator.java
@@ -53,7 +53,7 @@ public class MergeScoredPrimaryKeyIterator extends AbstractIterator<ScoredPrimar
     }
 
     @Override
-    public ScoredPrimaryKey computeNext()
+    protected ScoredPrimaryKey computeNext()
     {
         if (pq.isEmpty())
             return endOfData();

--- a/src/java/org/apache/cassandra/index/sai/utils/MergeScoredPrimaryKeyIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/MergeScoredPrimaryKeyIterator.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.index.sai.utils;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 
 import com.google.common.collect.Iterators;
@@ -28,6 +27,7 @@ import com.google.common.collect.PeekingIterator;
 
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 
 /**
@@ -35,7 +35,7 @@ import org.apache.cassandra.utils.CloseableIterator;
  * scores of the top element of each iterator and returning the {@link ScoredPrimaryKey} with the
  * highest score.
  */
-public class MergeScoredPrimaryKeyIterator implements CloseableIterator<ScoredPrimaryKey>
+public class MergeScoredPrimaryKeyIterator extends AbstractIterator<ScoredPrimaryKey>
 {
     private final PriorityQueue<PeekingIterator<ScoredPrimaryKey>> pq;
     private final List<CloseableIterator<ScoredPrimaryKey>> iteratorsToBeClosed;
@@ -51,17 +51,12 @@ public class MergeScoredPrimaryKeyIterator implements CloseableIterator<ScoredPr
         iteratorsToBeClosed = iterators;
         indexesToBeClosed = referencedIndexes;
     }
-    @Override
-    public boolean hasNext()
-    {
-        return !pq.isEmpty();
-    }
 
     @Override
-    public ScoredPrimaryKey next()
+    public ScoredPrimaryKey computeNext()
     {
-        if (!hasNext())
-            throw new NoSuchElementException();
+        if (pq.isEmpty())
+            return endOfData();
 
         // Get the iterator with the highest score
         var nextIter = pq.poll();

--- a/src/java/org/apache/cassandra/index/sai/utils/PriorityQueueIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PriorityQueueIterator.java
@@ -18,16 +18,15 @@
 
 package org.apache.cassandra.index.sai.utils;
 
-import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
 
-import org.apache.cassandra.utils.CloseableIterator;
+import org.apache.cassandra.utils.AbstractIterator;
 
 /**
  * An iterator that returns elements from a priority queue in order. This is different from
  * {@link PriorityQueue#iterator()} which returns elements in undefined order.
  */
-public class PriorityQueueIterator<T> implements CloseableIterator<T>
+public class PriorityQueueIterator<T> extends AbstractIterator<T>
 {
     private final PriorityQueue<T> pq;
 
@@ -37,21 +36,8 @@ public class PriorityQueueIterator<T> implements CloseableIterator<T>
     }
 
     @Override
-    public boolean hasNext()
+    public T computeNext()
     {
-        return !pq.isEmpty();
-    }
-
-    @Override
-    public T next()
-    {
-        if (!hasNext())
-            throw new NoSuchElementException();
-        return pq.poll();
-    }
-
-    @Override
-    public void close()
-    {
+        return !pq.isEmpty() ? pq.poll() : endOfData();
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/utils/PriorityQueueIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PriorityQueueIterator.java
@@ -36,7 +36,7 @@ public class PriorityQueueIterator<T> extends AbstractIterator<T>
     }
 
     @Override
-    public T computeNext()
+    protected T computeNext()
     {
         return !pq.isEmpty() ? pq.poll() : endOfData();
     }

--- a/src/java/org/apache/cassandra/index/sai/utils/ScoredRowIdPrimaryKeyMapIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/ScoredRowIdPrimaryKeyMapIterator.java
@@ -18,19 +18,18 @@
 
 package org.apache.cassandra.index.sai.utils;
 
-import java.util.NoSuchElementException;
-
 import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 
 /**
  * An iterator over scored primary keys ordered by the score descending
  * Not skippable.
  */
-public class ScoredRowIdPrimaryKeyMapIterator implements CloseableIterator<ScoredPrimaryKey>
+public class ScoredRowIdPrimaryKeyMapIterator extends AbstractIterator<ScoredPrimaryKey>
 {
     private final PrimaryKeyMap primaryKeyMap;
     private final CloseableIterator<ScoredRowId> scoredRowIdIterator;
@@ -46,16 +45,10 @@ public class ScoredRowIdPrimaryKeyMapIterator implements CloseableIterator<Score
     }
 
     @Override
-    public boolean hasNext()
+    public ScoredPrimaryKey computeNext()
     {
-        return scoredRowIdIterator.hasNext();
-    }
-
-    @Override
-    public ScoredPrimaryKey next()
-    {
-        if (!hasNext())
-            throw new NoSuchElementException();
+        if (!scoredRowIdIterator.hasNext())
+            return endOfData();
         var scoredRowId = scoredRowIdIterator.next();
         var primaryKey = primaryKeyMap.primaryKeyFromRowId(searcherContext.getSegmentRowIdOffset() + scoredRowId.getSegmentRowId());
         return new ScoredPrimaryKey(primaryKey, scoredRowId.getScore());

--- a/src/java/org/apache/cassandra/index/sai/utils/ScoredRowIdPrimaryKeyMapIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/ScoredRowIdPrimaryKeyMapIterator.java
@@ -45,7 +45,7 @@ public class ScoredRowIdPrimaryKeyMapIterator extends AbstractIterator<ScoredPri
     }
 
     @Override
-    public ScoredPrimaryKey computeNext()
+    protected ScoredPrimaryKey computeNext()
     {
         if (!scoredRowIdIterator.hasNext())
             return endOfData();


### PR DESCRIPTION
Clean up the iterators created by #929 based on this comment: https://github.com/datastax/cassandra/pull/955#discussion_r1470290255.

Changes:
* Use the `org.apache.cassandra.utils.AbstractIterator` abstract class to simplify iterators introduced in #929. The abstract class implements `Iterator<V>, PeekingIterator<V>, CloseableIterator<V>`, which means this is only an implementation change and doesn't affect signatures.