### PR TITLE
CNDB-8708 vsearch: Add new random_float_vector CQL native function

### DIFF
--- a/doc/modules/cassandra/pages/cql/functions.adoc
+++ b/doc/modules/cassandra/pages/cql/functions.adoc
@@ -238,6 +238,13 @@ For every xref:cql/types.adoc#native-types[type] supported by CQL, the function 
 Conversely, the function `blobAsType` takes a 64-bit `blob` argument and converts it to a `bigint` value. 
 For example, `bigintAsBlob(3)` returns `0x0000000000000003` and `blobAsBigint(0x0000000000000003)` returns `3`.
 
+[[vector-functions]]
+===== Vector functions
+
+A number of functions to operate with vectors of floats.
+
+include::cassandra:partial$vector-search/vector_functions.adoc[]
+
 [[user-defined-scalar-functions]]
 ==== User-defined functions
 

--- a/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
+++ b/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
@@ -1,0 +1,65 @@
+[cols=",",options="header",]
+|===
+|Function | Description
+
+| `similarity_cosine(vector, vector)` | Calculates the cosine similarity score between two float vectors of the same dimension.
+
+Examples:
+
+`similarity_cosine([0.1, 0.2], null)` -> `null`
+
+`similarity_cosine([0.1, 0.2], [0.1, 0.2])` -> `1`
+
+`similarity_cosine([0.1, 0.2], [-0.1, -0.2])` -> `0`
+
+`similarity_cosine([0.1, 0.2], [0.9, 0.8])` -> `0.964238`
+
+| `similarity_euclidean(vector, vector)` | Calculates the euclidian distance between two float vectors of the same dimension.
+
+Examples:
+
+`similarity_euclidean([0.1, 0.2], null)` -> `null`
+
+`similarity_euclidean([0.1, 0.2], [0.1, 0.2])` -> `1`
+
+`similarity_euclidean([0.1, 0.2], [-0.1, -0.2])` -> `0.833333`
+
+`similarity_euclidean([0.1, 0.2], [0.9, 0.8])` -> `0.5`
+
+| `similarity_dot_product(vector, vector)` | Calculates the dot product between two float vectors of the same dimension.
+
+Examples:
+
+`similarity_dot_product([0.1, 0.2], null)` -> `null`
+
+`similarity_dot_product([0.1, 0.2], [0.1, 0.2])` -> `0.525`
+
+`similarity_dot_product([0.1, 0.2], [-0.1, -0.2])` -> `0.475`
+
+`similarity_dot_product([0.1, 0.2], [0.9, 0.8])` -> `0.625`
+
+| `random_float_vector(int, float, float)` | Returns a new vector of floats with the specified dimension and where
+all components will be in the specified min-max range.
+
+Examples:
+
+`random_float_vector(2, -1.0, 1.0)` -> `[-0.695395, -0.395755]`
+
+`random_float_vector(2, -1.0, 1.0)` -> `[-0.58795, 0.690014]`
+
+`random_float_vector(2, 0.0, 1.0)` -> `[0.423859, 0.630168]`
+
+`random_float_vector(2, 0.0, 1.0)` -> `[0.468159, 0.283808]`
+
+| `normalize_l2(vector, float, float)` | Applies L2 normalization to the input vector.
+The result is a vector with the same direction but with a magnitude of 1.
+
+Examples:
+
+`normalize_l2([0.1])` -> `[1]`
+
+`normalize_l2([-0.7])` -> `[1]`
+
+`normalize_l2([3.0, 4.0])` -> `[0.6, 0.8]`
+
+|===

--- a/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
+++ b/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
@@ -30,13 +30,15 @@ Examples:
 
 Examples:
 
-`similarity_dot_product([0.1, 0.2], null)` -> `null`
+`similarity_dot_product([0.447214, 0.894427], null)` -> `null`
 
-`similarity_dot_product([0.1, 0.2], [0.1, 0.2])` -> `0.525`
+`similarity_dot_product([0.447214, 0.894427], [0.447214, 0.894427])` -> `1`
 
-`similarity_dot_product([0.1, 0.2], [-0.1, -0.2])` -> `0.475`
+`similarity_dot_product([0.447214, 0.894427], [-0.447214, -0.894427])` -> `0`
 
-`similarity_dot_product([0.1, 0.2], [0.9, 0.8])` -> `0.625`
+`similarity_dot_product([0.447214, 0.894427], [-0.447214, 0.894427])` -> `0.8`
+
+`similarity_dot_product([0.447214, 0.894427], [0.447214, -0.894427])` -> `0.2`
 
 | `random_float_vector(int, float, float)` | Returns a new vector of floats with the specified dimension and where
 all components will be in the specified min-max range.

--- a/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
+++ b/doc/modules/cassandra/partials/vector-search/vector_functions.adoc
@@ -51,7 +51,7 @@ Examples:
 
 `random_float_vector(2, 0.0, 1.0)` -> `[0.468159, 0.283808]`
 
-| `normalize_l2(vector, float, float)` | Applies L2 normalization to the input vector.
+| `normalize_l2(vector)` | Applies L2 normalization to the input vector.
 The result is a vector with the same direction but with a magnitude of 1.
 
 Examples:

--- a/src/java/org/apache/cassandra/cql3/Constants.java
+++ b/src/java/org/apache/cassandra/cql3/Constants.java
@@ -213,7 +213,7 @@ public abstract class Constants
 
     public static class Literal extends Term.Raw
     {
-        private final Type type;
+        public final Type type;
         private final String text;
         private final AbstractType<?> preferedType;
 

--- a/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
@@ -479,6 +479,12 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
             return getFrozenMap(column, UTF8Type.instance, UTF8Type.instance);
         }
 
+        public <T> List<T> getVector(String column, AbstractType<T> elementType, int dimension)
+        {
+            ByteBuffer raw = data.get(column);
+            return raw == null ? null : VectorType.getInstance(elementType, dimension).compose(raw);
+        }
+
         public List<ColumnSpecification> getColumns()
         {
             return columns;

--- a/src/java/org/apache/cassandra/cql3/functions/AggregateFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/AggregateFcts.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.db.marshal.*;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -66,7 +67,9 @@ public abstract class AggregateFcts
         functions.add(new FunctionFactory("max", FunctionParameter.anyType(true))
         {
             @Override
-            protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+            protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                           List<AbstractType<?>> argTypes,
+                                                           AbstractType<?> receiverType)
             {
                 AbstractType<?> type = argTypes.get(0);
                 return type.isCounter() ? maxFunctionForCounter : makeMaxFunction(type);
@@ -77,7 +80,9 @@ public abstract class AggregateFcts
         functions.add(new FunctionFactory("min", FunctionParameter.anyType(true))
         {
             @Override
-            protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+            protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                           List<AbstractType<?>> argTypes,
+                                                           AbstractType<?> receiverType)
             {
                 AbstractType<?> type = argTypes.get(0);
                 return type.isCounter() ? minFunctionForCounter : makeMinFunction(type);

--- a/src/java/org/apache/cassandra/cql3/functions/FromJsonFct.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FromJsonFct.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 
 import org.apache.cassandra.cql3.Json;
@@ -95,7 +96,9 @@ public class FromJsonFct extends NativeScalarFunction
         }
 
         @Override
-        protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+        protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                       List<AbstractType<?>> argTypes,
+                                                       AbstractType<?> receiverType)
         {
             if (receiverType == null)
                 throw new InvalidRequestException(format("%s() cannot be used in the selection clause of a SELECT statement", name.name));

--- a/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
@@ -62,17 +62,6 @@ public interface FunctionParameter
     void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType);
 
     /**
-     * @return the literal value, if any
-     */
-    default String getLiteral(AssignmentTestable arg)
-    {
-        if (arg instanceof Constants.Literal)
-            return ((Constants.Literal) arg).getRawText();
-        else
-            throw new IllegalArgumentException("Not a literal");
-    }
-
-    /**
      * @return a function parameter definition that accepts values of string-based data types (text, varchar and ascii)
      */
     static FunctionParameter string()
@@ -271,6 +260,9 @@ public interface FunctionParameter
             @Override
             public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
             {
+                if (arg instanceof Selectable.WithTerm)
+                    arg = ((Selectable.WithTerm) arg).rawTerm;
+
                 if (!(arg instanceof Constants.Literal))
                     throw invalidArgumentException(factory, arg);
 

--- a/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
@@ -240,6 +240,7 @@ public interface FunctionParameter
     }
 
     /**
+     * @param name the name of the function parameter
      * @param type the accepted type of literal
      * @param inferredType the inferred type of the literal
      * @return a function parameter definition that accepts a specific literal type

--- a/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FunctionParameter.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.selection.Selectable;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.ListType;
@@ -58,7 +59,18 @@ public interface FunctionParameter
         return arg.getCompatibleTypeIfKnown(keyspace);
     }
 
-    void validateType(FunctionName name, AssignmentTestable arg, AbstractType<?> argType);
+    void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType);
+
+    /**
+     * @return the literal value, if any
+     */
+    default String getLiteral(AssignmentTestable arg)
+    {
+        if (arg instanceof Constants.Literal)
+            return ((Constants.Literal) arg).getRawText();
+        else
+            throw new IllegalArgumentException("Not a literal");
+    }
 
     /**
      * @return a function parameter definition that accepts values of string-based data types (text, varchar and ascii)
@@ -89,12 +101,12 @@ public interface FunctionParameter
             }
 
             @Override
-            public void validateType(FunctionName name, AssignmentTestable arg, AbstractType<?> argType)
+            public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
             {
                 if (Arrays.stream(types).allMatch(t -> argType.testAssignment(t.getType()) == NOT_ASSIGNABLE))
                     throw new InvalidRequestException(format("Function %s requires an argument of type %s, " +
                                                              "but found argument %s of type %s",
-                                                             name, this, arg, argType.asCQL3Type()));
+                                                             factory, this, arg, argType.asCQL3Type()));
             }
 
             @Override
@@ -127,7 +139,7 @@ public interface FunctionParameter
             }
 
             @Override
-            public void validateType(FunctionName name, AssignmentTestable arg, AbstractType<?> argType)
+            public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
             {
                 // nothing to do here, all types are accepted
             }
@@ -159,9 +171,9 @@ public interface FunctionParameter
             }
 
             @Override
-            public void validateType(FunctionName name, AssignmentTestable arg, AbstractType<?> argType)
+            public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
             {
-                parameter.validateType(name, arg, argType);
+                parameter.validateType(factory, arg, argType);
             }
 
             @Override
@@ -195,7 +207,7 @@ public interface FunctionParameter
             }
 
             @Override
-            public void validateType(FunctionName name, AssignmentTestable arg, AbstractType<?> argType)
+            public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
             {
                 if (argType.isVector())
                 {
@@ -211,14 +223,57 @@ public interface FunctionParameter
                 }
 
                 throw new InvalidRequestException(format("Function %s requires a %s vector argument, " +
-                                "but found argument %s of type %s",
-                        name, type, arg, argType.asCQL3Type()));
+                                                         "but found argument %s of type %s",
+                                                         factory, type, arg, argType.asCQL3Type()));
             }
 
             @Override
             public String toString()
             {
                 return format("vector<%s, n>", type);
+            }
+        };
+    }
+
+    /**
+     * @param type the accepted type of literal
+     * @param inferredType the inferred type of the literal
+     * @return a function parameter definition that accepts a specific literal type
+     */
+    static FunctionParameter literal(Constants.Type type, AbstractType<?> inferredType)
+    {
+        return new FunctionParameter()
+        {
+            @Override
+            public AbstractType<?> inferType(String keyspace,
+                                             AssignmentTestable arg,
+                                             @Nullable AbstractType<?> receiverType,
+                                             @Nullable List<AbstractType<?>> inferredTypes)
+            {
+                return inferredType;
+            }
+
+            @Override
+            public void validateType(FunctionFactory factory, AssignmentTestable arg, AbstractType<?> argType)
+            {
+                if (!(arg instanceof Constants.Literal))
+                    throw invalidArgumentException(factory, arg);
+
+                Constants.Literal literal = (Constants.Literal) arg;
+                if (literal.type != type)
+                    throw invalidArgumentException(factory, arg);
+            }
+
+            private InvalidRequestException invalidArgumentException(FunctionFactory factory, AssignmentTestable arg)
+            {
+                throw new InvalidRequestException(format("Function %s requires a %s literal argument, but found %s",
+                                                         factory.name, this, arg));
+            }
+
+            @Override
+            public String toString()
+            {
+                return type.toString();
             }
         };
     }

--- a/src/java/org/apache/cassandra/cql3/functions/ToJsonFct.java
+++ b/src/java/org/apache/cassandra/cql3/functions/ToJsonFct.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.cql3.functions;
 
+import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -67,7 +68,9 @@ public class ToJsonFct extends NativeScalarFunction
         functions.add(new FunctionFactory("tojson", FunctionParameter.anyType(false))
         {
             @Override
-            protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+            protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                           List<AbstractType<?>> argTypes,
+                                                           AbstractType<?> receiverType)
             {
                 return ToJsonFct.getInstance(argTypes);
             }

--- a/src/java/org/apache/cassandra/cql3/functions/TokenFct.java
+++ b/src/java/org/apache/cassandra/cql3/functions/TokenFct.java
@@ -87,7 +87,9 @@ public class TokenFct extends NativeScalarFunction
             }
 
             @Override
-            protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+            protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                           List<AbstractType<?>> argTypes,
+                                                           AbstractType<?> receiverType)
             {
                 throw new AssertionError("Should be unreachable");
             }

--- a/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
@@ -102,8 +102,7 @@ public abstract class VectorFcts
         {
             // Get the vector type from the dimension argument. We need to do this here assuming that the argument is a
             // literal, so we know the dimension of the return type before actually executing the function.
-            AssignmentTestable arg = args.get(0);
-            int dimension = Integer.parseInt(parameters.get(0).getLiteral(arg));
+            int dimension = Integer.parseInt(args.get(0).toString());
             VectorType<Float> type = VectorType.getInstance(FloatType.instance, dimension);
 
             final NumberType<?> minType = (NumberType<?>) argTypes.get(1);

--- a/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
@@ -19,28 +19,32 @@ package org.apache.cassandra.cql3.functions;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Random;
 
+import io.github.jbellis.jvector.vector.VectorUtil;
+import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.NumberType;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
+import static java.lang.String.format;
+
 public abstract class VectorFcts
 {
-    private static boolean isFloatVector(AbstractType<?> type)
-    {
-        type = type.unwrap();
-        return type instanceof VectorType && ((VectorType<?>) type).getElementsType() == FloatType.instance;
-    }
-
     public static void addFunctionsTo(NativeFunctions functions)
     {
         functions.add(similarity_function("similarity_cosine", VectorSimilarityFunction.COSINE));
         functions.add(similarity_function("similarity_euclidean", VectorSimilarityFunction.EUCLIDEAN));
         functions.add(similarity_function("similarity_dot_product", VectorSimilarityFunction.DOT_PRODUCT));
+        functions.add(new RandomFloatVectorFunctionFactory());
+        functions.add(new NormalizeL2FunctionFactory());
     }
 
     private static FunctionFactory similarity_function(String name, VectorSimilarityFunction f)
@@ -50,7 +54,10 @@ public abstract class VectorFcts
                                    FunctionParameter.sameAs(0, FunctionParameter.vector(CQL3Type.Native.FLOAT)))
         {
             @Override
-            protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+            @SuppressWarnings("unchecked")
+            protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                           List<AbstractType<?>> argTypes,
+                                                           AbstractType<?> receiverType)
             {
                 // check that all arguments have the same vector dimensions
                 VectorType<Float> firstArgType = (VectorType<Float>) argTypes.get(0);
@@ -74,5 +81,111 @@ public abstract class VectorFcts
                 return FloatType.instance.decompose(f.compare(v1, v2));
             }
         };
+    }
+
+    /**
+     * CQL native function create a random float vector of a certaing dimension.
+     * All the components of the vector will be random floats between -1 and 1.
+     */
+    private static class RandomFloatVectorFunctionFactory extends FunctionFactory
+    {
+        private static final String NAME = "random_float_vector";
+
+        private RandomFloatVectorFunctionFactory()
+        {
+            super(NAME,
+                  FunctionParameter.literal(Constants.Type.INTEGER, Int32Type.instance),
+                  FunctionParameter.fixed(CQL3Type.Native.FLOAT, CQL3Type.Native.DOUBLE, CQL3Type.Native.INT),
+                  FunctionParameter.fixed(CQL3Type.Native.FLOAT, CQL3Type.Native.DOUBLE, CQL3Type.Native.INT));
+        }
+
+        @Override
+        protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                       List<AbstractType<?>> argTypes,
+                                                       AbstractType<?> receiverType)
+        {
+            // Get the vector type from the dimension argument. We need to do this here assuming that the argument is a
+            // literal, so we know the dimension of the return type before actually executing the function.
+            AssignmentTestable arg = args.get(0);
+            int dimension = Integer.parseInt(parameters.get(0).getLiteral(arg));
+            VectorType<Float> type = VectorType.getInstance(FloatType.instance, dimension);
+
+            final NumberType<?> minType = (NumberType<?>) argTypes.get(1);
+            final NumberType<?> maxType = (NumberType<?>) argTypes.get(2);
+
+            return new NativeScalarFunction(name.name, type, Int32Type.instance, minType, maxType)
+            {
+                private final Random random = new Random();
+
+                @Override
+                public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> args) throws InvalidRequestException
+                {
+                    // get the min argument
+                    ByteBuffer arg1 = args.get(1);
+                    if (arg1 == null || !arg1.hasRemaining())
+                        throw new InvalidRequestException(format("Min argument of function %s must not be null", name));
+                    float min = minType.compose(arg1).floatValue();
+
+                    // get the max argument
+                    ByteBuffer arg2 = args.get(2);
+                    if (arg2 == null || !arg2.hasRemaining())
+                        throw new InvalidRequestException(format("Max argument of function %s must not be null", name));
+                    float max = maxType.compose(arg2).floatValue();
+                    if (max <= min)
+                        throw new InvalidRequestException("Max value must be greater than min value");
+
+                    // generate the random vector within the ranges
+                    float[] vector = new float[dimension];
+                    for (int i = 0; i < dimension; i++)
+                    {
+                        vector[i] = min + random.nextFloat() * (max - min);
+                    }
+
+                    return type.getSerializer().serializeFloatArray(vector);
+                }
+            };
+        }
+    }
+
+    /**
+     * CQL native function to normalize a vector using L2 normalization.
+     */
+    private static class NormalizeL2FunctionFactory extends FunctionFactory
+    {
+        private static final String NAME = "normalize_l2";
+
+        public NormalizeL2FunctionFactory()
+        {
+            super(NAME, FunctionParameter.vector(CQL3Type.Native.FLOAT));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                       List<AbstractType<?>> argTypes,
+                                                       AbstractType<?> receiverType)
+        {
+            VectorType<Float> vectorType = (VectorType<Float>) argTypes.get(0);
+
+            return new NativeScalarFunction(name.name, vectorType, vectorType)
+            {
+                @Override
+                public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> args) throws InvalidRequestException
+                {
+                    // get the vector argument
+                    ByteBuffer arg0 = args.get(0);
+                    if (arg0 == null || !arg0.hasRemaining())
+                        return null;
+                    float[] vector = vectorType.getSerializer().deserializeFloatArray(arg0);
+
+                    // normalize
+                    float[] normalized = vector.clone();
+                    VectorUtil.l2normalize(normalized);
+
+                    // serialize the normalized vector
+                    return vectorType.getSerializer().serializeFloatArray(normalized);
+                }
+            };
+        }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
@@ -83,8 +83,8 @@ public abstract class VectorFcts
     }
 
     /**
-     * CQL native function create a random float vector of a certaing dimension.
-     * All the components of the vector will be random floats between -1 and 1.
+     * CQL native function create a random float vector of a certain dimension.
+     * All the components of the vector will be random floats between the specified min and max values.
      */
     private static class RandomFloatVectorFunctionFactory extends FunctionFactory
     {

--- a/src/java/org/apache/cassandra/cql3/selection/Selectable.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selectable.java
@@ -155,7 +155,7 @@ public interface Selectable extends AssignmentTestable
          */
         private static final ColumnIdentifier bindMarkerNameInSelection = new ColumnIdentifier("[selection]", true);
 
-        private final Term.Raw rawTerm;
+        public final Term.Raw rawTerm;
 
         public WithTerm(Term.Raw rawTerm)
         {

--- a/src/java/org/apache/cassandra/db/marshal/VectorType.java
+++ b/src/java/org/apache/cassandra/db/marshal/VectorType.java
@@ -21,12 +21,10 @@ package org.apache.cassandra.db.marshal;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Term;
@@ -344,6 +342,7 @@ public final class VectorType<T> extends AbstractType<List<T>>
         public abstract <V> List<V> split(V buffer, ValueAccessor<V> accessor);
         public abstract <V> V serializeRaw(List<V> elements, ValueAccessor<V> accessor);
         public abstract float[] deserializeFloatArray(ByteBuffer input);
+        public abstract ByteBuffer serializeFloatArray(float[] value);
 
         @Override
         public String toString(List<T> value)
@@ -478,6 +477,21 @@ public final class VectorType<T> extends AbstractType<List<T>>
             floatBuffer.get(floatArray);
 
             return floatArray;
+        }
+
+        @Override
+        public ByteBuffer serializeFloatArray(float[] value)
+        {
+            if (elementType != FloatType.instance)
+                throw new UnsupportedOperationException();
+
+            if (value.length != dimension)
+                throw new MarshalException(String.format("Required %d elements, but saw %d", dimension, value.length));
+
+            var fb = FloatBuffer.wrap(value);
+            var bb = ByteBuffer.allocate(fb.capacity() * Float.BYTES);
+            bb.asFloatBuffer().put(fb);
+            return bb;
         }
 
         @Override
@@ -617,6 +631,12 @@ public final class VectorType<T> extends AbstractType<List<T>>
         }
 
         public float[] deserializeFloatArray(ByteBuffer input)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuffer serializeFloatArray(float[] value)
         {
             throw new UnsupportedOperationException();
         }

--- a/test/unit/org/apache/cassandra/cql3/functions/FunctionFactoryTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/FunctionFactoryTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.Duration;
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -37,7 +38,6 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.TimeUUID;
 
 public class FunctionFactoryTest extends CQLTester
 {
@@ -48,7 +48,9 @@ public class FunctionFactoryTest extends CQLTester
     private static final FunctionFactory IDENTITY = new FunctionFactory("identity", FunctionParameter.anyType(true))
     {
         @Override
-        protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+        protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                       List<AbstractType<?>> argTypes,
+                                                       AbstractType<?> receiverType)
         {
             return new NativeScalarFunction(name.name, argTypes.get(0), argTypes.get(0))
             {
@@ -68,7 +70,9 @@ public class FunctionFactoryTest extends CQLTester
     private static final FunctionFactory TO_STRING = new FunctionFactory("tostring", FunctionParameter.anyType(false))
     {
         @Override
-        protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+        protected NativeFunction doGetOrCreateFunction(List<? extends AssignmentTestable> args,
+                                                       List<AbstractType<?>> argTypes,
+                                                       AbstractType<?> receiverType)
         {
             return new NativeScalarFunction(name.name, UTF8Type.instance, argTypes.get(0))
             {

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/CQLVectorTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/CQLVectorTest.java
@@ -135,41 +135,46 @@ public class CQLVectorTest extends CQLTester
         Assert.assertEquals(1, execute("SELECT value FROM %s WHERE pk = 0").size());
 
         // wrong number of arguments
-        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(INTEGER, [float|double|int], [float|double|int])",
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector())");
-        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(INTEGER, [float|double|int], [float|double|int])",
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1))");
-        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(INTEGER, [float|double|int], [float|double|int])",
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1, 1, 0))");
 
         // mandatory arguments
-        assertInvalidThrowMessage("Function system.random_float_vector requires a INTEGER literal argument, but found NULL",
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found NULL",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(null, null, null))");
-        assertInvalidThrowMessage("Function system.random_float_vector requires a INTEGER literal argument, but found NULL",
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found NULL",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(null, -1, 1))");
-        assertInvalidThrowMessage("Min argument of function system.random_float_vector must not be null",
+        assertInvalidThrowMessage("Min argument of function system.random_float_vector(literal_int, float, float) must not be null",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, null, null))");
-        assertInvalidThrowMessage("Max argument of function system.random_float_vector must not be null",
+        assertInvalidThrowMessage("Max argument of function system.random_float_vector(literal_int, float, float) must not be null",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1, null))");
-        assertInvalidThrowMessage("Min argument of function system.random_float_vector must not be null",
+        assertInvalidThrowMessage("Min argument of function system.random_float_vector(literal_int, float, float) must not be null",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, null, 1))");
 
         // wrong argument types
-        assertInvalidThrowMessage("Function system.random_float_vector requires a INTEGER literal argument, but found 'a'",
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found 'a'",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector('a', -1, 1))");
-        assertInvalidThrowMessage("Function system.random_float_vector requires a INTEGER literal argument, but found system.\"_add\"(1, 1)",
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found system.\"_add\"(1, 1)",
                                   InvalidRequestException.class,
                                   "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(1 + 1, -1, 1))");
-        assertInvalidThrowMessage("Function system.random_float_vector requires a INTEGER literal argument, but found value",
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found value",
                                   InvalidRequestException.class,
                                   "SELECT random_float_vector(value, -1, 1) FROM %s");
 


### PR DESCRIPTION
PR for [CNDB-8708](https://github.com/riptano/cndb/issues/8708). It adds a new `random_float_vector ` CQL native function. Its arguments are the number of dimensions of the vector, and the min and max values defining the range within the components will be. 

It also adds a new `normalize_l2` function. The functions can be used this way:
```
CREATE TABLE t (k int PRIMARY KEY, v vector<float, 1024>);
INSERT INTO t (k, v) VALUES (0, normalize_l2(random_float_vector(1024, -1, 1)));
```