### PR TITLE
Optimize ChunkCache#invalidateFile by tracking keysByFile

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -28,7 +28,6 @@ import java.util.function.Function;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.MoreExecutors;
-import org.cliffc.high_scale_lib.NonBlockingHashSet;
 import org.cliffc.high_scale_lib.NonBlockingIdentityHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cache;
 
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -68,6 +69,122 @@ public class ChunkCacheTest
 
         Assert.assertEquals(ChunkCache.instance.size(), 0);
         Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+    }
+
+    @Test
+    public void testInvalidateFileNotInCache()
+    {
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        ChunkCache.instance.invalidateFile("/tmp/does/not/exist/in/cache/or/on/file/system");
+    }
+
+    @Test
+    public void testRandomAccessReadersWithUpdatedFileAndMultipleChunksAndCacheInvalidation() throws IOException
+    {
+        File file = FileUtils.createTempFile("foo", null);
+        file.deleteOnExit();
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+
+        writeBytes(file, new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE * 3]);
+
+        try (FileHandle.Builder builder1 = new FileHandle.Builder(file).withChunkCache(ChunkCache.instance);
+             FileHandle handle1 = builder1.complete();
+             RandomAccessReader reader1 = handle1.createReader();
+             RandomAccessReader reader2 = handle1.createReader())
+        {
+            // Read 2 chunks and verify contents
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 2; i++)
+                Assert.assertEquals((byte) 0, reader1.readByte());
+
+            // Overwrite the file's contents
+            var bytes = new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE * 3];
+            Arrays.fill(bytes, (byte) 1);
+            writeBytes(file, bytes);
+
+            // Verify rebuffer pulls from cache for first 2 bytes and then from disk for third byte
+            reader1.seek(0);
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 2; i++)
+                Assert.assertEquals((byte) 0, reader1.readByte());
+            // Trigger read of next chunk and see it is the new data
+            Assert.assertEquals((byte) 1, reader1.readByte());
+
+            Assert.assertEquals(ChunkCache.instance.size(), 3);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 3);
+
+            // Invalidate cache for both chunks
+            ChunkCache.instance.invalidateFile(file.path());
+
+            // Verify cache is empty
+            Assert.assertEquals(ChunkCache.instance.size(), 0);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+
+            // Seek then verify that the new data is read
+            reader1.seek(0);
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 3; i++)
+                Assert.assertEquals((byte) 1, reader1.readByte());
+
+            // Verify a second reader gets the new data even though it was created before the cache was invalidated
+            Assert.assertEquals((byte) 1, reader2.readByte());
+        }
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+    }
+
+    @Test
+    public void testRandomAccessReadersForDifferentFilesWithCacheInvalidation() throws IOException
+    {
+        File fileFoo = FileUtils.createTempFile("foo", null);
+        fileFoo.deleteOnExit();
+        File fileBar = FileUtils.createTempFile("bar", null);
+        fileBar.deleteOnExit();
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileFoo.path()), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 0);
+
+        writeBytes(fileFoo, new byte[64]);
+        // Write different bytes for meaningful content validation
+        var barBytes = new byte[64];
+        Arrays.fill(barBytes, (byte) 1);
+        writeBytes(fileBar, barBytes);
+
+        try (FileHandle.Builder builderFoo = new FileHandle.Builder(fileFoo).withChunkCache(ChunkCache.instance);
+             FileHandle handleFoo = builderFoo.complete();
+             RandomAccessReader readerFoo = handleFoo.createReader())
+        {
+            Assert.assertEquals((byte) 0, readerFoo.readByte());
+
+            Assert.assertEquals(ChunkCache.instance.size(), 1);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileFoo.path()), 1);
+
+            try (FileHandle.Builder builderBar = new FileHandle.Builder(fileBar).withChunkCache(ChunkCache.instance);
+                 FileHandle handleBar = builderBar.complete();
+                 RandomAccessReader readerBar = handleBar.createReader())
+            {
+                Assert.assertEquals((byte) 1, readerBar.readByte());
+
+                Assert.assertEquals(ChunkCache.instance.size(), 2);
+                Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 1);
+
+                // Invalidate fileFoo and verify that only fileFoo's chunks are removed
+                ChunkCache.instance.invalidateFile(fileFoo.path());
+                Assert.assertEquals(ChunkCache.instance.size(), 1);
+                Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 1);
+            }
+        }
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+    }
+
+    private void writeBytes(File file, byte[] bytes) throws IOException
+    {
+        try (SequentialWriter writer = new SequentialWriter(file))
+        {
+            writer.write(bytes);
+            writer.flush();
+        }
     }
 
 }


### PR DESCRIPTION
This PR optimizes the `ChunkCache#invalidateFile` method by introducing a map that keeps track of the file to key set in the `ChunkCache`. The current solution is costly, as it iterates over the whole cache.

Context: While working on https://github.com/datastax/cassandra/pull/974, I noticed that we have the relevant entry points to keep an accurate mapping from `file` to `Key` in the `ChunkCache`. This implementation might create more objects than one based on a unique counter (such as the one found in CNDB), but given its simplicity, I think it is worth considering.

This is an alternative to https://github.com/datastax/cassandra/pull/974.

Note:

I also explored the possibility of using a weak concurrent map, like the one [here](https://github.com/raphw/weak-lock-free/blob/master/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java) to back the `keysByFile` map. A weak map is intriguing because it effectively cleans itself without any explicit work. However, since we have the `onRemoval` method in this class, it seems unnecessarily complex to use a map that tracks at the garbage collection level.