### PR TITLE
CNDB-8764: add schema_type table parameter

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.schema.CompactionParams;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.DroppedColumn;
 import org.apache.cassandra.schema.MemtableParams;
+import org.apache.cassandra.schema.SchemaType;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableParams;
 import org.apache.cassandra.schema.TableParams.Option;
@@ -208,6 +209,9 @@ public final class TableAttributes extends PropertyDefinitions
 
         if (hasOption(Option.CDC))
             builder.cdc(getBoolean(Option.CDC.toString(), false));
+
+        if (hasOption(Option.SCHEMA_TYPE))
+            builder.schemaType(SchemaType.fromString(getString(Option.SCHEMA_TYPE)));
 
         if (hasOption(Option.READ_REPAIR))
             builder.readRepair(ReadRepairStrategy.fromString(getString(Option.READ_REPAIR)));

--- a/src/java/org/apache/cassandra/schema/SchemaEvent.java
+++ b/src/java/org/apache/cassandra/schema/SchemaEvent.java
@@ -213,6 +213,7 @@ public final class SchemaEvent extends DiagnosticEvent
         ret.put("gcGraceSeconds", params.gcGraceSeconds);
         ret.put("bloomFilterFpChance", params.bloomFilterFpChance);
         ret.put("cdc", params.cdc);
+        ret.put("schema_type", params.schemaType.toString());
         ret.put("crcCheckChance", params.crcCheckChance);
         ret.put("memtableFlushPeriodInMs", params.memtableFlushPeriodInMs);
         ret.put("comment", params.comment);

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -163,6 +163,7 @@ public final class SchemaKeyspace
               + "speculative_retry text,"
               + "additional_write_policy text,"
               + "cdc boolean,"
+              + "schema_type text,"
               + "read_repair text,"
               + "PRIMARY KEY ((keyspace_name), table_name))");
 
@@ -233,6 +234,7 @@ public final class SchemaKeyspace
               + "speculative_retry text,"
               + "additional_write_policy text,"
               + "cdc boolean,"
+              + "schema_type text,"
               + "version int,"
               + "read_repair text,"
               + "PRIMARY KEY ((keyspace_name), view_name))");
@@ -602,6 +604,7 @@ public final class SchemaKeyspace
                .add("compression", params.compression.asMap())
                .add("memtable", params.memtable.asMap())
                .add("read_repair", params.readRepair.toString())
+               .add("schema_type", params.schemaType.toString())
                .add("extensions", params.extensions);
 
         // Only add CDC-enabled flag to schema if it's enabled on the node. This is to work around RTE's post-8099 if a 3.8+
@@ -1019,6 +1022,7 @@ public final class SchemaKeyspace
                                                      SpeculativeRetryPolicy.fromString(row.getString("additional_write_policy")) :
                                                      SpeculativeRetryPolicy.fromString("99PERCENTILE"))
                           .cdc(row.has("cdc") && row.getBoolean("cdc"))
+                          .schemaType(row.has("schema_type") ? SchemaType.fromString(row.getString("schema_type")) : SchemaType.TABLE)
                           .readRepair(getReadRepairStrategy(row))
                           .build();
     }

--- a/src/java/org/apache/cassandra/schema/SchemaType.java
+++ b/src/java/org/apache/cassandra/schema/SchemaType.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import org.apache.cassandra.exceptions.ConfigurationException;
+
+/**
+ * This is the type of schema on Astra.
+ * Astra handles both regular tables and Collections.
+ * A Collection has a special internal schema that allows users to work without a schema.
+ */
+public enum SchemaType {
+
+    /**
+     * Regular table
+     */
+    TABLE,
+    /**
+     * This is a Collection, handled by Stargate.
+     */
+    COLLECTION;
+
+    public static SchemaType fromString(String str)
+    {
+        if (str == null)
+        {
+            return TABLE;
+        }
+        try
+        {
+            return valueOf(str.toUpperCase());
+        } catch (IllegalArgumentException e)
+        {
+            throw new ConfigurationException(String.format("Invalid value %s for option '%s'", str, TableParams.Option.SCHEMA_TYPE));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -57,7 +57,8 @@ public final class TableParams
         ADDITIONAL_WRITE_POLICY,
         CRC_CHECK_CHANCE,
         CDC,
-        READ_REPAIR;
+        READ_REPAIR,
+        SCHEMA_TYPE;
 
         @Override
         public String toString()
@@ -82,6 +83,7 @@ public final class TableParams
     public final MemtableParams memtable;
     public final ImmutableMap<String, ByteBuffer> extensions;
     public final boolean cdc;
+    public final SchemaType schemaType;
     public final ReadRepairStrategy readRepair;
 
     private TableParams(Builder builder)
@@ -104,6 +106,7 @@ public final class TableParams
         memtable = builder.memtable;
         extensions = builder.extensions;
         cdc = builder.cdc;
+        schemaType = builder.schemaType;
         readRepair = builder.readRepair;
     }
 
@@ -130,6 +133,7 @@ public final class TableParams
                             .additionalWritePolicy(params.additionalWritePolicy)
                             .extensions(params.extensions)
                             .cdc(params.cdc)
+                            .schemaType(params.schemaType)
                             .readRepair(params.readRepair);
     }
 
@@ -218,6 +222,7 @@ public final class TableParams
             && memtable.equals(p.memtable)
             && extensions.equals(p.extensions)
             && cdc == p.cdc
+            && schemaType == p.schemaType
             && readRepair == p.readRepair;
     }
 
@@ -261,6 +266,7 @@ public final class TableParams
                           .add(Option.MEMTABLE.toString(), memtable)
                           .add(Option.EXTENSIONS.toString(), extensions)
                           .add(Option.CDC.toString(), cdc)
+                          .add(Option.SCHEMA_TYPE.toString(), schemaType)
                           .add(Option.READ_REPAIR.toString(), readRepair)
                           .toString();
     }
@@ -286,6 +292,10 @@ public final class TableParams
                .newLine()
                .append("AND crc_check_chance = ").append(crcCheckChance)
                .newLine();
+
+        if (schemaType != SchemaType.TABLE)
+            builder.append("AND schema_type = ").appendWithSingleQuotes(schemaType.toString())
+                   .newLine();
 
         if (!isView)
         {
@@ -330,6 +340,7 @@ public final class TableParams
         private MemtableParams memtable = MemtableParams.DEFAULT;
         private ImmutableMap<String, ByteBuffer> extensions = ImmutableMap.of();
         private boolean cdc;
+        private SchemaType schemaType = SchemaType.TABLE;
         private ReadRepairStrategy readRepair = ReadRepairStrategy.BLOCKING;
 
         public Builder()
@@ -428,6 +439,12 @@ public final class TableParams
         public Builder cdc(boolean val)
         {
             cdc = val;
+            return this;
+        }
+
+        public Builder schemaType(SchemaType val)
+        {
+            schemaType = val;
             return this;
         }
 

--- a/test/unit/org/apache/cassandra/cql3/SchemaTypeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/SchemaTypeStatementTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.apache.cassandra.schema.SchemaType;
+
+public class SchemaTypeStatementTest extends CQLTester
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CQLTester.setUpClass();
+    }
+
+    @Test
+    public void testSetOnCreate() throws Throwable
+    {
+        createTable("CREATE TABLE %s (key text, val int, primary key(key)) WITH schema_type = 'collection';");
+        Assert.assertEquals(currentTableMetadata().params.schemaType, SchemaType.COLLECTION);
+    }
+
+    @Test
+    public void testDefault() throws Throwable
+    {
+        createTable("CREATE TABLE %s (key text, val int, primary key(key));");
+        Assert.assertEquals(currentTableMetadata().params.schemaType, SchemaType.TABLE);
+    }
+
+    @Test
+    public void testAlter() throws Throwable
+    {
+        createTable("CREATE TABLE %s (key text, val int, primary key(key));");
+        Assert.assertEquals(currentTableMetadata().params.schemaType, SchemaType.TABLE);
+        execute("ALTER TABLE %s WITH schema_type = 'collection';");
+        Assert.assertEquals(currentTableMetadata().params.schemaType, SchemaType.COLLECTION);
+    }
+
+}


### PR DESCRIPTION
Motivation:
see https://github.com/riptano/cndb/issues/8764

Summary:
add a new table parameter "schema_type", the value can be NULL, 'table' and 'collection'm when it is null it is assumed to be 'table'.

This parameter is not used by Cassandra but it  will be used by CNDB in order to distinguish a regular CQL table from a table that is backing a Stargate Data API Collection