### PR TITLE
add source_model sai option to allow model-specific compression tuning

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -202,6 +202,7 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.MAXIMUM_NODE_CONNECTIONS,
                                                                      IndexWriterConfig.CONSTRUCTION_BEAM_WIDTH,
                                                                      IndexWriterConfig.SIMILARITY_FUNCTION,
+                                                                     IndexWriterConfig.SOURCE_MODEL,
                                                                      IndexWriterConfig.OPTIMIZE_FOR,
                                                                      LuceneAnalyzer.INDEX_ANALYZER,
                                                                      LuceneAnalyzer.QUERY_ANALYZER);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
@@ -116,7 +116,7 @@ public class IndexWriterConfig
                              int maximumNodeConnections,
                              int constructionBeamWidth,
                              VectorSimilarityFunction similarityFunction,
-                             VectorSourceModel defaultSourceModel,
+                             VectorSourceModel sourceModel,
                              OptimizeFor optimizeFor)
     {
         this.indexName = indexName;
@@ -125,7 +125,7 @@ public class IndexWriterConfig
         this.maximumNodeConnections = maximumNodeConnections;
         this.constructionBeamWidth = constructionBeamWidth;
         this.similarityFunction = similarityFunction;
-        this.sourceModel = defaultSourceModel;
+        this.sourceModel = sourceModel;
         this.optimizeFor = optimizeFor;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.disk.vector.OptimizeFor;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
@@ -44,7 +45,8 @@ public class IndexWriterConfig
     public static final String MAXIMUM_NODE_CONNECTIONS = "maximum_node_connections";
     public static final String CONSTRUCTION_BEAM_WIDTH = "construction_beam_width";
     public static final String SIMILARITY_FUNCTION = "similarity_function";
-    public static final String OPTIMIZE_FOR = "optimize_for";
+    public static final String SOURCE_MODEL = "source_model";
+    public static final String OPTIMIZE_FOR = "optimize_for"; // unused, retained for compatibility w/ old schemas
 
     public static final int MAXIMUM_MAXIMUM_NODE_CONNECTIONS = 512;
     public static final int MAXIMUM_CONSTRUCTION_BEAM_WIDTH = 3200;
@@ -60,12 +62,15 @@ public class IndexWriterConfig
                                                                 .map(e -> e.name())
                                                                 .collect(Collectors.joining(", "));
 
-    private static final OptimizeFor DEFAULT_OPTIMIZE_FOR = OptimizeFor.LATENCY;
-    private static final String validOptimizeFor = Arrays.stream(OptimizeFor.values())
-                                                         .map(Enum::name)
-                                                         .collect(Collectors.joining(", "));
+    private static final VectorSourceModel DEFAULT_SOURCE_MODEL = VectorSourceModel.OTHER;
+    private static final String validSourceModels = Arrays.stream(VectorSourceModel.values())
+                                                          .map(Enum::name)
+                                                          .collect(Collectors.joining(", "));
 
-    private static final IndexWriterConfig EMPTY_CONFIG = new IndexWriterConfig(null, -1, -1, -1, -1, null, null);
+    // no longer used
+    private static final OptimizeFor DEFAULT_OPTIMIZE_FOR = OptimizeFor.LATENCY;
+
+    private static final IndexWriterConfig EMPTY_CONFIG = new IndexWriterConfig(null, -1, -1, -1, -1, null, DEFAULT_SOURCE_MODEL, null);
 
     /**
      * Fully qualified index name, in the format "<keyspace>.<table>.<index_name>".
@@ -85,10 +90,10 @@ public class IndexWriterConfig
     private final int bkdPostingsMinLeaves;
 
     private final int maximumNodeConnections;
-
     private final int constructionBeamWidth;
-
     private final VectorSimilarityFunction similarityFunction;
+    private final VectorSourceModel sourceModel;
+
     private final OptimizeFor optimizeFor;
 
     public IndexWriterConfig(String indexName,
@@ -101,6 +106,7 @@ public class IndexWriterConfig
              DEFAULT_MAXIMUM_NODE_CONNECTIONS,
              DEFAULT_CONSTRUCTION_BEAM_WIDTH,
              DEFAULT_SIMILARITY_FUNCTION,
+             DEFAULT_SOURCE_MODEL,
              DEFAULT_OPTIMIZE_FOR);
     }
 
@@ -110,6 +116,7 @@ public class IndexWriterConfig
                              int maximumNodeConnections,
                              int constructionBeamWidth,
                              VectorSimilarityFunction similarityFunction,
+                             VectorSourceModel defaultSourceModel,
                              OptimizeFor optimizeFor)
     {
         this.indexName = indexName;
@@ -118,6 +125,7 @@ public class IndexWriterConfig
         this.maximumNodeConnections = maximumNodeConnections;
         this.constructionBeamWidth = constructionBeamWidth;
         this.similarityFunction = similarityFunction;
+        this.sourceModel = defaultSourceModel;
         this.optimizeFor = optimizeFor;
     }
 
@@ -151,6 +159,11 @@ public class IndexWriterConfig
         return similarityFunction;
     }
 
+    public VectorSourceModel getSourceModel()
+    {
+        return sourceModel;
+    }
+
     public static IndexWriterConfig fromOptions(String indexName, AbstractType<?> type, Map<String, String> options)
     {
         int minLeaves = DEFAULT_POSTING_LIST_MIN_LEAVES;
@@ -158,6 +171,7 @@ public class IndexWriterConfig
         int maximumNodeConnections = DEFAULT_MAXIMUM_NODE_CONNECTIONS;
         int queueSize = DEFAULT_CONSTRUCTION_BEAM_WIDTH;
         VectorSimilarityFunction similarityFunction = DEFAULT_SIMILARITY_FUNCTION;
+        VectorSourceModel sourceModel = DEFAULT_SOURCE_MODEL;
         OptimizeFor optimizeFor = DEFAULT_OPTIMIZE_FOR;
 
         if (options.get(POSTING_LIST_LVL_MIN_LEAVES) != null || options.get(POSTING_LIST_LVL_SKIP_OPTION) != null)
@@ -200,7 +214,8 @@ public class IndexWriterConfig
         else if (options.get(MAXIMUM_NODE_CONNECTIONS) != null ||
                  options.get(CONSTRUCTION_BEAM_WIDTH) != null ||
                  options.get(OPTIMIZE_FOR) != null ||
-                 options.get(SIMILARITY_FUNCTION) != null)
+                 options.get(SIMILARITY_FUNCTION) != null ||
+                 options.get(SOURCE_MODEL) != null)
         {
             if (!type.isVector())
                 throw new InvalidRequestException(String.format("CQL type %s cannot have vector options", type.asCQL3Type()));
@@ -251,23 +266,22 @@ public class IndexWriterConfig
                     throw new InvalidRequestException(String.format("Similarity function %s was not recognized for index %s. Valid values are: %s",
                                                                     option, indexName, validSimilarityFunctions));
                 }
-
             }
-            if (options.containsKey(OPTIMIZE_FOR))
+            if (options.containsKey(SOURCE_MODEL))
             {
-                String option = options.get(OPTIMIZE_FOR).toUpperCase();
+                String option = options.get(SOURCE_MODEL).toUpperCase();
                 try
                 {
-                    optimizeFor = OptimizeFor.valueOf(option);
+                    sourceModel = VectorSourceModel.valueOf(option);
                 }
                 catch (IllegalArgumentException e)
                 {
-                    throw new InvalidRequestException(String.format("optimize_for '%s' was not recognized for index %s. Valid values are: %s",
-                                                                    option, indexName, validOptimizeFor));
+                    throw new InvalidRequestException(String.format("source_model '%s' was not recognized for index %s. Valid values are: %s",
+                                                                    option, indexName, validSourceModels));
                 }
             }
         }
-        return new IndexWriterConfig(indexName, skip, minLeaves, maximumNodeConnections, queueSize, similarityFunction, optimizeFor);
+        return new IndexWriterConfig(indexName, skip, minLeaves, maximumNodeConnections, queueSize, similarityFunction, sourceModel, optimizeFor);
     }
 
     public static IndexWriterConfig defaultConfig(String indexName)
@@ -278,6 +292,7 @@ public class IndexWriterConfig
                                      DEFAULT_MAXIMUM_NODE_CONNECTIONS,
                                      DEFAULT_CONSTRUCTION_BEAM_WIDTH,
                                      DEFAULT_SIMILARITY_FUNCTION,
+                                     DEFAULT_SOURCE_MODEL,
                                      DEFAULT_OPTIMIZE_FOR);
     }
 
@@ -295,6 +310,6 @@ public class IndexWriterConfig
                              MAXIMUM_NODE_CONNECTIONS, maximumNodeConnections,
                              CONSTRUCTION_BEAM_WIDTH, constructionBeamWidth,
                              SIMILARITY_FUNCTION, similarityFunction,
-                             OPTIMIZE_FOR, optimizeFor);
+                             SOURCE_MODEL, sourceModel);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -82,10 +82,10 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
              var reader = pqFile.createReader())
         {
             reader.seek(pqSegmentOffset);
-            VectorCompression compressionType = VectorCompression.values()[reader.readByte()];
-            if (compressionType == VectorCompression.PRODUCT_QUANTIZATION)
+            VectorCompression.CompressionType compressionType = VectorCompression.CompressionType.values()[reader.readByte()];
+            if (compressionType == VectorCompression.CompressionType.PRODUCT_QUANTIZATION)
                 compressedVectors = PQVectors.load(reader, reader.getFilePointer());
-            else if (compressionType == VectorCompression.BINARY_QUANTIZATION)
+            else if (compressionType == VectorCompression.CompressionType.BINARY_QUANTIZATION)
                 compressedVectors = BQVectors.load(reader, reader.getFilePointer());
             else
                 compressedVectors = null;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
@@ -18,9 +18,48 @@
 
 package org.apache.cassandra.index.sai.disk.vector;
 
-public enum VectorCompression
+import io.github.jbellis.jvector.pq.BQVectors;
+import io.github.jbellis.jvector.pq.CompressedVectors;
+import io.github.jbellis.jvector.pq.PQVectors;
+
+public class VectorCompression
 {
-    NONE,
-    PRODUCT_QUANTIZATION,
-    BINARY_QUANTIZATION
+    public final CompressionType type;
+    public final int compressToBytes;
+
+    public VectorCompression(CompressionType type, int compressToBytes)
+    {
+        this.type = type;
+        this.compressToBytes = compressToBytes;
+    }
+
+    /**
+     * @return true if the given CompressedVectors implements a matching compression type and size
+     */
+    public boolean matches(CompressedVectors cv)
+    {
+        if (type == CompressionType.NONE)
+            return cv == null;
+        if (cv == null)
+            return false;
+
+        if (type == CompressionType.PRODUCT_QUANTIZATION)
+            return cv instanceof PQVectors && cv.getCompressedSize() == compressToBytes;
+
+        assert type == CompressionType.BINARY_QUANTIZATION;
+        // BQ algorithm is the same no matter what the size is
+        return cv instanceof BQVectors;
+    }
+
+    public String toString()
+    {
+        return String.format("VectorCompression(%s, %d)", type, compressToBytes);
+    }
+
+    public enum CompressionType
+    {
+        NONE,
+        PRODUCT_QUANTIZATION,
+        BINARY_QUANTIZATION
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.BINARY_QUANTIZATION;
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
+
+public enum VectorSourceModel
+{
+    ADA002,
+    OPENAI_V3_SMALL,
+    OPENAI_V3_LARGE,
+    BERT,
+    GECKO,
+
+    OTHER;
+
+    public static VectorSourceModel fromString(String value)
+    {
+        return valueOf(value.toUpperCase());
+    }
+
+    public VectorCompression preferredCompression(int originalDimension)
+    {
+        // if model is specified, use specifically tuned compression parameters
+        switch (this)
+        {
+            case ADA002:
+                return new VectorCompression(BINARY_QUANTIZATION, originalDimension / 8);
+            case OPENAI_V3_SMALL:
+                return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension / 16);
+            case OPENAI_V3_LARGE:
+                return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension / 16);
+            case BERT:
+                // VSTODO test if we can be more aggressive here
+                return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension / 4);
+            case GECKO:
+                return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension / 4);
+        }
+
+        // Model is unspecified / unknown, so we guess.
+        // Guessing heuristic is simple: 1536 dimensions is probably ada002, so use BQ.  Otherwise, use PQ.
+        assert this == OTHER : this;
+        if (originalDimension == 1536)
+            return new VectorCompression(BINARY_QUANTIZATION, originalDimension / 8);
+        return new VectorCompression(PRODUCT_QUANTIZATION, defaultPQBytesFor(originalDimension));
+    }
+
+    private static int defaultPQBytesFor(int originalDimension)
+    {
+        // the idea here is that higher dimensions compress well, but not so well that we should use fewer bits
+        // than a lower-dimension vector, which is what you could get with cutoff points to switch between (e.g.)
+        // D*0.5 and D*0.25.  Thus, the following ensures that bytes per vector is strictly increasing with D.
+        int compressedBytes;
+        if (originalDimension <= 32) {
+            // We are compressing from 4-byte floats to single-byte codebook indexes,
+            // so this represents compression of 4x
+            // * GloVe-25 needs 25 BPV to achieve good recall
+            compressedBytes = originalDimension;
+        }
+        else if (originalDimension <= 64) {
+            // * GloVe-50 performs fine at 25
+            compressedBytes = 32;
+        }
+        else if (originalDimension <= 200) {
+            // * GloVe-100 and -200 perform well at 50 and 100 BPV, respectively
+            compressedBytes = (int) (originalDimension * 0.5);
+        }
+        else if (originalDimension <= 400) {
+            // * NYTimes-256 actually performs fine at 64 BPV but we'll be conservative
+            //   since we don't want BPV to decrease
+            compressedBytes = 100;
+        }
+        else if (originalDimension <= 768) {
+            // allow BPV to increase linearly up to 192
+            compressedBytes = (int) (originalDimension * 0.25);
+        }
+        else if (originalDimension <= 1536) {
+            // * ada002 vectors have good recall even at 192 BPV = compression of 32x
+            compressedBytes = 192;
+        }
+        else {
+            // We have not tested recall with larger vectors than this, let's let it increase linearly
+            compressedBytes = (int) (originalDimension * 0.125);
+        }
+        return compressedBytes;
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompressionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.v3.V3VectorIndexSearcher;
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.BINARY_QUANTIZATION;
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.NONE;
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
+import static org.junit.Assert.assertTrue;
+
+public class VectorCompressionTest extends VectorTester
+{
+    @Test
+    public void testAda002() throws IOException
+    {
+        // ADA002 is always 1536
+        testOne(VectorSourceModel.ADA002, 1536, new VectorCompression(BINARY_QUANTIZATION, 1536 / 8));
+    }
+
+    @Test
+    public void testGecko() throws IOException
+    {
+        // GECKO is always 768
+        testOne(VectorSourceModel.GECKO, 768, new VectorCompression(PRODUCT_QUANTIZATION, 768 / 4));
+    }
+
+    @Test
+    public void testOpenAiV3Large() throws IOException
+    {
+        // V3_LARGE can be truncated
+        for (int i = 1; i < 3; i++)
+        {
+            int D = 3072 / i;
+            testOne(VectorSourceModel.OPENAI_V3_LARGE, D, new VectorCompression(PRODUCT_QUANTIZATION, D / 16));
+        }
+    }
+
+    @Test
+    public void testOpenAiV3Small() throws IOException
+    {
+        // V3_SMALL can be truncated
+        for (int i = 1; i < 3; i++)
+        {
+            int D = 1536 / i;
+            testOne(VectorSourceModel.OPENAI_V3_SMALL, D, new VectorCompression(PRODUCT_QUANTIZATION, D / 16));
+        }
+    }
+
+    @Test
+    public void testBert() throws IOException
+    {
+        // BERT is more of a family than a specific model
+        for (int i : List.of(128, 256, 512, 1024))
+        {
+            testOne(VectorSourceModel.BERT, i, new VectorCompression(PRODUCT_QUANTIZATION, i / 4));
+        }
+    }
+
+    @Test
+    public void testOther() throws IOException
+    {
+        // Glove
+        testOne(VectorSourceModel.OTHER, 25, new VectorCompression(PRODUCT_QUANTIZATION, 25));
+        testOne(VectorSourceModel.OTHER, 50, new VectorCompression(PRODUCT_QUANTIZATION, 32));
+        testOne(VectorSourceModel.OTHER, 100, new VectorCompression(PRODUCT_QUANTIZATION, 50));
+        testOne(VectorSourceModel.OTHER, 200, new VectorCompression(PRODUCT_QUANTIZATION, 100));
+        // Ada002
+        testOne(VectorSourceModel.OTHER, 1536, new VectorCompression(BINARY_QUANTIZATION, 1536 / 8));
+        // Something unknown and large
+        testOne(VectorSourceModel.OTHER, 2000, new VectorCompression(PRODUCT_QUANTIZATION, 2000 / 8));
+    }
+
+    @Test
+    public void testFewRows() throws IOException
+    {
+        testOne(1, VectorSourceModel.OTHER, 200, new VectorCompression(NONE, 200 * 8));
+        // BQ still works with tiny dataset
+        testOne(1, VectorSourceModel.ADA002, 1536, new VectorCompression(BINARY_QUANTIZATION, 1536 / 8));
+    }
+
+    private void testOne(VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
+    {
+        testOne(1024, model, originalDimension, expectedCompression);
+    }
+
+    private void testOne(int rows, VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
+    {
+        createTable("CREATE TABLE %s " + String.format("(pk int, v vector<float, %d>, PRIMARY KEY(pk))", originalDimension));
+        createIndex("CREATE CUSTOM INDEX ON %s(v) " + String.format("USING 'StorageAttachedIndex' WITH OPTIONS = {'source_model': '%s'}", model));
+        waitForIndexQueryable();
+
+        for (int i = 0; i < rows; i++)
+            execute("INSERT INTO %s (pk, v) VALUES (0, ?)", randomVector(originalDimension));
+        flush();
+        // also need to compact -- the larger models may flush mid-test automatically
+        compact();
+        waitForCompactionsFinished();
+
+        // good lord what a chore
+        var sim = getCurrentColumnFamilyStore().indexManager;
+        var index = (StorageAttachedIndex) sim.listIndexes().iterator().next();
+        var ssti = index.getIndexContext().getView().iterator().next();
+        try (var segment = ssti.getSegments().iterator().next();
+             var searcher = (V3VectorIndexSearcher) segment.getIndexSearcher())
+        {
+            var cv = searcher.getCompressedVectors();
+            var msg = String.format("Expected %s but got %s", expectedCompression,
+                                    cv == null ? "NONE" : cv.getClass().getSimpleName() + '@' + cv.getCompressedSize());
+            assertTrue(msg, expectedCompression.matches(cv));
+        }
+    }
+}


### PR DESCRIPTION
We still decide how to compress on save, but the logic is restructured:

* VectorCompression knows what compressed size should be, and adds a matches() method to use when we're looking for a previous codebook to refine.  (If we have a previous codebook, but it's for a different output size, we'll start fresh.)
* VectorSourceModel is where the per-model customization happens.  The guess-by-dimension logic also moves here.

Also pulled out some of the OPTIMIZE_FOR dead code while still allowing it as an option.

fixes #8711