### PR TITLE
DSP-23942 vsearch: Port CASSANDRA-19336

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Future version (tbd)
 Merged from 5.0:
  * Add guardrail for vector dimensions (CASSANDRA-18730)
  * Add support for CQL functions on collections, tuples and UDTs (CASSANDRA-17811)
+Merged from 4.0:
+ * Add new concurrent_merkle_tree_requests config property to prevent OOM during multi-range and/or multi-table repairs (CASSANDRA-19336)
 
 4.1
  * Request-Based Native Transport Rate-Limiting (CASSANDRA-16663)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -581,7 +581,7 @@ memtable_allocation_type: offheap_objects
 # There isn't a limit by default for backwards compatibility, but this can
 # produce OOM for  commands repairing multiple tables or multiple virtual nodes.
 # A limit of just 1 simultaneous Merkle tree request is generally recommended
-# with no virtual nodes so repair_session_space, and thereof the Merkle tree
+# with no virtual nodes so repair_session_space, and therefore the Merkle tree
 # resolution, can be high. For virtual nodes a value of 1 with the default
 # repair_session_space value will produce higher resolution Merkle trees
 # at the expense of speed. Alternatively, when working with virtual nodes it

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -558,16 +558,40 @@ concurrent_materialized_view_writes: 32
 #    off heap objects
 memtable_allocation_type: offheap_objects
 
-# Limit memory usage for Merkle tree calculations during repairs. The default
-# is 1/16th of the available heap. The main tradeoff is that smaller trees
-# have less resolution, which can lead to over-streaming data. If you see heap
-# pressure during repairs, consider lowering this, but you cannot go below
-# one megabyte. If you see lots of over-streaming, consider raising
-# this or using subrange repair.
+# Limit memory usage for Merkle tree calculations during repairs of a certain
+# table and common token range. Repair commands targetting multiple tables or
+# virtual nodes can exceed this limit depending on concurrent_merkle_tree_requests.
+#
+# The default is 1/16th of the available heap. The main tradeoff is that
+# smaller trees have less resolution, which can lead to over-streaming data.
+# If you see heap pressure during repairs, consider lowering this, but you
+# cannot go below one mebibyte. If you see lots of over-streaming, consider
+# raising this or using subrange repair.
 #
 # For more details see https://issues.apache.org/jira/browse/CASSANDRA-14096.
 #
 # repair_session_space_in_mb:
+
+# The number of simultaneous Merkle tree requests during repairs that can
+# be performed by a repair command. The size of each validation request is
+# limited by the repair_session_space property, so setting this to 1 will make
+# sure that a repair command doesn't exceed that limit, even if the repair
+# command is repairing multiple tables or multiple virtual nodes.
+#
+# There isn't a limit by default for backwards compatibility, but this can
+# produce OOM for  commands repairing multiple tables or multiple virtual nodes.
+# A limit of just 1 simultaneous Merkle tree request is generally recommended
+# with no virtual nodes so repair_session_space, and thereof the Merkle tree
+# resolution, can be high. For virtual nodes a value of 1 with the default
+# repair_session_space value will produce higher resolution Merkle trees
+# at the expense of speed. Alternatively, when working with virtual nodes it
+# can make sense to reduce the repair_session_space and increase the value of
+# concurrent_merkle_tree_requests because each range will contain fewer data.
+#
+# For more details see https://issues.apache.org/jira/browse/CASSANDRA-19336.
+#
+# A zero value means no limit.
+# concurrent_merkle_tree_requests: 0
 
 # Total space to use for commit logs on disk.
 #

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -142,6 +142,8 @@ public class Config
 
     public volatile long repair_request_timeout_in_ms = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
 
+    public volatile int concurrent_merkle_tree_requests = 0;
+
     public volatile boolean use_offheap_merkle_trees = true;
 
     public int storage_port = 7000;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -3049,6 +3049,16 @@ public class DatabaseDescriptor
         conf.repair_session_space_in_mb = sizeInMegabytes;
     }
 
+    public static int getConcurrentMerkleTreeRequests()
+    {
+        return conf.concurrent_merkle_tree_requests;
+    }
+
+    public static void setConcurrentMerkleTreeRequests(int value)
+    {
+        conf.concurrent_merkle_tree_requests = value;
+    }
+
     public static Float getMemtableCleanupThreshold()
     {
         return conf.memtable_cleanup_threshold;

--- a/src/java/org/apache/cassandra/repair/RepairSession.java
+++ b/src/java/org/apache/cassandra/repair/RepairSession.java
@@ -114,6 +114,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
     // Tasks(snapshot, validate request, differencing, ...) are run on taskExecutor
     public final ListeningExecutorService taskExecutor;
     public final boolean optimiseStreams;
+    public final Scheduler validationScheduler;
 
     private volatile boolean terminated = false;
 
@@ -130,6 +131,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
      */
     public RepairSession(UUID parentRepairSession,
                          UUID id,
+                         Scheduler validationScheduler,
                          CommonRange commonRange,
                          String keyspace,
                          RepairParallelism parallelismDegree,
@@ -142,6 +144,7 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
     {
         assert cfnames.length > 0 : "Repairing no column families seems pointless, doesn't it";
 
+        this.validationScheduler = validationScheduler;
         this.parentRepairSession = parentRepairSession;
         this.id = id;
         this.parallelismDegree = parallelismDegree;

--- a/src/java/org/apache/cassandra/repair/Scheduler.java
+++ b/src/java/org/apache/cassandra/repair/Scheduler.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.repair;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import javax.annotation.concurrent.GuardedBy;
+
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Task scheduler that limits the number of concurrent tasks across multiple executors.
+ */
+public interface Scheduler
+{
+    default <T> ListenableFuture<T> schedule(Supplier<ListenableFuture<T>> task, Executor executor)
+    {
+        return schedule(new Task<>(task, executor), executor);
+    }
+
+    <T> Task<T> schedule(Task<T> task, Executor executor);
+
+    static Scheduler build(int concurrentValidations)
+    {
+        return concurrentValidations <= 0
+               ? new NoopScheduler()
+               : new LimitedConcurrentScheduler(concurrentValidations);
+    }
+
+    final class NoopScheduler implements Scheduler
+    {
+        @Override
+        public <T> Task<T> schedule(Task<T> task, Executor executor)
+        {
+            executor.execute(task);
+            return task;
+        }
+    }
+
+    final class LimitedConcurrentScheduler implements Scheduler
+    {
+        private final int concurrentValidations;
+        @GuardedBy("this")
+        private int inflight = 0;
+        @GuardedBy("this")
+        private final Queue<Pair<Task<?>, Executor>> tasks = new LinkedList<>();
+
+        LimitedConcurrentScheduler(int concurrentValidations)
+        {
+            this.concurrentValidations = concurrentValidations;
+        }
+
+        @Override
+        public synchronized <T> Task<T> schedule(Task<T> task, Executor executor)
+        {
+            tasks.offer(Pair.create(task, executor));
+            maybeSchedule();
+            return task;
+        }
+
+        private synchronized void onDone()
+        {
+            inflight--;
+            maybeSchedule();
+        }
+
+        private void maybeSchedule()
+        {
+            if (inflight == concurrentValidations || tasks.isEmpty())
+                return;
+            inflight++;
+            Pair<Task<?>, Executor> pair = tasks.poll();
+            Futures.addCallback(pair.left, new FutureCallback<Object>() {
+                @Override
+                public void onSuccess(Object result)
+                {
+                    onDone();
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    onDone();
+                }
+            }, pair.right);
+            pair.right.execute(pair.left);
+        }
+    }
+
+    class Task<T> extends AbstractFuture<T> implements Runnable
+    {
+        private final Supplier<ListenableFuture<T>> supplier;
+        private final Executor executor;
+
+        public Task(Supplier<ListenableFuture<T>> supplier, Executor executor)
+        {
+            this.supplier = supplier;
+            this.executor = executor;
+        }
+
+        @Override
+        public void run()
+        {
+            Futures.addCallback(supplier.get(), new FutureCallback<T>() {
+                @Override
+                public void onSuccess(T result)
+                {
+                    set(result);
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    setException(t);
+                }
+            }, executor);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -73,6 +73,7 @@ import org.apache.cassandra.repair.ParentRepairSessionListener;
 import org.apache.cassandra.repair.RepairJobDesc;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.repair.RepairSession;
+import org.apache.cassandra.repair.Scheduler;
 import org.apache.cassandra.repair.consistent.CoordinatorSessions;
 import org.apache.cassandra.repair.consistent.LocalSessions;
 import org.apache.cassandra.repair.consistent.admin.CleanupSummary;
@@ -342,6 +343,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
                                              PreviewKind previewKind,
                                              boolean optimiseStreams,
                                              ListeningExecutorService executor,
+                                             Scheduler validationScheduler,
                                              String... cfnames)
     {
         if (range.endpoints.isEmpty())
@@ -350,7 +352,8 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         if (cfnames.length == 0)
             return null;
 
-        final RepairSession session = new RepairSession(parentRepairSession, UUIDGen.getTimeUUID(), range, keyspace,
+        final RepairSession session = new RepairSession(parentRepairSession, UUIDGen.getTimeUUID(),
+                                                        validationScheduler, range, keyspace,
                                                         parallelismDegree, isIncremental, pushRepair, pullRepair,
                                                         previewKind, optimiseStreams, cfnames);
 

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/ConcurrentValidationRequestsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/ConcurrentValidationRequestsTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.repair;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.NodeToolResult;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.repair.ValidationTask;
+import org.apache.cassandra.utils.MerkleTrees;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+/**
+ * Verifies that the config property {@code concurrent_merkle_tree_requests} limits the number of concurrent validation
+ * requests.
+ */
+public class ConcurrentValidationRequestsTest extends TestBaseImpl
+{
+    private static final int NODES = 4;
+    private static final int RF = 3;
+    private static final int TABLES = 5;
+    private static final int ROWS = 100;
+    private static final int MAX_REQUESTS = 1;
+
+    @Test
+    public void testConcurrentValidations() throws Throwable
+    {
+        try (Cluster cluster = init(builder().withNodes(NODES)
+                                             .withInstanceInitializer(ConcurrentValidationRequestsTest.BBHelper::install)
+                                             .withConfig(c -> c.set("concurrent_merkle_tree_requests", MAX_REQUESTS)
+                                                               .with(NETWORK, GOSSIP))
+                                             .start(), RF))
+        {
+            for (int t = 1; t <= TABLES; t++)
+                cluster.schemaChange(withKeyspace("CREATE TABLE %s.t" + t + " (k int PRIMARY KEY, v int)"));
+
+            int v = 0;
+            for (int k = 0; k < ROWS; k++)
+            {
+                v++;
+                for (int t = 1; t <= TABLES; t++)
+                {
+                    String insert = withKeyspace("INSERT INTO %s.t" + t + " (k, v) VALUES (?, ?)");
+                    cluster.coordinator(1).execute(insert, ConsistencyLevel.ALL, k, v);
+                }
+            }
+            cluster.forEach(x -> x.flush(KEYSPACE));
+
+            NodeToolResult res = cluster.get(1).nodetoolResult("repair", "-j=4", KEYSPACE);
+            res.asserts().success();
+        }
+    }
+
+    public static class BBHelper
+    {
+        /**
+         * Keeps track of the number of concurrent validation requests, which should never be greater than RF times
+         * the value of the {@code concurrent_merkle_tree_requests} config property.
+         */
+        public static volatile AtomicInteger requests = new AtomicInteger(0);
+
+        public static void install(ClassLoader cl, int node)
+        {
+            if (node != 1)
+                return;
+
+            new ByteBuddy().rebase(ValidationTask.class)
+                           .method(named("run"))
+                           .intercept(MethodDelegation.to(ConcurrentValidationRequestsTest.BBHelper.class))
+                           .method(named("treesReceived"))
+                           .intercept(MethodDelegation.to(ConcurrentValidationRequestsTest.BBHelper.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        @SuppressWarnings("unused")
+        public static void run(@SuperCall Callable<Void> zuper)
+        {
+            try
+            {
+                zuper.call();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+
+            int requests = BBHelper.requests.incrementAndGet();
+            if (requests > MAX_REQUESTS * RF)
+                throw new AssertionError("Too many concurrent validation requests: " + requests);
+        }
+
+        @SuppressWarnings("unused")
+        public static void treesReceived(MerkleTrees trees, @SuperCall Callable<Void> zuperCall)
+        {
+            requests.decrementAndGet();
+
+            try
+            {
+                zuperCall.call();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/ConcurrentValidationRequestsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/ConcurrentValidationRequestsTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.utils.MerkleTrees;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies that the config property {@code concurrent_merkle_tree_requests} limits the number of concurrent validation
@@ -49,12 +50,13 @@ public class ConcurrentValidationRequestsTest extends TestBaseImpl
     private static final int TABLES = 5;
     private static final int ROWS = 100;
     private static final int MAX_REQUESTS = 1;
+    private static final int NODE_TO_REPAIR = 1;
 
     @Test
     public void testConcurrentValidations() throws Throwable
     {
         try (Cluster cluster = init(builder().withNodes(NODES)
-                                             .withInstanceInitializer(ConcurrentValidationRequestsTest.BBHelper::install)
+                                             .withInstanceInitializer(ConcurrentValidationsCountingAssertion::install)
                                              .withConfig(c -> c.set("concurrent_merkle_tree_requests", MAX_REQUESTS)
                                                                .with(NETWORK, GOSSIP))
                                              .start(), RF))
@@ -62,10 +64,8 @@ public class ConcurrentValidationRequestsTest extends TestBaseImpl
             for (int t = 1; t <= TABLES; t++)
                 cluster.schemaChange(withKeyspace("CREATE TABLE %s.t" + t + " (k int PRIMARY KEY, v int)"));
 
-            int v = 0;
-            for (int k = 0; k < ROWS; k++)
+            for (int k = 0, v = 1; k < ROWS; k++, v++)
             {
-                v++;
                 for (int t = 1; t <= TABLES; t++)
                 {
                     String insert = withKeyspace("INSERT INTO %s.t" + t + " (k, v) VALUES (?, ?)");
@@ -74,29 +74,29 @@ public class ConcurrentValidationRequestsTest extends TestBaseImpl
             }
             cluster.forEach(x -> x.flush(KEYSPACE));
 
-            NodeToolResult res = cluster.get(1).nodetoolResult("repair", "-j=4", KEYSPACE);
+            NodeToolResult res = cluster.get(NODE_TO_REPAIR).nodetoolResult("repair", "-j=4", KEYSPACE);
             res.asserts().success();
         }
     }
 
-    public static class BBHelper
+    public static class ConcurrentValidationsCountingAssertion
     {
         /**
          * Keeps track of the number of concurrent validation requests, which should never be greater than RF times
          * the value of the {@code concurrent_merkle_tree_requests} config property.
          */
-        public static volatile AtomicInteger requests = new AtomicInteger(0);
+        public static final AtomicInteger requests = new AtomicInteger(0);
 
         public static void install(ClassLoader cl, int node)
         {
-            if (node != 1)
+            if (node != NODE_TO_REPAIR)
                 return;
 
             new ByteBuddy().rebase(ValidationTask.class)
                            .method(named("run"))
-                           .intercept(MethodDelegation.to(ConcurrentValidationRequestsTest.BBHelper.class))
+                           .intercept(MethodDelegation.to(ConcurrentValidationsCountingAssertion.class))
                            .method(named("treesReceived"))
-                           .intercept(MethodDelegation.to(ConcurrentValidationRequestsTest.BBHelper.class))
+                           .intercept(MethodDelegation.to(ConcurrentValidationsCountingAssertion.class))
                            .make()
                            .load(cl, ClassLoadingStrategy.Default.INJECTION);
         }
@@ -113,9 +113,9 @@ public class ConcurrentValidationRequestsTest extends TestBaseImpl
                 throw new RuntimeException(e);
             }
 
-            int requests = BBHelper.requests.incrementAndGet();
-            if (requests > MAX_REQUESTS * RF)
-                throw new AssertionError("Too many concurrent validation requests: " + requests);
+            int requests = ConcurrentValidationsCountingAssertion.requests.incrementAndGet();
+            assertTrue(String.format("Too many concurrent validation requests %d > %d", requests, MAX_REQUESTS * RF),
+                       requests <= MAX_REQUESTS * RF);
         }
 
         @SuppressWarnings("unused")

--- a/test/unit/org/apache/cassandra/repair/RepairJobTest.java
+++ b/test/unit/org/apache/cassandra/repair/RepairJobTest.java
@@ -113,7 +113,8 @@ public class RepairJobTest
                                         RepairParallelism parallelismDegree, boolean isIncremental, boolean pullRepair,
                                         PreviewKind previewKind, boolean optimiseStreams, String... cfnames)
         {
-            super(parentRepairSession, id, commonRange, keyspace, parallelismDegree, isIncremental, false, pullRepair, previewKind, optimiseStreams, cfnames);
+            super(parentRepairSession, id, Scheduler.build(0), commonRange, keyspace, parallelismDegree, isIncremental,
+                  false, pullRepair, previewKind, optimiseStreams, cfnames);
         }
 
         protected DebuggableThreadPoolExecutor createExecutor()

--- a/test/unit/org/apache/cassandra/repair/RepairSessionTest.java
+++ b/test/unit/org/apache/cassandra/repair/RepairSessionTest.java
@@ -71,7 +71,7 @@ public class RepairSessionTest
         IPartitioner p = Murmur3Partitioner.instance;
         Range<Token> repairRange = new Range<>(p.getToken(ByteBufferUtil.bytes(0)), p.getToken(ByteBufferUtil.bytes(100)));
         Set<InetAddressAndPort> endpoints = Sets.newHashSet(remote);
-        RepairSession session = new RepairSession(parentSessionId, sessionId,
+        RepairSession session = new RepairSession(parentSessionId, sessionId, Scheduler.build(0),
                                                   new CommonRange(endpoints, Collections.emptySet(), Arrays.asList(repairRange)),
                                                   "Keyspace1", RepairParallelism.SEQUENTIAL,
                                                   false, false, false,
@@ -191,7 +191,7 @@ public class RepairSessionTest
         IPartitioner p = Murmur3Partitioner.instance;
         Range<Token> repairRange = new Range<>(p.getToken(ByteBufferUtil.bytes(0)), p.getToken(ByteBufferUtil.bytes(100)));
         Set<InetAddressAndPort> endpoints = Sets.newHashSet(remote);
-        RepairSession session = new RepairSession(parentSessionId, sessionId,
+        RepairSession session = new RepairSession(parentSessionId, sessionId, Scheduler.build(0),
                                                   new CommonRange(endpoints, Collections.emptySet(), Arrays.asList(repairRange)),
                                                   "Keyspace1", RepairParallelism.SEQUENTIAL,
                                                   false, false, false,


### PR DESCRIPTION
Add new concurrent_merkle_tree_requests config property to prevent OOM during multi-range and/or multi-table repairs.

It ensures that the space taken by the Merkle trees of a repair command should never be higher than `concurrent_merkle_tree_requests`*`repair_session_space`, even if that command includes multiple tables or virtual nodes. This is only applied to the Merkle tree part of repair, and the rest of the steps preserve the same parallelism that they had.