### PR TITLE
Fix RandomAccessReader byte order for {float|int|long}Buffer

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -21,6 +21,7 @@
 package org.apache.cassandra.cache;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
@@ -190,6 +191,12 @@ public class ChunkCache
         {
             assert references.get() > 0;
             return buffer.duplicate();
+        }
+
+        @Override
+        public ByteOrder order()
+        {
+            return buffer.order();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -103,6 +103,12 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
     }
 
     @Override
+    public ByteOrder order()
+    {
+        return buffer.order();
+    }
+
+    @Override
     public FloatBuffer floatBuffer()
     {
         return buffer.asFloatBuffer();

--- a/src/java/org/apache/cassandra/io/util/MmappedRegions.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegions.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
@@ -228,6 +229,12 @@ public class MmappedRegions extends SharedCloseableImpl
         public ByteBuffer buffer()
         {
             return buffer.duplicate();
+        }
+
+        @Override
+        public ByteOrder order()
+        {
+            return buffer.order();
         }
 
         public FloatBuffer floatBuffer()

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -96,11 +96,13 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         long position = getPosition();
 
         FloatBuffer floatBuffer;
-        if (bh.offset() == 0 && position % Float.BYTES == 0)
+        if (bh.offset() == 0 && position % Float.BYTES == 0 && bh.order() == order)
         {
             // this is a separate code path because buffer() and asFloatBuffer() both allocate
             // new and relatively expensive xBuffer objects, so we want to avoid doing that
-            // twice, where possible
+            // twice, where possible. If the BufferHandler has a different underlying
+            // byte order, we duplicate first because there is not yet a way to configure
+            // the buffer handler to use the correct byte order.
             floatBuffer = bh.floatBuffer();
             floatBuffer.position(Ints.checkedCast(position / Float.BYTES));
         }
@@ -109,6 +111,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             // offset is non-zero, and probably not aligned to Float.BYTES, so
             // set the position before converting to FloatBuffer.
             var bb = bh.buffer();
+            bb.order(order);
             bb.position(Ints.checkedCast(position - bh.offset()));
             floatBuffer = bb.asFloatBuffer();
         }
@@ -132,11 +135,13 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         long position = getPosition();
 
         LongBuffer longBuffer;
-        if (bh.offset() == 0 && position % Long.BYTES == 0)
+        if (bh.offset() == 0 && position % Long.BYTES == 0 && bh.order() == order)
         {
             // this is a separate code path because buffer() and asLongBuffer() both allocate
             // new and relatively expensive xBuffer objects, so we want to avoid doing that
-            // twice, where possible
+            // twice, where possible. If the BufferHandler has a different underlying
+            // byte order, we duplicate first because there is not yet a way to configure
+            // the buffer handler to use the correct byte order.
             longBuffer = bh.longBuffer();
             longBuffer.position(Ints.checkedCast(position / Long.BYTES));
         }
@@ -145,6 +150,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             // offset is non-zero, and probably not aligned to Long.BYTES, so
             // set the position before converting to LongBuffer.
             var bb = bh.buffer();
+            bb.order(order);
             bb.position(Ints.checkedCast(position - bh.offset()));
             longBuffer = bb.asLongBuffer();
         }
@@ -181,11 +187,13 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
         long position = getPosition();
 
         IntBuffer intBuffer;
-        if (bh.offset() == 0 && position % Integer.BYTES == 0)
+        if (bh.offset() == 0 && position % Integer.BYTES == 0 && bh.order() == order)
         {
             // this is a separate code path because buffer() and asIntBuffer() both allocate
             // new and relatively expensive xBuffer objects, so we want to avoid doing that
-            // twice, where possible
+            // twice, where possible. If the BufferHandler has a different underlying
+            // byte order, we duplicate first because there is not yet a way to configure
+            // the buffer handler to use the correct byte order.
             intBuffer = bh.intBuffer();
             intBuffer.position(Ints.checkedCast(position / Integer.BYTES));
         }
@@ -194,6 +202,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             // offset is non-zero, and probably not aligned to Integer.BYTES, so
             // set the position before converting to IntBuffer.
             var bb = bh.buffer();
+            bb.order(order);
             bb.position(Ints.checkedCast(position - bh.offset()));
             intBuffer = bb.asIntBuffer();
         }

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -52,9 +52,11 @@ public interface Rebufferer extends ReaderFileProxy
         ByteBuffer buffer();
 
         /**
-         * Return the order of the {@link ByteBuffer} and other various buffers returned by this class. This is
-         * particularly relevant for the {@link #floatBuffer()}, {@link #intBuffer()} and {@link #longBuffer()} methods
-         * because the caller cannot change the order of those returned buffer objects.
+         * Return the order of the underlying {@link ByteBuffer} held by this class. This is only relevant for the
+         * {@link #floatBuffer()}, {@link #intBuffer()} and {@link #longBuffer()} methods because the caller cannot
+         * change the order of those returned buffer objects. Further, it is not generally relevant for calls to
+         * {@link #buffer()} since the call to {@link ByteBuffer#duplicate()} sets the byte order to
+         * {@link ByteOrder#BIG_ENDIAN} and the caller can change the order of the returned buffer.
          */
         ByteOrder order();
 

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
@@ -49,6 +50,13 @@ public interface Rebufferer extends ReaderFileProxy
          * The buffer must be treated as read-only.
          */
         ByteBuffer buffer();
+
+        /**
+         * Return the order of the {@link ByteBuffer} and other various buffers returned by this class. This is
+         * particularly relevant for the {@link #floatBuffer()}, {@link #intBuffer()} and {@link #longBuffer()} methods
+         * because the caller cannot change the order of those returned buffer objects.
+         */
+        ByteOrder order();
 
         default FloatBuffer floatBuffer()
         {
@@ -85,6 +93,12 @@ public interface Rebufferer extends ReaderFileProxy
         public ByteBuffer buffer()
         {
             return EMPTY_BUFFER;
+        }
+
+        @Override
+        public ByteOrder order()
+        {
+            return EMPTY_BUFFER.order();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -98,6 +99,12 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     {
         assert buffer != null : "Buffer holder has not been acquired";
         return buffer;
+    }
+
+    @Override
+    public ByteOrder order()
+    {
+        return buffer.order();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
+++ b/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.io.tries;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.BiFunction;
@@ -179,6 +180,12 @@ abstract public class AbstractTrieTestBase
         public ByteBuffer buffer()
         {
             return buffer;
+        }
+
+        @Override
+        public ByteOrder order()
+        {
+            return buffer.order();
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/io/util/RandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/RandomAccessReaderTest.java
@@ -181,22 +181,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyFloatArrayAligned() throws IOException
     {
-        testReadFullyFloatArray(0);
+        testReadFullyFloatArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyFloatArrayNotAligned() throws IOException
     {
-        testReadFullyFloatArray(1);
+        testReadFullyFloatArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyFloatArrayAligned2() throws IOException
     {
-        testReadFullyFloatArray(Float.BYTES);
+        testReadFullyFloatArray(Float.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyFloatArray(Float.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyFloatArray(int shift) throws IOException
+    private void testReadFullyFloatArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -211,7 +214,7 @@ public class RandomAccessReaderTest
         cases.add(new FloatReadArrayCase(2000));
         cases.add(new FloatReadArrayCase(2000));
 
-         int bigArraySize = 1 + (bufferSize / Float.BYTES);
+        int bigArraySize = 1 + (bufferSize / Float.BYTES);
         // ensure that in the test case we have a least one array that is bigger than the buffer size
         cases.add(new FloatReadArrayCase(bigArraySize));
         cases.add(new FloatReadArrayCase(bigArraySize));
@@ -222,6 +225,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -241,6 +245,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())
@@ -283,22 +288,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyLongArrayAligned() throws IOException
     {
-        testReadFullyLongArray(0);
+        testReadFullyLongArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyLongArrayNotAligned() throws IOException
     {
-        testReadFullyLongArray(1);
+        testReadFullyLongArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyLongArrayAligned2() throws IOException
     {
-        testReadFullyLongArray(Long.BYTES);
+        testReadFullyLongArray(Long.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyLongArray(Long.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyLongArray(int shift) throws IOException
+    private void testReadFullyLongArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -324,6 +332,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -344,6 +353,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())
@@ -387,22 +397,25 @@ public class RandomAccessReaderTest
     @Test
     public void testReadFullyIntArrayAligned() throws IOException
     {
-        testReadFullyIntArray(0);
+        testReadFullyIntArray(0, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(0, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyIntArrayNotAligned() throws IOException
     {
-        testReadFullyIntArray(1);
+        testReadFullyIntArray(1, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(1, ByteOrder.LITTLE_ENDIAN);
     }
 
     @Test
     public void testReadFullyIntArrayAligned2() throws IOException
     {
-        testReadFullyIntArray(Integer.BYTES);
+        testReadFullyIntArray(Integer.BYTES, ByteOrder.BIG_ENDIAN);
+        testReadFullyIntArray(Integer.BYTES, ByteOrder.LITTLE_ENDIAN);
     }
 
-    private void testReadFullyIntArray(int shift) throws IOException
+    private void testReadFullyIntArray(int shift, ByteOrder order) throws IOException
     {
         int bufferSize = 2048;
 
@@ -428,6 +441,7 @@ public class RandomAccessReaderTest
         File file = writeFile(writer -> {
             try
             {
+                writer.order(order);
                 // write some garbage in the beginning, in order to not have aligned reads
                 for (int i = 0; i < shift; i++)
                     writer.writeByte(0);
@@ -448,6 +462,7 @@ public class RandomAccessReaderTest
 
         try (ChannelProxy channel = new ChannelProxy(file);
              FileHandle.Builder builder = new FileHandle.Builder(channel)
+                                          .order(order)
                                           .bufferType(BufferType.OFF_HEAP).bufferSize(bufferSize);
              FileHandle fh = builder.complete();
              RandomAccessReader reader = fh.createReader())

--- a/test/unit/org/apache/cassandra/io/util/WrappingRebuffererTest.java
+++ b/test/unit/org/apache/cassandra/io/util/WrappingRebuffererTest.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import org.junit.Test;
 
@@ -105,6 +106,12 @@ public class WrappingRebuffererTest
         public ByteBuffer buffer()
         {
             return buffer;
+        }
+
+        @Override
+        public ByteOrder order()
+        {
+            return buffer.order();
         }
 
         public long fileLength()


### PR DESCRIPTION
Alternative to https://github.com/datastax/cassandra/pull/1066.

## Problem

Calls to `asFloatBuffer`, `asIntBuffer`, and `asLongBuffer` on a `ByteBuffer` inherit the source buffer's `ByteOrder`. In the `RandomAccessReader`, we sometimes skip the call to `duplicate` a byte buffer before calling these methods to avoid unnecessary object creation. That is problematic because https://github.com/datastax/cassandra/pull/1030 introduced the ability to configure a `RandomAccessReader` with a byte order, but that PR didn't correctly account for byte order on these primitive buffer objects.

## Alternative designs

* Add a byte order config to the `Rebufferer`. I tried this, but it ended up with a sprawling diff that would be very brittle.
* Add a byte order config to the `BufferHolder` and partially implement the logic in the classes that matter. This solution is decidedly less brittle than the `Rebufferer` solution, but it still has a number of "gotchas" as you can see in https://github.com/datastax/cassandra/pull/1066.

## This design

Only skip the `duplicate()` call before the call to `asFloatBuffer`, `asIntBuffer`, and `asLongBuffer` if the `BufferHandler` has the desired byte order. This is the simplest solution, and since there are no known cases where we need to support little endian float/int/long arrays, I think we should defer optimizing for a case that is not in use.

The updated tests fail without the changes made in the second commit.