### PR TITLE
DSP-23996: Ignore unknown fields while deserializing LocalInfo (ds-trunk)

### DIFF
--- a/src/java/org/apache/cassandra/nodes/LocalInfo.java
+++ b/src/java/org/apache/cassandra/nodes/LocalInfo.java
@@ -23,12 +23,14 @@ import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.Throwables;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class LocalInfo extends NodeInfo
 {
     private final String key = "local";

--- a/src/java/org/apache/cassandra/nodes/Nodes.java
+++ b/src/java/org/apache/cassandra/nodes/Nodes.java
@@ -275,13 +275,20 @@ public class Nodes
         maybeInitializeDirectories();
 
         // setup msgpack serialization
+        ObjectMapper objectMapper = createObjectMapper();
+
+        this.local = new Local(objectMapper, storageDirectory);
+        this.peers = new Peers(objectMapper, storageDirectory);
+    }
+
+    @VisibleForTesting
+    static ObjectMapper createObjectMapper()
+    {
         MessagePackFactory messagePackFactory = new MessagePackFactory();
         messagePackFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         ObjectMapper objectMapper = new ObjectMapper(messagePackFactory);
         objectMapper.registerModule(SerHelper.createMsgpackModule());
-
-        this.local = new Local(objectMapper, storageDirectory);
-        this.peers = new Peers(objectMapper, storageDirectory);
+        return objectMapper;
     }
 
     private void maybeInitializeDirectories()


### PR DESCRIPTION
The goal of this patch is to make LocalInfo class deserialization compatible with the local files that are created by DSE 6.8.

Equivalent patch for vsearch (https://github.com/datastax/cassandra/pull/1008)