### PR TITLE
Use Bounds for SinglePartitionReadCommand DataRange in SAI

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -55,7 +55,6 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
-import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
@@ -152,7 +151,6 @@ public class QueryController
 
     private final PrimaryKey.Factory keyFactory;
     private final PrimaryKey firstPrimaryKey;
-    private final PrimaryKey lastPrimaryKey;
 
     public QueryController(ColumnFamilyStore cfs,
                            ReadCommand command,
@@ -175,7 +173,6 @@ public class QueryController
 
         this.keyFactory = PrimaryKey.factory(cfs.metadata().comparator, indexFeatureSet);
         this.firstPrimaryKey = keyFactory.createTokenOnly(mergeRange.left.getToken());
-        this.lastPrimaryKey = keyFactory.createTokenOnly(mergeRange.right.getToken());
     }
 
     public PrimaryKey.Factory primaryKeyFactory()
@@ -188,10 +185,6 @@ public class QueryController
         return firstPrimaryKey;
     }
 
-    public PrimaryKey lastPrimaryKey()
-    {
-        return lastPrimaryKey;
-    }
 
     public TableMetadata metadata()
     {
@@ -791,7 +784,7 @@ public class QueryController
         {
             SinglePartitionReadCommand cmd = (SinglePartitionReadCommand) command;
             DecoratedKey key = cmd.partitionKey();
-            return Lists.newArrayList(new DataRange(new Range<>(key, key), cmd.clusteringIndexFilter()));
+            return Lists.newArrayList(new DataRange(new Bounds<>(key, key), cmd.clusteringIndexFilter()));
         }
         else if (command instanceof PartitionRangeReadCommand)
         {

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -164,7 +164,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     private static class ResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
     {
         private final PrimaryKey firstPrimaryKey;
-        private final PrimaryKey lastPrimaryKey;
         private final Iterator<DataRange> keyRanges;
         private AbstractBounds<PartitionPosition> currentKeyRange;
 
@@ -194,7 +193,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             this.keyFactory = controller.primaryKeyFactory();
 
             this.firstPrimaryKey = controller.firstPrimaryKey();
-            this.lastPrimaryKey = controller.lastPrimaryKey();
         }
 
         @Override
@@ -332,18 +330,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
          */
         private @Nullable PrimaryKey nextKey()
         {
-            if (!operation.hasNext())
-                return null;
-            PrimaryKey key = operation.next();
-            return isWithinUpperBound(key) ? key : null;
-        }
-
-        /**
-         * Returns true if the key is not greater than lastPrimaryKey
-         */
-        private boolean isWithinUpperBound(PrimaryKey key)
-        {
-            return lastPrimaryKey.token().isMinimum() || lastPrimaryKey.compareTo(key) >= 0;
+            return operation.hasNext() ? operation.next() : null;
         }
 
         /**


### PR DESCRIPTION
After switching to Bounds, we can remove an unnecessary upper bound check because Bounds#contains is strict, while Range#contains assumes that when `left.equals(right)`, we have a wrap around range, and that doesn't give us what we really want for single partition reads.

Here is the logic where `Range` determines if a `Range` wraps around:

```java
    /**
     * Tells if the given range is a wrap around.
     */
    public static <T extends RingPosition<T>> boolean isWrapAround(T left, T right)
    {
       return left.compareTo(right) >= 0;
    }
```

Meanwhile, `Bounds` gives us what we want:

```java
    public Bounds(T left, T right)
    {
        super(left, right);
        // unlike a Range, a Bounds may not wrap
        assert !strictlyWrapsAround(left, right) : "[" + left + "," + right + "]";
    }
```