### PR TITLE
DSP-24122 vsearch: Port minor changes in StatementRestrictions

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1476,7 +1476,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         {
             if (restrictions.usesSecondaryIndexing())
                 if (restrictions.needsDisjunctionSupport(table))
-                    restrictions.throwsRequiresIndexSupportingDisjunctionError(table);
+                    restrictions.throwsRequiresIndexSupportingDisjunctionError();
         }
 
         /** If ALLOW FILTERING was not specified, this verifies that it is not needed */


### PR DESCRIPTION
This PR ports back some very minor fixes and improvements that have been done in `StatementRestrictions` while porting OR support to DSE. It's just fixing some typos, alignement issues and code duplication, as requested [during review](https://github.com/riptano/bdp/pull/21037#pullrequestreview-2028306165).