### PR TITLE
DSP-24082: Port OSS vector tests and fixes and improvements around them

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -365,7 +365,7 @@ selectionTypeHint returns [Selectable.Raw s]
 
 selectionList returns [Selectable.Raw s]
     @init { List<Selectable.Raw> l = new ArrayList<>(); }
-    @after { $s = new Selectable.WithList.Raw(l); }
+    @after { $s = new Selectable.WithArrayLiteral.Raw(l); }
     : '[' ( t1=unaliasedSelector { l.add(t1); } ( ',' tn=unaliasedSelector { l.add(tn); } )* )? ']'
     ;
 

--- a/src/java/org/apache/cassandra/cql3/CQL3Type.java
+++ b/src/java/org/apache/cassandra/cql3/CQL3Type.java
@@ -686,6 +686,11 @@ public interface CQL3Type
             return this.frozen;
         }
 
+        public boolean isImplicitlyFrozen()
+        {
+            return isTuple() || isVector();
+        }
+
         public boolean isDuration()
         {
             return false;

--- a/src/java/org/apache/cassandra/cql3/Constants.java
+++ b/src/java/org/apache/cassandra/cql3/Constants.java
@@ -294,7 +294,7 @@ public abstract class Constants
         public AssignmentTestable.TestResult testAssignment(String keyspace, ColumnSpecification receiver)
         {
             CQL3Type receiverType = receiver.type.asCQL3Type();
-            if (receiverType.isCollection() || receiverType.isUDT())
+            if (receiverType.isCollection() || receiverType.isUDT() || receiverType.isVector())
                 return AssignmentTestable.TestResult.NOT_ASSIGNABLE;
 
             if (!(receiverType instanceof CQL3Type.Native))

--- a/src/java/org/apache/cassandra/cql3/Vectors.java
+++ b/src/java/org/apache/cassandra/cql3/Vectors.java
@@ -21,22 +21,17 @@ package org.apache.cassandra.cql3;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.cassandra.cql3.functions.Function;
-import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.ByteBufferAccessor;
-import org.apache.cassandra.db.marshal.FloatType;
-import org.apache.cassandra.db.marshal.ListType;
-import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-
-import static org.apache.cassandra.cql3.Constants.UNSET_VALUE;
 
 public class Vectors
 {
@@ -49,7 +44,51 @@ public class Vectors
 
     private static ColumnSpecification valueSpecOf(ColumnSpecification column)
     {
-        return new ColumnSpecification(column.ksName, column.cfName, new ColumnIdentifier("value(" + column.name + ")", true), elementsType(column.type));
+        return new ColumnSpecification(column.ksName, column.cfName, new ColumnIdentifier("value(" + column.name + ')', true), elementsType(column.type));
+    }
+
+    /**
+     * Tests that the vector with the specified elements can be assigned to the specified column.
+     *
+     * @param receiver the receiving column
+     * @param elements the vector elements
+     */
+    public static AssignmentTestable.TestResult testVectorAssignment(ColumnSpecification receiver,
+                                                                     List<? extends AssignmentTestable> elements)
+    {
+        if (!receiver.type.isVector())
+            return AssignmentTestable.TestResult.NOT_ASSIGNABLE;
+
+        // If there is no elements, we can't say it's an exact match (an empty vector if fundamentally polymorphic).
+        if (elements.isEmpty())
+            return AssignmentTestable.TestResult.WEAKLY_ASSIGNABLE;
+
+        ColumnSpecification valueSpec = valueSpecOf(receiver);
+        return AssignmentTestable.TestResult.testAll(receiver.ksName, valueSpec, elements);
+    }
+
+    /**
+     * Returns the exact VectorType from the items if it can be known.
+     *
+     * @param items the items mapped to the vector elements
+     * @param mapper the mapper used to retrieve the element types from the items
+     * @return the exact VectorType from the items if it can be known or <code>null</code>
+     */
+    public static <T> VectorType<?> getExactVectorTypeIfKnown(List<T> items,
+                                                              java.util.function.Function<T, AbstractType<?>> mapper)
+    {
+        // TODO - this doesn't feel right... if you are dealing with a literal then the value is `null`, so we will ignore
+        // if there are multiple times, we randomly select the first?  This logic matches Lists.getExactListTypeIfKnown but feels flawed
+        Optional<AbstractType<?>> type = items.stream().map(mapper).filter(Objects::nonNull).findFirst();
+        return type.isPresent() ? VectorType.getInstance(type.get(), items.size()) : null;
+    }
+
+    public static <T> VectorType<?> getPreferredCompatibleType(List<T> items,
+                                                               java.util.function.Function<T, AbstractType<?>> mapper)
+    {
+        Set<AbstractType<?>> types = items.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toSet());
+        AbstractType<?> type = AssignmentTestable.getCompatibleTypeIfKnown(types);
+        return type == null ? null : VectorType.getInstance(type, items.size());
     }
 
     public static class Literal extends Term.Raw

--- a/src/java/org/apache/cassandra/cql3/selection/MultiElementFactory.java
+++ b/src/java/org/apache/cassandra/cql3/selection/MultiElementFactory.java
@@ -27,9 +27,9 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.schema.ColumnMetadata;
 
 /**
- * A base <code>Selector.Factory</code> for collections or tuples.
+ * A base <code>Selector.Factory</code> for collections, tuples, and vectors.
  */
-abstract class CollectionFactory extends Factory
+abstract class MultiElementFactory extends Factory
 {
     /**
      * The collection or tuple type.
@@ -41,7 +41,7 @@ abstract class CollectionFactory extends Factory
      */
     private final SelectorFactories factories;
 
-    public CollectionFactory(AbstractType<?> type, SelectorFactories factories)
+    public MultiElementFactory(AbstractType<?> type, SelectorFactories factories)
     {
         this.type = type;
         this.factories = factories;

--- a/src/java/org/apache/cassandra/cql3/selection/SetSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SetSelector.java
@@ -49,7 +49,7 @@ final class SetSelector extends Selector
 
     public static Factory newFactory(final AbstractType<?> type, final SelectorFactories factories)
     {
-        return new CollectionFactory(type, factories)
+        return new MultiElementFactory(type, factories)
         {
             protected String getColumnName()
             {

--- a/src/java/org/apache/cassandra/cql3/selection/TupleSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/TupleSelector.java
@@ -46,7 +46,7 @@ final class TupleSelector extends Selector
 
     public static Factory newFactory(final AbstractType<?> type, final SelectorFactories factories)
     {
-        return new CollectionFactory(type, factories)
+        return new MultiElementFactory(type, factories)
         {
             protected String getColumnName()
             {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateAggregateStatement.java
@@ -103,11 +103,11 @@ public final class CreateAggregateStatement extends AlterSchemaStatement
             throw ire("Aggregate name '%s' is invalid", aggregateName);
 
         rawArgumentTypes.stream()
-                        .filter(raw -> !raw.isTuple() && raw.isFrozen())
+                        .filter(raw -> !raw.isImplicitlyFrozen() && raw.isFrozen())
                         .findFirst()
                         .ifPresent(t -> { throw ire("Argument '%s' cannot be frozen; remove frozen<> modifier from '%s'", t, t); });
 
-        if (!rawStateType.isTuple() && rawStateType.isFrozen())
+        if (!rawStateType.isImplicitlyFrozen() && rawStateType.isFrozen())
             throw ire("State type '%s' cannot be frozen; remove frozen<> modifier from '%s'", rawStateType, rawStateType);
 
         KeyspaceMetadata keyspace = schema.getNullable(keyspaceName);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateFunctionStatement.java
@@ -31,7 +31,6 @@ import org.apache.cassandra.auth.FunctionResource;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.*;
 import org.apache.cassandra.cql3.CQL3Type;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.functions.FunctionName;
@@ -102,11 +101,11 @@ public final class CreateFunctionStatement extends AlterSchemaStatement
             throw ire("Duplicate argument names for given function %s with argument names %s", functionName, argumentNames);
 
         rawArgumentTypes.stream()
-                        .filter(raw -> !raw.isTuple() && raw.isFrozen())
+                        .filter(raw -> !raw.isImplicitlyFrozen() && raw.isFrozen())
                         .findFirst()
                         .ifPresent(t -> { throw ire("Argument '%s' cannot be frozen; remove frozen<> modifier from '%s'", t, t); });
 
-        if (!rawReturnType.isTuple() && rawReturnType.isFrozen())
+        if (!rawReturnType.isImplicitlyFrozen() && rawReturnType.isFrozen())
             throw ire("Return type '%s' cannot be frozen; remove frozen<> modifier from '%s'", rawReturnType, rawReturnType);
 
         KeyspaceMetadata keyspace = schema.getNullable(keyspaceName);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropAggregateStatement.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.FunctionResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.cql3.CQL3Type;
-import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.Constants;
 import org.apache.cassandra.cql3.functions.FunctionName;
 import org.apache.cassandra.cql3.functions.UDAggregate;
@@ -95,7 +94,7 @@ public final class DropAggregateStatement extends AlterSchemaStatement
         }
 
         arguments.stream()
-                 .filter(raw -> !raw.isTuple() && raw.isFrozen())
+                 .filter(raw -> !raw.isImplicitlyFrozen() && raw.isFrozen())
                  .findFirst()
                  .ifPresent(t -> { throw ire("Argument '%s' cannot be frozen; remove frozen<> modifier from '%s'", t, t); });
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/DropFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/DropFunctionStatement.java
@@ -95,7 +95,7 @@ public final class DropFunctionStatement extends AlterSchemaStatement
         }
 
         arguments.stream()
-                 .filter(raw -> !raw.isTuple() && raw.isFrozen())
+                 .filter(raw -> !raw.isImplicitlyFrozen() && raw.isFrozen())
                  .findFirst()
                  .ifPresent(t -> { throw ire("Argument '%s' cannot be frozen; remove frozen<> modifier from '%s'", t, t); });
 

--- a/test/unit/org/apache/cassandra/cql3/functions/VectorFctsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/VectorFctsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.assertj.core.api.Assertions;
+
+public class VectorFctsTest extends CQLTester
+{
+    @BeforeClass
+    public static void setupClass()
+    {
+        System.setProperty("cassandra.float_only_vectors", "false");
+    }
+
+    @Test
+    public void randomVectorFunction() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
+
+        // correct usage
+        execute("INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1, 1))");
+        Assert.assertEquals(1, execute("SELECT value FROM %s WHERE pk = 0").size());
+
+        // wrong number of arguments
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector())");
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1))");
+        assertInvalidThrowMessage("Invalid number of arguments for function system.random_float_vector(literal_int, float, float)",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1, 1, 0))");
+
+        // mandatory arguments
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found NULL",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(null, null, null))");
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found NULL",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(null, -1, 1))");
+        assertInvalidThrowMessage("Min argument of function system.random_float_vector(literal_int, float, float) must not be null",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, null, null))");
+        assertInvalidThrowMessage("Max argument of function system.random_float_vector(literal_int, float, float) must not be null",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, -1, null))");
+        assertInvalidThrowMessage("Min argument of function system.random_float_vector(literal_int, float, float) must not be null",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, null, 1))");
+
+        // wrong argument types
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found 'a'",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector('a', -1, 1))");
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found system.\"_add\"(1, 1)",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(1 + 1, -1, 1))");
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found value",
+                                  InvalidRequestException.class,
+                                  "SELECT random_float_vector(value, -1, 1) FROM %s");
+        assertInvalidThrowMessage("Function system.random_float_vector(literal_int, float, float) requires a literal_int argument, " +
+                                  "but found 1 + 1",
+                                  InvalidRequestException.class,
+                                  "SELECT random_float_vector(1 + 1, -1, 1) FROM %s");
+
+        // wrong argument values
+        assertInvalidThrowMessage("Max value must be greater than min value",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(2, 1, -1))");
+
+        // correct function with wrong receiver type
+        assertInvalidThrowMessage("Type error: cannot assign result of function system.random_float_vector " +
+                                  "(type vector<float, 1>) to value (type vector<float, 2>)",
+                                  InvalidRequestException.class,
+                                  "INSERT INTO %s (pk, value) VALUES (0, random_float_vector(1, -1, 1))");
+
+        // test select
+        for (int dimension : new int[]{ 1, 2, 3, 10, 1000 })
+        {
+            assertSelectRandomVectorFunction(dimension, -1, 1);
+            assertSelectRandomVectorFunction(dimension, 0, 1);
+            assertSelectRandomVectorFunction(dimension, -1.5f, 1.5f);
+            assertSelectRandomVectorFunction(dimension, 0.999999f, 1);
+            assertSelectRandomVectorFunction(dimension, 0, 0.000001f);
+            assertSelectRandomVectorFunction(dimension, Float.MIN_VALUE, Float.MAX_VALUE);
+        }
+    }
+
+    private void assertSelectRandomVectorFunction(int dimension, float min, float max)
+    {
+        String functionCall = String.format("random_float_vector(%d, %f, %f)", dimension, min, max);
+        String select = "SELECT " + functionCall + " FROM %s";
+
+        for (int i = 0; i < 100; i++)
+        {
+            UntypedResultSet rs = execute(select);
+            Assertions.assertThat(rs).isNotEmpty();
+            Assertions.assertThat(rs.one().getVector("system." + functionCall, FloatType.instance, dimension))
+                      .hasSize(dimension)
+                      .allSatisfy(v -> Assertions.assertThat(v).isBetween(min, max));
+        }
+    }
+
+    @Test
+    public void normalizeL2Function() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>)");
+
+        execute("INSERT INTO %s (k, v) VALUES (0, ?)", vector(3.0f, 4.0f));
+
+        assertRows(execute("SELECT normalize_l2(v) FROM %s"), row(vector(0.6f, 0.8f)));
+        assertRows(execute("SELECT k, normalize_l2((vector<float, 2>) null) FROM %s"), row(0, null));
+
+        assertInvalidThrowMessage("Invalid number of arguments for function system.normalize_l2(vector<float, n>)",
+                                  InvalidRequestException.class,
+                                  "SELECT normalize_l2() FROM %s");
+        assertInvalidThrowMessage("Invalid number of arguments for function system.normalize_l2(vector<float, n>)",
+                                  InvalidRequestException.class,
+                                  "SELECT normalize_l2(v, 1) FROM %s");
+        assertInvalidThrowMessage("Function system.normalize_l2(vector<float, n>) requires a float vector argument, " +
+                                  "but found argument 123 of type int",
+                                  InvalidRequestException.class,
+                                  "SELECT normalize_l2(123) FROM %s");
+    }
+
+    @SafeVarargs
+    protected final <T> Vector<T> vector(T... values)
+    {
+        return new Vector<>(values);
+    }
+
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/VectorSimilarityFctsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/VectorSimilarityFctsTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(Parameterized.class)
+public class VectorSimilarityFctsTest extends CQLTester
+{
+    @Parameterized.Parameter
+    public String function;
+
+    @Parameterized.Parameter(1)
+    public VectorSimilarityFunction luceneFunction;
+
+    @Parameterized.Parameters(name = "{index}: function={0}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[][]{
+        { "system.similarity_cosine", VectorSimilarityFunction.COSINE },
+        { "system.similarity_euclidean", VectorSimilarityFunction.EUCLIDEAN },
+        { "system.similarity_dot_product", VectorSimilarityFunction.DOT_PRODUCT }
+        });
+    }
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        System.setProperty("cassandra.float_only_vectors", "false");
+    }
+
+    @Test
+    public void testVectorSimilarityFunction()
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int PRIMARY KEY, value vector<float, 2>, " +
+                              "l list<float>, " + // lists shouldn't be accepted by the functions
+                              "fl frozen<list<float>>, " + // frozen lists shouldn't be accepted by the functions
+                              "v1 vector<float, 1>, " + // 1-dimension vector to test missmatching dimensions
+                              "v_int vector<int, 2>, " + // int vectors shouldn't be accepted by the functions
+                              "v_double vector<double, 2>)");// double vectors shouldn't be accepted by the functions
+
+        float[] values = new float[]{ 1f, 2f };
+        Vector<Float> vector = vector(ArrayUtils.toObject(values));
+        Object[] similarity = row(luceneFunction.compare(values, values));
+
+        // basic functionality
+        execute("INSERT INTO %s (pk, value, l, fl, v1, v_int, v_double) VALUES (0, ?, ?, ?, ?, ?, ?)",
+                vector, list(1f, 2f), list(1f, 2f), vector(1f), vector(1, 2), vector(1d, 2d));
+        assertRows(execute("SELECT " + function + "(value, value) FROM %s"), similarity);
+
+        // literals
+        assertRows(execute("SELECT " + function + "(value, [1, 2]) FROM %s"), similarity);
+        assertRows(execute("SELECT " + function + "([1, 2], value) FROM %s"), similarity);
+        assertRows(execute("SELECT " + function + "([1, 2], [1, 2]) FROM %s"), similarity);
+
+        // bind markers
+        assertRows(execute("SELECT " + function + "(value, ?) FROM %s", vector), similarity);
+        assertRows(execute("SELECT " + function + "(?, value) FROM %s", vector), similarity);
+        assertThatThrownBy(() -> execute("SELECT " + function + "(?, ?) FROM %s", vector, vector))
+        .hasMessageContaining("Cannot infer type of argument ?");
+
+        // bind markers with type hints
+        assertRows(execute("SELECT " + function + "((vector<float, 2>) ?, ?) FROM %s", vector, vector), similarity);
+        assertRows(execute("SELECT " + function + "(?, (vector<float, 2>) ?) FROM %s", vector, vector), similarity);
+        assertRows(execute("SELECT " + function + "((vector<float, 2>) ?, (vector<float, 2>) ?) FROM %s", vector, vector), similarity);
+
+        // bind markers and literals
+        assertRows(execute("SELECT " + function + "([1, 2], ?) FROM %s", vector), similarity);
+        assertRows(execute("SELECT " + function + "(?, [1, 2]) FROM %s", vector), similarity);
+        assertRows(execute("SELECT " + function + "([1, 2], ?) FROM %s", vector), similarity);
+
+        // wrong column types with columns
+        assertThatThrownBy(() -> execute("SELECT " + function + "(l, value) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument l of type list<float>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(fl, value) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument fl of type frozen<list<float>>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, l) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument l of type list<float>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, fl) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument fl of type frozen<list<float>>");
+
+        // wrong column types with columns and literals
+        assertThatThrownBy(() -> execute("SELECT " + function + "(l, [1, 2]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument l of type list<float>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(fl, [1, 2]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument fl of type frozen<list<float>>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], l) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument l of type list<float>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], fl) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument fl of type frozen<list<float>>");
+
+        // wrong column types with cast literals
+        assertThatThrownBy(() -> execute("SELECT " + function + "((List<Float>)[1, 2], [3, 4]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument (list<float>)[1, 2] of type frozen<list<float>>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "((List<Float>)[1, 2], (List<Float>)[3, 4]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument (list<float>)[3, 4] of type frozen<list<float>>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], (List<Float>)[3, 4]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument (list<float>)[3, 4] of type frozen<list<float>>");
+
+        // wrong non-float vectors
+        assertThatThrownBy(() -> execute("SELECT " + function + "(v_int, [1, 2]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument v_int of type vector<int, 2>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(v_double, [1, 2]) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument v_double of type vector<double, 2>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], v_int) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument v_int of type vector<int, 2>");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], v_double) FROM %s"))
+        .hasMessageContaining("requires a float vector argument, but found argument v_double of type vector<double, 2>");
+
+        // mismatching dimensions with literals
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1, 2], [3]) FROM %s", vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, [1]) FROM %s", vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+        assertThatThrownBy(() -> execute("SELECT " + function + "([1], value) FROM %s", vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+
+        // mismatching dimensions with bind markers
+        assertThatThrownBy(() -> execute("SELECT " + function + "((vector<float, 1>) ?, value) FROM %s", vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, (vector<float, 1>) ?) FROM %s", vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+        assertThatThrownBy(() -> execute("SELECT " + function + "((vector<float, 2>) ?, (vector<float, 1>) ?) FROM %s", vector(1, 2), vector(1)))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+
+        // mismatching dimensions with columns
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, v1) FROM %s"))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(v1, value) FROM %s"))
+        .hasMessageContaining("All arguments must have the same vector dimensions");
+
+        // null arguments with literals
+        assertRows(execute("SELECT " + function + "(value, null) FROM %s"), row((Float) null));
+        assertRows(execute("SELECT " + function + "(null, value) FROM %s"), row((Float) null));
+        assertThatThrownBy(() -> execute("SELECT " + function + "(null, null) FROM %s"))
+        .hasMessageContaining("Cannot infer type of argument NULL in call to function " + function);
+
+        // null arguments with bind markers
+        assertRows(execute("SELECT " + function + "(value, ?) FROM %s", (Vector<Float>) null), row((Float) null));
+        assertRows(execute("SELECT " + function + "(?, value) FROM %s", (Vector<Float>) null), row((Float) null));
+        assertThatThrownBy(() -> execute("SELECT " + function + "(?, ?) FROM %s", null, null))
+        .hasMessageContaining("Cannot infer type of argument ? in call to function " + function);
+
+        // test all-zero vectors, only cosine similarity should reject them
+        if (luceneFunction == VectorSimilarityFunction.COSINE)
+        {
+            String expected = "doesn't support all-zero vectors";
+            assertThatThrownBy(() -> execute("SELECT " + function + "(value, [0, 0]) FROM %s")) .hasMessageContaining(expected);
+            assertThatThrownBy(() -> execute("SELECT " + function + "([0, 0], value) FROM %s")).hasMessageContaining(expected);
+        }
+        else
+        {
+            float expected = luceneFunction.compare(values, new float[]{ 0, 0 });
+            assertRows(execute("SELECT " + function + "(value, [0, 0]) FROM %s"), row(expected));
+            assertRows(execute("SELECT " + function + "([0, 0], value) FROM %s"), row(expected));
+        }
+
+        // not-assignable element types
+        assertThatThrownBy(() -> execute("SELECT " + function + "(value, ['a', 'b']) FROM %s WHERE pk=0"))
+            .hasMessageContaining("Type error: ['a', 'b'] cannot be passed as argument 1");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(['a', 'b'], value) FROM %s WHERE pk=0"))
+            .hasMessageContaining("Type error: ['a', 'b'] cannot be passed as argument 0");
+        assertThatThrownBy(() -> execute("SELECT " + function + "(['a', 'b'], ['a', 'b']) FROM %s WHERE pk=0"))
+            .hasMessageContaining("Type error: ['a', 'b'] cannot be passed as argument 0");
+    }
+
+    @SafeVarargs
+    protected final <T> Vector<T> vector(T... values)
+    {
+        return new Vector<>(values);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/VectorTypeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.quicktheories.QuickTheory.qt;
+
+public class VectorTypeTest
+{
+    @Test
+    public void composeAsFloat()
+    {
+        // dim
+        // data
+        Gen<Integer> dimGen = SourceDSL.integers().between(1, 100);
+        Gen<Float> floatGen = SourceDSL.floats().any();
+        Gen<Case> caseGen = rnd -> {
+            int dim = dimGen.generate(rnd);
+            float[] array = new float[dim];
+            for (int i = 0; i < dim; i++)
+                array[i] = floatGen.generate(rnd);
+            return new Case(dim, array);
+        };
+        qt().forAll(caseGen).checkAssert(c -> {
+            VectorType<Float> type = VectorType.getInstance(FloatType.instance, c.dim);
+            ByteBuffer bb = type.decompose(c.box());
+            assertThat(type.composeAsFloat(bb)).isEqualTo(c.values);
+            assertThat(c.unbox(type.compose(bb))).isEqualTo(c.values);
+            assertThat(type.getSerializer().serializeFloatArray(c.values)).isEqualTo(bb);
+        });
+    }
+
+    private static class Case
+    {
+        final int dim;
+        final float[] values;
+
+        private Case(int dim, float[] values)
+        {
+            this.dim = dim;
+            this.values = values;
+        }
+
+        List<Float> box()
+        {
+            List<Float> list = new ArrayList<>(dim);
+            for (int i = 0; i < dim; i++)
+                list.add(values[i]);
+            return list;
+        }
+
+        float[] unbox(List<Float> list)
+        {
+            assertThat(list).hasSize(dim);
+            float[] array = new float[dim];
+            for (int i = 0; i < dim; i++)
+                array[i] = list.get(i);
+            return array;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -794,11 +794,11 @@ public class VectorTypeTest extends VectorTester
                              "SELECT similarity_cosine(['a', 'b'], ['a', 'b']) FROM %s WHERE pk=0");
 
         // different vector sizes, message could be more informative
-        assertInvalidMessage("Required 2 elements, but saw 3",
+        assertInvalidMessage("All arguments must have the same vector dimensions",
                              "SELECT similarity_cosine(value, [2, 4, 6]) FROM %s WHERE pk=0");
-        assertInvalidMessage("Type error: value cannot be passed as argument 1",
+        assertInvalidMessage("All arguments must have the same vector dimensions",
                              "SELECT similarity_cosine([1, 2, 3], value) FROM %s WHERE pk=0");
-        assertInvalidMessage("Required 2 elements, but saw 3",
+        assertInvalidMessage("All arguments must have the same vector dimensions",
                              "SELECT similarity_cosine([1, 2], [3, 4, 5]) FROM %s WHERE pk=0");
     }
 


### PR DESCRIPTION
While porting the vector data type to DSE 6.9, we found that OSS has several vector tests, fixes and improvements that never made it into vsearch. This PR ports those changes into vsearch to make OSS, vsearch and DSE better aligned.

The most relevant fixes are:

- Don't accept empty byte buffers in vector columns.
- Reject all-zero vectors in `similarity_cosine`
- Better management of null arguments in vector similarity functions
- Better error messages on function arguments with wrong types

One thing I'm not porting here is the fixes to make vectors work with UDFs. I think we don't allow UDFs in Astra, and whereas we do support them in DSE, the solution there would probably be different to what we would need here.