### PR TITLE
Implement floatBuffer() for ChunkCache based Rebufferer

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -21,6 +21,9 @@
 package org.apache.cassandra.cache;
 
 import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -155,6 +158,31 @@ public class ChunkCache
             assert references.get() > 0;
             return buffer.duplicate();
         }
+
+        @Override
+        public FloatBuffer floatBuffer()
+        {
+            assert references.get() > 0;
+            // this does an implicit duplicate(), so we need to expose it directly to avoid doing it twice unnecessarily
+            return buffer.asFloatBuffer();
+        }
+
+        @Override
+        public IntBuffer intBuffer()
+        {
+            assert references.get() > 0;
+            // this does an implicit duplicate(), so we need to expose it directly to avoid doing it twice unnecessarily
+            return buffer.asIntBuffer();
+        }
+
+        @Override
+        public LongBuffer longBuffer()
+        {
+            assert references.get() > 0;
+            // this does an implicit duplicate(), so we need to expose it directly to avoid doing it twice unnecessarily
+            return buffer.asLongBuffer();
+        }
+
 
         @Override
         public long offset()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -84,6 +84,8 @@ public class Segment implements Closeable, SegmentOrdering
         }
         catch (Throwable e) // there's multiple things that can go wrong w/ version mismatch, so catch all of them
         {
+            logger.error("Failed to open searcher for segment {}:{} for index [{}] on column [{}] at version {}",
+                         sstableContext.descriptor(), metadata.segmentRowIdOffset, indexContext.getIndexName(), indexContext.getColumnName(), version, e);
             if (!List.of(Version.BA, Version.CA).contains(version))
             {
                 // we're only trying to recover from BA/CA confusion, this is something else

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -84,13 +84,15 @@ public class Segment implements Closeable, SegmentOrdering
         }
         catch (Throwable e) // there's multiple things that can go wrong w/ version mismatch, so catch all of them
         {
-            logger.error("Failed to open searcher for segment {}:{} for index [{}] on column [{}] at version {}",
-                         sstableContext.descriptor(), metadata.segmentRowIdOffset, indexContext.getIndexName(), indexContext.getColumnName(), version, e);
             if (!List.of(Version.BA, Version.CA).contains(version))
             {
                 // we're only trying to recover from BA/CA confusion, this is something else
                 throw e;
             }
+            
+            logger.debug("Failed to open searcher for segment {}:{} for index [{}] on column [{}] at version {}",
+                         sstableContext.descriptor(), metadata.segmentRowIdOffset, indexContext.getIndexName(), indexContext.getColumnName(), version, e);
+            
             // opening with the global format didn't work.  that means that (unless it's actually corrupt)
             // the correct version is whichever one the global format is not set to
             version = version == Version.CA ? Version.BA : Version.CA;

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -52,17 +52,17 @@ public interface Rebufferer extends ReaderFileProxy
 
         default FloatBuffer floatBuffer()
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 
         default IntBuffer intBuffer()
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 
         default LongBuffer longBuffer()
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 
         /**
@@ -85,6 +85,24 @@ public interface Rebufferer extends ReaderFileProxy
         public ByteBuffer buffer()
         {
             return EMPTY_BUFFER;
+        }
+
+        @Override
+        public FloatBuffer floatBuffer()
+        {
+            return EMPTY_BUFFER.asFloatBuffer();
+        }
+
+        @Override
+        public IntBuffer intBuffer()
+        {
+            return EMPTY_BUFFER.asIntBuffer();
+        }
+
+        @Override
+        public LongBuffer longBuffer()
+        {
+            return EMPTY_BUFFER.asLongBuffer();
         }
 
         @Override


### PR DESCRIPTION
Vector SAI use RandomAccessReader.readFully(float[] dest) that in turn use Rebufferer.floatBuffer(). We implement this method in order to allow Vector to work with NSS and the IndexChunkCache

Summary for changes:
- implement floatBuffer(), intBuffer() and longBuffer() for the ChunkCache implementation and for the EMPTY bufffer
- add some logs when we decide to fall back to another version of the Vector index