### PR TITLE
Use references to speed up intersections

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyWithSource.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyWithSource.java
@@ -95,6 +95,8 @@ public class PrimaryKeyWithSource implements PrimaryKey
     @Override
     public int compareTo(PrimaryKey o)
     {
+        if (this == o)
+            return 0;
         if (o instanceof PrimaryKeyWithSource)
         {
             var other = (PrimaryKeyWithSource) o;
@@ -107,6 +109,8 @@ public class PrimaryKeyWithSource implements PrimaryKey
     @Override
     public boolean equals(Object o)
     {
+        if (this == o)
+            return true;
         if (o instanceof PrimaryKeyWithSource)
         {
             var other = (PrimaryKeyWithSource) o;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -207,10 +207,10 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         if (clusteringComparator.size() == 0)
             return skinnyExactRowIdOrInvertedCeiling(key);
 
-        long pointId = cursor.getExactPointId(v -> key.asComparableBytes(v));
+        long pointId = cursor.getExactPointId(key::asComparableBytes);
         if (pointId >= 0)
             return pointId;
-        long ceiling = cursor.ceiling(v -> key.asComparableBytesMinPrefix(v));
+        long ceiling = cursor.ceiling(key::asComparableBytesMinPrefix);
         // Use min value since -(Long.MIN_VALUE) - 1 == Long.MAX_VALUE.
         return ceiling < 0 ? Long.MIN_VALUE : -ceiling - 1;
     }

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeUnionIterator.java
@@ -79,14 +79,14 @@ public class RangeUnionIterator extends RangeIterator
                     candidate = range;
             }
         }
-        if (candidate == null)
-            return endOfData();
-
         if (hitSkipToKey)
         {
             hitSkipToKey = false;
             return skipToKey;
         }
+
+        if (candidate == null)
+            return endOfData();
 
         return candidate.next();
     }


### PR DESCRIPTION
This PR is an alternative, less intrusive version of #903. The main idea is that we can speed up intersections by using the right references and then using reference equality checks. I don't have enough data to back this up yet.