### PR TITLE
Close iterator on uncaught exception to prevent leaks

### DIFF
--- a/src/java/org/apache/cassandra/utils/AbstractIterator.java
+++ b/src/java/org/apache/cassandra/utils/AbstractIterator.java
@@ -44,7 +44,16 @@ public abstract class AbstractIterator<V> implements Iterator<V>, PeekingIterato
         {
             case MUST_FETCH:
                 state = State.FAILED;
-                next = computeNext();
+                try
+                {
+                    next = computeNext();
+                }
+                catch (Throwable t)
+                {
+                    state = State.FAILED;
+                    close();
+                    throw t;
+                }
 
             default:
                 if (state == State.DONE)


### PR DESCRIPTION
We are getting "leak detected" messages like https://github.com/riptano/cndb/issues/8512 if exception was uncaught and not handled approptiately. 
This https://github.com/datastax/cassandra/pull/947 seem to have fixed some of the leaks, this PR opens more general approach for discussion