### PR TITLE
Create ReverseTrieTermsDictionaryReader; add collector to ReverseValueIterator

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.v1.trie;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+import org.apache.cassandra.io.tries.ReverseValueIterator;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.Rebufferer;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.SizedInts;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+/**
+ * Page-aware reverse iterator reader for a trie terms dictionary written by {@link TrieTermsDictionaryWriter}.
+ */
+public class ReverseTrieTermsDictionaryReader extends ReverseValueIterator<ReverseTrieTermsDictionaryReader> implements Iterator<Pair<ByteComparable, Long>>
+{
+    public ReverseTrieTermsDictionaryReader(Rebufferer rebufferer, long root)
+    {
+        super(rebufferer, root, true);
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return super.hasNext();
+    }
+
+    @Override
+    public Pair<ByteComparable, Long> next()
+    {
+        return nextValue(this::getKeyAndPayload);
+    }
+
+    private Pair<ByteComparable, Long> getKeyAndPayload()
+    {
+        return Pair.create(collectedKey(), getPayload(buf, payloadPosition(), payloadFlags()));
+    }
+
+    private static long getPayload(ByteBuffer contents, int payloadPos, int bytes)
+    {
+        return SizedInts.read(contents, payloadPos, bytes);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/RowIndexReverseIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/RowIndexReverseIterator.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 
 import org.apache.cassandra.io.sstable.format.trieindex.RowIndexReader.IndexInfo;
 import org.apache.cassandra.io.tries.ReverseValueIterator;
+import org.apache.cassandra.io.tries.ValueIterator;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
@@ -33,7 +34,7 @@ class RowIndexReverseIterator extends ReverseValueIterator<RowIndexReverseIterat
 
     public RowIndexReverseIterator(FileHandle file, long root, ByteComparable start, ByteComparable end)
     {
-        super(file.instantiateRebufferer(), root, start, end, true);
+        super(file.instantiateRebufferer(), root, start, end, ValueIterator.LeftBoundTreatment.ADMIT_PREFIXES);
     }
 
     public RowIndexReverseIterator(FileHandle file, TrieIndexEntry entry, ByteComparable end)

--- a/src/java/org/apache/cassandra/io/tries/BaseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/BaseValueIterator.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.tries;
+
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import org.apache.cassandra.io.util.Rebufferer;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+
+public abstract class BaseValueIterator<CONCRETE extends BaseValueIterator<CONCRETE>> extends Walker<CONCRETE>
+{
+    protected static final long NOT_PREPARED = -2;
+    protected final ByteSource limit;
+    protected final TransitionBytesCollector collector;
+    protected IterationPosition stack;
+    protected long next;
+
+    public BaseValueIterator(Rebufferer source, long root, ByteSource limit, boolean collecting)
+    {
+        super(source, root);
+        this.limit = limit;
+        collector = collecting ? new TransitionBytesCollector() : null;
+    }
+
+    /**
+     * Returns the payload node position.
+     * <p>
+     * This method must be async-read-safe, see {@link #advanceNode()}.
+     */
+    protected long nextPayloadedNode()
+    {
+        if (next != NOT_PREPARED)
+        {
+            long toReturn = next;
+            next = NOT_PREPARED;
+            return toReturn;
+        }
+        else
+            return advanceNode();
+    }
+
+    protected boolean hasNext()
+    {
+        if (next == NOT_PREPARED)
+            next = advanceNode();
+        return next != NONE;
+    }
+
+    protected <VALUE> VALUE nextValue(Supplier<VALUE> supplier)
+    {
+        long node = nextPayloadedNode();
+        if (node == NONE)
+            return null;
+        go(node);
+        return supplier.get();
+    }
+
+    protected long nextValueAsLong(LongSupplier supplier, long valueIfNone)
+    {
+        long node = nextPayloadedNode();
+        if (node == NONE)
+            return valueIfNone;
+        go(node);
+        return supplier.getAsLong();
+    }
+
+    protected ByteComparable collectedKey()
+    {
+        assert collector != null : "Cannot get a collected value from a non-collecting iterator";
+        return collector.toByteComparable();
+    }
+
+    protected abstract long advanceNode();
+
+    protected enum LeftBoundTreatment
+    {
+        ADMIT_PREFIXES,
+        ADMIT_EXACT,
+        GREATER
+    }
+
+    protected static class IterationPosition
+    {
+        final long node;
+        final int limit;
+        final IterationPosition prev;
+        int childIndex;
+
+        IterationPosition(long node, int childIndex, int limit, IterationPosition prev)
+        {
+            super();
+            this.node = node;
+            this.childIndex = childIndex;
+            this.limit = limit;
+            this.prev = prev;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("[Node %d, child %d, limit %d]", node, childIndex, limit);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -36,10 +36,12 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
 {
     static final int NOT_AT_LIMIT = Integer.MIN_VALUE;
     private final ByteSource limit;
+    private final TransitionBytesCollector collector;
     private IterationPosition stack;
     private long next;
     private static final long NOT_PREPARED = -2;
     private boolean reportingPrefixes;
+    private boolean popOnAdvance = false;
 
     static class IterationPosition
     {
@@ -60,9 +62,20 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
 
     protected ReverseValueIterator(Rebufferer source, long root)
     {
+        this(source, root, false);
+    }
+
+    protected ReverseValueIterator(Rebufferer source, long root, boolean collecting)
+    {
         super(source, root);
         limit = null;
+        collector = collecting ? new TransitionBytesCollector() : null;
         initializeNoRightBound(root, NOT_AT_LIMIT, false);
+    }
+
+    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, boolean admitPrefix)
+    {
+        this(source, root, start, end, admitPrefix, false);
     }
 
     /**
@@ -76,10 +89,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
      * </ul>
      * This behaviour is shared with the forward counterpart {@link ValueIterator}.
      */
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, boolean admitPrefix)
+    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, boolean admitPrefix, boolean collecting)
     {
         super(source, root);
         limit = start != null ? start.asComparableBytes(BYTE_COMPARABLE_VERSION) : null;
+        collector = collecting ? new TransitionBytesCollector() : null;
 
         if (end != null)
             initializeWithRightBound(root, end.asComparableBytes(BYTE_COMPARABLE_VERSION), admitPrefix, limit != null);
@@ -113,6 +127,8 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
                 break;
 
             prev = new IterationPosition(position, childIndex, limitByte, prev);
+            if (collector != null)
+                collector.add(s);
             go(transition(childIndex)); // childIndex is positive, this transition must exist
         }
 
@@ -133,7 +149,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
         reportingPrefixes = admitPrefix;
     }
 
-
+    protected ByteComparable collectedKey()
+    {
+        assert collector != null : "Cannot get a collected value from a non-collecting iterator";
+        return collector.toByteComparable();
+    }
 
     /**
      * Returns the position of the next node with payload contained in the iterated span.
@@ -164,6 +184,12 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
 
         long child;
         int transitionByte;
+
+        if (popOnAdvance)
+        {
+            popOnAdvance = false;
+            collector.pop();
+        }
 
         go(stack.node);
         while (true)
@@ -198,14 +224,21 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
                     // Note that on the exact match of the limit, stackTop.limit would be END_OF_STREAM.
                     // This comparison rejects the exact match; if we wanted to include it, we could test < 0 instead.
                     if (stackTop.limit == NOT_AT_LIMIT)
+                    {
+                        popOnAdvance = collector != null;
                         return stackTop.node;
+                    }
                     else if (reportingPrefixes)
                     {
                         reportingPrefixes = false; // if we are at limit position only report one prefix, the closest
+                        popOnAdvance = collector != null;
                         return stackTop.node;
                     }
                     // else skip this payload
                 }
+
+                if (collector != null)
+                    collector.pop();
 
                 if (stack == null)        // exhausted whole trie
                     return NONE;
@@ -226,6 +259,8 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
                     l = limit.next();
 
                 stack = new IterationPosition(child, transitionRange(), l, stack);
+                if (collector != null)
+                    collector.add(transitionByte);
             }
             else
             {

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -38,6 +38,7 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
     private final ByteSource limit;
     private IterationPosition stack;
     private long next;
+    private static final long NOT_PREPARED = -2;
     private boolean reportingPrefixes;
 
     static class IterationPosition
@@ -125,7 +126,10 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
     {
         go(root);
         stack = new IterationPosition(root, -1 - search(256), limitByte, null);
-        next = advanceNode();
+        if (hasPayload())
+            next = root;
+        else
+            next = NOT_PREPARED;
         reportingPrefixes = admitPrefix;
     }
 
@@ -136,10 +140,21 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
      */
     protected long nextPayloadedNode()
     {
-        long toReturn = next;
-        if (next != -1)
+        if (next != NOT_PREPARED)
+        {
+            long toReturn = next;
+            next = NOT_PREPARED;
+            return toReturn;
+        }
+        else
+            return advanceNode();
+    }
+
+    protected boolean hasNext()
+    {
+        if (next == NOT_PREPARED)
             next = advanceNode();
-        return toReturn;
+        return next != NONE;
     }
 
     long advanceNode()

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.io.tries;
 
+import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.io.util.Rebufferer;
@@ -99,6 +100,15 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
             initializeWithRightBound(root, end.asComparableBytes(BYTE_COMPARABLE_VERSION), admitPrefix, limit != null);
         else
             initializeNoRightBound(root, limit != null ? limit.next() : NOT_AT_LIMIT, admitPrefix);
+    }
+
+    protected <VALUE> VALUE nextValue(Supplier<VALUE> supplier)
+    {
+        long node = nextPayloadedNode();
+        if (node == NONE)
+            return null;
+        go(node);
+        return supplier.get();
     }
 
     void initializeWithRightBound(long root, ByteSource endStream, boolean admitPrefix, boolean hasLimit)

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.io.tries;
 
-import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.io.util.Rebufferer;
@@ -29,37 +28,15 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
  * <p>
  * The main utility of this class is the {@link #nextPayloadedNode()} method, which lists all nodes that contain a
  * payload within the requested bounds. The treatment of the bounds is non-standard (see
- * {@link #ReverseValueIterator(Rebufferer, long, ByteComparable, ByteComparable, boolean)}), necessary to properly walk
- * tries of prefixes and separators.
+ * {@link #ReverseValueIterator(Rebufferer, long, ByteComparable, ByteComparable, LeftBoundTreatment)}), necessary to
+ * properly walk tries of prefixes and separators.
  */
 @NotThreadSafe
-public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete>> extends Walker<Concrete>
+public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete>> extends BaseValueIterator<Concrete>
 {
     static final int NOT_AT_LIMIT = Integer.MIN_VALUE;
-    private final ByteSource limit;
-    private final TransitionBytesCollector collector;
-    private IterationPosition stack;
-    private long next;
-    private static final long NOT_PREPARED = -2;
-    private boolean reportingPrefixes;
-    private boolean popOnAdvance = false;
-
-    static class IterationPosition
-    {
-        final long node;
-        final int limit;
-        final IterationPosition prev;
-        int childIndex;
-
-        public IterationPosition(long node, int childIndex, int limit, IterationPosition prev)
-        {
-            super();
-            this.node = node;
-            this.childIndex = childIndex;
-            this.limit = limit;
-            this.prev = prev;
-        }
-    }
+    private LeftBoundTreatment reportingPrefixes;
+    private boolean popOnAdvance = true;
 
     protected ReverseValueIterator(Rebufferer source, long root)
     {
@@ -68,13 +45,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
 
     protected ReverseValueIterator(Rebufferer source, long root, boolean collecting)
     {
-        super(source, root);
-        limit = null;
-        collector = collecting ? new TransitionBytesCollector() : null;
-        initializeNoRightBound(root, NOT_AT_LIMIT, false);
+        super(source, root, null, collecting);
+        initializeNoRightBound(root, NOT_AT_LIMIT, LeftBoundTreatment.GREATER);
     }
 
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, boolean admitPrefix)
+    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix)
     {
         this(source, root, start, end, admitPrefix, false);
     }
@@ -90,11 +65,9 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
      * </ul>
      * This behaviour is shared with the forward counterpart {@link ValueIterator}.
      */
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, boolean admitPrefix, boolean collecting)
+    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, boolean collecting)
     {
-        super(source, root);
-        limit = start != null ? start.asComparableBytes(BYTE_COMPARABLE_VERSION) : null;
-        collector = collecting ? new TransitionBytesCollector() : null;
+        super(source, root, start != null ? start.asComparableBytes(BYTE_COMPARABLE_VERSION) : null, collecting);
 
         if (end != null)
             initializeWithRightBound(root, end.asComparableBytes(BYTE_COMPARABLE_VERSION), admitPrefix, limit != null);
@@ -102,16 +75,7 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
             initializeNoRightBound(root, limit != null ? limit.next() : NOT_AT_LIMIT, admitPrefix);
     }
 
-    protected <VALUE> VALUE nextValue(Supplier<VALUE> supplier)
-    {
-        long node = nextPayloadedNode();
-        if (node == NONE)
-            return null;
-        go(node);
-        return supplier.get();
-    }
-
-    void initializeWithRightBound(long root, ByteSource endStream, boolean admitPrefix, boolean hasLimit)
+    void initializeWithRightBound(long root, ByteSource endStream, LeftBoundTreatment admitPrefix, boolean hasLimit)
     {
         IterationPosition prev = null;
         boolean atLimit = hasLimit;
@@ -145,10 +109,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
         // Advancing now gives us first match.
         childIndex = -1 - childIndex;
         stack = new IterationPosition(position, childIndex, limitByte, prev);
-        next = advanceNode();
+        next = NOT_PREPARED;
+        popOnAdvance = false;
     }
 
-    private void initializeNoRightBound(long root, int limitByte, boolean admitPrefix)
+    private void initializeNoRightBound(long root, int limitByte, LeftBoundTreatment admitPrefix)
     {
         go(root);
         stack = new IterationPosition(root, -1 - search(256), limitByte, null);
@@ -156,38 +121,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
             next = root;
         else
             next = NOT_PREPARED;
+        popOnAdvance = false;
         reportingPrefixes = admitPrefix;
     }
 
-    protected ByteComparable collectedKey()
-    {
-        assert collector != null : "Cannot get a collected value from a non-collecting iterator";
-        return collector.toByteComparable();
-    }
-
-    /**
-     * Returns the position of the next node with payload contained in the iterated span.
-     */
-    protected long nextPayloadedNode()
-    {
-        if (next != NOT_PREPARED)
-        {
-            long toReturn = next;
-            next = NOT_PREPARED;
-            return toReturn;
-        }
-        else
-            return advanceNode();
-    }
-
-    protected boolean hasNext()
-    {
-        if (next == NOT_PREPARED)
-            next = advanceNode();
-        return next != NONE;
-    }
-
-    long advanceNode()
+    protected long advanceNode()
     {
         if (stack == null)
             return -1;
@@ -195,10 +133,13 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
         long child;
         int transitionByte;
 
-        if (popOnAdvance)
+        if (collector != null)
         {
-            popOnAdvance = false;
-            collector.pop();
+            // We need to pop the last character unless we have not yet advanced to an entry.
+            if (popOnAdvance)
+                collector.pop();
+            else
+                popOnAdvance = true;
         }
 
         go(stack.node);
@@ -214,7 +155,7 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
                 if (beyondLimit)
                 {
                     assert stack.limit >= 0;    // we are at a limit position (not in a node that's completely within the span)
-                    reportingPrefixes = false;  // there exists a smaller child than limit, no longer should report prefixes
+                    reportingPrefixes = null;  // there exists a smaller child than limit, no longer should report prefixes
                 }
             }
             else
@@ -233,15 +174,11 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
                     // If we are fully inside the covered space, report.
                     // Note that on the exact match of the limit, stackTop.limit would be END_OF_STREAM.
                     // This comparison rejects the exact match; if we wanted to include it, we could test < 0 instead.
-                    if (stackTop.limit == NOT_AT_LIMIT)
-                    {
-                        popOnAdvance = collector != null;
+                    if (stackTop.limit == NOT_AT_LIMIT || stackTop.limit == ByteSource.END_OF_STREAM && reportingPrefixes == LeftBoundTreatment.ADMIT_EXACT)
                         return stackTop.node;
-                    }
-                    else if (reportingPrefixes)
+                    else if (reportingPrefixes == LeftBoundTreatment.ADMIT_PREFIXES)
                     {
-                        reportingPrefixes = false; // if we are at limit position only report one prefix, the closest
-                        popOnAdvance = collector != null;
+                        reportingPrefixes = null; // if we are at limit position only report one prefix, the closest
                         return stackTop.node;
                     }
                     // else skip this payload

--- a/src/java/org/apache/cassandra/io/tries/Walker.java
+++ b/src/java/org/apache/cassandra/io/tries/Walker.java
@@ -411,7 +411,7 @@ public class Walker<VALUE extends Walker<VALUE>> implements AutoCloseable
 
         public ByteComparable toByteComparable()
         {
-            if (pos <= 0)
+            if (pos < 0)
                 return null;
             byte[] value = new byte[pos];
             System.arraycopy(bytes, 0, value, 0, pos);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryTest.java
@@ -361,20 +361,28 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader iterator = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp))
+             TrieTermsDictionaryReader iterator = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp);
+             ReverseTrieTermsDictionaryReader reverseIterator = new ReverseTrieTermsDictionaryReader(input.instantiateRebufferer(), fp))
         {
-            final Iterator<ByteComparable> expected = byteComparables.iterator();
-            int offset = 0;
-            while (iterator.hasNext())
-            {
-                assertTrue(expected.hasNext());
-                final Pair<ByteComparable, Long> actual = iterator.next();
-
-                assertEquals(0, compare(expected.next(), actual.left, OSS41));
-                assertEquals(offset++, actual.right.longValue());
-            }
-            assertFalse(expected.hasNext());
+            verifyOrder(iterator, byteComparables, true);
+            Collections.reverse(byteComparables);
+            verifyOrder(reverseIterator, byteComparables, false);
         }
+    }
+
+    private void verifyOrder(Iterator<Pair<ByteComparable, Long>> iterator, List<ByteComparable> byteComparables, boolean ascending)
+    {
+        var expected = byteComparables.iterator();
+        int offset = ascending ? 0 : byteComparables.size() - 1;
+        while (iterator.hasNext())
+        {
+            assertTrue(expected.hasNext()); // verify that hasNext is idempotent
+            final Pair<ByteComparable, Long> actual = iterator.next();
+            assertEquals(0, compare(expected.next(), actual.left, OSS41));
+            assertEquals(offset, actual.right.longValue());
+            offset += ascending ? 1 : -1;
+        }
+        assertFalse(expected.hasNext());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
+++ b/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.utils.PageAware;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
 @RunWith(Parameterized.class)
 abstract public class AbstractTrieTestBase
@@ -124,6 +125,18 @@ abstract public class AbstractTrieTestBase
             buf.put((byte) s.charAt(i));
         buf.rewind();
         return ByteComparable.fixedLength(buf);
+    }
+
+    protected String decodeSource(ByteComparable source)
+    {
+        if (source == null)
+            return null;
+        StringBuilder sb = new StringBuilder();
+        ByteComparable.Version version = ByteComparable.Version.OSS41;
+        ByteSource.Peekable stream = source.asPeekableBytes(version);
+        for (int b = stream.next(); b != ByteSource.END_OF_STREAM; b = stream.next())
+            sb.append((char) b);
+        return sb.toString();
     }
 
     protected String toBase(long v)

--- a/test/unit/org/apache/cassandra/io/tries/WalkerTest.java
+++ b/test/unit/org/apache/cassandra/io/tries/WalkerTest.java
@@ -22,11 +22,15 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.LongSupplier;
 import java.util.function.LongToIntFunction;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.agrona.collections.IntArrayList;
@@ -45,6 +49,26 @@ import static org.junit.Assert.assertNull;
 @SuppressWarnings({"unchecked", "RedundantSuppression"})
 public class WalkerTest extends AbstractTrieTestBase
 {
+    private static final Map<String, Integer> memoryTrieEntryMap = new TreeMap<>();
+
+    @BeforeClass
+    public static void setup()
+    {
+        // Initialize the memory representation of the trie
+        memoryTrieEntryMap.put("115", 1);
+        memoryTrieEntryMap.put("151", 2);
+        memoryTrieEntryMap.put("155", 3);
+        memoryTrieEntryMap.put("511", 4);
+        memoryTrieEntryMap.put("515", 5);
+        memoryTrieEntryMap.put("551", 6);
+        memoryTrieEntryMap.put("555555555555555555555555555555555555555555555555555555555555555555", 7);
+        memoryTrieEntryMap.put("70", 8);
+        memoryTrieEntryMap.put("7051", 9);
+        memoryTrieEntryMap.put("717", 10);
+        memoryTrieEntryMap.put("73", 11);
+        memoryTrieEntryMap.put("737", 12);
+    }
+
     @Test
     public void testWalker() throws IOException
     {
@@ -244,9 +268,9 @@ public class WalkerTest extends AbstractTrieTestBase
 
         if (admitPrefix != ValueIterator.LeftBoundTreatment.ADMIT_EXACT)
         {
-            ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos, source(from), source(to), admitPrefix == ValueIterator.LeftBoundTreatment.ADMIT_PREFIXES);
+            ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos, source(from), source(to), admitPrefix == ValueIterator.LeftBoundTreatment.ADMIT_PREFIXES, true);
             reverse(expected);
-            checkReturns(from + "<--" + to, rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), expected);
+            checkReturns(from + "<--" + to, rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), rit::collectedKey, expected);
             reverse(expected);  // return array in its original form if reused
         }
     }
@@ -256,12 +280,12 @@ public class WalkerTest extends AbstractTrieTestBase
     private void checkIterates(ByteBuffer buffer, long rootPos, int... expected)
     {
         Rebufferer source = new ByteBufRebufferer(buffer);
-        ValueIterator<?> it = new ValueIterator<>(source, rootPos);
-        checkReturns("Forward", it::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), expected);
+        ValueIterator<?> it = new ValueIterator<>(source, rootPos, true);
+        checkReturns("Forward", it::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), it::collectedKey, expected);
 
-        ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos);
+        ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos, true);
         reverse(expected);
-        checkReturns("Reverse", rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), expected);
+        checkReturns("Reverse", rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), rit::collectedKey, expected);
         reverse(expected);  // return array in its original form if reused
     }
 
@@ -281,12 +305,37 @@ public class WalkerTest extends AbstractTrieTestBase
         return TrieNode.at(buffer, pos).payloadFlags(buffer, pos);
     }
 
-    private void checkReturns(String testCase, LongSupplier supplier, LongToIntFunction mapper, int... expected)
+    private void checkReturns(String testCase,
+                              LongSupplier supplier,
+                              LongToIntFunction mapper,
+                              int... expected)
+    {
+        checkReturns(testCase, supplier, mapper, null, expected);
+    }
+
+    private void checkReturns(String testCase,
+                              LongSupplier supplier,
+                              LongToIntFunction mapper,
+                              Supplier<ByteComparable> byteComparableSupplier,
+                              int... expected)
     {
         IntArrayList list = new IntArrayList();
         while (true)
         {
             long pos = supplier.getAsLong();
+
+            if (byteComparableSupplier != null)
+            {
+                if (byteComparableSupplier.get() == null)
+                {
+                    assertEquals(-1, pos);
+                }
+                else
+                {
+                    String value = decodeSource(byteComparableSupplier.get());
+                    assertEquals(memoryTrieEntryMap.get(value), (Integer) mapper.applyAsInt(pos));
+                }
+            }
             if (pos == -1)
                 break;
             list.add(mapper.applyAsInt(pos));
@@ -541,19 +590,12 @@ public class WalkerTest extends AbstractTrieTestBase
     {
         IncrementalTrieWriter<Integer> builder = newTrieWriter(serializer, out);
         dump = true;
-        builder.add(source("115"), 1);
-        builder.add(source("151"), 2);
-        builder.add(source("155"), 3);
-        builder.add(source("511"), 4);
-        builder.add(source("515"), 5);
-        builder.add(source("551"), 6);
-        builder.add(source("555555555555555555555555555555555555555555555555555555555555555555"), 7);
-
-        builder.add(source("70"), 8);
-        builder.add(source("7051"), 9);
-        builder.add(source("717"), 10);
-        builder.add(source("73"), 11);
-        builder.add(source("737"), 12);
+        for (Map.Entry<String, Integer> entry : memoryTrieEntryMap.entrySet())
+        {
+            String key = entry.getKey();
+            Integer value = entry.getValue();
+            builder.add(source(key), value);
+        }
         return builder;
     }
 

--- a/test/unit/org/apache/cassandra/io/tries/WalkerTest.java
+++ b/test/unit/org/apache/cassandra/io/tries/WalkerTest.java
@@ -266,13 +266,10 @@ public class WalkerTest extends AbstractTrieTestBase
             }
         }
 
-        if (admitPrefix != ValueIterator.LeftBoundTreatment.ADMIT_EXACT)
-        {
-            ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos, source(from), source(to), admitPrefix == ValueIterator.LeftBoundTreatment.ADMIT_PREFIXES, true);
-            reverse(expected);
-            checkReturns(from + "<--" + to, rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), rit::collectedKey, expected);
-            reverse(expected);  // return array in its original form if reused
-        }
+        ReverseValueIterator<?> rit = new ReverseValueIterator<>(source, rootPos, source(from), source(to), admitPrefix, true);
+        reverse(expected);
+        checkReturns(from + "<--" + to, rit::nextPayloadedNode, pos -> getPayloadFlags(buffer, (int) pos), rit::collectedKey, expected);
+        reverse(expected);  // return array in its original form if reused
     }
 
 
@@ -323,21 +320,14 @@ public class WalkerTest extends AbstractTrieTestBase
         while (true)
         {
             long pos = supplier.getAsLong();
+            if (pos == -1)
+                break;
 
             if (byteComparableSupplier != null)
             {
-                if (byteComparableSupplier.get() == null)
-                {
-                    assertEquals(-1, pos);
-                }
-                else
-                {
-                    String value = decodeSource(byteComparableSupplier.get());
-                    assertEquals(memoryTrieEntryMap.get(value), (Integer) mapper.applyAsInt(pos));
-                }
+                String value = decodeSource(byteComparableSupplier.get());
+                assertEquals(memoryTrieEntryMap.get(value), (Integer) mapper.applyAsInt(pos));
             }
-            if (pos == -1)
-                break;
             list.add(mapper.applyAsInt(pos));
         }
         assertArrayEquals(testCase + ": " + list + " != " + Arrays.toString(expected), expected, list.toIntArray());


### PR DESCRIPTION
Motivation:

Be able to get the trie keys for SAI based descending ORDER BY queries.

Modifications:

* Lazily initialize `ReverseValueIterator`
* Support accumulating bytes in `ReverseValueIterator`
* Added `ReverseTrieTermsDictionaryReader` class to motivate changes to the `ReverseValueIterator` changes

This work mimics the changes made in https://github.com/datastax/cassandra/pull/876. It seems reasonable that we might want to create an abstraction to simplify the duplicated ideas in both the `ReverseValueIterator` and the `ValueIterator`, but I propose we defer that work for now.