### PR TITLE
Assume predicates are independent in selectivity estimation

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/RangeIntersectionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeIntersectionIterator.java
@@ -56,7 +56,7 @@ public class RangeIntersectionIterator extends RangeIterator
         return (INTERSECTION_CLAUSE_LIMIT <= 0) || (numberOfExpressions <= INTERSECTION_CLAUSE_LIMIT);
     }
 
-    private final List<RangeIterator> ranges;
+    public final List<RangeIterator> ranges;
     private final int[] rangeStats;
 
     private RangeIntersectionIterator(Builder.Statistics statistics, List<RangeIterator> ranges)

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.io.util.FileUtils;
 @SuppressWarnings("resource")
 public class RangeUnionIterator extends RangeIterator
 {
-    private final List<RangeIterator> ranges;
+    public final List<RangeIterator> ranges;
 
     private RangeUnionIterator(Builder.Statistics statistics, List<RangeIterator> ranges)
     {


### PR DESCRIPTION
Let's say we want to query for rows with `a = 1 AND b = 1`. If predicate `a = 1` matches 10% rows and predicate `b = 1` matches 20% of rows, we estimate the whole where clause matches only 2% of rows.

Previously we used `getMaxKeys` on the final iterator, but that works differently - it gives the maximum number of keys that could be returned, which is often way off from the expected value. In the abovementioned case it would estimate the selectivity of 10%.