### PR TITLE
cassandra-8773 Commit log replayer deletes files with invalid mutations after each replay cycle

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -415,9 +415,17 @@ public abstract class AbstractCommitLogSegmentManager
      */
     void handleReplayedSegment(final File file)
     {
-        // (don't decrease managed size, since this was never a "live" segment)
-        logger.trace("(Unopened) segment {} is no longer needed and will be deleted now", file);
-        FileUtils.deleteWithConfirm(file);
+        handleReplayedSegment(file, true);
+    }
+
+    void handleReplayedSegment(final File file, boolean toBeDeleted)
+    {
+        if (toBeDeleted)
+        {
+            // (don't decrease managed size, since this was never a "live" segment)
+            logger.trace("(Unopened) segment {} is no longer needed and will be deleted now", file);
+            FileUtils.deleteWithConfirm(file);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -415,16 +415,20 @@ public abstract class AbstractCommitLogSegmentManager
      */
     void handleReplayedSegment(final File file)
     {
-        handleReplayedSegment(file, true);
+        handleReplayedSegment(file, false);
     }
 
-    void handleReplayedSegment(final File file, boolean toBeDeleted)
+    void handleReplayedSegment(final File file, boolean hasInvalidMutations)
     {
-        if (toBeDeleted)
+        if (!hasInvalidMutations)
         {
             // (don't decrease managed size, since this was never a "live" segment)
             logger.trace("(Unopened) segment {} is no longer needed and will be deleted now", file);
             FileUtils.deleteWithConfirm(file);
+        }
+        else
+        {
+            logger.debug("File {} should not be deleted as it contains invalid mutations", file.name());
         }
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -271,7 +271,7 @@ public class CommitLog implements CommitLogMBean
         segmentsWithInvalidMutations = new ArrayList<>();
         replayer.commitLogReader.segmentsWithInvalidMutations.forEach((file) ->
         {
-            logger.warn("Skipped invalid mutations from file {}", file);
+            logger.warn("Skipped invalid mutations from file {}.", file);
             segmentsWithInvalidMutations.add(file);
         });
         return replayer.blockForWrites(flushReason);

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -36,8 +36,6 @@ import java.util.function.Function;
 import java.util.zip.CRC32;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.ArrayListMultimap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReadHandler.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReadHandler.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db.commitlog;
 import java.io.IOException;
 
 import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.schema.TableId;
 
 public interface CommitLogReadHandler
 {
@@ -73,4 +74,11 @@ public interface CommitLogReadHandler
      * @param desc CommitLogDescriptor for mutation being processed
      */
     void handleMutation(Mutation m, int size, int entryLocation, CommitLogDescriptor desc);
+
+    /**
+     * Process an invalid mutation
+     *
+     * @param id table id corresponding to the invalid mutation
+     */
+    void handleInvalidMutation(TableId id);
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
@@ -57,7 +57,7 @@ public class CommitLogReader
     public static final int ALL_MUTATIONS = -1;
     private final CRC32 checksum;
     private final Map<TableId, AtomicInteger> invalidMutations;
-    private final List<String> segmentsWithInvalidMutations;
+    private final Set<String> segmentsWithInvalidMutations;
 
     private byte[] buffer;
 
@@ -65,11 +65,11 @@ public class CommitLogReader
     {
         checksum = new CRC32();
         invalidMutations = new HashMap<>();
-        segmentsWithInvalidMutations = new ArrayList<>();
+        segmentsWithInvalidMutations = new HashSet<>();
         buffer = new byte[4096];
     }
 
-    public List<String> getSegmentsWithInvalidMutations()
+    public Set<String> getSegmentsWithInvalidMutations()
     {
         return segmentsWithInvalidMutations;
     }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReader.java
@@ -25,8 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.CRC32;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.ArrayListMultimap;
 import org.apache.cassandra.io.util.File;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -294,6 +294,11 @@ public class CommitLogReplayer implements CommitLogReadHandler
     @VisibleForTesting
     public static class MutationInitiator
     {
+        protected void onInvalidMutation(TableId id)
+        {
+            logger.debug("Invalid mutation detected by Cassandra for table id {}", id);
+        }
+
         protected Future<Integer> initiateMutation(final Mutation mutation,
                                                    final long segmentId,
                                                    final int serializedSize,
@@ -540,6 +545,12 @@ public class CommitLogReplayer implements CommitLogReadHandler
                 return true;
         }
         return false;
+    }
+
+    public void handleInvalidMutation(TableId id)
+    {
+        logger.info("Inside handleInvalidMutation of Cassandra");
+        mutationInitiator.onInvalidMutation(id);
     }
 
     public void handleMutation(Mutation m, int size, int entryLocation, CommitLogDescriptor desc)

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -296,7 +296,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
     {
         protected void onInvalidMutation(TableId id)
         {
-            logger.debug("Invalid mutation detected by Cassandra for table id {}", id);
+            logger.debug("Invalid mutation detected for table id {}", id);
         }
 
         protected Future<Integer> initiateMutation(final Mutation mutation,
@@ -547,9 +547,13 @@ public class CommitLogReplayer implements CommitLogReadHandler
         return false;
     }
 
+    public List<String> getSegmentsWithInvalidMutations()
+    {
+        return commitLogReader.getSegmentsWithInvalidMutations();
+    }
+
     public void handleInvalidMutation(TableId id)
     {
-        logger.info("Inside handleInvalidMutation of Cassandra");
         mutationInitiator.onInvalidMutation(id);
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -547,7 +548,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
         return false;
     }
 
-    public List<String> getSegmentsWithInvalidMutations()
+    public Set<String> getSegmentsWithInvalidMutations()
     {
         return commitLogReader.getSegmentsWithInvalidMutations();
     }

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -66,6 +66,7 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.security.EncryptionContext;
 import org.apache.cassandra.security.EncryptionContextGenerator;
 
@@ -499,5 +500,7 @@ public abstract class CommitLogStressTest
         public void handleUnrecoverableError(CommitLogReadException exception) throws IOException { }
 
         public void handleMutation(Mutation m, int size, int entryLocation, CommitLogDescriptor desc) { }
+
+        public void handleInvalidMutation(TableId id) {}
     }
 }

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogReaderTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogReaderTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.KillerForTests;
@@ -241,6 +242,8 @@ public class CommitLogReaderTest extends CQLTester
                 seenMutations.add(m);
             }
         }
+
+        public void handleInvalidMutation(TableId id){}
 
         public int seenMutationCount() { return seenMutations.size(); }
     }


### PR DESCRIPTION
- tracked commit log files with invalid mutations with `segmentsWithInvalidMutations`
- after a replay cycle, those commit log files with invalid mutations are not deleted
- if a commit log with invalid mutations, is successfully replayed later, it is removed.