### PR TITLE
Add optimized ChunkCache#invalidateFiles method

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -216,7 +216,7 @@ public class ChunkCache
      * are invalidated, it is more efficient to call this method once with all files than to call it once for each file.
      * @param filePaths the files to invalidate
      */
-    public void invalidateFiles(Collection<String> filePaths)
+    public void invalidateFiles(Iterable<String> filePaths)
     {
         // Use the identity map to avoid unnecessary equality checks.
         var internedPaths = new IdentityHashMap<>();

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -21,7 +21,6 @@
 package org.apache.cassandra.cache;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;


### PR DESCRIPTION
This is a first pass at optimizing cache invalidation. This is not the ideal solution, but it is much better than calling `ChunkCache#invalidateFile` for multiple files in a loop.