### PR TITLE
CNDB-9091: Histogram can now have the same boundaries as in DSE (#1069)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -308,6 +308,9 @@ public enum CassandraRelevantProperties
     /** Set this property to true in order to switch to micrometer metrics */
     USE_MICROMETER("cassandra.use_micrometer_metrics", "false"),
 
+    /** Set this property to true in order to use DSE-like histogram bucket boundaries and behaviour */
+    USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES("cassandra.use_dse_compatible_histogram_boundaries", "false"),
+
     /** Which class to use for coordinator client request metrics */
     CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY("cassandra.custom_client_request_metrics_provider_class"),
 

--- a/src/java/org/apache/cassandra/utils/EstimatedHistogram.java
+++ b/src/java/org/apache/cassandra/utils/EstimatedHistogram.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.utils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongArray;
 
@@ -25,10 +26,12 @@ import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.ISerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 
 public class EstimatedHistogram
 {
@@ -86,6 +89,14 @@ public class EstimatedHistogram
     }
 
     public static long[] newOffsets(int size, boolean considerZeroes)
+    {
+        if (CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean())
+            return DecayingEstimatedHistogramReservoir.newDseOffsets(size, considerZeroes);
+        else
+            return newCassandraOffsets(size, considerZeroes);
+    }
+
+    public static long[] newCassandraOffsets(int size, boolean considerZeroes)
     {
         long[] result = new long[size + (considerZeroes ? 1 : 0)];
         int i = 0;

--- a/test/unit/org/apache/cassandra/utils/EstimatedHistogramTest.java
+++ b/test/unit/org/apache/cassandra/utils/EstimatedHistogramTest.java
@@ -18,7 +18,13 @@
 */
 package org.apache.cassandra.utils;
 
+import java.util.Arrays;
+
+import org.junit.Assert;
 import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -178,5 +184,49 @@ public class EstimatedHistogramTest
         assertTrue(histogram.isOverflowed());
         histogram.clearOverflow();
         assertFalse(histogram.isOverflowed());
+    }
+
+    @Test
+    public void testDSEBoundaries()
+    {
+        boolean bucketBoundaries = CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.getBoolean();
+        try
+        {
+            CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.setBoolean(true);
+            // these boundaries were computed in DSE
+            long[] dseBoundaries = new long[]{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40,
+                                               48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792,
+                                               2048, 2560, 3072, 3584, 4096, 5120, 6144, 7168, 8192, 10240, 12288, 14336, 16384, 20480, 24576, 28672, 32768,
+                                               40960, 49152, 57344, 65536, 81920, 98304, 114688, 131072, 163840, 196608, 229376, 262144, 327680, 393216,
+                                               458752, 524288, 655360, 786432, 917504, 1048576, 1310720, 1572864, 1835008, 2097152, 2621440, 3145728, 3670016,
+                                               4194304, 5242880, 6291456, 7340032, 8388608, 10485760, 12582912, 14680064, 16777216, 20971520, 25165824,
+                                               29360128, 33554432, 41943040, 50331648, 58720256, 67108864, 83886080, 100663296, 117440512, 134217728,
+                                               167772160, 201326592, 234881024, 268435456, 335544320, 402653184, 469762048, 536870912, 671088640, 805306368,
+                                               939524096, 1073741824, 1342177280, 1610612736, 1879048192, 2147483648L, 2684354560L, 3221225472L, 3758096384L,
+                                               4294967296L, 5368709120L, 6442450944L, 7516192768L, 8589934592L, 10737418240L, 12884901888L, 15032385536L, 17179869184L,
+                                               21474836480L, 25769803776L, 30064771072L, 34359738368L, 42949672960L, 51539607552L, 60129542144L, 68719476736L,
+                                               85899345920L, 103079215104L, 120259084288L, 137438953472L, 171798691840L, 206158430208L, 240518168576L, 274877906944L,
+                                               343597383680L, 412316860416L, 481036337152L, 549755813888L, 687194767360L, 824633720832L, 962072674304L, 1099511627776L,
+                                               1374389534720L, 1649267441664L, 1924145348608L, 2199023255552L, 2748779069440L, 3298534883328L, 3848290697216L,
+                                               4398046511104L, 5497558138880L, 6597069766656L, 7696581394432L, 8796093022208L, 10995116277760L, 13194139533312L,
+                                               15393162788864L, 17592186044416L, 21990232555520L, 26388279066624L, 30786325577728L, 35184372088832L, 43980465111040L,
+                                               52776558133248L, 61572651155456L, 70368744177664L, 87960930222080L, 105553116266496L, 123145302310912L,
+                                               140737488355328L, 175921860444160L };
+
+            // the code below is O(n^2) so that we don't need to assume that boundaries are independent
+            // of the histogram size; this is not a problem since the number of boundaries is small
+            for (int size = 1; size <= dseBoundaries.length; size++)
+            {
+                EstimatedHistogram histogram = new EstimatedHistogram(size);
+                // compute subarray of dseBoundaries of size `size`
+                long[] subarray = new long[size];
+                System.arraycopy(dseBoundaries, 0, subarray, 0, size);
+                Assert.assertArrayEquals(subarray, histogram.getBucketOffsets());
+            }
+        }
+        finally
+        {
+            CassandraRelevantProperties.USE_DSE_COMPATIBLE_HISTOGRAM_BOUNDARIES.setBoolean(bucketBoundaries);
+        }
     }
 }


### PR DESCRIPTION
* CNDB-9091: Histogram can now have the same boundaries as in DSE
The behaviour is controlled via the cassandra.use_dse_compatible_histogram_boundaries system property