### PR TITLE
Support configuring ByteOrder on BufferHolder

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -205,12 +205,11 @@ public class ChunkCache
             // and that we don't change it once it has been set. The {float,int,long}Buffer methods rely implicitly
             // on buffer order, and we need to ensure that the order is set before they are called.
             var previousOrder = this.order.getAndSet(newOrder);
-            if (previousOrder == null || previousOrder == newOrder)
-                // Set the order even if the previous order was the same as the new order because we don't explicitly
-                // have safe publication guaranteeing our current thread will see the order set by another thread.
-                buffer.order(newOrder);
-            else
+            if (previousOrder != null && previousOrder != newOrder)
                 throw new IllegalStateException("Order has already been set to " + previousOrder + " and cannot be changed to " + newOrder + " for buffer " + buffer);
+            // Set the order even if the previous order was the same as the new order because we don't explicitly
+            // have safe publication guaranteeing our current thread will see the order set by another thread.
+            buffer.order(newOrder);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -193,9 +193,7 @@ public class ChunkCache
         public ByteBuffer buffer()
         {
             assert references.get() > 0;
-            var o = order.get();
-            assert o != null : "Order has not been set for buffer.";
-            return buffer.duplicate().order(o);
+            return buffer.duplicate().order(buffer.order());
         }
 
         @Override

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -39,6 +39,7 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
     protected final ChunkReader source;
     protected final ByteBuffer buffer;
     protected long offset = 0;
+    private ByteOrder order = null;
 
     abstract long alignedPosition(long position);
 
@@ -99,24 +100,37 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
 
     public ByteBuffer buffer()
     {
-        return buffer.duplicate();
+        assert order != null;
+        return buffer.duplicate().order(order);
+    }
+
+    @Override
+    public void order(ByteOrder newOrder)
+    {
+        if (order != null && order != newOrder)
+            throw new IllegalStateException("Buffer order cannot be changed");
+        order = newOrder;
+        buffer.order(order);
     }
 
     @Override
     public FloatBuffer floatBuffer()
     {
+        assert order != null : "Order has not been set for buffer.";
         return buffer.asFloatBuffer();
     }
 
     @Override
     public IntBuffer intBuffer()
     {
+        assert order != null : "Order has not been set for buffer.";
         return buffer.asIntBuffer();
     }
 
     @Override
     public LongBuffer longBuffer()
     {
+        assert order != null : "Order has not been set for buffer.";
         return buffer.asLongBuffer();
     }
 

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -100,8 +100,7 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
 
     public ByteBuffer buffer()
     {
-        assert order != null;
-        return buffer.duplicate().order(order);
+        return buffer.duplicate().order(buffer.order());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/util/LimitingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/LimitingRebufferer.java
@@ -20,6 +20,7 @@
  */
 package org.apache.cassandra.io.util;
 
+import java.nio.ByteOrder;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.primitives.Ints;

--- a/src/java/org/apache/cassandra/io/util/MmappedRegions.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegions.java
@@ -230,9 +230,7 @@ public class MmappedRegions extends SharedCloseableImpl
 
         public ByteBuffer buffer()
         {
-            var o = order.get();
-            assert o != null : "Order has not been set for buffer.";
-            return buffer.duplicate().order(o);
+            return buffer.duplicate().order(buffer.order());
         }
 
         @Override

--- a/src/java/org/apache/cassandra/io/util/MmappedRegions.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegions.java
@@ -242,12 +242,11 @@ public class MmappedRegions extends SharedCloseableImpl
             // and that we don't change it once it has been set. The {float,int,long}Buffer methods rely implicitly
             // on buffer order, and we need to ensure that the order is set before they are called.
             var previousOrder = this.order.getAndSet(newOrder);
-            if (previousOrder == null || previousOrder == newOrder)
-                // Set the order even if the previous order was the same as the new order because we don't explicitly
-                // have safe publication guaranteeing our current thread will see the order set by another thread.
-                buffer.order(newOrder);
-            else
+            if (previousOrder != null && previousOrder != newOrder)
                 throw new IllegalStateException("Order has already been set to " + previousOrder + " and cannot be changed to " + newOrder + " for buffer " + buffer);
+            // Set the order even if the previous order was the same as the new order because we don't explicitly
+            // have safe publication guaranteeing our current thread will see the order set by another thread.
+            buffer.order(newOrder);
         }
 
         public FloatBuffer floatBuffer()

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -72,9 +72,10 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         bufferHolder.release();
         bufferHolder = Rebufferer.EMPTY; // prevents double release if the call below fails
         bufferHolder = rebufferer.rebuffer(position);
+        bufferHolder.order(order); // Configures bufferHolder to return buffers with the correct byte order
         buffer = bufferHolder.buffer();
+        assert buffer.order() == order : "Buffer order is " + buffer.order() + " but expected " + order;
         buffer.position(Ints.checkedCast(position - bufferHolder.offset()));
-        buffer.order(order);
     }
 
     public ByteOrder order()
@@ -493,13 +494,13 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         }
         if (buffer.isDirect())
         {
-            temporaryBuffer = ByteBuffer.allocateDirect(size).order(buffer.order());
+            temporaryBuffer = ByteBuffer.allocateDirect(size);
         }
         else
         {
-            temporaryBuffer = ByteBuffer.allocate(size).order(buffer.order());
+            temporaryBuffer = ByteBuffer.allocate(size);
         }
-        return temporaryBuffer;
+        return temporaryBuffer.order(order);
     }
 
 }

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -46,15 +46,15 @@ public interface Rebufferer extends ReaderFileProxy
     {
         /**
          * Returns a useable buffer (i.e. one whose position and limit can be freely modified). Its limit will be set
-         * to the size of the available data in the buffer. Must call order() before calling this method to ensure
-         * the buffer is in the correct byte order.
+         * to the size of the available data in the buffer. If order() is called before buffer(), the buffer will have
+         * the specified ByteOrder.
          * The buffer must be treated as read-only.
          */
         ByteBuffer buffer();
 
         /**
          * Configure this BufferHolder to use the passed ByteOrder for all buffers, including those returned by buffer().
-         * Must be called before the first call to buffer(). Must handle concurrent calls correctly.
+         * Must handle concurrent calls correctly.
          * @param order
          */
         default void order(ByteOrder order)

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
@@ -45,23 +46,37 @@ public interface Rebufferer extends ReaderFileProxy
     {
         /**
          * Returns a useable buffer (i.e. one whose position and limit can be freely modified). Its limit will be set
-         * to the size of the available data in the buffer.
+         * to the size of the available data in the buffer. Must call order() before calling this method to ensure
+         * the buffer is in the correct byte order.
          * The buffer must be treated as read-only.
          */
         ByteBuffer buffer();
 
+        /**
+         * Configure this BufferHolder to use the passed ByteOrder for all buffers, including those returned by buffer().
+         * Must be called before the first call to buffer(). Must handle concurrent calls correctly.
+         * @param order
+         */
+        default void order(ByteOrder order)
+        {
+            throw new UnsupportedOperationException("not implemented in " + this.getClass());
+        }
+
         default FloatBuffer floatBuffer()
         {
+            // When implementing this, be sure to implement the order() method as well.
             throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 
         default IntBuffer intBuffer()
         {
+            // When implementing this, be sure to implement the order() method as well.
             throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 
         default LongBuffer longBuffer()
         {
+            // When implementing this, be sure to implement the order() method as well.
             throw new UnsupportedOperationException("not implemented in " + this.getClass());
         }
 

--- a/src/java/org/apache/cassandra/io/util/TailOverridingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/TailOverridingRebufferer.java
@@ -53,7 +53,7 @@ public class TailOverridingRebufferer extends WrappingRebufferer
         }
         else
         {
-            buffer = tail.duplicate();
+            buffer = tail.duplicate().order(order);
             offset = cutoff;
         }
         return this;

--- a/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -39,6 +40,7 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     protected BufferHolder bufferHolder;
     protected ByteBuffer buffer;
     protected long offset;
+    protected ByteOrder order = null;
 
     public WrappingRebufferer(Rebufferer source)
     {
@@ -50,6 +52,7 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     {
         assert buffer == null;
         bufferHolder = source.rebuffer(position);
+        bufferHolder.order(order);
         buffer = bufferHolder.buffer();
         offset = bufferHolder.offset();
 
@@ -98,6 +101,14 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     {
         assert buffer != null : "Buffer holder has not been acquired";
         return buffer;
+    }
+
+    @Override
+    public void order(ByteOrder newOrder)
+    {
+        assert buffer != null : "Buffer holder has not been acquired";
+        assert order == null || order == newOrder : "Order has been already set to " + order + " and is attempted to be set to " + newOrder;
+        buffer.order(newOrder);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/io/util/RandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/RandomAccessReaderTest.java
@@ -181,22 +181,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyFloatArrayAligned() throws IOException
     {
-        testReadFullyFloatArray(0);
+        testReadFullyFloatArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyFloatArrayNotAligned() throws IOException
     {
-        testReadFullyFloatArray(1);
+        testReadFullyFloatArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyFloatArrayAligned2() throws IOException
     {
-        testReadFullyFloatArray(Float.BYTES);
+        testReadFullyFloatArray(Float.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(Float.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyFloatArray(int shift) throws IOException
+    private void testReadFullyFloatArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -222,6 +225,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -241,6 +245,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())
@@ -283,22 +288,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyLongArrayAligned() throws IOException
     {
-        testReadFullyLongArray(0);
+        testReadFullyLongArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyLongArrayNotAligned() throws IOException
     {
-        testReadFullyLongArray(1);
+        testReadFullyLongArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyLongArrayAligned2() throws IOException
     {
-        testReadFullyLongArray(Long.BYTES);
+        testReadFullyLongArray(Long.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(Long.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyLongArray(int shift) throws IOException
+    private void testReadFullyLongArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -324,6 +332,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -344,6 +353,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())
@@ -387,22 +397,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyIntArrayAligned() throws IOException
     {
-        testReadFullyIntArray(0);
+        testReadFullyIntArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyIntArrayNotAligned() throws IOException
     {
-        testReadFullyIntArray(1);
+        testReadFullyIntArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyIntArrayAligned2() throws IOException
     {
-        testReadFullyIntArray(Integer.BYTES);
+        testReadFullyIntArray(Integer.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(Integer.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyIntArray(int shift) throws IOException
+    private void testReadFullyIntArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -428,6 +441,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -448,6 +462,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())


### PR DESCRIPTION
## Problem

Calls to `asFloatBuffer`, `asIntBuffer`, and `asLongBuffer` on a `ByteBuffer` inherit the source buffer's `ByteOrder`. In the `RandomAccessReader`, we skip the call to `duplicate` a byte buffer before calling these methods to avoid unnecessary object creation. That is problematic because https://github.com/datastax/cassandra/pull/1030 introduced the ability to configure a `RandomAccessReader` with a byte order, but we don't actually have a way to do that in the current design.

## Alternative designs

* Add a byte order config to the `Rebufferer`. I tried this, but it ended up with a sprawling diff that would be very brittle.
* Re-introduce the `duplicate()` call before the call to `asFloatBuffer`, `asIntBuffer`, and `asLongBuffer`. This seems like a nonstarter, but it would be (by far) the most simple solution. (As I write this, I am thinking this would be better since we don't actually have any use cases that rely on this yet, and perhaps down the road, the design would be easier to use if we write any of these primitive arrays in little endian.)

## This design

* Add a byte order config to the `BufferHolder` and partially implement the logic in the classes that matter. This solution is decidedly less brittle than the `Rebufferer` solution, but it still has a number of "gotchas" as you can see in the commit history on this PR.