### PR TITLE
SAI: close iterators when search init fails

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/TermIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TermIterator.java
@@ -91,6 +91,9 @@ public class TermIterator extends RangeIterator
                 if (logger.isDebugEnabled() && !(e1 instanceof AbortedOperationException))
                     logger.debug(String.format("Failed search an index %s, skipping.", index.getSSTable()), e1);
 
+                // Close the iterators that were successfully opened before the error
+                FileUtils.closeQuietly(tokens);
+
                 throw Throwables.cleaned(e1);
             }
         }


### PR DESCRIPTION
When building the collection of sstable and memtable iterators for search, if we hit an exception, we must close the iterators that were already created successfully.