### PR TITLE
update to beta3 and reuse Searcher objects

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -701,7 +701,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.2" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.3" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/VectorFcts.java
@@ -25,7 +25,6 @@ import io.github.jbellis.jvector.vector.ArrayVectorFloat;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorUtil;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
-import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.cql3.AssignmentTestable;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -34,7 +33,6 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.NumberType;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.transport.ProtocolVersion;
 
 import static java.lang.String.format;
@@ -42,8 +40,6 @@ import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.is
 
 public abstract class VectorFcts
 {
-    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
-
     public static void addFunctionsTo(NativeFunctions functions)
     {
         functions.add(similarity_function("similarity_cosine", VectorSimilarityFunction.COSINE, false));
@@ -82,6 +78,7 @@ public abstract class VectorFcts
                                                            VectorSimilarityFunction f,
                                                            boolean supportsZeroVectors)
     {
+        var vts = VectorizationProvider.getInstance().getVectorTypeSupport();
         return new NativeScalarFunction(name, FloatType.instance, type, type)
         {
             @Override
@@ -181,6 +178,7 @@ public abstract class VectorFcts
                                                        List<AbstractType<?>> argTypes,
                                                        AbstractType<?> receiverType)
         {
+            var vts = VectorizationProvider.getInstance().getVectorTypeSupport();
             VectorType<Float> vectorType = (VectorType<Float>) argTypes.get(0);
 
             return new NativeScalarFunction(name.name, vectorType, vectorType)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.function.IntConsumer;
 
-import javax.annotation.Nullable;
-
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
 import org.apache.cassandra.io.util.FileUtils;
@@ -39,7 +37,6 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
     private final GraphSearcher searcher;
     private final int topK;
     private final boolean inMemory;
-    private final AutoCloseable onClose;
     private final IntConsumer nodesVisitedConsumer;
     private Iterator<SearchResult.NodeScore> nodeScores;
     private int cumulativeNodesVisited;
@@ -53,14 +50,12 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
      * @param nodesVisitedConsumer a consumer that accepts the total number of nodes visited
      * @param topK the limit to pass to the {@link GraphSearcher} when resuming search
      * @param inMemory whether the graph is in memory or on disk (used for trace logging)
-     * @param onClose an {@link AutoCloseable} object to close when this iterator is closed
      */
     public AutoResumingNodeScoreIterator(GraphSearcher searcher,
                                          SearchResult result,
                                          IntConsumer nodesVisitedConsumer,
                                          int topK,
-                                         boolean inMemory,
-                                         @Nullable AutoCloseable onClose)
+                                         boolean inMemory)
     {
         this.searcher = searcher;
         this.nodeScores = Arrays.stream(result.getNodes()).iterator();
@@ -68,7 +63,6 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         this.nodesVisitedConsumer = nodesVisitedConsumer;
         this.topK = topK;
         this.inMemory = inMemory;
-        this.onClose = onClose;
     }
 
     @Override
@@ -98,6 +92,5 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
     public void close()
     {
         nodesVisitedConsumer.accept(cumulativeNodesVisited);
-        FileUtils.closeQuietly(onClose);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -122,7 +122,8 @@ public class CassandraOnHeapGraph<T>
     public CassandraOnHeapGraph(AbstractType<?> termComparator, IndexWriterConfig indexConfig, boolean forSearching)
     {
         serializer = (VectorType.VectorSerializer)termComparator.getSerializer();
-        vectorValues = new ConcurrentVectorValues(((VectorType<?>) termComparator).dimension);
+        var dimension = ((VectorType<?>) termComparator).dimension;
+        vectorValues = new ConcurrentVectorValues(dimension);
         similarityFunction = indexConfig.getSimilarityFunction();
         sourceModel = indexConfig.getSourceModel();
         // We need to be able to inexpensively distinguish different vectors, with a slower path
@@ -140,7 +141,7 @@ public class CassandraOnHeapGraph<T>
                                         indexConfig.getMaximumNodeConnections(),
                                         indexConfig.getConstructionBeamWidth(),
                                         1.2f,
-                                        1.2f);
+                                        dimension > 3 ? 1.2f : 2.0f);
         searchers = ThreadLocal.withInitial(() -> new GraphSearcher(builder.getGraph()));
     }
 

--- a/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
@@ -63,6 +63,12 @@ public class SAICodecUtils
         out.writeString(Version.LATEST.toString());
     }
 
+    public static int headerSize() {
+        // Lucene's string-writing code is complex, but this is what it works out to
+        // until version length exceeds 127 characters or we add non-ascii characters
+        return 7;
+    }
+
     public static void writeFooter(IndexOutput out) throws IOException
     {
         writeBEInt(out, FOOTER_MAGIC);


### PR DESCRIPTION
(the churn around writeData is from the changes to the Writer api that allow jvector to own the lifecycle more cleanly)