### PR TITLE
ChunkCacheMetrics: allow to set a prefix (to separate the IndexChunkCacheMetrics)

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
@@ -35,7 +35,12 @@ public interface ChunkCacheMetrics extends StatsCounter, CacheMetrics
 {
     static ChunkCacheMetrics create(ChunkCache cache)
     {
-        return USE_MICROMETER.getBoolean() ? new MicrometerChunkCacheMetrics(cache) : new CodahaleChunkCacheMetrics(cache);
+        return create(cache, "chunk_cache");
+    }
+
+    static ChunkCacheMetrics create(ChunkCache cache, String prefix)
+    {
+        return USE_MICROMETER.getBoolean() ? new MicrometerChunkCacheMetrics(cache, prefix) : new CodahaleChunkCacheMetrics(cache);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ChunkCacheMetrics.java
@@ -40,7 +40,9 @@ public interface ChunkCacheMetrics extends StatsCounter, CacheMetrics
 
     static ChunkCacheMetrics create(ChunkCache cache, String prefix)
     {
-        return USE_MICROMETER.getBoolean() ? new MicrometerChunkCacheMetrics(cache, prefix) : new CodahaleChunkCacheMetrics(cache);
+        return USE_MICROMETER.getBoolean()
+               ? new MicrometerChunkCacheMetrics(cache, prefix)
+               : new CodahaleChunkCacheMetrics(cache);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerChunkCacheMetrics.java
@@ -43,11 +43,6 @@ public class MicrometerChunkCacheMetrics extends MicrometerMetrics implements Ch
     private volatile Timer missLatency;
     private volatile Counter evictions;
 
-    public MicrometerChunkCacheMetrics(CacheSize cache)
-    {
-        this(cache, "chunk_cache");
-    }
-
     public MicrometerChunkCacheMetrics(CacheSize cache, String metricsPrefix)
     {
         this.cache = cache;


### PR DESCRIPTION
For NSS we have a new instance of the ChunkCache that backs all the index accesses. This patch allows to register the metrics for the IndexChunkCache with a different prefix