### PR TITLE
CNDB-8824 Optimize ChunkCache#invalidateFile by tracking keysByFile.

### DIFF
--- a/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.ChunkReader;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.RebuffererFactory;
 
@@ -54,6 +55,7 @@ public class ChunkCacheInterceptingTest
 
             ChunkReader chunkReader = mock(ChunkReader.class);
             when(chunkReader.chunkSize()).thenReturn(1024);
+            when(chunkReader.channel()).thenReturn(new ChannelProxy(new File("")));
 
             RebuffererFactory rebuferrerFactory = ChunkCache.maybeWrap(chunkReader);
             assertTrue("chunk cache didn't create our interceptor?", interceptor != null);

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cache;
 
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -68,6 +69,122 @@ public class ChunkCacheTest
 
         Assert.assertEquals(ChunkCache.instance.size(), 0);
         Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+    }
+
+    @Test
+    public void testInvalidateFileNotInCache()
+    {
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        ChunkCache.instance.invalidateFile("/tmp/does/not/exist/in/cache/or/on/file/system");
+    }
+
+    @Test
+    public void testRandomAccessReadersWithUpdatedFileAndMultipleChunksAndCacheInvalidation() throws IOException
+    {
+        File file = FileUtils.createTempFile("foo", null);
+        file.deleteOnExit();
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+
+        writeBytes(file, new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE * 3]);
+
+        try (FileHandle.Builder builder1 = new FileHandle.Builder(file).withChunkCache(ChunkCache.instance);
+             FileHandle handle1 = builder1.complete();
+             RandomAccessReader reader1 = handle1.createReader();
+             RandomAccessReader reader2 = handle1.createReader())
+        {
+            // Read 2 chunks and verify contents
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 2; i++)
+                Assert.assertEquals((byte) 0, reader1.readByte());
+
+            // Overwrite the file's contents
+            var bytes = new byte[RandomAccessReader.DEFAULT_BUFFER_SIZE * 3];
+            Arrays.fill(bytes, (byte) 1);
+            writeBytes(file, bytes);
+
+            // Verify rebuffer pulls from cache for first 2 bytes and then from disk for third byte
+            reader1.seek(0);
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 2; i++)
+                Assert.assertEquals((byte) 0, reader1.readByte());
+            // Trigger read of next chunk and see it is the new data
+            Assert.assertEquals((byte) 1, reader1.readByte());
+
+            Assert.assertEquals(ChunkCache.instance.size(), 3);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 3);
+
+            // Invalidate cache for both chunks
+            ChunkCache.instance.invalidateFile(file.path());
+
+            // Verify cache is empty
+            Assert.assertEquals(ChunkCache.instance.size(), 0);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+
+            // Seek then verify that the new data is read
+            reader1.seek(0);
+            for (int i = 0; i < RandomAccessReader.DEFAULT_BUFFER_SIZE * 3; i++)
+                Assert.assertEquals((byte) 1, reader1.readByte());
+
+            // Verify a second reader gets the new data even though it was created before the cache was invalidated
+            Assert.assertEquals((byte) 1, reader2.readByte());
+        }
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(file.path()), 0);
+    }
+
+    @Test
+    public void testRandomAccessReadersForDifferentFilesWithCacheInvalidation() throws IOException
+    {
+        File fileFoo = FileUtils.createTempFile("foo", null);
+        fileFoo.deleteOnExit();
+        File fileBar = FileUtils.createTempFile("bar", null);
+        fileBar.deleteOnExit();
+
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileFoo.path()), 0);
+        Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 0);
+
+        writeBytes(fileFoo, new byte[64]);
+        // Write different bytes for meaningful content validation
+        var barBytes = new byte[64];
+        Arrays.fill(barBytes, (byte) 1);
+        writeBytes(fileBar, barBytes);
+
+        try (FileHandle.Builder builderFoo = new FileHandle.Builder(fileFoo).withChunkCache(ChunkCache.instance);
+             FileHandle handleFoo = builderFoo.complete();
+             RandomAccessReader readerFoo = handleFoo.createReader())
+        {
+            Assert.assertEquals((byte) 0, readerFoo.readByte());
+
+            Assert.assertEquals(ChunkCache.instance.size(), 1);
+            Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileFoo.path()), 1);
+
+            try (FileHandle.Builder builderBar = new FileHandle.Builder(fileBar).withChunkCache(ChunkCache.instance);
+                 FileHandle handleBar = builderBar.complete();
+                 RandomAccessReader readerBar = handleBar.createReader())
+            {
+                Assert.assertEquals((byte) 1, readerBar.readByte());
+
+                Assert.assertEquals(ChunkCache.instance.size(), 2);
+                Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 1);
+
+                // Invalidate fileFoo and verify that only fileFoo's chunks are removed
+                ChunkCache.instance.invalidateFile(fileFoo.path());
+                Assert.assertEquals(ChunkCache.instance.size(), 1);
+                Assert.assertEquals(ChunkCache.instance.sizeOfFile(fileBar.path()), 1);
+            }
+        }
+        Assert.assertEquals(ChunkCache.instance.size(), 0);
+    }
+
+    private void writeBytes(File file, byte[] bytes) throws IOException
+    {
+        try (SequentialWriter writer = new SequentialWriter(file))
+        {
+            writer.write(bytes);
+            writer.flush();
+        }
     }
 
 }


### PR DESCRIPTION
Optimize the `ChunkCache#invalidateFile` method by introducing a map that keeps track of the file to key set in the `ChunkCache`. The current solution is costly, as it iterates over the whole cache.