### PR TITLE
SAI: log segment's index and column names on init

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -94,8 +94,9 @@ public class Segment implements Closeable, SegmentOrdering
             version = version == Version.CA ? Version.BA : Version.CA;
             searcher = version.onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
         }
-        logger.info("Opened searcher {} for segment {}:{} at version {}",
-                    searcher.getClass().getSimpleName(), sstableContext.descriptor(), metadata.segmentRowIdOffset, version);
+        logger.info("Opened searcher {} for segment {}:{} for index [{}] on column [{}] at version {}",
+                    searcher.getClass().getSimpleName(), sstableContext.descriptor(), metadata.segmentRowIdOffset,
+                    indexContext.getIndexName(), indexContext.getColumnName(), version);
         this.index = searcher;
     }
 


### PR DESCRIPTION
Sample log line:

> INFO  [ForkJoinPool.commonPool-worker-5] 2024-02-15 12:45:14,841 Segment.java:97 - Opened searcher InvertedIndexSearcher for segment file:///Users/michaelmarshall/dev/apache/cassandra/bin/../data/data/keyspace/table-3f5c9290953911eebe8a2ff180e5ea33/cb-3gbp_1n19_3r1402f2khukes3gh5-bti:0 for index [table_metadata_s_idx] on column [metadata_s] at version ca

This additional information helps make these log lines distinguishable.