### PR TITLE
WIP: push node token ranges to replica nodes

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
+import org.apache.cassandra.index.sai.utils.DataRangeFilterIterator;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
@@ -164,16 +165,11 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     private static class ResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
     {
         private final PrimaryKey firstPrimaryKey;
-        private final PrimaryKey lastPrimaryKey;
-        private final Iterator<DataRange> keyRanges;
-        private AbstractBounds<PartitionPosition> currentKeyRange;
-
         private final RangeIterator operation;
         private final FilterTree filterTree;
         private final QueryController controller;
         private final ReadExecutionController executionController;
         private final QueryContext queryContext;
-        private final PrimaryKey.Factory keyFactory;
 
         private PrimaryKey lastKey;
 
@@ -183,18 +179,15 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                                 ReadExecutionController executionController,
                                 QueryContext queryContext)
         {
-            this.keyRanges = controller.dataRanges().iterator();
-            this.currentKeyRange = keyRanges.next().keyRange();
-
-            this.operation = operation;
+            this.operation = new DataRangeFilterIterator(controller.dataRanges(),
+                                                         controller.primaryKeyFactory(),
+                                                         operation);
             this.filterTree = filterTree;
             this.controller = controller;
             this.executionController = executionController;
             this.queryContext = queryContext;
-            this.keyFactory = controller.primaryKeyFactory();
 
             this.firstPrimaryKey = controller.firstPrimaryKey();
-            this.lastPrimaryKey = controller.lastPrimaryKey();
         }
 
         @Override
@@ -248,54 +241,19 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         }
 
         /**
-         * Returns the next available key contained by one of the keyRanges.
-         * If the next key falls out of the current key range, it skips to the next key range, and so on.
-         * If no more keys or no more ranges are available, returns null.
-         */
-        private @Nullable PrimaryKey nextKeyInRange()
-        {
-            PrimaryKey key = nextKey();
-
-            while (key != null && !(currentKeyRange.contains(key.partitionKey())))
-            {
-                if (!currentKeyRange.right.isMinimum() && currentKeyRange.right.compareTo(key.partitionKey()) <= 0)
-                {
-                    // currentKeyRange before the currentKey so need to move currentKeyRange forward
-                    currentKeyRange = nextKeyRange();
-                    if (currentKeyRange == null)
-                        return null;
-                }
-                else
-                {
-                    // the following condition may be false if currentKeyRange.left is not inclusive,
-                    // and key == currentKeyRange.left; in this case we should not try to skipTo the beginning
-                    // of the range because that would be requesting the key to go backwards
-                    // (in some implementations, skipTo can go backwards, and we don't want that)
-                    if (currentKeyRange.left.getToken().compareTo(key.token()) > 0)
-                    {
-                        // key before the current range, so let's move the key forward
-                        skipTo(currentKeyRange.left.getToken());
-                    }
-                    key = nextKey();
-                }
-            }
-            return key;
-        }
-
-        /**
          * Returns the next available key contained by one of the keyRanges and selected by the queryController.
          * If the next key falls out of the current key range, it skips to the next key range, and so on.
          * If no more keys acceptd by the controller are available, returns null.
          */
          private @Nullable PrimaryKey nextSelectedKeyInRange()
         {
-            PrimaryKey key;
-            do
+            while (operation.hasNext())
             {
-                key = nextKeyInRange();
+                PrimaryKey key = operation.next();
+                if (controller.selects(key))
+                    return key;
             }
-            while (key != null && !controller.selects(key));
-            return key;
+            return null;
         }
 
         /**
@@ -320,46 +278,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 if (!operation.peek().partitionKey().equals(partitionKey))
                     return null;
 
-                key = nextKey();
+                key = operation.next();
             }
-            while (key != null && !controller.selects(key));
+            while (!controller.selects(key));
             return key;
-        }
-
-        /**
-         * Gets the next key from the underlying operation.
-         * Returns null if there are no more keys <= lastPrimaryKey.
-         */
-        private @Nullable PrimaryKey nextKey()
-        {
-            if (!operation.hasNext())
-                return null;
-            PrimaryKey key = operation.next();
-            return isWithinUpperBound(key) ? key : null;
-        }
-
-        /**
-         * Returns true if the key is not greater than lastPrimaryKey
-         */
-        private boolean isWithinUpperBound(PrimaryKey key)
-        {
-            return lastPrimaryKey.token().isMinimum() || lastPrimaryKey.compareTo(key) >= 0;
-        }
-
-        /**
-         * Gets the next key range from the underlying range iterator.
-         */
-        private @Nullable AbstractBounds<PartitionPosition> nextKeyRange()
-        {
-            return keyRanges.hasNext() ? keyRanges.next().keyRange() : null;
-        }
-
-        /**
-         * Convenience function to skip to a given token.
-         */
-        private void skipTo(@Nonnull Token token)
-        {
-            operation.skipTo(keyFactory.createTokenOnly(token));
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/utils/DataRangeFilterIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/DataRangeFilterIterator.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.cassandra.db.DataRange;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.AbstractIterator;
+
+/**
+ * An iterator that filters the input iterator based on the provided list of {@link DataRange}.
+ * The {@link DataRange} list must be ordered in ascending order of the partition key.
+ */
+public class DataRangeFilterIterator extends RangeIterator
+{
+    private final Iterator<AbstractBounds<PartitionPosition>> keyRanges;
+    private AbstractBounds<PartitionPosition> currentKeyRange;
+    private final PrimaryKey.Factory primaryKeyFactory;
+    private final RangeIterator input;
+
+    public DataRangeFilterIterator(List<DataRange> dataRanges, PrimaryKey.Factory primaryKeyFactory, RangeIterator input)
+    {
+        super(input);
+        assert dataRanges != null && !dataRanges.isEmpty();
+        this.keyRanges = dataRanges.stream().map(DataRange::keyRange).iterator();
+        this.currentKeyRange = keyRanges.next();
+        this.primaryKeyFactory = primaryKeyFactory;
+        this.input = input;
+    }
+
+    /**
+     * Returns the next available key contained by one of the keyRanges.
+     * If the next key falls out of the current key range, it skips to the next key range, and so on.
+     * If no more keys or no more ranges are available, returns endOfData().
+     */
+    @Override
+    protected PrimaryKey computeNext()
+    {
+        if (!input.hasNext())
+            return endOfData();
+
+        PrimaryKey key = input.next();
+        while (!(currentKeyRange.contains(key.partitionKey())))
+        {
+            if (!currentKeyRange.right.isMinimum() && currentKeyRange.right.compareTo(key.partitionKey()) <= 0)
+            {
+                // We enter this block when currentKeyRange does not contain the current key,
+                // and the current key is greater than the currentKeyRange.
+                if (!keyRanges.hasNext())
+                    return endOfData();
+                currentKeyRange = keyRanges.next();
+            }
+            else
+            {
+                // the following condition may be false if currentKeyRange.left is not inclusive,
+                // and key == currentKeyRange.left; in this case we should not try to skipTo the beginning
+                // of the range because that would be requesting the key to go backwards
+                // (in some implementations, skipTo can go backwards, and we don't want that)
+                if (currentKeyRange.left.getToken().compareTo(key.token()) > 0)
+                {
+                    // key before the current range, so let's move the key forward
+                    input.skipTo(primaryKeyFactory.createTokenOnly(currentKeyRange.left.getToken()));
+                }
+                if (!input.hasNext())
+                    return endOfData();
+                key = input.next();
+            }
+        }
+        return key;
+    }
+
+    @Override
+    public void performSkipTo(PrimaryKey nextToken)
+    {
+        input.skipTo(nextToken);
+    }
+
+    @Override
+    public void close()
+    {
+        FileUtils.closeQuietly(input);
+    }
+}

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
@@ -77,8 +77,9 @@ public class RangeCommands
                                                                    command.indexQueryPlan(),
                                                                    keyspace,
                                                                    consistencyLevel);
-        if (command.isTopK())
-            return new ScanAllRangesCommandIterator(keyspace, replicaPlans, command, replicaPlans.size(), queryStartNanoTime, readTracker);
+        // TODO should this be configurable or can we always skip?
+//        if (command.isTopK())
+//            return new ScanAllRangesCommandIterator(keyspace, replicaPlans, command, replicaPlans.size(), queryStartNanoTime, readTracker);
 
         int maxConcurrencyFactor = Math.min(replicaPlans.size(), MAX_CONCURRENT_RANGE_REQUESTS);
         int concurrencyFactor = maxConcurrencyFactor;

--- a/test/distributed/org/apache/cassandra/distributed/test/TestBaseImpl.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/TestBaseImpl.java
@@ -106,6 +106,11 @@ public class TestBaseImpl extends DistributedTestBase
         return TupleType.buildValue(bbs);
     }
 
+    protected static ByteBuffer vector(float... v)
+    {
+        return VectorType.getInstance(FloatType.instance, v.length).getSerializer().serializeFloatArray(v);
+    }
+
     protected void bootstrapAndJoinNode(Cluster cluster)
     {
         cluster.stream().forEach(node -> {

--- a/test/unit/org/apache/cassandra/index/sai/utils/DataRangeFilterIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/DataRangeFilterIteratorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.DataRange;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DataRangeFilterIteratorTest
+{
+    private final RowAwarePrimaryKeyFactory primaryKeyFactory = new RowAwarePrimaryKeyFactory(new ClusteringComparator());
+
+    @Test
+    public void testEmptyInputIterator()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(DataRange.allData(Murmur3Partitioner.instance));
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, RangeIterator.empty()))
+        {
+            assertFalse(filterIterator.hasNext());
+        }
+    }
+
+    @Test
+    public void testExpectWholeInputIterator()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(DataRange.allData(Murmur3Partitioner.instance));
+        var iter = new LongIterator(new long[]{1, 2, 3, 4, 5});
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, iter))
+        {
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(1), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(2), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(3), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(4), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(5), filterIterator.next());
+            assertFalse(filterIterator.hasNext());
+        }
+    }
+
+    @Test
+    public void testExpectParitialResult()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(buildDataRange(2, 4));
+        var iter = new LongIterator(new long[]{1, 2, 3, 4, 5});
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, iter))
+        {
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(3), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(4), filterIterator.next());
+        }
+    }
+
+    @Test
+    public void testMultipleDataRanges()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(buildDataRange(1, 3));
+        dataRanges.add(buildDataRange(6, 8));
+        var iter = new LongIterator(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9});
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, iter))
+        {
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(2), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(3), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(7), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(8), filterIterator.next());
+            assertFalse(filterIterator.hasNext());
+        }
+    }
+
+    @Test
+    public void testDisjointIteratorAndDataRange()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(buildDataRange(4, 10));
+        var iter = new LongIterator(new long[]{1,2,3,4});
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, iter))
+        {
+            assertFalse(filterIterator.hasNext());
+        }
+    }
+
+
+    @Test
+    public void testSkipToForFirstPrimaryKey()
+    {
+        var dataRanges = new ArrayList<DataRange>();
+        dataRanges.add(buildDataRange(2, 5));
+        var iter = new LongIterator(new long[]{1,2,3,4});
+        try (var filterIterator = new DataRangeFilterIterator(dataRanges, primaryKeyFactory, iter))
+        {
+            // We always skip to the first token, so just do that here
+            filterIterator.skipTo(LongIterator.fromToken(2));
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(3), filterIterator.next());
+            assertTrue(filterIterator.hasNext());
+            assertEquals(LongIterator.fromToken(4), filterIterator.next());
+            assertFalse(filterIterator.hasNext());
+        }
+    }
+
+    private DataRange buildDataRange(long start, long end)
+    {
+        return DataRange.forTokenRange(new Range<>(LongIterator.fromToken(start).token(), LongIterator.fromToken(end).token()));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/utils/LongIterator.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/LongIterator.java
@@ -17,11 +17,15 @@
  */
 package org.apache.cassandra.index.sai.utils;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongFunction;
 
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.SAITester;
 
 public class LongIterator extends RangeIterator
@@ -93,6 +97,10 @@ public class LongIterator extends RangeIterator
 
     private PrimaryKey fromTokenAndRowId(long token, long rowId)
     {
-        return SAITester.TEST_FACTORY.createTokenOnly(new Murmur3Partitioner.LongToken(token));
+        // Set up the primary key
+        var partitionKey = ByteBuffer.allocate(8);
+        partitionKey.putLong(token);
+        DecoratedKey key = new BufferDecoratedKey(new Murmur3Partitioner.LongToken(token), partitionKey);
+        return SAITester.TEST_FACTORY.createPartitionKeyOnly(key);
     }
 }


### PR DESCRIPTION
Introduce the DataRangeFilterIterator to abstract
out token range filtering on RangeIterators. This
class is then used by both the ResultRetriever and hybrid ANN queries to filter resulting PrimaryKeys to ensure they are within the requested bounds.

Note: ANN only queries will continue to be generally unrestricted. This might be changed in this PR
or in a later one. I am pushing the current branch to get tests running to see what breaks.