### PR TITLE
Skip writing vector graph if all ordinals are deleted

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -197,7 +197,18 @@ public class MemtableIndexWriter implements PerIndexWriter
     private void flushVectorIndex(DecoratedKey minKey, DecoratedKey maxKey, long startTime, Stopwatch stopwatch) throws IOException
     {
         var vectorIndex = (VectorMemtableIndex) memtableIndex;
-        SegmentMetadata.ComponentMetadataMap metadataMap = vectorIndex.writeData(indexDescriptor, indexContext, rowMapping::get);
+
+        // Get comprehensive set of deleted ordinals from the row mapping, and skip writing components to disk
+        // if all ordinals are deleted. This is when we account for range and partition deletions.
+        var deletedOrdinals = vectorIndex.computeDeletedOrdinals(rowMapping::get);
+        if (deletedOrdinals.size() == vectorIndex.size())
+        {
+            logger.debug(indexContext.logMessage("Whole graph is deleted. Skipping index flush for {}."), indexDescriptor.descriptor);
+            indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+            return;
+        }
+
+        SegmentMetadata.ComponentMetadataMap metadataMap = vectorIndex.writeData(indexDescriptor, indexContext, deletedOrdinals);
 
         completeIndexFlush(rowMapping.size(), startTime, stopwatch);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.disk.v1;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -189,7 +190,11 @@ public abstract class SegmentBuilder
         @Override
         protected SegmentMetadata.ComponentMetadataMap flushInternal(IndexDescriptor indexDescriptor, IndexContext indexContext) throws IOException
         {
-            return graphIndex.writeData(indexDescriptor, indexContext, p -> p);
+            // VSTODO this is a bit of a hack. We call computeDeletedOrdinals to call computeRowIds on each
+            // VectorPostings, which will populate the rowIds field, but if we refactor the code, we could skip that.
+            var deletedOrdinals = graphIndex.computeDeletedOrdinals(p -> p);
+            assert deletedOrdinals.isEmpty() : "Deleted ordinals should be empty when built during compaction";
+            return graphIndex.writeData(indexDescriptor, indexContext, Collections.emptySet());
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -361,9 +361,19 @@ public class VectorMemtableIndex implements MemtableIndex
         throw new UnsupportedOperationException();
     }
 
-    public SegmentMetadata.ComponentMetadataMap writeData(IndexDescriptor indexDescriptor, IndexContext indexContext, Function<PrimaryKey, Integer> postingTransformer) throws IOException
+    public Set<Integer> computeDeletedOrdinals(Function<PrimaryKey, Integer> ordinalMapper)
     {
-        return graph.writeData(indexDescriptor, indexContext, postingTransformer);
+        return graph.computeDeletedOrdinals(ordinalMapper);
+    }
+
+    public int size()
+    {
+        return graph.size();
+    }
+
+    public SegmentMetadata.ComponentMetadataMap writeData(IndexDescriptor indexDescriptor, IndexContext indexContext, Set<Integer> deletedOrdinals) throws IOException
+    {
+        return graph.writeData(indexDescriptor, indexContext, deletedOrdinals);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -31,6 +31,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -97,8 +98,11 @@ public class QueryController implements Plan.Executor
      * 0 disables the optimizer.
      * 1 enables the optimizer and tells the optimizer to respect the intersection clause limit.
      * Higher values enable the optimizer and disable the hard intersection clause limit.
+     * Note: the config is not final to simplify testing. It is initialized before other final objects in this class,
+     * so it is safely published.
      */
-    public static final int QUERY_OPT_LEVEL = Integer.getInteger("cassandra.sai.query.optimization.level", 1);
+    @VisibleForTesting
+    public static int QUERY_OPT_LEVEL = Integer.getInteger("cassandra.sai.query.optimization.level", 1);
 
     private final ColumnFamilyStore cfs;
     private final ReadCommand command;

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -98,8 +98,7 @@ public class QueryController implements Plan.Executor
      * 0 disables the optimizer.
      * 1 enables the optimizer and tells the optimizer to respect the intersection clause limit.
      * Higher values enable the optimizer and disable the hard intersection clause limit.
-     * Note: the config is not final to simplify testing. It is initialized before other final objects in this class,
-     * so it is safely published.
+     * Note: the config is not final to simplify testing.
      */
     @VisibleForTesting
     public static int QUERY_OPT_LEVEL = Integer.getInteger("cassandra.sai.query.optimization.level", 1);

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -905,7 +905,7 @@ public class VectorUpdateDeleteTest extends VectorTester
     {
         QueryController.QUERY_OPT_LEVEL = 0;
         setMaxBruteForceRows(0);
-        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, a int, str_val text, val vector<float, 3>)");
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
@@ -922,6 +922,34 @@ public class VectorUpdateDeleteTest extends VectorTester
         flush();
 
         assertRows(execute("SELECT PK FROM %s WHERE str_val = 'A' ORDER BY val ann of [1.0, 2.0, 3.0] LIMIT 1"));
+    }
+
+    @Test
+    public void testVectorIndexWithAllOrdinalsDeletedAndSomeViaRangeDeletion() throws Throwable
+    {
+        QueryController.QUERY_OPT_LEVEL = 0;
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // Insert two rows with different vectors to get different ordinals
+        execute("INSERT INTO %s (pk, a, str_val, val) VALUES (1, 1, 'A', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, a, str_val, val) VALUES (2, 1, 'A', [1.0, 2.0, 4.0])");
+
+        // Range delete the first row
+        execute("DELETE FROM %s WHERE pk = 1");
+        // Specifically delete the vector column second to hit a different code path.
+        execute("DELETE FROM %s WHERE pk = 2 AND a = 1");
+
+        // Insert another row without a vector
+        execute("INSERT INTO %s (pk, a, str_val) VALUES (2, 1, 'A')");
+        flush();
+
+        assertRows(execute("SELECT PK FROM %s WHERE str_val = 'A' ORDER BY val ann of [1.0, 2.0, 3.0] LIMIT 1"));
+        getCurrentColumnFamilyStore().getLiveSSTables();
     }
 
     private static void setChunkSize(final int selectivityLimit) throws Exception

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -900,6 +900,30 @@ public class VectorUpdateDeleteTest extends VectorTester
         });
     }
 
+    @Test
+    public void testVectorIndexWithAllOrdinalsDeletedViaRangeDeletion() throws Throwable
+    {
+        QueryController.QUERY_OPT_LEVEL = 0;
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, a int, str_val text, val vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // Insert a row with a vector
+        execute("INSERT INTO %s (pk, a, str_val, val) VALUES (1, 1, 'A', [1.0, 2.0, 3.0])");
+
+        // Range delete that row
+        execute("DELETE FROM %s WHERE pk = 1");
+
+        // Insert another row without a vector
+        execute("INSERT INTO %s (pk, a, str_val) VALUES (2, 1, 'A')");
+        flush();
+
+        assertRows(execute("SELECT PK FROM %s WHERE str_val = 'A' ORDER BY val ann of [1.0, 2.0, 3.0] LIMIT 1"));
+    }
+
     private static void setChunkSize(final int selectivityLimit) throws Exception
     {
         Field selectivity = QueryController.class.getDeclaredField("ORDER_CHUNK_SIZE");


### PR DESCRIPTION
Changes two components:

1. We will no longer write out the index components for vector indexes if all of the ordinals are deleted.
2. We can now handle vector graphs that were written without any non-deleted ordinals. This code is likely unnecessary, but protects us in the event any more of these indexes exist (the index that caused the issue was already deleted via compaction).