### PR TITLE
STAR-1908: Do not support token space coverage in BIG format

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -195,7 +195,7 @@ public class BigFormat implements SSTableFormat
     // we always incremented the major version.
     static class BigVersion extends Version
     {
-        public static final String current_version = "nc";
+        public static final String current_version = "nb";
         public static final String earliest_supported_version = "ma";
 
         // ma (3.0.0): swap bf hash order
@@ -207,7 +207,6 @@ public class BigFormat implements SSTableFormat
 
         // na (4.0-rc1): uncompressed chunks, pending repair session, isTransient, checksummed sstable metadata file, new Bloomfilter format
         // nb (4.0.0): originating host id
-        // nc (5.0): token space coverage
         //
         // NOTE: when adding a new version, please add that to LegacySSTableTest, too.
 
@@ -249,7 +248,7 @@ public class BigFormat implements SSTableFormat
             hasIsTransient = version.compareTo("na") >= 0;
             hasMetadataChecksum = version.compareTo("na") >= 0;
             hasOldBfFormat = version.compareTo("na") < 0;
-            hasTokenSpaceCoverage = version.compareTo("nc") >= 0;
+            hasTokenSpaceCoverage = false; // token space coverage has been introduced in BIG format in OA, which is introduced in Cassandra 5.0
         }
 
         @Override


### PR DESCRIPTION
Cassandra 4.0, and thus CC based on it supports BIG format up to N version. Token space coverage has been introduced in OSS starting from O version which comes with Cassandra 5.0.

We cannot support token space coverage in N version of BIG format as it would lead to producing sstables with the same format identifier and different binary structure.