### PR TITLE
Allow creating other instances of `ChunkCache`

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -53,11 +53,11 @@ public class ChunkCache
     private final static Logger logger = LoggerFactory.getLogger(ChunkCache.class);
 
     public static final int RESERVED_POOL_SPACE_IN_MB = 32;
-    public static final long cacheSize = 1024L * 1024L * Math.max(0, DatabaseDescriptor.getFileCacheSizeInMB() - RESERVED_POOL_SPACE_IN_MB);
     public static final boolean roundUp = DatabaseDescriptor.getFileCacheRoundUp();
 
-    private static boolean enabled = DatabaseDescriptor.getFileCacheEnabled() && cacheSize > 0;
-    public static final ChunkCache instance = enabled ? new ChunkCache(BufferPools.forChunkCache()) : null;
+    public static final ChunkCache instance = DatabaseDescriptor.getFileCacheEnabled()
+                                              ? new ChunkCache(BufferPools.forChunkCache(), DatabaseDescriptor.getFileCacheSizeInMB(), ChunkCacheMetrics::create)
+                                              : null;
 
     private final BufferPool bufferPool;
 
@@ -66,8 +66,10 @@ public class ChunkCache
     // safe for concurrent access.
     private final NonBlockingIdentityHashMap<String, NonBlockingHashSet<Key>> keysByFile;
     private final LoadingCache<Key, Buffer> cache;
+    private final long cacheSize;
     public final ChunkCacheMetrics metrics;
 
+    private boolean enabled;
     private Function<ChunkReader, RebuffererFactory> wrapper = this::wrap;
 
     static class Key
@@ -168,10 +170,12 @@ public class ChunkCache
         }
     }
 
-    private ChunkCache(BufferPool pool)
+    public ChunkCache(BufferPool pool, int cacheSizeInMB, Function<ChunkCache, ChunkCacheMetrics> createMetrics)
     {
+        cacheSize = 1024L * 1024L * Math.max(0, cacheSizeInMB - RESERVED_POOL_SPACE_IN_MB);
+        enabled = cacheSize > 0;
         bufferPool = pool;
-        metrics = ChunkCacheMetrics.create(this);
+        metrics = createMetrics.apply(this);
         keysByFile = new NonBlockingIdentityHashMap<>();
         cache = Caffeine.newBuilder()
                         .maximumWeight(cacheSize)
@@ -223,12 +227,12 @@ public class ChunkCache
         return new CachingRebufferer(file);
     }
 
-    public static RebuffererFactory maybeWrap(ChunkReader file)
+    public RebuffererFactory maybeWrap(ChunkReader file)
     {
         if (!enabled)
             return file;
 
-        return instance.wrapper.apply(file);
+        return wrapper.apply(file);
     }
 
     public void invalidateFile(String filePath)
@@ -243,7 +247,7 @@ public class ChunkCache
     @VisibleForTesting
     public void enable(boolean enabled)
     {
-        ChunkCache.enabled = enabled;
+        this.enabled = enabled;
         wrapper = this::wrap;
         cache.invalidateAll();
         metrics.reset();

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
@@ -53,7 +53,7 @@ public class ChunkCacheInterceptingTest
             when(chunkReader.chunkSize()).thenReturn(1024);
             when(chunkReader.channel()).thenReturn(new ChannelProxy(new File("")));
 
-            RebuffererFactory rebuferrerFactory = ChunkCache.maybeWrap(chunkReader);
+            RebuffererFactory rebuferrerFactory = ChunkCache.instance.maybeWrap(chunkReader);
             assertTrue("chunk cache didn't create our interceptor?", interceptor != null);
 
             rebuferrerFactory.instantiateRebufferer();

--- a/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CodahaleChunkCacheMetricsTest.java
@@ -96,7 +96,7 @@ public class CodahaleChunkCacheMetricsTest
         assertEquals(0.0, chunkCacheMetrics.missLatency(), 0.0);
 
         // Cache size was statically initialized 
-        assertEquals(ChunkCache.cacheSize, chunkCacheMetrics.capacity());
+        assertEquals(ChunkCache.instance.capacity(), chunkCacheMetrics.capacity());
 
         assertEquals(0, chunkCacheMetrics.size());
 


### PR DESCRIPTION
For the storage service, we want to experiment with having a dedicated chunk cache instance for index reads, one that can cache some reads but does not impact the data chunk cache hit rate negatively. It's a bit hard to do at the moment because:
1. the ctor is private (workaroundable with reflection but ...).
2. the size is actually a static variable, so we can't have a new instance of a different size.
3. the metrics kind of hardcode names assuming there is just one instance, so we need to able to use some different metrics class to change that.

Note that regardless of whether the experiment pan out on the storage service side, it doesn't feel like the few visibility updates here hurt much.