### PR TITLE
Improve error message when validating sai component footer

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
@@ -157,6 +157,19 @@ public class SAICodecUtils
         long remaining = in.length() - in.getFilePointer();
         long expected = CodecUtil.footerLength();
 
+        if (remaining >= 4)
+        {
+            final int magic = readBEInt(in);
+
+            if (magic != FOOTER_MAGIC)
+            {
+                String additionalDetails = "";
+                if (remaining != expected)
+                    additionalDetails = " (and invalid number of bytes: remaining=" + remaining + ", expected=" + expected + ", fp=" + in.getFilePointer() + ')';
+                throw new CorruptIndexException("codec footer mismatch (file truncated?): actual footer=" + magic + " vs expected footer=" + FOOTER_MAGIC + additionalDetails, in);
+            }
+        }
+
         if (!padded)
         {
             if (remaining < expected)
@@ -169,12 +182,6 @@ public class SAICodecUtils
             }
         }
 
-        final int magic = readBEInt(in);
-
-        if (magic != FOOTER_MAGIC)
-        {
-            throw new CorruptIndexException("codec footer mismatch (file truncated?): actual footer=" + magic + " vs expected footer=" + FOOTER_MAGIC, in);
-        }
 
         final int algorithmID = readBEInt(in);
 


### PR DESCRIPTION
When the code validates the footer, it complains if the remaining bytes don't match the footer lenght, but it does so before checking the footer magic. It means that when that error is triggered, you cannot really tell if the issue that you are trying to read the footer in the wrong place, or if the file genuinely has extra bytes after the footer.

This modify the logic a bit to check the magic first (as long as there is enough bytes), to disambiguate both problems more easily.