### PR TITLE
CNDB-8538: Fix PendingRangesCalculatorService

### DIFF
--- a/src/java/org/apache/cassandra/schema/Schema.java
+++ b/src/java/org/apache/cassandra/schema/Schema.java
@@ -736,7 +736,7 @@ public class Schema implements SchemaProvider
         // we send mutations to the correct set of bootstrapping nodes. Refer CASSANDRA-15433.
         if (keyspace.params.replication.klass != LocalStrategy.class && instance != null)
         {
-            PendingRangeCalculatorService.calculatePendingRanges(instance.getReplicationStrategy(), keyspace.name);
+            PendingRangeCalculatorService.instance.calculatePendingRanges(instance.getReplicationStrategy(), keyspace.name);
         }
     }
 

--- a/test/unit/org/apache/cassandra/locator/SimpleStrategyTest.java
+++ b/test/unit/org/apache/cassandra/locator/SimpleStrategyTest.java
@@ -229,7 +229,7 @@ public class SimpleStrategyTest
         {
             strategy = getStrategy(keyspaceName, tmd, new SimpleSnitch());
 
-            PendingRangeCalculatorService.calculatePendingRanges(strategy, keyspaceName);
+            PendingRangeCalculatorService.instance.calculatePendingRanges(strategy, keyspaceName);
 
             int replicationFactor = strategy.getReplicationFactor().allReplicas;
 


### PR DESCRIPTION
PRC is accounted for each keyspace separately. When PRC is requested, we select the affected keyspaces by the filter and add them to the CopyOnWriteArraySet. The PRC task consumes all the added keyspaces and removes them from the set.