### PR TITLE
Cache most-accessed graph nodes asynchronously instead of blocking startup

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -94,8 +94,8 @@ public class Segment implements Closeable, SegmentOrdering
             version = version == Version.CA ? Version.BA : Version.CA;
             searcher = version.onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
         }
-        logger.info("Opened searcher {} for segment {} at version {}",
-                    searcher.getClass().getName(), sstableContext.descriptor(), version);
+        logger.info("Opened searcher {} for segment {}:{} at version {}",
+                    searcher.getClass().getSimpleName(), sstableContext.descriptor(), metadata.segmentRowIdOffset, version);
         this.index = searcher;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -213,7 +213,7 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
                         return;
                     // target 1% of the vectors with a max distance of 3
                     int distance = Math.min(logBaseX(0.01d * graph.size(), graph.maxDegree()), 3);
-                    logger.debug("Caching {} to distance {}", graphHandle.path(), distance);
+                    logger.debug("Caching {}@{} to distance {}", this, graphHandle.path(), distance);
                     graph = new CachingGraphIndex((OnDiskGraphIndex<float[]>) graph, distance);
                 }
             });


### PR DESCRIPTION
Profiling indicates that this is the bottleneck on starting a node with many sstables / index segments.  With ~500 segments, the change here takes startup from minutes to seconds.