### PR TITLE
Fix VectorTester#setMaxBruteForceRows logic

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
@@ -226,7 +226,7 @@ public class OnDiskOrdinalsMap
             boolean called = false;
             int start = Math.max(startRowId, 0);
             int end = Math.min(endRowId, size);
-            for (int rowId = start; rowId < end; rowId++)
+            for (int rowId = start; rowId <= end; rowId++)
             {
                 called = true;
                 consumer.accept(rowId, rowId);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
@@ -226,7 +226,7 @@ public class OnDiskOrdinalsMap
             boolean called = false;
             int start = Math.max(startRowId, 0);
             int end = Math.min(endRowId, size);
-            for (int rowId = start; rowId <= end; rowId++)
+            for (int rowId = start; rowId < end; rowId++)
             {
                 called = true;
                 consumer.accept(rowId, rowId);

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -57,12 +57,12 @@ public class VectorTester extends SAITester
     static void setMaxBruteForceRows(int n) throws Throwable
     {
         var shouldUseBruteForce = InvokePointBuilder.newInvokePoint()
-                                                  .onClass("org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher")
+                                                  .onClass("org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher$CostEstimate")
                                                   .onMethod("shouldUseBruteForce")
                                                   .atEntry();
         var ab = ActionBuilder.newActionBuilder()
                               .actions()
-                              .doAction("$this.globalBruteForceRows = " + n);
+                              .doAction("$this.this$0.globalBruteForceRows = " + n);
         var changeBruteForceThreshold = Injections.newCustom("force_non_bruteforce_queries")
                                                   .add(shouldUseBruteForce)
                                                   .add(ab)


### PR DESCRIPTION
This is a hot fix. It works based on my testing locally and exposes two tailing test in `VectorTypeTest`.

I think we need a new way to configure brute force limits. Maybe we can do something as simple as setting a static variable and running all of our tests with and without brute force.