### PR TITLE
Warn on create vector index with too many dimensions

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -336,7 +336,7 @@ public class StorageAttachedIndex implements Index
             if (type.isValueLengthFixed() && IndexContext.MAX_VECTOR_TERM_SIZE < type.valueLengthIfFixed())
             {
                 AbstractType<?> elementType = ((VectorType<?>) type).elementType;
-                var error = String.format("An index of %s will produce terms of %s, " +
+                var error = String.format("Vector index created with %s will produce terms of %s, " +
                                           "exceeding the max vector term size of %s. " +
                                           "That sets an implicit limit of %d dimensions for %s vectors.",
                                           type.asCQL3Type(),
@@ -344,7 +344,9 @@ public class StorageAttachedIndex implements Index
                                           FBUtilities.prettyPrintMemory(IndexContext.MAX_VECTOR_TERM_SIZE),
                                           IndexContext.MAX_VECTOR_TERM_SIZE / elementType.valueLengthIfFixed(),
                                           elementType.asCQL3Type());
-                throw new InvalidRequestException(error);
+                // VSTODO until we can safely differentiate client and system requests, we can only log here
+                // Ticket for this: https://github.com/riptano/VECTOR-SEARCH/issues/85
+                logger.warn(error);
             }
         }
         else if (!SUPPORTED_TYPES.contains(type.asCQL3Type()) && !TypeUtil.isFrozen(type))

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -1481,10 +1481,11 @@ public class NativeIndexDDLTest extends SAITester
 
         // create a vector index producing terms over the max possible size
         createTable(String.format(table, dimensions + 1));
-        assertThatThrownBy(() -> execute(index))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessageContaining("An index of vector<float, 4097> will produce terms of 16.004KiB, " +
-                              "exceeding the max vector term size of 16.000KiB. " +
-                              "That sets an implicit limit of 4096 dimensions for float vectors.");
+        // VSTODO: uncomment when https://github.com/riptano/VECTOR-SEARCH/issues/85 is solved
+//        assertThatThrownBy(() -> execute(index))
+//        .isInstanceOf(InvalidRequestException.class)
+//        .hasMessageContaining("An index of vector<float, 4097> will produce terms of 16.004KiB, " +
+//                              "exceeding the max vector term size of 16.000KiB. " +
+//                              "That sets an implicit limit of 4096 dimensions for float vectors.");
     }
 }


### PR DESCRIPTION
We can revert this once we solve https://github.com/riptano/VECTOR-SEARCH/issues/85