### PR TITLE
SAI: support `IN ()` predicate

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -388,21 +388,6 @@ public class Operation
         }
     }
 
-    public static class OrNode extends OperatorNode
-    {
-        @Override
-        protected OperationType operationType()
-        {
-            return OperationType.OR;
-        }
-
-        @Override
-        protected Plan.Builder planBuilder(QueryController controller)
-        {
-            return controller.planFactory.unionBuilder();
-        }
-    }
-
     public static class AndNode extends OperatorNode
     {
         @Override
@@ -415,6 +400,21 @@ public class Operation
         protected Plan.Builder planBuilder(QueryController controller)
         {
             return controller.planFactory.intersectionBuilder();
+        }
+    }
+
+    public static class OrNode extends OperatorNode
+    {
+        @Override
+        protected OperationType operationType()
+        {
+            return OperationType.OR;
+        }
+
+        @Override
+        protected Plan.Builder planBuilder(QueryController controller)
+        {
+            return controller.planFactory.unionBuilder();
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -388,21 +388,6 @@ public class Operation
         }
     }
 
-    public static class AndNode extends OperatorNode
-    {
-        @Override
-        protected OperationType operationType()
-        {
-            return OperationType.AND;
-        }
-
-        @Override
-        protected Plan.Builder planBuilder(QueryController controller)
-        {
-            return controller.planFactory.intersectionBuilder();
-        }
-    }
-
     public static class OrNode extends OperatorNode
     {
         @Override
@@ -415,6 +400,21 @@ public class Operation
         protected Plan.Builder planBuilder(QueryController controller)
         {
             return controller.planFactory.unionBuilder();
+        }
+    }
+
+    public static class AndNode extends OperatorNode
+    {
+        @Override
+        protected OperationType operationType()
+        {
+            return OperationType.AND;
+        }
+
+        @Override
+        protected Plan.Builder planBuilder(QueryController controller)
+        {
+            return controller.planFactory.intersectionBuilder();
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -425,7 +425,7 @@ public class Operation
         @Override
         public void analyze(QueryController controller)
         {
-            expressionMap = analyzeGroup(controller, OperationType.AND, List.of(expression));
+            expressionMap = analyzeGroup(controller, OperationType.AND, Collections.singletonList(expression));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -264,7 +264,10 @@ public class Operation
             throw new UnsupportedOperationException();
         }
 
-        abstract void analyze(List<RowFilter.Expression> expressionList, QueryController controller);
+        /**
+         * Analyze the tree, potentially flattening it and storing the result in expressionMap.
+         */
+        abstract void analyze(QueryController controller);
 
         abstract FilterTree filterTree();
 
@@ -302,6 +305,10 @@ public class Operation
                                                                                                         ProtocolVersion.V3))));
                     offset += TypeSizes.INT_SIZE + ByteBufferAccessor.instance.getInt(expression.getIndexValue(), offset);
                 }
+                if (node.children().size() == 1)
+                    return node.children().get(0);
+                if (node.children().isEmpty())
+                    return new EmptyNode();
                 return node;
             }
             else
@@ -310,38 +317,19 @@ public class Operation
 
         Node analyzeTree(QueryController controller)
         {
-            List<RowFilter.Expression> expressionList = new ArrayList<>();
-            doTreeAnalysis(this, expressionList, controller);
-            if (!expressionList.isEmpty())
-                this.analyze(expressionList, controller);
+            analyze(controller);
             return this;
         }
 
-        void doTreeAnalysis(Node node, List<RowFilter.Expression> expressions, QueryController controller)
-        {
-            if (node instanceof ExpressionNode)
-                expressions.add(node.expression());
-            else
-            {
-                List<RowFilter.Expression> expressionList = new ArrayList<>();
-                for (Node child : node.children())
-                    doTreeAnalysis(child, expressionList, controller);
-                node.analyze(expressionList, controller);
-            }
-        }
-
+        @VisibleForTesting
         FilterTree buildFilter(QueryController controller)
         {
-            analyzeTree(controller);
-            FilterTree tree = filterTree();
-            for (Node child : children())
-                if (child.canFilter())
-                    tree.addChild(child.buildFilter(controller));
-            return tree;
+            analyze(controller);
+            return filterTree();
         }
     }
 
-    public static abstract class OperatorNode extends Node
+    static abstract class OperatorNode extends Node
     {
         List<Node> children = new ArrayList<>();
 
@@ -356,59 +344,77 @@ public class Operation
         {
             children.add(child);
         }
-    }
 
-    public static class AndNode extends OperatorNode
-    {
+        abstract protected OperationType operationType();
+        abstract protected Plan.Builder planBuilder(QueryController controller);
+
+        // expression list is the children that are leaf nodes... we could figure that out here...
         @Override
-        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        public void analyze(QueryController controller)
         {
-            expressionMap = analyzeGroup(controller, OperationType.AND, expressionList);
+            // This operation flattens the tree where possible and stores the result in expressionMap
+            List<RowFilter.Expression> expressionList = new ArrayList<>();
+            for (Node child : children)
+            {
+                if (child instanceof ExpressionNode)
+                    expressionList.add(child.expression());
+                else
+                    child.analyze(controller);
+            }
+            expressionMap = analyzeGroup(controller, operationType(), expressionList);
         }
 
         @Override
         FilterTree filterTree()
         {
-            return new FilterTree(OperationType.AND, expressionMap);
+            assert expressionMap != null;
+            var tree = new FilterTree(operationType(), expressionMap);
+            for (Node child : children())
+                if (child.canFilter())
+                    tree.addChild(child.filterTree());
+            return tree;
         }
 
         @Override
         Plan.KeysIteration plan(QueryController controller)
         {
-            var builder = controller.planFactory.intersectionBuilder();
+            var builder = planBuilder(controller);
             if (!expressionMap.isEmpty())
                 controller.buildPlanForExpressions(builder, expressionMap.values());
             for (Node child : children)
                 if (child.canFilter())
                     builder.add(child.plan(controller));
             return builder.build();
+        }
+    }
+
+    public static class AndNode extends OperatorNode
+    {
+        @Override
+        protected OperationType operationType()
+        {
+            return OperationType.AND;
+        }
+
+        @Override
+        protected Plan.Builder planBuilder(QueryController controller)
+        {
+            return controller.planFactory.intersectionBuilder();
         }
     }
 
     public static class OrNode extends OperatorNode
     {
         @Override
-        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        protected OperationType operationType()
         {
-            expressionMap = analyzeGroup(controller, OperationType.OR, expressionList);
+            return OperationType.OR;
         }
 
         @Override
-        FilterTree filterTree()
+        protected Plan.Builder planBuilder(QueryController controller)
         {
-            return new FilterTree(OperationType.OR, expressionMap);
-        }
-
-        @Override
-        Plan.KeysIteration plan(QueryController controller)
-        {
-            var builder = controller.planFactory.unionBuilder();
-            if (!expressionMap.isEmpty())
-                controller.buildPlanForExpressions(builder, expressionMap.values());
-            for (Node child : children)
-                if (child.canFilter())
-                    builder.add(child.plan(controller));
-            return builder.build();
+            return controller.planFactory.unionBuilder();
         }
     }
 
@@ -417,14 +423,15 @@ public class Operation
         RowFilter.Expression expression;
 
         @Override
-        public void analyze(List<RowFilter.Expression> expressionList, QueryController controller)
+        public void analyze(QueryController controller)
         {
-            expressionMap = analyzeGroup(controller, OperationType.AND, expressionList);
+            expressionMap = analyzeGroup(controller, OperationType.AND, List.of(expression));
         }
 
         @Override
         FilterTree filterTree()
         {
+            assert expressionMap != null;
             return new FilterTree(OperationType.AND, expressionMap);
         }
 
@@ -448,4 +455,34 @@ public class Operation
             return builder.build();
         }
     }
+
+    public static class EmptyNode extends Node
+    {
+        // A FilterTree that filters out all rows
+        private static final FilterTree EMPTY_TREE = new FilterTree(OperationType.OR, ArrayListMultimap.create());
+
+        @Override
+        boolean canFilter()
+        {
+            return true;
+        }
+
+        @Override
+        void analyze(QueryController controller)
+        {
+        }
+
+        @Override
+        FilterTree filterTree()
+        {
+            return EMPTY_TREE;
+        }
+
+        @Override
+        Plan.KeysIteration plan(QueryController controller)
+        {
+            return controller.planFactory.nothing;
+        }
+    }
+
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -356,7 +356,7 @@ public class QueryController implements Plan.Executor
 
     public FilterTree buildFilter()
     {
-        return Operation.Node.buildTree(filterOperation()).buildFilter(this);
+        return Operation.Node.buildTree(filterOperation()).analyzeTree(this).filterTree();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
@@ -127,9 +127,15 @@ public class ComplexQueryTest extends SAITester
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 8, 8, 4, 3, 3);
 
 
-        UntypedResultSet resultSet = execute("SELECT pk FROM %s WHERE (a = 1 AND c = 1) OR (b IN (3, 4) AND d = 2)");
 
-        assertRowsIgnoringOrder(resultSet, row(1), row(6), row(7) );
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE (a = 1 AND c = 1) OR (b IN (3, 4) AND d = 2)"), row(1), row(7), row(6));
+            // Shows that IN with an empty list produces no rows
+            assertRows(execute("SELECT pk FROM %s WHERE (a = 1 AND c = 1) OR (b IN () AND d = 2)"), row(1));
+            assertRows(execute("SELECT pk FROM %s WHERE b IN () AND d = 2"));
+            assertRows(execute("SELECT pk FROM %s WHERE b NOT IN () AND d = 2"), row(7), row(6));
+        });
+
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/QuerySet.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/QuerySet.java
@@ -63,6 +63,12 @@ public abstract class QuerySet extends CQLTester
             // Query full range
             assertRowsIgnoringOrder(tester.execute("SELECT * FROM %s WHERE value >= ? AND value <= ?", allRows[0][2], allRows[NUMBER_OF_VALUES - 1][2]), allRows);
 
+            // Edge cases with IN where we get no and all values. It is not valid to AND an IN predicate and others,
+            // so these two queries are comprehensive
+            assertRows(tester.execute("SELECT * FROM %s WHERE value IN ()"));
+            assertRowsIgnoringOrder(tester.execute("SELECT * FROM %s WHERE value NOT IN ()"), allRows);
+            assertRowsIgnoringOrder(tester.execute("SELECT * FROM %s WHERE (value IN ()) OR (value >= ? AND value <= ?)", allRows[0][2], allRows[NUMBER_OF_VALUES - 1][2]), allRows);
+
             // Query random ranges. This selects a series of random ranges and tests the different possible inclusivity
             // on them. This loops a reasonable number of times to cover as many ranges as possible without taking too long
             for (int range = 0; range < allRows.length / 4; range++)


### PR DESCRIPTION
Fixes: https://github.com/riptano/cndb/issues/8978

```
java.lang.UnsupportedOperationException: null
    at org.apache.cassandra.index.sai.plan.Operation$Node.expression(Operation.java:269)
    at org.apache.cassandra.index.sai.plan.Operation$Node.doTreeAnalysis(Operation.java:328)
    at org.apache.cassandra.index.sai.plan.Operation$Node.doTreeAnalysis(Operation.java:333)
    at org.apache.cassandra.index.sai.plan.Operation$Node.analyzeTree(Operation.java:319)
    at org.apache.cassandra.index.sai.plan.QueryController.buildIterator(QueryController.java:282)
    at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.analyze(StorageAttachedIndexSearcher.java:137)
    at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:123)
    at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:512)
    at org.apache.cassandra.db.MultiRangeReadCommand.searchStorage(MultiRangeReadCommand.java:274)
    at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:410)
    at org.apache.cassandra.db.ReadCommandVerbHandler.doVerb(ReadCommandVerbHandler.java:58)
    at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:79)
    at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:98)
    at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)
    at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
    at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
    at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
    at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:1623)
```

## Changes

Simplify the `Operator.Node` class by moving methods out of the base class and into the extensions. The data model is still a bit confusing, so I added comments to help explain what the `expressionMap` does. I also added an `EmptyNode` class to handle the edge case where we have `IN ()`