### PR TITLE
Fix testHybridIndexWithPartialRowInsertsAtSegmentBoundaries

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -1082,7 +1082,7 @@ public class VectorTypeTest extends VectorTester
 
         // Assert the opposite with these writes where the lower bound is not present. (This case actually pushes us to
         // use disk based ordinal mapping.)
-        execute("INSERT INTO %s (pk, val, vec) VALUES (2, 'A', [1, 1])");
+        execute("INSERT INTO %s (pk, val, vec) VALUES (2, 'A', [1, 2])");
         execute("INSERT INTO %s (pk, val) VALUES (1, 'A')");
 
         beforeAndAfterFlush(() -> {


### PR DESCRIPTION
This test is flaky because it assumes we are guaranteed to get a certain row, but that assumption is wrong when we have two identical vectors. The test is no longer flaky when we use a different vector.