### PR TITLE
CNDB-9091: Histogram can now have the same boundaries as in DSE

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -308,7 +308,7 @@ public enum CassandraRelevantProperties
     /** Set this property to true in order to switch to micrometer metrics */
     USE_MICROMETER("cassandra.use_micrometer_metrics", "false"),
 
-    /** Set this property to true in order to switch to micrometer metrics */
+    /** Set this property to true in order to use DSE-like histogram bucket boundaries and behaviour */
     USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES("cassandra.use_dse_compatible_histogram_boundaries", "false"),
 
     /** Which class to use for coordinator client request metrics */

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -308,6 +308,9 @@ public enum CassandraRelevantProperties
     /** Set this property to true in order to switch to micrometer metrics */
     USE_MICROMETER("cassandra.use_micrometer_metrics", "false"),
 
+    /** Set this property to true in order to switch to micrometer metrics */
+    USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES("cassandra.use_dse_compatible_histogram_boundaries", "false"),
+
     /** Which class to use for coordinator client request metrics */
     CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY("cassandra.custom_client_request_metrics_provider_class"),
 

--- a/src/java/org/apache/cassandra/metrics/DecayingEstimatedHistogramReservoir.java
+++ b/src/java/org/apache/cassandra/metrics/DecayingEstimatedHistogramReservoir.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongArray;
@@ -32,6 +33,7 @@ import com.google.common.primitives.Ints;
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.utils.EstimatedHistogram;
 
 import static java.lang.Math.max;
@@ -90,15 +92,32 @@ public class DecayingEstimatedHistogramReservoir implements Reservoir
     private static final int[] DISTRIBUTION_PRIMES = new int[] { 17, 19, 23, 29 };
 
     // The offsets used with a default sized bucket array without a separate bucket for zero values.
-    public static final long[] DEFAULT_WITHOUT_ZERO_BUCKET_OFFSETS = EstimatedHistogram.newOffsets(DEFAULT_BUCKET_COUNT, false);
+    private static final long[] DEFAULT_WITHOUT_ZERO_BUCKET_OFFSETS = EstimatedHistogram.newCassandraOffsets(DEFAULT_BUCKET_COUNT, false);
 
     // The offsets used with a default sized bucket array with a separate bucket for zero values.
-    public static final long[] DEFAULT_WITH_ZERO_BUCKET_OFFSETS = EstimatedHistogram.newOffsets(DEFAULT_BUCKET_COUNT, true);
+    private static final long[] DEFAULT_WITH_ZERO_BUCKET_OFFSETS = EstimatedHistogram.newCassandraOffsets(DEFAULT_BUCKET_COUNT, true);
 
     private static final int TABLE_BITS = 4;
     private static final int TABLE_MASK = -1 >>> (32 - TABLE_BITS);
     private static final float[] LOG2_TABLE = computeTable(TABLE_BITS);
     private static final float log2_12_recp = (float) (1d / slowLog2(1.2d));
+
+    // DSE COMPATIBILITY CHANGES START
+    // The DSE-compatible offsets used with a default sized bucket array without a separate bucket for zero values.
+    private static final long[] DEFAULT_DSE_WITHOUT_ZERO_BUCKET_OFFSETS = newDseOffsets(DEFAULT_BUCKET_COUNT, false);
+
+    // The DSE-compatibleoffsets used with a default sized bucket array with a separate bucket for zero values.
+    private static final long[] DEFAULT_DSE_WITH_ZERO_BUCKET_OFFSETS = newDseOffsets(DEFAULT_BUCKET_COUNT, true);
+
+    /** Values for calculating buckets and indexes */
+    final static int subBucketCount = 8;  // number of sub-buckets in each bucket
+    final static int subBucketHalfCount = subBucketCount / 2;
+    final static int unitMagnitude = 0; // power of two of the unit in bucket zero (2^0 = 1)
+    final static int subBucketCountMagnitude = 3; // power of two of the number of sub buckets
+    final static int subBucketHalfCountMagnitude = subBucketCountMagnitude - 1; // power of two of half the number of sub-buckets
+    final static long subBucketMask = (long)(subBucketCount - 1) << unitMagnitude;
+    final static int leadingZeroCountBase = 64 - unitMagnitude - subBucketHalfCountMagnitude - 1;
+    // DSE COMPATIBILITY CHANGES END
 
     private static float[] computeTable(int bits)
     {
@@ -198,14 +217,10 @@ public class DecayingEstimatedHistogramReservoir implements Reservoir
 
         if (bucketCount == DEFAULT_BUCKET_COUNT)
         {
-            if (considerZeroes == true)
-            {
-                bucketOffsets = DEFAULT_WITH_ZERO_BUCKET_OFFSETS;
-            }
+            if (CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean())
+                bucketOffsets = considerZeroes ? DEFAULT_DSE_WITH_ZERO_BUCKET_OFFSETS : DEFAULT_DSE_WITHOUT_ZERO_BUCKET_OFFSETS;
             else
-            {
-                bucketOffsets = DEFAULT_WITHOUT_ZERO_BUCKET_OFFSETS;
-            }
+                bucketOffsets = considerZeroes ? DEFAULT_WITH_ZERO_BUCKET_OFFSETS : DEFAULT_WITHOUT_ZERO_BUCKET_OFFSETS;
         }
         else
         {
@@ -258,6 +273,9 @@ public class DecayingEstimatedHistogramReservoir implements Reservoir
     @VisibleForTesting
     public static int findIndex(long[] bucketOffsets, long value)
     {
+        if (CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean())
+            return findIndexDse(bucketOffsets, value);
+
         // values below zero are nonsense, but we have never failed when presented them
         value = max(value, 0);
 
@@ -276,6 +294,48 @@ public class DecayingEstimatedHistogramReservoir implements Reservoir
 
         int firstCandidate = max(0, min(bucketOffsets.length - 1, ((int) fastLog12(value)) - offset));
         return value <= bucketOffsets[firstCandidate] ? firstCandidate : firstCandidate + 1;
+    }
+
+    private static int findIndexDse(long[] bucketOffsets, long value)
+    {
+        if (value < 0) {
+            throw new ArrayIndexOutOfBoundsException("Histogram recorded value cannot be negative.");
+        }
+
+        // Calculates the number of powers of two by which the value is greater than the biggest value that fits in
+        // bucket 0. This is the bucket index since each successive bucket can hold a value 2x greater.
+        // The mask maps small values to bucket 0.
+        final int bucketIndex = leadingZeroCountBase - Long.numberOfLeadingZeros(value | subBucketMask);
+
+        // For bucketIndex 0, this is just value, so it may be anywhere in 0 to subBucketCount.
+        // For other bucketIndex, this will always end up in the top half of subBucketCount: assume that for some bucket
+        // k > 0, this calculation will yield a value in the bottom half of 0 to subBucketCount. Then, because of how
+        // buckets overlap, it would have also been in the top half of bucket k-1, and therefore would have
+        // returned k-1 in getBucketIndex(). Since we would then shift it one fewer bits here, it would be twice as big,
+        // and therefore in the top half of subBucketCount.
+        final int subBucketIndex = (int)(value >>> (bucketIndex + unitMagnitude));
+
+        //assert(subBucketIndex < subBucketCount);
+        //assert(bucketIndex == 0 || (subBucketIndex >= subBucketHalfCount));
+        // Calculate the index for the first entry that will be used in the bucket (halfway through subBucketCount).
+        // For bucketIndex 0, all subBucketCount entries may be used, but bucketBaseIndex is still set in the middle.
+        final int bucketBaseIndex = (bucketIndex + 1) << subBucketHalfCountMagnitude;
+
+        // Calculate the offset in the bucket. This subtraction will result in a positive value in all buckets except
+        // the 0th bucket (since a value in that bucket may be less than half the bucket's 0 to subBucketCount range).
+        // However, this works out since we give bucket 0 twice as much space.
+        final int offsetInBucket = subBucketIndex - subBucketHalfCount;
+
+        // The following is the equivalent of ((subBucketIndex  - subBucketHalfCount) + bucketBaseIndex,
+        final int dseBucket = bucketBaseIndex + offsetInBucket;
+
+        // DSE bucket for zero values always exists, and during snapshot creation it is added to the second bucket
+        // if the histogram should not "considerZeroes".
+        // Cassandra does that differently. We either have or have not a separate bucket for zeroes.
+        // Thus, we should subtract 1 from the DSE index if we don't consider zeroes AND the value > 0.
+        final int zeroesCorrection = bucketOffsets[0] > 0 && value > 0 ? 1 : 0;
+
+        return min(bucketOffsets.length, bucketBaseIndex + offsetInBucket - zeroesCorrection);
     }
 
     /**
@@ -806,5 +866,36 @@ public class DecayingEstimatedHistogramReservoir implements Reservoir
         {
             return Objects.hash(min, max);
         }
+    }
+
+    public static long[] newDseOffsets(int size, boolean considerZeroes)
+    {
+        ArrayList<Long> ret = new ArrayList<>();
+        if (considerZeroes)
+            ret.add(0L);
+
+        for (int i = 1; i <= subBucketCount && ret.size() < size; i++)
+        {
+            ret.add((long) i);
+        }
+
+        long last = subBucketCount;
+        long unit = 1 << (unitMagnitude + 1);
+
+        while (ret.size() < size)
+        {
+            for (int i = 0; i < subBucketHalfCount; i++)
+            {
+                assert last + unit > last : "Overflow in DSE histogram bucket calculation; too big size requested: " + size;
+                last += unit;
+                ret.add(last);
+                if (ret.size() >= size)
+                    break;
+            }
+            unit *= 2;
+        }
+
+        assert ret.size() == size : "DSE histogram bucket count mismatch: " + ret.size() + " != " + size;
+        return ret.stream().mapToLong(i->i).toArray();
     }
 }

--- a/src/java/org/apache/cassandra/utils/EstimatedHistogram.java
+++ b/src/java/org/apache/cassandra/utils/EstimatedHistogram.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.utils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongArray;
 
@@ -25,10 +26,12 @@ import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.ISerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 
 public class EstimatedHistogram
 {
@@ -86,6 +89,14 @@ public class EstimatedHistogram
     }
 
     public static long[] newOffsets(int size, boolean considerZeroes)
+    {
+        if (CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean())
+            return DecayingEstimatedHistogramReservoir.newDseOffsets(size, considerZeroes);
+        else
+            return newCassandraOffsets(size, considerZeroes);
+    }
+
+    public static long[] newCassandraOffsets(int size, boolean considerZeroes)
     {
         long[] result = new long[size + (considerZeroes ? 1 : 0)];
         int i = 0;

--- a/test/unit/org/apache/cassandra/utils/EstimatedHistogramTest.java
+++ b/test/unit/org/apache/cassandra/utils/EstimatedHistogramTest.java
@@ -18,7 +18,13 @@
 */
 package org.apache.cassandra.utils;
 
+import java.util.Arrays;
+
+import org.junit.Assert;
 import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -178,5 +184,49 @@ public class EstimatedHistogramTest
         assertTrue(histogram.isOverflowed());
         histogram.clearOverflow();
         assertFalse(histogram.isOverflowed());
+    }
+
+    @Test
+    public void testDSEBoundaries()
+    {
+        boolean bucketBoundaries = CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean();
+        try
+        {
+            CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.setBoolean(true);
+            // these boundaries were computed in DSE
+            long[] dseBoundaries = new long[]{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40,
+                                               48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792,
+                                               2048, 2560, 3072, 3584, 4096, 5120, 6144, 7168, 8192, 10240, 12288, 14336, 16384, 20480, 24576, 28672, 32768,
+                                               40960, 49152, 57344, 65536, 81920, 98304, 114688, 131072, 163840, 196608, 229376, 262144, 327680, 393216,
+                                               458752, 524288, 655360, 786432, 917504, 1048576, 1310720, 1572864, 1835008, 2097152, 2621440, 3145728, 3670016,
+                                               4194304, 5242880, 6291456, 7340032, 8388608, 10485760, 12582912, 14680064, 16777216, 20971520, 25165824,
+                                               29360128, 33554432, 41943040, 50331648, 58720256, 67108864, 83886080, 100663296, 117440512, 134217728,
+                                               167772160, 201326592, 234881024, 268435456, 335544320, 402653184, 469762048, 536870912, 671088640, 805306368,
+                                               939524096, 1073741824, 1342177280, 1610612736, 1879048192, 2147483648L, 2684354560L, 3221225472L, 3758096384L,
+                                               4294967296L, 5368709120L, 6442450944L, 7516192768L, 8589934592L, 10737418240L, 12884901888L, 15032385536L, 17179869184L,
+                                               21474836480L, 25769803776L, 30064771072L, 34359738368L, 42949672960L, 51539607552L, 60129542144L, 68719476736L,
+                                               85899345920L, 103079215104L, 120259084288L, 137438953472L, 171798691840L, 206158430208L, 240518168576L, 274877906944L,
+                                               343597383680L, 412316860416L, 481036337152L, 549755813888L, 687194767360L, 824633720832L, 962072674304L, 1099511627776L,
+                                               1374389534720L, 1649267441664L, 1924145348608L, 2199023255552L, 2748779069440L, 3298534883328L, 3848290697216L,
+                                               4398046511104L, 5497558138880L, 6597069766656L, 7696581394432L, 8796093022208L, 10995116277760L, 13194139533312L,
+                                               15393162788864L, 17592186044416L, 21990232555520L, 26388279066624L, 30786325577728L, 35184372088832L, 43980465111040L,
+                                               52776558133248L, 61572651155456L, 70368744177664L, 87960930222080L, 105553116266496L, 123145302310912L,
+                                               140737488355328L, 175921860444160L };
+
+            // the code below is O(n^2) so that we don't need to assume that boundaries are independent
+            // of the histogram size; this is not a problem since the number of boundaries is small
+            for (int size = 1; size <= dseBoundaries.length; size++)
+            {
+                EstimatedHistogram histogram = new EstimatedHistogram(size);
+                // compute subarray of dseBoundaries of size `size`
+                long[] subarray = new long[size];
+                System.arraycopy(dseBoundaries, 0, subarray, 0, size);
+                Assert.assertArrayEquals(subarray, histogram.getBucketOffsets());
+            }
+        }
+        finally
+        {
+            CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.setBoolean(bucketBoundaries);
+        }
     }
 }


### PR DESCRIPTION
The behaviour is controlled via the cassandra.use_dse_compatible_histogram_boundaries system property