### PR TITLE
Fix VectorMemtableIndex#update logic to compare vectors

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -127,7 +127,7 @@ public class VectorMemtableIndex implements MemtableIndex
         }
         else
         {
-            different = IntStream.range(0, oldRemaining).anyMatch(i -> oldValue.get(i) != newValue.get(i));
+            different = indexContext.getValidator().compare(oldValue, newValue) != 0;
         }
 
         if (different)


### PR DESCRIPTION
Fix https://github.com/riptano/VECTOR-SEARCH/issues/88

This PR changes the buffer comparison logic to use the index's validator. The previous logic did not work correctly because it assumed all positions started at 0.