### PR TITLE
RandomAccessReader: remove some unnecessary temp buff creations

### DIFF
--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -114,7 +114,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         }
 
         int bytesToRead = Float.BYTES * dest.length;
-        if (dest.length > floatBuffer.remaining())
+        if (bytesToRead > floatBuffer.remaining())
         {
             // slow path -- desired slice is across region boundaries
             var bb = getTemporaryBuffer(bytesToRead);
@@ -199,7 +199,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         }
 
         int bytesToRead = Integer.BYTES * count;
-        if (count > intBuffer.remaining())
+        if (bytesToRead > intBuffer.remaining())
         {
             // slow path -- desired slice is across region boundaries
             var bb = getTemporaryBuffer(bytesToRead);


### PR DESCRIPTION
We use an unnecessarily lower value to create temporary buffers when we're near the buffer's boundary. This change uses the correct value. The tests from `RandomAccessReaderTest` cover this code and show correctness.