### PR TITLE
Make SET_ENTRY_OVERHEAD private static final

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeys.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeys.java
@@ -33,7 +33,7 @@ public class PrimaryKeys implements Iterable<PrimaryKey>
     private static final long EMPTY_SIZE = ObjectSizes.measure(new PrimaryKeys());
 
     // from https://github.com/gaul/java-collection-overhead
-    long SET_ENTRY_OVERHEAD = 36;
+    private static final long SET_ENTRY_OVERHEAD = 36;
 
     private final ConcurrentSkipListSet<PrimaryKey> keys = new ConcurrentSkipListSet<>();
 


### PR DESCRIPTION
Since the `PrimaryKeys` object is created for each unique term in an in memory SAI index, we can save some memory by making this value static.