### PR TITLE
Pool temporary ByteBuffers in RandomAccessReader#readFully(array)

### DIFF
--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -22,6 +22,9 @@ package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 
 import org.apache.cassandra.utils.memory.BufferPools;
 
@@ -96,8 +99,27 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
 
     public ByteBuffer buffer()
     {
-        return buffer;
+        return buffer.duplicate();
     }
+
+    @Override
+    public FloatBuffer floatBuffer()
+    {
+        return buffer.asFloatBuffer();
+    }
+
+    @Override
+    public IntBuffer intBuffer()
+    {
+        return buffer.asIntBuffer();
+    }
+
+    @Override
+    public LongBuffer longBuffer()
+    {
+        return buffer.asLongBuffer();
+    }
+
 
     public long offset()
     {

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -493,11 +493,11 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         }
         if (buffer.isDirect())
         {
-            temporaryBuffer = ByteBuffer.allocateDirect(size);
+            temporaryBuffer = ByteBuffer.allocateDirect(size).order(buffer.order());
         }
         else
         {
-            temporaryBuffer = ByteBuffer.allocate(size);
+            temporaryBuffer = ByteBuffer.allocate(size).order(buffer.order());
         }
         return temporaryBuffer;
     }

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -23,7 +23,6 @@ import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.primitives.Ints;
@@ -43,6 +42,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
     final Rebufferer rebufferer;
     private BufferHolder bufferHolder = Rebufferer.EMPTY;
     private final ByteOrder order;
+    ByteBuffer temporaryBuffer;
 
     /**
      * Only created through Builder
@@ -113,16 +113,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             floatBuffer = bb.asFloatBuffer();
         }
 
+        int bytesToRead = Float.BYTES * dest.length;
         if (dest.length > floatBuffer.remaining())
         {
             // slow path -- desired slice is across region boundaries
-            var bb = ByteBuffer.allocate(Float.BYTES * dest.length);
+            var bb = getTemporaryBuffer(bytesToRead);
             readFully(bb);
             floatBuffer = bb.asFloatBuffer();
         }
 
         floatBuffer.get(dest);
-        seek(position + (long) Float.BYTES * dest.length);
+        seek(position + bytesToRead);
     }
 
     @Override
@@ -148,16 +149,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             longBuffer = bb.asLongBuffer();
         }
 
-        if (dest.length > longBuffer.remaining())
+        int bytesToRead = Long.BYTES * dest.length;
+        if (bytesToRead > longBuffer.remaining())
         {
             // slow path -- desired slice is across region boundaries
-            var bb = ByteBuffer.allocate(Long.BYTES * dest.length);
+            var bb = getTemporaryBuffer(bytesToRead);
             readFully(bb);
             longBuffer = bb.asLongBuffer();
         }
 
         longBuffer.get(dest);
-        seek(position + (long) Long.BYTES * dest.length);
+        seek(position + bytesToRead);
     }
 
     /**
@@ -196,16 +198,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             intBuffer = bb.asIntBuffer();
         }
 
+        int bytesToRead = Integer.BYTES * count;
         if (count > intBuffer.remaining())
         {
             // slow path -- desired slice is across region boundaries
-            var bb = ByteBuffer.allocate(Integer.BYTES * count);
+            var bb = getTemporaryBuffer(bytesToRead);
             readFully(bb);
             intBuffer = bb.asIntBuffer();
         }
 
         intBuffer.get(dest, offset, count);
-        seek(position + (long) Integer.BYTES * count);
+        seek(position + bytesToRead);
     }
 
     @Override
@@ -296,7 +299,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         // close needs to be idempotent.
         if (buffer == null)
             return;
-
+        temporaryBuffer = null;
         bufferHolder.release();
         rebufferer.closeReader();
         buffer = null;
@@ -479,4 +482,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             throw t;
         }
     }
+
+    private ByteBuffer getTemporaryBuffer(int size)
+    {
+        if (temporaryBuffer != null
+            && temporaryBuffer.capacity() == size)
+        {
+            temporaryBuffer.clear();
+            return temporaryBuffer;
+        }
+        temporaryBuffer = ByteBuffer.allocateDirect(size);
+        return temporaryBuffer;
+    }
+
 }

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -42,7 +42,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
     final Rebufferer rebufferer;
     private BufferHolder bufferHolder = Rebufferer.EMPTY;
     private final ByteOrder order;
-    ByteBuffer temporaryBuffer;
+    private ByteBuffer temporaryBuffer;
 
     /**
      * Only created through Builder
@@ -491,7 +491,14 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             temporaryBuffer.clear();
             return temporaryBuffer;
         }
-        temporaryBuffer = ByteBuffer.allocateDirect(size);
+        if (buffer.isDirect())
+        {
+            temporaryBuffer = ByteBuffer.allocateDirect(size);
+        }
+        else
+        {
+            temporaryBuffer = ByteBuffer.allocate(size);
+        }
         return temporaryBuffer;
     }
 


### PR DESCRIPTION
This change saves some allocations in case we read a float[] larger than the bufferSize.
This change affects readFully for float[], long[] and int[].

There is also a fix in `BufferManagingRebufferer.buffer(),` probably that method from that class is used only in tests, otherwise we should have seen garbage reads in production.