### PR TITLE
Defer closing RangeIterator to prevent bug in resumable vector search

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
@@ -78,10 +77,10 @@ import static java.lang.Math.min;
 public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrdering
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    public static int GLOBAL_BRUTE_FORCE_ROWS = Integer.MAX_VALUE; // not final so test can inject its own setting
 
     private final JVectorLuceneOnDiskGraph graph;
     private final PrimaryKey.Factory keyFactory;
-    private int globalBruteForceRows; // not final so test can inject its own setting
     private final PairedSlidingWindowReservoir expectedActualNodesVisited = new PairedSlidingWindowReservoir(20);
     private final ThreadLocal<SparseFixedBitSet> cachedBitSets;
 
@@ -110,8 +109,6 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         this.graph = graph;
         this.keyFactory = PrimaryKey.factory(indexContext.comparator(), indexContext.indexFeatureSet());
         cachedBitSets = ThreadLocal.withInitial(() -> new SparseFixedBitSet(graph.size()));
-
-        globalBruteForceRows = Integer.MAX_VALUE;
     }
 
     @Override
@@ -401,7 +398,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             // brute force from sstable will also do a bunch of extra work (going through trie index to look up row).
             // VSTODO I'm not sure which one is more expensive (and it depends on things like sstable chunk cache hit ratio)
             // so I'm leaving it as a 1:1 ratio for now.
-            return nFilteredRows <= min(globalBruteForceRows, expectedNodesVisited);
+            return nFilteredRows <= min(GLOBAL_BRUTE_FORCE_ROWS, expectedNodesVisited);
         }
 
         public void updateStatistics(int actualNodesVisited)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -72,6 +72,7 @@ import static java.lang.Math.pow;
 public class VectorMemtableIndex implements MemtableIndex
 {
     private final Logger logger = LoggerFactory.getLogger(VectorMemtableIndex.class);
+    public static int GLOBAL_BRUTE_FORCE_ROWS = Integer.MAX_VALUE; // not final so test can inject its own setting
 
     private final IndexContext indexContext;
     private final CassandraOnHeapGraph<PrimaryKey> graph;
@@ -321,7 +322,7 @@ public class VectorMemtableIndex implements MemtableIndex
         // larger dimension should increase this, because comparisons are more expensive
         // lower chunk cache hit ratio should decrease this, because loading rows is more expensive
         double memoryToDiskFactor = 0.25;
-        return (int) max(limit, memoryToDiskFactor * expectedComparisons);
+        return (int) min(max(limit, memoryToDiskFactor * expectedComparisons), GLOBAL_BRUTE_FORCE_ROWS);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -455,16 +455,28 @@ public class QueryController implements Plan.Executor
     {
         List<CloseableIterator<ScoredPrimaryKey>> scoredPrimaryKeyIterators = new ArrayList<>();
         List<SSTableIndex> indexesToRelease = new ArrayList<>();
-        try (var iter = new OrderingFilterRangeIterator<>(source, ORDER_CHUNK_SIZE, queryContext, list -> this.getTopKRows(list, expression)))
+        OrderingFilterRangeIterator<IteratorsAndIndexes> iter = null;
+        try
         {
+            // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
+            // that might not be needed until a deeper search into the ordering index, which happens after
+            // we exit this block.
+            iter = new OrderingFilterRangeIterator<>(source, ORDER_CHUNK_SIZE, queryContext, list -> this.getTopKRows(list, expression));
             while (iter.hasNext())
             {
                 var next = iter.next();
                 scoredPrimaryKeyIterators.addAll(next.iterators);
                 indexesToRelease.addAll(next.referencedIndexes);
             }
+            return new MergeScoredPrimaryKeyIterator(scoredPrimaryKeyIterators, indexesToRelease, iter);
         }
-        return new MergeScoredPrimaryKeyIterator(scoredPrimaryKeyIterators, indexesToRelease);
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(iter);
+            FileUtils.closeQuietly(scoredPrimaryKeyIterators);
+            indexesToRelease.forEach(QueryController::releaseQuietly);
+            throw t;
+        }
     }
 
     private IteratorsAndIndexes getTopKRows(List<PrimaryKey> sourceKeys, RowFilter.Expression expression)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -36,7 +36,9 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.vector.ConcurrentVectorValues;
+import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
@@ -54,20 +56,10 @@ public class VectorTester extends SAITester
         setMaxBruteForceRows(n);
     }
 
-    static void setMaxBruteForceRows(int n) throws Throwable
+    static void setMaxBruteForceRows(int n)
     {
-        var shouldUseBruteForce = InvokePointBuilder.newInvokePoint()
-                                                  .onClass("org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher$CostEstimate")
-                                                  .onMethod("shouldUseBruteForce")
-                                                  .atEntry();
-        var ab = ActionBuilder.newActionBuilder()
-                              .actions()
-                              .doAction("$this.this$0.globalBruteForceRows = " + n);
-        var changeBruteForceThreshold = Injections.newCustom("force_non_bruteforce_queries")
-                                                  .add(shouldUseBruteForce)
-                                                  .add(ab)
-                                                  .build();
-        Injections.inject(changeBruteForceThreshold);
+        V2VectorIndexSearcher.GLOBAL_BRUTE_FORCE_ROWS = n;
+        VectorMemtableIndex.GLOBAL_BRUTE_FORCE_ROWS = n;
     }
 
     public static double rawIndexedRecall(Collection<float[]> vectors, float[] query, List<float[]> result, int topK) throws IOException

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -857,6 +857,39 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
+    public void updatedPrimaryKeysRequireResumeSearch() throws Throwable
+    {
+        setMaxBruteForceRows(0);
+
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+        disableCompaction(KEYSPACE);
+
+        // This test is fairly contrived, but it covers a bug we hit due to prematurely closed iterators.
+        // The general design for this test is to shadow all the close vectors and none of the far vectors.
+        // Choose a row count that will essentially force us to re-query the index that still has more rows to search.
+        // Create 1000 rows without any vectors so that we can get positive SAI hits that will later be invalidated.
+        for (int i = 0; i < 100; i++)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'A', ?)", i, vector(1, i));
+
+        for (int i = 100; i < 1000; i++)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'C', ?)", i, vector(1, i));
+
+        flush();
+
+        // Overwrite some of those rows
+        for (int i = 0; i < 50; i++)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'B', ?)", i, vector(1, i));
+
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE str_val = 'A' ORDER BY val ann of [1.0, 1.0] LIMIT 1"),
+                       row(50));
+        });
+    }
+
+    @Test
     public void testBruteForceRangeQueryWithUpdatedVectors1536D() throws Throwable
     {
         testBruteForceRangeQueryWithUpdatedVectors(1536);


### PR DESCRIPTION
As far as I can tell, this only impacts resumable search on memtable indexes because sstable indexes force all primary keys to load when building the `AcceptBits`.

Stack trace of bug:

```
java.lang.IllegalStateException: Attempted to seek in a closed RAR	
at org.apache.cassandra.io.util.RandomAccessReader.seek(RandomAccessReader.java:329)	
at org.apache.cassandra.index.sai.disk.io.IndexInputReader.seek(IndexInputReader.java:156)	
at org.apache.cassandra.index.sai.disk.v2.sortedterms.SortedTermsReader$Cursor.seekToPointId(SortedTermsReader.java:295)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyMap.supplier(RowAwarePrimaryKeyMap.java:253)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyMap.lambda$primaryKeyFromRowId$0(RowAwarePrimaryKeyMap.java:180)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory$RowAwarePrimaryKey.loadDeferred(RowAwarePrimaryKeyFactory.java:109)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory$RowAwarePrimaryKey.partitionKey(RowAwarePrimaryKeyFactory.java:93)	
at org.apache.cassandra.index.sai.disk.PrimaryKeyWithSource.partitionKey(PrimaryKeyWithSource.java:62)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory$RowAwarePrimaryKey.compareTo(RowAwarePrimaryKeyFactory.java:175)	
at org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory$RowAwarePrimaryKey.equals(RowAwarePrimaryKeyFactory.java:200)	
at java.base/java.util.HashMap.getNode(HashMap.java:578)	
at java.base/java.util.HashMap.containsKey(HashMap.java:602)	
at java.base/java.util.HashSet.contains(HashSet.java:213)	
at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex$KeyFilteringBits.get(VectorMemtableIndex.java:482)	
at io.github.jbellis.jvector.graph.GraphSearcher.resume(GraphSearcher.java:297)	
at io.github.jbellis.jvector.graph.GraphSearcher.resume(GraphSearcher.java:355)	
at org.apache.cassandra.index.sai.disk.vector.AutoResumingNodeScoreIterator.computeNext(AutoResumingNodeScoreIterator.java:80)	
at org.apache.cassandra.index.sai.disk.vector.AutoResumingNodeScoreIterator.computeNext(AutoResumingNodeScoreIterator.java:37)	
at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)	
at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex$NodeScoreToScoredPrimaryKeyIterator.computeNext(VectorMemtableIndex.java:514)	
at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex$NodeScoreToScoredPrimaryKeyIterator.computeNext(VectorMemtableIndex.java:498)	
at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)	
at com.google.common.collect.Iterators$PeekingImpl.hasNext(Iterators.java:1126)	
at org.apache.cassandra.index.sai.utils.MergeScoredPrimaryKeyIterator.computeNext(MergeScoredPrimaryKeyIterator.java:66)	
at org.apache.cassandra.index.sai.utils.MergeScoredPrimaryKeyIterator.computeNext(MergeScoredPrimaryKeyIterator.java:38)	
at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)	
at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher$ScoreOrderedResultRetriever.nextSelectedKeyInRange(StorageAttachedIndexSearcher.java:570)	
at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher$ScoreOrderedResultRetriever.nextRowIterator(StorageAttachedIndexSearcher.java:538)	
at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher$ScoreOrderedResultRetriever.computeNext(StorageAttachedIndexSearcher.java:520)	
at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher$ScoreOrderedResultRetriever.computeNext(StorageAttachedIndexSearcher.java:484)	
at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)	
at org.apache.cassandra.index.sai.plan.VectorTopKProcessor.filterInternal(VectorTopKProcessor.java:211)	
at org.apache.cassandra.index.sai.plan.VectorTopKProcessor.filter(VectorTopKProcessor.java:149)	
at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:127)	
at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:512)	
at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:410)	
at org.apache.cassandra.db.ReadCommandVerbHandler.doVerb(ReadCommandVerbHandler.java:58)	
at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:79)	
at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:98)	
at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)	
at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)	
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)	
at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)	
at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)	
at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)	
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)	
at java.base/java.lang.Thread.run(Thread.java:1623)
```