### PR TITLE
ChunkCache: improvements around Caffeine usage

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -62,6 +62,7 @@ public class ChunkCache
     private final static Logger logger = LoggerFactory.getLogger(ChunkCache.class);
 
     public static final int RESERVED_POOL_SPACE_IN_MB = 32;
+    private static final int INITIAL_CAPACITY = Integer.getInteger("cassandra.chunkcache_initialcapacity", 256);
     public static final boolean roundUp = DatabaseDescriptor.getFileCacheRoundUp();
 
     public static final ChunkCache instance = DatabaseDescriptor.getFileCacheEnabled()
@@ -215,6 +216,7 @@ public class ChunkCache
         keysByFile = new NonBlockingIdentityHashMap<>();
         cache = Caffeine.newBuilder()
                         .maximumWeight(cacheSize)
+                        .initialCapacity(INITIAL_CAPACITY)
                         .executor(MoreExecutors.directExecutor())
                         .weigher((key, buffer) -> ((Buffer) buffer).buffer.capacity())
                         .removalListener(this)

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -79,7 +79,7 @@ public class ChunkCache
             throw new RuntimeException(e);
         }
     }
-    private static final int CLEANER_THREADS = Integer.getInteger(("dse.chunk.cache.cleaner.threads",1);
+    private static final int CLEANER_THREADS = Integer.getInteger("dse.chunk.cache.cleaner.threads",1);
 
     public static final boolean roundUp = DatabaseDescriptor.getFileCacheRoundUp();
 

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -65,7 +65,7 @@ public class ChunkCache
     private final static Logger logger = LoggerFactory.getLogger(ChunkCache.class);
 
     public static final int RESERVED_POOL_SPACE_IN_MB = 32;
-    private static final int INITIAL_CAPACITY = Integer.getInteger("cassandra.chunkcache_initialcapacity", 4096);
+    private static final int INITIAL_CAPACITY = Integer.getInteger("cassandra.chunkcache_initialcapacity", 16);
     private static final Class PERFORM_CLEANUP_TASK_CLASS;
 
     static

--- a/src/java/org/apache/cassandra/concurrent/InlinedThreadLocalThread.java
+++ b/src/java/org/apache/cassandra/concurrent/InlinedThreadLocalThread.java
@@ -1,7 +1,19 @@
 /*
- * Copyright DataStax, Inc.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Please see the included license file for details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.cassandra.concurrent;
 

--- a/src/java/org/apache/cassandra/concurrent/InlinedThreadLocalThread.java
+++ b/src/java/org/apache/cassandra/concurrent/InlinedThreadLocalThread.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.concurrent;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.io.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import net.nicoulaj.compilecommand.annotations.Inline;
+import org.jctools.util.UnsafeAccess;
+import org.jctools.util.UnsafeRefArrayAccess;
+
+/**
+ * An intermediate class for forcing the position and ordering of reference fields which we intend to use as the backing
+ * storage for {@link InlinedThreadLocal} instances.
+ */
+@SuppressWarnings("unused")
+abstract class InlinedThreadLocalThreadLocalRefs extends FastThreadLocalThread
+{
+    // DO NOT ADD FURTHER FIELDS TO THIS CLASS OTHER THAN REFS FOR TL STORAGE
+    // Static fields are fine ;-), See note below after ref fields.
+    static final int MAX_LOCALS = 70;
+    static final long REF_BASE_OFFSET;
+    private static final Logger LOGGER = LoggerFactory.getLogger(InlinedThreadLocalThread.class);
+    private static final long REF_SHIFT = UnsafeRefArrayAccess.REF_ELEMENT_SHIFT;
+    private static final AtomicInteger FIRST_UNUSED_INDEX = new AtomicInteger();
+
+    public static int maxLocalsOverflow;
+
+    static
+    {
+        long minOffset = Long.MAX_VALUE;
+        // fields order is not guaranteed
+        for (int i = 0; i < MAX_LOCALS; i++)
+        {
+            String fieldName = "a" + i;
+            long fieldOffset = UnsafeAccess.fieldOffset(InlinedThreadLocalThreadLocalRefs.class, fieldName);
+            minOffset = Math.min(fieldOffset, minOffset);
+        }
+        REF_BASE_OFFSET = minOffset;
+    }
+
+    // Add further refs as needed and adjust the MAX_LOCALS constant accordingly
+    private Object a0, a1, a2, a3, a4, a5, a6, a7, a8, a9;
+    private Object a10, a11, a12, a13, a14, a15, a16, a17, a18, a19;
+    private Object a20, a21, a22, a23, a24, a25, a26, a27, a28, a29;
+    private Object a30, a31, a32, a33, a34, a35, a36, a37, a38, a39;
+    private Object a40, a41, a42, a43, a44, a45, a46, a47, a48, a49;
+    private Object a50, a51, a52, a53, a54, a55, a56, a57, a58, a59;
+    private Object a60, a61, a62, a63, a64, a65, a66, a67, a68, a69;
+    // DO NOT ADD FURTHER FIELDS TO THIS CLASS OTHER THAN REFS FOR TL REF STORAGE
+    // Adding further fields may cause these fields to mingle with the above allocate fields in term of their relative
+    // position. The get/set methods we use below rely on the reference fields above being laid out as a contiguous
+    // space.
+
+    InlinedThreadLocalThreadLocalRefs()
+    {
+        super();
+    }
+
+    InlinedThreadLocalThreadLocalRefs(Runnable target)
+    {
+        super(target);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target)
+    {
+        super(group, target);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(String name)
+    {
+        super(name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, String name)
+    {
+        super(group, name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(Runnable target, String name)
+    {
+        super(target, name);
+    }
+
+    InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target, String name)
+    {
+        super(group, target, name);
+    }
+
+    public InlinedThreadLocalThreadLocalRefs(ThreadGroup group, Runnable target, String name, long stackSize)
+    {
+        super(group, target, name, stackSize);
+    }
+
+    static long getRefOffset(long index)
+    {
+        if (index > MAX_LOCALS)
+        {
+            throw new IllegalStateException("FIRST_UNUSED_INDEX:" + index + " exceeds max: " + MAX_LOCALS);
+        }
+        return REF_BASE_OFFSET + (index << REF_SHIFT);
+    }
+
+    static long nextRefIndex()
+    {
+        int currIndex;
+        do
+        {
+            currIndex = FIRST_UNUSED_INDEX.get();
+            if (currIndex == MAX_LOCALS)
+            {
+                maxLocalsOverflow++;
+                return -1;
+            }
+        }
+        while (!FIRST_UNUSED_INDEX.compareAndSet(currIndex, currIndex + 1));
+        return currIndex;
+    }
+
+    @VisibleForTesting
+    static void resetIndexForTestingOnly()
+    {
+        // ONLY FOR TESTING!!!!
+        FIRST_UNUSED_INDEX.set(0);
+    }
+
+    @Inline
+    Object getThreadLocalRef(long offset)
+    {
+        return UnsafeAccess.UNSAFE.getObject(this, offset);
+    }
+
+    @Inline
+    void setThreadLocalRef(long offset, Object v)
+    {
+        UnsafeAccess.UNSAFE.putObject(this, offset, v);
+    }
+
+    void cleanupOnExit()
+    {
+        for (int i = 0; i < MAX_LOCALS; i++)
+        {
+            long offset = getRefOffset(i);
+            Object threadLocal = getThreadLocalRef(offset);
+            if (threadLocal == null)
+            {
+                continue;
+            }
+            // Maybe a pointless gesture, but might prevent GC nepotism (where dead objects in old gen keep young
+            // objects they refer to alive until an old gen GC removes them). In all likelihood the TL object have
+            // similar lifecycle to the thread and are therefore in the same generation.
+            setThreadLocalRef(offset, null);
+
+            // Rather than wait for the GC to pick these up, clean them now (particularly important for offheap buffers).
+            if (threadLocal instanceof ByteBuffer)
+            {
+                cleanupByteBuffer((ByteBuffer) threadLocal);
+            }
+            else if (threadLocal instanceof Closeable)
+            {
+                cleanupCloseable((Closeable) threadLocal);
+            }
+        }
+    }
+
+    private void cleanupCloseable(Closeable threadLocal)
+    {
+        try
+        {
+            threadLocal.close();
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Failed to close thread local resource on thread exit", e);
+        }
+    }
+
+    private void cleanupByteBuffer(ByteBuffer threadLocal)
+    {
+        try
+        {
+            FileUtils.clean(threadLocal);
+        }
+        catch (Throwable e)
+        {
+            LOGGER.error("Failed to clean DirectBuffer thread local resource on thread exit", e);
+        }
+    }
+
+}
+
+public class InlinedThreadLocalThread extends InlinedThreadLocalThreadLocalRefs
+{
+
+    public InlinedThreadLocalThread()
+    {
+        super();
+    }
+
+    public InlinedThreadLocalThread(Runnable target)
+    {
+        super(target);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target)
+    {
+        super(group, target);
+    }
+
+    public InlinedThreadLocalThread(String name)
+    {
+        super(name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, String name)
+    {
+        super(group, name);
+    }
+
+    public InlinedThreadLocalThread(Runnable target, String name)
+    {
+        super(target, name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target, String name)
+    {
+        super(group, target, name);
+    }
+
+    public InlinedThreadLocalThread(ThreadGroup group, Runnable target, String name, long stackSize)
+    {
+        super(group, target, name, stackSize);
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            super.run();
+        }
+        finally
+        {
+            cleanupOnExit();
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/concurrent/ParkedExecutor.java
+++ b/src/java/org/apache/cassandra/concurrent/ParkedExecutor.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.concurrent;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.utils.Flags;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+
+/**
+ * An executor which relies on the {@link ParkedThreadsMonitor} to unpark it's threads which are waiting on lock-less
+ * queues. How can threads wait on lock-less queues? They just park themselves when they see the queue as empty. Since
+ * this observation is non-atomic to other threads putting work on the queue, and since putting work on the queue of a
+ * parked thread doesn't notify the parked worker, we have the {@link ParkedThreadsMonitor} check when/if new work is
+ * available for parked threads and unpark them.
+ * <p>
+ * This has the benefit of removing the cost of {@link LockSupport#unpark(Thread)} from the threads which are trying to
+ * offload work onto the executor.
+ */
+public abstract class ParkedExecutor implements ShutdownableExecutor
+{
+    private static final Logger logger = LoggerFactory.getLogger(ParkedExecutor.class);
+    private static final Runnable POISON_PILL = () -> {};
+    volatile boolean isShutdown = false;
+
+    protected final ParkedThreadsMonitor monitor = ParkedThreadsMonitor.instance.get().orElseThrow(() -> new IllegalStateException("Cannot use because ParkedThreadsMonitor is disabled"));
+
+    /**
+     * Create a {@code ParkedExecutor} if {@link ParkedThreadsMonitor} is enabled, otherwise a standard executor.
+     *
+     * @param name A base name for the threads in the thread pool (not null)
+     * @param threadCount number of threads for the backing thread pool (>= 1)
+     */
+    public static ShutdownableExecutor createParkedExecutor(String name, int threadCount)
+    {
+        if (threadCount < 1)
+            throw new IllegalArgumentException("Less than 1 thread in thread pool is not allowed, but " + threadCount +" requested for pool " + name);
+        if (threadCount == 1)
+        {
+            return ParkedThreadsMonitor.IS_ENABLED ?
+                   new ParkedSingleThreadedExecutor(name) :
+                   new FallbackExecutor(Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(name).build()));
+        }
+        return ParkedThreadsMonitor.IS_ENABLED ?
+               new ParkedMultiThreadedExecutor(name, threadCount) :
+               new FallbackExecutor(Executors.newFixedThreadPool(threadCount, new ThreadFactoryBuilder().setNameFormat(name).build()));
+    }
+
+    private static void safeRun(Runnable r)
+    {
+        try
+        {
+            r.run();
+        }
+        catch (Throwable throwable)
+        {
+            JVMStabilityInspector.inspectThrowable(throwable);
+            logger.error("Error while runningThreadsBitmap tasks: ", throwable);
+        }
+    }
+
+    static class ParkedMultiThreadedExecutor extends ParkedExecutor implements ParkedThreadsMonitor.MonitorableThread
+    {
+        private final int allThreadsRunning;
+        private final Thread[] workers;
+        // bounded pre-allocated queue to avoid per task allocation overheads
+        private final MpmcArrayQueue<Runnable> tasks = new MpmcArrayQueue<>(1024);
+        // unbounded overflow for when the above is not enough
+        private final Queue<Runnable> overflowTasks = new ConcurrentLinkedQueue<>();
+        // this acts as an isRunning indicator bit map for the threads
+        private final AtomicInteger runningThreadsBitmap = new AtomicInteger();
+        private final int threadCount;
+
+        private ParkedMultiThreadedExecutor(String name, int threadCount)
+        {
+            if (threadCount > 32)
+                throw new IllegalStateException("ParkedExecutors pool size is limited to 32 threads currently");
+            this.threadCount = threadCount;
+            allThreadsRunning = -1 >>> (32 - threadCount);
+            workers = new Thread[threadCount];
+            NamedThreadFactory namedThreadFactory = new NamedThreadFactory(name);
+            for (int i = 0; i < threadCount; i++)
+            {
+                int tIndex = i;
+                workers[i] = namedThreadFactory.newThread(() -> processTasks(tIndex));
+                workers[i].start();
+            }
+
+            monitor.addThreadToMonitor(this);
+        }
+
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            isShutdown = true;
+            for (int i = 0; i < threadCount; i++)
+            {
+                // poison pill always on overflow
+                overflowTasks.offer(POISON_PILL);
+            }
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                workers[i].join();
+            }
+            monitor.removeThreadToMonitor(this);
+        }
+
+        @Override
+        public void execute(Runnable task)
+        {
+            if (isShutdown)
+                throw new RejectedExecutionException("Executor has already been shutdown");
+            // We have a bounded tasks queue, if it overflows we send via the unbounded MPMC queue. This can introduce
+            // task reordering, but this is valid behavior for an Executor.
+            if (!tasks.offer(task))
+                overflowTasks.offer(task);
+        }
+
+        private void processTasks(int threadIndex)
+        {
+            // the bit to set/unset in the runningThreadsBitmap for this thread index
+            int tMask = 1 << threadIndex;
+            setThreadRunning(tMask);
+
+            Runnable r;
+            while (true)
+            {
+                boolean noTask = true;
+                // always check both queues to ensure one cannot starve the other
+                if ((r = overflowTasks.poll()) != null)
+                {
+                    if (r == POISON_PILL)
+                        break;
+                    noTask = false;
+                    safeRun(r);
+                }
+                if ((r = tasks.relaxedPoll()) != null)
+                {
+                    // no poison on tasks queue
+                    noTask = false;
+                    safeRun(r);
+                }
+
+                if (noTask)
+                {
+                    setThreadNotRunning(tMask);
+                    LockSupport.park();
+                    setThreadRunning(tMask);
+
+                    if (Thread.interrupted())
+                        break;
+                }
+            }
+
+            // after poison pill observed make best effort to drain queue
+            while ((r = tasks.poll()) != null)
+            {
+                safeRun(r);
+            }
+        }
+
+        private void setThreadRunning(int tMask)
+        {
+            int current;
+            do
+            {
+                current = runningThreadsBitmap.get();
+            }
+            while (!runningThreadsBitmap.compareAndSet(current, Flags.add(current, tMask)));
+        }
+
+        private void setThreadNotRunning(int tMask)
+        {
+            int current;
+            do
+            {
+                current = runningThreadsBitmap.get();
+            }
+            while (!runningThreadsBitmap.compareAndSet(current, Flags.remove(current, tMask)));
+        }
+
+        @Override
+        public void unpark(long epoch)
+        {
+            int currentlyRunningMask = runningThreadsBitmap.get();
+            for (int i = 0; i < threadCount; i++)
+            {
+                if (!Flags.contains(currentlyRunningMask, 1 << i))
+                {
+                    Thread worker = workers[i];
+                    LockSupport.unpark(worker);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public boolean shouldUnpark(long epoch)
+        {
+            return (runningThreadsBitmap.get() != allThreadsRunning) &&
+                    !(tasks.isEmpty() && overflowTasks.isEmpty());
+        }
+    }
+
+    /**
+     * A specialized implementation for a single threaded executor allows us to use the unbounded MPSC queue for
+     * improved performance and simpler workflow.
+     */
+    static class ParkedSingleThreadedExecutor extends ParkedExecutor implements ParkedThreadsMonitor.MonitorableThread
+    {
+        private final Thread worker;
+        private final MpscUnboundedArrayQueue<Runnable> tasks = new MpscUnboundedArrayQueue<>(1024);
+        private final AtomicInteger running = new AtomicInteger();
+
+        private ParkedSingleThreadedExecutor(String name)
+        {
+            NamedThreadFactory namedThreadFactory = new NamedThreadFactory(name);
+            worker = namedThreadFactory.newThread(this::processTasks);
+            worker.start();
+            monitor.addThreadToMonitor(this);
+        }
+
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            isShutdown = true;
+            tasks.offer(POISON_PILL);
+            worker.join();
+            monitor.removeThreadToMonitor(this);
+        }
+
+        @Override
+        public void execute(Runnable task)
+        {
+            if (isShutdown)
+                throw new RejectedExecutionException("Executor has already been shutdown");
+            // This is an unbounded queue, so no need to check for failed offers
+            tasks.offer(task);
+        }
+
+        private void processTasks()
+        {
+            running.lazySet(1);
+
+            Runnable r;
+            while ((r = tasks.relaxedPoll()) != POISON_PILL)
+            {
+                if (r == null)
+                {
+                    running.lazySet(0);
+                    LockSupport.park();
+                    running.lazySet(1);
+
+                    if (Thread.interrupted())
+                        break;
+                    continue;
+                }
+                ParkedExecutor.safeRun(r);
+            }
+        }
+
+        @Override
+        public void unpark(long epoch)
+        {
+            int currentlyRunningMask = running.get();
+            if (currentlyRunningMask == 0)
+            {
+                LockSupport.unpark(this.worker);
+            }
+        }
+
+        @Override
+        public boolean shouldUnpark(long epoch)
+        {
+            return running.get() != 1 && !tasks.isEmpty();
+        }
+    }
+
+    static class FallbackExecutor implements ShutdownableExecutor
+    {
+        private final ExecutorService executor;
+
+        private FallbackExecutor(ExecutorService executor)
+        {
+            this.executor = executor;
+        }
+
+        @Override
+        public void shutdown() throws InterruptedException
+        {
+            executor.shutdownNow();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public void execute(Runnable command)
+        {
+            executor.execute(command);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/concurrent/ParkedExecutor.java
+++ b/src/java/org/apache/cassandra/concurrent/ParkedExecutor.java
@@ -1,7 +1,22 @@
 /*
- * Copyright DataStax, Inc.
  *
- * Please see the included license file for details.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 package org.apache.cassandra.concurrent;

--- a/src/java/org/apache/cassandra/concurrent/ParkedThreadsMonitor.java
+++ b/src/java/org/apache/cassandra/concurrent/ParkedThreadsMonitor.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.concurrent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.MonotonicClock;
+import org.apache.cassandra.utils.ThreadsFactory;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+
+/**
+ * This class is responsible for keeping tabs on threads that register as a {@link MonitorableThread}.
+ * <p/>
+ * When a {@link MonitorableThread} parks itself this thread wakes it up when ready to execute work, according to the
+ * {@link MonitorableThread#shouldUnpark(long)} method. This allows threads to (for example) use a non-blocking queue 
+ * without constantly spinning.
+ * <p/>
+ * It's up to the {@link MonitorableThread#shouldUnpark(long )} implementation to track its own state.
+ */
+public class ParkedThreadsMonitor
+{
+    public static final boolean IS_ENABLED = Boolean.parseBoolean(System.getProperty("dse.thread_monitor_enabled", "true"));
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParkedThreadsMonitor.class);
+
+    public static final Supplier<Optional<ParkedThreadsMonitor>> instance = Suppliers.memoize(() ->
+    {
+        if (IS_ENABLED)
+            return Optional.of(new ParkedThreadsMonitor());
+        else
+        {
+            LOGGER.warn("ParkedThreadsMonitor is DISABLED.");
+            return Optional.empty();
+        }
+    });
+
+    /*
+     * NOTE: parkNanos seems to operate as follows (on my machine, expect differences):
+     *  - 1 to 80ns   -> p50% is 400-500ns
+     *  - 80 to 100ns -> some instability, flip between 500ns and 52us
+     *  - > 100ns     -> p50% looks like 52us + parkTime
+     */
+    private static final long SLEEP_INTERVAL_NS = Long.getLong("dse.thread_monitor_sleep_nanos", 50000);
+    private static final boolean AUTO_CALIBRATE =
+      Boolean.parseBoolean(System.getProperty("dse.thread_monitor_auto_calibrate", "true")) &&
+        SLEEP_INTERVAL_NS > 0;
+
+    private static final Sleeper SLEEPER =
+        AUTO_CALIBRATE ? new CalibratingSleeper(SLEEP_INTERVAL_NS) : new Sleeper();
+
+    private final MpscUnboundedArrayQueue<Runnable> commands = new MpscUnboundedArrayQueue<>(128);
+    private final ArrayList<MonitorableThread> monitoredThreads =
+        new ArrayList<>(Runtime.getRuntime().availableProcessors() * 2);
+    private final ArrayList<Runnable> loopActions = new ArrayList<>(4);
+    private final Thread watcherThread;
+        
+    private volatile boolean shutdown;
+    
+    /**
+     * The epoch monotonically tracks how many times the monitor has run: each run is a new epoch, and at each run
+     * this will be passed to the {@link MonitorableThread} unpark methods, so they can use it to distinguish between
+     * calls happening for the same (or different) epoch.
+     */
+    private long epoch;
+
+    @VisibleForTesting
+    ParkedThreadsMonitor(long startEpoch)
+    {
+        epoch = startEpoch;
+        shutdown = false;
+        watcherThread = ThreadsFactory.newDaemonThread(this::run, "ParkedThreadsMonitor");
+        watcherThread.setPriority(Thread.MAX_PRIORITY);
+        watcherThread.start();
+    }
+    
+    private ParkedThreadsMonitor()
+    {
+        this(0);
+    }
+
+    private void run()
+    {
+        final ArrayList<Runnable> loopActions = this.loopActions;
+        final ArrayList<MonitorableThread> monitoredThreads = this.monitoredThreads;
+        final MpscUnboundedArrayQueue<Runnable> commands = this.commands;
+        while (!shutdown)
+        {
+            try
+            {
+                runCommands(commands);
+                executeLoopActions(loopActions);
+                monitorThreads(monitoredThreads);
+            }
+            catch (Throwable t)
+            {
+                JVMStabilityInspector.inspectThrowable(t);
+                LOGGER.error("ParkedThreadsMonitor exception: ", t);
+            }
+            finally
+            {
+                epoch++;
+            }
+            SLEEPER.sleep();
+        }
+        unparkOnShutdown(monitoredThreads);
+    }
+
+    private void monitorThreads(ArrayList<MonitorableThread> monitoredThreads)
+    {
+        if (monitoredThreads.isEmpty())
+            return;
+        
+        // To avoid biasing the work threads do based on their order of unparking, we start iterating from an offset
+        // based on the epoch, so it's cheap and always changing.
+        int offset = ((int) epoch & Integer.MAX_VALUE) % monitoredThreads.size();
+        for (int i = 0; i < monitoredThreads.size(); i++)
+        {
+            MonitorableThread thread = monitoredThreads.get((i + offset) % monitoredThreads.size());
+            try
+            {
+                if (thread.shouldUnpark(epoch))
+                {
+                    // TODO: add a counter we can track for unpark rate
+                    thread.unpark(epoch);
+                }
+            }
+            catch (Throwable t)
+            {
+                LOGGER.error("Exception unparking a monitored thread", t);
+            }
+        }
+    }
+
+    private void executeLoopActions(ArrayList<Runnable> loopActions)
+    {
+        for (int i = 0; i < loopActions.size(); i++)
+        {
+            Runnable action = loopActions.get(i);
+            try
+            {
+                action.run();
+            }
+            catch (Throwable t)
+            {
+                LOGGER.error("Exception running an action", t);
+            }
+        }
+    }
+
+    private void runCommands(MpscUnboundedArrayQueue<Runnable> commands)
+    {
+        // queue is almost always empty, so pre check makes sense
+        if (!commands.isEmpty())
+        {
+            commands.drain(Runnable::run);
+        }
+    }
+
+    private void unparkOnShutdown(ArrayList<MonitorableThread> monitoredThreads)
+    {
+        for (MonitorableThread thread : monitoredThreads)
+            thread.unpark(epoch);
+    }
+
+    /**
+     * Adds a collection of threads to monitor
+     */
+    public void addThreadsToMonitor(Collection<MonitorableThread> threads)
+    {
+        threads.forEach(this::addThreadToMonitor);
+    }
+
+    /**
+     * Adds a thread to monitor
+     */
+    public void addThreadToMonitor(MonitorableThread thread)
+    {
+        commands.offer(() -> monitoredThreads.add(thread));
+    }
+
+    /**
+     * Removes a thread from monitoring
+     */
+    public void removeThreadToMonitor(MonitorableThread thread)
+    {
+        commands.offer(() -> monitoredThreads.remove(thread));
+    }
+
+    /**
+     * Removes a collection of threads from monitoring
+     */
+    public void removeThreadsToMonitor(Collection<MonitorableThread> threads)
+    {
+        threads.forEach(this::removeThreadToMonitor);
+    }
+
+    /**
+     * Runs the specified action in each loop. Mainly used to avoid many threads doing the same work
+     * over and over.
+     */
+    public void addAction(Runnable action)
+    {
+        commands.offer(() -> loopActions.add(action));
+    }
+
+    public void shutdown()
+    {
+        shutdown = true;
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit timeUnit) throws InterruptedException
+    {
+        shutdown();
+        watcherThread.join(timeUnit.toMillis(timeout));
+        return !watcherThread.isAlive();
+    }
+
+    /**
+     * Interface for threads wishing to be watched by the {@link ParkedThreadsMonitor} in order to be unparked.
+     * <p/>
+     * When a Thread has no work to do it should park itself.
+     */
+    public static interface MonitorableThread
+    {
+        /**
+         * What a MonitorableThread should use to track it's current state
+         */
+        enum ThreadState
+        {
+            PARKED, // no work to do
+            UNPARKING, // unparked but not yet working
+            WORKING
+        }
+
+        /**
+         * Will unpark a {@link ThreadState#PARKED} thread.
+         * <br/>
+         * Called by {@link ParkedThreadsMonitor} AFTER {@link #shouldUnpark(long )} returns true.
+         * 
+         * @@param epoch A monotonic counter increased every time the {@link ParkedThreadsMonitor} runs, 
+         * see {@link ParkedThreadsMonitor#epoch}.
+         */
+        void unpark(long epoch);
+
+        /**
+         * Called continuously by the {@link ParkedThreadsMonitor} to decide if unpark() should be called on a
+         * thread.
+         * <br/>
+         * Should return true IFF the thread is parked and there (potentially) is work to be done when the thread is
+         * unparked.
+         * 
+         * @param epoch A monotonic counter increased every time the {@link ParkedThreadsMonitor} runs, 
+         * see {@link ParkedThreadsMonitor#epoch}.
+         */
+        boolean shouldUnpark(long epoch);
+    }
+
+    static class Sleeper
+    {
+        void sleep()
+        {
+            if (SLEEP_INTERVAL_NS > 0)
+                LockSupport.parkNanos(SLEEP_INTERVAL_NS);
+        }
+    }
+
+    @VisibleForTesting
+    public static class CalibratingSleeper extends Sleeper
+    {
+        final long targetNs;
+        long calibratedSleepNs;
+        long expSmoothedSleepTimeNs;
+        int comparisonDelay;
+
+        @VisibleForTesting
+        public CalibratingSleeper(long targetNs)
+        {
+            this.targetNs = targetNs;
+            this.calibratedSleepNs = targetNs;
+            this.expSmoothedSleepTimeNs = 0;
+        }
+
+        @VisibleForTesting
+        public void sleep()
+        {
+            long start = nanoTime();
+            park();
+            long sleptNs = nanoTime() - start;
+            if (expSmoothedSleepTimeNs == 0)
+                expSmoothedSleepTimeNs = sleptNs;
+            else
+                expSmoothedSleepTimeNs = (long) (0.001 * sleptNs + 0.999 * expSmoothedSleepTimeNs);
+
+            // calibrate sleep time if we miss target by more than 10%, wait for at least 100 observations
+            if (comparisonDelay < 100)
+            {
+                comparisonDelay++;
+            }
+            else if (expSmoothedSleepTimeNs > targetNs * 1.1)
+            {
+                calibratedSleepNs = (long) (calibratedSleepNs * 0.9) + 1;
+                expSmoothedSleepTimeNs = 0;
+                comparisonDelay = 0;
+            }
+            else if (expSmoothedSleepTimeNs < targetNs * 0.9)
+            {
+                calibratedSleepNs = (long) (calibratedSleepNs * 1.1);
+                expSmoothedSleepTimeNs = 0;
+                comparisonDelay = 0;
+            }
+        }
+
+        @VisibleForTesting
+        void park()
+        {
+            LockSupport.parkNanos(calibratedSleepNs);
+        }
+
+        @VisibleForTesting
+        long nanoTime()
+        {
+            return MonotonicClock.preciseTime.now();
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/concurrent/ShutdownableExecutor.java
+++ b/src/java/org/apache/cassandra/concurrent/ShutdownableExecutor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package org.apache.cassandra.concurrent;
+
+import java.util.concurrent.Executor;
+
+/**
+ * An executor you can shut down!
+ */
+public interface ShutdownableExecutor extends Executor
+{
+
+    /**
+     * Stop the threads started for this executor(if any), returns when the threads spawned for this executor have all
+     * been stopped. Wait as long as it takes.
+     * <p>
+     * Note that tasks sent via {@link #execute(Runnable)} may be stuck in queue indefinitely.
+     */
+    void shutdown() throws InterruptedException;
+}

--- a/src/java/org/apache/cassandra/concurrent/ShutdownableExecutor.java
+++ b/src/java/org/apache/cassandra/concurrent/ShutdownableExecutor.java
@@ -1,7 +1,22 @@
 /*
- * Copyright DataStax, Inc.
  *
- * Please see the included license file for details.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.apache.cassandra.concurrent;
 

--- a/src/java/org/apache/cassandra/utils/Flags.java
+++ b/src/java/org/apache/cassandra/utils/Flags.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+
+package org.apache.cassandra.utils;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+public interface Flags
+{
+    @Inline
+    static boolean isEmpty(int flags)
+    {
+        return flags == 0;
+    }
+
+    @Inline
+    static boolean containsAll(int flags, int testFlags)
+    {
+        return (flags & testFlags) == testFlags;
+    }
+
+    @Inline
+    static boolean contains(int flags, int testFlags)
+    {
+        return (flags & testFlags) != 0;
+    }
+
+    @Inline
+    static int add(int flags, int toAdd)
+    {
+        return flags | toAdd;
+    }
+
+    @Inline
+    static int remove(int flags, int toRemove)
+    {
+        return flags & ~toRemove;
+    }
+}

--- a/src/java/org/apache/cassandra/utils/Flags.java
+++ b/src/java/org/apache/cassandra/utils/Flags.java
@@ -1,7 +1,22 @@
 /*
- * Copyright DataStax, Inc.
  *
- * Please see the included license file for details.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 package org.apache.cassandra.utils;

--- a/src/java/org/apache/cassandra/utils/ThreadsFactory.java
+++ b/src/java/org/apache/cassandra/utils/ThreadsFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.concurrent.InlinedThreadLocalThread;
+
+public class ThreadsFactory
+{
+    /**
+     * @param name name of the thread for this executor
+     * @return a single threaded executor whose threads have names
+     */
+    public static ExecutorService newSingleThreadedExecutor(String name)
+    {
+        return Executors.newSingleThreadExecutor(new NamedThreadFactory(name));
+    }
+
+    /**
+     * @param r runnable task for the thread
+     * @param name for the thread
+     * @return a new daemon thread which has the given name and task
+     */
+    public static Thread newDaemonThread(Runnable r, String name)
+    {
+        return newThread(r, name, true);
+    }
+
+    /**
+     * @param r runnable task for the thread
+     * @param name for the thread
+     * @param isDaemon
+     * @return a new thread which has the given name and task
+     */
+    public static Thread newThread(Runnable r, String name, boolean isDaemon)
+    {
+        Thread t = new InlinedThreadLocalThread(r, name);
+        t.setDaemon(isDaemon);
+        return t;
+    }
+
+    public static void addShutdownHook(Runnable r, String name)
+    {
+        // shutdown hook threads should not be daemon
+        Runtime.getRuntime().addShutdownHook(newThread(r, name, false));
+    }
+}


### PR DESCRIPTION
This patch accumulates a few little improvements to how the ChunkCache uses Caffeine:
-  ability to configure the initial capacity of the cache inside of the ChunkCache (-cassandra.chunkcache_initialcapacity)
-  reduce the overhead of updating counters in the metrics (in DSE we have TPC that helps reducing contention)
-  port  https://datastax.jira.com/browse/DB-3063 "Use a non-blocking executor for ChunkCache cleanup", this required to import a few other classes related to ParkedExecutor
