### PR TITLE
Improve error messages for invalid SAI analyzer configuration

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
@@ -35,6 +35,7 @@ import com.google.common.base.Charsets;
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
@@ -151,7 +152,7 @@ public class LuceneAnalyzerTest
         assertArrayEquals(new String[]{}, list.toArray(new String[0]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidRequestException.class)
     public void testMissingSynonymArg() throws Exception
     {
         // The synonym filter takes a 'synonyms' argument, not a 'words' argument


### PR DESCRIPTION
Several error messages are now improved to help users understand what is incorrect about the analyzer config.

New checks:

* Better error message for invalid field names on the analyzer config itself
* Better error message for invalid `args` fields
* Better error message for invalid tokenizer, filter, and charFilter names

Here are the error messages for invalid tokenizer, filter, and charFilter names:

> Unknown tokenizer 'invalid'. Valid options: [simplePatternSplit, pattern, thai, edgeNGram, nGram, wikipedia, pathHierarchy, uax29UrlEmail, whitespace, classic, simplePattern, standard, keyword, letter]

> Unknown filter 'invalid'. Valid options: [brazilianStem, cjkBigram, truncate, fixBrokenOffsets, flattenGraph, concatenateGraph, greekLowercase, length, arabicNormalization, portugueseStem, elision, serbianNormalization, russianLightStem, scandinavianNormalization, Word2VecSynonym, decimalDigit, asciiFolding, germanStem, synonym, bulgarianStem, codepointCount, tokenOffsetPayload, patternReplace, typeAsSynonym, persianNormalization, limitTokenPosition, porterStem, greekStem, finnishLightStem, fingerprint, cjkWidth, reverseString, commonGrams, delimitedBoost, scandinavianFolding, hindiStem, spanishPluralStem, indonesianStem, trim, frenchLightStem, classic, patternTyping, fixedShingle, spanishMinimalStem, englishPossessive, synonymGraph, dictionaryCompoundWord, germanNormalization, keywordRepeat, minHash, removeDuplicates, snowballPorter, germanMinimalStem, norwegianLightStem, englishMinimalStem, norwegianMinimalStem, czechStem, soraniStem, hunspellStem, limitTokenOffset, persianStem, numericPayload, commonGramsQuery, soraniNormalization, swedishLightStem, kStem, frenchMinimalStem, keywordMarker, type, hyphenatedWords, capitalization, lowercase, protectedTerm, hungarianLightStem, teluguStem, wordDelimiter, italianLightStem, limitTokenCount, stop, swedishMinimalStem, galicianMinimalStem, portugueseMinimalStem, bengaliNormalization, galicianStem, turkishLowercase, bengaliStem, indicNormalization, keepWord, dropIfFlagged, latvianStem, portugueseLightStem, wordDelimiterGraph, apostrophe, arabicStem, delimitedTermFrequency, irishLowercase, typeAsPayload, edgeNGram, germanLightStem, hyphenationCompoundWord, patternCaptureGroup, stemmerOverride, spanishLightStem, delimitedPayload, hindiNormalization, norwegianNormalization, shingle, teluguNormalization, dateRecognizer, nGram, uppercase]

> Unknown charFilter 'invalid'. Valid options: [mapping, persian, cjkWidth, htmlStrip, patternReplace]