### PR TITLE
CNDB-6317 Internode compatibility with DSE. (vsearch)

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
@@ -215,8 +215,9 @@ public class CommitLogDescriptor
             case VERSION_30:
                 return MessagingService.VERSION_30;
             case VERSION_40:
-            case VERSION_DSE_68:
                 return MessagingService.VERSION_40;
+            case VERSION_DSE_68:
+                return MessagingService.VERSION_DSE_68;
             case VERSION_SG_10:
                 return MessagingService.VERSION_SG_10;
             default:

--- a/src/java/org/apache/cassandra/net/AcceptVersions.java
+++ b/src/java/org/apache/cassandra/net/AcceptVersions.java
@@ -22,12 +22,23 @@ package org.apache.cassandra.net;
  */
 class AcceptVersions
 {
-    final int min, max;
+    final int min, max, dse;
 
     AcceptVersions(int min, int max)
     {
+        this(min, max, -1);
+    }
+
+    AcceptVersions(int min, int max, int dse)
+    {
         this.min = min;
         this.max = max;
+        this.dse = dse;
+    }
+
+    public boolean acceptsDse()
+    {
+        return dse > 0;
     }
 
     @Override
@@ -37,6 +48,7 @@ class AcceptVersions
             return false;
 
         return min == ((AcceptVersions) that).min
-            && max == ((AcceptVersions) that).max;
+               && max == ((AcceptVersions) that).max
+               && dse == ((AcceptVersions) that).dse;
     }
 }

--- a/src/java/org/apache/cassandra/net/HandshakeProtocol.java
+++ b/src/java/org/apache/cassandra/net/HandshakeProtocol.java
@@ -125,7 +125,8 @@ class HandshakeProtocol
             flags |= ((framing.id & 1) << 2) | ((framing.id & 2) << 3);
             flags |= (requestMessagingVersion << 8);
 
-            if (requestMessagingVersion < VERSION_40 || acceptVersions.max < VERSION_40)
+            if ((requestMessagingVersion < VERSION_40 || acceptVersions.max < VERSION_40) &&
+                !(requestMessagingVersion == 255 && acceptVersions.acceptsDse()))
                 return flags; // for testing, permit serializing as though we are pre40
 
             flags |= (acceptVersions.min << 16);

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -52,11 +52,13 @@ import org.apache.cassandra.security.SSLFactory;
 import org.apache.cassandra.streaming.async.StreamingInboundHandler;
 import org.apache.cassandra.utils.memory.BufferPools;
 
-import static java.lang.Math.*;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.cassandra.net.MessagingService.*;
+import static org.apache.cassandra.net.MessagingService.VERSION_30;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.MessagingService.current_version;
+import static org.apache.cassandra.net.MessagingService.instance;
 import static org.apache.cassandra.net.MessagingService.minimum_version;
 import static org.apache.cassandra.net.SocketFactory.WIRETRACE;
 import static org.apache.cassandra.net.SocketFactory.newSslHandler;
@@ -232,9 +234,13 @@ public class InboundConnectionInitiator
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
         {
-            if (initiate == null) initiate(ctx, in);
-            else if (initiate.acceptVersions == null && confirmOutboundPre40 == null) confirmPre40(ctx, in);
-            else throw new IllegalStateException("Should no longer be on pipeline");
+            if (initiate == null)
+                initiate(ctx, in);
+            else if ((initiate.acceptVersions == null || initiate.acceptVersions.max == settings.acceptMessaging.dse)
+                     && confirmOutboundPre40 == null)
+                confirmPre40(ctx, in);
+            else
+                throw new IllegalStateException("Should no longer be on pipeline");
         }
 
         void initiate(ChannelHandlerContext ctx, ByteBuf in) throws IOException
@@ -263,36 +269,62 @@ public class InboundConnectionInitiator
                 else
                     accept = settings.acceptMessaging;
 
-                int useMessagingVersion = max(accept.min, min(accept.max, initiate.acceptVersions.max));
-                ByteBuf flush = new HandshakeProtocol.Accept(useMessagingVersion, accept.max).encode(ctx.alloc());
-
-                AsyncChannelPromise.writeAndFlush(ctx, flush, (ChannelFutureListener) future -> {
-                    if (!future.isSuccess())
-                        exceptionCaught(future.channel(), future.cause());
-                });
-
-                if (initiate.acceptVersions.min > accept.max)
+                boolean failed = false;
+                boolean isDse = false;
+                if (accept.dse > 0 && initiate.acceptVersions.max == accept.dse)
+                {
+                    logger.info("peer {} has DSE messaging versions ({}) ", ctx.channel().remoteAddress(), accept.dse);
+                    isDse = true;
+                }
+                else if (initiate.acceptVersions.min > accept.max)
                 {
                     logger.info("peer {} only supports messaging versions higher ({}) than this node supports ({})", ctx.channel().remoteAddress(), initiate.acceptVersions.min, current_version);
-                    failHandshake(ctx);
+                    failed = true;
                 }
                 else if (initiate.acceptVersions.max < accept.min)
                 {
                     logger.info("peer {} only supports messaging versions lower ({}) than this node supports ({})", ctx.channel().remoteAddress(), initiate.acceptVersions.max, minimum_version);
-                    failHandshake(ctx);
+                    failed = true;
+                }
+                if (isDse)
+                {
+                    assert initiate.type.isMessaging();
+
+                    // Second message to DSE is sent with version 10 (oss 3.0)
+                    ByteBuf response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.min, ctx.alloc());
+                    AsyncChannelPromise.writeAndFlush(ctx, response,
+                                                      (ChannelFutureListener) future -> {
+                                                          if (!future.isSuccess())
+                                                              exceptionCaught(future.channel(), future.cause());
+                                                      });
                 }
                 else
                 {
-                    if (initiate.type.isStreaming())
+                    int useMessagingVersion = max(accept.min, min(accept.max, initiate.acceptVersions.max));
+                    ByteBuf flush = new HandshakeProtocol.Accept(useMessagingVersion, accept.max).encode(ctx.alloc());
+                    AsyncChannelPromise.writeAndFlush(ctx, flush, (ChannelFutureListener) future -> {
+                        if (!future.isSuccess())
+                            exceptionCaught(future.channel(), future.cause());
+                    });
+                    if (failed)
+                    {
+                        failHandshake(ctx);
+                    }
+                    else if (initiate.type.isStreaming())
+                    {
                         setupStreamingPipeline(initiate.from, ctx);
+                    }
                     else
+                    {
                         setupMessagingPipeline(initiate.from, useMessagingVersion, initiate.acceptVersions.max, ctx.pipeline());
+                    }
                 }
             }
             else
             {
                 int version = initiate.requestMessagingVersion;
-                assert version < VERSION_40 && version >= settings.acceptMessaging.min;
+                assert (version < VERSION_40 && version >= settings.acceptMessaging.min) ||
+                       (version == settings.acceptMessaging.min && settings.acceptMessaging.acceptsDse());
                 logger.trace("Connection version {} from {}", version, ctx.channel().remoteAddress());
 
                 if (initiate.type.isStreaming())
@@ -309,7 +341,17 @@ public class InboundConnectionInitiator
                 {
                     // if this version is < the MS version the other node is trying
                     // to connect with, the other node will disconnect
-                    ByteBuf response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.max, ctx.alloc());
+                    ByteBuf response;
+                    if (version == settings.acceptMessaging.min && settings.acceptMessaging.acceptsDse())
+                    {
+                        // Min protocol is used for DSE CNDB compatibility
+                        response = HandshakeProtocol.Accept.respondPre40(version, ctx.alloc());
+                    }
+                    else
+                    {
+                        response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.max, ctx.alloc());
+                    }
+
                     AsyncChannelPromise.writeAndFlush(ctx, response,
                           (ChannelFutureListener) future -> {
                                if (!future.isSuccess())

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -202,6 +202,8 @@ public class MessagingService extends MessagingServiceMBeanImpl
 {
     private static final Logger logger = LoggerFactory.getLogger(MessagingService.class);
 
+    private static final int SUPPORTED_DSE_VERSION = Integer.getInteger("cassandra.dse.messaging.version", 4);
+
     // 8 bits version, so don't waste versions
     public static final int VERSION_30 = 10;
     public static final int VERSION_3014 = 11;
@@ -215,7 +217,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
     // DSE 6.8 version for backward compatibility
     public static final int VERSION_DSE_68 = 168;
 
-    static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version);
+    static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version, SUPPORTED_DSE_VERSION);
     static AcceptVersions accept_streaming = new AcceptVersions(current_version, current_version);
     static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, v -> v.ordinal()));
 

--- a/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
@@ -127,7 +127,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
     private Future<Result<SuccessType>> initiate(EventLoop eventLoop)
     {
         if (logger.isTraceEnabled())
-            logger.trace("creating outbound bootstrap to {}, requestVersion: {}", settings, requestMessagingVersion);
+                logger.trace("creating outbound bootstrap to {}, requestVersion: {}", settings, requestMessagingVersion);
 
         if (!settings.authenticate())
         {
@@ -147,8 +147,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
                                          {
                                              if (future.isCancelled() && !timedout.get())
                                                  resultPromise.cancel(true);
-                                             else if (future.isCancelled())
-                                                 resultPromise.tryFailure(new IOException("Timeout handshaking with " + settings.connectToId()));
+                                             else if (future.isCancelled()) resultPromise.tryFailure(new IOException("Timeout handshaking with " + settings.connectToId()));
                                              else
                                                  resultPromise.tryFailure(future.cause());
                                          }
@@ -332,7 +331,9 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
 
                     if (result.isSuccess())
                     {
-                        ConfirmOutboundPre40 message = new ConfirmOutboundPre40(settings.acceptVersions.max, settings.from);
+                        // Third handshake message carries PV 10 rather than PV 100.
+                        // Note that CC -> CC handshake doesn't use thrid message at all.
+                        ConfirmOutboundPre40 message = new ConfirmOutboundPre40(settings.acceptVersions.min, settings.from);
                         AsyncChannelPromise.writeAndFlush(ctx, message.encode());
                     }
                 }

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -189,7 +189,8 @@ public class ConnectionTest
             .withRequireClientAuth(false)
             .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA");
 
-    static final AcceptVersions legacy = new AcceptVersions(VERSION_30, VERSION_30);
+    // 30 is used for CNDB compatibility
+    static final AcceptVersions legacy = new AcceptVersions(VERSION_3014, VERSION_3014);
 
     static final List<Function<Settings, Settings>> MODIFIERS = ImmutableList.of(
         settings -> settings.outbound(outbound -> outbound.withAcceptVersions(legacy))
@@ -546,7 +547,7 @@ public class ConnectionTest
     public void testPre40() throws Throwable
     {
         MessagingService.instance().versions.set(FBUtilities.getBroadcastAddressAndPort(),
-                                                 MessagingService.VERSION_30);
+                                                 MessagingService.VERSION_3014);
 
         try
         {


### PR DESCRIPTION
* CC internode compatibility with DSE
* fix commit log version matching

It's a port of https://github.com/datastax/cassandra/pull/688 to vsearch branch. It's needed to ensure DSE 6.8 can communicate with 7.0.