### PR TITLE
POC: port ChunkCache and BufferPools from DSE (do not merge)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -220,6 +220,7 @@
         <string>--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED</string>
         <string>--add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED</string>
         <string>--add-exports java.sql/java.sql=ALL-UNNAMED</string>
+	<string>--add-exports java.base/sun.nio.ch=ALL-UNNAMED</string>
 
         <string>--add-opens java.base/java.lang.module=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.net=ALL-UNNAMED</string>
@@ -271,7 +272,7 @@
     </condition>
 
     <!-- needed to compile org.apache.cassandra.utils.JMXServerUtils -->
-    <condition property="jdk11-javac-exports" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED" else="">
+    <condition property="jdk11-javac-exports" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED " else="">
         <not>
             <equals arg1="${ant.java.version}" arg2="1.8"/>
         </not>

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeakLevel.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeakLevel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+/** Leak levels define the seriousness of a leak.  */
+public enum LeakLevel
+{
+    /** First level leaks are for resources that need some manual cleanup, for example by calling a release or close method.
+     * When these resources are leaked, and if there is no cleaner for automated cleaning, then a leak is bad news
+     * and will have negative consequences. */
+    FIRST_LEVEL,
+
+    /**
+     * Second level leaks are for resources that own a resource that needs manual cleanup. These resources are
+     * normally tracked only to help with debugging and if they are leaked there is no negative consequence.
+     * For example, the chunks in the cache live for a very long time, normally the creation of the chunk is
+     * not related to a leak. So reporting leaks of resources that temporarily owned a chunk by taking it from
+     * the cache, helps with debugging and ensures that leaks are reported even if the chunk is never evicted
+     * from the cache.*/
+    SECOND_LEVEL
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectionMXBean.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectionMXBean.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import java.util.List;
+
+/**
+ * An interface for customizing or retrieving leaks detection parameters. Refer to {@link LeaksDetectionParams} for
+ * a description of the parameters.
+ */
+public interface LeaksDetectionMXBean
+{
+    /**
+     * The name of the mbean that will be registered by {@link LeaksDetectorFactory}.
+     */
+    String LEAKS_DETECTION_MBEAN_NAME = "com.datastax.bdp.db.utils.leaks.detection:type=LeaksDetection,name=LeaksDetection";
+
+    /**
+     * @return the registered leak detectors, each of them described in a string formatted by {@link LeaksDetectionParams}.
+     */
+    List<String> getRegisteredDetectors();
+
+    /**
+     * Set the sampling probability for a specific resource detector.
+     */
+    void setSamplingProbability(String resourceName, double samplingProbability);
+
+    /**
+     * Set the sampling probability for all detectors.
+     */
+    void setSamplingProbability(double samplingProbability);
+
+    /**
+     * Set the max stacks cache size for a specific resource detector.
+     */
+    void setMaxStacksCacheSizeMb(String resourceName, int maxStacksCacheSizeMb);
+
+    /**
+     * Set the max stacks cache size for all detectors.
+     */
+    void setMaxStacksCacheSizeMb(int maxStacksCacheSizeMb);
+
+    /**
+     * Set the max number of access records for a specific resource detector.
+     */
+    void setNumAccessRecords(String resourceName, int numAccessRecords);
+
+    /**
+     * Set the max number of access records for all detectors.
+     */
+    void setNumAccessRecords(int numAccessRecords);
+
+    /**
+     * Set the max stack depth for a specific resource detector.
+     */
+    void setMaxStackDepth(String resourceName, int maxStackDepth);
+
+    /**
+     * Set the max stack depth for all detectors.
+     */
+    void setMaxStackDepth(int maxStackDepth);
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectionParams.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectionParams.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+
+/**
+ * The parameters for tracking a resource. This class groups the following properties:
+ * <p/>
+ * Sampling probability: a number between 0 and 1 specifying the percentage of instances that should be tracked.
+ * <p/>
+ * Max stacks cache size: the size in MB of a cache that contains call stack traces.
+ * <p/>
+ * Number of access records: this determines the number of call stack traces that are recorded for each resource when
+ * {@link LeaksTracker#record()} is called. This mechanism requires that the resource tracker is able to call this method,
+ * which may not be possible for some resources such as {@link java.nio.ByteBuffer}.
+ * These call stack traces are in addition to the creation call stack trace, which is always kept.
+ * <p/>
+ * Max stacks depth: the maximum depth to keep for a call stack trace. Normally only the bottom frames are sufficient for
+ * debugging and so we can save space. Also, this makes the cache effective, increasing the depth may increase the
+ * number of misses in the stacks cache, which means that a stack trace won't be available when a LEAK is logged.
+ */
+public class LeaksDetectionParams
+{
+    static final double DEFAULT_SAMPLING_PROBABILITY = Double.parseDouble(System.getProperty("dse.res_leak_sampling_prob", "0.01"));
+    private static final int DEFAULT_NUM_ACCESS_RECORDS = Integer.getInteger("dse.res_leak_num_access_records", 0);
+    private static final int MAX_STACK_DEPTH = Integer.getInteger("dse.res_leak_max_stack_depth", 30);
+    private static final int MAX_STACK_CACHE_SIZE_MB = Integer.getInteger("dse.res_leak_max_stack_cache_size_mb", 32);
+
+    /** non-final and public because of yaml config */
+    public double sampling_probability;
+    /** non-final and public because of yaml config */
+    public int max_stacks_cache_size_mb;
+    /** non-final and public because of yaml config */
+    public int num_access_records;
+    /** non-final and public because of yaml config */
+    public int max_stack_depth;
+
+    public LeaksDetectionParams()
+    {
+        this(DEFAULT_SAMPLING_PROBABILITY);
+    }
+
+    public LeaksDetectionParams(double sampling_probability)
+    {
+        this(sampling_probability, MAX_STACK_CACHE_SIZE_MB, DEFAULT_NUM_ACCESS_RECORDS, MAX_STACK_DEPTH);
+    }
+
+    public LeaksDetectionParams(double sampling_probability, int max_stacks_cache_size_mb, int num_access_records, int max_stack_depth)
+    {
+        Preconditions.checkArgument(sampling_probability >= 0 && sampling_probability <= 1, "Sampling probability must be between 0 and 1: {}", sampling_probability);
+        Preconditions.checkArgument(max_stacks_cache_size_mb >= 4, "Max stacks cache size should be at least 4 MiB but got %s MiB", max_stacks_cache_size_mb);
+        Preconditions.checkArgument(num_access_records >= 0, "Num access records should be positive or zero but got %s", num_access_records);
+        Preconditions.checkArgument(max_stack_depth > 0, "Max stack depth should be positive but got %s", max_stack_depth);
+
+        this.sampling_probability = sampling_probability;
+        this.max_stacks_cache_size_mb = max_stacks_cache_size_mb;
+        this.num_access_records = num_access_records;
+        this.max_stack_depth = max_stack_depth;
+    }
+
+    @VisibleForTesting
+    static LeaksDetectionParams create(double samplingProbability, int numAccessRecords)
+    {
+        return new LeaksDetectionParams(samplingProbability,
+                                        MAX_STACK_CACHE_SIZE_MB,
+                                        numAccessRecords,
+                                        MAX_STACK_DEPTH);
+    }
+
+    LeaksDetectionParams copy()
+    {
+        return new LeaksDetectionParams(sampling_probability,
+                                        max_stacks_cache_size_mb,
+                                        num_access_records,
+                                        max_stack_depth);
+    }
+
+    LeaksDetectionParams withSamplingProbability(double samplingProbability)
+    {
+        return new LeaksDetectionParams(samplingProbability,
+                                        max_stacks_cache_size_mb,
+                                        num_access_records,
+                                        max_stack_depth);
+    }
+
+    LeaksDetectionParams withMaxStacksCacheSizeMb(int maxStacksCacheSizeMb)
+    {
+        return new LeaksDetectionParams(sampling_probability,
+                                        maxStacksCacheSizeMb,
+                                        num_access_records,
+                                        max_stack_depth);
+    }
+
+    LeaksDetectionParams withNumAccessRecords(int numAccessRecords)
+    {
+        return new LeaksDetectionParams(sampling_probability,
+                                        max_stacks_cache_size_mb,
+                                        numAccessRecords,
+                                        max_stack_depth);
+    }
+
+    LeaksDetectionParams withMaxStackDepth(int maxStackDepth)
+    {
+        return new LeaksDetectionParams(sampling_probability,
+                                        max_stacks_cache_size_mb,
+                                        num_access_records,
+                                        maxStackDepth);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("Sampling probability: %f, Max stacks cache size MB: %d, num. access records: %d, max stack depth: %d",
+                             sampling_probability,
+                             max_stacks_cache_size_mb,
+                             num_access_records,
+                             max_stack_depth);
+    }
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetector.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetector.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.utils.UnsafeMemoryAccess;
+
+/**
+ * An interface for detecting leaks of resources that should get explicitly closed or released.
+ * <p/>
+ * Resources that should be tracked could be ref counted objects that need to perform some cleanup when the ref
+ * count is zero. For example {@link java.nio.ByteBuffer} instances that must be returned to a
+ * {@link org.apache.cassandra.utils.memory.buffers.BufferPool}, or objects using memory allocated
+ * with {@link UnsafeMemoryAccess#allocate(long)}.
+ * <p/>
+ * There should exist a detector per resource type and each detector will have dedicated parameters as described in
+ * {@link LeaksDetectionParams}. These parameters can be changed by calling {@link this#setParams(LeaksDetectionParams)}.
+ * <p/>
+ * Refer to {@link LeaksDetectorImpl} for implementation details.
+ *
+ * @param <T> the type of the resource that needs tracking
+ */
+public interface LeaksDetector<T>
+{
+    /**
+     * A cleaner is invoked when the instance that was being tracked has been leaked.
+     * <p/>
+     * A resource of type T may own resources that need cleaning of type C. T and C must be different because
+     * there can't be any strong reference to T. For example, a cache chunk may need to return buffers, in this case T would
+     * be the chunk and C either the byte buffer or an address belonging to the buffer pool. A resource may also
+     * have several types of resources that need cleaning and not just one. Some resources may be tracked for debugging only,
+     * in which case they have nothing that needs cleaning, in this case they simply won't need a cleaner.
+     *
+     * @param <C> the resource to be cleaned, this is not the same as the resource being tracked because there
+     *            can't be any strong references to the resource being tracked as explained in more details above.
+     */
+    interface Cleaner<C>
+    {
+        void clean(C resForCleaning);
+    }
+
+    /**
+     * Track the given resource instance for debugging only. Tracking only happens with the sampling probability that was
+     * last set with the {@link this#setParams(LeaksDetectionParams)} If the resource is leaked, some debug information
+     * such as the creation call-stack trace will be logged.
+     *
+     * @param resForTracking the resource to track
+     *
+     * @return a valid handle that should be closed before the resource goes out of scope, or null if this instance won't be tracked.
+     */
+    @Nullable
+    LeaksTracker<T> trackForDebug(T resForTracking);
+
+    /**
+     *  Track the given resource instance for debug and cleaning. Tracking only happens with the sampling probability that was
+     *  last set with the {@link this#setParams(LeaksDetectionParams)} If the resource is leaked, some debug information
+     *  such as the creation call-stack trace will be logged and the cleaner will be run if it is not null. It will
+     *  receive the resources passed into this method.
+     * <p/>
+     * <b>It is essential that the cleaner or the resource for cleaning do not strongly reference the resource for tracking.</b>
+     *
+     * @param resForTracking the resource to track
+     * @param cleaner an optional cleaner to be run when the resource is detected as leaked, it may be null
+     * @param resForCleaning the resource to be passed to the cleaner when it is run
+     *
+     * @return a valid handle that should be closed before the resource goes out of scope, or null if this instance won't be tracked.
+     */
+    @Nullable
+    <C> LeaksTracker<T> trackForDebug(T resForTracking, @Nullable Cleaner<C> cleaner, @Nullable C resForCleaning);
+
+    /**
+     * Track the given resource instance for cleaning only. Tracking happens all the time regardless of the sampling
+     * probability. If the resource is leaked, the cleaner will be run. The cleaner cannot be null. The cleaner will
+     * receive the resources passed into this method.
+     * <p/>
+     * <b>It is essential that the cleaner or the resource for cleaning do not strongly reference the resource for tracking.</b>
+     *
+     * @param resForTracking the resource to track
+     * @param cleaner code that will be run if the resource is leaked
+     * @param resForCleaning the resource to be passed to the cleaner when it is run
+     *
+     * @return a valid handle that should be closed before the resource goes out of scope,
+     */
+    <C> LeaksTracker<T> trackForCleaning(T resForTracking, Cleaner<C> cleaner, C resForCleaning);
+
+    /**
+     * Check for leaked resources, this is called periodically and so there is normally
+     * no need to call this method except for tests.
+     */
+    @VisibleForTesting
+    void checkForLeaks();
+
+    /**
+     * @return the type of resource being tracked for leaks
+     */
+    LeaksResource getResource();
+
+    /**
+     * @return the current parameters
+     */
+    LeaksDetectionParams getParams();
+
+    /**
+     * Change the parameters such as the sampling probability.
+     *
+     * @param params - the new parameters
+     *
+     * @return the old parameters
+     */
+    LeaksDetectionParams setParams(LeaksDetectionParams params);
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectorFactory.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectorFactory.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+/**
+ * A factory and repository of {@link LeaksDetector} instances. We need this repository because
+ * we want all the detectors in one place so that we can implement nodetool commands that update the
+ * detectors' parameters.
+ */
+public class LeaksDetectorFactory implements LeaksDetectionMXBean
+{
+    private final static LeaksDetectorFactory instance = createInstance();
+
+    private final CopyOnWriteArrayList<LeaksDetector> detectors = new CopyOnWriteArrayList<>();
+
+    private static LeaksDetectorFactory createInstance()
+    {
+        LeaksDetectorFactory ret = new LeaksDetectorFactory();
+        registerJMX(ret);
+        return ret;
+    }
+
+    /**
+     * Register the singleton instance as an mxBean.
+     */
+    private static void registerJMX(LeaksDetectorFactory factory)
+    {
+        try
+        {
+            MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+
+            ObjectName me = new ObjectName(LEAKS_DETECTION_MBEAN_NAME);
+            if (!mbs.isRegistered(me))
+                mbs.registerMBean(factory, new ObjectName(LEAKS_DETECTION_MBEAN_NAME));
+        }
+        catch (InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException | MalformedObjectNameException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create a leaks detector with the default parameters specified in the yaml. If no parameters
+     * have been specified in the yaml, then create one using the default parameters defined
+     * in {@link LeaksDetectionParams}.
+     */
+    public static <T> LeaksDetector<T> create(String name, Class cls, LeakLevel level)
+    {
+        return create(name, cls, LeaksDetectionParams.DEFAULT_SAMPLING_PROBABILITY, level);
+    }
+
+    /**
+     * Create a leaks detector with the default parameters specified in the yaml. If no parameters
+     * have been specified in the yaml, then create one using the given default sampling probability and
+     * the remaining default parameters defined in {@link LeaksDetectionParams}.
+     */
+    public static <T> LeaksDetector<T> create(String name, Class cls, double defaultSamplingProb, LeakLevel level)
+    {
+        return create(name, cls, DatabaseDescriptor.getLeaksDetectionParams(defaultSamplingProb), level);
+    }
+
+    /**
+     * Create a leaks detector with the given leaks detection parameters. This bypasses yaml
+     * configuration and default parameters defined in {@link LeaksDetectionParams}.
+     */
+    public static <T> LeaksDetector<T> create(String name, Class cls, LeaksDetectionParams params, LeakLevel level)
+    {
+        return create(LeaksResource.create(name, cls, level), params);
+    }
+
+    private static <T> LeaksDetector<T> create(LeaksResource resource, LeaksDetectionParams params)
+    {
+        return instance.add(resource, params);
+    }
+
+    /**
+     * Add a new detector and return it.
+     */
+    @VisibleForTesting
+    <T> LeaksDetector<T> add(LeaksResource resource, LeaksDetectionParams params)
+    {
+        LeaksDetector<T> ret = new LeaksDetectorImpl<>(resource, params);
+        detectors.add(ret);
+        return ret;
+    }
+
+    @Override
+    public List<String> getRegisteredDetectors()
+    {
+        return detectors.stream()
+                        .map(detector -> String.format("%-"+ LeaksResource.MAX_NAME_LENGTH + "s - %s", detector.getResource(), detector.getParams()))
+                        .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setSamplingProbability(String resourceName, double samplingProbability)
+    {
+        setProperty(resourceName, params ->params.withSamplingProbability(samplingProbability));
+    }
+
+    @Override
+    public void setSamplingProbability(double samplingProbability)
+    {
+        setProperty(params ->params.withSamplingProbability(samplingProbability));
+    }
+
+    @Override
+    public void setMaxStacksCacheSizeMb(String resourceName, int maxStacksCacheSizeMb)
+    {
+        setProperty(resourceName, params ->params.withMaxStacksCacheSizeMb(maxStacksCacheSizeMb));
+    }
+
+    @Override
+    public void setMaxStacksCacheSizeMb(int maxStacksCacheSizeMb)
+    {
+        setProperty(params ->params.withMaxStacksCacheSizeMb(maxStacksCacheSizeMb));
+    }
+
+    @Override
+    public void setNumAccessRecords(String resourceName, int numAccessRecords)
+    {
+        setProperty(resourceName, params ->params.withNumAccessRecords(numAccessRecords));
+    }
+
+    @Override
+    public void setNumAccessRecords(int numAccessRecords)
+    {
+        setProperty(params ->params.withNumAccessRecords(numAccessRecords));
+    }
+
+    @Override
+    public void setMaxStackDepth(String resourceName, int maxStackDepth)
+    {
+        setProperty(resourceName, params ->params.withMaxStackDepth(maxStackDepth));
+    }
+
+    @Override
+    public void setMaxStackDepth(int maxStackDepth)
+    {
+        setProperty(params ->params.withMaxStackDepth(maxStackDepth));
+    }
+
+    private void setProperty(String resourceName, Function<LeaksDetectionParams, LeaksDetectionParams> paramsProvider)
+    {
+        try
+        {
+            boolean found = false;
+            for (LeaksDetector detector : detectors)
+            {
+                if (detector.getResource().name.equals(resourceName))
+                {
+                    if (!found)
+                        found = true;
+                    detector.setParams(paramsProvider.apply(detector.getParams()));
+                }
+            }
+
+            if (!found)
+                throw new IllegalStateException(String.format("No detector found for resource %s", resourceName));
+        }
+        catch (Throwable t)
+        {
+            throw Throwables.propagate(t);
+        }
+    }
+
+    private void setProperty(Function<LeaksDetectionParams, LeaksDetectionParams> paramsProvider)
+    {
+        for (LeaksDetector detector : detectors)
+            detector.setParams(paramsProvider.apply(detector.getParams()));
+    }
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectorImpl.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksDetectorImpl.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The implementation of {@link LeaksDetector}.
+ * <p/>
+ * It tracks instances of its resource type according to the parameters specified by the current {@link LeaksDetectionParams}.
+ */
+class LeaksDetectorImpl<T> implements LeaksDetector<T>
+{
+    private static final Logger logger = LoggerFactory.getLogger(LeaksDetectorImpl.class);
+    private final static Charset CHARSET = StandardCharsets.UTF_8;
+
+    // Use this string to report a missing stack trace that has already been evicted form the stacks cache
+    private final static String STACK_TRACE_NO_LONGER_AVAILABLE = "Stack trace no longer available, increase stacks cache size for this resource using nodetool leaksdetection";
+
+    // Exclude the low level classes defined by LeaksDetectorImpl from the stack traces since they are not useful for debugging, they just waste space
+    private final static List<String> STACK_TRACE_EXCLUSIONS = Stream.concat(Stream.of(LeaksDetectorImpl.class.getDeclaredClasses()),
+                                                                             Stream.of(LeaksDetectorImpl.class))
+                                                                     .map(c -> c.getName())
+                                                                     .collect(Collectors.toList());
+    /**
+     * The resource being tracked.
+     */
+    private final LeaksResource resource;
+
+    /**
+     * A map that keeps a strong reference to all the phantom references. For a phantom reference to be enqueued, it must
+     * still be strongly reachable when the referent is finalized.
+     */
+    private final ConcurrentHashMap<LeaksTracker, LeakEntry> allTrackedResources = new ConcurrentHashMap<>();
+
+    /**
+     * The reference queue where the phantom references will be enqueued.
+     */
+    private final ReferenceQueue<? super T> refQueue;
+
+    /**
+     * The reporter is a helper class that logs a leak, it is abstracted for unit test mocks.
+     */
+    private final LeakReporter leakReporter;
+
+    /**
+     * Some parameters that control the operation of this leak detector, these can be changed by nodetool.
+     */
+    private volatile LeaksDetectionParams params;
+
+    /**
+     * A cache of call stack traces, used to avoid duplicating identical stacks and to put an upper bound on the memory
+     * kept for stack traces, not so much for avoiding the computation of a stack trace, which must be done anyway.
+     * <p/>
+     * If nodetool changes the parameters, we may need to create a new cache and copy the contents of the old one.
+     */
+    private volatile Cache<Long, String> stacksCache;
+
+    LeaksDetectorImpl(LeaksResource resource, LeaksDetectionParams params)
+    {
+        this(resource, params, new LeakReporter());
+    }
+
+    @VisibleForTesting
+    LeaksDetectorImpl(LeaksResource resource, double samplingProbability, int numAccessRecords, LeakReporter leakReporter)
+    {
+        this(resource, LeaksDetectionParams.create(samplingProbability, numAccessRecords), leakReporter);
+    }
+
+    private LeaksDetectorImpl(LeaksResource resource, LeaksDetectionParams params, LeakReporter leakReporter)
+    {
+        this.resource = resource;
+        this.params = params;
+        this.refQueue  = new ReferenceQueue<>();
+        this.leakReporter = leakReporter;
+        this.stacksCache = createStacksCache(params.max_stacks_cache_size_mb, null);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(this::checkForLeaks, 1, 1, TimeUnit.MINUTES);
+    }
+
+    private static Cache<Long, String> createStacksCache(int maxStacksCacheSizeMb, @Nullable Cache<Long, String> existing)
+    {
+        Cache<Long, String> ret = Caffeine.newBuilder()
+                                                  .maximumWeight(maxStacksCacheSizeMb * 1024 * 1024)
+                                                  .executor(Runnable::run)
+                                                  .weigher((key, val) -> Long.BYTES + ((String) val).getBytes().length)
+                                                  .build();
+        if (existing != null)
+            ret.putAll(existing.asMap());
+
+        return ret;
+    }
+
+    @Override
+    @Nullable
+    public LeaksTracker<T> trackForDebug(T resForTracking)
+    {
+        return trackForDebug(resForTracking, null, null);
+    }
+
+    @Override
+    @Nullable
+    public <C> LeaksTracker<T> trackForDebug(T resForTracking,  @Nullable Cleaner<C> cleaner, @Nullable C resForCleaning)
+    {
+        if (ThreadLocalRandom.current().nextDouble() > params.sampling_probability)
+            return null;
+
+        return new ReportingTracker(resForTracking, cleaner, resForCleaning);
+    }
+
+    @Override
+    public <C> LeaksTracker<T> trackForCleaning(T resForTracking,  Cleaner<C> cleaner, C resForCleaning)
+    {
+        if (cleaner == null)
+            throw new IllegalArgumentException("Cleaner cannot be null, did you mean to call trackForDebug()?");
+
+        return new CleaningTracker(resForTracking, cleaner, resForCleaning);
+    }
+
+    @Override
+    public LeaksResource getResource()
+    {
+        return resource;
+    }
+
+    @Override
+    public LeaksDetectionParams getParams()
+    {
+        return params;
+    }
+
+    @Override
+    public synchronized LeaksDetectionParams setParams(LeaksDetectionParams params)
+    {
+        LeaksDetectionParams ret = this.params;
+        this.params = params;
+
+        if (ret.max_stacks_cache_size_mb != params.max_stacks_cache_size_mb)
+            this.stacksCache.policy().eviction().get().setMaximum(params.max_stacks_cache_size_mb * 1024 * 1024);
+
+        return ret;
+    }
+
+    /**
+     * This is used by unit tests for checking that {@link this#setParams(LeaksDetectionParams)}.
+     *
+     * @return the stacks trace cache size
+     */
+    @VisibleForTesting
+    long getStacksCacheSize()
+    {
+        return this.stacksCache.policy().eviction().get().getMaximum();
+    }
+
+    /**
+     * Detect and report any leaks by scanning the ref queue. If a resource tracker is found and
+     * this tracker was not closed, then this is a leak.
+     */
+    @Override
+    @VisibleForTesting
+    public void checkForLeaks()
+    {
+        CleaningTracker ref;
+        while ((ref = (CleaningTracker) refQueue.poll()) != null)
+        {
+            // clear the reference, this is not automatically done by the GC, see
+            // https://docs.oracle.com/javase/7/docs/api/java/lang/ref/PhantomReference.html
+            ref.clear();
+
+            if (!ref.isClosed())
+            { // leak detected
+                ref.onResourceLeaked();
+                ref.close();
+            }
+        }
+    }
+
+    /**
+     * A class for reporting leaks, the default implementation simply logs to file but for tests we
+     * need to be able to mock this.
+     */
+    static class LeakReporter
+    {
+        void reportLeakedResource(LeaksResource resource, String details)
+        {
+            // com.datastax.bdp.test.ng.LeakDetectorInLogs intercepts this log message in DSE unit tests and only
+            // logs the description, that's why we need to use String.format()
+            logger.info(String.format("Debugging details for leaked resource %s:\n%s", resource, details));
+        }
+    }
+
+    /**
+     * Updates {@link  CleaningTracker#closed} atomically.
+     */
+    private static final AtomicIntegerFieldUpdater<LeaksDetectorImpl.CleaningTracker> closeUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(LeaksDetectorImpl.CleaningTracker.class, "closed");
+
+    /**
+     * Updates {@link  ReportingTracker#accessRecordsHead} atomically.
+     */
+    private static final AtomicReferenceFieldUpdater<LeaksDetectorImpl.ReportingTracker, Record> accessRecordHeadUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(LeaksDetectorImpl.ReportingTracker.class, Record.class, "accessRecordsHead");
+
+    private final Record BOTTOM_ACCESS_RECORD = new Record(Hashing.md5().hashString("", CHARSET).asLong());
+
+    /**
+     * An implementation of {@link LeaksTracker} that performs some cleaning when the resource is leaked
+     * if a cleaner is available.
+     */
+    private class CleaningTracker<C> extends PhantomReference<T> implements LeaksTracker<T>
+    {
+        final int trackedHash;
+
+        @Nullable final Cleaner<C> cleaner;
+        @Nullable final C resForCleaning;
+
+        volatile int closed;
+
+        CleaningTracker(T resForTracking,  @Nullable Cleaner<C> cleaner, @Nullable C resForCleaning)
+        {
+            super(resForTracking, refQueue);
+            assert resForTracking != null : "Resource cannot be null";
+
+            // Store the hash of the tracked object to later assert it in the close(...) method.
+            // It's important that we not store a reference to the referent as this would disallow it from
+            // be collected via the PhantomReference.
+            this.trackedHash = System.identityHashCode(resForTracking);
+            this.cleaner = cleaner;
+            this.resForCleaning = resForCleaning;
+            this.closed = 0;
+
+            allTrackedResources.put(this, LeakEntry.INSTANCE);
+        }
+
+        @Override
+        public void record()
+        {
+            // no op
+        }
+
+        @Override
+        public void onResourceLeaked()
+        {
+            String autoCleaningResult;
+            if (cleaner != null)
+            {
+                assert resForCleaning != null : "Expected non null resource for cleaning";
+                try
+                {
+                    cleaner.clean(resForCleaning);
+                    autoCleaningResult = "succeeded";
+                }
+                catch (Throwable t)
+                {
+                    JVMStabilityInspector.inspectThrowable(t);
+                    autoCleaningResult = String.format("failed with exception %s/%s", t.getClass().getName(), t.getMessage());
+                }
+            }
+            else
+            {
+                autoCleaningResult = "not attempted, no cleaner";
+            }
+
+            if (resource.level == LeakLevel.FIRST_LEVEL)
+            {
+                // com.datastax.bdp.test.ng.LeakDetectorInLogs intercepts this log message in DSE unit tests and only
+                // logs the description, that's why we need to use String.format()
+                logger.error(String.format("LEAK: %s was not released before it was garbage-collected. " +
+                                           "Please report this even if auto-cleaning succeeded. Auto cleaning result: %s.",
+                                            resource, autoCleaningResult));
+            }
+            else
+            {
+                // com.datastax.bdp.test.ng.LeakDetectorInLogs intercepts this log message in DSE unit tests and only
+                // logs the description, that's why we need to use String.format()
+                logger.warn(String.format("LEAK: %s was not released before it was garbage-collected. This resource " +
+                                          "is a debugging aid, no negative consequences follow from this leak. " +
+                                          "However, please report this nonetheless even if auto-cleaning succeeded. " +
+                                          "Auto cleaning result: %s.",
+                                          resource, autoCleaningResult));
+            }
+        }
+
+        @Override
+        public boolean close(T trackedObject)
+        {
+            // Ensure that the object that was tracked is the same as the one that was passed to close(...).
+            assert trackedHash == System.identityHashCode(trackedObject);
+
+            // We need to actually do the null check of the trackedObject after we close the leak because otherwise
+            // we may get false-positives. This can happen as the JIT / GC may be able to figure out that we do not
+            // need the trackedObject anymore and so already enqueue it for
+            // collection before we actually get a chance to close the enclosing ResourceLeak.
+            boolean ret = close() && trackedObject != null;
+            if (!ret)
+                logger.error("Close was called too late, there was a false positive LEAK for {}", trackedObject);
+            return ret;
+        }
+
+        private boolean close()
+        {
+            if (closeUpdater.compareAndSet(this, 0, 1))
+            {
+                allTrackedResources.remove(this);
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public boolean isClosed()
+        {
+            return closed == 1;
+        }
+    }
+
+    /**
+     * An implementation of {@link LeaksTracker} that in addition to perform cleaning, if a cleaner is available, it
+     * also reports a creation stack trace and multiple stack traces created each time {@link this#record()} is called.
+     */
+    private final class ReportingTracker<C> extends CleaningTracker<C>
+    {
+        final long creationStackDigest;
+        final String creationThreadName;
+        final String resourceDescription;
+        volatile Record accessRecordsHead;
+
+        ReportingTracker(T resForTracking,  @Nullable Cleaner<C> cleaner, @Nullable C resForCleaning)
+        {
+            super(resForTracking, cleaner, resForCleaning);
+
+            this.creationStackDigest = createStackTrace();
+            this.creationThreadName = Thread.currentThread().getName();
+            this.resourceDescription = resForTracking.toString();
+            this.accessRecordsHead = params.num_access_records > 0 ? BOTTOM_ACCESS_RECORD : null;
+        }
+
+        @Override
+        public void record()
+        {
+            if (accessRecordsHead == null || isClosed())
+                return;
+
+            record0();
+        }
+
+        @Override
+        public void onResourceLeaked()
+        {
+            super.onResourceLeaked();
+            leakReporter.reportLeakedResource(resource, getStacksTraces());
+        }
+
+        /**
+         * Record the current stack trace for a resource instance. Each instance has a queue of records, where a record
+         * contains the digest corresponding to a stack trace.
+         * <p/>
+         * If the queue has fewer than {@link LeaksDetectionParams#num_access_records} items, then the current stack trace is
+         * added as a new record, assuming no race with another thread.
+         * <p/>
+         * In case of a race only one thread will win and get to add a record with the current stack trace.
+         * <p/>
+         * If the queue already has {@link LeaksDetectionParams#num_access_records}, then this method works by exponentially
+         * backing off as more records are present. Each invocation has a 1 / 2^n chance of replacing the head of the
+         * queue with itself.
+         * <p/>
+         * This has a number of convenient properties:
+         *
+         * <ol>
+         * <li>  The last access will always recorded unless there is a race.
+         * <li>  Any access before {@link LeaksDetectionParams#num_access_records} will also always be recorded.
+         * <li>  It is possible to retain more records than the target, based upon the probability distribution.
+         * <li>  It is easy to keep a precise record of the number of elements in the stack, since each element has to know how tall the queue is.
+         * </ol>
+         */
+        private void record0()
+        {
+            Record oldHead = accessRecordHeadUpdater.get(this);
+            Record prevHead = oldHead;
+
+            int numElements = oldHead.pos + 1;
+            if (numElements >= params.num_access_records)
+            {
+                final int backOffFactor = Math.min(numElements - params.num_access_records, 30);
+                if (ThreadLocalRandom.current().nextInt(1 << backOffFactor) != 0)
+                {
+                    prevHead = oldHead.next;
+                }
+            }
+
+            Record newHead = new Record(prevHead, createStackTrace());
+            accessRecordHeadUpdater.compareAndSet(this, oldHead, newHead); // if we fail to update the stack trace due to a race, so be it
+        }
+
+        /**
+         * Create a call stack trace and check if an identical stack trace exists in the cache by relying on an MD5 digest.
+         * If a call stack trace with the same MD5 exists, use it. If not, insert the new one into the cache. Then return
+         * the MD5 digest.
+         * <p/>
+         * Note that we could return a digest whose stack trace gets evicted by the cache, in which case we will
+         * lose the stack trace. We're happy to accept this risk, the solution is to tell operators to make the cache
+         * larger.
+         * <p/>
+         * An error is logged in the extremely unlikely event of an MD5 collision.
+         * <p/>
+         * @return the MD5 digest for the stack trace that was created
+         */
+        private Long createStackTrace()
+        {
+            String stackTrace = getStackTrace(params.max_stack_depth);
+
+            Hasher hasher = Hashing.md5().newHasher();
+            hasher.putString(stackTrace, CHARSET); // hash the string because off-heap BBs get copied into on-heap arrays
+            Long hashCode = hasher.hash().asLong();
+
+            String ret = stacksCache.get(hashCode, key -> stackTrace);
+
+            if (!ret.equals(stackTrace))
+                logger.warn("MD5 collision for stack traces with MD5 {}, stack traces with this MD5 may be inaccurate", getDigestStr(hashCode));
+
+            return hashCode;
+        }
+
+        private String getStackTrace(int maxStackDepth)
+        {
+            StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+            StringBuilder buf = new StringBuilder(2048);
+            int numTraces = 0;
+
+            // skip the first one since that's the call to Thread.currentThread().getStackTrace()
+            for (int i = 1; i < stackTraceElements.length; i++)
+            {
+                StackTraceElement element = stackTraceElements[i];
+
+                if (STACK_TRACE_EXCLUSIONS.contains(element.getClassName()))
+                    continue;
+
+                numTraces++;
+                if (numTraces >= maxStackDepth)
+                    break;
+
+                buf.append('\t').append("at ");
+                buf.append(element.toString());
+                buf.append('\n');
+            }
+
+            return buf.toString();
+        }
+
+        private String getDigestStr(Long digest)
+        {
+            return String.format("%02x", digest);
+        }
+
+        String getStacksTraces()
+        {
+            StringBuilder buf = new StringBuilder(4096);
+
+            if (accessRecordsHead != null)
+            {
+                buf.append("Recent access records:\n");
+
+                Record record = accessRecordsHead;
+                Stack<Record> records = new Stack<>();
+
+                while(record != null && record.pos > 0)
+                {
+                    records.push(record);
+                    record = record.next;
+                }
+
+                while(!records.isEmpty())
+                {
+                    record = records.pop();
+                    buf.append("#").append(record.pos).append(" (").append(getDigestStr(record.digest)).append(") ").append(":\n");
+                    buf.append(getStackTrace(record.digest));
+                }
+            }
+
+            buf.append("< ")
+               .append(resourceDescription)
+               .append(" > \n");
+
+            buf.append("Created by thread ")
+               .append(creationThreadName)
+               .append(" with stack trace (")
+               .append(getDigestStr(creationStackDigest))
+               .append(") ")
+               .append(":\n");
+            buf.append(getStackTrace(creationStackDigest));
+
+            return buf.toString();
+        }
+
+        /**
+         * Get the stack trace for the MD5 digest if available, otherwise return {@link this#STACK_TRACE_NO_LONGER_AVAILABLE}.
+         */
+        private String getStackTrace(long digest)
+        {
+            String stackTrace = stacksCache.getIfPresent(digest);
+            if (stackTrace != null)
+                return stackTrace;
+
+            return STACK_TRACE_NO_LONGER_AVAILABLE;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("Resource id %d, num stacks: %d, closed: %s",
+                                 trackedHash,
+                                 accessRecordsHead == null ? 0: accessRecordsHead.pos + 1,
+                                 isClosed());
+        }
+    }
+
+    /**
+     * A class that carries a stack trace hash code for a resource.
+     */
+    private final static class Record
+    {
+        private final long digest;
+        @Nullable private final Record next;
+        private final int pos;
+
+        public Record(long digest)
+        {
+           this(null, digest);
+        }
+
+        Record(Record next, long digest)
+        {
+            this.digest = digest;
+            this.next = next;
+            this.pos = next == null ? 0 : next.pos + 1;
+        }
+
+        @Override
+        public String toString()
+        {
+           return String.format("%s@pos %d", digest, pos);
+        }
+    }
+
+    private static final class LeakEntry
+    {
+        private static final LeakEntry INSTANCE = new LeakEntry();
+        private static final int HASH = System.identityHashCode(INSTANCE);
+
+        private LeakEntry()
+        {
+        }
+
+        @Override
+        public int hashCode() {
+            return HASH;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj == this;
+        }
+    }
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksResource.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksResource.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * The identifier for a type of resource that can be tracked for leaks by {@link LeaksDetector}.
+ * <p/>
+ * A resource is normally identified by its class and by a name, used to distinguish resources for the same class,
+ * e.g. different buffer pools.
+ */
+class LeaksResource
+{
+    /**
+     * The maximum length of a resource name. This limitation is for the nodetool formatting: we want to align
+     * the names but we also cannot truncate them. Increase this value if required.
+     */
+    final static int MAX_NAME_LENGTH = 32;
+
+    final String name;
+    final Class cls;
+    final LeakLevel level;
+
+    private LeaksResource(String name, Class cls, LeakLevel level)
+    {
+        Preconditions.checkArgument(name.length() <= MAX_NAME_LENGTH, "Name is too long, max characters is %s: %s", MAX_NAME_LENGTH, name);
+        this.name = name;
+        this.cls = cls;
+        this.level = level;
+    }
+
+    public static LeaksResource create(String name, Class cls, LeakLevel level)
+    {
+        return new LeaksResource(name, cls, level);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, cls);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+
+        if (!(obj instanceof LeaksResource))
+            return false;
+
+        LeaksResource other = (LeaksResource) obj;
+        return Objects.equals(name, other.name) && Objects.equals(cls, other.cls);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s/%s", name, cls.getSimpleName());
+    }
+}

--- a/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksTracker.java
+++ b/src/java/com/datastax/bdp/db/utils/leaks/detection/LeaksTracker.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package com.datastax.bdp.db.utils.leaks.detection;
+
+/**
+ * A {@link LeaksTracker} is returned to the caller for each resource that is tracked by calling {@link LeaksDetector#trackForDebug(Object)}.
+ * <p/>
+ * Clients can optionally call {@link this#record()} to add information on how the resource is accessed in order
+ * to help with debugging.
+ * <p/>
+ * Clients *must* call {@link this#close(Object)} before the resource is garbage collected. To ensure the resource
+ * is not collected first, therefore causing false positives, it must be passed-in as an argument.
+ */
+public interface LeaksTracker<T>  {
+    /**
+     * Records the caller's current stack trace so that we can tell where the leaked
+     * resource was recently accessed.
+     */
+    void record();
+
+    /**
+     * Method called when the resource has been reported as leaked by the garbage collector.
+     */
+    void onResourceLeaked();
+
+    /**
+     * Close the leak so that we do not warn about leaked resources.
+     * After this method is called a leak associated with this ResourceLeakTracker should not be reported.
+     *
+     * @param trackedObject - the object being tracked. We need to receive this again to make sure the JIT / GC
+     *                        doesn't decide that the resource is already unreachable, e.g. if close is called
+     *                        asynchronously, therefore causing false positives, see
+     *                        https://github.com/netty/netty/pull/6087
+     *
+     * @return {@code true} if called first time, {@code false} if called already
+     */
+    boolean close(T trackedObject);
+
+    /**
+     * Returns true if the resource tracker was already closed.
+     *
+     * @return true if {@link this#close(Object)} was called
+     */
+    boolean isClosed();
+}

--- a/src/java/org/apache/cassandra/cache/ChunkCacheImpl.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCacheImpl.java
@@ -1,0 +1,934 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cache;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.bdp.db.utils.leaks.detection.LeakLevel;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksDetector;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksDetectorFactory;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksTracker;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.util.ChannelProxy;
+import org.apache.cassandra.io.util.ChunkReader;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.Rebufferer;
+import org.apache.cassandra.io.util.RebuffererFactory;
+import org.apache.cassandra.metrics.ChunkCacheMetrics;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.PageAware;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+import org.apache.cassandra.utils.UnsafeCopy;
+import org.apache.cassandra.utils.concurrent.ParkedExecutor;
+import org.apache.cassandra.utils.concurrent.ShutdownableExecutor;
+import org.apache.cassandra.utils.memory.BufferPool;
+
+public class ChunkCacheImpl
+implements AsyncCacheLoader<ChunkCacheImpl.Key, ChunkCacheImpl.Chunk>, RemovalListener<ChunkCacheImpl.Key, ChunkCacheImpl.Chunk>, CacheSize
+{
+    private static final Class PERFORM_CLEANUP_TASK_CLASS;
+
+    static
+    {
+        try
+        {
+            PERFORM_CLEANUP_TASK_CLASS = Class.forName("com.github.benmanes.caffeine.cache.BoundedLocalCache$PerformCleanupTask");
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final int CLEANER_THREADS = Integer.getInteger("dse.chunk.cache.cleaner.threads",1);
+    private static final Logger logger = LoggerFactory.getLogger(ChunkCacheImpl.class);
+
+    private final AsyncLoadingCache<Key, Chunk> cache;
+    private final ChunkCacheMetrics metrics;
+    private final LeaksDetector<Chunk> leakDetector;
+    private final long cacheSize;
+    private final BufferPool bufferPool;
+    private final ShutdownableExecutor cleanupExecutor;
+    private final LeaksDetector.Cleaner<long[]> leaksCleaner;
+
+    @VisibleForTesting
+    public static class Key
+    {
+        final ChunkReader file;
+        final long fileId;
+        final long position;
+        final int hashCode;
+
+        Key(ChunkReader file, long fileId, long position)
+        {
+            super();
+            this.file = file;
+            this.fileId = fileId;
+            this.position = position;
+            this.hashCode = computeHashCode();
+        }
+
+        private int computeHashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Long.hashCode(fileId);
+            result = prime * result + Long.hashCode(position);
+            return result;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (obj == null || !(obj instanceof Key))
+                return false;
+
+            Key other = (Key) obj;
+            return (fileId == other.fileId) && (position == other.position);
+        }
+
+        public String path()
+        {
+            return file.channel().filePath();
+        }
+
+        public String toString()
+        {
+            return path() + '@' + position;
+        }
+    }
+
+    /**
+     * An abstract chunk contains the common implementation for the single and multi-regions chunks, normally
+     * this is related to ref counting and calling the read methods in the chunk reader. The chunk implementations
+     * will then take care of implementing the read target so that they can accommodate the data that was read into
+     * either a single memory region or into multiple memory regions.
+     */
+    abstract class Chunk implements ChunkReader.ReadTarget<Chunk>
+    {
+        /** The offset in the file where the chunk is read */
+        final long offset;
+
+        /** The number of bytes read from disk, this could be less than the memory space allocated */
+        int bytesRead;
+
+        @VisibleForTesting
+        public volatile int references;
+
+        @Nullable
+        protected volatile LeaksTracker<Chunk> leak;
+
+        Chunk(long offset)
+        {
+            this.offset = offset;
+            this.bytesRead = 0; // Updated by ChunkReader.ReadTarget.setReadResult
+            this.references = 1; // Start referenced
+        }
+
+        /**
+         * Return the correct buffer depending on the position requested by the client, also taking a reference to this
+         * chunk.
+         *
+         * @param position the position requested by the client, this has not been aligned to neither the chunk nor the page
+         * @return the buffer covering this position, or null if no reference can be taken
+         */
+        @Nullable
+        Rebufferer.BufferHolder getReferencedBuffer(long position)
+        {
+            int refCount;
+            do
+            {
+                refCount = references;
+
+                if (refCount == 0)
+                    return null; // Buffer was released before we managed to reference it.
+
+            } while (!referencesUpdater.compareAndSet(this, refCount, refCount + 1));
+
+            if (leak != null)
+                leak.record();
+
+            return getBuffer(position);
+        }
+
+        /**
+         * Release the chunk when the cache or a reader no longer needs it.
+         */
+        public void release()
+        {
+            if (referencesUpdater.decrementAndGet(this) == 0)
+            {
+                if (leak != null)
+                    leak.close(this);
+
+                releaseBuffers();
+            }
+        }
+
+        /**
+         * Called when the chunk is evicted from the cache. It needs to release it but also to install
+         * auto-cleaning if not already done in the constructor.
+         * <p/>
+         * If the refCount is > 1, then we can create a leak detector that will run the cleaner on GC
+         * knowing that until we've released the reference count for the cache, the code in the {@link this#release()}
+         * method that runs when the ref count reaches zero cannot execute. So it's safe to install a new leak
+         * detector before calling {@link this#release()}.
+         */
+        void evicted()
+        {
+            int refCount = references;
+
+            // no leak detection and some one else has a reference, install a leak detector that will call the cleaner
+            // if the chunk is not released, if this other thread races us and calls release in the meantime, we know
+            // that the leak will be closed by release() when the ref count goes to zero by our call to release() just below
+            if (this.leak == null && refCount > 1)
+                this.leak = trackForCleaning();
+
+            // It's possible that a thread that has been preempted after taking a chunk, may take a reference before
+            // we release ours, e.g. in rebuffer(long position, ReaderConstraint rc). In this case the chunk won't be auto-cleaned.
+            // We could close this race by taking a reference again and retrying if after a release the ref count is > 0.
+            // However because the risk of a race is low, and auto-cleaning is only a last resort measure in case of bugs that
+            // we should aim at fixing, I prefer not to add code that executes only in extremely rare cases and it's hard to properly
+            // test. Each time a chunk is auto-cleaned an error will be logged, and this should alert us on fixing any bugs causing
+            // a chunk not to be cleaned manually. If the vast majority of leaked chunks are auto-cleaned, clients should not suffer
+            // from memory problems because of this race and so I prefer to avoid the risk.
+            release();
+        }
+
+        public Throwable onError(Throwable error, ByteBuffer buffer)
+        {
+            release();
+            return error;
+        }
+
+        public long offset()
+        {
+            return offset;
+        }
+
+        /**
+         * Return the correct buffer depending on the position requested by the client. The returned buffer cannot be
+         * null, but may be empty and must contain the given position
+         * (i.e. buf.offset <= position <= buf.offset + buf.buffer.limit where the latter can only be == if at the end
+         * of the file and buffer is empty).
+         *
+         * @param position the position requested by the client, this has not been aligned to neither the chunk nor the page
+         * @return the buffer covering this position, or null if no reference can be taken
+         */
+        abstract Rebufferer.BufferHolder getBuffer(long position);
+
+        /**
+         * @return the space taken by this chunk
+         */
+        abstract int capacity();
+
+        /**
+         * Release the addresses when this chunk is no longer used. Called when all references are released.
+         */
+        abstract void releaseBuffers();
+
+        /**
+         * @return a tracker that will automatically clean the chunk's buffer(s).
+         */
+        abstract LeaksTracker<Chunk> trackForCleaning();
+    }
+
+    private static final AtomicIntegerFieldUpdater<Chunk> referencesUpdater = AtomicIntegerFieldUpdater.newUpdater(Chunk.class, "references");
+
+    /**
+     * A chunk is a group of memory regions of size {@link PageAware#PAGE_SIZE} that will be allocated and released
+     * at the same time. The {@link ChunkReader} will read into a temporary buffer and then pass the results to the chunk
+     * via the implementation of {@link ChunkReader.ReadTarget} and specifically {@link ChunkReader.ReadTarget#setReadResult(ByteBuffer)}.
+     * The memory regions are taken from the buffer pool.
+     */
+    public class MultiRegionChunk extends Chunk
+    {
+        /** A list of memory addresses, each page has capacity of PageAware.PAGE_SIZE */
+        final long[] pages;
+
+        MultiRegionChunk(Key key, long[] pages)
+        {
+            super(key.position);
+            this.pages = pages;
+            this.leak = leakDetector.trackForDebug(this, leaksCleaner, pages);
+        }
+
+        @Override
+        public ByteBuffer constructTarget(int chunkSize)
+        {
+            return bufferPool.allocate(chunkSize);
+        }
+
+        @Override
+        public Throwable onError(Throwable error, ByteBuffer buffer)
+        {
+            if (buffer != null)
+                bufferPool.release(buffer);
+            return super.onError(error, buffer);
+        }
+
+        //@Override
+        public Chunk setReadResult(ByteBuffer result)
+        {
+            // copy the bytes read from the scratch buffer to the individual memory regions
+
+            int totRead = 0;
+            for (long page : pages)
+            {
+                int len = Math.min(PageAware.PAGE_SIZE, result.limit() - totRead);
+                if (len == 0)
+                    break; // nothing left to copy into remaining pages
+
+                UnsafeCopy.copyBufferToMemory(result, totRead, page, len);
+                totRead += len;
+            }
+
+            this.bytesRead = totRead;
+            bufferPool.release(result);
+            return this;
+        }
+
+        @Override
+        void releaseBuffers()
+        {
+            bufferPool.release(PageAware.PAGE_SIZE, pages);
+        }
+
+        LeaksTracker<Chunk> trackForCleaning()
+        {
+            return leakDetector.trackForCleaning(this, leaksCleaner, pages);
+        }
+
+        @Nullable
+        Buffer getBuffer(long position)
+        {
+            int index = PageAware.pageNum(position - offset);
+            if (index < 0 || index >= pages.length)
+                throw new IllegalArgumentException(String.format("Invalid position: %s, or index: %s (pages count: %s, position: %s, offset: %s", position - offset, index, pages.length, position, offset));
+
+            long pageAlignedPosition = PageAware.pageStart(position);
+            int bufferSize = Math.min(PageAware.PAGE_SIZE, Math.toIntExact(bytesRead - (index * PageAware.PAGE_SIZE)));
+            assert bufferSize > 0 && bufferSize <= PageAware.PAGE_SIZE : "Wrong buffer size: " + bufferSize + " at position " + position;
+
+            return new Buffer(pageAlignedPosition, pages[index], bufferSize);
+        }
+
+        int capacity()
+        {
+            return pages.length * PageAware.PAGE_SIZE;
+        }
+
+        /**
+         * A buffer holder that wraps an address of memory of a specific size. It creates a byte buffer on the fly
+         * when requested. The capacity of the memory region is assumed to be {@link PageAware#PAGE_SIZE}.
+         */
+        @VisibleForTesting
+        public class Buffer implements Rebufferer.BufferHolder
+        {
+            private final long offset;
+            private final long address;
+            private final int bufferSize;
+
+            Buffer(long offset, long address, int bufferSize)
+            {
+                this.offset = offset;
+                this.address = address;
+                this.bufferSize = bufferSize;
+            }
+
+            @Override
+            public ByteBuffer buffer()
+            {
+                return unsafeBuffer(); // no need to duplicate since unsafeBuffer() already creates a new hollow instance
+            }
+
+            @Override
+            public FloatBuffer floatBuffer()
+            {
+                return buffer().asFloatBuffer();
+            }
+
+            @Override
+            public IntBuffer intBuffer()
+            {
+                return buffer().asIntBuffer();
+            }
+
+            @Override
+            public LongBuffer longBuffer()
+            {
+                return buffer().asLongBuffer();
+            }
+
+            //@Override
+            public ByteBuffer unsafeBuffer()
+            {
+                assert references > 0 : "Already unreferenced";
+                return UnsafeByteBufferAccess.allocateByteBuffer(address, bufferSize, PageAware.PAGE_SIZE, ByteOrder.BIG_ENDIAN, null);
+            }
+
+            @Override
+            public long offset()
+            {
+                return offset;
+            }
+
+            @Override
+            public void release()
+            {
+                MultiRegionChunk.this.release();
+            }
+
+            /*
+            @Override
+            public ByteBuffer buffer(ByteBuffer buffer)
+            {
+                if (buffer == null || !buffer.isDirect())
+                    return buffer();
+
+                UnsafeByteBufferAccess.initByteBufferInstance(buffer, address, bufferSize, PageAware.PAGE_SIZE);
+                return buffer;
+            }*/
+        }
+    }
+
+    /**
+     * A chunk with a single memory region. This can be used for reading chunks of up to PageAware.PAGE_SIZE but note
+     * that the memory allocated will be always at least PageAware.PAGE_SIZE. It can also be used for larger chunks if
+     * the individual memory regions are contiguous, see {@link this#newChunk(Key)}. The memory region is taken from the pool.
+     * <p/>
+     * This class is a chunk but it behaves also as a {@link Rebufferer.BufferHolder} to save an allocation when {@link this#getBuffer(long)}
+     * is invoked.
+     */
+    @VisibleForTesting
+    public class SingleRegionChunk extends Chunk implements Rebufferer.BufferHolder
+    {
+        /** The memory address of the single page */
+        private final long address;
+
+        /** The number of pages behind the single memory region */
+        private final int numPages;
+
+        SingleRegionChunk(Key key, long pages[])
+        {
+            super(key.position);
+            // note we don't check again that the pages are contiguous because it is expensive
+            this.address = pages[0];
+            this.numPages = pages.length;
+            this.leak = leakDetector.trackForDebug(this, leaksCleaner, pages);
+        }
+
+        //@Override
+        public ByteBuffer constructTarget(int chunkSize)
+        {
+            // return the address of the contiguous memory region so that no temporary buffer will be created
+            assert chunkSize <= numPages * PageAware.PAGE_SIZE : "Received chunk too large: " + chunkSize + " for " + numPages + " pages.";
+            return UnsafeByteBufferAccess.allocateByteBuffer(address, chunkSize, ByteOrder.BIG_ENDIAN);
+        }
+
+        //@Override
+        public Chunk setReadResult(ByteBuffer result)
+        {
+            // the read result buffer should be a wrapper around the address we returned in targetAddress(), so no need to copy anything
+            assert UnsafeByteBufferAccess.getAddress(result) == address : "Expected result with same address";
+            this.bytesRead = result.limit();
+            return this;
+        }
+
+        @Override
+        public ByteBuffer buffer()
+        {
+            return unsafeBuffer(); // no need to duplicate since unsafeBuffer() already creates a new hollow instance
+        }
+
+        //@Override
+        public ByteBuffer unsafeBuffer()
+        {
+            assert references > 0 : "Already unreferenced";
+            return UnsafeByteBufferAccess.allocateByteBuffer(address, bytesRead, capacity(), ByteOrder.BIG_ENDIAN, null);
+        }
+
+        @Override
+        void releaseBuffers()
+        {
+            bufferPool.release(PageAware.PAGE_SIZE, UnsafeByteBufferAccess.splitContiguousRegion(address, PageAware.PAGE_SIZE, capacity()));
+        }
+
+        LeaksTracker<Chunk> trackForCleaning()
+        {
+            return leakDetector.trackForCleaning(this, leaksCleaner, UnsafeByteBufferAccess.splitContiguousRegion(address, PageAware.PAGE_SIZE, capacity()));
+        }
+
+        @Nullable
+        Rebufferer.BufferHolder getBuffer(long position)
+        {
+            return this;
+        }
+
+        int capacity()
+        {
+            return numPages * PageAware.PAGE_SIZE;
+        }
+    }
+
+    /**
+     * A single direct buffer chunk is a chunk with a single buffer that is allocated directly, without
+     * using the buffer pool. This is normally preferable for larger buffers and is used for chunks
+     * larger than or equal to {@link BufferPool#CACHED_FILE_READS_MBEAN_NAME}.
+     */
+    @VisibleForTesting
+    public class SingleDirectBuffer extends Chunk implements Rebufferer.BufferHolder
+    {
+        private final ByteBuffer buffer;
+
+        SingleDirectBuffer(Key key, int chunkSize)
+        {
+            super(key.position);
+            this.buffer = BufferType.OFF_HEAP_ALIGNED.allocate(chunkSize);
+            this.leak = leakDetector.trackForDebug(this, FileUtils::clean, buffer);
+        }
+
+        //@Override
+        public ByteBuffer constructTarget(int chunkSize)
+        {
+            // return the address of the contiguous memory region so that no temporary buffer will be created
+            assert chunkSize <= buffer.capacity(): "Received chunk too large: " + chunkSize + " for direct buffer of " + buffer.capacity() + " bytes.";
+            return buffer;
+        }
+
+        //@Override
+        public Chunk setReadResult(ByteBuffer result)
+        {
+            // the read result buffer should be the same buffer returned by constructTarget()
+            assert result == this.buffer : "Expected result to be the same buffer";
+            this.bytesRead = result.limit();
+            return this;
+        }
+
+        @Override
+        public ByteBuffer buffer()
+        {
+            return buffer.duplicate();
+        }
+
+        @Override
+        public FloatBuffer floatBuffer()
+        {
+            return buffer.asFloatBuffer();
+        }
+
+        @Override
+        public IntBuffer intBuffer()
+        {
+            return buffer.asIntBuffer();
+        }
+
+        @Override
+        public LongBuffer longBuffer()
+        {
+            return buffer.asLongBuffer();
+        }
+
+        //@Override
+        public ByteBuffer unsafeBuffer()
+        {
+            assert references > 0 : "Already unreferenced";
+            return buffer;
+        }
+
+        @Override
+        void releaseBuffers()
+        {
+            FileUtils.clean(buffer);
+        }
+
+        LeaksTracker<Chunk> trackForCleaning()
+        {
+            return leakDetector.trackForCleaning(this, FileUtils::clean, buffer);
+        }
+
+        //@Override
+        public ByteBuffer buffer(ByteBuffer buffer)
+        {
+            if (buffer == null || !buffer.isDirect())
+                return buffer();
+
+            UnsafeByteBufferAccess.initByteBufferInstance(buffer,
+                                                          UnsafeByteBufferAccess.getAddress(this.buffer),
+                                                          bytesRead,
+                                                          ByteOrder.BIG_ENDIAN);
+            return buffer;
+        }
+
+        @Nullable
+        Rebufferer.BufferHolder getBuffer(long position)
+        {
+            return this;
+        }
+
+        int capacity()
+        {
+            return buffer.capacity();
+        }
+    }
+
+    Chunk newChunk(Key key)
+    {
+        int chunkLength = key.file.chunkSize();
+
+        if (chunkLength >= BufferPool.CHUNK_DIRECT_ALLOC_SIZE_BYTES || BufferPool.DISABLED)
+            return new SingleDirectBuffer(key, chunkLength);
+
+        // Allocate a sufficient number of 4k pages to cover the chunk length, if the chunk length is zero
+        // then allocate at least one page (this was the existing behavior and at least in unit tests it can happen)
+        long[] pages = bufferPool.allocate(PageAware.PAGE_SIZE, Math.max(1, PageAware.numPages(chunkLength)));
+
+        if (pages.length == 1 || UnsafeByteBufferAccess.regionsAreContiguous(pages, PageAware.PAGE_SIZE, chunkLength))
+            return new SingleRegionChunk(key, pages);
+        else
+            return new MultiRegionChunk(key, pages);
+    }
+
+
+    public ChunkCacheImpl(ChunkCacheMetrics metrics, long cacheSize, BufferPool bufferPool)
+    {
+        this.cacheSize = cacheSize;
+        this.metrics = metrics;
+        cleanupExecutor = ParkedExecutor.createParkedExecutor("ChunkCacheCleanup", CLEANER_THREADS);
+
+        cache = Caffeine.newBuilder()
+                        .maximumWeight(cacheSize)
+                        .executor(r -> {
+                            if (r.getClass() == PERFORM_CLEANUP_TASK_CLASS)
+                                cleanupExecutor.execute(r);
+                            else
+                                r.run();
+                        })
+                        .weigher((key, chunk) -> ((Chunk) chunk).capacity())
+                        .recordStats(() -> metrics)
+                        .removalListener(this)
+                        .buildAsync(this);
+
+        this.bufferPool = bufferPool;
+        this.leakDetector = LeaksDetectorFactory.create("ChunkCache", Chunk.class, LeakLevel.FIRST_LEVEL);
+        this.leaksCleaner = addresses -> bufferPool.release(PageAware.PAGE_SIZE, addresses);
+
+        logger.info("Created chunk cache of size {}, allocating page-aligned buffers from cached reads pool except for sizes >= {}",
+                    FBUtilities.prettyPrintMemory(cacheSize),
+                    FBUtilities.prettyPrintMemory(BufferPool.CHUNK_DIRECT_ALLOC_SIZE_BYTES));
+
+        //if (BufferPool.CHUNK_DIRECT_ALLOC_SIZE_BYTES <= NativeMemoryMetrics.smallBufferThreshold)
+        //    logger.warn("Using direct aligned allocations for chunks as small as {} is not recommended",
+        //                FBUtilities.prettyPrintMemory(BufferPool.CHUNK_DIRECT_ALLOC_SIZE_BYTES));
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public CompletableFuture<Chunk> asyncLoad(Key key, Executor executor)
+    {
+        Chunk chunk = newChunk(key);
+        return key.file.readChunk(chunk.offset(), chunk.capacity(), chunk);
+    }
+
+    public Chunk syncLoad(Key key)
+    {
+        Chunk chunk = newChunk(key);
+        return key.file.readChunkBlocking(chunk.offset(), chunk.capacity(), chunk);
+    }
+
+    //@Override
+    public void onRemoval(Key key, Chunk chunk, RemovalCause cause)
+    {
+        chunk.evicted();
+    }
+
+    public void reset()
+    {
+        cache.synchronous().invalidateAll();
+        metrics.reset();
+    }
+
+    /**
+     * Manually ask the leak detector to run its checks so that any chunks that might have been leaked
+     * can be automatically cleaned.
+     *
+     * Normally these checks are run automatically by the leak detector. This method is here for tests that
+     * need to force a check at a specific time.
+     */
+    @VisibleForTesting
+    public void checkForLeakedChunks()
+    {
+        leakDetector.checkForLeaks();
+    }
+
+    public void close()
+    {
+        cache.synchronous().invalidateAll();
+        try
+        {
+            cleanupExecutor.shutdown();
+        }
+        catch (InterruptedException e)
+        {
+            logger.error("Interrupted during shutdown: ", e);
+        }
+    }
+
+    public RebuffererFactory wrap(ChunkReader file)
+    {
+        return new CachingRebufferer(file);
+    }
+
+    // TODO: Invalidate caches for obsoleted/MOVED_START tables?
+
+    /**
+     * Rebufferer providing cached chunks where data is obtained from the specified ChunkReader.
+     * <p>
+     * Thread-safe. One instance per SegmentedFile, created by FileHandle.Builder#maybeCached
+     * if the cache is enabled.
+     */
+    class CachingRebufferer implements Rebufferer, RebuffererFactory
+    {
+        private final ChunkReader source;
+        final long chunkAlignmentMask;
+        final long fileId;
+
+        public CachingRebufferer(ChunkReader file)
+        {
+            source = file;
+            int chunkSize = file.chunkSize();
+            assert Integer.bitCount(chunkSize) == 1 : String.format("%d must be a power of two", chunkSize);
+            chunkAlignmentMask = -chunkSize;
+            fileId = ChunkCache.fileIdFor(file);
+        }
+
+        @Override
+        public BufferHolder rebuffer(long position)
+        {
+            try
+            {
+                long chunkAlignedPos = position & chunkAlignmentMask;
+                BufferHolder buf;
+                Key chunkKey = new Key(source, fileId, chunkAlignedPos);
+
+                Chunk chunk;
+
+                int spin = 0;
+                //There is a small window when a released buffer/invalidated chunk
+                //is still in the cache. In this case it will return null
+                //so we spin loop while waiting for the cache to re-populate
+                while(true)
+                {
+                    // Using cache.get(k, compute) results in lots of allocation, rather risk the unlikely race...
+                    CompletableFuture<Chunk> cachedValue = cache.getIfPresent(chunkKey);
+                    if (cachedValue == null)
+                    {
+                        // this blocking read might compete with an another read, but the race is benign (under the assumption that caching is valid)
+                        CompletableFuture<Chunk> entry = new CompletableFuture<>();
+                        // Put the future in the cache first so the window of racing (and loading the same chunk twice) is small
+                        cache.put(chunkKey, entry);
+
+                        try
+                        {
+                            chunk = syncLoad(chunkKey);
+                        }
+                        catch (Throwable t)
+                        {
+                            // also signal other waiting readers
+                            entry.completeExceptionally(t);
+                            throw t;
+                        }
+                        entry.complete(chunk);
+                    }
+                    else
+                    {
+                        chunk = cachedValue.join();
+                    }
+
+                    buf = chunk.getReferencedBuffer(position);
+                    if (buf != null)
+                        return buf;
+
+                    if (++spin == 1024)
+                        logger.error("Spinning for {}", chunkKey);
+                }
+            }
+            catch (Throwable t)
+            {
+                Throwables.propagateIfInstanceOf(t.getCause(), CorruptSSTableException.class);
+                throw Throwables.propagate(t);
+            }
+        }
+
+
+        // This convoluted and racy loading is done in order to avoid nested read problems (see DB-3050 and JDK-8062841).
+        // These problems can actually happen in reality due to ReplicatedKeyProvider issuing reads during uncompression.
+        private CompletableFuture<Chunk> racyGetOrLoad(Key chunkKey)
+        {
+            CompletableFuture<Chunk> chunkFut = cache.getIfPresent(chunkKey);
+            if (chunkFut == null || chunkFut.isCompletedExceptionally())
+            {
+                final CompletableFuture<Chunk> finalChunkFut = new CompletableFuture<>();
+                cache.put(chunkKey, finalChunkFut);
+                try
+                {
+                    asyncLoad(chunkKey, null).handle((res, err) ->
+                                                     {
+                                                         if (err != null)
+                                                             // Ideally the now stale, exceptionally completed future should be
+                                                             // purged from the chunk cache immediately. As there's no nice way to
+                                                             // do that though (no remove(chunkKey) method, put(chunkKey, null)
+                                                             // throwing), it will have to be replaced on the next request for that
+                                                             // chunk.
+                                                             finalChunkFut.completeExceptionally(err);
+                                                         else if (res != null)
+                                                             finalChunkFut.complete(res);
+                                                         return null;
+                                                     });
+                }
+                catch (Throwable t)
+                {
+                    finalChunkFut.completeExceptionally(t);
+                    throw t;
+                }
+                chunkFut = finalChunkFut;
+            }
+            // This is guaranteed not to be null, and to be completed with the result of an async read of the chunk referenced
+            // by the key, but it's not guaranteed to be present (as in exactly the same future) in the chunk cache, or that
+            // the chunk with which it will be resolved will still have a "referencable" buffer.
+            return chunkFut;
+        }
+
+        //@Override
+        public int rebufferSize()
+        {
+            return Math.min(PageAware.PAGE_SIZE, source.chunkSize());
+        }
+
+        @Override
+        public void invalidateIfCached(long position)
+        {
+            long pageAlignedPos = position & chunkAlignmentMask;
+            cache.synchronous().invalidate(new Key(source, fileId, pageAlignedPos));
+        }
+
+        @Override
+        @SuppressWarnings("resource") // channel closed by the PrefetchingRebufferer
+        public Rebufferer instantiateRebufferer()
+        {
+
+            // Returning the cache content only if the file id matches
+            if (fileId == ChunkCache.fileIdFor(source))
+                return this;
+            return new CachingRebufferer(source);
+        }
+
+        @Override
+        public void close()
+        {
+            source.close();
+        }
+
+        @Override
+        public void closeReader()
+        {
+            // Instance is shared among readers. Nothing to release.
+        }
+
+        @Override
+        public ChannelProxy channel()
+        {
+            return source.channel();
+        }
+
+        @Override
+        public long fileLength()
+        {
+            return source.fileLength();
+        }
+
+        @Override
+        public double getCrcCheckChance()
+        {
+            return source.getCrcCheckChance();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CachingRebufferer:" + source;
+        }
+    }
+
+    @Override
+    public long capacity()
+    {
+        return cacheSize;
+    }
+
+    @Override
+    public void setCapacity(long capacity)
+    {
+        throw new UnsupportedOperationException("Chunk cache size cannot be changed.");
+    }
+
+    @Override
+    public int size()
+    {
+        return cache.synchronous().asMap().size();
+    }
+
+    @Override
+    public long weightedSize()
+    {
+        return cache.synchronous().policy().eviction()
+                    .map(policy -> policy.weightedSize().orElseGet(cache.synchronous()::estimatedSize))
+                    .orElseGet(cache.synchronous()::estimatedSize);
+    }
+
+}

--- a/src/java/org/apache/cassandra/io/util/ChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/ChunkReader.java
@@ -19,8 +19,12 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.base.Throwables;
 
 import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
 
 /**
  * RandomFileReader component that reads data from a file into a provided buffer and may have requirements over the
@@ -38,6 +42,21 @@ public interface ChunkReader extends RebuffererFactory
      */
     void readChunk(long position, ByteBuffer buffer);
 
+    default CompletableFuture<ByteBuffer> readChunkAsync(long position, ByteBuffer buffer) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                readChunk(position, buffer);
+                return buffer;
+            } catch (Throwable t) {
+                throw Throwables.propagate(t);
+            }
+        });
+    }
+
+    default void readChunkBlocking(long position, ByteBuffer buffer) {
+        readChunk(position, buffer);
+    }
+
     /**
      * Buffer size required for this rebufferer. Must be power of 2 if alignment is required.
      */
@@ -48,4 +67,100 @@ public interface ChunkReader extends RebuffererFactory
      * This is not guaranteed to be fulfilled.
      */
     BufferType preferredBufferType();
+
+    /**
+     * Read a chunk asynchronously using a {@link ReadTarget}. This method is a wrapper of {@link this#readChunk(long, ByteBuffer)},
+     * it merely asks the {@link ReadTarget} how the buffer should be provided.
+     *
+     * @param position the start position of the chunk
+     * @param chunkSize the amount of data to read from the file
+     * @param target the read target will receive the data read into the temporary buffer
+     *
+     * @return a future that will complete when the buffers in the chunk have been read
+     */
+    default <R> CompletableFuture<R> readChunk(long position, int chunkSize, ReadTarget<R> target)
+    {
+        ByteBuffer bufferToRelease = null;
+        try
+        {
+            ByteBuffer buffer = target.constructTarget(chunkSize);
+            bufferToRelease = buffer;
+            assert !buffer.isDirect() || (UnsafeByteBufferAccess.getAddress(buffer) & (512 - 1)) == 0 : "Buffer is not properly aligned!";
+
+            return readChunkAsync(position, buffer)
+                   .handle((result, err) -> {
+                       if (err != null)
+                           throw Throwables.propagate(target.onError(err, buffer));
+
+                       return target.setReadResult(result);
+                   });
+        }
+        catch (Throwable t)
+        {
+            throw Throwables.propagate(target.onError(t, bufferToRelease));
+        }
+    }
+
+    /**
+     * Read a chunk blocking using a {@link ReadTarget}. This method is a wrapper of {@link this#readChunkBlocking(long, ByteBuffer)},
+     * it merely asks the {@link ReadTarget} how the buffer should be provided.
+     *
+     * @param position the start position of the chunk
+     * @param chunkSize the amount of data to read from the file
+     * @param target the read target will receive the data read into the temporary buffer
+     *
+     * @return a future that will complete when the buffers in the chunk have been read.
+     */
+    default <R> R readChunkBlocking(long position, int chunkSize, ReadTarget<R> target)
+    {
+        ByteBuffer buffer = null;
+        try
+        {
+            buffer = target.constructTarget(chunkSize);
+            assert !buffer.isDirect() || (UnsafeByteBufferAccess.getAddress(buffer) & (512 - 1)) == 0 : "Buffer from pool is not properly aligned!";
+
+            readChunkBlocking(position, buffer);
+            return target.setReadResult(buffer);
+        }
+        catch (Throwable t)
+        {
+            throw Throwables.propagate(target.onError(t, buffer));
+        }
+    }
+
+    /**
+     * A read target provides a byte buffer for the read and receives the data read into the buffer or an error
+     * notification.
+     */
+    interface ReadTarget<R>
+    {
+        /**
+         * Return a buffer that is used as the target for the read.
+         *
+         * @param chunkSize the size of the memory to read
+         *
+         * @return a buffer large enough to accommodate chunkSize bytes
+         */
+        ByteBuffer constructTarget(int chunkSize);
+
+        /**
+         * Called when the read completes to do any necessary movement of data and release of temporary buffers.
+         *
+         * This method is not permitted to throw (since its job is to release buffers, we can't safely call onError
+         * if it does).
+         *
+         * @param result a byte buffer obtained from {@link #constructTarget} filled with the bytes that have been read.
+         */
+        R setReadResult(ByteBuffer result);
+
+        /**
+         * To be called if the loading encounters an error. Clean up any buffers allocated by
+         * {@link #constructTarget}.
+         *
+         * @param error The exception encountered.
+         * @param buffer The buffer that was supplied by {@link #constructTarget}.
+         * @return the error to pass on, must not be null.
+         */
+        Throwable onError(Throwable error, ByteBuffer buffer);
+    }
 }

--- a/src/java/org/apache/cassandra/metrics/CodahaleBufferPoolMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CodahaleBufferPoolMetrics.java
@@ -53,11 +53,11 @@ class CodahaleBufferPoolMetrics implements BufferPoolMetrics
 
         misses = Metrics.meter(factory.createMetricName("Misses"));
 
-        overflowSize = Metrics.register(factory.createMetricName("OverflowSize"), bufferPool::overflowMemoryInBytes);
+        overflowSize = Metrics.register(factory.createMetricName("OverflowSize"), bufferPool::overflowMemoryBytes);
 
-        usedSize = Metrics.register(factory.createMetricName("UsedSize"), bufferPool::usedSizeInBytes);
+        usedSize = Metrics.register(factory.createMetricName("UsedSize"), bufferPool::usedMemoryBytes);
 
-        size = Metrics.register(factory.createMetricName("Size"), bufferPool::sizeInBytes);
+        size = Metrics.register(factory.createMetricName("Size"), bufferPool::maxPoolSize);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/MicrometerBufferPoolMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerBufferPoolMetrics.java
@@ -58,9 +58,9 @@ public class MicrometerBufferPoolMetrics extends MicrometerMetrics implements Bu
     {
         super.register(newRegistry, newTags.and(NAME_TAG, scope));
 
-        gauge(TOTAL_SIZE_BYTES, bufferPool, BufferPool::sizeInBytes);
-        gauge(USED_SIZE_BYTES, bufferPool, BufferPool::usedSizeInBytes);
-        gauge(OVERFLOW_SIZE_BYTES, bufferPool, BufferPool::overflowMemoryInBytes);
+        gauge(TOTAL_SIZE_BYTES, bufferPool, BufferPool::allocatedMemoryBytes);
+        gauge(USED_SIZE_BYTES, bufferPool, BufferPool::usedMemoryBytes);
+        gauge(OVERFLOW_SIZE_BYTES, bufferPool, BufferPool::overflowMemoryBytes);
         gauge(OVERFLOW_ALLOCATIONS, misses, Meter::getMeanRate);
         gauge(POOL_ALLOCATIONS, hits, Meter::getMeanRate);
     }
@@ -91,19 +91,19 @@ public class MicrometerBufferPoolMetrics extends MicrometerMetrics implements Bu
     @Override
     public long overflowSize()
     {
-        return bufferPool.overflowMemoryInBytes();
+        return bufferPool.overflowMemoryBytes();
     }
 
     @Override
     public long usedSize()
     {
-        return bufferPool.usedSizeInBytes();
+        return bufferPool.usedMemoryBytes();
     }
 
     @Override
     public long size()
     {
-        return bufferPool.sizeInBytes();
+        return bufferPool.allocatedMemoryBytes();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/net/BufferPoolAllocator.java
+++ b/src/java/org/apache/cassandra/net/BufferPoolAllocator.java
@@ -71,7 +71,7 @@ public abstract class BufferPoolAllocator extends AbstractByteBufAllocator
 
     ByteBuffer getAtLeast(int size)
     {
-        return bufferPool.getAtLeast(size, BufferType.OFF_HEAP);
+        return bufferPool.get(size, BufferType.OFF_HEAP);
     }
 
     void put(ByteBuffer buffer)
@@ -81,13 +81,13 @@ public abstract class BufferPoolAllocator extends AbstractByteBufAllocator
 
     void putUnusedPortion(ByteBuffer buffer)
     {
-        bufferPool.putUnusedPortion(buffer);
+        bufferPool.put(buffer);
     }
 
     @VisibleForTesting
     public long usedSizeInBytes()
     {
-        return bufferPool.usedSizeInBytes();
+        return bufferPool.usedMemoryBytes();
     }
 
     void release()
@@ -125,7 +125,7 @@ public abstract class BufferPoolAllocator extends AbstractByteBufAllocator
         @Override
         protected ByteBuffer allocateDirect(int initialCapacity)
         {
-            return bufferPool.getAtLeast(initialCapacity, BufferType.OFF_HEAP);
+            return bufferPool.get(initialCapacity, BufferType.OFF_HEAP);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -436,7 +436,7 @@ public class InboundConnectionInitiator
                 from = InetAddressAndPort.getByAddressOverrideDefaults(address.getAddress(), address.getPort());
             }
 
-            BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
+            //BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
             pipeline.replace(this, "streamInbound", new StreamingInboundHandler(from, current_version, null));
 
             logger.info("{} streaming connection established, version = {}, framing = {}, encryption = {}",
@@ -458,12 +458,12 @@ public class InboundConnectionInitiator
             // record the "true" endpoint, i.e. the one the peer is identified with, as opposed to the socket it connected over
             instance().versions.set(from, maxMessagingVersion);
 
-            BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
+            //BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
             BufferPoolAllocator allocator = GlobalBufferPoolAllocator.instance;
             if (initiate.type == ConnectionType.LARGE_MESSAGES)
             {
                 // for large messages, swap the global pool allocator for a local one, to optimise utilisation of chunks
-                allocator = new LocalBufferPoolAllocator(pipeline.channel().eventLoop());
+                allocator = new LocalBufferPoolAllocator(pipeline.channel().eventLoop(), BufferPools.forNetworking());
                 pipeline.channel().config().setAllocator(allocator);
             }
 

--- a/src/java/org/apache/cassandra/net/LocalBufferPoolAllocator.java
+++ b/src/java/org/apache/cassandra/net/LocalBufferPoolAllocator.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.net;
 import java.nio.ByteBuffer;
 
 import io.netty.channel.EventLoop;
+import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.utils.memory.BufferPool;
 import org.apache.cassandra.utils.memory.BufferPools;
 
@@ -32,12 +33,12 @@ import org.apache.cassandra.utils.memory.BufferPools;
  */
 class LocalBufferPoolAllocator extends BufferPoolAllocator
 {
-    private final BufferPool.LocalPool pool;
+    private final BufferPool pool;
     private final EventLoop eventLoop;
 
-    LocalBufferPoolAllocator(EventLoop eventLoop)
+    LocalBufferPoolAllocator(EventLoop eventLoop, BufferPool pool)
     {
-        this.pool = BufferPools.forNetworking().create().recycleWhenFree(false);
+        this.pool = pool;
         this.eventLoop = eventLoop;
     }
 
@@ -46,7 +47,7 @@ class LocalBufferPoolAllocator extends BufferPoolAllocator
     {
         if (!eventLoop.inEventLoop())
             throw new IllegalStateException("get() called from outside of owning event loop");
-        return pool.get(size);
+        return pool.get(size, BufferType.OFF_HEAP);
     }
 
     @Override
@@ -54,12 +55,12 @@ class LocalBufferPoolAllocator extends BufferPoolAllocator
     {
         if (!eventLoop.inEventLoop())
             throw new IllegalStateException("getAtLeast() called from outside of owning event loop");
-        return pool.getAtLeast(size);
+        return pool.getAtLeast(size, BufferType.OFF_HEAP);
     }
 
     @Override
     public void release()
     {
-        pool.release();
+        // no-op
     }
 }

--- a/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
@@ -341,7 +341,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
                 ChannelPipeline pipeline = ctx.pipeline();
                 if (result.isSuccess())
                 {
-                    BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
+                    //BufferPools.forNetworking().setRecycleWhenFreeForCurrentThread(false);
                     if (type.isMessaging())
                     {
                         assert frameEncoder != null;

--- a/src/java/org/apache/cassandra/transport/Flusher.java
+++ b/src/java/org/apache/cassandra/transport/Flusher.java
@@ -45,9 +45,7 @@ abstract class Flusher implements Runnable
 {
     private static final Logger logger = LoggerFactory.getLogger(Flusher.class);
     @VisibleForTesting
-    public static final int MAX_FRAMED_PAYLOAD_SIZE =
-        Math.min(BufferPool.NORMAL_CHUNK_SIZE,
-                 FrameEncoder.Payload.MAX_SIZE - Math.max(FrameEncoderCrc.HEADER_AND_TRAILER_LENGTH, FrameEncoderLZ4.HEADER_AND_TRAILER_LENGTH));
+    public static final int MAX_FRAMED_PAYLOAD_SIZE =FrameEncoder.Payload.MAX_SIZE - Math.max(FrameEncoderCrc.HEADER_AND_TRAILER_LENGTH, FrameEncoderLZ4.HEADER_AND_TRAILER_LENGTH);
 
     static class FlushItem<T>
     {

--- a/src/java/org/apache/cassandra/utils/FileUtils.java
+++ b/src/java/org/apache/cassandra/utils/FileUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public final class FileUtils
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
+
+    /**
+     * Clean the buffer if it is a direct byte buffer. If the buffer was sliced from a parent slice, clean the parent
+     * if it was marked for cleaning with {@link SlicedBufferCleaner}. This is currently done by page aligned buffers,
+     * which are sliced from a larger parent that must be cleaned as well.
+     *
+     * @param buffer - the buffer to clean
+     */
+    public static void clean(ByteBuffer buffer)
+    {
+        if (buffer == null || !buffer.isDirect())
+            return;
+
+        if (!JavaVersionDependent.invokeCleaner(buffer))
+        {
+            ByteBuffer parent = SlicedBufferCleaner.cleanableParent(buffer);
+            if (parent != null)
+                clean(parent);
+        }
+    }
+
+
+    /**
+     * A small utility class for buffers that are sliced from larger buffers and that when cleaned require the parent
+     * buffer to be cleaned as well. This currently happens for page alignment with buffers allocated by
+     * {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED}. This method returns a slice but, upon cleaning
+     * the slice, the parent actually needs to be cleaned.
+     * <p/>
+     * {@link org.apache.cassandra.io.util.FileUtils#clean(ByteBuffer)} will recognize this attachment marker and know that
+     * it must clean the parent of the sliced buffer.
+     */
+    public final static class SlicedBufferCleaner
+    {
+        private final ByteBuffer attachment;
+        private volatile Runnable observer;
+
+        private SlicedBufferCleaner(ByteBuffer buffer)
+        {
+            Object attachment =  UnsafeByteBufferAccess.getAttachment(buffer);
+            assert attachment instanceof ByteBuffer : "Sliced buffers with cleanable parents should have ByteBuffer attachments";
+            this.attachment = (ByteBuffer) attachment;
+        }
+
+        public static ByteBuffer mark(ByteBuffer buffer)
+        {
+            UnsafeByteBufferAccess.setAttachment(buffer, new SlicedBufferCleaner(buffer));
+            return buffer;
+        }
+
+        // This is only used by unit tests to check that cleanableParent is called
+        @VisibleForTesting
+        public static boolean setObserver(ByteBuffer buffer, Runnable observer)
+        {
+            Object attachment = UnsafeByteBufferAccess.getAttachment(buffer);
+            if (attachment == null)
+                return false;
+
+            if (attachment instanceof SlicedBufferCleaner)
+            {
+                ((SlicedBufferCleaner) attachment).observer = observer;
+                return true;
+            }
+            else if (attachment instanceof ByteBuffer)
+            {
+                return setObserver((ByteBuffer) attachment, observer);
+            }
+
+            return false;
+        }
+
+        static ByteBuffer cleanableParent(ByteBuffer buffer)
+        {
+            Object attachment = UnsafeByteBufferAccess.getAttachment(buffer);
+            if (attachment == null || !(attachment instanceof SlicedBufferCleaner))
+                return null;
+
+            SlicedBufferCleaner cleaner = (SlicedBufferCleaner) attachment;
+            if (cleaner.observer != null)
+                cleaner.observer.run(); // for tests only
+
+            return cleaner.attachment;
+        }
+    }
+
+
+    /**
+     * Private constructor as the class contains only static methods.
+     */
+    private FileUtils()
+    {
+    }
+}

--- a/src/java/org/apache/cassandra/utils/Flags.java
+++ b/src/java/org/apache/cassandra/utils/Flags.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+public interface Flags
+{
+    @Inline
+    static boolean isEmpty(int flags)
+    {
+        return flags == 0;
+    }
+
+    @Inline
+    static boolean containsAll(int flags, int testFlags)
+    {
+        return (flags & testFlags) == testFlags;
+    }
+
+    @Inline
+    static boolean contains(int flags, int testFlags)
+    {
+        return (flags & testFlags) != 0;
+    }
+
+    @Inline
+    static int add(int flags, int toAdd)
+    {
+        return flags | toAdd;
+    }
+
+    @Inline
+    static int remove(int flags, int toRemove)
+    {
+        return flags & ~toRemove;
+    }
+}

--- a/src/java/org/apache/cassandra/utils/JavaVersionDependent.java
+++ b/src/java/org/apache/cassandra/utils/JavaVersionDependent.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+
+import sun.nio.ch.DirectBuffer;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JavaVersionDependent
+{
+
+    private static final long maxDirectMemory;
+
+    static
+    {
+        try
+        {
+            Class<?> cVM = Class.forName("sun.misc.VM");
+            maxDirectMemory = (Long) cVM.getDeclaredMethod("maxDirectMemory").invoke(null);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        try
+        {
+            Class<?> clsDirectBuffer = Class.forName("sun.nio.ch.DirectBuffer");
+            Method mDirectBufferCleaner = clsDirectBuffer.getMethod("cleaner");
+            MethodHandle mhDirectBufferCleaner = MethodHandles.lookup().unreflect(mDirectBufferCleaner);
+            Method mCleanerClean = mDirectBufferCleaner.getReturnType().getMethod("clean");
+            MethodHandle mhCleanerClean = MethodHandles.lookup().unreflect(mCleanerClean);
+
+            if (mhDirectBufferCleaner == null || mhCleanerClean == null)
+                throw new RuntimeException("Cleaner not available");
+
+            ByteBuffer buf = ByteBuffer.allocateDirect(1);
+            invokeCleaner(buf);
+        }
+        catch (Throwable t)
+        {
+            final Logger logger = LoggerFactory.getLogger(JavaVersionDependent.class);
+            logger.error("FATAL: Cannot initialize optimized memory deallocator. Some data, both in-memory and on-disk, may live longer due to garbage collection.", t);
+            JVMStabilityInspector.inspectThrowable(t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    public static boolean isJava11()
+    {
+        return false;
+    }
+
+    public static void doCheck()
+    {
+        if (!System.getProperty("java.version").startsWith("1.8.0"))
+            throw new RuntimeException("Java 8 required, but running " + System.getProperty("java.version"));
+    }
+
+    public static void onSpinWait(Supplier<Object> dummy)
+    {
+        dummy.get();
+    }
+
+    /**
+     * Hack to prevent the ugly "illegal access" warnings in Java 9+ like the following.
+     */
+    public static void preventIllegalAccessWarnings()
+    {
+        // no-op for Java 8
+    }
+
+
+    public static long getProcessID(Process process)
+    {
+        if (!SystemUtils.IS_OS_UNIX)
+        {
+            throw new UnsupportedOperationException("This method can be run only on Unix-like OS");
+        }
+        try
+        {
+            Class cls = Class.forName("java.lang.UNIXProcess");
+            Field field = FieldUtils.getDeclaredField(cls, "pid", true);
+            return field.getInt(process);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to get PID of a process " + process, e);
+        }
+    }
+
+    /**
+     * Invokes the cleaner on a direct byte buffer. Prefer calling {@link org.apache.cassandra.io.util.FileUtils#clean(ByteBuffer)}
+     * instead this method. This method is not capable of cleaning the parents of sliced byte buffers, for example the
+     * parents of buffers that were page aligned will not be cleaned causing a memory leak.
+     *
+     * @param directByteBuffer - the buffer to clean
+     * @return true if it was possible to clear the buffer memory, false otherwise
+     */
+    public static boolean invokeCleaner(ByteBuffer directByteBuffer)
+    {
+        if (directByteBuffer == null || !directByteBuffer.isDirect())
+            return false;
+
+        DirectBuffer db = (DirectBuffer) directByteBuffer;
+        if (db.cleaner() != null)
+        {
+            db.cleaner().clean();
+            return true;
+        }
+
+        return false;
+    }
+
+    public static long maxDirectMemory()
+    {
+        return maxDirectMemory;
+    }
+}

--- a/src/java/org/apache/cassandra/utils/UnsafeAccess.java
+++ b/src/java/org/apache/cassandra/utils/UnsafeAccess.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import sun.misc.Unsafe;
+
+public class UnsafeAccess
+{
+    public static final Unsafe UNSAFE;
+
+    static
+    {
+        UNSAFE = (Unsafe) AccessController.doPrivileged((PrivilegedAction<Object>) () ->
+        {
+            try
+            {
+                Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                return f.get(null);
+            }
+            catch (NoSuchFieldException | IllegalAccessException e)
+            {
+                // It doesn't matter what we throw;
+                // it's swallowed in getBest().
+                throw new Error();
+            }
+        });
+    }
+}

--- a/src/java/org/apache/cassandra/utils/UnsafeByteBufferAccess.java
+++ b/src/java/org/apache/cassandra/utils/UnsafeByteBufferAccess.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+import static org.apache.cassandra.utils.Architecture.IS_UNALIGNED;
+import static org.apache.cassandra.utils.UnsafeAccess.UNSAFE;
+
+public class UnsafeByteBufferAccess
+{
+    public static final long DIRECT_BYTE_BUFFER_LIMIT_OFFSET;
+    public static final long DIRECT_BYTE_BUFFER_POSITION_OFFSET;
+    public static final long DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET;
+    public static final long BYTE_BUFFER_OFFSET_OFFSET;
+    public static final long BYTE_BUFFER_HB_OFFSET;
+    public static final long BYTE_BUFFER_NATIVE_ORDER;
+    public static final long BYTE_BUFFER_BIG_ENDIAN;
+
+    public static final long DIRECT_BYTE_BUFFER_ADDRESS_OFFSET;
+    public static final long DIRECT_BYTE_BUFFER_CAPACITY_OFFSET;
+
+    public static final Class<?> DIRECT_BYTE_BUFFER_CLASS;
+    public static final Class<?> DIRECT_BYTE_BUFFER_R_CLASS;
+    public static final long BYTE_ARRAY_BASE_OFFSET;
+
+    /**
+     * Declare an empty direct byte buffer here that can be used instead of calling  ByteBuffer.allocateDirect(0).
+     * This is because the JVM allocates 1 byte even if calling allocateDirect(0) and this results in the nio memory
+     * counters for used and reserved memory to be off by one byte. However, we tell our users
+     * to expect these values to be equal. So we create our own empty buffer with a null address;
+     */
+    public static final ByteBuffer EMPTY_BUFFER;
+
+    static
+    {
+        try
+        {
+            DIRECT_BYTE_BUFFER_ADDRESS_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("address"));
+            DIRECT_BYTE_BUFFER_CAPACITY_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("capacity"));
+            DIRECT_BYTE_BUFFER_LIMIT_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("limit"));
+            DIRECT_BYTE_BUFFER_POSITION_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("position"));
+
+            DIRECT_BYTE_BUFFER_CLASS = ByteBuffer.allocateDirect(0).getClass();
+            DIRECT_BYTE_BUFFER_R_CLASS = ByteBuffer.allocateDirect(0).asReadOnlyBuffer().getClass();
+            DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET = UNSAFE.objectFieldOffset(DIRECT_BYTE_BUFFER_CLASS.getDeclaredField("att"));
+
+            BYTE_BUFFER_OFFSET_OFFSET = UNSAFE.objectFieldOffset(ByteBuffer.class.getDeclaredField("offset"));
+            BYTE_BUFFER_HB_OFFSET = UNSAFE.objectFieldOffset(ByteBuffer.class.getDeclaredField("hb"));
+            BYTE_BUFFER_NATIVE_ORDER = UNSAFE.objectFieldOffset(ByteBuffer.class.getDeclaredField("nativeByteOrder"));
+            BYTE_BUFFER_BIG_ENDIAN = UNSAFE.objectFieldOffset(ByteBuffer.class.getDeclaredField("bigEndian"));
+
+            BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+
+            EMPTY_BUFFER = allocateHollowDirectByteBuffer(); // null address and capacity set to 0
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Inline
+    public static long getAddress(ByteBuffer buffer)
+    {
+        return UNSAFE.getLong(buffer, DIRECT_BYTE_BUFFER_ADDRESS_OFFSET);
+    }
+
+    @Inline
+    public static Object getArray(ByteBuffer buffer)
+    {
+        return UNSAFE.getObject(buffer, BYTE_BUFFER_HB_OFFSET);
+    }
+
+    @Inline
+    public static int getOffset(ByteBuffer buffer)
+    {
+        return UNSAFE.getInt(buffer, BYTE_BUFFER_OFFSET_OFFSET);
+    }
+
+    @Inline
+    public static boolean nativeByteOrder(ByteBuffer buffer)
+    {
+        return UNSAFE.getBoolean(buffer, BYTE_BUFFER_NATIVE_ORDER);
+    }
+
+    @Inline
+    public static boolean bigEndian(ByteBuffer buffer)
+    {
+        return UNSAFE.getBoolean(buffer, BYTE_BUFFER_BIG_ENDIAN);
+    }
+
+    public static Object getAttachment(ByteBuffer instance)
+    {
+        assert instance.getClass() == DIRECT_BYTE_BUFFER_CLASS || instance.getClass() == DIRECT_BYTE_BUFFER_R_CLASS
+                : instance.getClass().getName();
+        return UNSAFE.getObject(instance, DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET);
+    }
+
+    public static void setAttachment(ByteBuffer instance, Object next)
+    {
+        assert instance.getClass() == DIRECT_BYTE_BUFFER_CLASS || instance.getClass() == DIRECT_BYTE_BUFFER_R_CLASS
+                : instance.getClass().getName();
+        UNSAFE.putObject(instance, DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET, next);
+    }
+
+    @Inline
+    static long bufferOffset(ByteBuffer buffer, Object array)
+    {
+        long srcOffset;
+        if (array != null)
+        {
+            srcOffset = BYTE_ARRAY_BASE_OFFSET + getOffset(buffer);
+        }
+        else
+        {
+            srcOffset = getAddress(buffer);
+        }
+        return srcOffset;
+    }
+
+    /**
+     * Why do this? because the JDK only bothers optimising DirectByteBuffer for the unaligned case.
+     */
+    @Inline
+    public static short getShort(ByteBuffer bb)
+    {
+        Object array = getArray(bb);
+        long srcOffset = bb.position() + bufferOffset(bb, array);
+
+        if (IS_UNALIGNED)
+        {
+            short x = UNSAFE.getShort(array, srcOffset);
+            return (nativeByteOrder(bb) ? x : Short.reverseBytes(x));
+        }
+        else
+            return UnsafeMemoryAccess.getShortByByte(array, srcOffset, bigEndian(bb));
+    }
+
+    /**
+     * Why do this? because the JDK only bothers optimising DirectByteBuffer for the unaligned case.
+     */
+    @Inline
+    public static int getInt(ByteBuffer bb)
+    {
+        Object array = getArray(bb);
+        long srcOffset = bb.position() + bufferOffset(bb, array);
+
+        if (IS_UNALIGNED)
+        {
+            int x = UNSAFE.getInt(array, srcOffset);
+            return (nativeByteOrder(bb)  ? x : Integer.reverseBytes(x));
+        }
+        else
+            return UnsafeMemoryAccess.getIntByByte(array, srcOffset, bigEndian(bb));
+    }
+
+    /**
+     * Why do this? because the JDK only bothers optimising DirectByteBuffer for the unaligned case.
+     */
+    @Inline
+    public static long getLong(ByteBuffer bb)
+    {
+        Object array = getArray(bb);
+        long srcOffset = bb.position() + bufferOffset(bb, array);
+
+        if (IS_UNALIGNED)
+        {
+            final long l = UNSAFE.getLong(array, srcOffset);
+            return (nativeByteOrder(bb) ? l : Long.reverseBytes(l));
+        }
+        else
+            return UnsafeMemoryAccess.getLongByByte(array, srcOffset, bigEndian(bb));
+    }
+
+    /**
+     * Why do this? because the JDK only bothers optimising DirectByteBuffer for the unaligned case.
+     */
+    @Inline
+    public static double getDouble(ByteBuffer bb)
+    {
+        return Double.longBitsToDouble(getLong(bb));
+
+    }
+
+    /**
+     * Why do this? because the JDK only bothers optimising DirectByteBuffer for the unaligned case.
+     */
+    @Inline
+    public static float getFloat(ByteBuffer bb)
+    {
+        return Float.intBitsToFloat(getInt(bb));
+    }
+
+    /**
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     * @return a new DirectByteBuffer setup with the address, length required, and native byte order
+     */
+    public static ByteBuffer allocateByteBuffer(long address, int length)
+    {
+        return allocateByteBuffer(address, length, ByteOrder.nativeOrder());
+    }
+
+    /**
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     * @param order byte order of the new buffer
+     * @return a new DirectByteBuffer setup with the address, length and order required
+     */
+    public static ByteBuffer allocateByteBuffer(long address, int length, ByteOrder order)
+    {
+        return allocateByteBuffer(address, length, order, null);
+    }
+
+    /**
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     * @param order byte order of the new buffer
+     * @param attachment byte buffer attachment
+     * @return a new DirectByteBuffer setup with the address, length and order required
+     */
+    public static ByteBuffer allocateByteBuffer(long address, int length, ByteOrder order, Object attachment)
+    {
+        return allocateByteBuffer(address, length, length, order, attachment);
+    }
+
+
+    /**
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     * @param capacity in bytes of the new buffer
+     * @param order byte order of the new buffer
+     * @param attachment byte buffer attachment
+     * @return a new DirectByteBuffer setup with the address, length and order required
+     */
+    public static ByteBuffer allocateByteBuffer(long address, int length, int capacity, ByteOrder order, Object attachment)
+    {
+        ByteBuffer instance = allocateHollowDirectByteBuffer(order);
+        initByteBufferInstance(instance, address, length, capacity);
+
+        if (attachment != null)
+            UNSAFE.putObject(instance, DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET, attachment);
+
+        return instance;
+    }
+
+    /**
+     * Hollow byte buffers are used as DirectByteBuffer fly weights. They should be used with care and
+     * consistently with methods prescribed below.
+     *
+     * @return a new DirectByteBuffer with native byte order (not ready for use as address/length are not set)
+     */
+    public static ByteBuffer allocateHollowDirectByteBuffer()
+    {
+        return allocateHollowDirectByteBuffer(ByteOrder.nativeOrder());
+    }
+
+    /**
+     * @param order byte order of the new buffer
+     * @return a new DirectByteBuffer with provided byte order (not ready for use as address/length are not set)
+     */
+    public static ByteBuffer allocateHollowDirectByteBuffer(ByteOrder order)
+    {
+        ByteBuffer instance;
+        try
+        {
+            instance = (ByteBuffer) UNSAFE.allocateInstance(DIRECT_BYTE_BUFFER_CLASS);
+        }
+        catch (InstantiationException e)
+        {
+            throw new AssertionError(e);
+        }
+        instance.order(order);
+        return instance;
+    }
+
+    /**
+     * @param instance presumably a previously allocated hollow buffer
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     */
+    public static void initByteBufferInstance(ByteBuffer instance, long address, int length)
+    {
+        initByteBufferInstance(instance, address, length, length);
+    }
+
+    /**
+     * @param instance presumably a previously allocated hollow buffer
+     * @param address the memory address to use for the new buffer
+     * @param length in bytes of the new buffer
+     * @param capacity in bytes of the new buffer
+     */
+    public static void initByteBufferInstance(ByteBuffer instance, long address, int length, int capacity)
+    {
+        setAddress(instance, address);
+        setCapacity(instance, capacity);
+        setPosition(instance, 0);
+        setLimit(instance, length);
+    }
+
+    /**
+     * Reset a hollow buffer to explicitly prevent further use.
+     *
+     * @param instance presumably a previously allocated hollow buffer
+     */
+    public static void resetByteBufferInstance(ByteBuffer instance)
+    {
+        setAddress(instance, 0);
+        setPosition(instance, 0);
+        setCapacity(instance, 0);
+        setLimit(instance, 0);
+        setAttachment(instance, null);
+    }
+
+    /**
+     * @param instance presumably a previously allocated hollow buffer
+     * @param address the memory address to set for buffer instance
+     * @param length in bytes to set for buffer instance
+     * @param order byte order to set for buffer instance
+     */
+    public static void initByteBufferInstance(ByteBuffer instance, long address, int length, ByteOrder order)
+    {
+        initByteBufferInstance(instance, address, length);
+        instance.order(order);
+    }
+
+    /**
+     * This method has the same effect of calling {@link ByteBuffer#duplicate()} but instead of allocating, it
+     * duplicates into the given hollow buffer. Note that attachment and byte order are not duplicated. Attachment
+     * ref copy would potentially keep that ref alive and would require clearing it after the hollowBuffer is used.
+     * Byte order not getting duplicated is consistent with {@link ByteBuffer#duplicate()}.
+     *
+     * @param source
+     * @param hollowBuffer
+     * @return hollowBuffer
+     */
+    public static ByteBuffer duplicateDirectByteBuffer(ByteBuffer source, ByteBuffer hollowBuffer, boolean withAttachment)
+    {
+        assert source.isDirect() && hollowBuffer.isDirect();
+        setAddress(hollowBuffer, getAddress(source));
+        setPosition(hollowBuffer, getPosition(source));
+        setLimit(hollowBuffer, getLimit(source));
+        setCapacity(hollowBuffer, getCapacity(source));
+
+        if (withAttachment)
+            UNSAFE.putObject(hollowBuffer, DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET, UNSAFE.getObject(source, DIRECT_BYTE_BUFFER_ATTACHMENT_OFFSET));
+
+        return hollowBuffer;
+    }
+
+    /**
+     * Check if a list of memory addresses represent a contiguous region of memory.
+     * <p/>
+     * This method returns false if:
+     * <ul>
+     *     <li> The addresses are not contiguous </li>
+     *     <li> The addresses are not ordered </li>
+     * </ul>
+     *
+     * @param addresses a bunch of addresses, hopefully contiguous, hopefully sorted
+     * @param addressSize the size of each individual memory region
+     * @param limit the required contiguous region size
+     *
+     * @return true if the addresses represent a contiguous region, false otherwise
+     *
+     * @throws IllegalArgumentException if the total size of the addresses is less than the required size.
+     */
+    public static boolean regionsAreContiguous(long[] addresses, int addressSize, int limit)
+    {
+        long start = addresses[0];
+        int size = addressSize;
+        for (int i = 1; i < addresses.length && size < limit; i++)
+        {
+            if (addresses[i] - size != start)
+                return false;
+
+            size += addressSize;
+        }
+
+        if (size < limit)
+            throw new IllegalArgumentException("Total size of buffers must exceed limit");
+
+        return true;
+    }
+
+    /**
+     * Split a contiguous memory region into multiple regions of size addressSize.
+     * The region was previously determined contiguous by calling {@link this#regionsAreContiguous(long[], int, int)}.
+     * This method reconstitutes the original regions.
+     *
+     * @param address the address of the contiguous region
+     * @param addressSize the size of each individual memory region
+     * @param limit the total contiguous region size, must be a multiple of addressSize
+     *
+     * @return an array containing the addresses of the individual regions
+     */
+    public static long[] splitContiguousRegion(long address, int addressSize, int limit)
+    {
+        if (address <= 0)
+            throw new IllegalStateException("Address should be valid: " + address);
+
+        if ((limit / addressSize) * addressSize != limit)
+            throw new IllegalStateException( "Limit should be a multiple of address size: " + limit + ", " + addressSize);
+
+        long[] ret = new long[limit / addressSize];
+        for (int i = 0; i < ret.length; i++)
+            ret[i] = address + i * addressSize;
+
+        return ret;
+    }
+
+    private static int getCapacity(ByteBuffer source)
+    {
+        return UNSAFE.getInt(source, DIRECT_BYTE_BUFFER_CAPACITY_OFFSET);
+    }
+
+    private static int getLimit(ByteBuffer source)
+    {
+        return UNSAFE.getInt(source, DIRECT_BYTE_BUFFER_LIMIT_OFFSET);
+    }
+
+    private static void setPosition(ByteBuffer hollowBuffer, int position)
+    {
+        UNSAFE.putInt(hollowBuffer, DIRECT_BYTE_BUFFER_POSITION_OFFSET, position);
+    }
+
+    private static int getPosition(ByteBuffer source)
+    {
+        return UNSAFE.getInt(source, DIRECT_BYTE_BUFFER_POSITION_OFFSET);
+    }
+
+    private static void setLimit(ByteBuffer instance, int length)
+    {
+        UNSAFE.putInt(instance, DIRECT_BYTE_BUFFER_LIMIT_OFFSET, length);
+    }
+
+    private static void setCapacity(ByteBuffer instance, int length)
+    {
+        UNSAFE.putInt(instance, DIRECT_BYTE_BUFFER_CAPACITY_OFFSET, length);
+    }
+
+    private static void setAddress(ByteBuffer instance, long address)
+    {
+        if (instance.isReadOnly())
+            throw new ReadOnlyBufferException();
+
+        UNSAFE.putLong(instance, DIRECT_BYTE_BUFFER_ADDRESS_OFFSET, address);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/UnsafeCopy.java
+++ b/src/java/org/apache/cassandra/utils/UnsafeCopy.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+import static org.apache.cassandra.utils.UnsafeAccess.UNSAFE;
+import static org.apache.cassandra.utils.UnsafeByteBufferAccess.*;
+
+public abstract class UnsafeCopy
+{
+    private static final long UNSAFE_COPY_THRESHOLD = 1024 * 1024L; // copied from java.nio.Bits
+
+    private static final long MIN_COPY_THRESHOLD = 6;
+
+    @Inline
+    public static void copyBufferToMemory(ByteBuffer srcBuffer, long tgtAddress)
+    {
+        copyBufferToMemory(srcBuffer, srcBuffer.position(), tgtAddress, srcBuffer.remaining());
+    }
+
+    @Inline
+    public static void copyMemoryToBuffer(long srcAddress, ByteBuffer dstBuffer, int length)
+    {
+        copyMemoryToBuffer(srcAddress, dstBuffer, dstBuffer.position(), length);
+    }
+
+    /**
+     * Callers assumed to have sanitized arguments.
+     */
+    @Inline
+    public static void copyMemoryToArray(long srcAddress, byte[] dstArray, int dstOffset, int length)
+    {
+        copy0(null, srcAddress, dstArray, BYTE_ARRAY_BASE_OFFSET + dstOffset, length);
+    }
+
+    @Inline
+    public static void copyBufferToArray(ByteBuffer srcBuf, byte[] dstArray, int dstOffset)
+    {
+        copyBufferToArray(srcBuf, srcBuf.position(), dstArray, dstOffset, srcBuf.remaining());
+    }
+
+    @Inline
+    public static void copyBufferToArray(ByteBuffer srcBuf, int srcPosition, byte[] dstArray, int dstOffset, int length)
+    {
+        if (length > (dstArray.length - dstOffset))
+        {
+            throw new IllegalArgumentException("Cannot copy " + length + " bytes into array of length " + dstArray.length + " at offset " + dstOffset);
+        }
+        Object src = UnsafeByteBufferAccess.getArray(srcBuf);
+        long srcOffset = bufferOffset(srcBuf, src) + srcPosition;
+        copy0(src, srcOffset, dstArray, BYTE_ARRAY_BASE_OFFSET + dstOffset, length);
+    }
+
+    /**
+     * Callers assumed to have sanitized arguments.
+     */
+    @Inline
+    public static void copyBufferToMemory(ByteBuffer srcBuf, int srcPosition, long dstAddress, int length)
+    {
+        Object src = UnsafeByteBufferAccess.getArray(srcBuf);
+        long srcOffset = bufferOffset(srcBuf, src) + srcPosition;
+        copy0(src, srcOffset, null, dstAddress, length);
+    }
+
+    /**
+     * Callers assumed to have sanitized arguments.
+     */
+    @Inline
+    public static void copyMemoryToBuffer(long srcAddress, ByteBuffer dstBuf, int dstPosition, int length)
+    {
+        if (dstBuf.isReadOnly())
+            throw new ReadOnlyBufferException();
+
+        Object dst = UnsafeByteBufferAccess.getArray(dstBuf);
+        long dstOffset = bufferOffset(dstBuf, dst) + dstPosition;
+        copy0(null, srcAddress, dst, dstOffset, length);
+    }
+
+    /**
+     * Callers assumed to have sanitized arguments.
+     */
+    @Inline
+    public static void copyArrayToMemory(byte[] src, int srcPosition, long dstAddress, int length)
+    {
+        long srcOffset = BYTE_ARRAY_BASE_OFFSET + srcPosition;
+        copy0(src, srcOffset, null, dstAddress, length);
+    }
+
+    /**
+     * Callers assumed to have sanitized arguments.
+     */
+    @Inline
+    public static void copyMemoryToMemory(long srcAddress, long dstAddress, long length)
+    {
+        copy0(null, srcAddress, null, dstAddress, length);
+    }
+
+    /**
+     * Generic memory copy for copying array/memory to array/memory. Arguments are assumes sanitized by callers. Failure
+     * to sanitize arguments MAY CRASH THE VM, or worse, MAY CORRUPT MEMORY. Use with care.
+     *
+     * @param src       null or a byte[]
+     * @param srcOffset address (iff src == null) or offset in bytes within src (index + BYTE_ARRAY_BASE_OFFSET)
+     * @param dst       null or a byte[]
+     * @param dstOffset address (iff dst == null) or offset in bytes within dst (index + BYTE_ARRAY_BASE_OFFSET)
+     * @param length    number of bytes to copy
+     */
+    @Inline
+    public static void copy0(Object src, long srcOffset, Object dst, long dstOffset, long length)
+    {
+        // TODO: is this a valid optimization? how was this verified and on what machines?
+        if (length <= MIN_COPY_THRESHOLD)
+        {
+            for (int i = 0 ; i < length ; i++)
+            {
+                byte b = UNSAFE.getByte(src, srcOffset + i);
+                UNSAFE.putByte(dst, dstOffset + i, b);
+            }
+            return;
+        }
+
+        // Takes a conservative view of time to safepoint issues which may be induced by large uninterruptible copies,
+        // especially when considering offheap mapped buffers. This should be handled by JVM implementation of copy but
+        // is not on OpenJDK (is on Zing, maybe others), so we compensate in the same way NIO Bits does.
+        while (length > 0)
+        {
+            long size = (length > UNSAFE_COPY_THRESHOLD) ? UNSAFE_COPY_THRESHOLD : length;
+            // if src or dst are null, the offsets are absolute base addresses
+            UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+            length -= size;
+            srcOffset += size;
+            dstOffset += size;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/UnsafeMemoryAccess.java
+++ b/src/java/org/apache/cassandra/utils/UnsafeMemoryAccess.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.sun.jna.Native;
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+import static org.apache.cassandra.utils.Architecture.IS_UNALIGNED;
+import static org.apache.cassandra.utils.UnsafeAccess.UNSAFE;
+
+/**
+ * This class is used for native memory access, in particular for temporary internal memory access. The methods are
+ * therefore optimized for nativeByteOrder access, i.e. the byte order will depend on the platform. This is not suitable
+ * for externally visible data (e.g. network/files).
+ */
+public class UnsafeMemoryAccess
+{
+    public static final boolean BIG_ENDIAN = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
+
+    private static final AtomicLong memoryAllocated = new AtomicLong(0);
+
+    @Inline
+    public static void setByte(long address, byte b)
+    {
+        UNSAFE.putByte(address, b);
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static void setShort(long address, short s)
+    {
+        if (IS_UNALIGNED)
+            UNSAFE.putShort(address, s);
+        else
+            putShortByByte(address, s);
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static void setInt(long address, int i)
+    {
+        if (IS_UNALIGNED)
+            UNSAFE.putInt(address, i);
+        else
+            putIntByByte(address, i);
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static void setLong(long address, long l)
+    {
+        if (IS_UNALIGNED)
+            UNSAFE.putLong(address, l);
+        else
+            putLongByByte(address, l);
+    }
+
+    @Inline
+    public static byte getByte(long address)
+    {
+        return UNSAFE.getByte(address);
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static int getUnsignedShort(long address)
+    {
+        return (IS_UNALIGNED ? UNSAFE.getShort(address) : getShortByByte(null, address, BIG_ENDIAN)) & 0xffff;
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static int getInt(long address)
+    {
+        return IS_UNALIGNED ? UNSAFE.getInt(null, address) : getIntByByte(null, address, BIG_ENDIAN);
+    }
+
+    /**
+     * For direct memory access ONLY (not for DirectByteBuffer used for files/network), so native byte ordering is used.
+     */
+    @Inline
+    public static long getLong(long address)
+    {
+        return IS_UNALIGNED ? UNSAFE.getLong(address) : getLongByByte(null, address, BIG_ENDIAN);
+    }
+
+    public static long getLongByByte(Object o, long address, boolean bigEndian)
+    {
+        if (bigEndian)
+        {
+            return (((long) UNSAFE.getByte(o, address    )       ) << 56) |
+                   (((long) UNSAFE.getByte(o, address + 1) & 0xff) << 48) |
+                   (((long) UNSAFE.getByte(o, address + 2) & 0xff) << 40) |
+                   (((long) UNSAFE.getByte(o, address + 3) & 0xff) << 32) |
+                   (((long) UNSAFE.getByte(o, address + 4) & 0xff) << 24) |
+                   (((long) UNSAFE.getByte(o, address + 5) & 0xff) << 16) |
+                   (((long) UNSAFE.getByte(o, address + 6) & 0xff) << 8) |
+                   (((long) UNSAFE.getByte(o, address + 7) & 0xff)      );
+        }
+        else
+        {
+            return (((long) UNSAFE.getByte(o, address + 7)       ) << 56) |
+                   (((long) UNSAFE.getByte(o, address + 6) & 0xff) << 48) |
+                   (((long) UNSAFE.getByte(o, address + 5) & 0xff) << 40) |
+                   (((long) UNSAFE.getByte(o, address + 4) & 0xff) << 32) |
+                   (((long) UNSAFE.getByte(o, address + 3) & 0xff) << 24) |
+                   (((long) UNSAFE.getByte(o, address + 2) & 0xff) << 16) |
+                   (((long) UNSAFE.getByte(o, address + 1) & 0xff) << 8) |
+                   (((long) UNSAFE.getByte(o, address    ) & 0xff)      );
+        }
+    }
+
+    public static int getIntByByte(Object o, long address, boolean bigEndian)
+    {
+        if (bigEndian)
+        {
+            return (((int) UNSAFE.getByte(o, address    )       ) << 24) |
+                   (((int) UNSAFE.getByte(o, address + 1) & 0xff) << 16) |
+                   (((int) UNSAFE.getByte(o, address + 2) & 0xff) << 8 ) |
+                   (((int) UNSAFE.getByte(o, address + 3) & 0xff)      );
+        }
+        else
+        {
+            return (((int) UNSAFE.getByte(o, address + 3)       ) << 24) |
+                   (((int) UNSAFE.getByte(o, address + 2) & 0xff) << 16) |
+                   (((int) UNSAFE.getByte(o, address + 1) & 0xff) << 8) |
+                   (((int) UNSAFE.getByte(o, address    ) & 0xff)      );
+        }
+    }
+
+    public static short getShortByByte(Object o, long address, boolean bigEndian)
+    {
+        if (bigEndian)
+        {
+            return (short) ((((int) UNSAFE.getByte(o, address    )       ) << 8) |
+                            (((int) UNSAFE.getByte(o, address + 1) & 0xff)     ));
+        }
+        else
+        {
+            return (short) ((((int) UNSAFE.getByte(o, address + 1)       ) << 8) |
+                            (((int) UNSAFE.getByte(o, address    ) & 0xff)      ));
+        }
+    }
+
+    public static void putLongByByte(long address, long value)
+    {
+        if (BIG_ENDIAN)
+        {
+            UNSAFE.putByte(address, (byte) (value >> 56));
+            UNSAFE.putByte(address + 1, (byte) (value >> 48));
+            UNSAFE.putByte(address + 2, (byte) (value >> 40));
+            UNSAFE.putByte(address + 3, (byte) (value >> 32));
+            UNSAFE.putByte(address + 4, (byte) (value >> 24));
+            UNSAFE.putByte(address + 5, (byte) (value >> 16));
+            UNSAFE.putByte(address + 6, (byte) (value >> 8));
+            UNSAFE.putByte(address + 7, (byte) (value));
+        }
+        else
+        {
+            UNSAFE.putByte(address + 7, (byte) (value >> 56));
+            UNSAFE.putByte(address + 6, (byte) (value >> 48));
+            UNSAFE.putByte(address + 5, (byte) (value >> 40));
+            UNSAFE.putByte(address + 4, (byte) (value >> 32));
+            UNSAFE.putByte(address + 3, (byte) (value >> 24));
+            UNSAFE.putByte(address + 2, (byte) (value >> 16));
+            UNSAFE.putByte(address + 1, (byte) (value >> 8));
+            UNSAFE.putByte(address, (byte) (value));
+        }
+    }
+
+    public static void putIntByByte(long address, int value)
+    {
+        if (BIG_ENDIAN)
+        {
+            UNSAFE.putByte(address, (byte) (value >> 24));
+            UNSAFE.putByte(address + 1, (byte) (value >> 16));
+            UNSAFE.putByte(address + 2, (byte) (value >> 8));
+            UNSAFE.putByte(address + 3, (byte) (value));
+        }
+        else
+        {
+            UNSAFE.putByte(address + 3, (byte) (value >> 24));
+            UNSAFE.putByte(address + 2, (byte) (value >> 16));
+            UNSAFE.putByte(address + 1, (byte) (value >> 8));
+            UNSAFE.putByte(address, (byte) (value));
+        }
+    }
+
+    public static void putShortByByte(long address, short value)
+    {
+        if (BIG_ENDIAN)
+        {
+            UNSAFE.putByte(address, (byte) (value >> 8));
+            UNSAFE.putByte(address + 1, (byte) (value));
+        }
+        else
+        {
+            UNSAFE.putByte(address + 1, (byte) (value >> 8));
+            UNSAFE.putByte(address, (byte) (value));
+        }
+    }
+
+    public static int pageSize()
+    {
+        return UNSAFE.pageSize();
+    }
+
+    public static long allocate(long size)
+    {
+        memoryAllocated.addAndGet(size);
+        return Native.malloc(size);
+    }
+
+    public static void free(long peer, long size)
+    {
+        memoryAllocated.addAndGet(-size);
+        Native.free(peer);
+    }
+
+    public static long allocated()
+    {
+        return memoryAllocated.get();
+    }
+
+    public static void fill(long address, long count, byte b)
+    {
+        UNSAFE.setMemory(address, count, b);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/DseThreadLocal.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/DseThreadLocal.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.utils.concurrent;
+
+/**
+ * Common interface for {@link ThreadLocal} alternatives. Note that in this interface `null` is considered a special
+ * value used for removal so initial value suppliers which return null are incompatible.
+ */
+public interface DseThreadLocal<T>
+{
+    /**
+     * @see ThreadLocal#get()
+     * @return current value, or if current value is null initialize (assuming an initial supplier is present)
+     */
+    T get();
+
+
+    /**
+     * @param value to set the thread local value. Setting to `null` may trigger re-initialization if a supplier
+     *              is set up.
+     */
+    void set(T value);
+
+    /**
+     * This method is only usable for TLs with no initial value supplier.
+     *
+     * @return true if set, false otherwise.
+     */
+    boolean isSet();
+
+    /**
+     * Same as set(null). A default implementation is not provided as the method is present in some implementors already.
+     */
+    void remove();
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/InlinedThreadLocal.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/InlinedThreadLocal.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import net.nicoulaj.compilecommand.annotations.DontInline;
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+/**
+ * An implementation of {@link DseThreadLocal} which specializes for {@link InlinedThreadLocalThread} to treat instances
+ * as fields of the current thread instance.
+ */
+class InlinedThreadLocal<T> extends ThreadLocal<T> implements DseThreadLocal<T>
+{
+    static final Supplier EMPTY_SUPPLIER = () -> null;
+    private final long offset;
+    private final Supplier<T> initialValueSupplier;
+
+    InlinedThreadLocal(long index, Supplier<T> initialValueSupplier)
+    {
+        Objects.requireNonNull(initialValueSupplier);
+        this.offset = InlinedThreadLocalThread.getRefOffset(index);
+        this.initialValueSupplier = initialValueSupplier;
+    }
+
+    @Override
+    @Inline
+    public T get()
+    {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof InlinedThreadLocalThread)
+        {
+            InlinedThreadLocalThread inlinedThreadLocalThread = (InlinedThreadLocalThread) thread;
+            Object o = inlinedThreadLocalThread.getThreadLocalRef(offset);
+            if (o != null)
+                return (T) o;
+
+            Supplier<T> initialValueSupplier = this.initialValueSupplier;
+            if (initialValueSupplier == EMPTY_SUPPLIER)
+                return null;
+
+            return allocate(inlinedThreadLocalThread, initialValueSupplier);
+        }
+        else
+        {
+            return getSlow();
+        }
+    }
+
+    @DontInline
+    private T getSlow()
+    {
+        return super.get();
+    }
+
+    @DontInline
+    private T allocate(
+            InlinedThreadLocalThread inlinedThreadLocalThread,
+            Supplier<T> initialValueSupplier)
+    {
+        T o = initialValueSupplier.get();
+        // Supplier returning null is a degenerate case, please fix
+        assert  (o != null);
+
+        inlinedThreadLocalThread.setThreadLocalRef(offset, o);
+        return o;
+    }
+
+    @Override
+    @Inline
+    public void set(T v)
+    {
+        Thread thread = Thread.currentThread();
+        if (thread instanceof InlinedThreadLocalThread)
+        {
+            InlinedThreadLocalThread inlinedThreadLocalThread = (InlinedThreadLocalThread) thread;
+            inlinedThreadLocalThread.setThreadLocalRef(offset, v);
+        }
+        else
+        {
+            setSlow(v);
+        }
+    }
+
+    @DontInline
+    private void setSlow(T v)
+    {
+        if (v != null)
+        {
+            super.set(v);
+        }
+        else
+        {
+            // this forces consistent use of `null` as special value
+            super.remove();
+        }
+    }
+
+    @Override
+    public boolean isSet()
+    {
+        assert initialValueSupplier == EMPTY_SUPPLIER;
+        Thread thread = Thread.currentThread();
+        if (thread instanceof InlinedThreadLocalThread)
+        {
+            InlinedThreadLocalThread inlinedThreadLocalThread = (InlinedThreadLocalThread) thread;
+            Object o = inlinedThreadLocalThread.getThreadLocalRef(offset);
+            return o != null;
+        }
+        else
+        {
+            // note the inconsistency here where isSet can trigger initialization of the thread local.
+            return super.get() != null;
+        }
+    }
+
+    @Override
+    public void remove()
+    {
+        set(null);
+    }
+
+    @Override
+    protected T initialValue()
+    {
+        return initialValueSupplier.get();
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/InlinedThreadLocalThread.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/InlinedThreadLocalThread.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.utils.concurrent;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.io.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import net.nicoulaj.compilecommand.annotations.Inline;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeRefArrayAccess;
+
+/**
+ * An intermediate class for forcing the position and ordering of reference fields which we intend to use as the backing
+ * storage for {@link InlinedThreadLocal} instances.
+ */
+@SuppressWarnings("unused")
+abstract class InlinedThreadLocalThreadLocalRefs extends FastThreadLocalThread
+{
+    // DO NOT ADD FURTHER FIELDS TO THIS CLASS OTHER THAN REFS FOR TL STORAGE
+    // Static fields are fine ;-), See note below after ref fields.
+    static final int MAX_LOCALS = 70;
+    static final long REF_BASE_OFFSET;
+    private static final Logger LOGGER = LoggerFactory.getLogger(InlinedThreadLocalThread.class);
+    private static final long REF_SHIFT = UnsafeRefArrayAccess.REF_ELEMENT_SHIFT;
+    private static final AtomicInteger FIRST_UNUSED_INDEX = new AtomicInteger();
+
+    public static int maxLocalsOverflow;
+
+    static
+    {
+        long minOffset = Long.MAX_VALUE;
+        // fields order is not guaranteed
+        for (int i = 0; i < MAX_LOCALS; i++)
+        {
+            String fieldName = "a" + i;
+            long fieldOffset = UnsafeAccess.fieldOffset(InlinedThreadLocalThreadLocalRefs.class, fieldName);
+            minOffset = Math.min(fieldOffset, minOffset);
+        }
+        REF_BASE_OFFSET = minOffset;
+    }
+
+    // Add further refs as needed and adjust the MAX_LOCALS constant accordingly
+    private Object a0, a1, a2, a3, a4, a5, a6, a7, a8, a9;
+    private Object a10, a11, a12, a13, a14, a15, a16, a17, a18, a19;
+    private Object a20, a21, a22, a23, a24, a25, a26, a27, a28, a29;
+    private Object a30, a31, a32, a33, a34, a35, a36, a37, a38, a39;
+    private Object a40, a41, a42, a43, a44, a45, a46, a47, a48, a49;
+    private Object a50, a51, a52, a53, a54, a55, a56, a57, a58, a59;
+    private Object a60, a61, a62, a63, a64, a65, a66, a67, a68, a69;
+    // DO NOT ADD FURTHER FIELDS TO THIS CLASS OTHER THAN REFS FOR TL REF STORAGE
+    // Adding further fields may cause these fields to mingle with the above allocate fields in term of their relative
+    // position. The get/set methods we use below rely on the reference fields above being laid out as a contiguous
+    // space.
+
+    InlinedThreadLocalThreadLocalRefs()
+    {
+        super();
+    }
+
+    InlinedThreadLocalThreadLocalRefs(Runnable target)
+    {
+        super(target);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target)
+    {
+        super(group, target);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(String name)
+    {
+        super(name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, String name)
+    {
+        super(group, name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(Runnable target, String name)
+    {
+        super(target, name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target, String name)
+    {
+        super(group, target, name);
+    }
+
+    public InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target, String name, long stackSize)
+    {
+        super(group, target, name, stackSize);
+    }
+
+    static long getRefOffset(long index)
+    {
+        if (index > MAX_LOCALS)
+        {
+            throw new IllegalStateException("FIRST_UNUSED_INDEX:" + index + " exceeds max: " + MAX_LOCALS);
+        }
+        return REF_BASE_OFFSET + (index << REF_SHIFT);
+    }
+
+    static long nextRefIndex()
+    {
+        int currIndex;
+        do
+        {
+            currIndex = FIRST_UNUSED_INDEX.get();
+            if (currIndex == MAX_LOCALS)
+            {
+                maxLocalsOverflow++;
+                return -1;
+            }
+        }
+        while (!FIRST_UNUSED_INDEX.compareAndSet(currIndex, currIndex + 1));
+        return currIndex;
+    }
+
+    @VisibleForTesting
+    static void resetIndexForTestingOnly()
+    {
+        // ONLY FOR TESTING!!!!
+        FIRST_UNUSED_INDEX.set(0);
+    }
+
+    @Inline
+    Object getThreadLocalRef(long offset)
+    {
+        return UnsafeAccess.UNSAFE.getObject(this, offset);
+    }
+
+    @Inline
+    void setThreadLocalRef(long offset, Object v)
+    {
+        UnsafeAccess.UNSAFE.putObject(this, offset, v);
+    }
+
+    void cleanupOnExit()
+    {
+        for (int i = 0; i < MAX_LOCALS; i++)
+        {
+            long offset = getRefOffset(i);
+            Object threadLocal = getThreadLocalRef(offset);
+            if (threadLocal == null)
+            {
+                continue;
+            }
+            // Maybe a pointless gesture, but might prevent GC nepotism (where dead objects in old gen keep young
+            // objects they refer to alive until an old gen GC removes them). In all likelihood the TL object have
+            // similar lifecycle to the thread and are therefore in the same generation.
+            setThreadLocalRef(offset, null);
+
+            // Rather than wait for the GC to pick these up, clean them now (particularly important for offheap buffers).
+            if (threadLocal instanceof ByteBuffer)
+            {
+                cleanupByteBuffer((ByteBuffer) threadLocal);
+            }
+            else if (threadLocal instanceof Closeable)
+            {
+                cleanupCloseable((Closeable) threadLocal);
+            }
+        }
+    }
+
+    private void cleanupCloseable(Closeable threadLocal)
+    {
+        try
+        {
+            threadLocal.close();
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Failed to close thread local resource on thread exit", e);
+        }
+    }
+
+    private void cleanupByteBuffer(ByteBuffer threadLocal)
+    {
+        try
+        {
+            FileUtils.clean(threadLocal);
+        }
+        catch (Throwable e)
+        {
+            LOGGER.error("Failed to clean DirectBuffer thread local resource on thread exit", e);
+        }
+    }
+
+}
+
+public class InlinedThreadLocalThread extends InlinedThreadLocalThreadLocalRefs
+{
+
+    public InlinedThreadLocalThread()
+    {
+        super();
+    }
+
+    public InlinedThreadLocalThread(Runnable target)
+    {
+        super(target);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target)
+    {
+        super(group, target);
+    }
+
+    public InlinedThreadLocalThread(String name)
+    {
+        super(name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, String name)
+    {
+        super(group, name);
+    }
+
+    public InlinedThreadLocalThread(Runnable target, String name)
+    {
+        super(target, name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target, String name)
+    {
+        super(group, target, name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target, String name, long stackSize)
+    {
+        super(group, target, name, stackSize);
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            super.run();
+        }
+        finally
+        {
+            cleanupOnExit();
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/LongAdder.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/LongAdder.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import static org.apache.cassandra.utils.UnsafeAccess.UNSAFE;
+
+/**
+ * A class equivalent to {@link java.util.concurrent.atomic.LongAdder} except that
+ * it creates a Cell per core-thread as soon as needed, and a further Cell to be
+ * shared by every other thread. The dedicated cells are updated with an ordered put,
+ * aka as lazy set, rather than a full volatile write, whilst the shared Cell is
+ * updated with CAS.
+ *
+ * The ordered put guarantees atomicity, just like a volatile write, but not
+ * total ordering. So we may miss the latest value when reading, but we can
+ * tolerate this (the reading thread will see the value in a matter of nanoseconds).
+ */
+public class LongAdder
+{
+    // to prevent false sharing we need to pad by 2 cache lines, typically 64b per cache line.
+    private static final int FALSE_SHARING_PAD = 128;
+    private static final int COUNTER_OFFSET_SCALE = Integer.numberOfTrailingZeros(FALSE_SHARING_PAD);
+    private static final int SIZEOF_LONG = 8;
+    private static final long COUNTER_ARRAY_BASE;
+
+    static
+    {
+        try
+        {
+            // first counter offset in array, padded to the 'left'
+            COUNTER_ARRAY_BASE = UNSAFE.arrayBaseOffset(long[].class) + FALSE_SHARING_PAD;
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final int numCores;
+    private final long[] values;
+
+    public LongAdder()
+    {
+        this.numCores = TPCUtils.getNumCores();
+        // each counter is padded to the right by 2 cache lines(128b) and we need one extra pad on the left
+        this.values = new long[(numCores + 2)*(FALSE_SHARING_PAD / SIZEOF_LONG)];
+    }
+
+    public void add(long x)
+    {
+        int coreId = TPCUtils.getCoreId();
+
+        add(x, coreId);
+    }
+
+    public void add(long x, int coreId)
+    {
+        if (x == 0)
+            return;
+
+        // only the last index requires a cas, for the rest an ordered put is sufficient since only one thread will
+        // update the value.
+        long offset = counterOffset(coreId);
+        if (coreId < numCores)
+        {
+            // This will not work with concurrent reset
+            long value = UNSAFE.getLong(values, offset);
+            UNSAFE.putOrderedLong(values, offset, value + x);
+        }
+        else
+        {
+            UNSAFE.getAndAddLong(values, offset, x);
+        }
+    }
+
+    private long counterOffset(int coreId)
+    {
+        return COUNTER_ARRAY_BASE + (coreId << COUNTER_OFFSET_SCALE);
+    }
+
+    public void increment() {
+        add(1L);
+    }
+
+    public void decrement() {
+        add(-1L);
+    }
+
+    public long sum()
+    {
+        long sum = 0;
+        long[] values = this.values;
+        for (int i = 0; i <= numCores;i++)
+            sum += UNSAFE.getLongVolatile(values, counterOffset(i));
+
+        return sum;
+    }
+
+    public void reset()
+    {
+        long[] values = this.values;
+        for (int i = 0; i <= numCores;i++)
+            UNSAFE.getAndSetLong(values, counterOffset(i), 0);
+    }
+
+    public String toString() {
+        // a breakpoint in the constructor before initializing values will cause a SEGFAULT because the debugger calls toString()
+        return values == null ? "0" : Long.toString(sum());
+    }
+
+    /**
+     * Equivalent to {@link #sum}.
+     *
+     * @return the sum
+     */
+    public long longValue() {
+        return sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as an {@code int} after a narrowing
+     * primitive conversion.
+     */
+    public int intValue() {
+        return (int)sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as a {@code float}
+     * after a widening primitive conversion.
+     */
+    public float floatValue() {
+        return (float)sum();
+    }
+
+    /**
+     * Returns the {@link #sum} as a {@code double} after a widening
+     * primitive conversion.
+     */
+    public double doubleValue() {
+        return (double)sum();
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/ParkedExecutor.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ParkedExecutor.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.utils.Flags;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+
+/**
+ * An executor which relies on the {@link ParkedThreadsMonitor} to unpark it's threads which are waiting on lock-less
+ * queues. How can threads wait on lock-less queues? They just park themselves when they see the queue as empty. Since
+ * this observation is non-atomic to other threads putting work on the queue, and since putting work on the queue of a
+ * parked thread doesn't notify the parked worker, we have the {@link ParkedThreadsMonitor} check when/if new work is
+ * available for parked threads and unpark them.
+ * <p>
+ * This has the benefit of removing the cost of {@link LockSupport#unpark(Thread)} from the threads which are trying to
+ * offload work onto the executor.
+ */
+public abstract class ParkedExecutor implements ShutdownableExecutor
+{
+    private static final Logger logger = LoggerFactory.getLogger(ParkedExecutor.class);
+    private static final Runnable POISON_PILL = () -> {};
+    volatile boolean isShutdown = false;
+
+    protected final ParkedThreadsMonitor monitor = ParkedThreadsMonitor.instance.get().orElseThrow(() -> new IllegalStateException("Cannot use because ParkedThreadsMonitor is disabled"));
+
+    /**
+     * Create a {@code ParkedExecutor} if {@link ParkedThreadsMonitor} is enabled, otherwise a standard executor.
+     *
+     * @param name A base name for the threads in the thread pool (not null)
+     * @param threadCount number of threads for the backing thread pool (>= 1)
+     */
+    public static ShutdownableExecutor createParkedExecutor(String name, int threadCount)
+    {
+        if (threadCount < 1)
+            throw new IllegalArgumentException("Less than 1 thread in thread pool is not allowed, but " + threadCount +" requested for pool " + name);
+        if (threadCount == 1)
+        {
+            return ParkedThreadsMonitor.IS_ENABLED ?
+                   new ParkedSingleThreadedExecutor(name) :
+                   new FallbackExecutor(Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(name).build()));
+        }
+        return ParkedThreadsMonitor.IS_ENABLED ?
+               new ParkedMultiThreadedExecutor(name, threadCount) :
+               new FallbackExecutor(Executors.newFixedThreadPool(threadCount, new ThreadFactoryBuilder().setNameFormat(name).build()));
+    }
+
+    private static void safeRun(Runnable r)
+    {
+        try
+        {
+            r.run();
+        }
+        catch (Throwable throwable)
+        {
+            JVMStabilityInspector.inspectThrowable(throwable);
+            logger.error("Error while runningThreadsBitmap tasks: ", throwable);
+        }
+    }
+
+    static class ParkedMultiThreadedExecutor extends ParkedExecutor implements ParkedThreadsMonitor.MonitorableThread
+    {
+        private final int allThreadsRunning;
+        private final Thread[] workers;
+        // bounded pre-allocated queue to avoid per task allocation overheads
+        private final MpmcArrayQueue<Runnable> tasks = new MpmcArrayQueue<>(1024);
+        // unbounded overflow for when the above is not enough
+        private final Queue<Runnable> overflowTasks = new ConcurrentLinkedQueue<>();
+        // this acts as an isRunning indicator bit map for the threads
+        private final AtomicInteger runningThreadsBitmap = new AtomicInteger();
+        private final int threadCount;
+
+        private ParkedMultiThreadedExecutor(String name, int threadCount)
+        {
+            if (threadCount > 32)
+                throw new IllegalStateException("ParkedExecutors pool size is limited to 32 threads currently");
+            this.threadCount = threadCount;
+            allThreadsRunning = -1 >>> (32 - threadCount);
+            workers = new Thread[threadCount];
+            NamedThreadFactory namedThreadFactory = new NamedThreadFactory(name);
+            for (int i = 0; i < threadCount; i++)
+            {
+                int tIndex = i;
+                workers[i] = namedThreadFactory.newThread(() -> processTasks(tIndex));
+                workers[i].start();
+            }
+
+            monitor.addThreadToMonitor(this);
+        }
+
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            isShutdown = true;
+            for (int i = 0; i < threadCount; i++)
+            {
+                // poison pill always on overflow
+                overflowTasks.offer(POISON_PILL);
+            }
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                workers[i].join();
+            }
+            monitor.removeThreadToMonitor(this);
+        }
+
+        @Override
+        public void execute(Runnable task)
+        {
+            if (isShutdown)
+                throw new RejectedExecutionException("Executor has already been shutdown");
+            // We have a bounded tasks queue, if it overflows we send via the unbounded MPMC queue. This can introduce
+            // task reordering, but this is valid behavior for an Executor.
+            if (!tasks.offer(task))
+                overflowTasks.offer(task);
+        }
+
+        private void processTasks(int threadIndex)
+        {
+            // the bit to set/unset in the runningThreadsBitmap for this thread index
+            int tMask = 1 << threadIndex;
+            setThreadRunning(tMask);
+
+            Runnable r;
+            while (true)
+            {
+                boolean noTask = true;
+                // always check both queues to ensure one cannot starve the other
+                if ((r = overflowTasks.poll()) != null)
+                {
+                    if (r == POISON_PILL)
+                        break;
+                    noTask = false;
+                    safeRun(r);
+                }
+                if ((r = tasks.relaxedPoll()) != null)
+                {
+                    // no poison on tasks queue
+                    noTask = false;
+                    safeRun(r);
+                }
+
+                if (noTask)
+                {
+                    setThreadNotRunning(tMask);
+                    LockSupport.park();
+                    setThreadRunning(tMask);
+
+                    if (Thread.interrupted())
+                        break;
+                }
+            }
+
+            // after poison pill observed make best effort to drain queue
+            while ((r = tasks.poll()) != null)
+            {
+                safeRun(r);
+            }
+        }
+
+        private void setThreadRunning(int tMask)
+        {
+            int current;
+            do
+            {
+                current = runningThreadsBitmap.get();
+            }
+            while (!runningThreadsBitmap.compareAndSet(current, Flags.add(current, tMask)));
+        }
+
+        private void setThreadNotRunning(int tMask)
+        {
+            int current;
+            do
+            {
+                current = runningThreadsBitmap.get();
+            }
+            while (!runningThreadsBitmap.compareAndSet(current, Flags.remove(current, tMask)));
+        }
+
+        @Override
+        public void unpark(long epoch)
+        {
+            int currentlyRunningMask = runningThreadsBitmap.get();
+            for (int i = 0; i < threadCount; i++)
+            {
+                if (!Flags.contains(currentlyRunningMask, 1 << i))
+                {
+                    Thread worker = workers[i];
+                    LockSupport.unpark(worker);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public boolean shouldUnpark(long epoch)
+        {
+            return (runningThreadsBitmap.get() != allThreadsRunning) &&
+                    !(tasks.isEmpty() && overflowTasks.isEmpty());
+        }
+    }
+
+    /**
+     * A specialized implementation for a single threaded executor allows us to use the unbounded MPSC queue for
+     * improved performance and simpler workflow.
+     */
+    static class ParkedSingleThreadedExecutor extends ParkedExecutor implements ParkedThreadsMonitor.MonitorableThread
+    {
+        private final Thread worker;
+        private final MpscUnboundedArrayQueue<Runnable> tasks = new MpscUnboundedArrayQueue<>(1024);
+        private final AtomicInteger running = new AtomicInteger();
+
+        private ParkedSingleThreadedExecutor(String name)
+        {
+            NamedThreadFactory namedThreadFactory = new NamedThreadFactory(name);
+            worker = namedThreadFactory.newThread(this::processTasks);
+            worker.start();
+            monitor.addThreadToMonitor(this);
+        }
+
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            isShutdown = true;
+            tasks.offer(POISON_PILL);
+            worker.join();
+            monitor.removeThreadToMonitor(this);
+        }
+
+        @Override
+        public void execute(Runnable task)
+        {
+            if (isShutdown)
+                throw new RejectedExecutionException("Executor has already been shutdown");
+            // This is an unbounded queue, so no need to check for failed offers
+            tasks.offer(task);
+        }
+
+        private void processTasks()
+        {
+            running.lazySet(1);
+
+            Runnable r;
+            while ((r = tasks.relaxedPoll()) != POISON_PILL)
+            {
+                if (r == null)
+                {
+                    running.lazySet(0);
+                    LockSupport.park();
+                    running.lazySet(1);
+
+                    if (Thread.interrupted())
+                        break;
+                    continue;
+                }
+                ParkedExecutor.safeRun(r);
+            }
+        }
+
+        @Override
+        public void unpark(long epoch)
+        {
+            int currentlyRunningMask = running.get();
+            if (currentlyRunningMask == 0)
+            {
+                LockSupport.unpark(this.worker);
+            }
+        }
+
+        @Override
+        public boolean shouldUnpark(long epoch)
+        {
+            return running.get() != 1 && !tasks.isEmpty();
+        }
+    }
+
+    static class FallbackExecutor implements ShutdownableExecutor
+    {
+        private final ExecutorService executor;
+
+        private FallbackExecutor(ExecutorService executor)
+        {
+            this.executor = executor;
+        }
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            executor.shutdownNow();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public void execute(Runnable command)
+        {
+            executor.execute(command);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/ParkedThreadsMonitor.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ParkedThreadsMonitor.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.MonotonicClock;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+
+/**
+ * This class is responsible for keeping tabs on threads that register as a {@link MonitorableThread}.
+ * <p/>
+ * When a {@link MonitorableThread} parks itself this thread wakes it up when ready to execute work, according to the
+ * {@link MonitorableThread#shouldUnpark(long)} method. This allows threads to (for example) use a non-blocking queue 
+ * without constantly spinning.
+ * <p/>
+ * It's up to the {@link MonitorableThread#shouldUnpark(long )} implementation to track its own state.
+ */
+public class ParkedThreadsMonitor
+{
+    public static final boolean IS_ENABLED = Boolean.parseBoolean(System.getProperty("dse.thread_monitor_enabled", "true"));
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParkedThreadsMonitor.class);
+
+    public static final Supplier<Optional<ParkedThreadsMonitor>> instance = Suppliers.memoize(() ->
+    {
+        if (IS_ENABLED)
+            return Optional.of(new ParkedThreadsMonitor());
+        else
+        {
+            LOGGER.warn("ParkedThreadsMonitor is DISABLED.");
+            return Optional.empty();
+        }
+    });
+
+    /*
+     * NOTE: parkNanos seems to operate as follows (on my machine, expect differences):
+     *  - 1 to 80ns   -> p50% is 400-500ns
+     *  - 80 to 100ns -> some instability, flip between 500ns and 52us
+     *  - > 100ns     -> p50% looks like 52us + parkTime
+     */
+    private static final long SLEEP_INTERVAL_NS = Long.getLong("dse.thread_monitor_sleep_nanos", 50000);
+    private static final boolean AUTO_CALIBRATE =
+    Boolean.parseBoolean(System.getProperty("dse.thread_monitor_auto_calibrate", "true")) &&
+        SLEEP_INTERVAL_NS > 0;
+
+    private static final Sleeper SLEEPER =
+        AUTO_CALIBRATE ? new CalibratingSleeper(SLEEP_INTERVAL_NS) : new Sleeper();
+
+    private final MpscUnboundedArrayQueue<Runnable> commands = new MpscUnboundedArrayQueue<>(128);
+    private final ArrayList<MonitorableThread> monitoredThreads =
+        new ArrayList<>(Runtime.getRuntime().availableProcessors() * 2);
+    private final ArrayList<Runnable> loopActions = new ArrayList<>(4);
+    private final Thread watcherThread;
+        
+    private volatile boolean shutdown;
+    
+    /**
+     * The epoch monotonically tracks how many times the monitor has run: each run is a new epoch, and at each run
+     * this will be passed to the {@link MonitorableThread} unpark methods, so they can use it to distinguish between
+     * calls happening for the same (or different) epoch.
+     */
+    private long epoch;
+
+    @VisibleForTesting
+    ParkedThreadsMonitor(long startEpoch)
+    {
+        epoch = startEpoch;
+        shutdown = false;
+        watcherThread = ThreadsFactory.newDaemonThread(this::run, "ParkedThreadsMonitor");
+        watcherThread.setPriority(Thread.MAX_PRIORITY);
+        watcherThread.start();
+    }
+    
+    private ParkedThreadsMonitor()
+    {
+        this(0);
+    }
+
+    private void run()
+    {
+        final ArrayList<Runnable> loopActions = this.loopActions;
+        final ArrayList<MonitorableThread> monitoredThreads = this.monitoredThreads;
+        final MpscUnboundedArrayQueue<Runnable> commands = this.commands;
+        while (!shutdown)
+        {
+            try
+            {
+                runCommands(commands);
+                executeLoopActions(loopActions);
+                monitorThreads(monitoredThreads);
+            }
+            catch (Throwable t)
+            {
+                JVMStabilityInspector.inspectThrowable(t);
+                LOGGER.error("ParkedThreadsMonitor exception: ", t);
+            }
+            finally
+            {
+                epoch++;
+            }
+            SLEEPER.sleep();
+        }
+        unparkOnShutdown(monitoredThreads);
+    }
+
+    private void monitorThreads(ArrayList<MonitorableThread> monitoredThreads)
+    {
+        if (monitoredThreads.isEmpty())
+            return;
+        
+        // To avoid biasing the work threads do based on their order of unparking, we start iterating from an offset
+        // based on the epoch, so it's cheap and always changing.
+        int offset = ((int) epoch & Integer.MAX_VALUE) % monitoredThreads.size();
+        for (int i = 0; i < monitoredThreads.size(); i++)
+        {
+            MonitorableThread thread = monitoredThreads.get((i + offset) % monitoredThreads.size());
+            try
+            {
+                if (thread.shouldUnpark(epoch))
+                {
+                    // TODO: add a counter we can track for unpark rate
+                    thread.unpark(epoch);
+                }
+            }
+            catch (Throwable t)
+            {
+                LOGGER.error("Exception unparking a monitored thread", t);
+            }
+        }
+    }
+
+    private void executeLoopActions(ArrayList<Runnable> loopActions)
+    {
+        for (int i = 0; i < loopActions.size(); i++)
+        {
+            Runnable action = loopActions.get(i);
+            try
+            {
+                action.run();
+            }
+            catch (Throwable t)
+            {
+                LOGGER.error("Exception running an action", t);
+            }
+        }
+    }
+
+    private void runCommands(MpscUnboundedArrayQueue<Runnable> commands)
+    {
+        // queue is almost always empty, so pre check makes sense
+        if (!commands.isEmpty())
+        {
+            commands.drain(Runnable::run);
+        }
+    }
+
+    private void unparkOnShutdown(ArrayList<MonitorableThread> monitoredThreads)
+    {
+        for (MonitorableThread thread : monitoredThreads)
+            thread.unpark(epoch);
+    }
+
+    /**
+     * Adds a collection of threads to monitor
+     */
+    public void addThreadsToMonitor(Collection<MonitorableThread> threads)
+    {
+        threads.forEach(this::addThreadToMonitor);
+    }
+
+    /**
+     * Adds a thread to monitor
+     */
+    public void addThreadToMonitor(MonitorableThread thread)
+    {
+        commands.offer(() -> monitoredThreads.add(thread));
+    }
+
+    /**
+     * Removes a thread from monitoring
+     */
+    public void removeThreadToMonitor(MonitorableThread thread)
+    {
+        commands.offer(() -> monitoredThreads.remove(thread));
+    }
+
+    /**
+     * Removes a collection of threads from monitoring
+     */
+    public void removeThreadsToMonitor(Collection<MonitorableThread> threads)
+    {
+        threads.forEach(this::removeThreadToMonitor);
+    }
+
+    /**
+     * Runs the specified action in each loop. Mainly used to avoid many threads doing the same work
+     * over and over.
+     */
+    public void addAction(Runnable action)
+    {
+        commands.offer(() -> loopActions.add(action));
+    }
+
+    public void shutdown()
+    {
+        shutdown = true;
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit timeUnit) throws InterruptedException
+    {
+        shutdown();
+        watcherThread.join(timeUnit.toMillis(timeout));
+        return !watcherThread.isAlive();
+    }
+
+    /**
+     * Interface for threads wishing to be watched by the {@link ParkedThreadsMonitor} in order to be unparked.
+     * <p/>
+     * When a Thread has no work to do it should park itself.
+     */
+    public static interface MonitorableThread
+    {
+        /**
+         * What a MonitorableThread should use to track it's current state
+         */
+        enum ThreadState
+        {
+            PARKED, // no work to do
+            UNPARKING, // unparked but not yet working
+            WORKING
+        }
+
+        /**
+         * Will unpark a {@link ThreadState#PARKED} thread.
+         * <br/>
+         * Called by {@link ParkedThreadsMonitor} AFTER {@link #shouldUnpark(long )} returns true.
+         * 
+         * @@param epoch A monotonic counter increased every time the {@link ParkedThreadsMonitor} runs, 
+         * see {@link ParkedThreadsMonitor#epoch}.
+         */
+        void unpark(long epoch);
+
+        /**
+         * Called continuously by the {@link ParkedThreadsMonitor} to decide if unpark() should be called on a
+         * thread.
+         * <br/>
+         * Should return true IFF the thread is parked and there (potentially) is work to be done when the thread is
+         * unparked.
+         * 
+         * @param epoch A monotonic counter increased every time the {@link ParkedThreadsMonitor} runs, 
+         * see {@link ParkedThreadsMonitor#epoch}.
+         */
+        boolean shouldUnpark(long epoch);
+    }
+
+    static class Sleeper
+    {
+        void sleep()
+        {
+            if (SLEEP_INTERVAL_NS > 0)
+                LockSupport.parkNanos(SLEEP_INTERVAL_NS);
+        }
+    }
+
+    @VisibleForTesting
+    public static class CalibratingSleeper extends Sleeper
+    {
+        final long targetNs;
+        long calibratedSleepNs;
+        long expSmoothedSleepTimeNs;
+        int comparisonDelay;
+
+        @VisibleForTesting
+        public CalibratingSleeper(long targetNs)
+        {
+            this.targetNs = targetNs;
+            this.calibratedSleepNs = targetNs;
+            this.expSmoothedSleepTimeNs = 0;
+        }
+
+        @VisibleForTesting
+        public void sleep()
+        {
+            long start = nanoTime();
+            park();
+            long sleptNs = nanoTime() - start;
+            if (expSmoothedSleepTimeNs == 0)
+                expSmoothedSleepTimeNs = sleptNs;
+            else
+                expSmoothedSleepTimeNs = (long) (0.001 * sleptNs + 0.999 * expSmoothedSleepTimeNs);
+
+            // calibrate sleep time if we miss target by more than 10%, wait for at least 100 observations
+            if (comparisonDelay < 100)
+            {
+                comparisonDelay++;
+            }
+            else if (expSmoothedSleepTimeNs > targetNs * 1.1)
+            {
+                calibratedSleepNs = (long) (calibratedSleepNs * 0.9) + 1;
+                expSmoothedSleepTimeNs = 0;
+                comparisonDelay = 0;
+            }
+            else if (expSmoothedSleepTimeNs < targetNs * 0.9)
+            {
+                calibratedSleepNs = (long) (calibratedSleepNs * 1.1);
+                expSmoothedSleepTimeNs = 0;
+                comparisonDelay = 0;
+            }
+        }
+
+        @VisibleForTesting
+        void park()
+        {
+            LockSupport.parkNanos(calibratedSleepNs);
+        }
+
+        @VisibleForTesting
+        long nanoTime()
+        {
+            return MonotonicClock.preciseTime.now();
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/ShutdownableExecutor.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ShutdownableExecutor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.concurrent.Executor;
+
+/**
+ * An executor you can shut down!
+ */
+public interface ShutdownableExecutor extends Executor
+{
+
+    /**
+     * Stop the threads started for this executor(if any), returns when the threads spawned for this executor have all
+     * been stopped. Wait as long as it takes.
+     * <p>
+     * Note that tasks sent via {@link #execute(Runnable)} may be stuck in queue indefinitely.
+     */
+    void shutdown() throws InterruptedException;
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/TPCUtils.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/TPCUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.concurrent.*;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+/**
+ * Utility class with static methods meant to make working and interacting with TPC easier. Please note this class
+ * must never implement methods causing initialization of the TPC state, so please do not call any {@link TPC} static
+ * methods here.
+ */
+public class TPCUtils
+{
+    private static final int NUM_CORES = DatabaseDescriptor.getTPCCores();
+
+    public static int getCoreId()
+    {
+        return getCoreId(Thread.currentThread());
+    }
+
+    /**
+     * @return the core id for TPC threads, otherwise the number of cores. Callers can verify if the returned
+     * core is valid via {@link #isValidCoreId(int)}, or alternatively can allocate an
+     * array with length num_cores + 1, and use thread safe operations only on the last element.
+     */
+    public static int getCoreId(Thread t)
+    {
+        // return t instanceof TPCThread ? ((TPCThread) t).coreId() : NUM_CORES;
+        return NUM_CORES;
+    }
+
+
+    /**
+     *
+     * @return the configured number of TPC cores
+     */
+    public static int getNumCores()
+    {
+        return NUM_CORES;
+    }
+
+    /**
+     * Check if this is a valid core id.
+     *
+     * @param coreId the core id to check.
+     *
+     * @return true if the core id is valid, that is it is &gt= 0 and &lt {@link DatabaseDescriptor#getTPCCores()}.
+     */
+    public static boolean isValidCoreId(int coreId)
+    {
+        return coreId >= 0 && coreId < NUM_CORES;
+    }
+
+    public static void blockingAwait(CompletableFuture<?> completable)
+    {
+        //ensureNotOnTPCThread("Calling blockingAwait");
+
+        completable.join();
+    }
+
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/ThreadsFactory.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/ThreadsFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.utils.concurrent.InlinedThreadLocalThread;
+
+public class ThreadsFactory
+{
+    /**
+     * @param name name of the thread for this executor
+     * @return a single threaded executor whose threads have names
+     */
+    public static ExecutorService newSingleThreadedExecutor(String name)
+    {
+        return Executors.newSingleThreadExecutor(new NamedThreadFactory(name));
+    }
+
+    /**
+     * @param r runnable task for the thread
+     * @param name for the thread
+     * @return a new daemon thread which has the given name and task
+     */
+    public static Thread newDaemonThread(Runnable r, String name)
+    {
+        return newThread(r, name, true);
+    }
+
+    /**
+     * @param r runnable task for the thread
+     * @param name for the thread
+     * @param isDaemon
+     * @return a new thread which has the given name and task
+     */
+    public static Thread newThread(Runnable r, String name, boolean isDaemon)
+    {
+        Thread t = new InlinedThreadLocalThread(r, name);
+        t.setDaemon(isDaemon);
+        return t;
+    }
+
+    public static void addShutdownHook(Runnable r, String name)
+    {
+        // shutdown hook threads should not be daemon
+        Runtime.getRuntime().addShutdownHook(newThread(r, name, false));
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/AttachmentMarker.java
+++ b/src/java/org/apache/cassandra/utils/memory/AttachmentMarker.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+
+import javax.annotation.Nullable;
+
+import com.datastax.bdp.db.utils.leaks.detection.LeaksDetector;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksTracker;
+
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+
+/**
+ * A small utility class for buffers that are allocated directly,
+ * in this case we need to mark them as allocated by a pool so that we can confidently
+ * update the memory used when the buffer is returned.
+ */
+final class AttachmentMarker
+{
+    private final Object attachment;
+    private final BufferPool bufferPool;
+    @Nullable private final LeaksTracker leak;
+
+    private AttachmentMarker(ByteBuffer buffer, BufferPool bufferPool, LeaksDetector<ByteBuffer> leaksDetector)
+    {
+        this.attachment =  UnsafeByteBufferAccess.getAttachment(buffer);
+        this.bufferPool = bufferPool;
+        this.leak = leaksDetector.trackForDebug(buffer);
+    }
+
+    Object attachment()
+    {
+        return attachment;
+    }
+
+    static void mark(ByteBuffer buffer, BufferPool bufferPool, LeaksDetector<ByteBuffer> leaksDetector)
+    {
+        UnsafeByteBufferAccess.setAttachment(buffer, new AttachmentMarker(buffer, bufferPool, leaksDetector));
+    }
+
+    static AttachmentMarker unmark(ByteBuffer buffer, BufferPool bufferPool)
+    {
+        Object attachment = UnsafeByteBufferAccess.getAttachment(buffer);
+        if (!(attachment instanceof AttachmentMarker))
+            return null;
+
+        AttachmentMarker marker = ((AttachmentMarker) attachment);
+
+        // restore the original attachment, which is either the slab or the cleaner for buffers that were allocated directly
+        UnsafeByteBufferAccess.setAttachment(buffer, marker.attachment);
+
+        if (marker.bufferPool == bufferPool)
+        {
+            // if the buffer is being tracked then close the tracking operation
+            if (marker.leak != null)
+                marker.leak.close(buffer);
+
+            return marker;
+        }
+        else
+        {
+            // this is a serious programming error
+            assert false : "Buffer was returned to the wrong pool!";
+            return null;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -18,1606 +18,212 @@
 
 package org.apache.cassandra.utils.memory;
 
-import java.lang.ref.PhantomReference;
-import java.lang.ref.ReferenceQueue;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.ArrayDeque;
-import java.util.Collections;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.concurrent.atomic.LongAdder;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
-import net.nicoulaj.compilecommand.annotations.Inline;
-import org.apache.cassandra.concurrent.InfiniteLoopExecutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.netty.util.concurrent.FastThreadLocal;
+import com.datastax.bdp.db.utils.leaks.detection.LeakLevel;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksDetector;
+import com.datastax.bdp.db.utils.leaks.detection.LeaksDetectorFactory;
 
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.metrics.BufferPoolMetrics;
-import org.apache.cassandra.utils.NoSpamLogger;
-import org.apache.cassandra.utils.concurrent.Ref;
 
-import static com.google.common.collect.ImmutableList.of;
-import static org.apache.cassandra.utils.ExecutorUtils.*;
-import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
-import static org.apache.cassandra.utils.memory.MemoryUtil.isExactlyDirect;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
 
-/**
- * A pool of ByteBuffers that can be recycled to reduce system direct memory fragmentation and improve buffer allocation
- * performance.
- * <p/>
- *
- * Each {@link BufferPool} instance has one {@link GlobalPool} which allocates two kinds of chunks:
- * <ul>
- *     <li>Macro Chunk
- *       <ul>
- *         <li>A memory slab that has size of MACRO_CHUNK_SIZE which is 64 * NORMAL_CHUNK_SIZE</li>
- *         <li>Used to allocate normal chunk with size of NORMAL_CHUNK_SIZE</li>
- *       </ul>
- *     </li>
- *     <li>Normal Chunk
- *       <ul>
- *         <li>Used by {@link LocalPool} to serve buffer allocation</li>
- *         <li>Minimum allocation unit is NORMAL_CHUNK_SIZE / 64</li>
- *       </ul>
- *     </li>
- * </ul>
- *
- * {@link GlobalPool} maintains two kinds of freed chunks, fully freed chunks where all buffers are released, and
- * partially freed chunks where some buffers are not released, eg. held by {@link org.apache.cassandra.cache.ChunkCache}.
- * Partially freed chunks are used to improve cache utilization and have lower priority compared to fully freed chunks.
- *
- * <p/>
- *
- * {@link LocalPool} is a thread local pool to serve buffer allocation requests. There are two kinds of local pool:
- * <ul>
- *     <li>Normal Pool:
- *       <ul>
- *         <li>used to serve allocation size that is larger than half of NORMAL_ALLOCATION_UNIT but less than NORMAL_CHUNK_SIZE</li>
- *         <li>when there is insufficient space in the local queue, it will request global pool for more normal chunks</li>
- *         <li>when normal chunk is recycled either fully or partially, it will be passed to global pool to be used by other pools</li>
- *       </ul>
- *     </li>
- *     <li>Tiny Pool:
- *       <ul>
- *         <li>used to serve allocation size that is less than NORMAL_ALLOCATION_UNIT</li>
- *         <li>when there is insufficient space in the local queue, it will request parent normal pool for more tiny chunks</li>
- *         <li>when tiny chunk is fully freed, it will be passed to paretn normal pool and corresponding buffer in the parent normal chunk is freed</li>
- *       </ul>
- *     </li>
- * </ul>
- *
- * Note: even though partially freed chunks improves cache utilization when chunk cache holds outstanding buffer for
- * arbitrary period, there is still fragmentation in the partially freed chunk because of non-uniform allocation size.
- * <p/>
- *
- * The lifecycle of a normal Chunk:
- * <pre>
- *    new                      acquire                      release                    recycle
- * ────────→ in GlobalPool ──────────────→ in LocalPool ──────────────→ EVICTED  ──────────────────┐
- *           owner = null                  owner = LocalPool            owner = null               │
- *           status = IN_USE               status = IN_USE              status = EVICTED           │
- *              ready                      serves get / free            serves free only           │
- *                ↑                                                                                │
- *                └────────────────────────────────────────────────────────────────────────────────┘
- * </pre>
- */
-public class BufferPool
+
+
+public abstract class BufferPool implements BufferPoolMXBean
 {
-    /** The size of a page aligned buffer, 128KiB */
-    public static final int NORMAL_CHUNK_SIZE = 128 << 10;
-    public static final int NORMAL_ALLOCATION_UNIT = NORMAL_CHUNK_SIZE / 64;
-    public static final int TINY_CHUNK_SIZE = NORMAL_ALLOCATION_UNIT;
-    public static final int TINY_ALLOCATION_UNIT = TINY_CHUNK_SIZE / 64;
-    public static final int TINY_ALLOCATION_LIMIT = TINY_CHUNK_SIZE / 2;
+    /** The size for direct allocations performed by the chunk cache. Chunks with size >= of this value will be allocated directly
+     * and not taken from the pool. This property is defined here rather than in {@link ChunkCache} because it is used by
+     * the {@link DiskOptimizationStrategy}, which is part of client initialization. We don't want to start server components
+     * for clients. */
+    public static final int CHUNK_DIRECT_ALLOC_SIZE_BYTES = Math.max(0, Integer.getInteger("dse.chunk_cache.direct_alloc_size_in_kb", 256)) * 1024;
+    /**
+     * Set this to true to avoid using buffer pools, see {@link BufferPoolDisabled}. When buffer pools are
+     * disabled, each buffer is allocated using {@link org.apache.cassandra.io.compress.BufferType#OFF_HEAP_ALIGNED}.
+     * This is not recommended and should be used only for tests.
+     */
+    public static final boolean DISABLED = Boolean.getBoolean("cassandra.test.disable_buffer_pool");
 
-    private static final Logger logger = LoggerFactory.getLogger(BufferPool.class);
-    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 15L, TimeUnit.MINUTES);
-    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocateDirect(0);
+    /**
+     * A cleanup operation will run periodically to try and release memory that is no longer used by tiered pools, this
+     * parameter controls how frequently the cleanup operation runs.
+     */
+    static final int CLEANUP_INTERVAL_MILLIS = Integer.getInteger("dse.buffer_pool_cleanup_interval_ms", 5000);
 
-    private volatile Debug debug = Debug.NO_OP;
+    /**
+     * A thread waiting for another thread to allocate a shared slab will wait for at most this time before giving up.
+     */
+    static final int CONTENTION_WAIT_TIME_MILLIS =  Integer.getInteger("dse.buffer_pool_contention_wait_time_ms", 5000);
 
-    protected final String name;
+    /** The minimum size of a page aligned buffer, 1Kib. Below this the requested size will be rounded up. Must be a power of two. */
+    public static final int MIN_DIRECT_READS_BUFFER_SIZE = 1 << 10;
+
+    /** The maximum size of a page aligned buffer, 64KiB. Beyond this a direct allocation will be performed. Must be a power of two. */
+    public static final int MAX_DIRECT_READS_BUFFER_SIZE = 64 << 10;
+
+    /** The size of a thread local slab to serve short lived buffers, 1MB. */
+    public static final int THREAD_LOCAL_SLAB_SIZE = 1 << 20;
+
+    /** The number of buffers that will be served by a single bitmap slab in sized tiered pool. This should be a multiple of 32,
+     * see {@link MemorySlabWithBitmap#MemorySlabWithBitmap(int, int)} for the reason, and how to remove this limitation. */
+    public static final int NUM_BUFFERS_PER_SLAB = 1024;
+
+    /**
+     * The maximum number of buffers that will be stashed by a thread for long lived sized tired pools.
+     */
+    public static final int MAX_THREAD_LOCAL_BUFFERS = 64;
+
+    /**
+     * The maximum number of free buffers in a size tiered pool.
+     *
+     * When there are more than MAX_NUM_FREE_BUFFERS in a pool, a periodic cleanup operation
+     * will check for any slabs that are completely free, and if it finds any, they will be released
+     * so that the memory can be re-used. See {@link #CLEANUP_INTERVAL_MILLIS}.
+     * */
+    public static final int MAX_NUM_FREE_BUFFERS = NUM_BUFFERS_PER_SLAB * 2;
+
+    static
+    {
+        Preconditions.checkArgument(CONTENTION_WAIT_TIME_MILLIS > 0,
+                                    "CONTENTION_WAIT_TIME_MILLIS must be positive, set it to a large value if it's causing problems: %s",
+                                    CONTENTION_WAIT_TIME_MILLIS);
+    }
+
+    private final LeaksDetector leaksDetector;
     protected final BufferPoolMetrics metrics;
-    private final long memoryUsageThreshold;
-    private final String readableMemoryUsageThreshold;
+    protected final long maxPoolSize;
 
-    /**
-     * Size of unpooled buffer being allocated outside of buffer pool in bytes.
-     */
-    private final LongAdder overflowMemoryUsage = new LongAdder();
-
-    /**
-     * Size of buffer being used in bytes, including pooled buffer and unpooled buffer.
-     */
-    private final LongAdder memoryInUse = new LongAdder();
-
-    /**
-     * Size of allocated buffer pool slabs in bytes
-     */
-    private final AtomicLong memoryAllocated = new AtomicLong();
-
-    /** A global pool of chunks (page aligned buffers) */
-    private final GlobalPool globalPool;
-
-    /** Allow partially freed chunk to be recycled for allocation*/
-    private final boolean recyclePartially;
-
-    /** A thread local pool of chunks, where chunks come from the global pool */
-    private final FastThreadLocal<LocalPool> localPool = new FastThreadLocal<LocalPool>()
+    protected BufferPool(String name, long maxPoolSize)
     {
-        @Override
-        protected LocalPool initialValue()
-        {
-            return new LocalPool();
-        }
-
-        protected void onRemoval(LocalPool value)
-        {
-            value.release();
-        }
-    };
-
-    private final Set<LocalPoolRef> localPoolReferences = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    private final ReferenceQueue<Object> localPoolRefQueue = new ReferenceQueue<>();
-    private final InfiniteLoopExecutor localPoolCleaner;
-
-    public BufferPool(String name, long memoryUsageThreshold, boolean recyclePartially)
-    {
-        this.name = name;
-        this.memoryUsageThreshold = memoryUsageThreshold;
-        this.readableMemoryUsageThreshold = prettyPrintMemory(memoryUsageThreshold);
-        this.globalPool = new GlobalPool();
+        this.leaksDetector = LeaksDetectorFactory.create(name, ByteBuffer.class, LeakLevel.FIRST_LEVEL);
         this.metrics = BufferPoolMetrics.create(name, this);
-        this.recyclePartially = recyclePartially;
-        this.localPoolCleaner = new InfiniteLoopExecutor("LocalPool-Cleaner-" + name, this::cleanupOneReference).start();
+        this.maxPoolSize = maxPoolSize;
     }
 
     /**
-     * @return a local pool instance and caller is responsible to release the pool
-     */
-    public LocalPool create()
-    {
-        return new LocalPool();
-    }
-
-    public ByteBuffer get(int size, BufferType bufferType)
-    {
-        if (bufferType == BufferType.ON_HEAP)
-            return allocate(size, bufferType);
-        else
-            return localPool.get().get(size);
-    }
-
-    public ByteBuffer getAtLeast(int size, BufferType bufferType)
-    {
-        if (bufferType == BufferType.ON_HEAP)
-            return allocate(size, bufferType);
-        else
-            return localPool.get().getAtLeast(size);
-    }
-
-    /** Unlike the get methods, this will return null if the pool is exhausted */
-    public ByteBuffer tryGet(int size)
-    {
-        return localPool.get().tryGet(size, false);
-    }
-
-    public ByteBuffer tryGetAtLeast(int size)
-    {
-        return localPool.get().tryGet(size, true);
-    }
-
-    private ByteBuffer allocate(int size, BufferType bufferType)
-    {
-        updateOverflowMemoryUsage(size);
-        return bufferType == BufferType.ON_HEAP
-               ? ByteBuffer.allocate(size)
-               : ByteBuffer.allocateDirect(size);
-    }
-
-    public void put(ByteBuffer buffer)
-    {
-        if (isExactlyDirect(buffer))
-            localPool.get().put(buffer);
-        else
-            updateOverflowMemoryUsage(-buffer.capacity());
-    }
-
-    public void putUnusedPortion(ByteBuffer buffer)
-    {
-        if (isExactlyDirect(buffer))
-        {
-            LocalPool pool = localPool.get();
-            if (buffer.limit() > 0)
-                pool.putUnusedPortion(buffer);
-            else
-                pool.put(buffer);
-        }
-    }
-
-    private void updateOverflowMemoryUsage(int size)
-    {
-        overflowMemoryUsage.add(size);
-    }
-
-    public void setRecycleWhenFreeForCurrentThread(boolean recycleWhenFree)
-    {
-        localPool.get().recycleWhenFree(recycleWhenFree);
-    }
-
-    /**
-     * @return buffer size being allocated, including pooled buffers and unpooled buffers
-     */
-    public long sizeInBytes()
-    {
-        return memoryAllocated.get() + overflowMemoryUsage.longValue();
-    }
-
-    /**
-     * @return buffer size being used, including used pooled buffers and unpooled buffers
-     */
-    public long usedSizeInBytes()
-    {
-        return memoryInUse.longValue() + overflowMemoryUsage.longValue();
-    }
-
-    /**
-     * @return unpooled buffer size being allocated outside of buffer pool.
-     */
-    public long overflowMemoryInBytes()
-    {
-        return overflowMemoryUsage.longValue();
-    }
-
-    /**
-     * @return maximum pooled buffer size in bytes
-     */
-    public long memoryUsageThreshold()
-    {
-        return memoryUsageThreshold;
-    }
-
-    @VisibleForTesting
-    public GlobalPool globalPool()
-    {
-        return globalPool;
-    }
-
-    /**
-     * Forces to recycle free local chunks back to the global pool.
-     * This is needed because if buffers were freed by a different thread than the one
-     * that allocated them, recycling might not have happened and the local pool may still own some
-     * fully empty chunks.
-     */
-    @VisibleForTesting
-    public void releaseLocal()
-    {
-        localPool.get().release();
-    }
-
-    interface Debug
-    {
-        public static Debug NO_OP = new Debug()
-        {
-            @Override
-            public void registerNormal(Chunk chunk) {}
-
-            @Override
-            public void acquire(Chunk chunk) {}
-            @Override
-            public void recycleNormal(Chunk oldVersion, Chunk newVersion) {}
-            @Override
-            public void recyclePartial(Chunk chunk) { }
-        };
-
-        void registerNormal(Chunk chunk);
-        void acquire(Chunk chunk);
-        void recycleNormal(Chunk oldVersion, Chunk newVersion);
-        void recyclePartial(Chunk chunk);
-    }
-
-    public void debug(Debug setDebug)
-    {
-        assert setDebug != null;
-        this.debug = setDebug;
-    }
-
-    interface Recycler
-    {
-        /**
-         * Recycle a fully freed chunk
-         */
-        void recycle(Chunk chunk);
-
-        /**
-         * @return true if chunk can be reused before fully freed.
-         */
-        boolean canRecyclePartially();
-
-        /**
-         * Recycle a partially freed chunk
-         */
-        void recyclePartially(Chunk chunk);
-    }
-
-    /**
-     * A queue of page aligned buffers, the chunks, which have been sliced from bigger chunks,
-     * the macro-chunks, also page aligned. Macro-chunks are allocated as long as we have not exceeded the
-     * memory maximum threshold, MEMORY_USAGE_THRESHOLD and are never released.
+     * Return a new buffer, either freshly allocated or taken from an existing pool.
      *
-     * This class is shared by multiple thread local pools and must be thread-safe.
+     * @param size the buffer size
+     *
+     * @return the buffer
      */
-    final class GlobalPool implements Supplier<Chunk>, Recycler
+    public ByteBuffer allocate(int size)
     {
-        /** The size of a bigger chunk, 1 MiB, must be a multiple of NORMAL_CHUNK_SIZE */
-        static final int MACRO_CHUNK_SIZE = 64 * NORMAL_CHUNK_SIZE;
-        private final String READABLE_MACRO_CHUNK_SIZE = prettyPrintMemory(MACRO_CHUNK_SIZE);
+        if (size < 0)
+            throw new IllegalArgumentException("Size must be >=0: " + size);
 
-        private final Queue<Chunk> macroChunks = new ConcurrentLinkedQueue<>();
-        // TODO (future): it would be preferable to use a CLStack to improve cache occupancy; it would also be preferable to use "CoreLocal" storage
-        // It contains fully free chunks and when it runs out, partially freed chunks will be used.
-        private final Queue<Chunk> chunks = new ConcurrentLinkedQueue<>();
-        // Partially freed chunk which is recirculated whenever chunk has free spaces to
-        // improve buffer utilization when chunk cache is holding a piece of buffer for a long period.
-        // Note: fragmentation still exists, as holes are with different sizes.
-        private final Queue<Chunk> partiallyFreedChunks = new ConcurrentLinkedQueue<>();
+        if (size == 0)
+            return UnsafeByteBufferAccess.EMPTY_BUFFER;
 
-        /** Used in logging statements to lazily build a human-readable current memory usage. */
-        private final Object readableMemoryUsage =
-            new Object() { @Override public String toString() { return prettyPrintMemory(sizeInBytes()); } };
+        ByteBuffer ret = allocate0(size);
 
-        public GlobalPool()
-        {
-            assert Integer.bitCount(NORMAL_CHUNK_SIZE) == 1; // must be a power of 2
-            assert Integer.bitCount(MACRO_CHUNK_SIZE) == 1; // must be a power of 2
-            assert MACRO_CHUNK_SIZE % NORMAL_CHUNK_SIZE == 0; // must be a multiple
-        }
+        if (ret != null)
+            AttachmentMarker.mark(ret, this, leaksDetector);
 
-        /** Return a chunk, the caller will take owership of the parent chunk. */
-        public Chunk get()
-        {
-            Chunk chunk = getInternal();
-            if (chunk != null)
-                debug.acquire(chunk);
-            return chunk;
-        }
-
-        private Chunk getInternal()
-        {
-            Chunk chunk = chunks.poll();
-            if (chunk != null)
-                return chunk;
-
-            chunk = allocateMoreChunks();
-            if (chunk != null)
-                return chunk;
-
-            // another thread may have just allocated last macro chunk, so make one final attempt before returning null
-            chunk = chunks.poll();
-
-            // try to use partially freed chunk if there is no more fully freed chunk.
-            return chunk == null ? partiallyFreedChunks.poll() : chunk;
-        }
-
-        /**
-         * This method might be called by multiple threads and that's fine if we add more
-         * than one chunk at the same time as long as we don't exceed the MEMORY_USAGE_THRESHOLD.
-         */
-        private Chunk allocateMoreChunks()
-        {
-            while (true)
-            {
-                long cur = memoryAllocated.get();
-                if (cur + MACRO_CHUNK_SIZE > memoryUsageThreshold)
-                {
-                    if (memoryUsageThreshold > 0)
-                    {
-                        noSpamLogger.info("Maximum memory usage reached ({}) for {} buffer pool, cannot allocate chunk of {}",
-                                          readableMemoryUsageThreshold, name, READABLE_MACRO_CHUNK_SIZE);
-                    }
-                    return null;
-                }
-                if (memoryAllocated.compareAndSet(cur, cur + MACRO_CHUNK_SIZE))
-                    break;
-            }
-
-            // allocate a large chunk
-            Chunk chunk;
-            try
-            {
-                chunk = new Chunk(null, allocateDirectAligned(MACRO_CHUNK_SIZE));
-            }
-            catch (OutOfMemoryError oom)
-            {
-                noSpamLogger.error("{} buffer pool failed to allocate chunk of {}, current size {} ({}). " +
-                                   "Attempting to continue; buffers will be allocated in on-heap memory which can degrade performance. " +
-                                   "Make sure direct memory size (-XX:MaxDirectMemorySize) is large enough to accommodate off-heap memtables and caches.",
-                                   name, READABLE_MACRO_CHUNK_SIZE, readableMemoryUsage, oom.getClass().getName());
-                return null;
-            }
-
-            chunk.acquire(null);
-            macroChunks.add(chunk);
-
-            final Chunk callerChunk = new Chunk(this, chunk.get(NORMAL_CHUNK_SIZE));
-            debug.registerNormal(callerChunk);
-            for (int i = NORMAL_CHUNK_SIZE; i < MACRO_CHUNK_SIZE; i += NORMAL_CHUNK_SIZE)
-            {
-                Chunk add = new Chunk(this, chunk.get(NORMAL_CHUNK_SIZE));
-                chunks.add(add);
-                debug.registerNormal(add);
-            }
-            return callerChunk;
-        }
-
-        @Override
-        public void recycle(Chunk chunk)
-        {
-            Chunk recycleAs = new Chunk(chunk);
-            debug.recycleNormal(chunk, recycleAs);
-            chunks.add(recycleAs);
-        }
-
-        @Override
-        public void recyclePartially(Chunk chunk)
-        {
-            debug.recyclePartial(chunk);
-            partiallyFreedChunks.add(chunk);
-        }
-
-        @Override
-        public boolean canRecyclePartially()
-        {
-            return recyclePartially;
-        }
-
-        /** This is not thread safe and should only be used for unit testing. */
-        @VisibleForTesting
-        void unsafeFree()
-        {
-            while (!chunks.isEmpty())
-                chunks.poll().unsafeFree();
-
-            while (!partiallyFreedChunks.isEmpty())
-                partiallyFreedChunks.poll().unsafeFree();
-
-            while (!macroChunks.isEmpty())
-                macroChunks.poll().unsafeFree();
-        }
-
-        @VisibleForTesting
-        boolean isPartiallyFreed(Chunk chunk)
-        {
-            return partiallyFreedChunks.contains(chunk);
-        }
-
-        @VisibleForTesting
-        boolean isFullyFreed(Chunk chunk)
-        {
-            return chunks.contains(chunk);
-        }
+        return ret;
     }
 
-    private static class MicroQueueOfChunks
-    {
-
-        // a microqueue of Chunks:
-        //  * if any are null, they are at the end;
-        //  * new Chunks are added to the last null index
-        //  * if no null indexes available, the smallest is swapped with the last index, and this replaced
-        //  * this results in a queue that will typically be visited in ascending order of available space, so that
-        //    small allocations preferentially slice from the Chunks with the smallest space available to furnish them
-        // WARNING: if we ever change the size of this, we must update removeFromLocalQueue, and addChunk
-        private Chunk chunk0, chunk1, chunk2;
-        private int count;
-
-        // add a new chunk, if necessary evicting the chunk with the least available memory (returning the evicted chunk)
-        private Chunk add(Chunk chunk)
-        {
-            switch (count)
-            {
-                case 0:
-                    chunk0 = chunk;
-                    count = 1;
-                    break;
-                case 1:
-                    chunk1 = chunk;
-                    count = 2;
-                    break;
-                case 2:
-                    chunk2 = chunk;
-                    count = 3;
-                    break;
-                case 3:
-                {
-                    Chunk release;
-                    int chunk0Free = chunk0.freeSlotCount();
-                    int chunk1Free = chunk1.freeSlotCount();
-                    int chunk2Free = chunk2.freeSlotCount();
-                    if (chunk0Free < chunk1Free)
-                    {
-                        if (chunk0Free < chunk2Free)
-                        {
-                            release = chunk0;
-                            chunk0 = chunk;
-                        }
-                        else
-                        {
-                            release = chunk2;
-                            chunk2 = chunk;
-                        }
-                    }
-                    else
-                    {
-                        if (chunk1Free < chunk2Free)
-                        {
-                            release = chunk1;
-                            chunk1 = chunk;
-                        }
-                        else
-                        {
-                            release = chunk2;
-                            chunk2 = chunk;
-                        }
-                    }
-                    return release;
-                }
-                default:
-                    throw new IllegalStateException();
-            }
-            return null;
-        }
-
-        private void remove(Chunk chunk)
-        {
-            // since we only have three elements in the queue, it is clearer, easier and faster to just hard code the options
-            if (chunk0 == chunk)
-            {   // remove first by shifting back second two
-                chunk0 = chunk1;
-                chunk1 = chunk2;
-            }
-            else if (chunk1 == chunk)
-            {   // remove second by shifting back last
-                chunk1 = chunk2;
-            }
-            else if (chunk2 != chunk)
-            {
-                return;
-            }
-            // whatever we do, the last element must be null
-            chunk2 = null;
-            --count;
-        }
-
-        ByteBuffer get(int size, boolean sizeIsLowerBound, ByteBuffer reuse)
-        {
-            ByteBuffer buffer;
-            if (null != chunk0)
-            {
-                if (null != (buffer = chunk0.get(size, sizeIsLowerBound, reuse)))
-                    return buffer;
-                if (null != chunk1)
-                {
-                    if (null != (buffer = chunk1.get(size, sizeIsLowerBound, reuse)))
-                        return buffer;
-                    if (null != chunk2 && null != (buffer = chunk2.get(size, sizeIsLowerBound, reuse)))
-                        return buffer;
-                }
-            }
-            return null;
-        }
-
-        private void forEach(Consumer<Chunk> consumer)
-        {
-            forEach(consumer, count, chunk0, chunk1, chunk2);
-        }
-
-        private void clearForEach(Consumer<Chunk> consumer)
-        {
-            int oldCount = count;
-            Chunk chunk0 = this.chunk0, chunk1 = this.chunk1, chunk2 = this.chunk2;
-            count = 0;
-            this.chunk0 = this.chunk1 = this.chunk2 = null;
-            forEach(consumer, oldCount, chunk0, chunk1, chunk2);
-        }
-
-        private static void forEach(Consumer<Chunk> consumer, int count, Chunk chunk0, Chunk chunk1, Chunk chunk2)
-        {
-            switch (count)
-            {
-                case 3:
-                    consumer.accept(chunk2);
-                case 2:
-                    consumer.accept(chunk1);
-                case 1:
-                    consumer.accept(chunk0);
-            }
-        }
-
-        private <T> void removeIf(BiPredicate<Chunk, T> predicate, T value)
-        {
-            // do not release matching chunks before we move null chunks to the back of the queue;
-            // because, with current buffer release from another thread, "chunk#release()" may eventually come back to
-            // "removeIf" causing NPE as null chunks are not at the back of the queue.
-            Chunk toRelease0 = null, toRelease1 = null, toRelease2 = null;
-
-            try
-            {
-                switch (count)
-                {
-                    case 3:
-                        if (predicate.test(chunk2, value))
-                        {
-                            --count;
-                            toRelease2 = chunk2;
-                            chunk2 = null;
-                        }
-                    case 2:
-                        if (predicate.test(chunk1, value))
-                        {
-                            --count;
-                            toRelease1 = chunk1;
-                            chunk1 = null;
-                        }
-                    case 1:
-                        if (predicate.test(chunk0, value))
-                        {
-                            --count;
-                            toRelease0 = chunk0;
-                            chunk0 = null;
-                        }
-                        break;
-                    case 0:
-                        return;
-                }
-                switch (count)
-                {
-                    case 2:
-                        // Find the only null item, and shift non-null so that null is at chunk2
-                        if (chunk0 == null)
-                        {
-                            chunk0 = chunk1;
-                            chunk1 = chunk2;
-                            chunk2 = null;
-                        }
-                        else if (chunk1 == null)
-                        {
-                            chunk1 = chunk2;
-                            chunk2 = null;
-                        }
-                        break;
-                    case 1:
-                        // Find the only non-null item, and shift it to chunk0
-                        if (chunk1 != null)
-                        {
-                            chunk0 = chunk1;
-                            chunk1 = null;
-                        }
-                        else if (chunk2 != null)
-                        {
-                            chunk0 = chunk2;
-                            chunk2 = null;
-                        }
-                        break;
-                }
-            }
-            finally
-            {
-                if (toRelease0 != null)
-                    toRelease0.release();
-
-                if (toRelease1 != null)
-                    toRelease1.release();
-
-                if (toRelease2 != null)
-                    toRelease2.release();
-            }
-        }
-
-        private void release()
-        {
-            clearForEach(Chunk::release);
-        }
-
-        private void unsafeRecycle(boolean forceEvicted)
-        {
-            clearForEach(chunk -> Chunk.unsafeRecycle(chunk, forceEvicted));
-        }
+    public ByteBuffer get(int size, BufferType bufferType) {
+        return allocate(size);
     }
+
+    public ByteBuffer getAtLeast(int size, BufferType bufferType) {
+        return allocate(size);
+    }
+
+    public void put(ByteBuffer buffer) {
+        release(buffer);
+    }
+
+    public void putUnusedPortion(ByteBuffer buffer) {
+        release(buffer);
+    }
+
+    abstract ByteBuffer allocate0(int size);
 
     /**
-     * A thread local class that grabs chunks from the global pool for this thread allocations.
-     * Only one thread can do the allocations but multiple threads can release the allocations.
+     * Return the buffer to the pool, or release its memory if it's not part of the pool.
+     *
+     * @param buffer - the buffer to return
      */
-    public final class LocalPool implements Recycler
+    public void release(ByteBuffer buffer)
     {
-        private final Queue<ByteBuffer> reuseObjects;
-        private final Supplier<Chunk> parent;
-        private final LocalPoolRef leakRef;
+        assert buffer != null : "Buffer should not be null";
+        assert buffer.isDirect() : "Buffer should not be on heap";
 
-        private final MicroQueueOfChunks chunks = new MicroQueueOfChunks();
+        AttachmentMarker marker = AttachmentMarker.unmark(buffer, this);
 
-        private final Thread owningThread = Thread.currentThread();
-
-        /**
-         * If we are on outer LocalPool, whose chunks are == NORMAL_CHUNK_SIZE, we may service allocation requests
-         * for buffers much smaller than
-         */
-        private LocalPool tinyPool;
-        private final int tinyLimit;
-        private boolean recycleWhenFree = true;
-
-        public LocalPool()
+        if (marker == null)
         {
-            this.parent = globalPool;
-            this.tinyLimit = TINY_ALLOCATION_LIMIT;
-            this.reuseObjects = new ArrayDeque<>();
-            localPoolReferences.add(leakRef = new LocalPoolRef(this, localPoolRefQueue));
-        }
-
-        /**
-         * Invoked by an existing LocalPool, to create a child pool
-         */
-        private LocalPool(LocalPool parent)
-        {
-            this.parent = () -> {
-                ByteBuffer buffer = parent.tryGetInternal(TINY_CHUNK_SIZE, false);
-                return buffer == null ? null : new Chunk(parent, buffer);
-            };
-            this.tinyLimit = 0; // we only currently permit one layer of nesting (which brings us down to 32 byte allocations, so is plenty)
-            this.reuseObjects = parent.reuseObjects; // we share the same ByteBuffer object reuse pool, as we both have the same exclusive access to it
-            localPoolReferences.add(leakRef = new LocalPoolRef(this, localPoolRefQueue));
-        }
-
-        private LocalPool tinyPool()
-        {
-            if (tinyPool == null)
-                tinyPool = new LocalPool(this).recycleWhenFree(recycleWhenFree);
-            return tinyPool;
-        }
-
-        public void put(ByteBuffer buffer)
-        {
-            Chunk chunk = Chunk.getParentChunk(buffer);
-            int size = buffer.capacity();
-
-            if (chunk == null)
-            {
+            // Not our buffer
+            if (buffer != UnsafeByteBufferAccess.EMPTY_BUFFER)
                 FileUtils.clean(buffer);
-                updateOverflowMemoryUsage(-size);
-            }
-            else
-            {
-                put(buffer, chunk);
-                memoryInUse.add(-size);
-            }
-        }
-
-        private void put(ByteBuffer buffer, Chunk chunk)
-        {
-            LocalPool owner = chunk.owner;
-            if (owner != null && owner == tinyPool)
-            {
-                tinyPool.put(buffer, chunk);
-                return;
-            }
-
-            long free = chunk.free(buffer);
-
-            if (free == -1L && owner == this && owningThread == Thread.currentThread() && recycleWhenFree)
-            {
-                // The chunk was fully freed, and we're the owner - let's release the chunk from this pool
-                // and give it back to the parent.
-                //
-                // We can remove the chunk from our local queue only if we're the owner of the chunk,
-                // and we're running this code on the thread that owns this local pool
-                // because the local queue is not thread safe.
-                //
-                // Please note that we may end up running `put` on a different thread when we're called
-                // from chunk.tryRecycle() on a child chunk which was previously owned by tinyPool of this pool.
-                // Such tiny chunk will point to this pool with its recycler reference. Thanks to the recycler, a thread
-                // that returns the tiny chunk can end up here in a LocalPool that's not neccessarily local to the
-                // calling thread, as there is no guarantee a child chunk is returned to the pool
-                // by the same thread that originally allocated it.
-                // It is ok we skip recycling in such case, and it does not cause
-                // a leak because those chunks are still referenced by the local pool.
-                remove(chunk);
-                chunk.release();
-            }
-            else if (chunk.owner == null)
-            {
-                // The chunk has no owner, so we can attempt to recycle it from any thread because we don't need
-                // to remove it from the local pool.
-                // For normal chunk this would recycle the chunk fully or partially if not already recycled.
-                // For tiny chunk, this would recycle the tiny chunk back to the parent chunk,
-                // if this chunk is completely free.
-                chunk.tryRecycle();
-            }
-
-            if (owner == this && owningThread == Thread.currentThread())
-            {
-                MemoryUtil.setAttachment(buffer, null);
-                MemoryUtil.setDirectByteBuffer(buffer, 0, 0);
-                reuseObjects.add(buffer);
-            }
-        }
-
-        public void putUnusedPortion(ByteBuffer buffer)
-        {
-            Chunk chunk = Chunk.getParentChunk(buffer);
-            int originalCapacity = buffer.capacity();
-            int size = originalCapacity - buffer.limit();
-
-            if (chunk == null)
-            {
-                updateOverflowMemoryUsage(-size);
-                return;
-            }
-
-            chunk.freeUnusedPortion(buffer);
-            // Calculate the actual freed bytes which may be different from `size` when pooling is involved
-            memoryInUse.add(buffer.capacity() - originalCapacity);
-        }
-
-        public ByteBuffer get(int size)
-        {
-            return get(size, false);
-        }
-
-        public ByteBuffer getAtLeast(int size)
-        {
-            return get(size, true);
-        }
-
-        private ByteBuffer get(int size, boolean sizeIsLowerBound)
-        {
-            ByteBuffer ret = tryGet(size, sizeIsLowerBound);
-            if (ret != null)
-                return ret;
-
-            if (size > NORMAL_CHUNK_SIZE)
-            {
-                if (logger.isTraceEnabled())
-                    logger.trace("Requested buffer size {} is bigger than {}; allocating directly",
-                                 prettyPrintMemory(size),
-                                 prettyPrintMemory(NORMAL_CHUNK_SIZE));
-            }
-            else
-            {
-                if (logger.isTraceEnabled())
-                    logger.trace("Requested buffer size {} has been allocated directly due to lack of capacity", prettyPrintMemory(size));
-            }
-
-            return allocate(size, BufferType.OFF_HEAP);
-        }
-
-        private ByteBuffer tryGet(int size, boolean sizeIsLowerBound)
-        {
-            LocalPool pool = this;
-            if (size <= tinyLimit)
-            {
-                if (size <= 0)
-                {
-                    if (size == 0)
-                        return EMPTY_BUFFER;
-                    throw new IllegalArgumentException("Size must be non-negative (" + size + ')');
-                }
-
-                pool = tinyPool();
-            }
-            else if (size > NORMAL_CHUNK_SIZE)
-            {
-                metrics.markMissed();
-                return null;
-            }
-
-            ByteBuffer ret = pool.tryGetInternal(size, sizeIsLowerBound);
-            if (ret != null)
-            {
-                metrics.markHit();
-                memoryInUse.add(ret.capacity());
-            }
-            else
-            {
-                metrics.markMissed();
-            }
-            return ret;
-        }
-
-        @Inline
-        private ByteBuffer tryGetInternal(int size, boolean sizeIsLowerBound)
-        {
-            ByteBuffer reuse = this.reuseObjects.poll();
-            ByteBuffer buffer = chunks.get(size, sizeIsLowerBound, reuse);
-            if (buffer != null)
-            {
-                return buffer;
-            }
-
-            // else ask the global pool
-            Chunk chunk = addChunkFromParent();
-            if (chunk != null)
-            {
-                ByteBuffer result = chunk.get(size, sizeIsLowerBound, reuse);
-                if (result != null)
-                    return result;
-            }
-
-            if (reuse != null)
-                this.reuseObjects.add(reuse);
-            return null;
-        }
-
-        // recycle entire tiny chunk from tiny pool back to local pool
-        @Override
-        public void recycle(Chunk chunk)
-        {
-            ByteBuffer buffer = chunk.slab;
-            Chunk parentChunk = Chunk.getParentChunk(buffer);
-            assert parentChunk != null;  // tiny chunk always has a parent chunk
-            put(buffer, parentChunk);
-        }
-
-        @Override
-        public void recyclePartially(Chunk chunk)
-        {
-            throw new UnsupportedOperationException("Tiny chunk doesn't support partial recycle.");
-        }
-
-        @Override
-        public boolean canRecyclePartially()
-        {
-            // tiny pool doesn't support partial recycle, as we want to have tiny chunk fully freed and put back to
-            // parent normal chunk.
-            return false;
-        }
-
-        private void remove(Chunk chunk)
-        {
-            chunks.remove(chunk);
-            if (tinyPool != null)
-                tinyPool.chunks.removeIf((child, parent) -> Chunk.getParentChunk(child.slab) == parent, chunk);
-        }
-
-        private Chunk addChunkFromParent()
-        {
-            Chunk chunk = parent.get();
-            if (chunk == null)
-                return null;
-
-            addChunk(chunk);
-            return chunk;
-        }
-
-        private void addChunk(Chunk chunk)
-        {
-            chunk.acquire(this);
-            Chunk evict = chunks.add(chunk);
-            if (evict != null)
-            {
-                if (tinyPool != null)
-                    // releasing tiny chunks may result in releasing current evicted chunk
-                    tinyPool.chunks.removeIf((child, parent) -> Chunk.getParentChunk(child.slab) == parent, evict);
-                evict.release();
-            }
-        }
-
-        public void release()
-        {
-            if (tinyPool != null)
-                tinyPool.release();
-
-            chunks.release();
-            reuseObjects.clear();
-            localPoolReferences.remove(leakRef);
-            leakRef.clear();
-        }
-
-        @VisibleForTesting
-        void unsafeRecycle(boolean forceEvicted)
-        {
-            chunks.unsafeRecycle(forceEvicted);
-        }
-
-        @VisibleForTesting
-        public boolean isTinyPool()
-        {
-            return !(parent instanceof GlobalPool);
-        }
-
-        public LocalPool recycleWhenFree(boolean recycleWhenFree)
-        {
-            this.recycleWhenFree = recycleWhenFree;
-            if (tinyPool != null)
-                tinyPool.recycleWhenFree = recycleWhenFree;
-            return this;
-        }
-    }
-
-    private static final class LocalPoolRef extends PhantomReference<LocalPool>
-    {
-        private final MicroQueueOfChunks chunks;
-        public LocalPoolRef(LocalPool localPool, ReferenceQueue<? super LocalPool> q)
-        {
-            super(localPool, q);
-            chunks = localPool.chunks;
-        }
-
-        public void release()
-        {
-            chunks.release();
-        }
-    }
-
-    private void cleanupOneReference() throws InterruptedException
-    {
-        Object obj = localPoolRefQueue.remove(100);
-        if (obj instanceof LocalPoolRef)
-        {
-            ((LocalPoolRef) obj).release();
-            localPoolReferences.remove(obj);
-        }
-    }
-
-    private static ByteBuffer allocateDirectAligned(int capacity)
-    {
-        int align = MemoryUtil.pageSize();
-        if (Integer.bitCount(align) != 1)
-            throw new IllegalArgumentException("Alignment must be a power of 2");
-
-        ByteBuffer buffer = ByteBuffer.allocateDirect(capacity + align);
-        long address = MemoryUtil.getAddress(buffer);
-        long offset = address & (align -1); // (address % align)
-
-        if (offset == 0)
-        { // already aligned
-            buffer.limit(capacity);
         }
         else
-        { // shift by offset
-            int pos = (int)(align - offset);
-            buffer.position(pos);
-            buffer.limit(pos + capacity);
+        {
+            release0(buffer, marker);
         }
-
-        return buffer.slice();
     }
 
     /**
-     * A memory chunk: it takes a buffer (the slab) and slices it
-     * into smaller buffers when requested.
+     * Release the buffer or return it to the pool.
      *
-     * It divides the slab into 64 units and keeps a long mask, freeSlots,
-     * indicating if a unit is in use or not. Each bit in freeSlots corresponds
-     * to a unit, if the bit is set then the unit is free (available for allocation)
-     * whilst if it is not set then the unit is in use.
-     *
-     * When we receive a request of a given size we round up the size to the nearest
-     * multiple of allocation units required. Then we search for n consecutive free units,
-     * where n is the number of units required. We also align to page boundaries.
-     *
-     * When we reiceve a release request we work out the position by comparing the buffer
-     * address to our base address and we simply release the units.
+     * @param buffer the buffer
      */
-    final static class Chunk
+    abstract void release0(ByteBuffer buffer, AttachmentMarker marker);
+
+    /**
+     * Bulk allocate multiple memory regions.
+     *
+     * @param size The size of each individual memory region
+     * @param numAddresses the number of memory regions to allocateion
+     *
+     * @return an array containing the addresses of the memory regions allocated
+     */
+    public long[] allocate(int size, int numAddresses)
     {
-        enum Status
-        {
-            /** The slab is serving or ready to serve requests */
-            IN_USE,
-            /** The slab is not serving requests and ready for partial recycle*/
-            EVICTED;
-        }
-
-        private final ByteBuffer slab;
-        final long baseAddress;
-        private final int shift;
-
-        // it may be 0L when all slots are allocated after "get" or when all slots are freed after "free"
-        private volatile long freeSlots;
-        private static final AtomicLongFieldUpdater<Chunk> freeSlotsUpdater = AtomicLongFieldUpdater.newUpdater(Chunk.class, "freeSlots");
-
-        // the pool that is _currently allocating_ from this Chunk
-        // if this is set, it means the chunk may not be recycled because we may still allocate from it;
-        // if it has been unset the local pool has finished with it, and it may be recycled
-        private volatile LocalPool owner;
-        private final Recycler recycler;
-
-        private static final AtomicReferenceFieldUpdater<Chunk, Status> statusUpdater =
-                AtomicReferenceFieldUpdater.newUpdater(Chunk.class, Status.class, "status");
-        private volatile Status status = Status.IN_USE;
-
-        @VisibleForTesting
-        Object debugAttachment;
-
-        Chunk(Chunk recycle)
-        {
-            assert recycle.freeSlots == 0L;
-            this.slab = recycle.slab;
-            this.baseAddress = recycle.baseAddress;
-            this.shift = recycle.shift;
-            this.freeSlots = -1L;
-            this.recycler = recycle.recycler;
-        }
-
-        Chunk(Recycler recycler, ByteBuffer slab)
-        {
-            assert MemoryUtil.isExactlyDirect(slab);
-            this.recycler = recycler;
-            this.slab = slab;
-            this.baseAddress = MemoryUtil.getAddress(slab);
-
-            // The number of bits by which we need to shift to obtain a unit
-            // "31 &" is because numberOfTrailingZeros returns 32 when the capacity is zero
-            this.shift = 31 & (Integer.numberOfTrailingZeros(slab.capacity() / 64));
-            // -1 means all free whilst 0 means all in use
-            this.freeSlots = slab.capacity() == 0 ? 0L : -1L;
-        }
-
-        /**
-         * Acquire the chunk for future allocations: set the owner
-         */
-        void acquire(LocalPool owner)
-        {
-            assert this.owner == null;
-            this.owner = owner;
-        }
-
-        /**
-         * Set the owner to null and return the chunk to the global pool if the chunk is fully free.
-         * This method must be called by the LocalPool when it is certain that
-         * the local pool shall never try to allocate any more buffers from this chunk.
-         */
-        void release()
-        {
-            this.owner = null;
-            boolean statusUpdated = setEvicted();
-            assert statusUpdated : "Status of chunk " + this + " was not IN_USE.";
-            tryRecycle();
-        }
-
-        /**
-         * If the chunk is free, changes the chunk's status to IN_USE and returns the chunk to the pool
-         * that it was acquired from.
-         *
-         * Can recycle the chunk partially if the recycler supports it.
-         * This method can be called from multiple threads safely.
-         *
-         * Calling this method on a chunk that's currently in use (either owned by a LocalPool or already recycled)
-         * has no effect.
-         */
-        void tryRecycle()
-        {
-            // Note that this may race with release(), therefore the order of those checks does matter.
-            // The EVICTED check may fail if the chunk was already partially recycled.
-            if (status != Status.EVICTED)
-                return;
-            if (owner != null)
-                return;
-
-            // We must use consistently either tryRecycleFully or tryRecycleFullyOrPartially,
-            // but we must not mix those for a single chunk, because they use a different mechanism for guarding
-            // that the chunk would be recycled at most once until the next acquire.
-            //
-            // If the recycler cannot recycle blocks partially, we have to make sure freeSlots was zeroed properly.
-            // Only one thread can transition freeSlots from -1 to 0 atomically, so this is a good way
-            // of ensuring only one thread recycles the block. In this case the chunk's status is
-            // updated only after freeSlots CAS succeeds.
-            //
-            // If the recycler can recycle blocks partially, we use the status field
-            // to guard at-most-once recycling. We cannot rely on atomically updating freeSlots from -1 to 0, because
-            // in this case we cannot expect freeSlots to be -1 (if it was, it wouldn't be partial).
-            if (recycler.canRecyclePartially())
-                tryRecycleFullyOrPartially();
-            else
-                tryRecycleFully();
-        }
-
-        /**
-         * Returns this chunk to the pool where it was acquired from, if it wasn't returned already.
-         * The chunk does not have to be totally free, but should have some free bits.
-         * However, if the chunk is fully free, it is released fully, not partially.
-         */
-        private void tryRecycleFullyOrPartially()
-        {
-            assert recycler.canRecyclePartially();
-            if (free() > 0 && setInUse())
-            {
-                assert owner == null;
-                if (!tryRecycleFully())   // prefer to recycle fully, as fully free chunks are returned to a higher priority queue
-                    recyclePartially();
-            }
-        }
-
-        private boolean tryRecycleFully()
-        {
-            if (!isFree() || !freeSlotsUpdater.compareAndSet(this, -1L, 0L))
-                return false;
-
-            recycleFully();
-            return true;
-        }
-
-        private void recyclePartially()
-        {
-            assert owner == null;
-            assert status == Status.IN_USE;
-
-            recycler.recyclePartially(this);
-        }
-
-        private void recycleFully()
-        {
-            assert owner == null;
-            assert freeSlots == 0L;
-
-            Status expectedStatus = recycler.canRecyclePartially() ? Status.IN_USE : Status.EVICTED;
-            boolean statusUpdated = setStatus(expectedStatus, Status.IN_USE);
-            // impossible: could only happen if another thread updated the status in the meantime
-            assert statusUpdated : "Status of chunk " + this + " was not " + expectedStatus;
-
-            recycler.recycle(this);
-        }
-
-        /**
-         * We stash the chunk in the attachment of a buffer
-         * that was returned by get(), this method simply
-         * retrives the chunk that sliced a buffer, if any.
-         */
-        static Chunk getParentChunk(ByteBuffer buffer)
-        {
-            Object attachment = MemoryUtil.getAttachment(buffer);
-
-            if (attachment instanceof Chunk)
-                return (Chunk) attachment;
-
-            if (attachment instanceof Ref)
-                return ((Ref<Chunk>) attachment).get();
-
-            return null;
-        }
-
-        void setAttachment(ByteBuffer buffer)
-        {
-            if (Ref.DEBUG_ENABLED)
-                MemoryUtil.setAttachment(buffer, new Ref<>(this, null));
-            else
-                MemoryUtil.setAttachment(buffer, this);
-        }
-
-        boolean releaseAttachment(ByteBuffer buffer)
-        {
-            Object attachment = MemoryUtil.getAttachment(buffer);
-            if (attachment == null)
-                return false;
-
-            if (Ref.DEBUG_ENABLED)
-                ((Ref<Chunk>) attachment).release();
-
-            return true;
-        }
-
-        @VisibleForTesting
-        long setFreeSlots(long val)
-        {
-            long ret = freeSlots;
-            freeSlots = val;
-            return ret;
-        }
-
-        int capacity()
-        {
-            return 64 << shift;
-        }
-
-        final int unit()
-        {
-            return 1 << shift;
-        }
-
-        final boolean isFree()
-        {
-            return freeSlots == -1L;
-        }
-
-        /** The total free size */
-        int free()
-        {
-            return Long.bitCount(freeSlots) * unit();
-        }
-
-        int freeSlotCount()
-        {
-            return Long.bitCount(freeSlots);
-        }
-
-        ByteBuffer get(int size)
-        {
-            return get(size, false, null);
-        }
-
-        /**
-         * Return the next available slice of this size. If
-         * we have exceeded the capacity we return null.
-         */
-        ByteBuffer get(int size, boolean sizeIsLowerBound, ByteBuffer into)
-        {
-            // how many multiples of our units is the size?
-            // we add (unit - 1), so that when we divide by unit (>>> shift), we effectively round up
-            int slotCount = (size - 1 + unit()) >>> shift;
-            if (sizeIsLowerBound)
-                size = slotCount << shift;
-
-            // if we require more than 64 slots, we cannot possibly accommodate the allocation
-            if (slotCount > 64)
-                return null;
-
-            // convert the slotCount into the bits needed in the bitmap, but at the bottom of the register
-            long slotBits = -1L >>> (64 - slotCount);
-
-            // in order that we always allocate page aligned results, we require that any allocation is "somewhat" aligned
-            // i.e. any single unit allocation can go anywhere; any 2 unit allocation must begin in one of the first 3 slots
-            // of a page; a 3 unit must go in the first two slots; and any four unit allocation must be fully page-aligned
-
-            // to achieve this, we construct a searchMask that constrains the bits we find to those we permit starting
-            // a match from. as we find bits, we remove them from the mask to continue our search.
-            // this has an odd property when it comes to concurrent alloc/free, as we can safely skip backwards if
-            // a new slot is freed up, but we always make forward progress (i.e. never check the same bits twice),
-            // so running time is bounded
-            long searchMask = 0x1111111111111111L;
-            searchMask *= 15L >>> ((slotCount - 1) & 3);
-            // i.e. switch (slotCount & 3)
-            // case 1: searchMask = 0xFFFFFFFFFFFFFFFFL
-            // case 2: searchMask = 0x7777777777777777L
-            // case 3: searchMask = 0x3333333333333333L
-            // case 0: searchMask = 0x1111111111111111L
-
-            // truncate the mask, removing bits that have too few slots proceeding them
-            searchMask &= -1L >>> (slotCount - 1);
-
-            // this loop is very unroll friendly, and would achieve high ILP, but not clear if the compiler will exploit this.
-            // right now, not worth manually exploiting, but worth noting for future
-            while (true)
-            {
-                long cur = freeSlots;
-                // find the index of the lowest set bit that also occurs in our mask (i.e. is permitted alignment, and not yet searched)
-                // we take the index, rather than finding the lowest bit, since we must obtain it anyway, and shifting is more efficient
-                // than multiplication
-                int index = Long.numberOfTrailingZeros(cur & searchMask);
-
-                // if no bit was actually found, we cannot serve this request, so return null.
-                // due to truncating the searchMask this immediately terminates any search when we run out of indexes
-                // that could accommodate the allocation, i.e. is equivalent to checking (64 - index) < slotCount
-                if (index == 64)
-                    return null;
-
-                // remove this bit from our searchMask, so we don't return here next round
-                searchMask ^= 1L << index;
-                // if our bits occur starting at the index, remove ourselves from the bitmask and return
-                long candidate = slotBits << index;
-                if ((candidate & cur) == candidate)
-                {
-                    // here we are sure we will manage to CAS successfully without changing candidate because
-                    // there is only one thread allocating at the moment, the concurrency is with the release
-                    // operations only
-                    while (true)
-                    {
-                        // clear the candidate bits (freeSlots &= ~candidate)
-                        if (freeSlotsUpdater.compareAndSet(this, cur, cur & ~candidate))
-                            break;
-
-                        cur = freeSlots;
-                        // make sure no other thread has cleared the candidate bits
-                        assert ((candidate & cur) == candidate);
-                    }
-                    return set(index << shift, size, into);
-                }
-            }
-        }
-
-        private ByteBuffer set(int offset, int size, ByteBuffer into)
-        {
-            if (into == null)
-                into = MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
-            MemoryUtil.sliceDirectByteBuffer(slab, into, offset, size);
-            setAttachment(into);
-            return into;
-        }
-
-        /**
-         * Round the size to the next unit multiple.
-         */
-        int roundUp(int v)
-        {
-            return BufferPool.roundUp(v, unit());
-        }
-
-        /**
-         * Release a buffer. Return:
-         *   -1L if it is free (and so we should tryRecycle if owner is now null)
-         *    some other value otherwise
-         **/
-        long free(ByteBuffer buffer)
-        {
-            if (!releaseAttachment(buffer))
-                return 1L;
-
-            int size = roundUp(buffer.capacity());
-            long address = MemoryUtil.getAddress(buffer);
-            assert (address >= baseAddress) & (address + size <= baseAddress + capacity());
-
-            int position = ((int)(address - baseAddress)) >> shift;
-
-            int slotCount = size >> shift;
-            long slotBits = 0xffffffffffffffffL >>> (64 - slotCount);
-            long shiftedSlotBits = (slotBits << position);
-
-            long next;
-            while (true)
-            {
-                long cur = freeSlots;
-                next = cur | shiftedSlotBits;
-                assert next == (cur ^ shiftedSlotBits); // ensure no double free
-                if (freeSlotsUpdater.compareAndSet(this, cur, next))
-                    return next;
-            }
-        }
-
-        void freeUnusedPortion(ByteBuffer buffer)
-        {
-            int size = roundUp(buffer.limit());
-            int capacity = roundUp(buffer.capacity());
-            if (size == capacity)
-                return;
-
-            long address = MemoryUtil.getAddress(buffer);
-            assert (address >= baseAddress) & (address + size <= baseAddress + capacity());
-
-            // free any spare slots above the size we are using
-            int position = ((int)(address + size - baseAddress)) >> shift;
-            int slotCount = (capacity - size) >> shift;
-
-            long slotBits = 0xffffffffffffffffL >>> (64 - slotCount);
-            long shiftedSlotBits = (slotBits << position);
-
-            long next;
-            while (true)
-            {
-                long cur = freeSlots;
-                next = cur | shiftedSlotBits;
-                assert next == (cur ^ shiftedSlotBits); // ensure no double free
-                if (freeSlotsUpdater.compareAndSet(this, cur, next))
-                    break;
-            }
-            MemoryUtil.setByteBufferCapacity(buffer, size);
-        }
-
-        @Override
-        public String toString()
-        {
-            return String.format("[slab %s, slots bitmap %s, capacity %d, free %d, owner %s, recycler %s]", slab, Long.toBinaryString(freeSlots), capacity(), free(), owner, recycler);
-        }
-
-        @VisibleForTesting
-        public LocalPool owner()
-        {
-            return this.owner;
-        }
-
-        @VisibleForTesting
-        void unsafeFree()
-        {
-            Chunk parent = getParentChunk(slab);
-            if (parent != null)
-                parent.free(slab);
-            else
-                FileUtils.cleanWithAttachment(slab);
-        }
-
-        static void unsafeRecycle(Chunk chunk, boolean forceRecycle)
-        {
-            if (chunk != null)
-            {
-                chunk.owner = null;
-                chunk.freeSlots = 0L;
-                if (forceRecycle && !chunk.recycler.canRecyclePartially())
-                    chunk.setEvicted();
-                chunk.recycleFully();
-            }
-        }
-
-        Status status()
-        {
-            return status;
-        }
-
-        private boolean setStatus(Status current, Status update)
-        {
-            return statusUpdater.compareAndSet(this, current, update);
-        }
-
-        private boolean setInUse()
-        {
-            return setStatus(Status.EVICTED, Status.IN_USE);
-        }
-
-        private boolean setEvicted()
-        {
-            return setStatus(Status.IN_USE, Status.EVICTED);
-        }
+        throw new IllegalStateException("This buffer pool does not support this functionality");
     }
 
-    @VisibleForTesting
-    public static int roundUp(int size)
+    /**
+     * Bulk release multiple addresses, only {@link PermanentBufferPool} implements this.
+     *
+     * @param size The size of each individual memory region
+     * @param addresses The memory addresses to be released.
+     */
+    public void release(int size, long[] addresses)
     {
-        if (size <= TINY_ALLOCATION_LIMIT)
-            return roundUp(size, TINY_ALLOCATION_UNIT);
-        return roundUp(size, NORMAL_ALLOCATION_UNIT);
+        throw new IllegalStateException("This buffer pool does not support this functionality");
     }
 
+    /**
+     * Forces a cleanup operation. This is only visible for testing, since there is a private periodic
+     * task that runs cleanup. Cleanup must be performed only by a single thread at a time.
+     */
     @VisibleForTesting
-    public static int roundUp(int size, int unit)
-    {
-        int mask = unit - 1;
-        return (size + mask) & ~mask;
-    }
+    public abstract void cleanup();
 
-    @VisibleForTesting
-    public void shutdownLocalCleaner(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException
-    {
-        shutdownNow(of(localPoolCleaner));
-        awaitTermination(timeout, unit, of(localPoolCleaner));
-    }
-
-    @VisibleForTesting
+    /**
+     * @return the metrics for this buffer pool
+     */
     public BufferPoolMetrics metrics()
     {
         return metrics;
     }
 
-    /** This is not thread safe and should only be used for unit testing. */
-    @VisibleForTesting
-    public void unsafeReset()
+    /**
+     * @return the maximum memory that this buffer pool can allocate permanently.
+     */
+    public long maxPoolSize()
     {
-        unsafeReset(false);
-    }
-    @VisibleForTesting
-    public void unsafeReset(boolean forceEvicted)
-    {
-        overflowMemoryUsage.reset();
-        memoryInUse.reset();
-        memoryAllocated.set(0);
-        localPool.get().unsafeRecycle(forceEvicted);
-        globalPool.unsafeFree();
+        return maxPoolSize;
     }
 
-    @VisibleForTesting
-    Chunk unsafeCurrentChunk()
-    {
-        return localPool.get().chunks.chunk0;
-    }
 
-    @VisibleForTesting
-    int unsafeNumChunks()
-    {
-        LocalPool pool = localPool.get();
-        return   (pool.chunks.chunk0 != null ? 1 : 0)
-                 + (pool.chunks.chunk1 != null ? 1 : 0)
-                 + (pool.chunks.chunk2 != null ? 1 : 0);
-    }
 }

--- a/src/java/org/apache/cassandra/utils/memory/BufferPoolDisabled.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPoolDisabled.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.concurrent.LongAdder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A buffer pool that does no pooling at all, it simply allocates directly.
+ */
+class BufferPoolDisabled extends BufferPool
+{
+    private static final Logger logger = LoggerFactory.getLogger(BufferPoolDisabled.class);
+
+    private final LongAdder memory;
+
+    BufferPoolDisabled(String name, long maxPoolSize)
+    {
+        super(name, maxPoolSize);
+        this.memory = new LongAdder();
+
+        logger.info("{} pool is disabled", name);
+    }
+
+    /**
+     * Return a buffer of the specified size by allocating it directly using {@link BufferType#OFF_HEAP_ALIGNED}.
+     * <p/>
+     * The buffer will always be off heap and page aligned, even when it is very small, which could be wasteful.
+     * <p/>
+     * @param size  - the size of the buffer to return
+     *
+     * @return a buffer of the specified size either taken from the pool or allocated directly
+     */
+    @Override
+    public ByteBuffer allocate0(int size)
+    {
+        memory.add(size);
+        //metrics.overflowAllocs.mark();
+        return BufferType.OFF_HEAP_ALIGNED.allocate(size);
+    }
+
+    /**
+     * Release the memory allocated for this buffer.
+     *
+     * @param buffer - the buffer to release
+     */
+    @Override
+    public void release0(ByteBuffer buffer, AttachmentMarker marker)
+    {
+        memory.add(-buffer.capacity());  // this may be wrong if the buffer was not allocated with this pool
+        FileUtils.clean(buffer);
+    }
+
+    @Override
+    public void cleanup()
+    {
+    }
+
+    /**
+     * @return The total memory currently used by clients.
+     */
+    @Override
+    public long usedMemoryBytes()
+    {
+        return memory.longValue();
+    }
+
+    /**
+     * @return The total memory currently allocated by the pool.
+     */
+    @Override
+    public long allocatedMemoryBytes()
+    {
+        return usedMemoryBytes();
+    }
+
+    /**
+     * @return The total memory allocated for buffers that are not in the pool.
+     */
+    @Override
+    public long overflowMemoryBytes()
+    {
+        return usedMemoryBytes();
+    }
+
+    /**
+     * @return the number of allocations performed directly
+     */
+    public double missedAllocationsMeanRate()
+    {
+        return -1;
+    }
+
+    /**
+     * @return the detailed status of the buffer pool
+     */
+    public String status()
+    {
+        return "Buffer pool disabled";
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/BufferPoolMXBean.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPoolMXBean.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+public interface BufferPoolMXBean
+{
+    /**
+     * The name of the buffer pool used by the file cache, see {@link org.apache.cassandra.cache.ChunkCache}.
+     */
+    String CACHED_FILE_READS_MBEAN_NAME = "org.apache.cassandra.utils.memory.buffer:type=BufferPool,name=CachedFileReads";
+
+    /**
+     * The name of the buffer pool used by direct reads, such as for streaming, hints,  or when the chunk cache is disabled.
+     */
+    String DIRECT_FILE_READS_MBEAN_NAME = "org.apache.cassandra.utils.memory.buffer:type=BufferPool,name=DirectFileReads";
+
+    /**
+     * @return The total memory currently used by clients.
+    */
+    long usedMemoryBytes();
+
+    /**
+     * @return The total memory currently allocated by the pool.
+     */
+    long allocatedMemoryBytes();
+
+    /**
+     * @return The total memory allocated for buffers that are not in the pool.
+     */
+    long overflowMemoryBytes();
+
+    /**
+     * @return the mean rate of allocations performed directly
+     */
+    double missedAllocationsMeanRate();
+
+    /**
+     * @return the detailed status of the buffer pool
+     */
+    String status();
+}

--- a/src/java/org/apache/cassandra/utils/memory/BufferPools.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPools.java
@@ -25,8 +25,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.utils.PageAware;
+import org.xerial.snappy.buffer.BufferAllocatorFactory;
 
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
+import static org.apache.cassandra.utils.memory.BufferPool.MAX_DIRECT_READS_BUFFER_SIZE;
+import static org.apache.cassandra.utils.memory.BufferPool.THREAD_LOCAL_SLAB_SIZE;
 
 public class BufferPools
 {
@@ -36,21 +40,41 @@ public class BufferPools
      * Used by chunk cache to store decompressed data and buffers may be held by chunk cache for arbitrary period.
      */
     private static final long FILE_MEMORY_USAGE_THRESHOLD = DatabaseDescriptor.getFileCacheSizeInMB() * 1024L * 1024L;
-    private static final BufferPool CHUNK_CACHE_POOL = new BufferPool("chunk-cache", FILE_MEMORY_USAGE_THRESHOLD, true);
 
     /**
      * Used by client-server or inter-node requests, buffers should be released immediately after use.
      */
     private static final long NETWORKING_MEMORY_USAGE_THRESHOLD = DatabaseDescriptor.getNetworkingCacheSizeInMB() * 1024L * 1024L;
-    private static final BufferPool NETWORKING_POOL = new BufferPool("networking", NETWORKING_MEMORY_USAGE_THRESHOLD, false);
+
+
+    /**
+     * The buffer pool instance used by the chunk cache. It's created with a maximum pool size of
+     * {@link DatabaseDescriptor#getFileCacheSizeInMB()} Mib.
+     */
+    private final static BufferPool CHUNK_CACHE_POOL = createPermanent("CachedReadsBufferPool",
+                                                                       BufferPoolMXBean.CACHED_FILE_READS_MBEAN_NAME,
+                                                                       PageAware.PAGE_SIZE, // file cache only uses PAGE_SIZE buffer sizes
+                                                                       PageAware.PAGE_SIZE,
+                                                                       FILE_MEMORY_USAGE_THRESHOLD);
+
+    /**
+     * The buffer pool instance used for direct reads. It's created with a maximum pool size of
+     * {@link DatabaseDescriptor#getNetworkingCacheSizeInMB()} and it can be used for reading hints, streaming checksummed
+     * files or by the chunk readers when the cache is disabled.
+     */
+    private final static BufferPool NETWORKING_POOL = createTemporary("DirectReadsBufferPool",
+                                                                      BufferPoolMXBean.DIRECT_FILE_READS_MBEAN_NAME,
+                                                                      THREAD_LOCAL_SLAB_SIZE,
+                                                                      MAX_DIRECT_READS_BUFFER_SIZE * 2,
+                                                                      NETWORKING_MEMORY_USAGE_THRESHOLD);
 
     static
     {
         logger.info("Global buffer pool limit is {} for {} and {} for {}",
                     prettyPrintMemory(FILE_MEMORY_USAGE_THRESHOLD),
-                    CHUNK_CACHE_POOL.name,
+                    BufferPoolMXBean.CACHED_FILE_READS_MBEAN_NAME,
                     prettyPrintMemory(NETWORKING_MEMORY_USAGE_THRESHOLD),
-                    NETWORKING_POOL.name);
+                    BufferPoolMXBean.DIRECT_FILE_READS_MBEAN_NAME);
 
         CHUNK_CACHE_POOL.metrics().register3xAlias();
     }
@@ -72,8 +96,44 @@ public class BufferPools
 
     public static void shutdownLocalCleaner(long timeout, TimeUnit unit) throws TimeoutException, InterruptedException
     {
-        CHUNK_CACHE_POOL.shutdownLocalCleaner(timeout, unit);
-        NETWORKING_POOL.shutdownLocalCleaner(timeout, unit);
+
+    }
+
+
+    /**
+     * Create a buffer pool suitable for potentially long-lived buffers, such as those stored in a cache.
+     *
+     * @param name the name of the pool, for the metrics
+     * @param mbeanName the mbean name, for nodetool bufferpool status
+     * @param minBufferSize the minimum buffer size, below this buffer sizes are rounded up
+     * @param maxBufferSize the maximum buffer size, beyond this direct allocations are performed
+     * @param maxPoolSize the maximum size of the pool, memory below this value is not released but kept for later
+     *
+     * @return the buffer pool just created
+     */
+    public static BufferPool createPermanent(String name, String mbeanName, int minBufferSize, int maxBufferSize, long maxPoolSize)
+    {
+        BufferPool ret = BufferPool.DISABLED ? new BufferPoolDisabled(name, maxPoolSize) : new PermanentBufferPool(name, minBufferSize, maxBufferSize, maxPoolSize);
+
+        return ret;
+    }
+
+    /**
+     * Create a buffer pool suitable for temporary buffers, that must be released quickly.
+     *
+     * @param name the name of the pool, for the metrics
+     * @param mbeanName the mbean name, for nodetool bufferpool status
+     * @param slabSize the size of the slab for slicing temporary buffers from
+     * @param maxBufferSize the maximum buffer size, beyond this direct allocations are performed
+     * @param maxPoolSize the maximum size of the pool, memory below this value is not released but kept for later
+     *
+     * @return the buffer pool just created
+     */
+    public static BufferPool createTemporary(String name, String mbeanName, int slabSize, int maxBufferSize, long maxPoolSize)
+    {
+        BufferPool ret = BufferPool.DISABLED ? new BufferPoolDisabled(name, maxPoolSize) : new TemporaryBufferPool(name, slabSize, maxBufferSize, maxPoolSize);
+
+        return ret;
     }
 
 }

--- a/src/java/org/apache/cassandra/utils/memory/MemorySlabWithBitmap.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemorySlabWithBitmap.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+
+import static org.apache.cassandra.utils.UnsafeAccess.UNSAFE;
+
+/**
+ * A memory slab with a bitmap: it allocates a large buffer (the slab) and it slices it
+ * into smaller buffers when requested. The only supported slice size is the bufferSize,
+ * where bufferSize is specified in the constructor. The buffer size must be a power of two
+ * and the slab size, or the capacity of the slab, should be a multiple of the buffer size
+ * and a power of 2.
+ *
+ * Each bufferSize is allocated to a bit in an integer.
+ * A bit is set to 1 to indicate the corresponding buffer is available, and to 0 to indicate that it is in use.
+ * Multiple integers are appended into an array, the buffers allocations bitmap, to produce a bitmap that covers
+ * the entire slab.
+ *
+ * When multiple buffers are requested, the pool will try to use consecutive addresses, if they are available.
+ *
+ * When a buffer is released, the pool works out the position in the bitmap by comparing the buffer
+ * address to its base address, and it releases the corresponding bit in the bitmap.
+ */
+@ThreadSafe // except for closing, only a single thread should own a slab that is about to be closed
+final class MemorySlabWithBitmap
+{
+    private static final long BITMAP_ARRAY_BASE;
+    private static final int SHIFT;
+    private static final int NUM_BUFFERS_PER_SINGLE_BITMAP;
+    private static final int SINGLE_BITMAP_SHIFT;
+
+    /**
+     * A state machine for removing slabs that are full from the owning pool, and returning them to the pool when
+     * they have space. It is also used for releasing slabs when they are completely free and no longer required.
+     * <p/>
+     * Slabs that are serving requests are {@link Status#ONLINE}. When they become full, the thread
+     * that successfully removes them from the pool, will also set the status as {@link Status#OFFLINE}.
+     * When a buffer is returned to the slab, and the slab has therefore regained some space, if the slab is
+     * {@link Status#OFFLINE}, the thread that successfully sets the status as {@link Status#ONLINE}, will also add the
+     * slab back to pool. Because the slab is set as @link Status#OFFLINE} before the buffer is returned to the user,
+     * we're guaranteed that there will be at least one buffer returned with the slab status {@link Status#OFFLINE},
+     * and that therefore the slab will be reintegrated into the pool.
+     * <p/>
+     * During cleanup, if a slab is completely free and taken off the pool, then it can be released. In this case,
+     * the cleanup thread will set the status as {@link Status#CLOSED} and the slab memory will also be released.
+     * No buffers will be returned from slabs that are {@link Status#CLOSED}. So we are also using the status to
+     * prevent allocations after the memory has been released.
+     */
+    enum Status
+    {
+        /** The slab is serving requests */
+        ONLINE,
+        /** The slab is not serving requests (for example because it is full) */
+        OFFLINE,
+        /** The slab has been permanently released (it's an error to use a slab in this state) */
+        CLOSED
+    }
+
+    private final ByteBuffer slab;
+    private final long baseAddress;
+    private final int bufferSize;
+    private final int shift;
+    private final int[] buffersAllocationBitmap;
+
+    private static final AtomicReferenceFieldUpdater<MemorySlabWithBitmap, Status> statusUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(MemorySlabWithBitmap.class, Status.class, "status");
+    private volatile Status status;
+
+    static
+    {
+        try
+        {
+            BITMAP_ARRAY_BASE = UNSAFE.arrayBaseOffset(int[].class);
+
+            int scale = UNSAFE.arrayIndexScale(int[].class);
+            SHIFT = 31 - Integer.numberOfLeadingZeros(scale);
+
+            NUM_BUFFERS_PER_SINGLE_BITMAP = 32; // The number of bits in an integer
+            SINGLE_BITMAP_SHIFT = Integer.numberOfTrailingZeros(NUM_BUFFERS_PER_SINGLE_BITMAP); // to avoid a division
+        }
+        catch (Exception e)
+        {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    MemorySlabWithBitmap(int bufferSize, int capacity)
+    {
+        assert bufferSize > 0 && Integer.bitCount(bufferSize) == 1 :
+                                    "buffer size must be positive and a power of two: " + bufferSize;
+        assert Integer.numberOfTrailingZeros(bufferSize) <= 31 :
+                                    "buffer size must be at most 2^31: " + bufferSize;
+        assert capacity > bufferSize && Integer.bitCount(capacity) == 1 :
+                                    "capacity must be > bufferSize and a power of two:" + capacity;
+
+        this.slab = BufferType.OFF_HEAP_ALIGNED.allocate(capacity);
+        this.baseAddress = UnsafeByteBufferAccess.getAddress(slab);
+        this.bufferSize = bufferSize;
+        this.shift = Integer.numberOfTrailingZeros(bufferSize); // to avoid a division
+
+        int len = capacity >> (shift + SINGLE_BITMAP_SHIFT);
+        this.buffersAllocationBitmap = new int[len];
+        Arrays.fill(this.buffersAllocationBitmap, -1); // -1 means all free whilst 0 means all in use
+
+        this.status = Status.ONLINE;
+    }
+
+    long baseAddress()
+    {
+        return baseAddress;
+    }
+
+    private boolean casBitmap(int current, int update, int index)
+    {
+        long offset = BITMAP_ARRAY_BASE + (index << SHIFT);
+        return UNSAFE.compareAndSwapInt(buffersAllocationBitmap, offset, current, update);
+    }
+
+    int capacity()
+    {
+        return slab.capacity();
+    }
+
+    final int bufferSize()
+    {
+        return bufferSize;
+    }
+
+    ByteOrder order()
+    {
+        return slab.order();
+    }
+
+    /**
+     * @return true if the slab is completely free, that is all the bits are 1
+     *
+     * Note that due to concurrent access there is no guarantee that the result returned
+     * will be accurate. This method should be used as in indication only, or concurrent
+     * access should be prevented.
+     */
+    final boolean isFree()
+    {
+        // Because buffersAllocationBitmap is normally quite short, it's probably faster to & all
+        // values and only check the final value
+        int val = -1;
+        for (int bitmap : buffersAllocationBitmap)
+            val &= bitmap;
+
+        return val == -1;
+    }
+
+    /**
+     * @return true if the slab is completely full, that is all the bits are 0
+     *
+     * Note that due to concurrent access there is no guarantee that the result returned
+     * will be accurate. This method should be used as in indication only, or concurrent
+     * access should be prevented.
+     */
+    final boolean isFull()
+    {
+        // Because buffersAllocationBitmap is normally quite short, it's probably faster to | all
+        // values and only check the final value
+        int val = 0;
+        for (int bitmap : buffersAllocationBitmap)
+            val |= bitmap;
+
+        return val == 0;
+    }
+
+    /**
+     * @return The total free size.
+     *
+     * Note that due to concurrent access there is no guarantee that the result returned
+     * will be accurate. This method should be used as in indication only, or concurrent
+     * access should be prevented.
+     **/
+    int freeSpace()
+    {
+        int ret = 0;
+        for (int bitmap : buffersAllocationBitmap)
+            ret += Integer.bitCount(bitmap);
+
+        return ret << shift; // same as ret * bufferSize;
+    }
+
+    Status status()
+    {
+        return status;
+    }
+
+    private boolean setStatus(Status current, Status update)
+    {
+        return statusUpdater.compareAndSet(this, current, update);
+    }
+
+    boolean setOnline()
+    {
+        return setStatus(Status.OFFLINE, Status.ONLINE);
+    }
+
+    boolean setOffline()
+    {
+        return setStatus(Status.ONLINE, Status.OFFLINE);
+    }
+
+    boolean close()
+    {
+        assert isFree() : "Slab must be free before closing it";
+        if (setStatus(status(), Status.CLOSED))
+        {
+            FileUtils.clean(slab);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Allocate memory addresses of size {@link this#bufferSize} until the addresses array is filled.
+     * Return the number of addresses that were added to the array.
+     *
+     * If possible, addresses are allocated contiguously, in order to perform less work and reduce contention
+     * between threads. If this is not possible, then addressed are taken one by one. This is slow but ensures
+     * that fragmentation does not prevent allocating memory.
+     *
+     * @param addresses an array of addresses to fill
+     * @param idx the index in the addresses array where to start allocating new regions
+     * @param threadId the thread id is used to reduce contention by starting at a different index in {@link this#buffersAllocationBitmap}.
+     *                 For TPC threads this can be the TPC core id. If contention is not an issue it can be simply passed in as zero.
+     *
+     * @return the number of addresses that were allocated from the slab and passed to the array
+     */
+    int allocateMemory(long[] addresses, int idx, long threadId)
+    {
+        Status status = status();
+
+        assert threadId >= 0 : "Thread id cannot be negative: " + threadId;
+        assert idx < addresses.length : "idx should be less than addresses length: " + idx + " " + addresses.length;
+        assert status != Status.CLOSED : "Slab was closed";
+
+        // it's OK to request buffers on OFFLINE slabs due to races, but they are full, so we're wasting our time
+        if (status != Status.ONLINE)
+            return 0;
+
+        int bitmap = Math.toIntExact((threadId & (buffersAllocationBitmap.length - 1)) - 1); // (threadId % buffersAllocationBitmap.length) -1
+        int allocated = idx;
+
+        for (int i = 0; allocated < addresses.length && i < buffersAllocationBitmap.length; i++)
+        {
+            bitmap++;
+            if (bitmap >= buffersAllocationBitmap.length)
+                bitmap = 0;
+
+            int reserved = reserveFromBitmap(bitmap, addresses.length - allocated);
+            while (reserved != 0)
+            {
+                // Issue the buffer corresponding to the lowest set bit in reserved
+                int index = Integer.numberOfTrailingZeros(reserved);
+                int offset = ((bitmap << SINGLE_BITMAP_SHIFT) + index) << shift; // << shift is same as * bufferSize
+                addresses[allocated++] = baseAddress + offset;
+                reserved ^= 1 << index;
+            }
+        }
+
+        return allocated - idx;
+    }
+
+    /**
+     * Tries to reserve howMany bits from the given integer in the bitmap. If fewer than that are available,
+     * reserve as many as there are available.
+     * <p/>
+     * Returns bitset of what we managed to reserve.
+     */
+    private int reserveFromBitmap(int bitmap, int howMany)
+    {
+        int current;
+        while ((current = buffersAllocationBitmap[bitmap]) != 0)
+        {
+            int left = current;
+            // Clear at most howMany lowest-order bits from the bitmap
+            for (int i = howMany; left != 0 && i > 0; --i)
+                left &= left - 1;   // strip the lowest-order bit from the number
+
+            // Try to mark these bits as allocated
+            if (casBitmap(current, left, bitmap))
+                return current ^ left; // Success. The xor returns the bits we managed to clear.
+
+            // Someone beat us to it, try again with the updated bitmap value
+        }
+        return 0;
+    }
+
+    /**
+     * Returns true if this address belongs to the slab.
+     *
+     * @param address the address to check
+     *
+     * @return true if the address belongs to the slab.
+     */
+    boolean hasAddress(long address)
+    {
+        return address >= baseAddress & address < baseAddress + capacity();
+    }
+
+    /**
+     * Release the memory for this address.
+     *
+     * @param address the address whose memory is being returned to the slab.
+     */
+    void release(long address)
+    {
+        assert hasAddress(address) : "Invalid address: " + address + " - for: " + this.toString();
+
+        int numBitmaps = (int)(address - baseAddress) >> shift;
+        int index = numBitmaps >> SINGLE_BITMAP_SHIFT;
+
+        int position = numBitmaps - (index << SINGLE_BITMAP_SHIFT);
+        int shiftedBitmapBits = (1 << position);
+
+        while (true)
+        {
+            int cur = buffersAllocationBitmap[index];
+            int next = cur | shiftedBitmapBits;
+            assert next == (cur ^ shiftedBitmapBits); // ensure no double free
+            if (casBitmap(cur, next, index))
+                return;
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("[%s, capacity %d, free %d]",
+                             Arrays.stream(buffersAllocationBitmap)
+                                   .mapToObj(i -> String.format("%32s", Integer.toBinaryString(i)).replace(' ', '0'))
+                                   .reduce((s1, s2) -> s1.concat(',' + s2))
+                                   .orElse(""),
+                             capacity(),
+                             freeSpace());
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/MemorySlabWithBumpPtr.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemorySlabWithBumpPtr.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.MonotonicClock;
+import org.apache.cassandra.utils.PageAware;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+
+/**
+ * A memory slab with a simple bump-the-pointer strategy: it allocates a large buffer (the slab) and it slices it
+ * into smaller buffers when requested. A pointer tracks the position of the memory in the slab that is still free.
+ * Once the end of the slab is reached, no more buffers are served. Different buffer sizes are supported and buffer
+ * start positions are always page aligned.
+ * <p/>
+ * Once the end of the slab is reached and no more buffers can be issued, then the slab can no longer be used
+ * but it's memory can be recycled by creating a new slab with the same memory. This can only be done when all
+ * the served buffers have been released. For this purpose a reference counter is incremented when the slab is created
+ * and each time a buffer is returned. When the reference count has reached zero, the memory can be recycled.
+ * <p/>
+ * This class assumes that only one thread can release the initial reference count in the constructor and destroy
+ * or recycle the memory. Multiple threads can however take and return buffers. The thread that must release the initial
+ * reference count receives a special buffer from {@link this#allocate(int)}: {@link this#BOUNDARY_CROSSED}.
+ * The thread that receives this buffer, must unreference the slab and retry the allocation with a new slab.
+ * {@link this#unreference()} must be called only once.
+ * <p/>
+ * Both {@link #unreference()} and {@link #release(ByteBuffer)} return a boolean. Only one caller will
+ * receive true, when the reference count reaches zero. The caller that receives
+ * true must either destroy this slab or recycle it into a new one by calling {@link #destroy()} or {@link #recycle()}
+ * respectively. {@link #unreference()} must be called exactly once per byte buffer returned and once for the entire slab,
+ * it cannot be called more times than this.
+ * <p/>
+ * Once destroyed or recycled, the number of references is set to a negative value. At this point the
+ * slab cannot be used and {@link #allocate(int)} will return null. {@link #recycle()} and  {@link #destroy()} will
+ * throw an {@link AssertionError} or an {@link IllegalStateException} if called again.
+ * */
+class MemorySlabWithBumpPtr
+{
+    /** A sentinel value that is returned by {@link this#allocate(int)} to indicate to the caller that
+     * the boundary was crossed.
+     */
+    static final ByteBuffer BOUNDARY_CROSSED = ByteBuffer.allocate(0);
+
+    private final ByteBuffer slab;
+    private final long baseAddress;
+    private final AtomicInteger position;
+    private final AtomicInteger numReferences;
+    private final long createdAt;
+
+    MemorySlabWithBumpPtr(int capacity)
+    {
+        this(BufferType.OFF_HEAP_ALIGNED.allocate(capacity));
+    }
+
+    private MemorySlabWithBumpPtr(ByteBuffer slab)
+    {
+        this.slab = slab;
+        this.baseAddress = UnsafeByteBufferAccess.getAddress(slab);
+        this.position = new AtomicInteger(0);
+        this.numReferences = new AtomicInteger(1); // start referenced, calling thread owns this slab
+        this.createdAt = MonotonicClock.preciseTime.now();
+    }
+
+    /**
+     * Allocates a new buffer by bumping the current position forward.
+     *
+     * If the pointer crosses the boundary, then {@link this#BOUNDARY_CROSSED} is returned. This signals to the caller that it's time
+     * to use a new slab. If the pointer is already beyond the boundary then null is returned.
+     *
+     * @param bufferSize the buffer size
+     * @return a buffer of the requested size, or {@link this#BOUNDARY_CROSSED} if the end was reached or null if
+     *         the original position was already beyond the end.
+     *
+     * @throws AssertionError if the buffer size is <= 0 or if the slab is not referenced (numReferences <= 0)
+     */
+    public ByteBuffer allocate(int bufferSize)
+    {
+        assert bufferSize > 0 : "BufferSize must be positive:" + bufferSize;
+
+        if (numReferences.get() <= 0 || position.get() > slab.capacity())
+            return null; // prevent incrementing position unnecessarily with the getAndAdd()
+
+        int padded = Math.toIntExact(PageAware.padded(bufferSize));
+        int bufferPos = position.getAndAdd(padded);
+
+        if (bufferPos < 0)
+        {
+            // overflow only happened with utests without the  if (numReferences.get() <= 0 || position.get() > slab.capacity()) above
+            return null;
+        }
+        else if ((bufferPos + padded) <= slab.capacity())
+        {
+            // Landed within the slab, we get a chance to allocate a buffer
+            if (reference())
+            {
+                // returning a valid buffer
+                return UnsafeByteBufferAccess.allocateByteBuffer(baseAddress + bufferPos, bufferSize, slab.order(), this);
+            }
+            else
+            {
+                // the thread that received the boundary beat us and has already unreferenced this slab
+                return null;
+            }
+        }
+        else if (bufferPos <= slab.capacity())
+        {
+            // landed beyond the slab but started within the slab
+            return BOUNDARY_CROSSED;
+        }
+        else
+        {
+            // landed and started beyond the slab
+            return null;
+        }
+    }
+
+    /**
+     * Increase the reference count but only if in the meantime no other thread has set the count to zero or neg.ve.
+     *
+     * @return true if the reference count was incremented, false otherwise
+     */
+    private boolean reference()
+    {
+        int refCount;
+        do
+        {
+            refCount = numReferences.get();
+
+            if (refCount <= 0)
+                return false;
+
+        } while (!numReferences.compareAndSet(refCount, refCount + 1));
+
+        return true;
+    }
+
+    /**
+     * Return the buffer to the slab: check the address is valid and release the reference count by calling
+     * {@link this#unreference()}.
+     *
+     * @param buffer the buffer that is being released
+     * @return true if the last reference was released and the caller must destroy or recycle the slab.
+     */
+    public boolean release(ByteBuffer buffer)
+    {
+        long address = UnsafeByteBufferAccess.getAddress(buffer);
+        assert (address >= baseAddress) && (address <= baseAddress + slab.capacity()) :
+                String.format("Buffer address out of range: %s, %d", this, address);
+
+        // prevent further use without re-initialization
+        UnsafeByteBufferAccess.resetByteBufferInstance(buffer);
+
+        return unreference();
+    }
+
+    /**
+     * Called by the owner of this slab to indicate that no more buffers will be taken from this slab.
+     * Release the reference count by one and return true if the last reference was released and the
+     * caller must destroy or recycle the slab.
+     *
+     * @return true if the last reference was released and the caller must destroy or recycle the slab.
+     */
+    boolean unreference()
+    {
+        long numReferences = this.numReferences.decrementAndGet();
+        assert numReferences >= 0 : "unreference() or release(ByteBuffer) have been called too many times, refer to class javadoc";
+        return numReferences == 0;
+    }
+
+    /**
+     * Return the free space still available for allocations. If the slab is being accessed by concurrent threads,
+     * then this result may not be accurate if another thread allocates a buffer in parallel. It should only therefore
+     * be used for testing.
+     *
+     * @return the free space still available for allocations
+     */
+    int free()
+    {
+        return Math.max(0, slab.capacity() - position.get());
+    }
+
+    /**
+     * @return the base address
+     */
+    long baseAddress()
+    {
+        return baseAddress;
+    }
+
+    /**
+     * @return the maximum capacity of this slab
+     */
+    int capacity()
+    {
+        return slab.capacity();
+    }
+
+    /**
+     * @return the number of references to this slab
+     */
+    int numReferences()
+    {
+        return numReferences.get();
+    }
+
+    /**
+     * @return a new slab using the same memory
+     *
+     * @throws IllegalStateException if the slab was already recycled or destroyed.
+     */
+    MemorySlabWithBumpPtr recycle()
+    {
+        int numReferences = this.numReferences.get();
+        assert numReferences == 0 : "Slab should have been unreferenced and all buffers returned before recycling: " + toString(numReferences);
+
+        if (this.numReferences.compareAndSet(0, -1))
+        {
+            return new MemorySlabWithBumpPtr(slab);
+        }
+
+        throw new IllegalStateException("Failed to recycle slab, wrong ref. count or concurrent access: " + toString());
+    }
+
+    /**
+     * Destroy the slab by releasing its memory and setting the reference count to -1.
+     *
+     * @throws IllegalStateException if the slab was already referenced or destroyed.
+     */
+    void destroy()
+    {
+        int numReferences = this.numReferences.get();
+        assert numReferences == 0 : "Slab should have been unreferenced and all buffers returned before destroying: " + toString(numReferences);
+
+        if (this.numReferences.compareAndSet(0, -2))
+            FileUtils.clean(slab);
+        else
+            throw new IllegalStateException("Failed to destroy slab, wrong ref. count or concurrent access: " + toString());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toString(numReferences.get());
+    }
+
+    private String toString(int numReferences)
+    {
+        return String.format("[Addr: %d, Pos %d, capacity %d, num. references: %d, created: %d ms ago]",
+                             baseAddress,
+                             position.get(),
+                             slab.capacity(),
+                             numReferences,
+                             MonotonicClock.preciseTime.now()- createdAt);
+    }
+
+
+}

--- a/src/java/org/apache/cassandra/utils/memory/PermanentBufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/PermanentBufferPool.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+import org.apache.cassandra.utils.concurrent.LongAdder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.FBUtilities;
+
+/**
+ * A buffer pool suitable for buffers that can potentially be long lived or permanent.
+ * <p/>
+ * This pool is typically used by a cache, such as the {@link org.apache.cassandra.cache.ChunkCache},
+ * where some buffers may be retained for a long time whilst other buffers may be released sooner.
+ * <p/>
+ * It uses an inner pool, {@link SizeTieredPool} that contains sub-pools, one for each buffer size
+ * rounded to a power of two. This class takes care of allocating memory directly if the inner pool
+ * is exhausted or if the buffer is larger than {@link SizeTieredPool#maxBufferSize()}.
+ * <p/>
+ * To avoid fragmentation because of the long lived nature of buffers, this pool only supports
+ * a limited set of sizes, from a minimum to a maximum size, refer to {@link SizeTieredPool } for more details.
+ */
+@ThreadSafe
+class PermanentBufferPool extends BufferPool
+{
+    private static final Logger logger = LoggerFactory.getLogger(PermanentBufferPool.class);
+    private final static NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 30L, TimeUnit.SECONDS);
+
+    private final SizeTieredPool pool;
+    private final LongAdder overflowMemoryUsage;
+
+    PermanentBufferPool(String name, int minBufferSize, int maxBufferSize, long maxPoolSize)
+    {
+        super(name, maxPoolSize);
+
+        this.pool = new SizeTieredPool(minBufferSize, maxBufferSize, NUM_BUFFERS_PER_SLAB, maxPoolSize, CLEANUP_INTERVAL_MILLIS);
+        this.overflowMemoryUsage = new LongAdder();
+
+        logger.info("{} is enabled, max is {}", name, FBUtilities.prettyPrintMemory(maxPoolSize));
+    }
+
+    @Override
+    public ByteBuffer allocate0(int size)
+    {
+        ByteBuffer buf;
+        if (size > pool.maxBufferSize())
+        {
+            noSpamLogger.debug("Requested buffer size {} that is bigger than {}, allocating directly",
+                               FBUtilities.prettyPrintMemory(size),
+                               FBUtilities.prettyPrintMemory(pool.maxBufferSize()));
+
+            buf = realAllocate(size);
+        }
+        else
+        {
+            long address = pool.allocate(size, 1)[0];
+            if (address == -1)
+            {
+                noSpamLogger.debug("Requested buffer size {} has been allocated directly due to buffer pool exhausted",
+                                   FBUtilities.prettyPrintMemory(size));
+
+                buf = realAllocate(size);
+            }
+            else
+            {
+                buf = UnsafeByteBufferAccess.allocateByteBuffer(address, size, pool.order(), pool);
+            }
+        }
+
+        return buf;
+    }
+
+    private ByteBuffer realAllocate(int size)
+    {
+        //metrics.overflowAllocs.mark();
+
+        ByteBuffer ret = BufferType.OFF_HEAP_ALIGNED.allocate(size);
+        overflowMemoryUsage.add(ret.capacity());
+
+        return ret;
+    }
+
+    @Override
+    public void release0(ByteBuffer buffer, AttachmentMarker marker)
+    {
+        if (marker.attachment() instanceof SizeTieredPool)
+        {
+            pool.release(buffer.capacity(), new long[] { UnsafeByteBufferAccess.getAddress(buffer) });
+        }
+        else
+        {
+            overflowMemoryUsage.add(-buffer.capacity());
+            FileUtils.clean(buffer);
+        }
+    }
+
+    @Override
+    public long[] allocate(int size, int numRegions)
+    {
+        if (size > pool.maxBufferSize())
+            throw new IllegalStateException("Expected size to be less than " + pool.maxBufferSize());
+
+        long[] ret = pool.allocate(size, numRegions);
+
+        try
+        {
+            for (int i = 0; i < ret.length; i++)
+            {
+                if (ret[i] == -1)
+                    throw new IllegalStateException(String.format("Failed to allocate address nr. %d of size %d: buffer pool is probably exhausted, " +
+                                                                "consider setting file_cache_size_in_mb and inflight_data_overhead_in_mb in the yaml", i, size));
+            }
+        }
+        catch (Throwable t)
+        {
+            release(size, ret);
+            throw t;
+        }
+
+        return ret;
+    }
+
+    @Override
+    public void release(int size, long[] addresses)
+    {
+        pool.release(size, addresses);
+    }
+
+    @Override
+    public void cleanup()
+    {
+        pool.cleanup();
+    }
+
+    /**
+     * @return The total memory currently used by clients.
+     */
+    @Override
+    public long usedMemoryBytes()
+    {
+        return pool.usedMemoryBytes() + overflowMemoryBytes();
+    }
+
+    /**
+     * @return The total memory currently allocated by the pool.
+     */
+    @Override
+    public long allocatedMemoryBytes()
+    {
+        return pool.allocatedMemoryBytes() + overflowMemoryBytes();
+    }
+
+    /**
+     * @return The total memory allocated for buffers that are not in the pool.
+     */
+    @Override
+    public long overflowMemoryBytes()
+    {
+        return overflowMemoryUsage.longValue();
+    }
+
+    /**
+     * @return the number of allocations performed directly
+     */
+    public double missedAllocationsMeanRate()
+    {
+        return -1;
+    }
+
+    /**
+     * @return the detailed status of the buffer pool
+     */
+    public String status()
+    {
+        return toString();
+    }
+
+    @Override
+    public String toString()
+    {
+       return String.format("BufferPool for long lived buffers: %s%sOverflow: %s",
+                            pool.toString(),
+                            System.lineSeparator(),
+                            FBUtilities.prettyPrintMemory(overflowMemoryUsage.longValue()));
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/SizeTieredPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/SizeTieredPool.java
@@ -1,0 +1,713 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.concurrent.DseThreadLocal;
+import org.apache.cassandra.utils.concurrent.InlinedThreadLocalThread;
+import org.apache.cassandra.utils.concurrent.LongAdder;
+import org.apache.cassandra.utils.concurrent.TPCUtils;
+import org.apache.cassandra.utils.concurrent.ThreadLocals;
+
+import static org.apache.cassandra.utils.MonotonicClock.approxTime;
+import static org.apache.cassandra.utils.memory.BufferPool.CONTENTION_WAIT_TIME_MILLIS;
+
+/**
+ * A pool of buffers organized by buffer size.
+ * </p>
+ * For each power of two between the minimum and maximum buffer sizes, this pool contains a sub-pool
+ * for that size. Each sub-pool contains a queue of {@link MemorySlabWithBitmap} that have some space,
+ * enough to allocate at least one buffer.
+ * Because the subPools are organized by size, the first slab found on the queue will return a buffer of that size,
+ * unless there is a race with another thread, in which case the operation is retried.
+ * </p>
+ * Periodically a cleanup operation will release any additional free memory that is no longer used by a sub-pool.
+ * </p>
+ * This class is a global class, accessed by multiple threads, and as such all operations must be thread safe
+ * without the need for external synchronization.
+ * </p>
+ * The minimum and maximum buffer sizes should be powers of two.
+ */
+@ThreadSafe
+final class SizeTieredPool
+{
+    private final static Logger logger = LoggerFactory.getLogger(SizeTieredPool.class);
+    private final static NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 30L, TimeUnit.SECONDS);
+    private final static MemorySlabWithBitmap MEMORY_SLAB_SENTINEL = new MemorySlabWithBitmap(1, 4);
+
+    private final int minBufferSize;
+    private final int minLog2Ceil;
+    private final int maxBufferSize;
+    private final int numBuffersPerSlab;
+    private final long maxPoolSize;
+
+    /** This arrays contains all powers of twos starting at minBufferSize (index zero)
+     * and ending at maxBufferSize (last valid index). */
+    private final SubPool[] subPools;
+
+    /** This is the memory that has been reserved so far by all sub-pools. It cannot exceed {@link this#maxPoolSize}. */
+    private final AtomicLong reservedMemory;
+
+    SizeTieredPool(int minBufferSize, int maxBufferSize, int numBuffersPerSlab, long maxPoolSize, long cleanupIntervalMillis)
+    {
+        Preconditions.checkArgument(Integer.bitCount(minBufferSize) == 1, "minBufferSize must be a power of two (%s)", minBufferSize);
+        Preconditions.checkArgument(Integer.bitCount(maxBufferSize) == 1, "maxBufferSize must be a power of two (%s)", maxBufferSize);
+
+        this.minBufferSize = minBufferSize;
+        this.minLog2Ceil = 32 - Integer.numberOfLeadingZeros(minBufferSize - 1); // perf. optimization
+        this.maxBufferSize = maxBufferSize;
+        this.numBuffersPerSlab = numBuffersPerSlab;
+        this.maxPoolSize = maxPoolSize;
+        this.reservedMemory = new AtomicLong(0L);
+
+        this.subPools = new SubPool[toIndex(maxBufferSize) + 1];
+        for (int i = 0; i < subPools.length; i++)
+            this.subPools[i] = new SubPool(toSize(i));
+
+        if (cleanupIntervalMillis > 0)
+            ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(this::cleanup, cleanupIntervalMillis, cleanupIntervalMillis, TimeUnit.MILLISECONDS);
+    }
+
+    long[] allocate(int size, int numRegions)
+    {
+        int index = toIndex(size);
+
+        SubPool subPool = subPools[index];
+        return subPool.allocate(size, numRegions);
+    }
+
+    ByteOrder order()
+    {
+        return MEMORY_SLAB_SENTINEL.order();
+    }
+
+    void release(int size, long[] addresses)
+    {
+        int index = toIndex(size); // because there is a MemorySlabWithBitmap, index will be valid
+        SubPool subPool = subPools[index];
+        subPool.release(size, addresses);
+    }
+
+    long usedMemoryBytes()
+    {
+        return Arrays.stream(subPools).mapToLong(SubPool::usedMemoryBytes).sum();
+    }
+
+    long allocatedMemoryBytes()
+    {
+        return Arrays.stream(subPools).mapToLong(SubPool::allocatedMemoryBytes).sum();
+    }
+
+    int maxBufferSize()
+    {
+        return maxBufferSize;
+    }
+
+    /** Convert the size into an index in the subPools array, no preconditions checks on the size here for
+     * performance reasons, callers should pass a size >= . {@link this#minBufferSize}. */
+    private int toIndex(int size)
+    {
+        int log2Ceil = 32 - Integer.numberOfLeadingZeros(size - 1);
+        return Math.max(0, log2Ceil - minLog2Ceil);
+    }
+
+    /** Convert the index into the subPools array into the corresponding size*/
+    private int toSize(int index)
+    {
+        return 1 << minLog2Ceil + index;
+    }
+
+    private boolean reserveMemory(int capacity)
+    {
+        while (true)
+        {
+            long cur = reservedMemory.get();
+            if (cur + capacity > maxPoolSize)
+            {
+                noSpamLogger.info("Maximum memory usage reached ({}), cannot reserve size of {}", maxPoolSize, capacity);
+                return false;
+            }
+
+            if (reservedMemory.compareAndSet(cur, cur + capacity))
+                return true;
+        }
+    }
+
+    long reservedMemory()
+    {
+        return reservedMemory.get();
+    }
+
+    @VisibleForTesting
+    int numSlabs(int size)
+    {
+        int index = toIndex(size);
+        return subPools[index].numFreeSlabs();
+    }
+
+    @VisibleForTesting
+    void cleanup()
+    {
+        for (SubPool subPool : subPools)
+            subPool.cleanup();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder str = new StringBuilder();
+        str.append("Size-tiered from ")
+           .append(FBUtilities.prettyPrintMemory(minBufferSize))
+           .append(" to ")
+           .append(FBUtilities.prettyPrintMemory(maxBufferSize))
+           .append(" buffers, using ")
+           .append(numBuffersPerSlab)
+           .append(" buffers per slab.")
+           .append(System.lineSeparator())
+           .append("Sub pools:");
+
+        for (int i = 0; i < subPools.length; i++)
+        {
+            long numSlabs = subPools[i].numSlabs();
+
+            str.append(System.lineSeparator())
+               .append("Buffer size ")
+               .append(FBUtilities.prettyPrintMemory(toSize(i)))
+               .append(": ")
+               .append(FBUtilities.prettyPrintMemory(subPools[i].memoryInUse.longValue()))
+               .append(" used, ")
+               .append(FBUtilities.prettyPrintMemory(subPools[i].memoryAllocated.longValue()))
+               .append(" allocated, ")
+               .append(numSlabs)
+               .append(" slabs.");
+        }
+        return str.toString();
+    }
+
+    @ThreadSafe
+    private class SubPool
+    {
+        final int bufferSize;
+        final int maxFreeMemory;
+        final ConcurrentLinkedQueue<MemorySlabWithBitmap> free;
+        final ConcurrentSkipListMap<Long, MemorySlabWithBitmap> slabs;
+        final ConcurrentMap<Long, ThreadLocalStash> threadLocalStashes;
+        final AtomicReference<MemorySlabWithBitmap> current;
+        final DseThreadLocal<ThreadLocalStash> threadLocalStash;
+        final LongAdder memoryAllocated;
+        final LongAdder memoryInUse;
+        final AtomicLong lastCleanupTime;
+
+        SubPool(int bufferSize)
+        {
+            Preconditions.checkArgument(((long)bufferSize * (long)numBuffersPerSlab) == bufferSize * numBuffersPerSlab,
+                                        "bufferSize x numBuffersPerSlab should not overflow a max int size: %s x %s",
+                                        bufferSize, numBuffersPerSlab);
+
+            this.bufferSize = bufferSize;
+            this.maxFreeMemory = BufferPool.MAX_NUM_FREE_BUFFERS * bufferSize;
+            this.free = new ConcurrentLinkedQueue<>();
+            this.slabs = new ConcurrentSkipListMap<>();
+            this.threadLocalStashes = new ConcurrentHashMap<>();
+            this.current = new AtomicReference<>(null);
+            this.threadLocalStash = ThreadLocals.withInitial(this::createThreadLocalStash);
+            this.memoryAllocated = new LongAdder();
+            this.memoryInUse = new LongAdder();
+            this.lastCleanupTime = new AtomicLong(-1L);
+        }
+
+        ThreadLocalStash createThreadLocalStash()
+        {
+            // InlinedThreadLocalThread will call close() to cleanup on exit, other threads will not
+            Thread thread = Thread.currentThread();
+            //assert thread instanceof TPCThread : "Only TPC threads should use thread local";
+            return new ThreadLocalStash(thread, this, BufferPool.MAX_THREAD_LOCAL_BUFFERS);
+
+        }
+
+        /**
+         * Allocate new memory regions (a region is a slice in a direct byte buffer slab). If the memory is
+         * available on the current slab, then this is all that is required. Otherwise the slab must be switched
+         * with a new slab.
+         *
+         * @param size the size of the memory regions to be allocated
+         * @param numRegions the number of memory regions to be allocated
+         *
+         * @return the address of the memory regions of size {@code size} that were allocated
+         */
+        long[] allocate(final int size, final int numRegions)
+        {
+            assert size <= this.bufferSize : "Expected size to be the same or smaller than sub-pool size";
+
+            int coreId = TPCUtils.getCoreId();
+            long[] ret = new long[numRegions];
+            MemorySlabWithBitmap current = this.current.get();
+
+            // First try to allocate from the current slab
+            int allocated = allocateFromCurrent(current, ret, 0, coreId);
+            if (allocated == ret.length)
+                return increaseMemUsed(ret, size);
+
+            do
+            {
+                // The slab must be replaced, either we replace it or wait for a replacement
+                if (current != MEMORY_SLAB_SENTINEL && this.current.compareAndSet(current, MEMORY_SLAB_SENTINEL))
+                {
+                    if (current != null)
+                        current.setOffline();
+
+                    current = getNextSlab();
+                    this.current.set(current); // publish to other threads, even if null
+                }
+                else
+                {
+                    current = this.current.get();
+
+                    long start = approxTime.now();
+                    long now = start;
+                    while (current == MEMORY_SLAB_SENTINEL && (now - start <= CONTENTION_WAIT_TIME_MILLIS))
+                    {
+                        // wait for next slab, make non-TPC threads yield immediately and TPC threads yield after 100 millis
+                        if (!TPCUtils.isValidCoreId(coreId) || (now - start >= 100))
+                            Thread.yield();
+
+                        now = approxTime.now();
+                        current = this.current.get();
+                    }
+                }
+
+                if (current == null || current == MEMORY_SLAB_SENTINEL)
+                    break; // OOM or Failed to wait
+
+                allocated += allocateFromCurrent(current, ret, allocated, coreId);
+
+            } while (allocated < ret.length);
+
+            return increaseMemUsed(ret, size);
+        }
+
+        /**
+         * Allocate memory regions from the thread local stash, if available, and if this fails then from the current slab,
+         * if the slab is valid (not a sentinel and not null).
+         * <p/>
+         *
+         * @param current - the current slab
+         * @param addresses - the array of addresses where to store the allocated region addresses
+         * @param alreadyAllocated - the number of addresses already allocated in the addresses array
+         * @param coreId - the thread core id, needed to determine if we can rely on the thread local stash
+         *
+         * @return the number of regions allocated
+         */
+        private int allocateFromCurrent(MemorySlabWithBitmap current, final long[] addresses, final int alreadyAllocated, final int coreId)
+        {
+            // First try the TL stash
+            boolean hasThreadLocal = TPCUtils.isValidCoreId(coreId);
+            int allocated = alreadyAllocated;
+            if (hasThreadLocal)
+                allocated += maybeTakeFromLocalStash(addresses, allocated);
+
+            // Then try the current slab if it is a valid slab
+            if (current == null || current == MEMORY_SLAB_SENTINEL)
+                return allocated - alreadyAllocated;
+
+            while (allocated < addresses.length)
+            {
+                int newlyAllocated = 0;
+                if (hasThreadLocal)
+                {
+                    // TPC threads
+                    if (replenish(current))
+                        newlyAllocated = maybeTakeFromLocalStash(addresses, allocated);
+                }
+                else
+                {
+                    // Other threads
+                    newlyAllocated = current.allocateMemory(addresses, allocated, coreId);
+                }
+
+                if (newlyAllocated == 0)
+                    break;
+
+                allocated += newlyAllocated;
+            }
+
+            return allocated - alreadyAllocated;
+        }
+		
+        /**
+         * Increment memory used for the allocated regions.
+         */
+        private long[] increaseMemUsed(long[] ret, int size)
+        {
+            int totSize = 0;
+            for (int i = 0; i < ret.length; i++)
+            {
+                if (ret[i] > 0)
+                    totSize += size;
+                else
+                    ret[i] = -1; // this signals an alloc failure
+            }
+
+            memoryInUse.add(totSize);
+            return ret;
+        }
+
+        private int maybeTakeFromLocalStash(final long[] ret, final int idx)
+        {
+            return threadLocalStash.get().take(ret, idx);
+        }
+
+        private boolean replenish(MemorySlabWithBitmap current)
+        {
+            return threadLocalStash.get().replenish(current);
+        }
+
+        @Nullable
+        private MemorySlabWithBitmap getNextSlab()
+        {
+            MemorySlabWithBitmap ret = free.poll();
+            if (ret == null)
+                ret = allocateSlab();
+
+            return ret;
+        }
+
+        void release(int size, long[] addresses)
+        {
+            int released = release(addresses);
+            memoryInUse.add(-(size * released));
+        }
+
+        int release(long[] addresses)
+        {
+            Map.Entry<Long, MemorySlabWithBitmap> entry = null;
+            int released = 0;
+
+            for (int i = 0; i < addresses.length; i++)
+            {
+                if (addresses[i] == -1)
+                    continue;
+
+                if (entry == null || !entry.getValue().hasAddress(addresses[i]))
+                {
+                    entry = slabs.floorEntry(addresses[i]);
+                    if (entry == null || !entry.getValue().hasAddress(addresses[i]))
+                    {
+                        noSpamLogger.error("Failed to release address {}", addresses[i]);
+                        continue;
+                    }
+                }
+
+                MemorySlabWithBitmap memorySlab = entry.getValue();
+                memorySlab.release(addresses[i]);
+
+                addresses[i] = -1;
+                released++;
+
+                MemorySlabWithBitmap.Status status = memorySlab.status();
+                if (status == MemorySlabWithBitmap.Status.OFFLINE && memorySlab.setOnline())
+                    free.offer(memorySlab);
+            }
+
+            return released;
+        }
+
+        long usedMemoryBytes()
+        {
+            return memoryInUse.longValue();
+        }
+
+        long allocatedMemoryBytes()
+        {
+            return memoryAllocated.longValue();
+        }
+
+        /**
+         *  Try releasing unused memory.
+         *
+         *  Normally a sub-pool will always have some memory in use because the chunk cache will have some content.
+         *  However, if a buffer size is completely discarded, e.g. the only table using a buffer size has been dropped
+         *  or altered, we'd like to detect this. If the sub-pool no longer has any memory in use, we assume this buffer
+         *  size is no longer in use and recall the thread-local stashes before attempting to release any slabs that are
+         *  completely free.
+         *
+         *  If we have more than maxFreeMemory already available, we attempt to release any slabs that are completely free.
+         *  The reasoning in this case is that we may fail to release slabs due to fragmentation but, if the sub-pool is
+         *  winding down due to a change in buffer size, we will succeed with the next attempts whilst if the sub-pool
+         *  is still actively used, then the amount of unused memory should be below the threshold and so this condition
+         *  should not be triggered too frequently.
+         *
+         *  It's not safe to free the current slab due to a possible race with allocating threads, so a sub-pool no longer
+         *  in use will waste at least one slab. I didn't think it worth it increasing the complexity to release a single slab
+         *  since it's not much memory and the subpool may later on become used again.
+         */
+        void cleanup()
+        {
+            long totUsed = memoryInUse.longValue();
+            long totMemory = memoryAllocated.longValue();
+
+            if (totMemory == 0)
+                return; // no memory allocated
+
+            if (totUsed == 0)
+            {
+                recallThreadLocalStashes();
+                releaseFreeSlabs();
+            }
+            else if (totMemory - totUsed >= maxFreeMemory)
+            {
+                releaseFreeSlabs();
+            }
+        }
+
+        /**
+         * Recall all the thread local stashes for this sub-pool. Currently only TPC threads can have thread local
+         * stashes and so the core id of the stash will always be valid.
+         * <p/>
+         * Because the thread local stash is not thread safe, {@link ThreadLocalStash#drain()} needs to execute on the actual TPC core
+         * and this method must wait until all thread local stashes have been drained. This method should only be called from
+         * the cleanup executor and so it should not be already on the TPC thread, and this is checked by the use of
+         * blockingAwait(CompletableFuture).
+         * */
+        private void recallThreadLocalStashes()
+        {
+            Collection<ThreadLocalStash> stashes = threadLocalStashes.values();
+            CompletableFuture<Void>[] futures = new CompletableFuture[stashes.size()];
+
+            int i = 0;
+            for (ThreadLocalStash stash : stashes)
+                futures[i++] = CompletableFuture.runAsync(stash::drain);
+
+            TPCUtils.blockingAwait(CompletableFuture.allOf(futures));
+        }
+
+        private void releaseFreeSlabs()
+        {
+            boolean done = false;
+            MemorySlabWithBitmap memorySlab;
+            MemorySlabWithBitmap first = null;
+
+            while(!done && (memorySlab = free.poll()) != null)
+            {
+                if (first == null)
+                    first = memorySlab;
+                else if (first == memorySlab)
+                    done = true;
+
+                if (memorySlab.isFree())
+                {
+                    releaseSlab(memorySlab);
+                    if (memorySlab == first)
+                        first = null;
+                }
+                else
+                {
+                    free.offer(memorySlab);
+                }
+            }
+        }
+
+        int numFreeSlabs()
+        {
+            MemorySlabWithBitmap memorySlab = current.get();
+            return free.size() + (memorySlab != null && memorySlab != MEMORY_SLAB_SENTINEL ? 1 : 0);
+        }
+
+        int numSlabs()
+        {
+            return Math.toIntExact(memoryAllocated.longValue() / capacity());
+        }
+
+        private int capacity()
+        {
+            return bufferSize * numBuffersPerSlab;
+        }
+
+        /**
+         * Allocate a slab if memory can be reserved
+         *
+         * @return a newly allocated slab or null
+         */
+        private @Nullable MemorySlabWithBitmap allocateSlab()
+        {
+            int capacity = capacity();
+            try
+            {
+                if (!reserveMemory(capacity))
+                    return null;
+
+                memoryAllocated.add(capacity);
+                MemorySlabWithBitmap ret = new MemorySlabWithBitmap(bufferSize, capacity);
+                if (slabs.putIfAbsent(ret.baseAddress(), ret) != null)
+                { // There can't be an existing slab with the same base address
+                    ret.close();
+                    throw new IllegalStateException("Found slab with same base address when allocating a new slab");
+                }
+                return ret;
+            }
+            catch (Throwable t)
+            {
+                reservedMemory.addAndGet(-capacity);
+                memoryAllocated.add(-capacity);
+                throw t;
+            }
+        }
+
+        private void releaseSlab(MemorySlabWithBitmap memorySlab)
+        {
+            long capacity = memorySlab.capacity();
+            noSpamLogger.debug("Releasing free slab of {}.", FBUtilities.prettyPrintMemory(capacity));
+
+            // the slab must be removed before calling close() because once the memory is released, another slab
+            // could be created with the same memory and inserted into the map using the same base address as the key
+            MemorySlabWithBitmap removed = slabs.remove(memorySlab.baseAddress());
+            boolean closed = memorySlab.close();
+            if (closed)
+            {
+                reservedMemory.addAndGet(-capacity);
+                memoryAllocated.add(-capacity);
+            }
+
+            assert removed == memorySlab && closed :
+                   String.format("Problem releasing memory slab memory: memorySlab=%s, slab removed=%s, closed=%b",
+                                 memorySlab, removed, closed);
+        }
+    }
+
+    /**
+     * A stash of thread-local buffers.
+     * <p/>
+     * Threads that inherit from {@link InlinedThreadLocalThread} will stash a few buffers,
+     * in order to reduce contention.
+     */
+    @NotThreadSafe
+    private static class ThreadLocalStash implements Closeable
+    {
+        final long threadId;
+        final SubPool parent;
+        final int maxNumAddresses;
+        final int coreId;
+
+        volatile Addresses addresses;
+
+        ThreadLocalStash(Thread thread, SubPool parent, int maxNumAddresses)
+        {
+            this.threadId = thread.getId();
+            this.parent = parent;
+            this.addresses = new Addresses(maxNumAddresses);
+            this.maxNumAddresses = maxNumAddresses;
+            this.coreId = TPCUtils.getCoreId(thread);
+            parent.threadLocalStashes.putIfAbsent(threadId, this);
+        }
+
+        int take(final long[] ret, final int idx)
+        {
+            return addresses.take(ret, idx);
+        }
+
+        boolean replenish(MemorySlabWithBitmap memorySlab)
+        {
+            return this.addresses.allocate(memorySlab, coreId);
+        }
+
+        void drain()
+        {
+            if (addresses.isEmpty())
+                return;
+
+            long[] toFree = new long[addresses.available()];
+            addresses.take(toFree, 0);
+            assert addresses.isEmpty() : "Expected addresses to be empty";
+
+            int released = parent.release(toFree);
+            assert released == toFree.length : "Failed to release some buffers when draining thread local stash";
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            drain();
+            parent.threadLocalStashes.remove(threadId);
+        }
+
+        /**
+         * A wrapper around a list of addresses, which are accesses in FIFO order.
+         * <p/>
+         * We need a wrapper because we want to avoid boxing the long, therefore
+         * we don't use any of the existing Java generic collections or queues.
+         */
+        @NotThreadSafe
+        private final static class Addresses
+        {
+            private final long[] addresses;
+            int prod; // producer index
+            int cons; // consumer index
+
+            Addresses(int numAddresses)
+            {
+                this.addresses = new long[numAddresses];
+
+                reset();
+            }
+
+            private void reset()
+            {
+                prod = cons = 0;
+            }
+
+            private boolean isEmpty()
+            {
+                return cons == prod;
+            }
+
+            private boolean allocate(MemorySlabWithBitmap slab, int coreId)
+            {
+                assert isEmpty() : "allocate should have been called on an empty thread local";
+                reset();
+
+                prod = slab.allocateMemory(addresses, 0, coreId);
+                return prod > 0;
+            }
+
+            // Fill ret with as many addresses as possible starting at idx
+            private int take(final long[] ret, final int idx)
+            {
+                int allocated = idx;
+                while (cons < prod && allocated < ret.length)
+                    ret[allocated++] = addresses[cons++];
+                return allocated - idx;
+            }
+
+            private int available()
+            {
+                return prod - cons;
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/TemporaryBufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/TemporaryBufferPool.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.MonotonicClock;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.concurrent.DseThreadLocal;
+import org.apache.cassandra.utils.concurrent.ThreadLocals;
+
+/**
+ * A buffer pool suitable for temporary buffers that are released quickly afterwards and ideally in temporal order,
+ * that is first allocated first released.
+ * <p/>
+ * This pool is typically used to obtain short lived buffers for read operations in order to reuse the buffers
+ * multiple times.
+ * <p/>
+ * It uses a list of bump the pointer slabs, {@link MemorySlabWithBumpPtr}. TPC threads have a dedicated slab
+ * stored in a thread local. Other threads share a global slab instead. This is because IO threads may need
+ * buffers from this pool and the number of IO threads is currently unbounded, see DB-3124.
+ * <p/>
+ * A slab will be used as long as it has space. When the slab is created, and each time a buffer is taken, a counter
+ * is increased. When the slab has reached the end, or each time a buffer is returned, this counter is decreased.
+ * When this counter reaches zero, the slab will be returned to the queue if the total allocated
+ * memory is below the limit, otherwise the slab will be released.
+ */
+@ThreadSafe
+class TemporaryBufferPool extends BufferPool
+{
+    private static final Logger logger = LoggerFactory.getLogger(TemporaryBufferPool.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 30L, TimeUnit.SECONDS);
+
+    private final ConcurrentLinkedQueue<MemorySlabWithBumpPtr> slabs;
+    private final DseThreadLocal<MemorySlabWithBumpPtr> threadLocalSlab;
+    private final int slabSize;
+    private final int maxBufferSize;
+    private final AtomicLong allocated;
+    private final AtomicLong used;
+
+    private AtomicReference<MemorySlabWithBumpPtr> sharedSlab;
+
+    TemporaryBufferPool(String name, int slabSize, int maxBufferSize, long maxPoolSize)
+    {
+        super(name, maxPoolSize);
+
+        Preconditions.checkArgument(slabSize > 0, "Slab size should be positive: %s", slabSize);
+        Preconditions.checkArgument(maxBufferSize > 0, "Max buffer size should be positive: %s", maxBufferSize);
+        Preconditions.checkArgument(maxPoolSize > 0, "Max pool size should be positive: %s", maxPoolSize);
+        Preconditions.checkArgument(maxBufferSize < slabSize, "Max buffer size %s should be less than slab size %s", maxBufferSize, slabSize);
+        Preconditions.checkArgument(slabSize < maxPoolSize, "Slab size %s should be less than max pool size %s", slabSize, maxPoolSize);
+
+
+        this.slabs = new ConcurrentLinkedQueue<>();
+        this.threadLocalSlab = ThreadLocals.withInitial(this::newSlab);
+        this.slabSize = slabSize;
+        this.maxBufferSize = maxBufferSize;
+        this.allocated = new AtomicLong(0);
+        this.used = new AtomicLong(0);
+
+        logger.info("{} is enabled, max is {}", name, FBUtilities.prettyPrintMemory(maxPoolSize));
+
+        // Create an initial slab to be shared among all non-TPC threads
+        this.sharedSlab = new AtomicReference<>(newSlab());
+    }
+
+    @Override
+    public ByteBuffer allocate0(int bufferSize)
+    {
+        ByteBuffer ret;
+        if (bufferSize > maxBufferSize)
+        {
+            noSpamLogger.debug("Requested buffer size {} that is bigger than {}",
+                               FBUtilities.prettyPrintMemory(bufferSize),
+                               FBUtilities.prettyPrintMemory(maxBufferSize));
+
+            ret = allocateDirect(bufferSize);
+        }
+        else
+        {
+            //if (Thread.currentThread() instanceof TPCThread)
+            //    ret = allocateFromThreadLocal(bufferSize);
+            //else
+                ret = allocateFromShared(bufferSize);
+        }
+
+        if (ret != null)
+            used.getAndAdd(bufferSize);
+
+        return ret;
+    }
+
+    private ByteBuffer allocateDirect(int bufferSize)
+    {
+        noSpamLogger.debug(("Allocating buffer of {} bytes directly, current status: [{}]"), bufferSize, toString());
+
+        ByteBuffer ret = BufferType.OFF_HEAP_ALIGNED.allocate(bufferSize); // may throw an OOM
+        //metrics.overflowAllocs.mark(); // direct allocations are marked as overflow allocations
+        return ret;
+    }
+
+    /**
+     * Takes a buffer from the thread local slab if this thread does have a thread local slab.
+     */
+    private ByteBuffer allocateFromThreadLocal(int bufferSize)
+    {
+        MemorySlabWithBumpPtr slab = threadLocalSlab.get();
+        if (slab == null)
+        {   // this occurs if there was an OOM preventing a new slab from being installed
+            slab = newSlab(); // may throw an OOM
+            threadLocalSlab.set(slab);
+        }
+
+        ByteBuffer ret = slab.allocate(bufferSize);
+        assert ret != null : "Expected valid buffer or boundary crossed: " + slab + " size requested: " + bufferSize;
+
+        if (ret == MemorySlabWithBumpPtr.BOUNDARY_CROSSED)
+        {
+            threadLocalSlab.set(null);
+
+            if (slab.unreference())
+                returnSlab(slab);
+
+            slab = newSlab(); // may throw an OOM
+            threadLocalSlab.set(slab);
+
+            ret = slab.allocate(bufferSize);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Takes a buffer from the shared slab. This method could fail due to too much contention.
+     */
+    private ByteBuffer allocateFromShared(int bufferSize)
+    {
+        ByteBuffer ret;
+        long start = MonotonicClock.preciseTime.now();
+
+        MemorySlabWithBumpPtr current;
+        do
+        {
+            current = sharedSlab.get();
+            if (current == null)
+                current = createSharedSlabFollowingOOM(); // may throw, in which case sharedSlab will be unchanged
+
+            ret = current.allocate(bufferSize);
+
+            if (ret == MemorySlabWithBumpPtr.BOUNDARY_CROSSED)
+            {
+                // need to switch shared, only one thread can get this result
+                switchSharedSlab(current); // may throw, but will set sharedSlab to null first
+            }
+            else if (ret == null)
+            {
+                Thread.yield(); // yield a bit so that another thread replaces the slab
+            }
+            else
+            {
+                // valid buffer, return it
+                return ret;
+            }
+
+        } while (MonotonicClock.preciseTime.now() - start <= CONTENTION_WAIT_TIME_MILLIS);
+
+        throw new OutOfMemoryError(String.format("Failed to allocate byte buffer from temporary pool, waited for too long (%d ms), current shared slab: %s",
+                                                 MonotonicClock.preciseTime.now()  - start,
+                                                 current));
+    }
+
+    /**
+     * If a thread receives a {@link MemorySlabWithBumpPtr#BOUNDARY_CROSSED}, then this thread will call
+     * this method to create a new shared slab. Only one thread can execute this method. The current slab
+     * will be unreferenced.
+     *
+     * @param current  the current slab to be unreferenced
+     * @return the new shared slab
+     * @throws OutOfMemoryError
+     */
+    @Nullable
+    private MemorySlabWithBumpPtr switchSharedSlab(MemorySlabWithBumpPtr current)
+    {
+        MemorySlabWithBumpPtr replacement = null;
+        try
+        {
+            replacement = newSlab(); // may throw an OOM, in which case we want to publish a null replacement
+        }
+        finally
+        {
+            boolean res = sharedSlab.compareAndSet(current, replacement);
+            assert res : "Multiple threads raced on boundary, this was not expected: " + current;
+
+            // Unreference the current only after having replaced it otherwise a TPC thread could recycle and put it
+            // in its thread local whilst the other threads are still trying to use it
+            if (current.unreference())
+                returnSlab(current); // This would throw only if it fails the assertion
+        }
+
+        return replacement;
+    }
+
+    /**
+     * If there is an OOM {@link this#switchSharedSlab(MemorySlabWithBumpPtr)} will publish a null slab. When
+     * this happens, this method is called to try and allocate a new slab. Unlike {@link this#switchSharedSlab(MemorySlabWithBumpPtr)},
+     * several threads may execute this method.
+     *
+     * @return the new shared slab
+     * @throws OutOfMemoryError
+     */
+    private MemorySlabWithBumpPtr createSharedSlabFollowingOOM()
+    {
+        MemorySlabWithBumpPtr slab = newSlab(); // may throw an OOM
+        if (!sharedSlab.compareAndSet(null, slab))
+        {
+            // another thread beat us
+            slab.unreference();
+            returnSlab(slab);
+            slab = sharedSlab.get();
+        }
+
+        return slab;
+    }
+
+    @Override
+    public void release0(ByteBuffer buffer, AttachmentMarker marker)
+    {
+        used.getAndAdd(-buffer.capacity());
+
+        if (marker.attachment() instanceof MemorySlabWithBumpPtr)
+        {
+            MemorySlabWithBumpPtr slab = (MemorySlabWithBumpPtr) marker.attachment();
+
+            // Return the buffer to the slab, if release returns true then
+            // the owning thread is no longer using the slab and all buffers
+            // have been returned, we must therefore recycle it
+            if (slab.release(buffer))
+                returnSlab(slab);
+        }
+        else
+        {
+            FileUtils.clean(buffer);
+        }
+}
+
+    /**
+     * Either create a new slab or recycle an existing one.
+     *
+     * @return a slab ready to be used for allocating buffers
+     *
+     * @throws OutOfMemoryError if OOM
+     */
+    private MemorySlabWithBumpPtr newSlab()
+    {
+        MemorySlabWithBumpPtr ret = slabs.poll();
+        if (ret == null)
+        {
+            ret = new MemorySlabWithBumpPtr(slabSize); // may throw OOM
+            allocated.getAndAdd(slabSize);
+            if (allocated.get() > maxPoolSize)
+            {
+                noSpamLogger.debug("Allocated slab beyond maxPoolSize {}, allocated: {}",
+                                   FBUtilities.prettyPrintMemory(maxPoolSize),
+                                   FBUtilities.prettyPrintMemory(allocated.get()));
+
+                //metrics.overflowAllocs.mark();
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * Either add the slab to the queue or destroy it.
+     *
+     * @param slab the slab to re-use or destroy
+     */
+    private void returnSlab(MemorySlabWithBumpPtr slab)
+    {
+        assert slab.numReferences() == 0 : "Slab is still referenced:" +  slab;
+
+        if (allocated.get() > maxPoolSize)
+        {
+            slab.destroy();
+            allocated.getAndAdd(-slabSize);
+        }
+        else
+        {
+            slab = slab.recycle();
+            if (!slabs.offer(slab)) // cannot return false but just in case
+            {
+                slab.unreference();
+                slab.destroy();
+                allocated.getAndAdd(-slabSize);
+                assert false : "Unbounded queue failed to add recycled slab";
+            }
+        }
+    }
+
+    @Override
+    public void cleanup()
+    {
+        // small pool, no op
+    }
+
+    @Override
+    public long usedMemoryBytes()
+    {
+        return used.get();
+    }
+
+    @Override
+    public long allocatedMemoryBytes()
+    {
+        return allocated.get();
+    }
+
+    @Override
+    public long overflowMemoryBytes()
+    {
+        return Math.max(0, allocatedMemoryBytes() - maxPoolSize);
+    }
+
+    @Override
+    public double missedAllocationsMeanRate()
+    {
+        return -1;
+    }
+
+    @Override
+    public String status()
+    {
+        return toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("BufferPool for temporary buffers: allocated %s, used %s, overflow %s, overflow allocations mean rate %f",
+                             FBUtilities.prettyPrintMemory(allocatedMemoryBytes()),
+                             FBUtilities.prettyPrintMemory(usedMemoryBytes()),
+                             FBUtilities.prettyPrintMemory(overflowMemoryBytes()),
+                             missedAllocationsMeanRate());
+    }
+}

--- a/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
+++ b/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
@@ -435,7 +435,7 @@ public class ConnectionBurnTest
                                         checkStoppedTo  .accept(endpoint, getConnections(endpoint, true ));
                                         checkStoppedFrom.accept(endpoint, getConnections(endpoint, false));
                                     }
-                                    long inUse = BufferPools.forNetworking().usedSizeInBytes();
+                                    long inUse = BufferPools.forNetworking().usedMemoryBytes();
                                     if (inUse > 0)
                                     {
 //                                        try

--- a/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
+++ b/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.*;
 public class LongBufferPoolTest
 {
     private static final Logger logger = LoggerFactory.getLogger(LongBufferPoolTest.class);
-
+/*
     private static final int AVG_BUFFER_SIZE = 16 << 10;
     private static final int STDEV_BUFFER_SIZE = 10 << 10; // picked to ensure exceeding buffer size is rare, but occurs
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
@@ -272,15 +272,15 @@ public class LongBufferPoolTest
             }
         }
 
-        /**
+        *//**
          * Implementers must assure all buffers were returned to the buffer pool on run exit.
-         */
+         *//*
         interface MemoryFreeTask
         {
             void run();
         }
 
-        /**
+        *//**
          * If the main test loop requested stopping the threads by setting
          * {@link TestEnvironment#shouldFreeMemoryAndSuspend},
          * waits until all threads reach this call and then frees the memory by running the given memory free task.
@@ -289,7 +289,7 @@ public class LongBufferPoolTest
          * The call exits after {@link TestEnvironment#resumeAllocationsBarrier} is reached by all threads.
          *
          * @param task the task that should return all buffers held by this thread to the buffer pool
-         */
+         *//*
         void maybeSuspendAndFreeMemory(MemoryFreeTask task) throws InterruptedException, BrokenBarrierException
         {
             if (shouldFreeMemoryAndSuspend)
@@ -494,9 +494,9 @@ public class LongBufferPoolTest
                 while (recycleFromNeighbour());
             }
 
-            /**
+            *//**
              * Returns all allocated buffers back to the buffer pool.
-             */
+             *//*
             void freeAll()
             {
                 while (checks.size() > 0)
@@ -722,9 +722,9 @@ public class LongBufferPoolTest
         }
     }
 
-    /**
+    *//**
      * A single producer, single consumer queue.
-     */
+     *//*
     private static final class SPSCQueue<V>
     {
         static final class Node<V>
@@ -764,5 +764,5 @@ public class LongBufferPoolTest
     private static int sum1toN(int n)
     {
         return (n * (n + 1)) / 2;
-    }
+    }*/
 }

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -879,8 +879,8 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                                 .thenRun(() -> {
                                     // when the instance is eventually stopped, we need to release buffer pools manually
                                     // they are assumed to gone along with JVM, but this is not the case in dtests
-                                    BufferPools.forNetworking().unsafeReset(true);
-                                    BufferPools.forChunkCache().unsafeReset(true);
+                                    //BufferPools.forNetworking().unsafeReset(true);
+                                    //BufferPools.forChunkCache().unsafeReset(true);
                                 });
     }
 

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.io.util.SequentialWriter;
 
 public class ChunkCacheTest
 {
-    @BeforeClass
+  /*  @BeforeClass
     public static void setupDD()
     {
         DatabaseDescriptor.daemonInitialization();
@@ -185,6 +185,6 @@ public class ChunkCacheTest
             writer.write(bytes);
             writer.flush();
         }
-    }
+    }*/
 
 }

--- a/test/unit/org/apache/cassandra/metrics/BufferPoolMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/BufferPoolMetricsTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class BufferPoolMetricsTest
 {
-    private BufferPool bufferPool;
+    /*private BufferPool bufferPool;
     private BufferPoolMetrics metrics;
 
     // Test with both MicrometerBufferPoolMetrics and CodahaleBufferPoolMetrics
@@ -263,5 +263,5 @@ public class BufferPoolMetricsTest
     {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
         () -> bufferPool.get(-1, BufferType.OFF_HEAP));
-    }
+    }*/
 }

--- a/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
@@ -17,81 +17,173 @@
  * under the License.
  *
  */
+
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
 package org.apache.cassandra.utils.memory;
 
 import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.concurrent.*;
-
-import com.google.common.collect.Iterables;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.UnsafeByteBufferAccess;
+import org.apache.cassandra.utils.UnsafeMemoryAccess;
 
 import static org.junit.Assert.*;
 
+@RunWith(Parameterized.class)
 public class BufferPoolTest
 {
-    private BufferPool bufferPool;
+    private static final Logger logger = LoggerFactory.getLogger(BufferPoolTest.class);
 
-    @Before
-    public void setUp()
+    private final static long MEMORY_USAGE_THRESHOLD = 128 * 1024L * 1024L;
+
+    /** The minimum size of a page aligned buffer, 1Kib. Below this the requested size will be rounded up. Must be a power of two. */
+    private final static int MIN_BUFFER_SIZE = BufferPool.MIN_DIRECT_READS_BUFFER_SIZE;
+
+    /** The maximum size of a page aligned buffer, 64KiB. Beyond this a direct allocation will be performed. Must be a power of two. */
+    private final static int MAX_BUFFER_SIZE = BufferPool.MAX_DIRECT_READS_BUFFER_SIZE;
+
+    /** The size of a thread local slab to serve short lived buffers, 4MB. */
+    private final static int SLAB_SIZE = BufferPool.THREAD_LOCAL_SLAB_SIZE;
+
+    private final static Random rand = new Random(1287502554245L);
+
+    private final BufferPool bufferPool;
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> generateData()
     {
-        bufferPool = new BufferPool("test_pool", 8 * 1024 * 1024, true);
+        DatabaseDescriptor.daemonInitialization();
+
+        return Arrays.asList(new Object[][]{
+        { new PermanentBufferPool("PermanentBufferPoolTest", MIN_BUFFER_SIZE, MAX_BUFFER_SIZE, MEMORY_USAGE_THRESHOLD) },
+        { new TemporaryBufferPool("TemporaryBufferPoolTest", SLAB_SIZE, MAX_BUFFER_SIZE * 2, MEMORY_USAGE_THRESHOLD) },
+        });
+    }
+
+    public BufferPoolTest(BufferPool bufferPool)
+    {
+        this.bufferPool = bufferPool;
+    }
+
+    @After
+    public void cleanUp()
+    {
+        assertEquals(bufferPool.toString(), 0, bufferPool.usedMemoryBytes());
+        bufferPool.cleanup();
     }
 
     @Test
-    public void testGetPut()
+    public void testStatus()
     {
-        final int size = RandomAccessReader.DEFAULT_BUFFER_SIZE;
-
-        ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
-        assertNotNull(buffer);
-        assertEquals(size, buffer.capacity());
-        assertEquals(true, buffer.isDirect());
-        assertEquals(size, bufferPool.usedSizeInBytes());
-
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
-
-        bufferPool.put(buffer);
-        assertEquals(null, bufferPool.unsafeCurrentChunk());
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
-        assertEquals(0, bufferPool.usedSizeInBytes());
+        assertNotNull(bufferPool.status());
+        assertNotNull(bufferPool.toString());
     }
 
     @Test
-    public void testTryGet()
+    public void testAllocRelease()
     {
         final int size = RandomAccessReader.DEFAULT_BUFFER_SIZE;
 
-        ByteBuffer buffer = bufferPool.tryGet(size);
+        ByteBuffer buffer = bufferPool.allocate(size);
         assertNotNull(buffer);
         assertEquals(size, buffer.capacity());
-        assertEquals(true, buffer.isDirect());
-        assertEquals(size, bufferPool.usedSizeInBytes());
+        assertTrue(buffer.isDirect());
+        assertEquals(size, bufferPool.usedMemoryBytes());
 
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
+        bufferPool.release(buffer);
+        assertEquals(0, bufferPool.usedMemoryBytes());
+    }
 
-        bufferPool.put(buffer);
-        assertEquals(null, bufferPool.unsafeCurrentChunk());
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
-        assertEquals(0, bufferPool.usedSizeInBytes());
+    @Test
+    public void testMemoryAddressesAlloc()
+    {
+        if (bufferPool instanceof TemporaryBufferPool)
+            return; // only the permanent pool supports this feature
+
+        final int bufferSize = RandomAccessReader.DEFAULT_BUFFER_SIZE;
+        // We want to test a few addresses. Here we test a number of addresses sufficient to cover two slabs
+        final int numAddresses = BufferPool.NUM_BUFFERS_PER_SLAB * 2;
+
+        final byte[] written = new byte[bufferSize];
+        final byte[] read = new byte[bufferSize];
+
+        long[] addresses = bufferPool.allocate(bufferSize, numAddresses);
+        assertNotNull(addresses);
+        assertEquals(numAddresses, addresses.length);
+
+        for (long address : addresses)
+        {
+            assertNotEquals(-1, address);
+            assertNotEquals(0, address);
+
+            ByteBuffer buffer = UnsafeByteBufferAccess.allocateByteBuffer(address, bufferSize);
+            assertEquals(bufferSize, buffer.capacity());
+            assertTrue(buffer.isDirect());
+
+            rand.nextBytes(written);
+            buffer.put(written);
+            buffer.rewind();
+
+            buffer.get(read);
+            assertArrayEquals(written, read);
+        }
+
+        assertEquals(numAddresses * bufferSize, bufferPool.usedMemoryBytes());
+
+        bufferPool.release(bufferSize, addresses);
+
+        for (long address : addresses)
+        {
+            assertEquals(-1, address);
+        }
+
+        assertEquals(0, bufferPool.usedMemoryBytes());
+    }
+
+    @Test
+    public void testMemoryAddressesAllocWithOOM()
+    {
+        if (bufferPool instanceof TemporaryBufferPool)
+            return; // only the permanent pool supports this feature
+
+        // addresses cannot be allocated beyond the max pool size so we should get an OOM without risking exceeding max direct memory
+        final long maxSize = MEMORY_USAGE_THRESHOLD;
+        final int bufferSize = MAX_BUFFER_SIZE;
+        final int numAddresses = Math.toIntExact(maxSize / bufferSize + 2);
+
+        try
+        {
+            bufferPool.allocate(bufferSize, numAddresses);
+            fail("Expected OutOfMemoryError");
+        }
+        catch (RuntimeException | OutOfMemoryError e)
+        {
+            // make sure all buffers were returned to the pool
+            assertEquals(0, this.bufferPool.usedMemoryBytes());
+
+            if (e instanceof  RuntimeException)
+                JVMStabilityInspector.inspectThrowable(e);
+        }
     }
 
     @Test
     public void testPageAligned()
     {
-        final int size = 1024;
-        for (int i = size;
-                 i <= BufferPool.NORMAL_CHUNK_SIZE;
-                 i += size)
+        for (int i = MIN_BUFFER_SIZE; i <= MAX_BUFFER_SIZE; i += MIN_BUFFER_SIZE)
         {
             checkPageAligned(i);
         }
@@ -99,341 +191,116 @@ public class BufferPoolTest
 
     private void checkPageAligned(int size)
     {
-        ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
+        ByteBuffer buffer = bufferPool.allocate(size);
         assertNotNull(buffer);
         assertEquals(size, buffer.capacity());
         assertTrue(buffer.isDirect());
 
-        long address = MemoryUtil.getAddress(buffer);
-        assertTrue((address % MemoryUtil.pageSize()) == 0);
+        long address = UnsafeByteBufferAccess.getAddress(buffer);
+        assertEquals(0, address % UnsafeMemoryAccess.pageSize());
 
-        bufferPool.put(buffer);
+        bufferPool.release(buffer);
     }
 
     @Test
-    public void testDifferentSizes() throws InterruptedException
+    public void testDifferentSizes()
     {
         final int size1 = 1024;
         final int size2 = 2048;
 
-        ByteBuffer buffer1 = bufferPool.get(size1, BufferType.OFF_HEAP);
+        ByteBuffer buffer1 = bufferPool.allocate(size1);
         assertNotNull(buffer1);
         assertEquals(size1, buffer1.capacity());
-        assertEquals(size1, bufferPool.usedSizeInBytes());
 
-        ByteBuffer buffer2 = bufferPool.get(size2, BufferType.OFF_HEAP);
+        ByteBuffer buffer2 = bufferPool.allocate(size2);
         assertNotNull(buffer2);
         assertEquals(size2, buffer2.capacity());
-        assertEquals(size1 + size2, bufferPool.usedSizeInBytes());
 
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
+        assertEquals(size1 + size2, bufferPool.usedMemoryBytes());
 
-        bufferPool.put(buffer1);
-        bufferPool.put(buffer2);
+        bufferPool.release(buffer1);
+        bufferPool.release(buffer2);
 
-        assertEquals(null, bufferPool.unsafeCurrentChunk());
-        assertEquals(BufferPool.GlobalPool.MACRO_CHUNK_SIZE, bufferPool.sizeInBytes());
-        assertEquals(0, bufferPool.usedSizeInBytes());
+        assertEquals(0, bufferPool.usedMemoryBytes());
     }
 
     @Test
-    public void testMaxMemoryExceededDirect()
+    public void testMaxMemoryExceeded()
     {
-        requestDoubleMaxMemory();
-    }
+        final int bufferSize = RandomAccessReader.DEFAULT_BUFFER_SIZE;
+        final long totalSize = MEMORY_USAGE_THRESHOLD * 2;
+        final int numBuffers = Math.toIntExact(totalSize / bufferSize);
+        boolean hitlimit = false;
 
-    @Test
-    public void testMaxMemoryExceededHeap()
-    {
-        requestDoubleMaxMemory();
-    }
-
-    @Test
-    public void testMaxMemoryExceeded_SameAsChunkSize()
-    {
-        requestDoubleMaxMemory();
-    }
-
-    @Test
-    public void testMaxMemoryExceeded_SmallerThanChunkSize()
-    {
-        bufferPool = new BufferPool("test_pool", BufferPool.GlobalPool.MACRO_CHUNK_SIZE / 2, false);
-        requestDoubleMaxMemory();
-    }
-
-    @Test
-    public void testRecycle()
-    {
-        requestUpToSize(RandomAccessReader.DEFAULT_BUFFER_SIZE, 3 * BufferPool.NORMAL_CHUNK_SIZE);
-    }
-
-    private void requestDoubleMaxMemory()
-    {
-        requestUpToSize(RandomAccessReader.DEFAULT_BUFFER_SIZE, (int)(2 * bufferPool.memoryUsageThreshold()));
-    }
-
-    private void requestUpToSize(int bufferSize, int totalSize)
-    {
-        final int numBuffers = totalSize / bufferSize;
+        assertEquals(0, bufferPool.usedMemoryBytes());
+        assertEquals(0, bufferPool.overflowMemoryBytes());
 
         List<ByteBuffer> buffers = new ArrayList<>(numBuffers);
         for (int i = 0; i < numBuffers; i++)
         {
-            ByteBuffer buffer = bufferPool.get(bufferSize, BufferType.OFF_HEAP);
+            ByteBuffer buffer = bufferPool.allocate(bufferSize);
             assertNotNull(buffer);
             assertEquals(bufferSize, buffer.capacity());
-            assertTrue(buffer.isDirect());
+
+            if (bufferPool.usedMemoryBytes() > MEMORY_USAGE_THRESHOLD)
+            {
+                assertTrue(bufferPool.overflowMemoryBytes() > 0);
+                assertTrue(bufferPool.missedAllocationsMeanRate() > 0);
+                hitlimit = true;
+            }
+
             buffers.add(buffer);
         }
 
         for (ByteBuffer buffer : buffers)
-            bufferPool.put(buffer);
+            bufferPool.release(buffer);
+
+        assertEquals(bufferPool.toString(), 0, bufferPool.usedMemoryBytes());
+        assertEquals(bufferPool.toString(), 0, bufferPool.overflowMemoryBytes());
+        assertTrue(hitlimit);
     }
 
     @Test
     public void testBigRequest()
     {
-        final int size = BufferPool.NORMAL_CHUNK_SIZE + 1;
+        final int size = (MAX_BUFFER_SIZE * 2) + 1;
 
-        ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
+        ByteBuffer buffer = bufferPool.allocate(size);
         assertNotNull(buffer);
         assertEquals(size, buffer.capacity());
-        bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testFillUpChunks()
-    {
-        final int size = RandomAccessReader.DEFAULT_BUFFER_SIZE;
-        final int numBuffers = BufferPool.NORMAL_CHUNK_SIZE / size;
-
-        List<ByteBuffer> buffers1 = new ArrayList<>(numBuffers);
-        List<ByteBuffer> buffers2 = new ArrayList<>(numBuffers);
-        for (int i = 0; i < numBuffers; i++)
-            buffers1.add(bufferPool.get(size, BufferType.OFF_HEAP));
-
-        BufferPool.Chunk chunk1 = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk1);
-
-        for (int i = 0; i < numBuffers; i++)
-            buffers2.add(bufferPool.get(size, BufferType.OFF_HEAP));
-
-        assertEquals(2, bufferPool.unsafeNumChunks());
-
-        for (ByteBuffer buffer : buffers1)
-            bufferPool.put(buffer);
-
-        assertEquals(1, bufferPool.unsafeNumChunks());
-
-        for (ByteBuffer buffer : buffers2)
-            bufferPool.put(buffer);
-
-        assertEquals(0, bufferPool.unsafeNumChunks());
-
-        buffers2.clear();
-    }
-
-    @Test
-    public void testOutOfOrderFrees()
-    {
-        final int size = 4096;
-        final int maxFreeSlots = BufferPool.NORMAL_CHUNK_SIZE / size;
-
-        final int[] idxs = new int[maxFreeSlots];
-        for (int i = 0; i < maxFreeSlots; i++)
-            idxs[i] = i;
-
-        doTestFrees(size, maxFreeSlots, idxs);
-    }
-
-    @Test
-    public void testInOrderFrees()
-    {
-        final int size = 4096;
-        final int maxFreeSlots = BufferPool.NORMAL_CHUNK_SIZE / size;
-
-        final int[] idxs = new int[maxFreeSlots];
-        for (int i = 0; i < maxFreeSlots; i++)
-            idxs[i] = maxFreeSlots - 1 - i;
-
-        doTestFrees(size, maxFreeSlots, idxs);
-    }
-
-    @Test
-    public void testRandomFrees()
-    {
-        doTestRandomFrees(12345567878L);
-
-        bufferPool.unsafeReset();
-        doTestRandomFrees(20452249587L);
-
-        bufferPool.unsafeReset();
-        doTestRandomFrees(82457252948L);
-
-        bufferPool.unsafeReset();
-        doTestRandomFrees(98759284579L);
-
-        bufferPool.unsafeReset();
-        doTestRandomFrees(19475257244L);
-    }
-
-    private void doTestRandomFrees(long seed)
-    {
-        final int size = 4096;
-        final int maxFreeSlots = BufferPool.NORMAL_CHUNK_SIZE / size;
-
-        final int[] idxs = new int[maxFreeSlots];
-        for (int i = 0; i < maxFreeSlots; i++)
-            idxs[i] = maxFreeSlots - 1 - i;
-
-        Random rnd = new Random();
-        rnd.setSeed(seed);
-        for (int i = idxs.length - 1; i > 0; i--)
-        {
-            int idx = rnd.nextInt(i+1);
-            int v = idxs[idx];
-            idxs[idx] = idxs[i];
-            idxs[i] = v;
-        }
-
-        doTestFrees(size, maxFreeSlots, idxs);
-    }
-
-    private void doTestFrees(final int size, final int maxFreeSlots, final int[] toReleaseIdxs)
-    {
-        List<ByteBuffer> buffers = new ArrayList<>(maxFreeSlots);
-        for (int i = 0; i < maxFreeSlots; i++)
-        {
-            buffers.add(bufferPool.get(size, BufferType.OFF_HEAP));
-        }
-
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertFalse(chunk.isFree());
-
-        int freeSize = BufferPool.NORMAL_CHUNK_SIZE - maxFreeSlots * size;
-        assertEquals(freeSize, chunk.free());
-
-        for (int i : toReleaseIdxs)
-        {
-            ByteBuffer buffer = buffers.get(i);
-            assertNotNull(buffer);
-            assertEquals(size, buffer.capacity());
-
-            bufferPool.put(buffer);
-
-            freeSize += size;
-            if (freeSize == chunk.capacity())
-                assertEquals(0, chunk.free());
-            else
-                assertEquals(freeSize, chunk.free());
-        }
-
-        assertFalse(chunk.isFree());
-    }
-
-    @Test
-    public void testDifferentSizeBuffersOnOneChunk()
-    {
-        int[] sizes = new int[] {
-            5, 1024, 4096, 8, 16000, 78, 512, 256, 63, 55, 89, 90, 255, 32, 2048, 128
-        };
-
-        int sum = 0;
-        List<ByteBuffer> buffers = new ArrayList<>(sizes.length);
-        for (int i = 0; i < sizes.length; i++)
-        {
-            ByteBuffer buffer = bufferPool.get(sizes[i], BufferType.OFF_HEAP);
-            assertNotNull(buffer);
-            assertTrue(buffer.capacity() >= sizes[i]);
-            buffers.add(buffer);
-
-            sum += bufferPool.unsafeCurrentChunk().roundUp(buffer.capacity());
-        }
-
-        // else the test will fail, adjust sizes as required
-        assertTrue(sum <= BufferPool.GlobalPool.MACRO_CHUNK_SIZE);
-
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-
-        Random rnd = new Random();
-        rnd.setSeed(298347529L);
-        while (buffers.size() > 1)
-        {
-            int index = rnd.nextInt(buffers.size());
-            ByteBuffer buffer = buffers.remove(index);
-
-            bufferPool.put(buffer);
-        }
-        bufferPool.put(buffers.remove(0));
-
-        assertEquals(null, bufferPool.unsafeCurrentChunk());
-        assertEquals(0, chunk.free());
-    }
-
-    @Test
-    public void testChunkExhausted()
-    {
-        final int size = BufferPool.NORMAL_CHUNK_SIZE / 64; // 1kbit
-        int[] sizes = new int[128];
-        Arrays.fill(sizes, size);
-
-        int sum = 0;
-        List<ByteBuffer> buffers = new ArrayList<>(sizes.length);
-        for (int i = 0; i < sizes.length; i++)
-        {
-            ByteBuffer buffer = bufferPool.get(sizes[i], BufferType.OFF_HEAP);
-            assertNotNull(buffer);
-            assertTrue(buffer.capacity() >= sizes[i]);
-            buffers.add(buffer);
-
-            sum += buffer.capacity();
-        }
-
-        // else the test will fail, adjust sizes as required
-        assertTrue(sum <= BufferPool.GlobalPool.MACRO_CHUNK_SIZE);
-
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-
-        for (int i = 0; i < sizes.length; i++)
-        {
-            bufferPool.put(buffers.get(i));
-        }
-
-        assertEquals(null, bufferPool.unsafeCurrentChunk());
-        assertEquals(0, chunk.free());
+        bufferPool.release(buffer);
     }
 
     @Test
     public void testCompactIfOutOfCapacity()
     {
+        if (bufferPool instanceof TemporaryBufferPool)
+            return;
+
         final int size = 4096;
-        final int numBuffersInChunk = BufferPool.GlobalPool.MACRO_CHUNK_SIZE / size;
+        final int numBuffersInSlab = BufferPool.NUM_BUFFERS_PER_SLAB;
 
-        List<ByteBuffer> buffers = new ArrayList<>(numBuffersInChunk);
-        Set<Long> addresses = new HashSet<>(numBuffersInChunk);
+        List<ByteBuffer> buffers = new ArrayList<>(numBuffersInSlab);
+        Set<Long> addresses = new HashSet<>(numBuffersInSlab);
 
-        for (int i = 0; i < numBuffersInChunk; i++)
+        for (int i = 0; i < numBuffersInSlab; i++)
         {
-            ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
+            ByteBuffer buffer = bufferPool.allocate(size);
             buffers.add(buffer);
-            addresses.add(MemoryUtil.getAddress(buffer));
+            addresses.add(UnsafeByteBufferAccess.getAddress(buffer));
         }
 
-        for (int i = numBuffersInChunk - 1; i >= 0; i--)
-            bufferPool.put(buffers.get(i));
+        for (int i = numBuffersInSlab - 1; i >= 0; i--)
+            bufferPool.release(buffers.get(i));
 
         buffers.clear();
 
-        for (int i = 0; i < numBuffersInChunk; i++)
+        for (int i = 0; i < numBuffersInSlab; i++)
         {
-            ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
+            ByteBuffer buffer = bufferPool.allocate(size);
             assertNotNull(buffer);
             assertEquals(size, buffer.capacity());
-            assert addresses.remove(MemoryUtil.getAddress(buffer));
+            addresses.remove(UnsafeByteBufferAccess.getAddress(buffer));
 
             buffers.add(buffer);
         }
@@ -441,76 +308,7 @@ public class BufferPoolTest
         assertTrue(addresses.isEmpty()); // all 5 released buffers were used
 
         for (ByteBuffer buffer : buffers)
-            bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testHeapBuffer()
-    {
-        ByteBuffer buffer = bufferPool.get(1024, BufferType.ON_HEAP);
-        assertNotNull(buffer);
-        assertEquals(1024, buffer.capacity());
-        assertFalse(buffer.isDirect());
-        assertNotNull(buffer.array());
-        bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testSingleBufferOneChunk()
-    {
-        checkBuffer(0);
-
-        checkBuffer(1);
-        checkBuffer(2);
-        checkBuffer(4);
-        checkBuffer(5);
-        checkBuffer(8);
-        checkBuffer(16);
-        checkBuffer(32);
-        checkBuffer(64);
-
-        checkBuffer(65);
-        checkBuffer(127);
-        checkBuffer(128);
-
-        checkBuffer(129);
-        checkBuffer(255);
-        checkBuffer(256);
-
-        checkBuffer(512);
-        checkBuffer(1024);
-        checkBuffer(2048);
-        checkBuffer(4096);
-        checkBuffer(8192);
-        checkBuffer(16384);
-
-        checkBuffer(16385);
-        checkBuffer(32767);
-        checkBuffer(32768);
-
-        checkBuffer(32769);
-        checkBuffer(33172);
-        checkBuffer(33553);
-        checkBuffer(36000);
-        checkBuffer(65535);
-        checkBuffer(65536);
-
-        checkBuffer(65537);
-    }
-
-    private void checkBuffer(int size)
-    {
-        ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
-        assertEquals(size, buffer.capacity());
-
-        if (size > 0 && size < BufferPool.NORMAL_CHUNK_SIZE)
-        {
-            BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-            assertNotNull(chunk);
-            assertEquals(chunk.capacity(), chunk.free() + chunk.roundUp(size));
-        }
-
-        bufferPool.put(buffer);
+            bufferPool.release(buffer);
     }
 
     @Test
@@ -528,539 +326,40 @@ public class BufferPoolTest
 
         for (int size : sizes)
         {
-            ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
+            ByteBuffer buffer = bufferPool.allocate(size);
             assertEquals(size, buffer.capacity());
 
             buffers.add(buffer);
         }
 
         for (ByteBuffer buffer : buffers)
-            bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testBuffersWithGivenSlots()
-    {
-        checkBufferWithGivenSlots(21241, (-1L << 27) ^ (1L << 40));
-    }
-
-    private void checkBufferWithGivenSlots(int size, long freeSlots)
-    {
-        //first allocate to make sure there is a chunk
-        ByteBuffer buffer = bufferPool.get(size, BufferType.OFF_HEAP);
-
-        // now get the current chunk and override the free slots mask
-        BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-        long oldFreeSlots = chunk.setFreeSlots(freeSlots);
-
-        // now check we can still get the buffer with the free slots mask changed
-        ByteBuffer buffer2 = bufferPool.get(size, BufferType.OFF_HEAP);
-        assertEquals(size, buffer.capacity());
-        bufferPool.put(buffer2);
-
-        // unsafeReset the free slots
-        chunk.setFreeSlots(oldFreeSlots);
-        bufferPool.put(buffer);
+            bufferPool.release(buffer);
     }
 
     @Test
     public void testZeroSizeRequest()
     {
-        ByteBuffer buffer = bufferPool.get(0, BufferType.OFF_HEAP);
+        ByteBuffer buffer = bufferPool.allocate(0);
         assertNotNull(buffer);
         assertEquals(0, buffer.capacity());
-        bufferPool.put(buffer);
+        bufferPool.release(buffer);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeSizeRequest()
     {
-        bufferPool.get(-1, BufferType.OFF_HEAP);
+        bufferPool.allocate(-1);
     }
 
     @Test
-    public void testMT_SameSizeImmediateReturn() throws InterruptedException
+    public void testDisabled()
     {
-        checkMultipleThreads(40, 1, true, RandomAccessReader.DEFAULT_BUFFER_SIZE);
+        BufferPoolDisabled bufferPoolDisabled = new BufferPoolDisabled("DisabledBufferPoolTest", MEMORY_USAGE_THRESHOLD);
+        assertNotNull(bufferPoolDisabled.allocate(0));
+
+        ByteBuffer buffer = bufferPoolDisabled.allocate(4096);
+        assertEquals(4096, buffer.capacity());
+        bufferPoolDisabled.release(buffer);
     }
 
-    @Test
-    public void testMT_SameSizePostponedReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40, 1, false, RandomAccessReader.DEFAULT_BUFFER_SIZE);
-    }
-
-    @Test
-    public void testMT_TwoSizesOneBufferImmediateReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40, 1, true, 1024, 2048);
-    }
-
-    @Test
-    public void testMT_TwoSizesOneBufferPostponedReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40, 1, false, 1024, 2048);
-    }
-
-    @Test
-    public void testMT_TwoSizesTwoBuffersImmediateReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40, 2, true, 1024, 2048);
-    }
-
-    @Test
-    public void testMT_TwoSizesTwoBuffersPostponedReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40, 2, false, 1024, 2048);
-    }
-
-    @Test
-    public void testMT_MultipleSizesOneBufferImmediateReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40,
-                             1,
-                             true,
-                             1024,
-                             2048,
-                             3072,
-                             4096,
-                             5120);
-    }
-
-    @Test
-    public void testMT_MultipleSizesOneBufferPostponedReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40,
-                             1,
-                             false,
-                             1024,
-                             2048,
-                             3072,
-                             4096,
-                             5120);
-    }
-
-    @Test
-    public void testMT_MultipleSizesMultipleBuffersImmediateReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40,
-                             4,
-                             true,
-                             1024,
-                             2048,
-                             3072,
-                             4096,
-                             5120);
-    }
-
-    @Test
-    public void testMT_MultipleSizesMultipleBuffersPostponedReturn() throws InterruptedException
-    {
-        checkMultipleThreads(40,
-                             3,
-                             false,
-                             1024,
-                             2048,
-                             3072,
-                             4096,
-                             5120);
-    }
-
-    private void checkMultipleThreads(int threadCount, int numBuffersPerThread, final boolean returnImmediately, final int ... sizes) throws InterruptedException
-    {
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        final CountDownLatch finished = new CountDownLatch(threadCount);
-
-        for (int i = 0; i < threadCount; i++)
-        {
-            final int[] threadSizes = new int[numBuffersPerThread];
-            for (int j = 0; j < threadSizes.length; j++)
-                threadSizes[j] = sizes[(i * numBuffersPerThread + j) % sizes.length];
-
-            final Random rand = new Random();
-            executorService.submit(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    try
-                    {
-                        Thread.sleep(rand.nextInt(3));
-
-                        List<ByteBuffer> toBeReturned = new ArrayList<ByteBuffer>(threadSizes.length);
-
-                        for (int j = 0; j < threadSizes.length; j++)
-                        {
-                            ByteBuffer buffer = bufferPool.get(threadSizes[j], BufferType.OFF_HEAP);
-                            assertNotNull(buffer);
-                            assertEquals(threadSizes[j], buffer.capacity());
-
-                            for (int i = 0; i < 10; i++)
-                                buffer.putInt(i);
-
-                            buffer.rewind();
-
-                            Thread.sleep(rand.nextInt(3));
-
-                            for (int i = 0; i < 10; i++)
-                                assertEquals(i, buffer.getInt());
-
-                            if (returnImmediately)
-                                bufferPool.put(buffer);
-                            else
-                                toBeReturned.add(buffer);
-
-                            assertTrue(bufferPool.sizeInBytes() > 0);
-                        }
-
-                        Thread.sleep(rand.nextInt(3));
-
-                        for (ByteBuffer buffer : toBeReturned)
-                            bufferPool.put(buffer);
-                    }
-                    catch (Exception ex)
-                    {
-                        ex.printStackTrace();
-                        fail(ex.getMessage());
-                    }
-                    finally
-                    {
-                        finished.countDown();
-                    }
-                }
-            });
-        }
-
-        finished.await();
-        assertEquals(0, executorService.shutdownNow().size());
-
-        // Make sure thread local storage gets GC-ed
-        for (int i = 0; i < 5; i++)
-        {
-            System.gc();
-            Thread.sleep(100);
-        }
-    }
-
-    @Ignore
-    public void testMultipleThreadsReleaseSameBuffer() throws InterruptedException
-    {
-        doMultipleThreadsReleaseBuffers(45, 4096);
-    }
-
-    @Ignore
-    public void testMultipleThreadsReleaseDifferentBuffer() throws InterruptedException
-    {
-        doMultipleThreadsReleaseBuffers(45, 4096, 8192);
-    }
-
-    private void doMultipleThreadsReleaseBuffers(final int threadCount, final int ... sizes) throws InterruptedException
-    {
-        final ByteBuffer[] buffers = new ByteBuffer[sizes.length];
-        int sum = 0;
-        for (int i = 0; i < sizes.length; i++)
-        {
-            buffers[i] = bufferPool.get(sizes[i], BufferType.OFF_HEAP);
-            assertNotNull(buffers[i]);
-            assertEquals(sizes[i], buffers[i].capacity());
-            sum += bufferPool.unsafeCurrentChunk().roundUp(buffers[i].capacity());
-        }
-
-        final BufferPool.Chunk chunk = bufferPool.unsafeCurrentChunk();
-        assertNotNull(chunk);
-        assertFalse(chunk.isFree());
-
-        // if we use multiple chunks the test will fail, adjust sizes accordingly
-        assertTrue(sum < BufferPool.GlobalPool.MACRO_CHUNK_SIZE);
-
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        final CountDownLatch finished = new CountDownLatch(threadCount);
-
-        for (int i = 0; i < threadCount; i++)
-        {
-            final int idx = i % sizes.length;
-            final ByteBuffer buffer = buffers[idx];
-
-            executorService.submit(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    try
-                    {
-                        assertNotSame(chunk, bufferPool.unsafeCurrentChunk());
-                        bufferPool.put(buffer);
-                    }
-                    catch (AssertionError ex)
-                    { //this is expected if we release a buffer more than once
-                        ex.printStackTrace();
-                    }
-                    catch (Throwable t)
-                    {
-                        t.printStackTrace();
-                        fail(t.getMessage());
-                    }
-                    finally
-                    {
-                        finished.countDown();
-                    }
-                }
-            });
-        }
-
-        finished.await();
-        assertEquals(0, executorService.shutdownNow().size());
-
-        executorService = null;
-
-        // Make sure thread local storage gets GC-ed
-        System.gc();
-        System.gc();
-        System.gc();
-
-        assertTrue(bufferPool.unsafeCurrentChunk().isFree());
-
-        //make sure the main thread can still allocate buffers
-        ByteBuffer buffer = bufferPool.get(sizes[0], BufferType.OFF_HEAP);
-        assertNotNull(buffer);
-        assertEquals(sizes[0], buffer.capacity());
-        bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testOverflowAllocation()
-    {
-        int macroChunkSize = BufferPool.GlobalPool.MACRO_CHUNK_SIZE;
-        int allocationSize = BufferPool.NORMAL_CHUNK_SIZE;
-        int allocations = BufferPool.GlobalPool.MACRO_CHUNK_SIZE / allocationSize;
-
-        // occupy entire buffer pool
-        List<ByteBuffer> buffers = new ArrayList<>();
-        allocate(allocations, allocationSize, buffers);
-
-        assertEquals(macroChunkSize, bufferPool.sizeInBytes());
-        assertEquals(macroChunkSize, bufferPool.usedSizeInBytes());
-        assertEquals(0, bufferPool.overflowMemoryInBytes());
-
-        // allocate overflow due to pool exhaust
-        ByteBuffer overflowBuffer = bufferPool.get(BufferPool.NORMAL_ALLOCATION_UNIT, BufferType.OFF_HEAP);
-
-        assertEquals(macroChunkSize + overflowBuffer.capacity(), bufferPool.sizeInBytes());
-        assertEquals(macroChunkSize + overflowBuffer.capacity(), bufferPool.usedSizeInBytes());
-        assertEquals(overflowBuffer.capacity(), bufferPool.overflowMemoryInBytes());
-
-        // free all buffer
-        bufferPool.put(overflowBuffer);
-        release(buffers);
-
-        assertEquals(macroChunkSize, bufferPool.sizeInBytes());
-        assertEquals(0, bufferPool.usedSizeInBytes());
-        assertEquals(0, bufferPool.overflowMemoryInBytes());
-
-        // allocate overflow due to on-heap
-        overflowBuffer = bufferPool.get(BufferPool.NORMAL_ALLOCATION_UNIT, BufferType.ON_HEAP);
-        assertEquals(macroChunkSize + overflowBuffer.capacity(), bufferPool.sizeInBytes());
-        assertEquals(overflowBuffer.capacity(), bufferPool.usedSizeInBytes());
-        assertEquals(overflowBuffer.capacity(), bufferPool.overflowMemoryInBytes());
-        bufferPool.put(overflowBuffer);
-
-        // allocate overflow due to over allocation size
-        overflowBuffer = bufferPool.get(2 * BufferPool.NORMAL_CHUNK_SIZE, BufferType.ON_HEAP);
-        assertEquals(macroChunkSize + overflowBuffer.capacity(), bufferPool.sizeInBytes());
-        assertEquals(overflowBuffer.capacity(), bufferPool.usedSizeInBytes());
-        assertEquals(overflowBuffer.capacity(), bufferPool.overflowMemoryInBytes());
-    }
-
-    @Test
-    public void testRecyclePartialFreeChunk()
-    {
-        // normal chunk size is 128kb
-        int halfNormalChunk = BufferPool.NORMAL_CHUNK_SIZE / 2; // 64kb, half of normal chunk
-        List<ByteBuffer> toRelease = new ArrayList<>();
-
-        // allocate three buffers on different chunks
-        ByteBuffer buffer0 = bufferPool.get(halfNormalChunk, BufferType.OFF_HEAP);
-        BufferPool.Chunk chunk0 = BufferPool.Chunk.getParentChunk(buffer0);
-        assertFalse(chunk0.isFree());
-        allocate(1, halfNormalChunk, toRelease); // allocate remaining buffers in the chunk
-
-        ByteBuffer buffer1 = bufferPool.get(halfNormalChunk, BufferType.OFF_HEAP);
-        BufferPool.Chunk chunk1 = BufferPool.Chunk.getParentChunk(buffer1);
-        assertFalse(chunk1.isFree());
-        assertNotEquals(chunk0, chunk1);
-        allocate(1, halfNormalChunk, toRelease); // allocate remaining buffers in the chunk
-
-        ByteBuffer buffer2 = bufferPool.get(halfNormalChunk, BufferType.OFF_HEAP);
-        BufferPool.Chunk chunk2 = BufferPool.Chunk.getParentChunk(buffer2);
-        assertFalse(chunk2.isFree());
-        assertNotEquals(chunk0, chunk2);
-        assertNotEquals(chunk1, chunk2);
-        allocate(1, halfNormalChunk, toRelease); // allocate remaining buffers in the chunk
-
-        // now all 3 chunks in local pool is full, allocate one more buffer to evict chunk2
-        ByteBuffer buffer3 = bufferPool.get(halfNormalChunk, BufferType.OFF_HEAP);
-        BufferPool.Chunk chunk3 = BufferPool.Chunk.getParentChunk(buffer3);
-        assertNotEquals(chunk0, chunk3);
-        assertNotEquals(chunk1, chunk3);
-        assertNotEquals(chunk2, chunk3);
-
-        // verify chunk2 got evicted, it doesn't have an owner
-        assertNotNull(chunk0.owner());
-        assertEquals(BufferPool.Chunk.Status.IN_USE, chunk0.status());
-        assertNotNull(chunk1.owner());
-        assertEquals(BufferPool.Chunk.Status.IN_USE, chunk1.status());
-        assertNull(chunk2.owner());
-        assertEquals(BufferPool.Chunk.Status.EVICTED, chunk2.status());
-
-        // release half buffers for chunk0/1/2
-        release(toRelease);
-        BufferPool.Chunk partiallyFreed = chunk2;
-
-        // try to recirculate chunk2 and verify freed space
-        assertFalse(bufferPool.globalPool().isFullyFreed(partiallyFreed));
-        assertTrue(bufferPool.globalPool().isPartiallyFreed(partiallyFreed));
-        assertEquals(BufferPool.Chunk.Status.IN_USE, partiallyFreed.status());
-        assertEquals(halfNormalChunk, partiallyFreed.free());
-        ByteBuffer buffer = partiallyFreed.get(halfNormalChunk, false, null);
-        assertEquals(halfNormalChunk, buffer.capacity());
-
-        // cleanup allocated buffers
-        for (ByteBuffer buf : Arrays.asList(buffer0, buffer1, buffer2, buffer3, buffer))
-            bufferPool.put(buf);
-
-        // verify that fully freed chunk are prioritized over partially freed chunks
-        List<BufferPool.Chunk> remainingChunks = new ArrayList<>();
-        BufferPool.Chunk chunkForAllocation;
-        while ((chunkForAllocation = bufferPool.globalPool().get()) != null)
-            remainingChunks.add(chunkForAllocation);
-
-        int totalNormalChunks = BufferPool.GlobalPool.MACRO_CHUNK_SIZE / BufferPool.NORMAL_CHUNK_SIZE; // 64;
-        assertEquals(totalNormalChunks, remainingChunks.size());
-        assertSame(partiallyFreed, remainingChunks.get(remainingChunks.size() - 1)); // last one is partially freed
-
-        // cleanup polled chunks
-        remainingChunks.forEach(BufferPool.Chunk::release);
-    }
-
-    @Test
-    public void testTinyPool()
-    {
-        int total = 0;
-        final int size = BufferPool.TINY_ALLOCATION_UNIT;
-        final int allocationPerChunk = 64;
-
-        // occupy 3 tiny chunks
-        List<ByteBuffer> buffers0 = new ArrayList<>();
-        BufferPool.Chunk chunk0 = allocate(allocationPerChunk, size, buffers0);
-        assertTrue(chunk0.owner().isTinyPool());
-        List<ByteBuffer> buffers1 = new ArrayList<>();
-        BufferPool.Chunk chunk1 = allocate(allocationPerChunk, size, buffers1);
-        assertTrue(chunk1.owner().isTinyPool());
-        List<ByteBuffer> buffers2 = new ArrayList<>();
-        BufferPool.Chunk chunk2 = allocate(allocationPerChunk, size, buffers2);
-        assertTrue(chunk2.owner().isTinyPool());
-        total += 3 * BufferPool.TINY_CHUNK_SIZE;
-        assertEquals(total, bufferPool.usedSizeInBytes());
-
-        // allocate another tiny chunk.. chunk2 should be evicted
-        List<ByteBuffer> buffers3 = new ArrayList<>();
-        BufferPool.Chunk chunk3 = allocate(allocationPerChunk, size, buffers3);
-        assertTrue(chunk3.owner().isTinyPool());
-        total += BufferPool.TINY_CHUNK_SIZE;
-        assertEquals(total, bufferPool.usedSizeInBytes());
-
-        // verify chunk2 is full and evicted
-        assertEquals(0, chunk2.free());
-        assertNull(chunk2.owner());
-
-        // release chunk2's buffer
-        for (int i = 0; i < buffers2.size(); i++)
-        {
-            bufferPool.put(buffers2.get(i));
-            total -= buffers2.get(i).capacity();
-            assertEquals(total, bufferPool.usedSizeInBytes());
-        }
-
-        // cleanup allocated buffers
-        for (ByteBuffer buffer : Iterables.concat(buffers0, buffers1, buffers3))
-            bufferPool.put(buffer);
-    }
-
-    @Test
-    public void testReleaseLocal()
-    {
-        final int size = BufferPool.TINY_ALLOCATION_UNIT;
-        final int allocationPerChunk = 64;
-
-        // occupy 3 tiny chunks
-        List<ByteBuffer> buffers0 = new ArrayList<>();
-        BufferPool.Chunk chunk0 = allocate(allocationPerChunk, size, buffers0);
-        List<ByteBuffer> buffers1 = new ArrayList<>();
-        BufferPool.Chunk chunk1 = allocate(allocationPerChunk, size, buffers1);
-        List<ByteBuffer> buffers2 = new ArrayList<>();
-        BufferPool.Chunk chunk2 = allocate(allocationPerChunk, size, buffers2);
-
-        // release them from the pool
-        bufferPool.releaseLocal();
-
-        assertNull(chunk0.owner());
-        assertNull(chunk1.owner());
-        assertNull(chunk2.owner());
-        assertEquals(BufferPool.Chunk.Status.EVICTED, chunk0.status());
-        assertEquals(BufferPool.Chunk.Status.EVICTED, chunk1.status());
-        assertEquals(BufferPool.Chunk.Status.EVICTED, chunk2.status());
-
-        // cleanup allocated buffers, that should still work fine even though we released them from the localPool
-        for (ByteBuffer buffer : Iterables.concat(buffers0, buffers1, buffers2))
-            bufferPool.put(buffer);
-
-        assertEquals(0, bufferPool.usedSizeInBytes());
-    }
-
-    @Test
-    public void testPuttingUnusedPortion()
-    {
-        final int expectedCapacity = BufferPool.TINY_ALLOCATION_UNIT * 4;
-        final int quarterUnit = BufferPool.TINY_ALLOCATION_UNIT / 4;
-        final int requestedCapacity = expectedCapacity - 3 * quarterUnit;
-
-        ByteBuffer buffer = bufferPool.getAtLeast(requestedCapacity, BufferType.OFF_HEAP);
-        assertNotNull(buffer);
-        assertEquals(expectedCapacity, buffer.capacity());
-        assertEquals(expectedCapacity, bufferPool.usedSizeInBytes());
-
-        buffer.limit(requestedCapacity); // 3.25 x unit
-        bufferPool.putUnusedPortion(buffer);
-
-        // the unused portion was too small to be returned, the buffer remains unchanged
-        assertEquals(expectedCapacity, buffer.capacity());
-        // used size is didn't change either
-        assertEquals(expectedCapacity, bufferPool.usedSizeInBytes());
-
-        buffer.limit(expectedCapacity - BufferPool.TINY_ALLOCATION_UNIT); // 3.0 x unit
-        bufferPool.putUnusedPortion(buffer);
-
-        // now we should notice a change
-        assertEquals(BufferPool.TINY_ALLOCATION_UNIT * 3, buffer.capacity());
-        assertEquals(BufferPool.TINY_ALLOCATION_UNIT * 3, bufferPool.usedSizeInBytes());
-
-        bufferPool.put(buffer);
-
-        assertEquals(0, bufferPool.usedSizeInBytes());
-    }
-
-    private BufferPool.Chunk allocate(int num, int bufferSize, List<ByteBuffer> buffers)
-    {
-        for (int i = 0; i < num; i++)
-            buffers.add(bufferPool.get(bufferSize, BufferType.OFF_HEAP));
-
-        return BufferPool.Chunk.getParentChunk(buffers.get(buffers.size() - 1));
-    }
-
-    private void release(List<ByteBuffer> toRelease)
-    {
-        for (ByteBuffer buffer : toRelease)
-            bufferPool.put(buffer);
-    }
 }


### PR DESCRIPTION
This is a trial (not meant to be committed or reviewed) to port the ChunkCache implementation for DSE to VSearch.

The main problem is that you have to also import a different BufferPool implementation (because the DSE implementation is working in a totally different way and the ChunkCache leverages some features)


I had also to import lot of utility classes and port mock implementations of mechanisms related to TPC.

The main goal of this PR it to give an idea of the complexity of this port, in case we want to go this way