### PR TITLE
Reenable LegacyIndexCqlTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/LegacyIndexCqlTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LegacyIndexCqlTest.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.io.util.File;
 
 import static org.junit.Assert.assertEquals;
 
-@Ignore // FIXME broken due to little-endian upgrade to Lucene 9.5
 public class LegacyIndexCqlTest extends SAITester
 {
     @Test


### PR DESCRIPTION
The condition motivating this `@Ignore` was resolved in #1030, but only one of the two tests was re-enabled.