### PR TITLE
Fix hybrid queries on empty tables

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -775,7 +775,7 @@ public class QueryController
     {
         float selectivity;
 
-        if (iterator.getMaxKeys() == 0 || totalRowCount == 0)
+        if (iterator.getMaxKeys() == 0)
             return 0.0f;
 
         // For intersection and union we assume predicates are independent

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -775,6 +775,9 @@ public class QueryController
     {
         float selectivity;
 
+        if (iterator.getMaxKeys() == 0)
+            return 0.0f;
+
         // For intersection and union we assume predicates are independent
         // (column values are not correlated with each other).
         // This assumption is not neccesarily true, but we have no statistical information to do any better.

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -775,7 +775,7 @@ public class QueryController
     {
         float selectivity;
 
-        if (iterator.getMaxKeys() == 0)
+        if (iterator.getMaxKeys() == 0 || totalRowCount == 0)
             return 0.0f;
 
         // For intersection and union we assume predicates are independent

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -1089,4 +1089,17 @@ public class VectorTypeTest extends VectorTester
             assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"), row(1));
         });
     }
+
+    @Test
+    public void testQueryOnEmptyTable() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"));
+        });
+    }
 }


### PR DESCRIPTION
There is currently a bug where a hybrid query on an empty table fails with this exception:

```
Caused by: java.lang.IllegalArgumentException: perItemSuccessRate must not be NaN
	at org.apache.cassandra.index.sai.utils.SoftLimitUtil.softLimit(SoftLimitUtil.java:49)
	at org.apache.cassandra.index.sai.plan.QueryController.estimateSortThenFilterCost(QueryController.java:327)
	at org.apache.cassandra.index.sai.plan.QueryController.decideFilterSortOrder(QueryController.java:302)
	at org.apache.cassandra.index.sai.plan.QueryController.buildScoredPrimaryKeyIterator(QueryController.java:287)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.buildScoredPrimaryKeyIterator(StorageAttachedIndexSearcher.java:147)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:125)
...
```