### PR TITLE
Make SAI sstable components immutable

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -413,6 +413,9 @@ public enum CassandraRelevantProperties
 
     // Allow disabling deletions of corrupt index components for troubleshooting
     DELETE_CORRUPT_SAI_COMPONENTS("cassandra.sai.delete_corrupt_components", "true"),
+    // Allow restoring legacy behavior of deleting sai components before a rebuild (which implies a rebuild cannot be
+    // done without first stopping reads on that index)
+    IMMUTABLE_SAI_COMPONENTS("cassandra.sai.immutable_components", "false"),
 
     // Enables parallel index read.
     USE_PARALLEL_INDEX_READ("cassandra.index_read.parallel", "true"),

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -245,7 +245,7 @@ public interface IndexRegistry
             }
 
             @Override
-            public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
+            public Set<Component> componentsForNewSSTable()
             {
                 return null;
             }

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.TableMetadata;
@@ -244,7 +245,13 @@ public interface IndexRegistry
             }
 
             @Override
-            public Set<Component> getComponents()
+            public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
+            {
+                return null;
+            }
+
+            @Override
+            public Set<Component> activeComponents(SSTableReader sstable)
             {
                 return null;
             }

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1760,7 +1760,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
             if (notice.memtable().isEmpty())
             {
                 IndexBuildDecider.Decision decision = IndexBuildDecider.instance.onSSTableAdded(notice);
-                build(decision, notice.added, false);
+                build(decision, notice.added);
             }
         }
         else if (notification instanceof SSTableListChangedNotification)
@@ -1768,11 +1768,11 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
             SSTableListChangedNotification notice = (SSTableListChangedNotification) notification;
 
             IndexBuildDecider.Decision decision = IndexBuildDecider.instance.onSSTableListChanged(notice);
-            build(decision, notice.added, false);
+            build(decision, notice.added);
         }
     }
 
-    private void build(IndexBuildDecider.Decision decision, Iterable<SSTableReader> sstables, boolean onlyIndexWithComponents)
+    private void build(IndexBuildDecider.Decision decision, Iterable<SSTableReader> sstables)
     {
         if (decision == IndexBuildDecider.Decision.ASYNC)
         {
@@ -1780,7 +1780,6 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
                               indexes.values()
                                      .stream()
                                      .filter(Index::shouldBuildBlocking)
-                                     .filter(i -> !onlyIndexWithComponents || !i.getComponents().isEmpty())
                                      .collect(Collectors.toSet()),
                               false);
         }
@@ -1790,7 +1789,6 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
                                  indexes.values()
                                         .stream()
                                         .filter(Index::shouldBuildBlocking)
-                                        .filter(i -> !onlyIndexWithComponents || !i.getComponents().isEmpty())
                                         .collect(Collectors.toSet()),
                                  false);
         }

--- a/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
@@ -120,16 +120,16 @@ public class SingletonIndexGroup implements Index.Group
     }
 
     @Override
-    public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
+    public Set<Component> componentsForNewSSTable()
     {
         // This class is only used for indexes that don't use per-sstable components, aka not-SAI (note that SASI uses
         // some "file" per sstable, but it is not a `Component` in practice). We could add an equivalent
-        // `componentsForNewBuild` method in `Index`, so that we can call `delegate.componentsForNewBuild` here, but
+        // `componentsForNewSSTable` method in `Index`, so that we can call `delegate.componentsForNewBuild` here, but
         // this would kind of weird for SAI because of the per-sstable components: should they be returned by such
         // method on `Index` or not? Tldr, for SAI, it's cleaner to deal with components created at the group level,
         // which is what `StorageAttachedIndexGroup.componentsForNewBuild` does, and it's simpler to always use
         // `StorageAttachedIndexGroup` for SAI, which is the case. So at that point, adding an
-        // `Index.componentsForNewBuild` method would just be dead code, so let's avoid it.
+        // `Index.componentsForNewSSTable` method would just be dead code, so let's avoid it.
         return Collections.emptySet();
     }
 

--- a/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
@@ -21,6 +21,7 @@
 
 package org.apache.cassandra.index;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -33,10 +34,13 @@ import org.apache.cassandra.db.WriteContext;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
 
 /**
@@ -66,6 +70,10 @@ public class SingletonIndexGroup implements Index.Group
     public void addIndex(Index index)
     {
         Preconditions.checkState(delegate == null);
+        // This class does not work for SAI because the `componentsForNewBuid` method would be incorrect (so more
+        // generally, it does not work for indexes that use dedicated sstable components, which is only SAI). See
+        // comments on `componentsForNewBuid` for more details.
+        Preconditions.checkState(!(index instanceof StorageAttachedIndex), "This shoudl not be used with SAI");
         delegate = index;
         indexes.add(index);
     }
@@ -112,9 +120,23 @@ public class SingletonIndexGroup implements Index.Group
     }
 
     @Override
-    public Set<Component> getComponents()
+    public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
     {
-        Preconditions.checkNotNull(delegate);
-        return delegate.getComponents();
+        // This class is only used for indexes that don't use per-sstable components, aka not-SAI (note that SASI uses
+        // some "file" per sstable, but it is not a `Component` in practice). We could add an equivalent
+        // `componentsForNewBuild` method in `Index`, so that we can call `delegate.componentsForNewBuild` here, but
+        // this would kind of weird for SAI because of the per-sstable components: should they be returned by such
+        // method on `Index` or not? Tldr, for SAI, it's cleaner to deal with components created at the group level,
+        // which is what `StorageAttachedIndexGroup.componentsForNewBuild` does, and it's simpler to always use
+        // `StorageAttachedIndexGroup` for SAI, which is the case. So at that point, adding an
+        // `Index.componentsForNewBuild` method would just be dead code, so let's avoid it.
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Component> activeComponents(SSTableReader sstable)
+    {
+        // Same rermarks as for `componentsForNewBuid`.
+        return Collections.emptySet();
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -37,8 +37,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
-import org.apache.cassandra.index.sai.disk.vector.VectorValidation;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +44,7 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.filter.RowFilter;
@@ -66,6 +65,7 @@ import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
+import org.apache.cassandra.index.sai.disk.vector.VectorValidation;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableRangeIterator;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
@@ -123,7 +123,7 @@ public class IndexContext
     private final ColumnMetadata column;
     private final IndexTarget.Type indexType;
     private final AbstractType<?> validator;
-    private final Memtable.Owner owner;
+    private final ColumnFamilyStore owner;
 
     // Config can be null if the column context is "fake" (i.e. created for a filtering expression).
     private final IndexMetadata config;
@@ -150,7 +150,7 @@ public class IndexContext
                         @Nonnull ColumnMetadata column,
                         @Nonnull IndexTarget.Type indexType,
                         IndexMetadata config,
-                        @Nonnull Memtable.Owner owner)
+                        @Nonnull ColumnFamilyStore owner)
     {
         this.keyspace = keyspace;
         this.table = table;
@@ -566,9 +566,9 @@ public class IndexContext
         return viewManager.getView().size() * Version.latest().onDiskFormat().openFilesPerIndex(this);
     }
 
-    public void drop(Collection<SSTableReader> sstablesToRebuild)
+    public void prepareSSTablesForRebuild(Collection<SSTableReader> sstablesToRebuild)
     {
-        viewManager.drop(sstablesToRebuild);
+        viewManager.prepareSSTablesForRebuild(sstablesToRebuild);
     }
 
     public boolean isIndexed()
@@ -810,9 +810,9 @@ public class IndexContext
             {
                 if (validate)
                 {
-                    if (!context.indexDescriptor.validatePerIndexComponents(this))
+                    if (!context.indexDescriptor.perIndexComponents(this).validateComponents(context.sstable, owner.getTracker(), false))
                     {
-                        logger.warn(logMessage("Invalid per-column component for SSTable {}"), context.descriptor());
+                        // Note that a precise warning is already logged by the validation if there is an issue.
                         invalid.add(context);
                         return;
                     }

--- a/src/java/org/apache/cassandra/index/sai/SSTableContext.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContext.java
@@ -20,7 +20,8 @@ package org.apache.cassandra.index.sai;
 import com.google.common.base.Objects;
 
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Throwables;
@@ -37,17 +38,20 @@ import org.apache.cassandra.utils.concurrent.SharedCloseableImpl;
 public class SSTableContext extends SharedCloseableImpl
 {
     public final SSTableReader sstable;
-    public final IndexDescriptor indexDescriptor;
+    private final IndexComponents.ForRead perSSTableComponents;
+    public final PrimaryKey.Factory primaryKeyFactory;
     public final PrimaryKeyMap.Factory primaryKeyMapFactory;
 
     private SSTableContext(SSTableReader sstable,
-                           IndexDescriptor indexDescriptor,
+                           IndexComponents.ForRead perSSTableComponents,
+                           PrimaryKey.Factory primaryKeyFactory,
                            PrimaryKeyMap.Factory primaryKeyMapFactory,
                            Cleanup cleanup)
     {
         super(cleanup);
         this.sstable = sstable;
-        this.indexDescriptor = indexDescriptor;
+        this.perSSTableComponents = perSSTableComponents;
+        this.primaryKeyFactory = primaryKeyFactory;
         this.primaryKeyMapFactory = primaryKeyMapFactory;
     }
 
@@ -55,13 +59,17 @@ public class SSTableContext extends SharedCloseableImpl
     {
         super(copy);
         this.sstable = copy.sstable;
-        this.indexDescriptor = copy.indexDescriptor;
+        this.perSSTableComponents = copy.perSSTableComponents;
+        this.primaryKeyFactory = copy.primaryKeyFactory;
         this.primaryKeyMapFactory = copy.primaryKeyMapFactory;
     }
 
     @SuppressWarnings("resource")
-    public static SSTableContext create(SSTableReader sstable, IndexDescriptor indexDescriptor)
+    public static SSTableContext create(SSTableReader sstable, IndexComponents.ForRead perSSTableComponents)
     {
+        var onDiskFormat = perSSTableComponents.version().onDiskFormat();
+        PrimaryKey.Factory primaryKeyFactory = onDiskFormat.newPrimaryKeyFactory(sstable.metadata().comparator);
+
         Ref<? extends SSTableReader> sstableRef = null;
         PrimaryKeyMap.Factory primaryKeyMapFactory = null;
 
@@ -74,11 +82,11 @@ public class SSTableContext extends SharedCloseableImpl
                 throw new IllegalStateException("Couldn't acquire reference to the sstable: " + sstable);
             }
 
-            primaryKeyMapFactory = indexDescriptor.newPrimaryKeyMapFactory(sstable);
+            primaryKeyMapFactory = onDiskFormat.newPrimaryKeyMapFactory(perSSTableComponents, primaryKeyFactory, sstable);
 
             Cleanup cleanup = new Cleanup(primaryKeyMapFactory, sstableRef);
 
-            return new SSTableContext(sstable, indexDescriptor, primaryKeyMapFactory, cleanup);
+            return new SSTableContext(sstable, perSSTableComponents, primaryKeyFactory, primaryKeyMapFactory, cleanup);
         }
         catch (Throwable t)
         {
@@ -89,6 +97,14 @@ public class SSTableContext extends SharedCloseableImpl
 
             throw Throwables.unchecked(Throwables.close(t, primaryKeyMapFactory));
         }
+    }
+
+    /**
+     * Returns the concrete on-disk perSStable components used by this context instance.
+     */
+    public IndexComponents.ForRead usedPerSSTableComponents()
+    {
+        return perSSTableComponents;
     }
 
     @Override
@@ -110,9 +126,9 @@ public class SSTableContext extends SharedCloseableImpl
         return sstable;
     }
 
-    public IndexDescriptor indexDescriptor()
+    public PrimaryKey.Factory primaryKeyFactory()
     {
-        return indexDescriptor;
+        return primaryKeyFactory;
     }
 
     public PrimaryKeyMap.Factory primaryKeyMapFactory()
@@ -125,7 +141,7 @@ public class SSTableContext extends SharedCloseableImpl
      */
     public int openFilesPerSSTable()
     {
-        return indexDescriptor.getVersion().onDiskFormat().openFilesPerSSTable();
+        return perSSTableComponents.version().onDiskFormat().openFilesPerSSTable();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/SSTableContext.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContext.java
@@ -60,12 +60,11 @@ public class SSTableContext extends SharedCloseableImpl
     }
 
     @SuppressWarnings("resource")
-    public static SSTableContext create(SSTableReader sstable)
+    public static SSTableContext create(SSTableReader sstable, IndexDescriptor indexDescriptor)
     {
         Ref<? extends SSTableReader> sstableRef = null;
         PrimaryKeyMap.Factory primaryKeyMapFactory = null;
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createFrom(sstable);
         try
         {
             sstableRef = sstable.tryRef();

--- a/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
@@ -131,11 +131,13 @@ public class SSTableContextManager
         // 2. it uses a "complete" set of per-sstable components (not that we always initially create a `SSTableContext`
         //    from a complete set, so if it is not complete, it means the previous components have been corrupted, and
         //    we want to use the new one (a rebuild)).
-        // 2. it uses "up-to-date" per-sstable components.
+        // 3. it uses "up-to-date" per-sstable components.
         if (previousContext != null && previousContext.usedPerSSTableComponents().isComplete() && previousContext.usedPerSSTableComponents().hasSameVersionAndGenerationThan(perSSTableComponents))
             return previousContext;
 
         // Now, if we create a new one, we should close the previous one if it exists.
+        // Note that `SSTableIndex` references `SSTableContext` through a `#sharedCopy() so even if there is still
+        // index referencing this context currently in use, this will not break ongoing queries.
         if (previousContext != null)
             previousContext.close();
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -94,13 +94,10 @@ import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.analyzer.LuceneAnalyzer;
 import org.apache.cassandra.index.sai.analyzer.NonTokenizingOptions;
 import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.index.sai.view.View;
 import org.apache.cassandra.index.transactions.IndexTransaction;
-import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -143,11 +140,11 @@ public class StorageAttachedIndex implements Index
                                 if (!isFullRebuild)
                                 {
                                     ss = sstablesToRebuild.stream()
-                                                          .filter(s -> !IndexDescriptor.createFrom(s).isPerIndexBuildComplete(indexContext))
+                                                          .filter(s -> !group.descriptorFor(s).isPerIndexBuildComplete(indexContext))
                                                           .collect(Collectors.toList());
                                 }
 
-                                group.dropIndexSSTables(ss, sai);
+                                group.prepareIndexSSTablesForRebuild(ss, sai);
 
                                 ss.forEach((sstable) ->
                                            {
@@ -520,9 +517,11 @@ public class StorageAttachedIndex implements Index
             valid = false;
 
             // in case of dropping table, SSTable indexes should already been removed by SSTableListChangedNotification.
-            Set<Component> toRemove = getComponents();
             for (SSTableIndex sstableIndex : indexContext.getView().getIndexes())
-                sstableIndex.getSSTable().unregisterComponents(toRemove, baseCfs.getTracker());
+            {
+                var components = sstableIndex.getSSTableContext().indexDescriptor.perIndexComponents(getIndexContext());
+                sstableIndex.getSSTable().unregisterComponents(components.allAsCustomComponents(), baseCfs.getTracker());
+            }
 
             indexContext.invalidate(true);
             return null;
@@ -740,7 +739,7 @@ public class StorageAttachedIndex implements Index
             //   2. The SSTable is not marked compacted
             //   3. The column index does not have a completion marker
             if (!view.containsSSTable(sstable) && !sstable.isMarkedCompacted() &&
-                !IndexDescriptor.createFrom(sstable).isPerIndexBuildComplete(indexContext))
+                !group.descriptorFor(sstable).isPerIndexBuildComplete(indexContext))
             {
                 nonIndexed.add(sstable);
             }
@@ -810,17 +809,6 @@ public class StorageAttachedIndex implements Index
     public SSTableFlushObserver getFlushObserver(Descriptor descriptor, LifecycleNewTracker tracker)
     {
         throw new UnsupportedOperationException("Storage-attached index flush observers should never be created directly.");
-    }
-
-    @Override
-    public Set<Component> getComponents()
-    {
-        return Version.latest().onDiskFormat()
-                             .perIndexComponents(indexContext)
-                             .stream()
-                             .map(c -> new Component(Component.Type.CUSTOM,
-                                                     Version.latest().fileNameFormatter().format(c, indexContext)))
-                             .collect(Collectors.toSet());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -18,10 +18,12 @@
 package org.apache.cassandra.index.sai;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -36,7 +38,6 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.RegularAndStaticColumns;
@@ -48,8 +49,8 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.metrics.IndexGroupMetrics;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.TableStateMetrics;
@@ -66,7 +67,6 @@ import org.apache.cassandra.notifications.MemtableRenewedNotification;
 import org.apache.cassandra.notifications.SSTableAddedNotification;
 import org.apache.cassandra.notifications.SSTableListChangedNotification;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Throwables;
 
 /**
@@ -94,7 +94,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
         this.queryMetrics = new TableQueryMetrics(baseCfs.metadata());
         this.stateMetrics = new TableStateMetrics(baseCfs.metadata(), this);
         this.groupMetrics = new IndexGroupMetrics(baseCfs.metadata(), this);
-        this.contextManager = new SSTableContextManager();
+        this.contextManager = new SSTableContextManager(baseCfs.getTracker());
 
         Tracker tracker = baseCfs.getTracker();
         tracker.subscribe(this);
@@ -130,9 +130,21 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
          */
         if (indices.isEmpty())
         {
-            for (SSTableReader sstable : contextManager.sstables())
-                sstable.unregisterComponents(IndexDescriptor.createFrom(sstable).getLivePerSSTableComponents(), baseCfs.getTracker());
-            deletePerSSTableFiles(baseCfs.getLiveSSTables());
+            // We unregister the per-sstable components first, then we clear the context, which closes all the contexts
+            // and unsure there is not more reference to it. When that's done, we can safely remove the component files
+            // on disk. Note that we copy the contexts list because we're going to clear the manager, and we need to
+            // make sure this does not clear the `contexts` collection below (since it exists to be used after the clear).
+            Collection<SSTableContext> contexts = new ArrayList<>(contextManager.allContexts());
+            contexts.forEach(context -> {
+                var components = context.indexDescriptor.perSSTableComponents();
+                context.sstable.unregisterComponents(components.allAsCustomComponents(), baseCfs.getTracker());
+            });
+
+            contextManager.clear();
+
+            contexts.forEach(context -> {
+                context.indexDescriptor.perSSTableComponents().forWrite().forceDeleteAllComponents();
+            });
         }
     }
 
@@ -227,7 +239,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     @Override
     public SSTableFlushObserver getFlushObserver(Descriptor descriptor, LifecycleNewTracker tracker, TableMetadata tableMetadata, long keyCount)
     {
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, tableMetadata.partitioner, tableMetadata.comparator);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, tableMetadata);
         try
         {
             return new StorageAttachedIndexWriter(indexDescriptor, indices, tracker, keyCount);
@@ -250,31 +262,66 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     }
 
     @Override
-    public Set<Component> getComponents()
+    public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
     {
-        return getComponents(indices);
+        return componentsForNewBuid(descriptor, metadata, indices);
     }
 
-    static Set<Component> getComponents(Collection<StorageAttachedIndex> indices)
+    static Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata, Collection<StorageAttachedIndex> indices)
     {
-        Set<Component> components = Version.latest().onDiskFormat()
-                                                  .perSSTableComponents()
-                                                  .stream()
-                                                  .map(c -> new Component(Component.Type.CUSTOM,
-                                                                          Version.latest().fileNameFormatter().format(c, null)))
-                                                  .collect(Collectors.toSet());
-        indices.forEach(index -> components.addAll(index.getComponents()));
+        // The components created depends, amongst other things, on the generation that needs to be used for the new
+        // build (which depends on the version, but that's always the latest for new builds). That generation is always
+        // 0 for new sstables, but may not be for rebuilds. To handle that, we rely on the same logic used when we do
+        // write the new components (`IndexDescriptor.newPerSSTableGroupWriter`/`IndexDescriptor.newPerIndexGroupWriter`),
+        // even if we don't write anything at that point.
+        // Do note that we create an `IndexDescriptor` from scratch, rather than getting the one from the context
+        // manager, because in some cases, the underlying sstable will simply not exist yet (and when that's the case,
+        // we don't want to populate the context just yet). It will exist if this is called as part of a rebuild or is
+        // the build of a new index on an existing sstable, but this is also called for sstables that we're about to
+        // flush or about to create as result of compaction. Of course, we could get it from the context in the case of
+        // existing stables, and create it otherwise, but it doesn't feel worth bothering here.
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, metadata);
+        Set<Component> components = indexDescriptor
+                                    .newPerSSTableComponentsForWrite()
+                                    .addAllComponentsForVersion()
+                                    .all()
+                                    .stream()
+                                    .map(IndexComponent::asCustomComponent)
+                                    .collect(Collectors.toSet());
+
+        for (StorageAttachedIndex index : indices)
+        {
+            indexDescriptor.newPerIndexComponentsForWrite(index.getIndexContext())
+                           .addAllComponentsForVersion()
+                           .all()
+                           .stream()
+                           .map(IndexComponent::asCustomComponent)
+                           .forEach(components::add);
+        }
+
         return components;
     }
 
-    // This differs from getComponents in that it only returns index components that exist on disk.
-    // It avoids errors being logged by the SSTable.readTOC method when we have an empty index.
-    @VisibleForTesting
-    public static Set<Component> getLiveComponents(SSTableReader sstable, Collection<StorageAttachedIndex> indices)
+    @Override
+    public Set<Component> activeComponents(SSTableReader sstable)
     {
-        IndexDescriptor indexDescriptor = IndexDescriptor.createFrom(sstable);
-        Set<Component> components = indexDescriptor.getLivePerSSTableComponents();
-        indices.stream().forEach(index -> components.addAll(indexDescriptor.getLivePerIndexComponents(index.getIndexContext())));
+        IndexDescriptor indexDescriptor = contextManager.getOrCreateIndexDescriptor(sstable);
+        Set<Component> components = indexDescriptor
+                                    .perSSTableComponents()
+                                    .all()
+                                    .stream()
+                                    .map(IndexComponent::asCustomComponent)
+                                    .collect(Collectors.toSet());
+
+        for (StorageAttachedIndex index : indices)
+        {
+            indexDescriptor.perIndexComponents(index.getIndexContext())
+                           .all()
+                           .stream()
+                           .map(IndexComponent::asCustomComponent)
+                           .forEach(components::add);
+        }
+
         return components;
     }
 
@@ -308,17 +355,11 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
         }
     }
 
-    void deletePerSSTableFiles(Collection<SSTableReader> sstables)
-    {
-        contextManager.release(sstables);
-        sstables.forEach(sstableReader -> IndexDescriptor.createFrom(sstableReader).deletePerSSTableIndexComponents());
-    }
-
-    void dropIndexSSTables(Collection<SSTableReader> ss, StorageAttachedIndex index)
+    void prepareIndexSSTablesForRebuild(Collection<SSTableReader> ss, StorageAttachedIndex index)
     {
         try
         {
-            index.getIndexContext().drop(ss);
+            index.getIndexContext().prepareSSTablesForRebuild(ss);
         }
         catch (Throwable t)
         {
@@ -338,42 +379,24 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     public synchronized Set<StorageAttachedIndex> onSSTableChanged(Collection<SSTableReader> removed, Iterable<SSTableReader> added,
                                                             Set<StorageAttachedIndex> indexes, boolean validate)
     {
-        Pair<Set<SSTableContext>, Set<SSTableReader>> results = contextManager.update(removed, added, validate);
+        Optional<Set<SSTableContext>> optValid = contextManager.update(removed, added, validate);
 
-        if (!results.right.isEmpty())
+        if (optValid.isEmpty())
         {
-            results.right.forEach(sstable -> {
-                IndexDescriptor indexDescriptor = IndexDescriptor.createFrom(sstable);
-                indexDescriptor.deletePerSSTableIndexComponents();
-                // Column indexes are invalid if their SSTable-level components are corrupted so delete
-                // their associated index files and mark them non-queryable.
-                indices.forEach(index -> {
-                    if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
-                        indexDescriptor.deleteColumnIndex(index.getIndexContext());
-                    index.makeIndexNonQueryable();
-                });
-
-                if (!CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
-                    logger.debug("Leaving believed-corrupt files for SSTable {} in place after failure loading per-sstable components", sstable);
-            });
-            return indices;
+            // This means at least one sstable had invalid per-sstable components, so mark all indexes non-queryable.
+            indices.forEach(StorageAttachedIndex::makeIndexNonQueryable);
+            return indexes;
         }
 
         Set<StorageAttachedIndex> incomplete = new HashSet<>();
 
         for (StorageAttachedIndex index : indexes)
         {
-            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, results.left, validate);
+            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, optValid.get(), validate);
 
             if (!invalid.isEmpty())
             {
-                // Delete the index files and mark the index non-queryable, as its view may be compromised,
-                // and incomplete, for our callers:
-                if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
-                    invalid.forEach(context -> context.indexDescriptor.deleteColumnIndex(index.getIndexContext()));
-                else
-                    logger.debug("Leaving believed-corrupt files for {} in place after failure loading per-column components",
-                                 invalid.stream().map(SSTableContext::toString).collect(Collectors.joining(", ")));
+                // Mark the index non-queryable, as its view may be compromised, and incomplete, for our callers.
                 index.makeIndexNonQueryable();
                 incomplete.add(index);
             }
@@ -429,6 +452,12 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
      */
     public long totalDiskUsage()
     {
+        // Note that this only account the "active" files. That is, if we have old versions/generations or incomplete
+        // build still on disk, those won't be counted. Counting only "live" data here is consistent with the fact
+        // that `TableStateMetrics.diskUsagePercentageOfBaseTable` compare the number obtain from this to the base
+        // table "live" disk space use. But there is certainly a small risk for being misleading, and where base
+        // tables expose both a "liveDiskSpaceUsed" and "totalDiskSpaceUsed", SAI only exposes "diskUsageBytes", which
+        // has we just mentioned is the "live" usage. Might be worth improving at some point.
         return diskUsage() + indices.stream().flatMap(i -> i.getIndexContext().getView().getIndexes().stream())
                                     .mapToLong(SSTableIndex::sizeOfPerColumnComponents).sum();
     }
@@ -447,6 +476,17 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     public SSTableContextManager sstableContextManager()
     {
         return contextManager;
+    }
+
+    /**
+     * Returns the {@link IndexDescriptor} for the given {@link SSTableReader} (which must belong to the base table
+     * of this group).
+     * Note that this always return a non-null value, since all sstables must be indexed, but that descriptor could
+     * be "empty" if the sstable has never had an index built yet.
+     */
+    public IndexDescriptor descriptorFor(SSTableReader sstable)
+    {
+        return contextManager.getOrCreateIndexDescriptor(sstable);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMapIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMapIterator.java
@@ -71,12 +71,13 @@ public final class PrimaryKeyMapIterator extends RangeIterator
         KeyFilter filter;
         TableMetadata metadata = ctx.sstable().metadata();
         // if not row-aware, we don't have clustering
-        if (ctx.indexDescriptor().getVersion().onDiskFormat().indexFeatureSet().isRowAware() && metadata.hasStaticColumns())
+        var perSSTableComponents = ctx.usedPerSSTableComponents();
+        if (perSSTableComponents.version().onDiskFormat().indexFeatureSet().isRowAware() && metadata.hasStaticColumns())
             filter = KeyFilter.KEYS_WITH_CLUSTERING;
         else // the table doesn't consist anything we want to filter out, so let's use the cheap option
             filter = KeyFilter.ALL;
 
-        if (ctx.indexDescriptor().isSSTableEmpty())
+        if (perSSTableComponents.isEmpty())
             return RangeIterator.empty();
 
         PrimaryKeyMap keys = ctx.primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
@@ -87,7 +88,7 @@ public final class PrimaryKeyMapIterator extends RangeIterator
             return RangeIterator.empty();
         }
 
-        PrimaryKey.Factory pkFactory = ctx.indexDescriptor.primaryKeyFactory;
+        PrimaryKey.Factory pkFactory = ctx.primaryKeyFactory();
         Token minToken = keyRange.left.getToken();
         PrimaryKey minKeyBound = pkFactory.createTokenOnly(minToken);
         PrimaryKey sstableMinKey = keys.primaryKeyFromRowId(0);

--- a/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
@@ -36,9 +36,11 @@ import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.tries.MemtableTrie;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
+import org.apache.cassandra.schema.TableMetadata;
 
 /**
  * Writes all on-disk index structures attached to a given SSTable.
@@ -62,33 +64,42 @@ public class StorageAttachedIndexWriter implements SSTableFlushObserver
     private long sstableRowId = 0;
 
     public StorageAttachedIndexWriter(IndexDescriptor indexDescriptor,
+                                      TableMetadata tableMetadata,
                                       Collection<StorageAttachedIndex> indices,
                                       LifecycleNewTracker lifecycleNewTracker,
                                       long keyCount) throws IOException
     {
-        this(indexDescriptor, indices, lifecycleNewTracker, keyCount, false);
+        this(indexDescriptor, tableMetadata, indices, lifecycleNewTracker, keyCount, false);
     }
 
     public StorageAttachedIndexWriter(IndexDescriptor indexDescriptor,
+                                      TableMetadata tableMetadata,
                                       Collection<StorageAttachedIndex> indices,
                                       LifecycleNewTracker lifecycleNewTracker,
                                       long keyCount,
                                       boolean perIndexComponentsOnly) throws IOException
     {
+        // We always write at the latest version (through what that version is can be configured for specific cases)
+        var onDiskFormat = Version.latest().onDiskFormat();
         this.indexDescriptor = indexDescriptor;
-        this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
+        // Note: I think there is a silent assumption here. That is, the PK factory we use here must be for the latest
+        // format version, because that is what `IndexContext.keyFactory` always uses (see ctor)
+        this.primaryKeyFactory = onDiskFormat.newPrimaryKeyFactory(tableMetadata.comparator);
         this.indices = indices;
         this.rowMapping = RowMapping.create(lifecycleNewTracker.opType());
-        this.perIndexWriters = indices.stream().map(i -> indexDescriptor.newPerIndexWriter(i,
-                                                                                           lifecycleNewTracker,
-                                                                                           rowMapping,
-                                                                                           keyCount))
+        this.perIndexWriters = indices.stream().map(i -> onDiskFormat.newPerIndexWriter(i,
+                                                                                        indexDescriptor,
+                                                                                        lifecycleNewTracker,
+                                                                                        rowMapping,
+                                                                                        keyCount))
                                       .filter(Objects::nonNull) // a null here means the column had no data to flush
                                       .collect(Collectors.toList());
 
         // If the SSTable components are already being built by another index build then we don't want
-        // to build them again so use a null writer
-        this.perSSTableWriter = perIndexComponentsOnly ? PerSSTableWriter.NONE : indexDescriptor.newPerSSTableWriter();
+        // to build them again so use a NO-OP writer
+        this.perSSTableWriter = perIndexComponentsOnly
+                                ? PerSSTableWriter.NONE
+                                : onDiskFormat.newPerSSTableWriter(indexDescriptor);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/format/ComponentDiscovery.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/ComponentDiscovery.java
@@ -134,7 +134,7 @@ class ComponentDiscovery
             forGroup.types.add(parsed.component);
         }
 
-        // We then do an additional path to remove any group that is not complete.
+        // We then do an additional pass to remove any group that is not complete.
         invalid.clear();
         for (Map.Entry<String, DiscoveredComponents> entry : discovered.groups.entrySet())
         {
@@ -172,7 +172,7 @@ class ComponentDiscovery
                     continue;
 
                 // And all start with "SAI" (the rest can depend on the version, but that part is common to all version)
-                if (!component.name.startsWith("SAI"))
+                if (!component.name.startsWith(Version.SAI_DESCRIPTOR))
                     continue;
 
                 // Lastly, we check that the component file exists. If it doesn't, then we assume something is wrong

--- a/src/java/org/apache/cassandra/index/sai/disk/format/ComponentDiscovery.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/ComponentDiscovery.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.format;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.util.PathUtils;
+import org.apache.cassandra.utils.NoSpamLogger;
+
+/**
+ * Helper methods/classes used by `IndexDescriptor` to discover, from disk, the index components that a sstable has.
+ * <p>
+ * Not meant to be exposed outside this package; the public facing API for components is {@link IndexDescriptor}.
+ */
+class ComponentDiscovery
+{
+    private static final Logger logger = LoggerFactory.getLogger(ComponentDiscovery.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
+
+    static class DiscoveredGroups
+    {
+        Map<String, DiscoveredComponents> groups = new HashMap<>();
+
+        @Override
+        public String toString()
+        {
+            return groups.entrySet().stream().map(e -> e.getKey() + ": " + e.getValue()).collect(Collectors.joining(", ", "{", "}"));
+        }
+    }
+
+    static class DiscoveredComponents
+    {
+        Version version;
+        int generation;
+        final Set<IndexComponentType> types = EnumSet.noneOf(IndexComponentType.class);
+
+        @Override
+        public String toString()
+        {
+            return String.format("version=%s, generation=%d, types=%s", version, generation, types);
+        }
+    }
+
+    static DiscoveredGroups discoverComponents(Descriptor descriptor)
+    {
+        DiscoveredGroups groups = tryDiscoverComponentsFromTOC(descriptor);
+        return groups == null
+               ? discoverComponentsFromDiskFallback(descriptor)
+               : groups;
+    }
+
+    private static IndexComponentType completionMarker(@Nullable String name)
+    {
+        return name == null ? IndexComponentType.GROUP_COMPLETION_MARKER : IndexComponentType.COLUMN_COMPLETION_MARKER;
+    }
+
+    private static @Nullable DiscoveredGroups tryDiscoverComponentsFromTOC(Descriptor descriptor)
+    {
+        Set<Component> componentsFromToc = readSAIComponentFromSSTableTOC(descriptor);
+        if (componentsFromToc == null)
+            return null;
+
+        // We collect all the version/generation for which we have files on disk for the per-sstable parts and every
+        // per-index found.
+        DiscoveredGroups discovered = new DiscoveredGroups();
+        Set<String> invalid = new HashSet<>();
+        for (Component component : componentsFromToc)
+        {
+            // We try parsing it as an SAI index name, and ignore if it doesn't match.
+            var opt = Version.tryParseFileName(component.name);
+            if (opt.isEmpty())
+                continue;
+
+            var parsed = opt.get();
+            String indexName = parsed.indexName;
+
+            if (invalid.contains(indexName))
+                continue;
+
+            DiscoveredComponents forGroup = discovered.groups.computeIfAbsent(indexName, __ -> new DiscoveredComponents());
+            // Make sure it is the same version and generation that any we've seen so far.
+            if (forGroup.version == null)
+            {
+                forGroup.version = parsed.version;
+                forGroup.generation = parsed.generation;
+            }
+            else if (!forGroup.version.equals(parsed.version) || forGroup.generation != parsed.generation)
+            {
+                logger.error("Found multiple versions/generations of SAI components in TOC for SSTable {}: cannot load {}",
+                             descriptor, indexName == null ? "per-SSTable components" : "per-index components of " + indexName);
+
+                discovered.groups.remove(indexName);
+                invalid.add(indexName);
+                continue;
+            }
+            forGroup.types.add(parsed.component);
+        }
+
+        // We then do an additional path to remove any group that is not complete.
+        invalid.clear();
+        for (Map.Entry<String, DiscoveredComponents> entry : discovered.groups.entrySet())
+        {
+            String name = entry.getKey();
+            DiscoveredComponents components = entry.getValue();
+
+            // If it's in the TOC, it should have a completion marker: if we don't, it's either a bug in the code that
+            // rewrote the TOC incorrectly, or the marker was lost. In any case, worth logging an error.
+            if (!components.types.contains(completionMarker(name)))
+            {
+                logger.error("Found no completion marker for SAI components in TOC for SSTable {}: cannot load {}",
+                             descriptor, name == null ? "per-SSTable components" : "per-index components of " + name);
+                invalid.add(name);
+            }
+        }
+
+        invalid.forEach(discovered.groups::remove);
+        return discovered;
+    }
+
+    // Returns `null` if something fishy happened while reading the components from the TOC and we should fall back
+    // to `discoverComponentsFromDiskFallback` for safety.
+    private static @Nullable Set<Component> readSAIComponentFromSSTableTOC(Descriptor descriptor)
+    {
+        try
+        {
+            // We skip the check for missing components on purpose: we do the existence check here because we want to
+            // know when it fails.
+            Set<Component> components = SSTable.readTOC(descriptor, false);
+            Set<Component> SAIComponents = new HashSet<>();
+            for (Component component : components)
+            {
+                // We only care about SAI components, which are "custom"
+                if (component.type != Component.Type.CUSTOM)
+                    continue;
+
+                // And all start with "SAI" (the rest can depend on the version, but that part is common to all version)
+                if (!component.name.startsWith("SAI"))
+                    continue;
+
+                // Lastly, we check that the component file exists. If it doesn't, then we assume something is wrong
+                // with the TOC and we fall back to scanning the disk. This is admittedly a bit conservative, but
+                // we do have test data in `test/data/legacy-sai/aa` where the TOC is broken: it lists components that
+                // simply do not match the accompanying files (the index name differs), and it is unclear if this is
+                // just a mistake made while gathering the test data or if some old version used to write broken TOC
+                // for some reason (more precisely, it is hard to be entirely sure this isn't the later).
+                // Overall, there is no real reason for the TOC to list non-existing files (typically, when we remove
+                // an index, the TOC is rewritten to omit the removed component _before_ the files are deleted), so
+                // falling back conservatively feels reasonable.
+                if (!descriptor.fileFor(component).exists())
+                {
+                    noSpamLogger.warn("The TOC file for SSTable {} lists SAI component {} but it doesn't exists. Assuming the TOC is corrupted somehow and falling back on disk scanning (which may be slower)", descriptor, component.name);
+                    return null;
+                }
+
+                SAIComponents.add(component);
+            }
+            return SAIComponents;
+        }
+        catch (NoSuchFileException e)
+        {
+            // This is totally fine when we're building an `IndexDescriptor` for a new sstable that does not exist.
+            // But if the sstable exist, then that's less expected as we should have a TOC. But because we want to
+            // be somewhat resilient to losing the TOC and that historically the TOC hadn't been relyed on too strongly,
+            // we return `null` which trigger the fall-back path to scan disk.
+            if (descriptor.fileFor(Component.DATA).exists())
+            {
+                noSpamLogger.warn("SSTable {} exists (its data component exists) but it has no TOC file. Will use disk scanning to discover SAI components as fallback (which may be slower).", descriptor);
+                return null;
+            }
+
+            return Collections.emptySet();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // San disk to find all the SAI components for the provided descriptor that exists on disk. Then pick
+    // the approriate set of those components (the highest version/generation for which there is a completion marker).
+    // This is only use a fallback when there is no TOC file for the sstable because this will scan the whole
+    // table directory every time and this can be a bit inefficient, especially when some tiered storage is used
+    // underneath where scanning a directory may be particularly expensive.
+    private static DiscoveredGroups discoverComponentsFromDiskFallback(Descriptor descriptor)
+    {
+        // We first collect all the version/generation for which we have files on disk.
+        Map<String, Map<Version, IntObjectMap<Set<IndexComponentType>>>> candidates = Maps.newHashMap();
+
+        PathUtils.forEach(descriptor.directory.toPath(), path -> {
+            String filename = path.getFileName().toString();
+            // First, we skip any file that do not belong to the sstable this is a descriptor for.
+            if (!filename.startsWith(descriptor.filenamePart()))
+                return;
+
+            // Then we try parsing it as an SAI index file name, and if it matches and is for the requested context,
+            // add it to the candidates.
+            Version.tryParseFileName(filename)
+                   .ifPresent(parsed -> candidates.computeIfAbsent(parsed.indexName, __ -> new HashMap<>())
+                                                  .computeIfAbsent(parsed.version, __ -> new IntObjectHashMap<>())
+                                                  .computeIfAbsent(parsed.generation, __ -> EnumSet.noneOf(IndexComponentType.class))
+                                                  .add(parsed.component));
+        });
+
+        DiscoveredGroups discovered = new DiscoveredGroups();
+        for (var entry : candidates.entrySet())
+        {
+            String name = entry.getKey();
+            var candidatesForContext = entry.getValue();
+
+            // The "active" components are then the most recent generation of the most recent version for which we have
+            // a completion marker.
+            IndexComponentType completionMarker = completionMarker(name);
+
+            for (Version version : Version.ALL)
+            {
+                IntObjectMap<Set<IndexComponentType>> versionCandidates = candidatesForContext.get(version);
+                if (versionCandidates == null)
+                    continue;
+
+                OptionalInt maxGeneration = versionCandidates.entrySet()
+                                                             .stream()
+                                                             .filter(e -> e.getValue().contains(completionMarker))
+                                                             .mapToInt(Map.Entry::getKey)
+                                                             .max();
+
+                if (maxGeneration.isPresent())
+                {
+                    var components = new DiscoveredComponents();
+                    components.version = version;
+                    components.generation = maxGeneration.getAsInt();
+                    components.types.addAll(versionCandidates.get(maxGeneration.getAsInt()));
+                    discovered.groups.put(name, components);
+                    break;
+                }
+            }
+        }
+        return discovered;
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentType.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentType.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.format;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * This is a definitive list of all the on-disk components for all versions
+ */
+public enum IndexComponentType
+{
+    /**
+     * Stores per-index metadata.
+     *
+     * V1
+     */
+    META("Meta"),
+    /**
+     * KDTree written by {@code BKDWriter} indexes mappings of term to one ore more segment row IDs
+     * (segment row ID = SSTable row ID - segment row ID offset).
+     *
+     * V1
+     */
+    KD_TREE("KDTree"),
+    KD_TREE_POSTING_LISTS("KDTreePostingLists"),
+
+    /**
+     * Vector index components
+     */
+    VECTOR("Vector"),
+    PQ("PQ"),
+
+    /**
+     * Term dictionary written by {@code TrieTermsDictionaryWriter} stores mappings of term and
+     * file pointer to posting block on posting file.
+     *
+     * V1
+     */
+    TERMS_DATA("TermsData"),
+    /**
+     * Stores postings written by {@code PostingsWriter}
+     *
+     * V1
+     */
+    POSTING_LISTS("PostingLists"),
+    /**
+     * If present indicates that the column index build completed successfully
+     *
+     * V1
+     */
+    COLUMN_COMPLETION_MARKER("ColumnComplete"),
+
+    // per-sstable components
+    /**
+     * Partition key token value for rows including row tombstone and static row. (access key is rowId)
+     *
+     * V1 V2
+     */
+    TOKEN_VALUES("TokenValues"),
+    /**
+     * Partition key offset in sstable data file for rows including row tombstone and static row. (access key is
+     * rowId)
+     *
+     * V1
+     */
+    OFFSETS_VALUES("OffsetsValues"),
+    /**
+     * An on-disk trie containing the primary keys used for looking up the rowId from a partition key
+     *
+     * V2
+     */
+    PRIMARY_KEY_TRIE("PrimaryKeyTrie"),
+    /**
+     * Prefix-compressed blocks of primary keys used for rowId to partition key lookups
+     *
+     * V2
+     */
+    PRIMARY_KEY_BLOCKS("PrimaryKeyBlocks"),
+    /**
+     * Encoded sequence of offsets to primary key blocks
+     *
+     * V2
+     */
+    PRIMARY_KEY_BLOCK_OFFSETS("PrimaryKeyBlockOffsets"),
+    /**
+     * Stores per-sstable metadata.
+     *
+     * V1
+     */
+    GROUP_META("GroupMeta"),
+    /**
+     * If present indicates that the per-sstable index build completed successfully
+     *
+     * V1 V2
+     */
+    GROUP_COMPLETION_MARKER("GroupComplete");
+
+    public final String representation;
+
+    IndexComponentType(String representation)
+    {
+        this.representation = representation;
+    }
+
+    static final Map<String, IndexComponentType> byRepresentation = new HashMap<>();
+    static
+    {
+        for (IndexComponentType component : values())
+            byRepresentation.put(component.representation, component);
+    }
+
+    public static @Nullable IndexComponentType fromRepresentation(String representation)
+    {
+        return byRepresentation.get(representation);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.format;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.lifecycle.Tracker;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
+
+/**
+ * Represents a related group of concrete SAI components files which are either all the per-sstable components of a
+ * given sstable, or all the components of a particular column index (for a given sstable).
+ * <p>
+ * The members of a component group correspond to actual SAI component files on disk, and are components that are
+ * written together. A group is identified by:
+ * <ul>
+ *     <li>the sstable it is the components of (identified by the sstable {@link #descriptor()})</li>
+ *     <li>the index ({@link #context()}) for the components, which is {@code null} for the per-sstable components</li>
+ *     <li>the version the components are using. All the components of a group are on the same version</li>
+ *     <li>the generation, within the version, of the group/components. Generations are used when
+ *     {@link CassandraRelevantProperties#IMMUTABLE_SAI_COMPONENTS} is used, to avoid new builds to override (and thus
+ *     mutate) older builds. When the option of immutable components is not used, then the generation is fixed to 0.
+ *     See below for more details.</li>
+ * </ul>
+ * <p>
+ *
+ * <h2>Immutable components</h2>
+ *
+ * As mentioned above, when {@link CassandraRelevantProperties#IMMUTABLE_SAI_COMPONENTS} is enabled, existing components
+ * are not overwritten by new builds (the underlying intent is to allow rebuilding without stopping reads (to the
+ * rebuilt indexes). But unless a rebuild uses a different version than the existing components, the new components
+ * need "something" to distinguish them from the old ones, and it is what the generation provides.
+ * <p>
+ * The generation is specific to a component group, meaning that all the components of a group share the same
+ * generation (or to put it another way, if 2 components only differ by their generation, then they belong to different
+ * build and thus different groups), but that different groups can have different generations. For instance, if a
+ * specific index is rebuilt but without rebuilding the per-sstable components of each sstable, then after that rebuild
+ * the per-sstable groups will have generation 0, but the index groups will have generation 1.
+ * <p>
+ * When a sstable is "loaded", the "active" set of components to use is based on finding, for each kind of groups
+ * (per-sstable and per-index), the "complete" (see next paragraph) set of components with the highest version, and
+ * highest generation within that version.
+ * <p>
+ * A group of components may or may not be "complete" ({@link #isComplete()}): it is complete if the completion marker
+ * component for that group is present. Groups are temporarily incomplete during writing, but can also be more
+ * permanently incomplete for 2 main reasons: a build may fail mid-way, leaving one or more group incomplete, or we can
+ * have some corruption of the component files of some sort (corruption could here mean that a file is mistakenly
+ * deleted, or that the content of the file is corrupted somehow; the later triggers a removal of the corrupted file and
+ * of the completion marker, but not of the other component of the group). The bumping of generations takes incomplete
+ * groups into account, and so incomplete groups are not overridden either. Essentially, the generation used by a new
+ * build is always one more than the highest generation of any component found on disk (for the group in question, and
+ * the version we writting, usually {@link Version#latest()}).
+ */
+public interface IndexComponents
+{
+    /**
+     * SSTable this is the group of.
+     */
+    Descriptor descriptor();
+
+    /**
+     * The {@link IndexDescriptor} that created this group.
+     * <p>
+     * Note that {@link IndexDescriptor} essentially tracks the active and created groups for a sstable, and so a group
+     * always comes from a particular {@link IndexDescriptor} instance.
+     */
+    IndexDescriptor indexDescriptor();
+
+    /**
+     * Context of the group.
+     *
+     * @return the context of the index this is a group of, or {@code null} if the group is a per-sstable group.
+     */
+    @Nullable IndexContext context();
+
+    /**
+     * Version used by the components of the groups.
+     */
+    Version version();
+
+    /**
+     * Generation used by the components of the groups.
+     * <p>
+     * The result of flush or compaction is always at generation 0; only rebuilding can generate higher generations.
+     */
+    int generation();
+
+    /**
+     * Whether that's a per-index group, that is one with components specific to a given index. Otherwise, it is a
+     * per-sstable group, that is one with components shared by all the SAI indexes (on that sstable).
+     */
+    default boolean isPerIndexGroup()
+    {
+        return context() != null;
+    }
+
+    /**
+     * The specific component "kind" used for storing the metadata of this group.
+     */
+    default IndexComponentType metadataComponent()
+    {
+        return isPerIndexGroup() ? IndexComponentType.META : IndexComponentType.GROUP_META;
+    }
+
+    /**
+     * The specific component "kind" used as a completion marker for this group.
+     */
+    default IndexComponentType completionMarkerComponent()
+    {
+        return isPerIndexGroup() ? IndexComponentType.COLUMN_COMPLETION_MARKER : IndexComponentType.GROUP_COMPLETION_MARKER;
+    }
+
+    default String logMessage(String message)
+    {
+        return indexDescriptor().logMessage(message);
+    }
+
+    /**
+     * Whether the provided component "kind" exists in this group.
+     */
+    boolean has(IndexComponentType component);
+
+    /**
+     * Whether this group is complete, meaning that is has a completion marker.
+     */
+    default boolean isComplete()
+    {
+        return has(completionMarkerComponent());
+    }
+
+    /**
+     * An empty group is one that is complete, but has only a completion marker and no other components.
+     */
+    boolean isEmpty();
+
+    /**
+     * The complete set of component types that are expected for this group version.
+     */
+    default Set<IndexComponentType> expectedComponentsForVersion()
+    {
+        return isPerIndexGroup()
+               ? version().onDiskFormat().perIndexComponents(context())
+               : version().onDiskFormat().perSSTableComponents();
+    }
+
+    /**
+     * Specialisation of {@link IndexComponents} used when working with complete and active groups, and so mostly used
+     * for reading components.
+     */
+    interface ForRead extends IndexComponents
+    {
+        IndexComponent.ForRead get(IndexComponentType component);
+
+        /**
+         * The total size on disk used by the components of this group.
+         */
+        long liveSizeOnDiskInBytes();
+
+        Collection<IndexComponent.ForRead> all();
+
+        default Set<Component> allAsCustomComponents()
+        {
+            return all()
+                   .stream()
+                   .map(IndexComponent::asCustomComponent)
+                   .collect(Collectors.toSet());
+        }
+
+        /**
+         * Validates this group and its components.
+         * <p>
+         * This method both check that the group has all the components that it should have, and that the content of
+         * those components are, as far as this method can determine, valid.
+         * <p>
+         * If the group is invalid, then it will be invalidated by calling {@link #invalidate}. Specifics about what
+         * failed validation is also be logged.
+         *
+         * @param sstable the sstable object for which the component are validated (which should correspond to
+         *               {@code this.descriptor()}). This must be provided so if some components are invalid, they
+         *               can be unregistered.
+         * @param tracker the {@link Tracker} of the table (of the sstable/components). Like the sstable, this is used
+         *                as part of unregistering the components when they are invalid.
+         * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
+         *                         basic checks on the header and footers will be performed.
+         * @return whether the group is valid.
+         */
+        boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum);
+
+        /**
+         * Marks the group as invalid/broken.
+         * <p>
+         * If it is an active group, it will remove it as active in the underlying {@link IndexDescriptor}. It will also
+         * at least delete the completion marker to ensure the group does not get used on any reload/restart.
+         * <p>
+         * Please note that this method is <b>already</b> called by {@link #validateComponents} if the group
+         * is found invalid: it is exposed here for case where we have reason to think the group is invalid but
+         * validation hasn't detected it for some reason.
+         *
+         * @param sstable the sstable object for which the component are invalidated (which should correspond to
+         *               {@code this.descriptor()}). This must be provided so the invalidated components are
+         *               unregistered.
+         * @param tracker the {@link Tracker} of the table (of the sstable/components). Like the sstable, this is used
+         *                as part of unregistering the components.
+         */
+        void invalidate(SSTable sstable, Tracker tracker);
+
+        /**
+         * Returns a {@link ForWrite} view of this group, mostly for calling {@link ForWrite#forceDeleteAllComponents()} at
+         * appropriate times.
+         */
+        ForWrite forWrite();
+    }
+
+    /**
+     * Specialisation of {@link IndexComponents} used when doing a new index build and thus writting a new group of
+     * components.
+     * <p>
+     * This extends {@link ForRead} because we sometimes read previously written components to write other ones in the group
+     */
+    interface ForWrite extends ForRead
+    {
+        /**
+         * Adds the provided component "kind" to this writer, or return the previously added one if it had already
+         * been added.
+         */
+        IndexComponent.ForWrite addOrGet(IndexComponentType component);
+
+        /**
+         * Adds to this writer all the components that the version of this writer defines.
+         *
+         * @return this writer (for chaining purposes).
+         */
+        default ForWrite addAllComponentsForVersion()
+        {
+            expectedComponentsForVersion().forEach(this::addOrGet);
+            return this;
+        }
+
+        /**
+         * Delete the files of all the components in this writer (and remove them so that the group will be empty
+         * afterward).
+         */
+        void forceDeleteAllComponents();
+
+        /**
+         * Writes the completion marker file for the group on disk and, if said write succeeds, adds the components
+         * of this writer to the {@link IndexDescriptor} that created this writer (and so no additional components
+         * should be added to this writer after this call).
+         */
+        void markComplete() throws IOException;
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 /**
  * Represents a related group of concrete SAI components files which are either all the per-sstable components of a
@@ -164,8 +165,18 @@ public interface IndexComponents
     default Set<IndexComponentType> expectedComponentsForVersion()
     {
         return isPerIndexGroup()
-               ? version().onDiskFormat().perIndexComponents(context())
-               : version().onDiskFormat().perSSTableComponents();
+               ? version().onDiskFormat().perIndexComponentTypes(context())
+               : version().onDiskFormat().perSSTableComponentTypes();
+    }
+
+    default boolean hasSameVersionAndGenerationThan(IndexComponents other)
+    {
+        return version().equals(other.version()) && generation() == other.generation();
+    }
+
+    default ByteComparable.Version byteComparableVersionFor(IndexComponentType component)
+    {
+        return version().byteComparableVersionFor(component, descriptor().version);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -19,21 +19,35 @@
 package org.apache.cassandra.index.sai.disk.format;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.ByteOrder;
+import java.nio.file.NoSuchFileException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
+import org.apache.cassandra.db.lifecycle.Tracker;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
@@ -51,11 +65,15 @@ import org.apache.cassandra.index.sai.utils.IndexFileUtils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.io.util.PathUtils;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.util.IOUtils;
@@ -69,7 +87,7 @@ import org.apache.lucene.util.IOUtils;
  * of the current on-disk components and files. It is responsible for opening files for use by
  * writers and readers.
  * <p>
- * Each sstable has per-index components ({@link IndexComponent}) associated with it, and also components
+ * Each sstable has per-index components ({@link IndexComponentType}) associated with it, and also components
  * that are shared by all indexes (notably, the components that make up the PrimaryKeyMap).
  * <p>
  * IndexDescriptor's remaining responsibility is to act as a proxy to the {@link OnDiskFormat}
@@ -78,6 +96,7 @@ import org.apache.lucene.util.IOUtils;
 public class IndexDescriptor
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
     // TODO Because indexes can be added at any time to existing data, the Version of a column index
     // may not match the Version of the base sstable.  OnDiskFormat + IndexFeatureSet + IndexDescriptor
@@ -90,162 +109,330 @@ public class IndexDescriptor
     public final ClusteringComparator clusteringComparator;
     public final PrimaryKey.Factory primaryKeyFactory;
 
-    // versions and components.  null context = per-sstable entry
-    private final Map<IndexContext, Version> versions = Maps.newHashMap();
-    private final Map<IndexContext, Set<IndexComponent>> components = Maps.newHashMap();
-    private final Map<AttachedIndexComponent, File> fileMap = Maps.newHashMap();
+    // For each context (null is used for per-sstable ones), the concrete set of existing and "active" components (it is
+    // possible for multiple version and/or generation of a component to exists "on disk"; the "active" one is the most
+    // recent version and generation that is fully built (has a completion marker)).
+    private final Map<IndexContext, IndexComponentsImpl> groups = Maps.newHashMap();
 
-    /**
-     * A component together with the group it belongs to.
-     */
-    private static class AttachedIndexComponent
-    {
-        public final IndexContext context; // may be null
-        public final IndexComponent component;
-
-        public AttachedIndexComponent(IndexComponent component, IndexContext context)
-        {
-            this.component = component;
-            this.context = context;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(context, component);
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            AttachedIndexComponent that = (AttachedIndexComponent) o;
-            return Objects.equals(context, that.context) && component == that.component;
-        }
-    }
-
-    private IndexDescriptor(Version version, Descriptor descriptor, IPartitioner partitioner, ClusteringComparator clusteringComparator)
+    private IndexDescriptor(Descriptor descriptor, IPartitioner partitioner, ClusteringComparator clusteringComparator)
     {
         this.descriptor = descriptor;
         this.partitioner = partitioner;
         this.clusteringComparator = clusteringComparator;
-        this.primaryKeyFactory = PrimaryKey.factory(clusteringComparator, version.onDiskFormat().indexFeatureSet());
 
-        versions.put(null, version);
-        components.put(null, Sets.newHashSet());
+        // Populating the per-sstable components. Not that this needs to happen first to have the proper version below.
+        populatePerSSTableComponents();
+        assert groups.containsKey(null);
+
+        this.primaryKeyFactory = PrimaryKey.factory(clusteringComparator, getVersion().onDiskFormat().indexFeatureSet());
     }
 
-    public static IndexDescriptor createNew(Descriptor descriptor, IPartitioner partitioner, ClusteringComparator clusteringComparator)
+    private void populatePerSSTableComponents()
     {
-        return new IndexDescriptor(Version.latest(), descriptor, partitioner, clusteringComparator);
+        populateComponents( null);
     }
 
-    public static IndexDescriptor createFrom(SSTableReader sstable)
+    private void maybePopulateComponents(IndexContext context)
     {
-        // see if we have a completion component on disk, and if so use that version
+        if (!groups.containsKey(context))
+            populateComponents(context);
+
+        assert groups.containsKey(context);
+    }
+
+    private void populateComponents(@Nullable IndexContext context)
+    {
+        if (tryPopulateComponentsFromTOC(context))
+            return;
+
+        discoverComponentsFromDiskFallback(context);
+    }
+
+    private boolean tryPopulateComponentsFromTOC(@Nullable IndexContext context)
+    {
+        Set<Component> componentsFromToc = readSAIComponentFromSSTableTOC(descriptor);
+        if (componentsFromToc == null)
+            return false;
+
+        // We first collect all the version/generation for which we have files on disk.
+        String indexName = context == null ? null : context.getIndexName();
+        Version version = null;
+        int generation = -1;
+        Set<IndexComponentType> foundTypes = EnumSet.noneOf(IndexComponentType.class);
+        for (Component component : componentsFromToc)
+        {
+            // We try parsing it as an SAI index name, and ignore if it doesn't match
+            // candidates.
+            var opt = Version.tryParseFileName(component.name);
+            if (opt.isEmpty())
+                continue;
+
+            var parsed = opt.get();
+            if (!Objects.equals(parsed.indexName, indexName))
+                continue;
+
+            // It is a component we're looking for. Make sure it is the same version and generation that any we've
+            // seen so far.
+            if (version == null)
+            {
+                version = parsed.version;
+                generation = parsed.generation;
+            }
+            else if (!version.equals(parsed.version) || generation != parsed.generation)
+            {
+                logger.error("Found multiple versions/generations of SAI components in TOC for SSTable {}: cannot load {}",
+                            descriptor, context == null ? "per-SSTable components" : "per-index components of " + indexName);
+                // Reset to null so the "default" empty group is used as we exit the loop
+                version = null;
+                break;
+            }
+
+            foundTypes.add(parsed.component);
+        }
+
+        IndexComponentType completionMarkerType = context == null
+                                                  ? IndexComponentType.GROUP_COMPLETION_MARKER
+                                                  : IndexComponentType.COLUMN_COMPLETION_MARKER;
+        if (version != null)
+        {
+            // If it's in the TOC, it should have a completion marker: if we don't, it's either a bug in the code that
+            // rewrote the TOC incorrectly, or the marker was lost. In any case, worth logging an error.
+            if (!foundTypes.contains(completionMarkerType))
+            {
+                logger.error("Found no completion marker for SAI components in TOC for SSTable {}: cannot load {}",
+                             descriptor, context == null ? "per-SSTable components" : "per-index components of " + indexName);
+            }
+            else
+            {
+                IndexComponentsImpl components = new IndexComponentsImpl(context, version, generation);
+                foundTypes.forEach(components::addOrGet);
+                components.isComplete = true;
+                groups.put(context, components);
+                return true;
+            }
+        }
+
+        // If we get here, we haven't found any set of valid components. We register an empty group "marker" for the current
+        // version (but invalid generation -1) to avoid re-reading the TOC for the same result and indicate we now know
+        // what version we should use for a new build.
+        groups.put(context, new IndexComponentsImpl(context, Version.latest(), -1));
+        return true;
+    }
+
+    // Returns `null` if something fishy happened while reading the components from the TOC and we should fall back
+    // to `discoverComponentsFromDiskFallback` for safety.
+    private static @Nullable Set<Component> readSAIComponentFromSSTableTOC(Descriptor descriptor)
+    {
+        try
+        {
+            // We skip the check for missing components on purpose: we do the existence check here because we want to
+            // know when it fails.
+            Set<Component> components = SSTable.readTOC(descriptor, false);
+            Set<Component> SAIComponents = new HashSet<>();
+            for (Component component : components)
+            {
+                // We only care about SAI components, which are "custom"
+                if (component.type != Component.Type.CUSTOM)
+                    continue;
+
+                // And all start with "SAI" (the rest can depend on the version, but that part is common to all version)
+                if (!component.name.startsWith("SAI"))
+                    continue;
+
+                // Lastly, we check that the component file exists. If it doesn't, then we assume something is wrong
+                // with the TOC and we fall back to scanning the disk. This is admittedly a bit conservative, but
+                // we do have test data in `test/data/legacy-sai/aa` where the TOC is broken: it lists components that
+                // simply do not match the accompanying files (the index name differs), and it is unclear if this is
+                // just a mistake made while gathering the test data or if some old version used to write broken TOC
+                // for some reason (more precisely, it is hard to be entirely sure this isn't the later).
+                // Overall, there is no real reason for the TOC to list non-existing files (typically, when we remove
+                // an index, the TOC is rewritten to omit the removed component _before_ the files are deleted), so
+                // falling back conservatively feels reasonable.
+                if (!descriptor.fileFor(component).exists())
+                {
+                    noSpamLogger.warn("The TOC file for SSTable {} lists SAI component {} but it doesn't exists. Assuming the TOC is corrupted somehow and falling back on disk scanning (which may be slower)");
+                    return null;
+                }
+
+                SAIComponents.add(component);
+            }
+            return SAIComponents;
+        }
+        catch (NoSuchFileException e)
+        {
+            // This is totally fine when we're building an `IndexDescriptor` for a new sstable that does not exist.
+            // But if the sstable exist, then that's less expected as we should have a TOC. But because we want to
+            // be somewhat resilient to losing the TOC and that historically the TOC hadn't been relyed on too strongly,
+            // we return `null` which trigger the fall-back path to scan disk.
+            if (descriptor.fileFor(Component.DATA).exists())
+            {
+                noSpamLogger.warn("SSTable {} exists (its data component exists) but it has no TOC file. Will use disk scanning to discover SAI components as fallback (which may be slower).", descriptor);
+                return null;
+            }
+
+            return Collections.emptySet();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    // San disk to find all the SAI components that belong to the provided context and exists on disk. Then pick
+    // the approriate set of those components (the highest version/generation for which there is a completion marker).
+    // This is only use a fallback when there is no TOC file for the sstable because this will scan the whole
+    // table directory every time and this can be a bit inefficient, especially when some tiered storage is used
+    // underneath where scanning a directory may be particularly expensive.
+    private void discoverComponentsFromDiskFallback(@Nullable IndexContext context)
+    {
+        // We first collect all the version/generation for which we have files on disk.
+        String indexName = context == null ? null : context.getIndexName();
+        Map<Version, IntObjectMap<Set<IndexComponentType>>> candidates = Maps.newHashMap();
+
+        PathUtils.forEach(descriptor.directory.toPath(), path -> {
+            String filename = path.getFileName().toString();
+            // First, we skip any file that do not belong to the sstable this is a descriptor for.
+            if (!filename.startsWith(descriptor.filenamePart()))
+                return;
+
+            // Then we try parsing it as an SAI index file name, and if it matches and is for the requested context,
+            // add it to the candidates.
+            Version.tryParseFileName(filename)
+                   .ifPresent(parsed -> {
+                       if (Objects.equals(parsed.indexName, indexName))
+                       {
+                           candidates.computeIfAbsent(parsed.version, __ -> new IntObjectHashMap<>())
+                                     .computeIfAbsent(parsed.generation, __ -> EnumSet.noneOf(IndexComponentType.class))
+                                     .add(parsed.component);
+                       }
+                   });
+        });
+
+        // The "active" components are then the most recent generation of the most recent version for which we have
+        // a completion marker.
+        IndexComponentType completionMarker = context == null
+                                          ? IndexComponentType.GROUP_COMPLETION_MARKER
+                                          : IndexComponentType.COLUMN_COMPLETION_MARKER;
+
         for (Version version : Version.ALL)
         {
-            if (componentExistsOnDisk(version, sstable.descriptor, IndexComponent.GROUP_COMPLETION_MARKER, null))
-                return new IndexDescriptor(version,
-                                           sstable.descriptor,
-                                           sstable.metadata().partitioner,
-                                           sstable.metadata().comparator);
+            IntObjectMap<Set<IndexComponentType>> versionCandidates = candidates.get(version);
+            if (versionCandidates == null)
+                continue;
+
+            OptionalInt maxGeneration = versionCandidates.entrySet()
+                                                         .stream()
+                                                         .filter(entry -> entry.getValue().contains(completionMarker))
+                                                         .mapToInt(Map.Entry::getKey)
+                                                         .max();
+
+            if (maxGeneration.isPresent())
+            {
+                IndexComponentsImpl components = new IndexComponentsImpl(context, version, maxGeneration.getAsInt());
+                versionCandidates.get(maxGeneration.getAsInt()).forEach(components::addOrGet);
+                components.isComplete = true;
+                groups.put(context, components);
+                return;
+            }
         }
-        // we always want a non-null IndexDescriptor, even if it's empty
-        return new IndexDescriptor(Version.latest(),
-                                   sstable.descriptor,
-                                   sstable.metadata().partitioner,
-                                   sstable.metadata().comparator);
+        // If we get here, we haven't found any set of valid components. We register an empty group "marker" for the
+        // current version (but invalid generation -1) to avoid re-scanning the disk for the same result.
+        groups.put(context, new IndexComponentsImpl(context, Version.latest(), -1));
     }
 
-    public boolean hasComponent(IndexComponent component)
+    public static IndexDescriptor create(SSTableReader sstable)
     {
-        registerPerSSTableComponents();
-        return components.get(null).contains(component);
+        return create(sstable.descriptor, sstable.metadata());
     }
 
-    public boolean hasComponent(IndexComponent component, IndexContext context)
+    public static IndexDescriptor create(Descriptor descriptor, TableMetadata metadata)
     {
-        registerPerIndexComponents(context);
-        var components = this.components.get(context);
-        return components != null && components.contains(component);
+        return create(descriptor, metadata.partitioner, metadata.comparator);
     }
 
-    public String componentFileName(IndexComponent component)
+    // Should not be used directly. Only exists for tests.
+    @VisibleForTesting
+    public static IndexDescriptor create(Descriptor descriptor, IPartitioner partitioner, ClusteringComparator clusteringComparator)
     {
-        return versions.get(null).fileNameFormatter().format(component, null);
+        return new IndexDescriptor(descriptor, partitioner, clusteringComparator);
     }
 
-    public String componentFileName(IndexComponent component, IndexContext context)
+    public IndexComponents.ForRead perSSTableComponents()
     {
-        return getVersion(context).fileNameFormatter().format(component, context);
+        return groups.get(null);
+    }
+
+    public IndexComponents.ForRead perIndexComponents(IndexContext context)
+    {
+        maybePopulateComponents(context);
+        return groups.get(context);
+    }
+
+    public IndexComponents.ForWrite newPerSSTableComponentsForWrite()
+    {
+        return newComponentsForWrite(null);
+    }
+
+    public IndexComponents.ForWrite newPerIndexComponentsForWrite(IndexContext context)
+    {
+        maybePopulateComponents(context);
+        return newComponentsForWrite(context);
+    }
+
+    private IndexComponents.ForWrite newComponentsForWrite(@Nullable IndexContext context)
+    {
+        var currentComponents = groups.get(context);
+        // If we're "bumping" the version compared to the existing group, then we can use generation 0. Otherwise, we
+        // have to bump the generation, unless we're using immutable components, in which case we always use generation 0.
+        // Unless we don't use immutable components, in which case we always use generation 0.
+        Version newVersion = Version.latest();
+        if (newVersion.useImmutableComponentFiles())
+        {
+            int candidateGeneration = currentComponents.version().equals(newVersion)
+                                      ? currentComponents.generation() + 1
+                                      : 0;
+            // Usually, we'll just use `candidateGeneration`, but we want to avoid overriding existing file (it's
+            // theoretically possible that the next generation was created at some other point, but then corrupted,
+            // and so we falled back on the previous generation but some of those file for the next generation still
+            // exists). So we check repeatedly increment the generation until we find one for which no files exist.
+            return createFirstGenerationAvailableComponents(context, newVersion, candidateGeneration);
+        }
+        else
+        {
+            return new IndexComponentsImpl(context, newVersion, 0);
+        }
+    }
+
+    private IndexComponentsImpl createFirstGenerationAvailableComponents(@Nullable IndexContext context, Version version, int startGeneration)
+    {
+        int generationToTest = startGeneration;
+        while (true)
+        {
+            IndexComponentsImpl candidate = new IndexComponentsImpl(context, version, generationToTest);
+            if (candidate.expectedComponentsForVersion().stream().noneMatch(candidate::componentExistsOnDisk))
+                return candidate;
+
+            noSpamLogger.warn(logMessage("Wanted to use generation {} for new build of {} SAI components of {}, but found some existing components on disk for that generation (maybe leftover from an incomplete/corrupted build?); trying next generation"),
+                              generationToTest,
+                              context == null ? "per-SSTable" : "per-index",
+                              descriptor);
+            generationToTest++;
+        }
     }
 
     public Version getVersion()
     {
-        return getVersion(null);
+        return perSSTableComponents().version();
     }
 
     public Version getVersion(IndexContext context)
     {
-        return versions.computeIfAbsent(context, __ ->
-        {
-            for (Version version : Version.ALL)
-            {
-                var marker = context == null ? IndexComponent.GROUP_COMPLETION_MARKER : IndexComponent.COLUMN_COMPLETION_MARKER;
-                if (componentExistsOnDisk(version, descriptor, marker, context))
-                    return version;
-            }
-            // this is called by flush while creating new index files, as well as loading files that already exist
-            return Version.latest();
-        });
-    }
-
-    /**
-     * Returns true if the given component exists on disk for the given index.
-     * If context is null, the component is assumed to be a per-sstable component.
-     */
-    private static boolean componentExistsOnDisk(Version version, Descriptor descriptor, IndexComponent component, IndexContext context)
-    {
-        var file = fileFor(descriptor, version, component, context);
-        return file.exists();
-    }
-
-    public File fileFor(IndexComponent component)
-    {
-        var ac = new AttachedIndexComponent(component, null);
-        return fileMap.computeIfAbsent(ac, __ -> createFile(component, null));
-    }
-
-    public File fileFor(IndexComponent component, IndexContext context)
-    {
-        return fileMap.computeIfAbsent(new AttachedIndexComponent(component, context),
-                                                     p -> createFile(component, context));
-    }
-
-    public Set<Component> getLivePerSSTableComponents()
-    {
-        registerPerSSTableComponents();
-        return components.get(null).stream()
-                         .map(c -> new Component(Component.Type.CUSTOM, componentFileName(c)))
-                         .collect(Collectors.toSet());
-    }
-
-    public Set<Component> getLivePerIndexComponents(IndexContext context)
-    {
-        registerPerIndexComponents(context);
-        var components = this.components.get(context);
-        return components == null
-               ? Collections.emptySet()
-               : components.stream()
-                 .map(c -> new Component(Component.Type.CUSTOM, componentFileName(c, context)))
-                 .collect(Collectors.toSet());
+        return perIndexComponents(context).version();
     }
 
     public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(SSTableReader sstable) throws IOException
     {
-        return versions.get(null).onDiskFormat().newPrimaryKeyMapFactory(this, sstable);
+        return getVersion().onDiskFormat().newPrimaryKeyMapFactory(this, sstable);
     }
 
     public SearchableIndex newSearchableIndex(SSTableContext sstableContext, IndexContext context)
@@ -257,7 +444,7 @@ public class IndexDescriptor
 
     public PerSSTableWriter newPerSSTableWriter() throws IOException
     {
-        return versions.get(null).onDiskFormat().newPerSSTableWriter(this);
+        return perSSTableComponents().version().onDiskFormat().newPerSSTableWriter(this);
     }
 
     public PerIndexWriter newPerIndexWriter(StorageAttachedIndex index,
@@ -269,14 +456,6 @@ public class IndexDescriptor
     }
 
     /**
-     * @return true if the per-sstable index components have been built and are complete
-     */
-    public boolean isPerSSTableBuildComplete()
-    {
-        return hasComponent(IndexComponent.GROUP_COMPLETION_MARKER);
-    }
-
-    /**
      * Returns true if the per-column index components have been built and are valid.
      *
      * @param context The {@link IndexContext} for the index
@@ -284,251 +463,23 @@ public class IndexDescriptor
      */
     public boolean isPerIndexBuildComplete(IndexContext context)
     {
-        return hasComponent(IndexComponent.GROUP_COMPLETION_MARKER) &&
-               hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, context);
+        return perSSTableComponents().isComplete() && perIndexComponents(context).isComplete();
     }
 
     public boolean isSSTableEmpty()
     {
-        return isPerSSTableBuildComplete() && numberOfComponents(null) == 1;
+        return perSSTableComponents().isEmpty();
     }
 
     public boolean isIndexEmpty(IndexContext context)
     {
-        return isPerIndexBuildComplete(context) && numberOfComponents(context) == 1;
-    }
-
-    public long sizeOnDiskOfPerSSTableComponents()
-    {
-        return versions.get(null).onDiskFormat()
-                       .perSSTableComponents()
-                       .stream()
-                       .map(this::fileFor)
-                       .filter(File::exists)
-                       .mapToLong(File::length)
-                       .sum();
-    }
-
-    public long sizeOnDiskOfPerIndexComponents(IndexContext context)
-    {
-        registerPerIndexComponents(context);
-        var components = this.components.get(context);
-        if (components == null)
-            return 0;
-
-        return components.stream()
-                         .map(c -> new AttachedIndexComponent(c, context))
-                         .map(fileMap::get)
-                         .filter(java.util.Objects::nonNull)
-                         .filter(File::exists)
-                         .mapToLong(File::length)
-                         .sum();
-    }
-
-    @VisibleForTesting
-    public long sizeOnDiskOfPerIndexComponent(IndexComponent component, IndexContext context)
-    {
-        var components = this.components.get(context);
-        if (components == null)
-            return 0;
-
-        return components.stream()
-                         .filter(c -> c == component)
-                         .map(c -> new AttachedIndexComponent(c, context))
-                         .map(fileMap::get)
-                         .filter(java.util.Objects::nonNull)
-                         .filter(File::exists)
-                         .mapToLong(File::length)
-                         .sum();
-    }
-
-    public boolean validatePerIndexComponents(IndexContext context)
-    {
-        logger.debug("validatePerIndexComponents called for " + context.getIndexName());
-        registerPerIndexComponents(context);
-        return getVersion(context).onDiskFormat().validatePerIndexComponents(this, context, false);
-    }
-
-    public boolean validatePerIndexComponentsChecksum(IndexContext context)
-    {
-        registerPerIndexComponents(context);
-        return getVersion(context).onDiskFormat().validatePerIndexComponents(this, context, true);
-    }
-
-    public boolean validatePerSSTableComponents()
-    {
-        registerPerSSTableComponents();
-        return versions.get(null).onDiskFormat().validatePerSSTableComponents(this, false);
-    }
-
-    public boolean validatePerSSTableComponentsChecksum()
-    {
-        registerPerSSTableComponents();
-        return versions.get(null).onDiskFormat().validatePerSSTableComponents(this, true);
-    }
-
-    public void deletePerSSTableIndexComponents()
-    {
-        registerPerSSTableComponents();
-        var perSSTableComponents = components.get(null);
-        perSSTableComponents.stream()
-                            .map(c -> fileMap.remove(new AttachedIndexComponent(c, null)))
-                            .filter(java.util.Objects::nonNull)
-                            .forEach(this::deleteComponent);
-        perSSTableComponents.clear();
-    }
-
-    public void deleteColumnIndex(IndexContext context)
-    {
-        registerPerIndexComponents(context);
-        var components = this.components.get(context);
-        if (components == null)
-            return;
-
-        components.stream()
-                  .map(c -> new AttachedIndexComponent(c, context))
-                  .map(fileMap::remove)
-                  .filter(java.util.Objects::nonNull)
-                  .forEach(this::deleteComponent);
-        components.clear();
-    }
-
-    public void createComponentOnDisk(IndexComponent component) throws IOException
-    {
-        com.google.common.io.Files.touch(fileFor(component).toJavaIOFile());
-        registerPerSSTableComponent(component);
-    }
-
-    public void createComponentOnDisk(IndexComponent component, IndexContext context) throws IOException
-    {
-        com.google.common.io.Files.touch(fileFor(component, context).toJavaIOFile());
-        components.computeIfAbsent(context, k -> Sets.newHashSet()).add(component);
-    }
-
-    public IndexInput openPerSSTableInput(IndexComponent component)
-    {
-        return IndexFileUtils.instance.openBlockingInput(createPerSSTableFileHandle(component));
-    }
-
-    public ChecksumIndexInput openCheckSummedPerSSTableInput(IndexComponent component)
-    {
-        var indexInput = openPerSSTableInput(component);
-        return checksumIndexInput(null, indexInput);
-    }
-
-    public IndexInput openPerIndexInput(IndexComponent component, IndexContext context)
-    {
-        return IndexFileUtils.instance.openBlockingInput(createPerIndexFileHandle(component, context));
-    }
-
-    public ChecksumIndexInput openCheckSummedPerIndexInput(IndexComponent component, IndexContext context)
-    {
-        var indexInput = openPerIndexInput(component, context);
-        return checksumIndexInput(context, indexInput);
-    }
-
-    /**
-     * Returns a ChecksumIndexInput that reads the indexInput in the correct endianness for the context.
-     * These files were written by the Lucene {@link org.apache.lucene.store.DataOutput}. When written by
-     * Lucene 7.5, {@link org.apache.lucene.store.DataOutput} wrote the file using big endian formatting.
-     * After the upgrade to Lucene 9, the {@link org.apache.lucene.store.DataOutput} writes in little endian
-     * formatting.
-     *
-     * @param context The index context
-     * @param indexInput The index input to read
-     * @return A ChecksumIndexInput that reads the indexInput in the correct endianness for the context
-     */
-    private ChecksumIndexInput checksumIndexInput(IndexContext context, IndexInput indexInput)
-    {
-        return getVersion(context) == Version.AA
-               ? new EndiannessReverserChecksumIndexInput(indexInput)
-               : new BufferedChecksumIndexInput(indexInput);
-    }
-
-    public IndexOutputWriter openPerSSTableOutput(IndexComponent component) throws IOException
-    {
-        return openPerSSTableOutput(component, false);
-    }
-
-    public IndexOutputWriter openPerSSTableOutput(IndexComponent component, boolean append) throws IOException
-    {
-        final File file = fileFor(component);
-
-        if (logger.isTraceEnabled())
-            logger.trace(logMessage("Creating SSTable attached index output for component {} on file {}..."),
-                         component,
-                         file);
-
-        IndexOutputWriter writer = IndexFileUtils.instance.openOutput(file, getVersion().onDiskFormat().byteOrderFor(component, null), append);
-
-        registerPerSSTableComponent(component);
-
-        return writer;
-    }
-
-    public IndexOutputWriter openPerIndexOutput(IndexComponent component, IndexContext context) throws IOException
-    {
-        return openPerIndexOutput(component, context, false);
-    }
-
-    public IndexOutputWriter openPerIndexOutput(IndexComponent component, IndexContext context, boolean append) throws IOException
-    {
-        final File file = fileFor(component, context);
-
-        if (logger.isTraceEnabled())
-            logger.trace(context.logMessage("Creating sstable attached index output for component {} on file {}..."),
-                         component,
-                         file);
-
-        IndexOutputWriter writer = IndexFileUtils.instance.openOutput(file, getVersion().onDiskFormat().byteOrderFor(component, context), append);
-
-        registerPerSSTableComponent(component);
-
-        return writer;
-    }
-
-    public FileHandle createPerSSTableFileHandle(IndexComponent component)
-    {
-        try (final FileHandle.Builder builder = StorageProvider.instance.fileHandleBuilderFor(this, component))
-        {
-            return addByteOrderAndComplete(builder, component, null);
-        }
-    }
-
-    public FileHandle createPerIndexFileHandle(IndexComponent component, IndexContext context)
-    {
-        try (final FileHandle.Builder builder = StorageProvider.instance.fileHandleBuilderFor(this, component, context))
-        {
-            return addByteOrderAndComplete(builder, component, context);
-        }
-    }
-
-    private FileHandle addByteOrderAndComplete(FileHandle.Builder builder, IndexComponent component, IndexContext context)
-    {
-        var order = getVersion(context).onDiskFormat().byteOrderFor(component, context);
-        return builder.order(order).complete();
-    }
-
-    /**
-     * Opens a file handle for the provided index component similarly to {@link #createPerIndexFileHandle(IndexComponent, IndexContext)},
-     * but this method shoud be called instead of the aforemented one if the access is done "as part of flushing", that is
-     * before the full index that this is a part of has been finalized.
-     * <p>
-     * The use of this method can allow specific storage providers, typically tiered storage ones, to distinguish accesses
-     * that happen "at flush time" from other accesses, as the related file may be in different tier of storage.
-     */
-    public FileHandle createFlushTimePerIndexFileHandle(IndexComponent indexComponent, IndexContext indexContext)
-    {
-        try (final FileHandle.Builder builder = StorageProvider.instance.flushTimeFileHandleBuilderFor(this, indexComponent, indexContext))
-        {
-            return builder.complete();
-        }
+        return perSSTableComponents().isComplete() && perIndexComponents(context).isEmpty();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(descriptor, versions.get(null));
+        return Objects.hash(descriptor, getVersion());
     }
 
     @Override
@@ -538,7 +489,7 @@ public class IndexDescriptor
         if (o == null || getClass() != o.getClass()) return false;
         IndexDescriptor other = (IndexDescriptor)o;
         return Objects.equals(descriptor, other.descriptor) &&
-               Objects.equals(versions.get(null), other.versions.get(null));
+               Objects.equals(getVersion(), other.getVersion());
     }
 
     @Override
@@ -556,42 +507,7 @@ public class IndexDescriptor
                              message);
     }
 
-    private void registerPerSSTableComponents()
-    {
-        versions.get(null).onDiskFormat().perSSTableComponents()
-                .stream()
-                .filter(c -> !components.get(null).contains(c) && fileFor(c).exists())
-                .forEach(components.get(null)::add);
-    }
-
-    private void registerPerIndexComponents(IndexContext context)
-    {
-        Set<IndexComponent> components = this.components.computeIfAbsent(context, k -> Sets.newHashSet());
-        getVersion(context).onDiskFormat().perIndexComponents(context)
-                           .stream()
-                           .filter(c -> !components.contains(c) && fileFor(c, context).exists())
-                           .forEach(components::add);
-    }
-
-    private int numberOfComponents(IndexContext context)
-    {
-        return components.containsKey(context) ? components.get(context).size() : 0;
-    }
-
-    private File createFile(IndexComponent component, IndexContext context)
-    {
-        Component customComponent = new Component(Component.Type.CUSTOM, componentFileName(component, context));
-        return descriptor.fileFor(customComponent);
-    }
-
-    public static File fileFor(Descriptor descriptor, Version version, IndexComponent component, IndexContext context)
-    {
-        var componentFileName = version.fileNameFormatter().format(component, context);
-        var customComponent = new Component(Component.Type.CUSTOM, componentFileName);
-        return descriptor.fileFor(customComponent);
-    }
-
-    private void deleteComponent(File file)
+    private static void deleteComponentFile(File file)
     {
         logger.debug("Deleting storage attached index component file {}", file);
         try
@@ -604,13 +520,360 @@ public class IndexDescriptor
         }
     }
 
-    private void registerPerSSTableComponent(IndexComponent component)
+    private class IndexComponentsImpl implements IndexComponents.ForWrite
     {
-        components.get(null).add(component);
-    }
+        private final @Nullable IndexContext context;
+        private final Version version;
+        private final int generation;
 
-    public ByteComparable.Version getEncodingVersion(IndexComponent indexComponent)
-    {
-        return getVersion().byteComparableVersionFor(indexComponent, descriptor.version);
+        private final Map<IndexComponentType, IndexComponentImpl> components = new EnumMap<>(IndexComponentType.class);
+
+        // Mark groups that are complete (and should not have new components added).
+        private volatile boolean isComplete;
+
+        private IndexComponentsImpl(@Nullable IndexContext context, Version version, int generation)
+        {
+            this.context = context;
+            this.version = version;
+            this.generation = generation;
+        }
+
+        private boolean componentExistsOnDisk(IndexComponentType component)
+        {
+            return new IndexComponentImpl(component).file().exists();
+        }
+
+        @Override
+        public Descriptor descriptor()
+        {
+            return descriptor;
+        }
+
+        @Override
+        public IndexDescriptor indexDescriptor()
+        {
+            return IndexDescriptor.this;
+        }
+
+        @Nullable
+        @Override
+        public IndexContext context()
+        {
+            return context;
+        }
+
+        @Override
+        public Version version()
+        {
+            return version;
+        }
+
+        @Override
+        public int generation()
+        {
+            return generation;
+        }
+
+        @Override
+        public boolean has(IndexComponentType component)
+        {
+            return components.containsKey(component);
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return isComplete() && components.size() == 1;
+        }
+
+        @Override
+        public Collection<IndexComponent.ForRead> all()
+        {
+            return Collections.unmodifiableCollection(components.values());
+        }
+
+        @Override
+        public boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum)
+        {
+            if (isEmpty())
+                return true;
+
+            boolean isValid = true;
+            for (IndexComponentType expected : expectedComponentsForVersion())
+            {
+                var component = components.get(expected);
+                if (component == null)
+                {
+                    logger.warn(logMessage("Missing index component {} from SSTable {}"), expected, descriptor);
+                    isValid = false;
+                }
+                else if (!version().onDiskFormat().validateIndexComponent(component, validateChecksum))
+                {
+                    logger.warn(logMessage("Invalid/corrupted component {} for SSTable {}"), expected, descriptor);
+                    if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                    {
+                        // We delete the corrupted file. Yes, this may break ongoing reads to that component, but
+                        // if something is wrong with the file, we're rather fail loudly from that point on than
+                        // risking reading and returning corrupted data.
+                        deleteComponentFile(component.file());
+                        // Note that invalidation will also delete the completion marker
+                    }
+                    else
+                    {
+                        logger.debug("Leaving believed-corrupt component {} of SSTable {} in place because {} is false", expected, descriptor, CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getKey());
+                    }
+
+                    isValid = false;
+                }
+            }
+            if (!isValid)
+                invalidate(sstable, tracker);
+            return isValid;
+        }
+
+        @Override
+        public void invalidate(SSTable sstable, Tracker tracker)
+        {
+            // This rewrite the TOC to stop listing the components, which ensures that the `populateComponents` call
+            // at the end of this method create an "empty" group.
+            sstable.unregisterComponents(allAsCustomComponents(), tracker);
+
+            // We delete the completion marker, to make it clear the group of components shouldn't be used anymore,
+            // in particular for the following "populate" call. Note it's comparatively safe to do so in that the
+            // marker is never accessed during reads, so we cannot break ongoing operations here.
+            var marker = components.remove(completionMarkerComponent());
+            if (marker != null)
+                deleteComponentFile(marker.file());
+
+            // Keeping legacy behavior if immutable components is disabled.
+            if (!version.useImmutableComponentFiles() && CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                forceDeleteAllComponents();
+
+            groups.remove(context);
+            IndexDescriptor.this.populateComponents(context);
+        }
+
+        @Override
+        public ForWrite forWrite()
+        {
+            // The difference between Reader and Writer is just to make code cleaner and make it clear when we read
+            // components from when we write/modify them. But this concrete implementatation is both in practice.
+            return this;
+        }
+
+        @Override
+        public IndexComponent.ForRead get(IndexComponentType component)
+        {
+            IndexComponentImpl info = components.get(component);
+            Preconditions.checkNotNull(info, "SSTable %s has no %s component for version %s and generation %s", descriptor, component, version, generation);
+            return info;
+        }
+
+        @Override
+        public long liveSizeOnDiskInBytes()
+        {
+            return components.values().stream().map(IndexComponentImpl::file).mapToLong(File::length).sum();
+        }
+
+        @Override
+        public IndexComponent.ForWrite addOrGet(IndexComponentType component)
+        {
+            Preconditions.checkArgument(!isComplete, "Should not add components for SSTable %s at this point; the completion marker has already been written", descriptor);
+            // When a sstable doesn't have any complete group, we use a marker empty one with a generation of -1:
+            Preconditions.checkArgument(generation >= 0, "Should not be adding component to empty components");
+            return components.computeIfAbsent(component, IndexComponentImpl::new);
+        }
+
+        @Override
+        public void forceDeleteAllComponents()
+        {
+            components.values()
+                      .stream()
+                      .map(IndexComponentImpl::file)
+                      .forEach(IndexDescriptor::deleteComponentFile);
+            components.clear();
+        }
+
+        @Override
+        public void markComplete() throws IOException
+        {
+            addOrGet(completionMarkerComponent()).createEmpty();
+            isComplete = true;
+            groups.put(context, this);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(descriptor, context, version, generation);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IndexComponentsImpl that = (IndexComponentsImpl) o;
+            return Objects.equals(descriptor, that.descriptor())
+                   && Objects.equals(context, that.context)
+                   && Objects.equals(version, that.version)
+                   && generation == that.generation;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%s components for %s (v: %s, gen: %d): %s",
+                                 context == null ? "Per-SSTable" : "Per-Index",
+                                 descriptor,
+                                 version,
+                                 generation,
+                                 components.values());
+        }
+
+        private class IndexComponentImpl implements IndexComponent.ForRead, IndexComponent.ForWrite
+        {
+            private final IndexComponentType component;
+
+            private volatile String filenamePart;
+            private volatile File file;
+
+            private IndexComponentImpl(IndexComponentType component)
+            {
+                this.component = component;
+            }
+
+            @Override
+            public IndexComponentsImpl parent()
+            {
+                return IndexComponentsImpl.this;
+            }
+
+            @Override
+            public IndexComponentType componentType()
+            {
+                return component;
+            }
+
+            @Override
+            public ByteOrder byteOrder()
+            {
+                return version.onDiskFormat().byteOrderFor(component, context);
+            }
+
+            @Override
+            public String fileNamePart()
+            {
+                // Not thread-safe, but not really the end of the world if called multiple time
+                if (filenamePart == null)
+                    filenamePart = version.fileNameFormatter().format(component, context, generation);
+                return filenamePart;
+            }
+
+            @Override
+            public Component asCustomComponent()
+            {
+                return new Component(Component.Type.CUSTOM, fileNamePart());
+            }
+
+            @Override
+            public File file()
+            {
+                // Not thread-safe, but not really the end of the world if called multiple time
+                if (file == null)
+                    file = descriptor.fileFor(asCustomComponent());
+                return file;
+            }
+
+            @Override
+            public FileHandle createFileHandle()
+            {
+                try (final FileHandle.Builder builder = StorageProvider.instance.fileHandleBuilderFor(this))
+                {
+                    return builder.order(byteOrder()).complete();
+                }
+            }
+
+            @Override
+            public FileHandle createFlushTimeFileHandle()
+            {
+                try (final FileHandle.Builder builder = StorageProvider.instance.flushTimeFileHandleBuilderFor(this))
+                {
+                    return builder.order(byteOrder()).complete();
+                }
+            }
+
+            @Override
+            public IndexInput openInput()
+            {
+                return IndexFileUtils.instance.openBlockingInput(createFileHandle());
+            }
+
+            @Override
+            public ChecksumIndexInput openCheckSummedInput()
+            {
+                var indexInput = openInput();
+                return checksumIndexInput(indexInput);
+            }
+
+            /**
+             * Returns a ChecksumIndexInput that reads the indexInput in the correct endianness for the context.
+             * These files were written by the Lucene {@link org.apache.lucene.store.DataOutput}. When written by
+             * Lucene 7.5, {@link org.apache.lucene.store.DataOutput} wrote the file using big endian formatting.
+             * After the upgrade to Lucene 9, the {@link org.apache.lucene.store.DataOutput} writes in little endian
+             * formatting.
+             *
+             * @param indexInput The index input to read
+             * @return A ChecksumIndexInput that reads the indexInput in the correct endianness for the context
+             */
+            private ChecksumIndexInput checksumIndexInput(IndexInput indexInput)
+            {
+                if (version == Version.AA)
+                    return new EndiannessReverserChecksumIndexInput(indexInput);
+                else
+                    return new BufferedChecksumIndexInput(indexInput);
+            }
+
+            @Override
+            public IndexOutputWriter openOutput(boolean append) throws IOException
+            {
+                File file = file();
+
+                if (logger.isTraceEnabled())
+                    logger.trace(this.parent().logMessage("Creating SSTable attached index output for component {} on file {}..."),
+                                 component,
+                                 file);
+
+                return IndexFileUtils.instance.openOutput(file, byteOrder(), append);
+            }
+
+            @Override
+            public void createEmpty() throws IOException
+            {
+                com.google.common.io.Files.touch(file().toJavaIOFile());
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash(this.parent(), component);
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                IndexComponentImpl that = (IndexComponentImpl) o;
+                return Objects.equals(this.parent(), that.parent())
+                       && component == that.component;
+            }
+
+            @Override
+            public String toString()
+            {
+                return file().toString();
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -54,7 +54,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
  *     return objects that will interact with the on-disk components or return information about the on-disk
  *     components. If they take an {@link IndexContext} as well they will be interacting with per-index files
  *     otherwise they will be interacting with per-sstable files</li>
- *     <li>Methods taking an {@link IndexComponent}. These methods only interact with a single component or
+ *     <li>Methods taking an {@link IndexComponentType}. These methods only interact with a single component or
  *     set of components</li>
  *
  * To add a new version,
@@ -134,56 +134,33 @@ public interface OnDiskFormat
                                             long keyCount);
 
     /**
-     * Validate all the per-SSTable on-disk components and throw if a component is not valid
+     * Validate the provided on-disk components (that must be for this version).
      *
-     * @param indexDescriptor The {@link IndexDescriptor} for the SSTable
+     * @param component The component to validate
      * @param checksum {@code true} if the checksum should be tested as part of the validation
      *
-     * @return true if all the per-SSTable components are valid
+     * @return true if the component is valid
      */
-    public boolean validatePerSSTableComponents(IndexDescriptor indexDescriptor, boolean checksum);
+    boolean validateIndexComponent(IndexComponent.ForRead component, boolean checksum);
 
     /**
-     * Validate all the per-index on-disk components and throw if a component is not valid
-     *
-     * @param descriptor The {@link IndexDescriptor} for the SSTable
-     * @param context The {@link IndexContext} holding the per-index information for the index
-     * @param checksum {@code true} if the checksum should be tested as part of the validation
-     *
-     * @return true if all the per-index components are valid
-     */
-    default boolean validatePerIndexComponents(IndexDescriptor descriptor, IndexContext context, boolean checksum)
-    {
-        for (IndexComponent component : perIndexComponents(context))
-        {
-            if (descriptor.isIndexEmpty(context))
-                continue;
-            if (!validateOneIndexComponent(component, descriptor, context, checksum))
-                return false;
-        }
-        return true;
-    }
-
-    boolean validateOneIndexComponent(IndexComponent component, IndexDescriptor descriptor, IndexContext context, boolean checksum);
-
-    /**
-     * Returns the set of {@link IndexComponent} for the per-SSTable part of an index.
+     * Returns the set of {@link IndexComponentType} for the per-SSTable part of an index.
      * This is a complete set of components that could exist on-disk. It does not imply that the
      * components currently exist on-disk.
      *
-     * @return The set of {@link IndexComponent} for the per-SSTable index
+     * @return The set of {@link IndexComponentType} for the per-SSTable index
      */
-    public Set<IndexComponent> perSSTableComponents();
+    public Set<IndexComponentType> perSSTableComponents();
 
     /**
-     * Returns the set of {@link IndexComponent} for the per-index part of an index.
+     * Returns the set of {@link IndexComponentType} for the per-index part of an index.
      * This is a complete set of components that could exist on-disk. It does not imply that the
      * components currently exist on-disk.
      *
      * @param indexContext The {@link IndexContext} for the index
-     * @return The set of {@link IndexComponent} for the per-index index
+     * @return The set of {@link IndexComponentType} for the per-index index
      */
-    public Set<IndexComponent> perIndexComponents(IndexContext indexContext);
+    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext);
 
     /**
      * Return the number of open per-SSTable files that can be open during a query.
@@ -205,11 +182,11 @@ public interface OnDiskFormat
     public int openFilesPerIndex(IndexContext indexContext);
 
     /**
-     * Return the {@link ByteOrder} for the given {@link IndexComponent} and {@link IndexContext}.
+     * Return the {@link ByteOrder} for the given {@link IndexComponentType} and {@link IndexContext}.
      *
-     * @param component - The {@link IndexComponent} for the index
+     * @param component - The {@link IndexComponentType} for the index
      * @param context - The {@link IndexContext} for the index
-     * @return The {@link ByteOrder} for the file associated with the {@link IndexComponent}
+     * @return The {@link ByteOrder} for the file associated with the {@link IndexComponentType}
      */
-    public ByteOrder byteOrderFor(IndexComponent component, IndexContext context);
+    public ByteOrder byteOrderFor(IndexComponentType component, IndexContext context);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -78,27 +78,29 @@ public interface OnDiskFormat
      * @param comparator
      * @return the primary key factory
      */
-    public PrimaryKey.Factory primaryKeyFactory(ClusteringComparator comparator);
+    public PrimaryKey.Factory newPrimaryKeyFactory(ClusteringComparator comparator);
 
     /**
      * Returns a {@link PrimaryKeyMap.Factory} for the SSTable
      *
-     * @param indexDescriptor The {@link IndexDescriptor} for the SSTable
-     * @param sstable The {@link SSTableReader} associated with the {@link IndexDescriptor}
+     * @param perSSTableComponents The concrete sstable components to use for the factory
+     * @param primaryKeyFactory The {@link PrimaryKey.Factory} corresponding to the provided {@code perSSTableComponents}.
+     * @param sstable The {@link SSTableReader} associated with the per-sstable components
      * @return a {@link PrimaryKeyMap.Factory} for the SSTable
      * @throws IOException
      */
-    public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable) throws IOException;
+    public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable) throws IOException;
 
     /**
      * Create a new {@link SearchableIndex} for an on-disk index. This is held by the {@SSTableIndex}
      * and shared between queries.
      *
      * @param sstableContext The {@link SSTableContext} holding the per-SSTable information for the index
-     * @param indexContext The {@link IndexContext} holding the per-index information for the index
-     * @return
+     * @param perIndexComponents The group of per-index sstable components to use/read for the returned index (which
+     *                           also link to the underlying {@link IndexContext} for the index).
+     * @return the created {@link SearchableIndex}.
      */
-    public SearchableIndex newSearchableIndex(SSTableContext sstableContext, IndexContext indexContext);
+    public SearchableIndex newSearchableIndex(SSTableContext sstableContext, IndexComponents.ForRead perIndexComponents);
 
     IndexSearcher newIndexSearcher(SSTableContext sstableContext,
                                    IndexContext indexContext,
@@ -145,22 +147,22 @@ public interface OnDiskFormat
 
     /**
      * Returns the set of {@link IndexComponentType} for the per-SSTable part of an index.
-     * This is a complete set of components that could exist on-disk. It does not imply that the
+     * This is a complete set of componentstypes that could exist on-disk. It does not imply that the
      * components currently exist on-disk.
      *
      * @return The set of {@link IndexComponentType} for the per-SSTable index
      */
-    public Set<IndexComponentType> perSSTableComponents();
+    public Set<IndexComponentType> perSSTableComponentTypes();
 
     /**
      * Returns the set of {@link IndexComponentType} for the per-index part of an index.
-     * This is a complete set of components that could exist on-disk. It does not imply that the
+     * This is a complete set of component types that could exist on-disk. It does not imply that the
      * components currently exist on-disk.
      *
      * @param indexContext The {@link IndexContext} for the index
      * @return The set of {@link IndexComponentType} for the per-index index
      */
-    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext);
+    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext);
 
     /**
      * Return the number of open per-SSTable files that can be open during a query.

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -229,7 +229,7 @@ public class Version
     //
     // Format: <sstable descriptor>-SAI+<version>(+<generation>)(+<index name>)+<component name>.db
     //
-    private static final String SAI_DESCRIPTOR = "SAI";
+    public static final String SAI_DESCRIPTOR = "SAI";
     private static final String SAI_SEPARATOR = "+";
     private static final String EXTENSION = ".db";
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -18,15 +18,20 @@
 package org.apache.cassandra.index.sai.disk.format;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
-import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -40,9 +45,9 @@ public class Version
     // 6.8 formats
     public static final Version AA = new Version("aa", V1OnDiskFormat.instance, Version::aaFileNameFormat);
     // Stargazer
-    public static final Version BA = new Version("ba", V2OnDiskFormat.instance, (c, i) -> stargazerFileNameFormat(c, i, "ba"));
+    public static final Version BA = new Version("ba", V2OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ba"));
     // Converged Cassandra with JVector
-    public static final Version CA = new Version("ca", V3OnDiskFormat.instance, (c, i) -> stargazerFileNameFormat(c, i, "ca"));
+    public static final Version CA = new Version("ca", V3OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ca"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
     // are more likely to match the latest version so we want to test that one first.
@@ -54,6 +59,8 @@ public class Version
     // write newer versions of the on-disk formats. This is volatile rather than final so that tests may
     // use reflection to change it and safely publish across threads.
     private static volatile Version LATEST = parse(System.getProperty("cassandra.sai.latest.version", "ca"));
+
+    private static final Pattern GENERATION_PATTERN = Pattern.compile("\\d+");
 
     private final String version;
     private final OnDiskFormat onDiskFormat;
@@ -118,13 +125,66 @@ public class Version
         return fileNameFormatter;
     }
 
+    public boolean useImmutableComponentFiles()
+    {
+        // We only enable "immutable" components (meaning that new build don't delete or replace old versions) if the
+        // flag is set and even then, only starting at version CA. There is no reason to need it for older versions,
+        // and if older versions are involved, it means we likely want backward compatible behaviour.
+        return CassandraRelevantProperties.IMMUTABLE_SAI_COMPONENTS.getBoolean() && onOrAfter(Version.CA);
+    }
+
+
     public static interface FileNameFormatter
     {
         /**
-         * Format filename for given index component and index context.  Only the filename is
-         * returned, not a full path.
+         * Format filename for given index component, context and generation.  Only the "component" part of the
+         * filename is returned (so the suffix of the full filename), not a full path.
          */
-        public String format(IndexComponent indexComponent, IndexContext indexContext);
+        public String format(IndexComponentType indexComponentType, IndexContext indexContext, int generation);
+    }
+
+    /**
+     * Try to parse the provided file name as a SAI component file name.
+     *
+     * @param filename the file name to try to parse.
+     * @return the information parsed from the provided file name if it can be sucessfully parsed, or an empty optional
+     * if the file name is not recognized as a SAI component file name for a supported version.
+     */
+    public static Optional<ParsedFileName> tryParseFileName(String filename)
+    {
+        if (!filename.endsWith(".db"))
+            return Optional.empty();
+
+        // For flexibility, we handle both "full" filename, of the form "<descriptor>-SAI+....db", or just the component
+        // part, that is "SAI+....db". In the former, the following `lastIndexOf` will match, and we'll set
+        // `startOfComponent` at the begining of "SAI", and in the later it will not match and return -1, which, with
+        // the +1 will also be set at the begining of "SAI".
+        int startOfComponent = filename.lastIndexOf('-') + 1;
+
+        String componentStr = filename.substring(startOfComponent);
+        if (componentStr.startsWith("SAI_"))
+            return tryParseAAFileName(componentStr);
+        else if (componentStr.startsWith("SAI" + SAI_SEPARATOR))
+            return tryParseStargazerFileName(componentStr);
+        else
+            return Optional.empty();
+
+    }
+
+    public static class ParsedFileName
+    {
+        public final Version version;
+        public final IndexComponentType component;
+        public final @Nullable String indexName;
+        public final int generation;
+
+        private ParsedFileName(Version version, IndexComponentType component, @Nullable String indexName, int generation)
+        {
+            this.version = version;
+            this.component = component;
+            this.indexName = indexName;
+            this.generation = generation;
+        }
     }
 
     //
@@ -135,43 +195,92 @@ public class Version
     private static final String VERSION_AA_PER_SSTABLE_FORMAT = "SAI_%s.db";
     private static final String VERSION_AA_PER_INDEX_FORMAT = "SAI_%s_%s.db";
 
-    private static String aaFileNameFormat(IndexComponent indexComponent, IndexContext indexContext)
+    private static String aaFileNameFormat(IndexComponentType indexComponentType, IndexContext indexContext, int generation)
     {
+        Preconditions.checkArgument(generation == 0, "Generation is not supported for AA version");
         StringBuilder stringBuilder = new StringBuilder();
 
-        stringBuilder.append(indexContext == null ? String.format(VERSION_AA_PER_SSTABLE_FORMAT, indexComponent.representation)
-                                                  : String.format(VERSION_AA_PER_INDEX_FORMAT, indexContext.getIndexName(), indexComponent.representation));
+        stringBuilder.append(indexContext == null ? String.format(VERSION_AA_PER_SSTABLE_FORMAT, indexComponentType.representation)
+                                                  : String.format(VERSION_AA_PER_INDEX_FORMAT, indexContext.getIndexName(), indexComponentType.representation));
 
         return stringBuilder.toString();
+    }
+
+    private static Optional<ParsedFileName> tryParseAAFileName(String componentStr)
+    {
+        int generation = 0;
+        int lastSepIdx = componentStr.lastIndexOf('_');
+        if (lastSepIdx == -1)
+            return Optional.empty();
+
+        String indexComponentStr = componentStr.substring(lastSepIdx + 1, componentStr.length() - 3);
+        IndexComponentType indexComponentType = IndexComponentType.fromRepresentation(indexComponentStr);
+
+        String indexName = null;
+        int firstSepIdx = componentStr.indexOf('_');
+        if (firstSepIdx != -1 && firstSepIdx != lastSepIdx)
+            indexName = componentStr.substring(firstSepIdx + 1, lastSepIdx);
+
+        return Optional.of(new ParsedFileName(AA, indexComponentType, indexName, generation));
     }
 
     //
     // Stargazer filename formatter. This is the current SAI on-disk filename format
     //
-    // Format: <sstable descriptor>-SAI+<version>(+<index name>)+<component name>.db
+    // Format: <sstable descriptor>-SAI+<version>(+<generation>)(+<index name>)+<component name>.db
     //
     private static final String SAI_DESCRIPTOR = "SAI";
     private static final String SAI_SEPARATOR = "+";
     private static final String EXTENSION = ".db";
 
-    private static String stargazerFileNameFormat(IndexComponent indexComponent, IndexContext indexContext, String version)
+    private static String stargazerFileNameFormat(IndexComponentType indexComponentType, IndexContext indexContext, int generation, String version)
     {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(SAI_DESCRIPTOR);
         stringBuilder.append(SAI_SEPARATOR).append(version);
+        if (generation > 0)
+            stringBuilder.append(SAI_SEPARATOR).append(generation);
         if (indexContext != null)
             stringBuilder.append(SAI_SEPARATOR).append(indexContext.getIndexName());
-        stringBuilder.append(SAI_SEPARATOR).append(indexComponent.representation);
+        stringBuilder.append(SAI_SEPARATOR).append(indexComponentType.representation);
         stringBuilder.append(EXTENSION);
 
         return stringBuilder.toString();
     }
 
-    public ByteComparable.Version byteComparableVersionFor(IndexComponent component, org.apache.cassandra.io.sstable.format.Version sstableFormatVersion)
+    public ByteComparable.Version byteComparableVersionFor(IndexComponentType component, org.apache.cassandra.io.sstable.format.Version sstableFormatVersion)
     {
-        return this == AA && component == IndexComponent.TERMS_DATA
+        return this == AA && component == IndexComponentType.TERMS_DATA
                ? sstableFormatVersion.getByteComparableVersion()
                : ByteComparable.Version.OSS41;
+    }
+
+    private static Optional<ParsedFileName> tryParseStargazerFileName(String componentStr)
+    {
+        // We skip the beginning `SAI+` and ending `.db` parts.
+        String[] splits = componentStr.substring(4, componentStr.length() - 3).split("\\+");
+        if (splits.length < 2 || splits.length > 4)
+            return Optional.empty();
+
+        Version version = parse(splits[0]);
+        IndexComponentType indexComponentType = IndexComponentType.fromRepresentation(splits[splits.length - 1]);
+
+        int generation = 0;
+        String indexName = null;
+        if (splits.length > 2)
+        {
+            // If we have 4 parts, then we know we have both the generation and index name. If we have 3
+            // however, it means we have either one, but we don't know which, so we chekc if the additional
+            // part is a number or not to distinguish.
+            boolean hasGeneration = splits.length == 4 || GENERATION_PATTERN.matcher(splits[1]).matches();
+            boolean hasIndexName = splits.length == 4 || !hasGeneration;
+            if (hasGeneration)
+                generation = Integer.parseInt(splits[1]);
+            if (hasIndexName)
+                indexName = splits[splits.length - 2];
+        }
+
+        return Optional.of(new ParsedFileName(version, indexComponentType, indexName, generation));
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PostingListRangeIterator;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.ScoredPrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
@@ -46,19 +46,16 @@ public abstract class IndexSearcher implements Closeable, SegmentOrdering
     protected final PrimaryKeyMap.Factory primaryKeyMapFactory;
     final PerIndexFiles indexFiles;
     protected final SegmentMetadata metadata;
-    final IndexDescriptor indexDescriptor;
     protected final IndexContext indexContext;
 
     protected IndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
                             PerIndexFiles perIndexFiles,
                             SegmentMetadata segmentMetadata,
-                            IndexDescriptor indexDescriptor,
                             IndexContext indexContext)
     {
         this.primaryKeyMapFactory = primaryKeyMapFactory;
         this.indexFiles = perIndexFiles;
         this.metadata = segmentMetadata;
-        this.indexDescriptor = indexDescriptor;
         this.indexContext = indexContext;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -68,10 +68,10 @@ public class InvertedIndexSearcher extends IndexSearcher
         String footerPointerString = map.get(SAICodecUtils.FOOTER_POINTER);
         long footerPointer = footerPointerString == null ? -1 : Long.parseLong(footerPointerString);
 
-        var perIndexComponents = perIndexFiles.perIndexComponents();
+        var perIndexComponents = perIndexFiles.usedPerIndexComponents();
         reader = new TermsReader(indexContext,
                                  indexFiles.termsData(),
-                                 perIndexComponents.version().byteComparableVersionFor(IndexComponentType.TERMS_DATA, perIndexComponents.descriptor().version),
+                                 perIndexComponents.byteComparableVersionFor(IndexComponentType.TERMS_DATA),
                                  indexFiles.postingLists(),
                                  root, footerPointer);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -30,9 +30,10 @@ import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.metrics.MulticastQueryEventListeners;
 import org.apache.cassandra.index.sai.metrics.QueryEventListener;
@@ -51,26 +52,26 @@ public class InvertedIndexSearcher extends IndexSearcher
     private final TermsReader reader;
     private final QueryEventListener.TrieIndexEventListener perColumnEventListener;
 
-    InvertedIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
+    InvertedIndexSearcher(SSTableContext sstableContext,
                           PerIndexFiles perIndexFiles,
                           SegmentMetadata segmentMetadata,
-                          IndexDescriptor indexDescriptor,
                           IndexContext indexContext) throws IOException
     {
-        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexDescriptor, indexContext);
+        super(sstableContext.primaryKeyMapFactory(), perIndexFiles, segmentMetadata, indexContext);
 
-        long root = metadata.getIndexRoot(IndexComponent.TERMS_DATA);
+        long root = metadata.getIndexRoot(IndexComponentType.TERMS_DATA);
         assert root >= 0;
 
         perColumnEventListener = (QueryEventListener.TrieIndexEventListener)indexContext.getColumnQueryMetrics();
 
-        Map<String,String> map = metadata.componentMetadatas.get(IndexComponent.TERMS_DATA).attributes;
+        Map<String,String> map = metadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).attributes;
         String footerPointerString = map.get(SAICodecUtils.FOOTER_POINTER);
         long footerPointer = footerPointerString == null ? -1 : Long.parseLong(footerPointerString);
 
-        reader = new TermsReader(indexDescriptor,
-                                 indexContext,
+        var perIndexComponents = perIndexFiles.perIndexComponents();
+        reader = new TermsReader(indexContext,
                                  indexFiles.termsData(),
+                                 perIndexComponents.version().byteComparableVersionFor(IndexComponentType.TERMS_DATA, perIndexComponents.descriptor().version),
                                  indexFiles.postingLists(),
                                  root, footerPointer);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
@@ -30,8 +30,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.BKDReader;
 import org.apache.cassandra.index.sai.metrics.MulticastQueryEventListeners;
 import org.apache.cassandra.index.sai.metrics.QueryEventListener;
@@ -53,14 +52,13 @@ public class KDTreeIndexSearcher extends IndexSearcher
     KDTreeIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
                         PerIndexFiles perIndexFiles,
                         SegmentMetadata segmentMetadata,
-                        IndexDescriptor indexDescriptor,
                         IndexContext indexContext) throws IOException
     {
-        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexDescriptor, indexContext);
+        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexContext);
 
-        final long bkdPosition = metadata.getIndexRoot(IndexComponent.KD_TREE);
+        final long bkdPosition = metadata.getIndexRoot(IndexComponentType.KD_TREE);
         assert bkdPosition >= 0;
-        final long postingsPosition = metadata.getIndexRoot(IndexComponent.KD_TREE_POSTING_LISTS);
+        final long postingsPosition = metadata.getIndexRoot(IndexComponentType.KD_TREE_POSTING_LISTS);
         assert postingsPosition >= 0;
 
         bkdReader = new BKDReader(indexContext,

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -57,16 +57,19 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private final IndexComponents.ForWrite perIndexComponents;
     private final MemtableIndex memtableIndex;
+    private final PrimaryKey.Factory pkFactory;
     private final RowMapping rowMapping;
 
     public MemtableIndexWriter(MemtableIndex memtableIndex,
                                IndexComponents.ForWrite perIndexComponents,
+                               PrimaryKey.Factory pkFactory,
                                RowMapping rowMapping)
     {
         assert rowMapping != null && rowMapping != RowMapping.DUMMY : "Row mapping must exist during FLUSH.";
 
         this.perIndexComponents = perIndexComponents;
         this.memtableIndex = memtableIndex;
+        this.pkFactory = pkFactory;
         this.rowMapping = rowMapping;
     }
 
@@ -135,11 +138,6 @@ public class MemtableIndexWriter implements PerIndexWriter
         }
     }
 
-    private PrimaryKey.Factory pkFactory()
-    {
-        return perIndexComponents.indexDescriptor().primaryKeyFactory;
-    }
-
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, long maxSegmentRowId) throws IOException
     {
         long numRows;
@@ -180,8 +178,8 @@ public class MemtableIndexWriter implements PerIndexWriter
                                                        numRows,
                                                        terms.getMinSSTableRowId(),
                                                        terms.getMaxSSTableRowId(),
-                                                       pkFactory().createPartitionKeyOnly(minKey),
-                                                       pkFactory().createPartitionKeyOnly(maxKey),
+                                                       pkFactory.createPartitionKeyOnly(minKey),
+                                                       pkFactory.createPartitionKeyOnly(maxKey),
                                                        terms.getMinTerm(),
                                                        terms.getMaxTerm(),
                                                        indexMetas);
@@ -214,8 +212,8 @@ public class MemtableIndexWriter implements PerIndexWriter
                                                        rowMapping.size(),
                                                        0,
                                                        rowMapping.maxSegmentRowId,
-                                                       pkFactory().createPartitionKeyOnly(minKey),
-                                                       pkFactory().createPartitionKeyOnly(maxKey),
+                                                       pkFactory.createPartitionKeyOnly(minKey),
+                                                       pkFactory.createPartitionKeyOnly(maxKey),
                                                        ByteBufferUtil.bytes(0), // VSTODO by pass min max terms for vectors
                                                        ByteBufferUtil.bytes(0), // VSTODO by pass min max terms for vectors
                                                        metadataMap);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -34,8 +34,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
 import org.apache.cassandra.index.sai.disk.PerIndexWriter;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.ImmutableOneDimPointValues;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.NumericIndexWriter;
@@ -56,20 +55,17 @@ public class MemtableIndexWriter implements PerIndexWriter
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private final IndexDescriptor indexDescriptor;
-    private final IndexContext indexContext;
+    private final IndexComponents.ForWrite perIndexComponents;
     private final MemtableIndex memtableIndex;
     private final RowMapping rowMapping;
 
     public MemtableIndexWriter(MemtableIndex memtableIndex,
-                               IndexDescriptor indexDescriptor,
-                               IndexContext indexContext,
+                               IndexComponents.ForWrite perIndexComponents,
                                RowMapping rowMapping)
     {
         assert rowMapping != null && rowMapping != RowMapping.DUMMY : "Row mapping must exist during FLUSH.";
 
-        this.indexDescriptor = indexDescriptor;
-        this.indexContext = indexContext;
+        this.perIndexComponents = perIndexComponents;
         this.memtableIndex = memtableIndex;
         this.rowMapping = rowMapping;
     }
@@ -77,7 +73,7 @@ public class MemtableIndexWriter implements PerIndexWriter
     @Override
     public IndexContext indexContext()
     {
-        return indexContext;
+        return perIndexComponents.context();
     }
 
     @Override
@@ -91,8 +87,8 @@ public class MemtableIndexWriter implements PerIndexWriter
     @Override
     public void abort(Throwable cause)
     {
-        logger.warn(indexContext.logMessage("Aborting index memtable flush for {}..."), indexDescriptor.descriptor, cause);
-        indexDescriptor.deleteColumnIndex(indexContext);
+        logger.warn(perIndexComponents.logMessage("Aborting index memtable flush for {}..."), perIndexComponents.descriptor(), cause);
+        perIndexComponents.forceDeleteAllComponents();
     }
 
     @Override
@@ -104,17 +100,17 @@ public class MemtableIndexWriter implements PerIndexWriter
         {
             if (!rowMapping.hasRows() || (memtableIndex == null) || memtableIndex.isEmpty())
             {
-                logger.debug(indexContext.logMessage("No indexed rows to flush from SSTable {}."), indexDescriptor.descriptor);
+                logger.debug(perIndexComponents.logMessage("No indexed rows to flush from SSTable {}."), perIndexComponents.descriptor());
                 // Write a completion marker even though we haven't written anything to the index
                 // so we won't try to build the index again for the SSTable
-                indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+                perIndexComponents.markComplete();
                 return;
             }
 
             final DecoratedKey minKey = rowMapping.minKey.partitionKey();
             final DecoratedKey maxKey = rowMapping.maxKey.partitionKey();
 
-            if (indexContext.isVector())
+            if (indexContext().isVector())
             {
                 flushVectorIndex(minKey, maxKey, start, stopwatch);
             }
@@ -124,7 +120,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
                 try (MemtableTermsIterator terms = new MemtableTermsIterator(memtableIndex.getMinTerm(), memtableIndex.getMaxTerm(), iterator))
                 {
-                    long cellCount = flush(minKey, maxKey, indexContext.getValidator(), terms, rowMapping.maxSegmentRowId);
+                    long cellCount = flush(minKey, maxKey, indexContext().getValidator(), terms, rowMapping.maxSegmentRowId);
 
                     completeIndexFlush(cellCount, start, stopwatch);
                 }
@@ -132,11 +128,16 @@ public class MemtableIndexWriter implements PerIndexWriter
         }
         catch (Throwable t)
         {
-            logger.error(indexContext.logMessage("Error while flushing index {}"), t.getMessage(), t);
-            indexContext.getIndexMetrics().memtableIndexFlushErrors.inc();
+            logger.error(perIndexComponents.logMessage("Error while flushing index {}"), t.getMessage(), t);
+            indexContext().getIndexMetrics().memtableIndexFlushErrors.inc();
 
             throw t;
         }
+    }
+
+    private PrimaryKey.Factory pkFactory()
+    {
+        return perIndexComponents.indexDescriptor().primaryKeyFactory;
     }
 
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, long maxSegmentRowId) throws IOException
@@ -146,7 +147,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
         if (TypeUtil.isLiteral(termComparator))
         {
-            try (InvertedIndexWriter writer = new InvertedIndexWriter(indexDescriptor, indexContext))
+            try (InvertedIndexWriter writer = new InvertedIndexWriter(perIndexComponents))
             {
                 indexMetas = writer.writeAll(terms);
                 numRows = writer.getPostingsCount();
@@ -154,13 +155,12 @@ public class MemtableIndexWriter implements PerIndexWriter
         }
         else
         {
-            try (NumericIndexWriter writer = new NumericIndexWriter(indexDescriptor,
-                                                                    indexContext,
+            try (NumericIndexWriter writer = new NumericIndexWriter(perIndexComponents,
                                                                     TypeUtil.fixedSizeOf(termComparator),
                                                                     maxSegmentRowId,
                                                                     // Due to stale entries in IndexMemtable, we may have more indexed rows than num of rowIds.
                                                                     Integer.MAX_VALUE,
-                                                                    indexContext.getIndexWriterConfig()))
+                                                                    indexContext().getIndexWriterConfig()))
             {
                 indexMetas = writer.writeAll(ImmutableOneDimPointValues.fromTermEnum(terms, termComparator));
                 numRows = writer.getPointCount();
@@ -171,7 +171,7 @@ public class MemtableIndexWriter implements PerIndexWriter
         // so that the index is correctly identified as being empty (only having a completion marker)
         if (numRows == 0)
         {
-            indexDescriptor.deleteColumnIndex(indexContext);
+            perIndexComponents.forceDeleteAllComponents();
             return 0;
         }
 
@@ -180,13 +180,13 @@ public class MemtableIndexWriter implements PerIndexWriter
                                                        numRows,
                                                        terms.getMinSSTableRowId(),
                                                        terms.getMaxSSTableRowId(),
-                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(minKey),
-                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(maxKey),
+                                                       pkFactory().createPartitionKeyOnly(minKey),
+                                                       pkFactory().createPartitionKeyOnly(maxKey),
                                                        terms.getMinTerm(),
                                                        terms.getMaxTerm(),
                                                        indexMetas);
 
-        try (MetadataWriter writer = new MetadataWriter(indexDescriptor.openPerIndexOutput(IndexComponent.META, indexContext)))
+        try (MetadataWriter writer = new MetadataWriter(perIndexComponents))
         {
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
@@ -203,45 +203,45 @@ public class MemtableIndexWriter implements PerIndexWriter
         var deletedOrdinals = vectorIndex.computeDeletedOrdinals(rowMapping::get);
         if (deletedOrdinals.size() == vectorIndex.size())
         {
-            logger.debug(indexContext.logMessage("Whole graph is deleted. Skipping index flush for {}."), indexDescriptor.descriptor);
-            indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+            logger.debug(perIndexComponents.logMessage("Whole graph is deleted. Skipping index flush for {}."), perIndexComponents.descriptor());
+            perIndexComponents.markComplete();
             return;
         }
 
-        SegmentMetadata.ComponentMetadataMap metadataMap = vectorIndex.writeData(indexDescriptor, deletedOrdinals);
-
-        completeIndexFlush(rowMapping.size(), startTime, stopwatch);
+        SegmentMetadata.ComponentMetadataMap metadataMap = vectorIndex.writeData(perIndexComponents, deletedOrdinals);
 
         SegmentMetadata metadata = new SegmentMetadata(0,
                                                        rowMapping.size(),
                                                        0,
                                                        rowMapping.maxSegmentRowId,
-                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(minKey),
-                                                       indexDescriptor.primaryKeyFactory.createPartitionKeyOnly(maxKey),
+                                                       pkFactory().createPartitionKeyOnly(minKey),
+                                                       pkFactory().createPartitionKeyOnly(maxKey),
                                                        ByteBufferUtil.bytes(0), // VSTODO by pass min max terms for vectors
                                                        ByteBufferUtil.bytes(0), // VSTODO by pass min max terms for vectors
                                                        metadataMap);
 
-        try (MetadataWriter writer = new MetadataWriter(indexDescriptor.openPerIndexOutput(IndexComponent.META, indexContext)))
+        try (MetadataWriter writer = new MetadataWriter(perIndexComponents))
         {
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
+
+        completeIndexFlush(rowMapping.size(), startTime, stopwatch);
     }
 
     private void completeIndexFlush(long cellCount, long startTime, Stopwatch stopwatch) throws IOException
     {
-        indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+        perIndexComponents.markComplete();
 
-        indexContext.getIndexMetrics().memtableIndexFlushCount.inc();
+        indexContext().getIndexMetrics().memtableIndexFlushCount.inc();
 
         long elapsedTime = stopwatch.elapsed(TimeUnit.MILLISECONDS);
 
-        logger.debug(indexContext.logMessage("Completed flushing {} memtable index cells to SSTable {}. Duration: {} ms. Total elapsed: {} ms"),
+        logger.debug(perIndexComponents.logMessage("Completed flushing {} memtable index cells to SSTable {}. Duration: {} ms. Total elapsed: {} ms"),
                      cellCount,
-                     indexDescriptor.descriptor,
+                     perIndexComponents.descriptor(),
                      elapsedTime - startTime,
                      elapsedTime);
 
-        indexContext.getIndexMetrics().memtableFlushCellsPerSecond.update((long) (cellCount * 1000.0 / Math.max(1, elapsedTime - startTime)));
+        indexContext().getIndexMetrics().memtableFlushCellsPerSecond.update((long) (cellCount * 1000.0 / Math.max(1, elapsedTime - startTime)));
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MetadataSource.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MetadataSource.java
@@ -24,9 +24,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.io.IndexInput;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
@@ -45,23 +44,12 @@ public class MetadataSource
         this.components = components;
     }
 
-    public static MetadataSource loadGroupMetadata(IndexDescriptor indexDescriptor) throws IOException
+    public static MetadataSource loadMetadata(IndexComponents.ForRead components) throws IOException
     {
-        try (var input = indexDescriptor.openCheckSummedPerSSTableInput(IndexComponent.GROUP_META))
+        IndexComponent.ForRead metadataComponent = components.get(components.metadataComponent());
+        try (var input = metadataComponent.openCheckSummedInput())
         {
-            var version = indexDescriptor.getVersion();
-            var order = version.onDiskFormat().byteOrderFor(IndexComponent.GROUP_META, null);
-            return MetadataSource.load(input, version, order);
-        }
-    }
-
-    public static MetadataSource loadColumnMetadata(IndexDescriptor indexDescriptor, IndexContext indexContext) throws IOException
-    {
-        try (var input = indexDescriptor.openCheckSummedPerIndexInput(IndexComponent.META, indexContext))
-        {
-            var version = indexDescriptor.getVersion(indexContext);
-            var order = version.onDiskFormat().byteOrderFor(IndexComponent.META, indexContext);
-            return MetadataSource.load(input, version, order);
+            return MetadataSource.load(input, components.version(), metadataComponent.byteOrder());
         }
     }
 
@@ -93,6 +81,11 @@ public class MetadataSource
         SAICodecUtils.checkFooter(input);
 
         return new MetadataSource(version, components);
+    }
+
+    public IndexInput get(IndexComponent component)
+    {
+        return get(component.fileNamePart());
     }
 
     public IndexInput get(String name)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MetadataWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MetadataWriter.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.index.sai.disk.ModernResettableByteBuffersIndexOutput;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.io.IndexOutput;
 import org.apache.cassandra.index.sai.disk.oldlucene.LegacyResettableByteBuffersIndexOutput;
-import org.apache.cassandra.index.sai.disk.oldlucene.ResettableByteBuffersIndexOutput;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.lucene.util.BytesRef;
 
@@ -37,9 +37,9 @@ public class MetadataWriter implements Closeable
     private final IndexOutput output;
     private final Map<String, BytesRef> map = new HashMap<>();
 
-    public MetadataWriter(IndexOutput output)
+    public MetadataWriter(IndexComponents.ForWrite components) throws IOException
     {
-        this.output = output;
+        this.output = components.addOrGet(components.metadataComponent()).openOutput();
     }
 
     public IndexOutput builder(String name)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -60,6 +60,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     @ThreadSafe
     public static class PartitionAwarePrimaryKeyMapFactory implements Factory
     {
+        private final IndexComponents.ForRead perSSTableComponents;
         private final LongArray.Factory tokenReaderFactory;
         private final LongArray.Factory offsetReaderFactory;
         private final MetadataSource metadata;
@@ -75,6 +76,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         {
             try
             {
+                this.perSSTableComponents = perSSTableComponents;
                 this.metadata = MetadataSource.loadMetadata(perSSTableComponents);
 
                 IndexComponent.ForRead offsetsComponent = perSSTableComponents.get(IndexComponentType.OFFSETS_VALUES);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -26,8 +26,9 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.BlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.MonotonicBlockPackedReader;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
@@ -45,9 +46,9 @@ import org.apache.cassandra.utils.Throwables;
  * This uses the following on-disk structures:
  * <ul>
  *     <li>Block-packed structure for rowId to token lookups using {@link BlockPackedReader}.
- *     Uses component {@link IndexComponent#TOKEN_VALUES} </li>
+ *     Uses component {@link IndexComponentType#TOKEN_VALUES} </li>
  *     <li>Monotonic-block-packed structure for rowId to partition key offset lookups using {@link MonotonicBlockPackedReader}.
- *     Uses component {@link IndexComponent#OFFSETS_VALUES} </li>
+ *     Uses component {@link IndexComponentType#OFFSETS_VALUES} </li>
  * </ul>
  *
  * This uses a {@link KeyFetcher} to read the {@link org.apache.cassandra.db.DecoratedKey} for a {@link PrimaryKey} from the
@@ -70,22 +71,26 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         private FileHandle token = null;
         private FileHandle offset = null;
 
-        public PartitionAwarePrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable)
+        public PartitionAwarePrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, SSTableReader sstable, PrimaryKey.Factory primaryKeyFactory)
         {
             try
             {
-                this.metadata = MetadataSource.loadGroupMetadata(indexDescriptor);
-                NumericValuesMeta offsetsMeta = new NumericValuesMeta(this.metadata.get(indexDescriptor.componentFileName(IndexComponent.OFFSETS_VALUES)));
-                NumericValuesMeta tokensMeta = new NumericValuesMeta(this.metadata.get(indexDescriptor.componentFileName(IndexComponent.TOKEN_VALUES)));
+                this.metadata = MetadataSource.loadMetadata(perSSTableComponents);
 
-                token = indexDescriptor.createPerSSTableFileHandle(IndexComponent.TOKEN_VALUES);
-                offset = indexDescriptor.createPerSSTableFileHandle(IndexComponent.OFFSETS_VALUES);
+                IndexComponent.ForRead offsetsComponent = perSSTableComponents.get(IndexComponentType.OFFSETS_VALUES);
+                IndexComponent.ForRead tokensComponent = perSSTableComponents.get(IndexComponentType.TOKEN_VALUES);
+
+                NumericValuesMeta offsetsMeta = new NumericValuesMeta(this.metadata.get(offsetsComponent));
+                NumericValuesMeta tokensMeta = new NumericValuesMeta(this.metadata.get(tokensComponent));
+
+                token = tokensComponent.createFileHandle();
+                offset = offsetsComponent.createFileHandle();
 
                 this.tokenReaderFactory = new BlockPackedReader(token, tokensMeta);
                 this.offsetReaderFactory = new MonotonicBlockPackedReader(offset, offsetsMeta);
-                this.partitioner = indexDescriptor.partitioner;
+                this.partitioner = sstable.metadata().partitioner;
                 this.keyFetcher = new KeyFetcher(sstable);
-                this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;
+                this.primaryKeyFactory = primaryKeyFactory;
                 this.sstableId = sstable.getId();
             }
             catch (Throwable t)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
@@ -36,13 +36,13 @@ public class PerIndexFiles implements Closeable
     private static final Logger logger = org.slf4j.LoggerFactory.getLogger(PerIndexFiles.class);
 
     private final Map<IndexComponentType, FileHandle> files = new EnumMap<>(IndexComponentType.class);
-    private final IndexComponents.ForRead componentsGroup;
+    private final IndexComponents.ForRead perIndexComponents;
 
-    public PerIndexFiles(IndexComponents.ForRead componentsGroup)
+    public PerIndexFiles(IndexComponents.ForRead perIndexComponents)
     {
-        this.componentsGroup = componentsGroup;
+        this.perIndexComponents = perIndexComponents;
 
-        var toOpen = new HashSet<>(componentsGroup.expectedComponentsForVersion());
+        var toOpen = new HashSet<>(perIndexComponents.expectedComponentsForVersion());
         toOpen.remove(IndexComponentType.META);
         toOpen.remove(IndexComponentType.COLUMN_COMPLETION_MARKER);
 
@@ -51,7 +51,7 @@ public class PerIndexFiles implements Closeable
         {
             try
             {
-                files.put(component, componentsGroup.get(component).createFileHandle());
+                files.put(component, perIndexComponents.get(component).createFileHandle());
                 componentsPresent.add(component);
             }
             catch (UncheckedIOException e)
@@ -60,12 +60,12 @@ public class PerIndexFiles implements Closeable
             }
         }
 
-        logger.info("Components present for {} are {}", componentsGroup.indexDescriptor(), componentsPresent);
+        logger.info("Components present for {} are {}", perIndexComponents.indexDescriptor(), componentsPresent);
     }
 
-    public IndexComponents.ForRead perIndexComponents()
+    public IndexComponents.ForRead usedPerIndexComponents()
     {
-        return componentsGroup;
+        return perIndexComponents;
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
@@ -108,9 +108,9 @@ public class PerIndexFiles implements Closeable
     {
         FileHandle file = files.get(indexComponentType);
         if (file == null)
-            throw new IllegalArgumentException(String.format(componentsGroup.logMessage("Component %s not found for SSTable %s"),
+            throw new IllegalArgumentException(String.format(perIndexComponents.logMessage("Component %s not found for SSTable %s"),
                                                              indexComponentType,
-                                                             componentsGroup.descriptor()));
+                                                             perIndexComponents.descriptor()));
 
         return file;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PerIndexFiles.java
@@ -26,9 +26,8 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 
-import org.apache.cassandra.index.sai.IndexContext;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 
@@ -36,25 +35,23 @@ public class PerIndexFiles implements Closeable
 {
     private static final Logger logger = org.slf4j.LoggerFactory.getLogger(PerIndexFiles.class);
 
-    private final Map<IndexComponent, FileHandle> files = new EnumMap<>(IndexComponent.class);
-    private final IndexDescriptor indexDescriptor;
-    private final IndexContext indexContext;
+    private final Map<IndexComponentType, FileHandle> files = new EnumMap<>(IndexComponentType.class);
+    private final IndexComponents.ForRead componentsGroup;
 
-    public PerIndexFiles(IndexDescriptor indexDescriptor, IndexContext indexContext)
+    public PerIndexFiles(IndexComponents.ForRead componentsGroup)
     {
-        this.indexDescriptor = indexDescriptor;
-        this.indexContext = indexContext;
+        this.componentsGroup = componentsGroup;
 
-        var toOpen = new HashSet<>(indexDescriptor.getVersion(indexContext).onDiskFormat().perIndexComponents(indexContext));
-        toOpen.remove(IndexComponent.META);
-        toOpen.remove(IndexComponent.COLUMN_COMPLETION_MARKER);
+        var toOpen = new HashSet<>(componentsGroup.expectedComponentsForVersion());
+        toOpen.remove(IndexComponentType.META);
+        toOpen.remove(IndexComponentType.COLUMN_COMPLETION_MARKER);
 
-        var componentsPresent = new HashSet<IndexComponent>();
-        for (IndexComponent component : toOpen)
+        var componentsPresent = new HashSet<IndexComponentType>();
+        for (IndexComponentType component : toOpen)
         {
             try
             {
-                files.put(component, indexDescriptor.createPerIndexFileHandle(component, indexContext));
+                files.put(component, componentsGroup.get(component).createFileHandle());
                 componentsPresent.add(component);
             }
             catch (UncheckedIOException e)
@@ -63,52 +60,57 @@ public class PerIndexFiles implements Closeable
             }
         }
 
-        logger.info("Components present for {} are {}", indexDescriptor, componentsPresent);
+        logger.info("Components present for {} are {}", componentsGroup.indexDescriptor(), componentsPresent);
+    }
+
+    public IndexComponents.ForRead perIndexComponents()
+    {
+        return componentsGroup;
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle termsData()
     {
-        return getFile(IndexComponent.TERMS_DATA).sharedCopy();
+        return getFile(IndexComponentType.TERMS_DATA).sharedCopy();
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle postingLists()
     {
-        return getFile(IndexComponent.POSTING_LISTS).sharedCopy();
+        return getFile(IndexComponentType.POSTING_LISTS).sharedCopy();
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle kdtree()
     {
-        return getFile(IndexComponent.KD_TREE).sharedCopy();
+        return getFile(IndexComponentType.KD_TREE).sharedCopy();
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle kdtreePostingLists()
     {
-        return getFile(IndexComponent.KD_TREE_POSTING_LISTS).sharedCopy();
+        return getFile(IndexComponentType.KD_TREE_POSTING_LISTS).sharedCopy();
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle vectors()
     {
-        return getFile(IndexComponent.VECTOR).sharedCopy();
+        return getFile(IndexComponentType.VECTOR).sharedCopy();
     }
 
     /** It is the caller's responsibility to close the returned file handle. */
     public FileHandle pq()
     {
-        return getFile(IndexComponent.PQ).sharedCopy();
+        return getFile(IndexComponentType.PQ).sharedCopy();
     }
 
-    public FileHandle getFile(IndexComponent indexComponent)
+    public FileHandle getFile(IndexComponentType indexComponentType)
     {
-        FileHandle file = files.get(indexComponent);
+        FileHandle file = files.get(indexComponentType);
         if (file == null)
-            throw new IllegalArgumentException(String.format(indexContext.logMessage("Component %s not found for SSTable %s"),
-                                                             indexComponent,
-                                                             indexDescriptor.descriptor));
+            throw new IllegalArgumentException(String.format(componentsGroup.logMessage("Component %s not found for SSTable %s"),
+                                                             indexComponentType,
+                                                             componentsGroup.descriptor()));
 
         return file;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,16 +37,15 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.disk.PerIndexWriter;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.Throwables;
 
 /**
  * Column index writer that accumulates (on-heap) indexed data from a compacted SSTable as it's being flushed to disk.
@@ -55,7 +55,7 @@ public class SSTableIndexWriter implements PerIndexWriter
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableIndexWriter.class);
 
-    private final IndexDescriptor indexDescriptor;
+    private final IndexComponents.ForWrite perIndexComponents;
     private final IndexContext indexContext;
     private final int nowInSec = FBUtilities.nowInSeconds();
     private final AbstractAnalyzer analyzer;
@@ -68,12 +68,12 @@ public class SSTableIndexWriter implements PerIndexWriter
     // segment writer
     private SegmentBuilder currentBuilder;
     private final List<SegmentMetadata> segments = new ArrayList<>();
-    private long maxSSTableRowId;
 
-    public SSTableIndexWriter(IndexDescriptor indexDescriptor, IndexContext indexContext, NamedMemoryLimiter limiter, BooleanSupplier isIndexValid, long keyCount)
+    public SSTableIndexWriter(IndexComponents.ForWrite perIndexComponents, NamedMemoryLimiter limiter, BooleanSupplier isIndexValid, long keyCount)
     {
-        this.indexDescriptor = indexDescriptor;
-        this.indexContext = indexContext;
+        this.perIndexComponents = perIndexComponents;
+        this.indexContext = perIndexComponents.context();
+        Preconditions.checkNotNull(indexContext, "Provided components %s are the per-sstable ones, expected per-index ones", perIndexComponents);
         this.analyzer = indexContext.getAnalyzerFactory().create();
         this.limiter = limiter;
         this.isIndexValid = isIndexValid;
@@ -110,7 +110,6 @@ public class SSTableIndexWriter implements PerIndexWriter
             if (value != null)
                 addTerm(TypeUtil.encode(value.duplicate(), indexContext.getValidator()), key, sstableRowId, indexContext.getValidator());
         }
-        maxSSTableRowId = sstableRowId;
     }
 
     @Override
@@ -133,7 +132,7 @@ public class SSTableIndexWriter implements PerIndexWriter
                 flushSegment();
                 elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
                 logger.debug(indexContext.logMessage("Completed flush of final segment for SSTable {}. Duration: {} ms. Total elapsed: {} ms"),
-                             indexDescriptor.descriptor,
+                             perIndexComponents.descriptor(),
                              elapsed - start,
                              elapsed);
             }
@@ -144,11 +143,11 @@ public class SSTableIndexWriter implements PerIndexWriter
                 long bytesAllocated = currentBuilder.totalBytesAllocated();
                 long globalBytesUsed = currentBuilder.release(indexContext);
                 logger.debug(indexContext.logMessage("Flushing final segment for SSTable {} released {}. Global segment memory usage now at {}."),
-                             indexDescriptor.descriptor, FBUtilities.prettyPrintMemory(bytesAllocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
+                             perIndexComponents.descriptor(), FBUtilities.prettyPrintMemory(bytesAllocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
             }
 
             writeSegmentsMetadata();
-            indexDescriptor.createComponentOnDisk(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+            perIndexComponents.markComplete();
         }
         finally
         {
@@ -166,7 +165,7 @@ public class SSTableIndexWriter implements PerIndexWriter
     {
         aborted = true;
 
-        logger.warn(indexContext.logMessage("Aborting SSTable index flush for {}..."), indexDescriptor.descriptor, cause);
+        logger.warn(indexContext.logMessage("Aborting SSTable index flush for {}..."), perIndexComponents.descriptor(), cause);
 
         // It's possible for the current builder to be unassigned after we flush a final segment.
         if (currentBuilder != null)
@@ -176,13 +175,13 @@ public class SSTableIndexWriter implements PerIndexWriter
             long allocated = currentBuilder.totalBytesAllocated();
             long globalBytesUsed = currentBuilder.release(indexContext);
             logger.debug(indexContext.logMessage("Aborting index writer for SSTable {} released {}. Global segment memory usage now at {}."),
-                         indexDescriptor.descriptor, FBUtilities.prettyPrintMemory(allocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
+                         perIndexComponents.descriptor(), FBUtilities.prettyPrintMemory(allocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
         }
 
         if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
-            indexDescriptor.deleteColumnIndex(indexContext);
+            perIndexComponents.forceDeleteAllComponents();
         else
-            logger.debug("Skipping delete of index components after failure on index build of {}.{}", indexDescriptor, indexContext);
+            logger.debug("Skipping delete of index components after failure on index build of {}.{}", perIndexComponents.indexDescriptor(), indexContext);
     }
 
     /**
@@ -263,7 +262,7 @@ public class SSTableIndexWriter implements PerIndexWriter
         {
             long bytesAllocated = currentBuilder.totalBytesAllocated();
 
-            SegmentMetadata segmentMetadata = currentBuilder.flush(indexDescriptor, indexContext);
+            SegmentMetadata segmentMetadata = currentBuilder.flush();
 
             long flushMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
 
@@ -290,13 +289,13 @@ public class SSTableIndexWriter implements PerIndexWriter
             long globalBytesUsed = currentBuilder.release(indexContext);
             currentBuilder = null;
             logger.debug(indexContext.logMessage("Flushing index segment for SSTable {} released {}. Global segment memory usage now at {}."),
-                         indexDescriptor.descriptor, FBUtilities.prettyPrintMemory(bytesAllocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
+                         perIndexComponents.descriptor(), FBUtilities.prettyPrintMemory(bytesAllocated), FBUtilities.prettyPrintMemory(globalBytesUsed));
 
         }
         catch (Throwable t)
         {
-            logger.error(indexContext.logMessage("Failed to build index for SSTable {}."), indexDescriptor.descriptor, t);
-            indexDescriptor.deleteColumnIndex(indexContext);
+            logger.error(indexContext.logMessage("Failed to build index for SSTable {}."), perIndexComponents.descriptor(), t);
+            perIndexComponents.forceDeleteAllComponents();
 
             indexContext.getIndexMetrics().segmentFlushErrors.inc();
 
@@ -309,7 +308,7 @@ public class SSTableIndexWriter implements PerIndexWriter
         if (segments.isEmpty())
             return;
 
-        try (MetadataWriter writer = new MetadataWriter(indexDescriptor.openPerIndexOutput(IndexComponent.META, indexContext)))
+        try (MetadataWriter writer = new MetadataWriter(perIndexComponents))
         {
             SegmentMetadata.write(writer, segments);
         }
@@ -330,23 +329,23 @@ public class SSTableIndexWriter implements PerIndexWriter
             // otherwise, build on heap (which will create PQ for next time, if we have enough vectors)
             var pqi = CassandraOnHeapGraph.getPqIfPresent(indexContext, vc -> vc.type == VectorCompression.CompressionType.PRODUCT_QUANTIZATION);
             if (pqi == null || pqi.unitVectors.isEmpty() || !V3OnDiskFormat.ENABLE_LTM_CONSTRUCTION) {
-                builder = new SegmentBuilder.VectorOnHeapSegmentBuilder(indexDescriptor, indexContext, rowIdOffset, keyCount, limiter);
+                builder = new SegmentBuilder.VectorOnHeapSegmentBuilder(perIndexComponents, rowIdOffset, keyCount, limiter);
             } else {
-                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(indexDescriptor, indexContext, rowIdOffset, keyCount, limiter, pqi.pq, pqi.unitVectors.get());
+                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(perIndexComponents, rowIdOffset, keyCount, limiter, pqi.pq, pqi.unitVectors.get());
             }
         }
         else if (indexContext.isLiteral())
         {
-            builder = new SegmentBuilder.RAMStringSegmentBuilder(rowIdOffset, indexContext.getValidator(), limiter);
+            builder = new SegmentBuilder.RAMStringSegmentBuilder(perIndexComponents, rowIdOffset, limiter);
         }
         else
         {
-            builder = new SegmentBuilder.KDTreeSegmentBuilder(rowIdOffset, indexContext.getValidator(), limiter, indexContext.getIndexWriterConfig());
+            builder = new SegmentBuilder.KDTreeSegmentBuilder(perIndexComponents, rowIdOffset, limiter, indexContext.getIndexWriterConfig());
         }
 
         long globalBytesUsed = limiter.increment(builder.totalBytesAllocated());
         logger.debug(indexContext.logMessage("Created new segment builder while flushing SSTable {}. Global segment memory usage now at {}."),
-                     indexDescriptor.descriptor,
+                     perIndexComponents.descriptor(),
                      FBUtilities.prettyPrintMemory(globalBytesUsed));
 
         return builder;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -73,7 +73,7 @@ public class Segment implements Closeable, SegmentOrdering
         this.indexFiles = indexFiles;
         this.metadata = metadata;
 
-        var version = sstableContext.indexDescriptor.getVersion(indexContext);
+        var version = indexFiles.usedPerIndexComponents().version();
         IndexSearcher searcher = version.onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
         logger.info("Opened searcher {} for segment {}:{} for index [{}] on column [{}] at version {}",
                     searcher.getClass().getSimpleName(),

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -33,14 +33,14 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sai.disk.PostingList;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 
 /**
- * Multiple {@link SegmentMetadata} are stored in {@link IndexComponent#META} file, each corresponds to an on-disk
+ * Multiple {@link SegmentMetadata} are stored in {@link IndexComponentType#META} file, each corresponds to an on-disk
  * index segment.
  */
 public class SegmentMetadata implements Comparable<SegmentMetadata>
@@ -211,9 +211,9 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         }
     }
 
-    long getIndexRoot(IndexComponent indexComponent)
+    long getIndexRoot(IndexComponentType indexComponentType)
     {
-        return componentMetadatas.get(indexComponent).root;
+        return componentMetadatas.get(indexComponentType).root;
     }
 
     public int toSegmentRowId(long sstableRowId)
@@ -228,7 +228,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
 
     public static class ComponentMetadataMap
     {
-        private final Map<IndexComponent, ComponentMetadata> metas = new HashMap<>();
+        private final Map<IndexComponentType, ComponentMetadata> metas = new HashMap<>();
 
         ComponentMetadataMap(IndexInput input) throws IOException
         {
@@ -236,7 +236,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
 
             for (int i = 0; i < size; i++)
             {
-                metas.put(IndexComponent.valueOf(input.readString()), new ComponentMetadata(input));
+                metas.put(IndexComponentType.valueOf(input.readString()), new ComponentMetadata(input));
             }
         }
 
@@ -244,40 +244,40 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         {
         }
 
-        public void put(IndexComponent indexComponent, long root, long offset, long length)
+        public void put(IndexComponentType indexComponentType, long root, long offset, long length)
         {
-            metas.put(indexComponent, new ComponentMetadata(root, offset, length));
+            metas.put(indexComponentType, new ComponentMetadata(root, offset, length));
         }
 
-        public void put(IndexComponent indexComponent, long root, long offset, long length, Map<String, String> additionalMap)
+        public void put(IndexComponentType indexComponentType, long root, long offset, long length, Map<String, String> additionalMap)
         {
-            metas.put(indexComponent, new ComponentMetadata(root, offset, length, additionalMap));
+            metas.put(indexComponentType, new ComponentMetadata(root, offset, length, additionalMap));
         }
 
         private void write(IndexOutput output) throws IOException
         {
             output.writeInt(metas.size());
 
-            for (Map.Entry<IndexComponent, ComponentMetadata> entry : metas.entrySet())
+            for (Map.Entry<IndexComponentType, ComponentMetadata> entry : metas.entrySet())
             {
                 output.writeString(entry.getKey().name());
                 entry.getValue().write(output);
             }
         }
 
-        public ComponentMetadata get(IndexComponent indexComponent)
+        public ComponentMetadata get(IndexComponentType indexComponentType)
         {
-            if (!metas.containsKey(indexComponent))
-                throw new IllegalArgumentException(indexComponent + " ComponentMetadata not found");
+            if (!metas.containsKey(indexComponentType))
+                throw new IllegalArgumentException(indexComponentType + " ComponentMetadata not found");
 
-            return metas.get(indexComponent);
+            return metas.get(indexComponentType);
         }
 
         public Map<String, Map<String, String>> asMap()
         {
             Map<String, Map<String, String>> metaAttributes = new HashMap<>();
 
-            for (Map.Entry<IndexComponent, ComponentMetadata> entry : metas.entrySet())
+            for (Map.Entry<IndexComponentType, ComponentMetadata> entry : metas.entrySet())
             {
                 String name = entry.getKey().name();
                 ComponentMetadata metadata = entry.getValue();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
@@ -32,8 +32,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.io.IndexInput;
 import org.apache.cassandra.index.sai.disk.v1.postings.MergePostingList;
 import org.apache.cassandra.index.sai.disk.v1.postings.PostingsReader;
@@ -72,11 +71,11 @@ public class TermsReader implements Closeable
     private final FileHandle termDictionaryFile;
     private final FileHandle postingsFile;
     private final long termDictionaryRoot;
-    private final ByteComparable.Version encodingVersion;
+    private final ByteComparable.Version termDictionaryFileEncodingVersion;
 
-    public TermsReader(IndexDescriptor indexDescriptor,
-                       IndexContext indexContext,
+    public TermsReader(IndexContext indexContext,
                        FileHandle termsData,
+                       ByteComparable.Version termsDataEncodingVersion,
                        FileHandle postingLists,
                        long root,
                        long termsFooterPointer) throws IOException
@@ -85,7 +84,7 @@ public class TermsReader implements Closeable
         termDictionaryFile = termsData;
         postingsFile = postingLists;
         termDictionaryRoot = root;
-        this.encodingVersion = indexDescriptor.getEncodingVersion(IndexComponent.TERMS_DATA);
+        this.termDictionaryFileEncodingVersion = termsDataEncodingVersion;
 
         try (final IndexInput indexInput = IndexFileUtils.instance.openInput(termDictionaryFile))
         {
@@ -196,7 +195,7 @@ public class TermsReader implements Closeable
 
         public long lookupTermDictionary(ByteComparable term)
         {
-            try (TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(termDictionaryFile.instantiateRebufferer(), termDictionaryRoot, encodingVersion))
+            try (TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(termDictionaryFile.instantiateRebufferer(), termDictionaryRoot, termDictionaryFileEncodingVersion))
             {
                 final long offset = reader.exactMatch(term);
 
@@ -244,7 +243,7 @@ public class TermsReader implements Closeable
                                                                                   lower,
                                                                                   upper,
                                                                                   true,
-                                                                                  encodingVersion))
+                                                                                  termDictionaryFileEncodingVersion))
             {
                 if (!reader.hasNext())
                     return PostingList.EMPTY;
@@ -317,7 +316,7 @@ public class TermsReader implements Closeable
 
         private TermsScanner(long segmentOffset)
         {
-            this.termsDictionaryReader = new TrieTermsDictionaryReader(termDictionaryFile.instantiateRebufferer(), termDictionaryRoot, encodingVersion);
+            this.termsDictionaryReader = new TrieTermsDictionaryReader(termDictionaryFile.instantiateRebufferer(), termDictionaryRoot, termDictionaryFileEncodingVersion);
             this.minTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMinTerm().asComparableBytes(ByteComparable.Version.OSS41)));
             this.maxTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMaxTerm().asComparableBytes(ByteComparable.Version.OSS41)));
             this.segmentOffset = segmentOffset;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -39,6 +39,8 @@ import org.apache.cassandra.index.sai.disk.PerIndexWriter;
 import org.apache.cassandra.index.sai.disk.PerSSTableWriter;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.SearchableIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
@@ -66,24 +68,24 @@ public class V1OnDiskFormat implements OnDiskFormat
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final Set<IndexComponent> PER_SSTABLE_COMPONENTS = EnumSet.of(IndexComponent.GROUP_COMPLETION_MARKER,
-                                                                                 IndexComponent.GROUP_META,
-                                                                                 IndexComponent.TOKEN_VALUES,
-                                                                                 IndexComponent.OFFSETS_VALUES);
+    private static final Set<IndexComponentType> PER_SSTABLE_COMPONENTS = EnumSet.of(IndexComponentType.GROUP_COMPLETION_MARKER,
+                                                                                     IndexComponentType.GROUP_META,
+                                                                                     IndexComponentType.TOKEN_VALUES,
+                                                                                     IndexComponentType.OFFSETS_VALUES);
 
-    private static final Set<IndexComponent> LITERAL_COMPONENTS = EnumSet.of(IndexComponent.COLUMN_COMPLETION_MARKER,
-                                                                             IndexComponent.META,
-                                                                             IndexComponent.TERMS_DATA,
-                                                                             IndexComponent.POSTING_LISTS);
-    private static final Set<IndexComponent> NUMERIC_COMPONENTS = EnumSet.of(IndexComponent.COLUMN_COMPLETION_MARKER,
-                                                                             IndexComponent.META,
-                                                                             IndexComponent.KD_TREE,
-                                                                             IndexComponent.KD_TREE_POSTING_LISTS);
+    private static final Set<IndexComponentType> LITERAL_COMPONENTS = EnumSet.of(IndexComponentType.COLUMN_COMPLETION_MARKER,
+                                                                                 IndexComponentType.META,
+                                                                                 IndexComponentType.TERMS_DATA,
+                                                                                 IndexComponentType.POSTING_LISTS);
+    private static final Set<IndexComponentType> NUMERIC_COMPONENTS = EnumSet.of(IndexComponentType.COLUMN_COMPLETION_MARKER,
+                                                                                 IndexComponentType.META,
+                                                                                 IndexComponentType.KD_TREE,
+                                                                                 IndexComponentType.KD_TREE_POSTING_LISTS);
 
     /**
      * Global limit on heap consumed by all index segment building that occurs outside the context of Memtable flush.
      *
-     * Note that to avoid flushing extremely small index segments, a segment is only flushed when
+     * Note that to avoid flushing extremly small index segments, a segment is only flushed when
      * both the global size of all building segments has breached the limit and the size of the
      * segment in question reaches (segment_write_buffer_space_mb / # currently building column indexes).
      *
@@ -147,7 +149,7 @@ public class V1OnDiskFormat implements OnDiskFormat
     @Override
     public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable) throws IOException
     {
-        return new PartitionAwarePrimaryKeyMap.PartitionAwarePrimaryKeyMapFactory(indexDescriptor, sstable);
+        return new PartitionAwarePrimaryKeyMap.PartitionAwarePrimaryKeyMapFactory(indexDescriptor.perSSTableComponents(), sstable, indexDescriptor.primaryKeyFactory);
     }
 
     @Override
@@ -164,13 +166,13 @@ public class V1OnDiskFormat implements OnDiskFormat
     {
         if (indexContext.isLiteral())
             return new InvertedIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
-        return new KDTreeIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+        return new KDTreeIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, indexContext);
     }
 
     @Override
     public PerSSTableWriter newPerSSTableWriter(IndexDescriptor indexDescriptor) throws IOException
     {
-        return new SSTableComponentsWriter(indexDescriptor);
+        return new SSTableComponentsWriter(indexDescriptor.newPerSSTableComponentsForWrite());
     }
 
     @Override
@@ -180,6 +182,7 @@ public class V1OnDiskFormat implements OnDiskFormat
                                             RowMapping rowMapping,
                                             long keyCount)
     {
+        IndexComponents.ForWrite perIndexComponents = indexDescriptor.newPerIndexComponentsForWrite(index.getIndexContext());
         // If we're not flushing or we haven't yet started the initialization build, flush from SSTable contents.
         if (tracker.opType() != OperationType.FLUSH || !index.canFlushFromMemtableIndex())
         {
@@ -187,50 +190,18 @@ public class V1OnDiskFormat implements OnDiskFormat
             logger.debug(index.getIndexContext().logMessage("Starting a compaction index build. Global segment memory usage: {}"),
                          prettyPrintMemory(limiter.currentBytesUsed()));
 
-            return new SSTableIndexWriter(indexDescriptor, index.getIndexContext(), limiter, index.isIndexValid(), keyCount);
+            return new SSTableIndexWriter(perIndexComponents, limiter, index.isIndexValid(), keyCount);
         }
 
         return new MemtableIndexWriter(index.getIndexContext().getPendingMemtableIndex(tracker),
-                                       indexDescriptor,
-                                       index.getIndexContext(),
+                                       perIndexComponents,
                                        rowMapping);
     }
 
-    @Override
-    public boolean validatePerSSTableComponents(IndexDescriptor indexDescriptor, boolean checksum)
-    {
-        for (IndexComponent indexComponent : perSSTableComponents())
-        {
-            if (isBuildCompletionMarker(indexComponent))
-                continue;
-
-            try (IndexInput input = indexDescriptor.openPerSSTableInput(indexComponent))
-            {
-                Version earliest = getExpectedEarliestVersion(indexComponent);
-                if (checksum)
-                    SAICodecUtils.validateChecksum(input);
-                else
-                    SAICodecUtils.validate(input, earliest);
-            }
-            catch (Throwable e)
-            {
-                if (logger.isDebugEnabled())
-                {
-                    logger.debug(indexDescriptor.logMessage("{} failed for index component {} on SSTable {}"),
-                                 (checksum ? "Checksum validation" : "Validation"),
-                                 indexComponent,
-                                 indexDescriptor.descriptor);
-                }
-                return false;
-            }
-        }
-        return true;
-    }
-
-    protected Version getExpectedEarliestVersion(IndexComponent indexComponent)
+    protected Version getExpectedEarliestVersion(IndexContext context, IndexComponentType indexComponentType)
     {
         Version earliest = Version.EARLIEST;
-        if (isVectorDataComponent(indexComponent))
+        if (isVectorDataComponent(context, indexComponentType))
         {
             if (!Version.latest().onOrAfter(Version.VECTOR_EARLIEST))
                 throw new IllegalStateException("Configured latest version " + Version.latest() + " is not compatible with vector index");
@@ -240,33 +211,35 @@ public class V1OnDiskFormat implements OnDiskFormat
     }
 
     @Override
-    public boolean validateOneIndexComponent(IndexComponent component, IndexDescriptor descriptor, IndexContext context, boolean checksum)
+    public boolean validateIndexComponent(IndexComponent.ForRead component, boolean checksum)
     {
-        if (isBuildCompletionMarker(component))
+        if (component.isCompletionMarker())
             return true;
+
         // starting with v3, vector components include proper headers and checksum; skip for earlier versions
-        if (context.isVector()
-            && isVectorDataComponent(component)
-            && !descriptor.getVersion(context).onDiskFormat().indexFeatureSet().hasVectorIndexChecksum())
+        IndexContext context = component.parent().context();
+        if (isVectorDataComponent(context, component.componentType())
+            && !component.parent().version().onDiskFormat().indexFeatureSet().hasVectorIndexChecksum())
         {
             return true;
         }
 
-        try (IndexInput input = descriptor.openPerIndexInput(component, context))
+        Version earliest = getExpectedEarliestVersion(context, component.componentType());
+        try (IndexInput input = component.openInput())
         {
             if (checksum)
                 SAICodecUtils.validateChecksum(input);
             else
-                SAICodecUtils.validate(input);
+                SAICodecUtils.validate(input, earliest);
         }
         catch (Throwable e)
         {
             if (logger.isDebugEnabled())
             {
-                logger.debug(descriptor.logMessage("{} failed for index component {} on SSTable {}"),
+                logger.debug(component.parent().logMessage("{} failed for index component {} on SSTable {}"),
                              (checksum ? "Checksum validation" : "Validation"),
                              component,
-                             descriptor.descriptor,
+                             component.parent().descriptor(),
                              e);
             }
             return false;
@@ -275,13 +248,13 @@ public class V1OnDiskFormat implements OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponent> perSSTableComponents()
+    public Set<IndexComponentType> perSSTableComponents()
     {
         return PER_SSTABLE_COMPONENTS;
     }
 
     @Override
-    public Set<IndexComponent> perIndexComponents(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext)
     {
         if (TypeUtil.isLiteral(indexContext.getValidator()))
             return LITERAL_COMPONENTS;
@@ -302,23 +275,20 @@ public class V1OnDiskFormat implements OnDiskFormat
     }
 
     @Override
-    public ByteOrder byteOrderFor(IndexComponent indexComponent, IndexContext context)
+    public ByteOrder byteOrderFor(IndexComponentType indexComponentType, IndexContext context)
     {
         return ByteOrder.BIG_ENDIAN;
     }
 
-    protected boolean isBuildCompletionMarker(IndexComponent indexComponent)
-    {
-        return indexComponent == IndexComponent.GROUP_COMPLETION_MARKER ||
-               indexComponent == IndexComponent.COLUMN_COMPLETION_MARKER;
-    }
-
     /** vector data components (that did not have checksums before v3) */
-    private boolean isVectorDataComponent(IndexComponent indexComponent)
+    private boolean isVectorDataComponent(IndexContext context, IndexComponentType indexComponentType)
     {
-        return indexComponent == IndexComponent.VECTOR ||
-               indexComponent == IndexComponent.PQ ||
-               indexComponent == IndexComponent.TERMS_DATA ||
-               indexComponent == IndexComponent.POSTING_LISTS;
+        if (context == null || !context.isVector())
+            return false;
+
+        return indexComponentType == IndexComponentType.VECTOR ||
+               indexComponentType == IndexComponentType.PQ ||
+               indexComponentType == IndexComponentType.TERMS_DATA ||
+               indexComponentType == IndexComponentType.POSTING_LISTS;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.SearchableIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeConcatIterator;
@@ -78,11 +79,12 @@ public class V1SearchableIndex implements SearchableIndex
         this.indexContext = indexContext;
         try
         {
-            this.indexFiles = new PerIndexFiles(sstableContext.indexDescriptor, indexContext);
+            IndexComponents.ForRead perIndexComponents = sstableContext.indexDescriptor.perIndexComponents(indexContext);
+            this.indexFiles = new PerIndexFiles(perIndexComponents);
 
             ImmutableList.Builder<Segment> segmentsBuilder = ImmutableList.builder();
 
-            final MetadataSource source = MetadataSource.loadColumnMetadata(sstableContext.indexDescriptor, indexContext);
+            final MetadataSource source = MetadataSource.loadMetadata(perIndexComponents);
 
             metadatas = SegmentMetadata.load(source, sstableContext.indexDescriptor.primaryKeyFactory);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -74,19 +74,18 @@ public class V1SearchableIndex implements SearchableIndex
     private final long numRows;
     private PerIndexFiles indexFiles;
 
-    public V1SearchableIndex(SSTableContext sstableContext, IndexContext indexContext)
+    public V1SearchableIndex(SSTableContext sstableContext, IndexComponents.ForRead perIndexComponents)
     {
-        this.indexContext = indexContext;
+        this.indexContext = perIndexComponents.context();
         try
         {
-            IndexComponents.ForRead perIndexComponents = sstableContext.indexDescriptor.perIndexComponents(indexContext);
             this.indexFiles = new PerIndexFiles(perIndexComponents);
 
             ImmutableList.Builder<Segment> segmentsBuilder = ImmutableList.builder();
 
             final MetadataSource source = MetadataSource.loadMetadata(perIndexComponents);
 
-            metadatas = SegmentMetadata.load(source, sstableContext.indexDescriptor.primaryKeyFactory);
+            metadatas = SegmentMetadata.load(source, sstableContext.primaryKeyFactory());
 
             for (SegmentMetadata metadata : metadatas)
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/NumericValuesWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/NumericValuesWriter.java
@@ -19,11 +19,9 @@ package org.apache.cassandra.index.sai.disk.v1.bitpack;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteOrder;
 
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.io.IndexOutput;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.v1.MetadataWriter;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 
@@ -33,52 +31,40 @@ public class NumericValuesWriter implements Closeable
     public static final int MONOTONIC_BLOCK_SIZE = Integer.getInteger("dse.sai.numeric_values.monotonic_block_size", 16384);
     public static final int BLOCK_SIZE = Integer.getInteger("dse.sai.numeric_values.block_size", 128);
 
+    private final IndexComponent.ForWrite components;
     private final IndexOutput output;
     private final AbstractBlockPackedWriter writer;
     private final MetadataWriter metadataWriter;
-    private final String componentName;
     private final int blockSize;
     private long count = 0;
 
-    public NumericValuesWriter(String componentName,
-                               IndexOutput indexOutput,
+    public NumericValuesWriter(IndexComponent.ForWrite components,
                                MetadataWriter metadataWriter,
                                boolean monotonic) throws IOException
     {
-        this(componentName, indexOutput, metadataWriter, monotonic, monotonic ? MONOTONIC_BLOCK_SIZE : BLOCK_SIZE);
+        this(components, metadataWriter, monotonic, monotonic ? MONOTONIC_BLOCK_SIZE : BLOCK_SIZE);
     }
 
-    public NumericValuesWriter(IndexDescriptor indexDescriptor,
-                               IndexComponent component,
+    public NumericValuesWriter(IndexComponent.ForWrite components,
                                MetadataWriter metadataWriter,
                                boolean monotonic,
                                int blockSize) throws IOException
     {
-        this(indexDescriptor.componentFileName(component),
-             indexDescriptor.openPerSSTableOutput(component),
-             metadataWriter,
-             monotonic,
-             blockSize);
-    }
+        this.components = components;
+        this.output = components.openOutput();
+        SAICodecUtils.writeHeader(output);
 
-    private NumericValuesWriter(String componentName,
-                                IndexOutput indexOutput,
-                                MetadataWriter metadataWriter,
-                                boolean monotonic, int blockSize) throws IOException
-    {
-        SAICodecUtils.writeHeader(indexOutput);
-        this.writer = monotonic ? new MonotonicBlockPackedWriter(indexOutput, blockSize)
-                                : new BlockPackedWriter(indexOutput, blockSize);
-        this.output = indexOutput;
-        this.componentName = componentName;
+        this.writer = monotonic ? new MonotonicBlockPackedWriter(output, blockSize)
+                                : new BlockPackedWriter(output, blockSize);
         this.metadataWriter = metadataWriter;
         this.blockSize = blockSize;
+
     }
 
     @Override
     public void close() throws IOException
     {
-        try (IndexOutput o = metadataWriter.builder(componentName))
+        try (IndexOutput o = metadataWriter.builder(components.fileNamePart()))
         {
             final long fp = writer.finish();
             SAICodecUtils.writeFooter(output);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsWriter.java
@@ -29,11 +29,10 @@ import org.slf4j.LoggerFactory;
 
 import org.agrona.collections.IntArrayList;
 import org.agrona.collections.LongArrayList;
-import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.io.IndexOutput;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.disk.oldlucene.DirectWriterAdapter;
 import org.apache.cassandra.index.sai.disk.oldlucene.LuceneCompat;
@@ -110,9 +109,9 @@ public class PostingsWriter implements Closeable
     private long maxDelta;
     private long totalPostings;
 
-    public PostingsWriter(IndexDescriptor indexDescriptor, IndexContext indexContext) throws IOException
+    public PostingsWriter(IndexComponents.ForWrite components) throws IOException
     {
-        this(indexDescriptor, indexContext, BLOCK_SIZE);
+        this(components, BLOCK_SIZE);
     }
 
     public PostingsWriter(IndexOutput dataOutput) throws IOException
@@ -121,9 +120,9 @@ public class PostingsWriter implements Closeable
     }
 
     @VisibleForTesting
-    PostingsWriter(IndexDescriptor indexDescriptor, IndexContext indexContext, int blockSize) throws IOException
+    PostingsWriter(IndexComponents.ForWrite components, int blockSize) throws IOException
     {
-        this(indexDescriptor.openPerIndexOutput(IndexComponent.POSTING_LISTS, indexContext, true), blockSize);
+        this(components.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true), blockSize);
     }
 
     private PostingsWriter(IndexOutput dataOutput, int blockSize) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
@@ -25,11 +25,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
-import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v1.postings.PostingsWriter;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
@@ -45,10 +44,10 @@ public class InvertedIndexWriter implements Closeable
     private final PostingsWriter postingsWriter;
     private long postingsAdded;
 
-    public InvertedIndexWriter(IndexDescriptor indexDescriptor, IndexContext indexContext) throws IOException
+    public InvertedIndexWriter(IndexComponents.ForWrite components) throws IOException
     {
-        this.termsDictionaryWriter = new TrieTermsDictionaryWriter(indexDescriptor, indexContext);
-        this.postingsWriter = new PostingsWriter(indexDescriptor, indexContext);
+        this.termsDictionaryWriter = new TrieTermsDictionaryWriter(components);
+        this.postingsWriter = new PostingsWriter(components);
     }
 
     /**
@@ -89,8 +88,8 @@ public class InvertedIndexWriter implements Closeable
         map.put(SAICodecUtils.FOOTER_POINTER, "" + footerPointer.getValue());
 
         // Postings list file pointers are stored directly in TERMS_DATA, so a root is not needed.
-        components.put(IndexComponent.POSTING_LISTS, -1, postingsOffset, postingsLength);
-        components.put(IndexComponent.TERMS_DATA, termsRoot, termsOffset, termsLength, map);
+        components.put(IndexComponentType.POSTING_LISTS, -1, postingsOffset, postingsLength);
+        components.put(IndexComponentType.TERMS_DATA, termsRoot, termsOffset, termsLength, map);
 
         return components;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
@@ -50,7 +50,8 @@ public class TrieTermsDictionaryWriter implements Closeable
 
         SAICodecUtils.writeHeader(termDictionaryOutput);
         // we pass the output as SequentialWriter, but we keep IndexOutputWriter around to write footer on flush
-        termsDictionaryWriter = IncrementalTrieWriter.open(TrieTermsDictionaryReader.trieSerializer, termDictionaryOutput.asSequentialWriter(), indexDescriptor.getEncodingVersion(IndexComponent.TERMS_DATA));
+        var encodingVersion = components.byteComparableVersionFor(IndexComponentType.TERMS_DATA);
+        termsDictionaryWriter = IncrementalTrieWriter.open(TrieTermsDictionaryReader.trieSerializer, termDictionaryOutput.asSequentialWriter(), encodingVersion);
     }
 
     public void add(ByteComparable term, long postingListOffset) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
@@ -23,9 +23,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
-import org.apache.cassandra.index.sai.IndexContext;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.tries.IncrementalTrieWriter;
@@ -44,9 +43,9 @@ public class TrieTermsDictionaryWriter implements Closeable
     private final IndexOutputWriter termDictionaryOutput;
     private final long startOffset;
 
-    TrieTermsDictionaryWriter(IndexDescriptor indexDescriptor, IndexContext indexContext) throws IOException
+    TrieTermsDictionaryWriter(IndexComponents.ForWrite components) throws IOException
     {
-        termDictionaryOutput = indexDescriptor.openPerIndexOutput(IndexComponent.TERMS_DATA, indexContext, true);
+        termDictionaryOutput = components.addOrGet(IndexComponentType.TERMS_DATA).openOutput(true);
         startOffset = termDictionaryOutput.getFilePointer();
 
         SAICodecUtils.writeHeader(termDictionaryOutput);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -32,7 +32,8 @@ import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.LongArray;
 import org.apache.cassandra.index.sai.disk.v1.MetadataSource;
@@ -56,10 +57,10 @@ import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
  * This uses the following on-disk structures:
  * <ul>
  *     <li>Block-packed structure for rowId to token lookups using {@link BlockPackedReader}.
- *     Uses component {@link IndexComponent#TOKEN_VALUES} </li>
+ *     Uses component {@link IndexComponentType#TOKEN_VALUES} </li>
  *     <li>A sorted-terms structure for rowId to {@link PrimaryKey} and {@link PrimaryKey} to rowId lookups using
- *     {@link SortedTermsReader}. Uses components {@link IndexComponent#PRIMARY_KEY_TRIE}, {@link IndexComponent#PRIMARY_KEY_BLOCKS},
- *     {@link IndexComponent#PRIMARY_KEY_BLOCK_OFFSETS}</li>
+ *     {@link SortedTermsReader}. Uses components {@link IndexComponentType#PRIMARY_KEY_TRIE}, {@link IndexComponentType#PRIMARY_KEY_BLOCKS},
+ *     {@link IndexComponentType#PRIMARY_KEY_BLOCK_OFFSETS}</li>
  * </ul>
  *
  * While the {@link RowAwarePrimaryKeyMapFactory} is threadsafe, individual instances of the {@link RowAwarePrimaryKeyMap}
@@ -86,16 +87,17 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         {
             try
             {
-                MetadataSource metadataSource = MetadataSource.loadGroupMetadata(indexDescriptor);
-                NumericValuesMeta tokensMeta = new NumericValuesMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.TOKEN_VALUES)));
-                SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS)));
-                NumericValuesMeta blockOffsetsMeta = new NumericValuesMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS)));
+                IndexComponents.ForRead perSSTableComponents = indexDescriptor.perSSTableComponents();
+                MetadataSource metadataSource = MetadataSource.loadMetadata(perSSTableComponents);
+                NumericValuesMeta tokensMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.TOKEN_VALUES)));
+                SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS)));
+                NumericValuesMeta blockOffsetsMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS)));
 
-                token = indexDescriptor.createPerSSTableFileHandle(IndexComponent.TOKEN_VALUES);
+                token = perSSTableComponents.get(IndexComponentType.TOKEN_VALUES).createFileHandle();
                 this.tokenReaderFactory = new BlockPackedReader(token, tokensMeta);
-                this.termsDataBlockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS);
-                this.termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
-                this.termsTrie = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_TRIE);
+                this.termsDataBlockOffsets = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS).createFileHandle();
+                this.termsData = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS).createFileHandle();
+                this.termsTrie = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_TRIE).createFileHandle();
                 this.sortedTermsReader = new SortedTermsReader(termsData, termsDataBlockOffsets, termsTrie, sortedTermsMeta, blockOffsetsMeta);
                 this.partitioner = sstable.metadata().partitioner;
                 this.primaryKeyFactory = indexDescriptor.primaryKeyFactory;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PerSSTableWriter;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
@@ -89,15 +90,15 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public PrimaryKey.Factory primaryKeyFactory(ClusteringComparator comparator)
+    public PrimaryKey.Factory newPrimaryKeyFactory(ClusteringComparator comparator)
     {
         return new RowAwarePrimaryKeyFactory(comparator);
     }
 
     @Override
-    public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexDescriptor indexDescriptor, SSTableReader sstable) throws IOException
+    public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable)
     {
-        return new RowAwarePrimaryKeyMap.RowAwarePrimaryKeyMapFactory(indexDescriptor, sstable);
+        return new RowAwarePrimaryKeyMap.RowAwarePrimaryKeyMapFactory(perSSTableComponents, primaryKeyFactory, sstable);
     }
 
     @Override
@@ -118,15 +119,15 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
     {
         if (indexContext.isVector())
             return VECTOR_COMPONENTS_V2;
-        return super.perIndexComponents(indexContext);
+        return super.perIndexComponentTypes(indexContext);
     }
 
     @Override
-    public Set<IndexComponentType> perSSTableComponents()
+    public Set<IndexComponentType> perSSTableComponentTypes()
     {
         return PER_SSTABLE_COMPONENTS;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -32,18 +32,15 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PerSSTableWriter;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
-import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.lucene.store.IndexInput;
 
 /**
  * Updates SAI OnDiskFormat to include full PK -> offset mapping, and adds vector components.
@@ -52,18 +49,18 @@ public class V2OnDiskFormat extends V1OnDiskFormat
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final Set<IndexComponent> PER_SSTABLE_COMPONENTS = EnumSet.of(IndexComponent.GROUP_COMPLETION_MARKER,
-                                                                                 IndexComponent.GROUP_META,
-                                                                                 IndexComponent.TOKEN_VALUES,
-                                                                                 IndexComponent.PRIMARY_KEY_TRIE,
-                                                                                 IndexComponent.PRIMARY_KEY_BLOCKS,
-                                                                                 IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS);
+    private static final Set<IndexComponentType> PER_SSTABLE_COMPONENTS = EnumSet.of(IndexComponentType.GROUP_COMPLETION_MARKER,
+                                                                                     IndexComponentType.GROUP_META,
+                                                                                     IndexComponentType.TOKEN_VALUES,
+                                                                                     IndexComponentType.PRIMARY_KEY_TRIE,
+                                                                                     IndexComponentType.PRIMARY_KEY_BLOCKS,
+                                                                                     IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS);
 
-    public static final Set<IndexComponent> VECTOR_COMPONENTS_V2 = EnumSet.of(IndexComponent.COLUMN_COMPLETION_MARKER,
-                                                                              IndexComponent.META,
-                                                                              IndexComponent.VECTOR,
-                                                                              IndexComponent.TERMS_DATA,
-                                                                              IndexComponent.POSTING_LISTS);
+    public static final Set<IndexComponentType> VECTOR_COMPONENTS_V2 = EnumSet.of(IndexComponentType.COLUMN_COMPLETION_MARKER,
+                                                                                  IndexComponentType.META,
+                                                                                  IndexComponentType.VECTOR,
+                                                                                  IndexComponentType.TERMS_DATA,
+                                                                                  IndexComponentType.POSTING_LISTS);
 
     public static final V2OnDiskFormat instance = new V2OnDiskFormat();
 
@@ -110,49 +107,18 @@ public class V2OnDiskFormat extends V1OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 
     @Override
     public PerSSTableWriter newPerSSTableWriter(IndexDescriptor indexDescriptor) throws IOException
     {
-        return new SSTableComponentsWriter(indexDescriptor);
+        return new SSTableComponentsWriter(indexDescriptor.newPerSSTableComponentsForWrite());
     }
 
     @Override
-    public boolean validatePerSSTableComponents(IndexDescriptor indexDescriptor, boolean checksum)
-    {
-        for (IndexComponent indexComponent : perSSTableComponents())
-        {
-            if (isBuildCompletionMarker(indexComponent))
-                continue;
-
-            try (IndexInput input = indexDescriptor.openPerSSTableInput(indexComponent))
-            {
-                Version earliest = getExpectedEarliestVersion(indexComponent);
-                if (checksum)
-                    SAICodecUtils.validateChecksum(input);
-                else
-                    SAICodecUtils.validate(input, earliest);
-            }
-            catch (Throwable e)
-            {
-                if (logger.isDebugEnabled())
-                {
-                    logger.debug(indexDescriptor.logMessage("{} failed for index component {} on SSTable {}"),
-                                 (checksum ? "Checksum validation" : "Validation"),
-                                 indexComponent,
-                                 indexDescriptor.descriptor);
-                }
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public Set<IndexComponent> perIndexComponents(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext)
     {
         if (indexContext.isVector())
             return VECTOR_COMPONENTS_V2;
@@ -160,7 +126,7 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponent> perSSTableComponents()
+    public Set<IndexComponentType> perSSTableComponents()
     {
         return PER_SSTABLE_COMPONENTS;
     }
@@ -172,10 +138,10 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public ByteOrder byteOrderFor(IndexComponent indexComponent, IndexContext context)
+    public ByteOrder byteOrderFor(IndexComponentType indexComponentType, IndexContext context)
     {
         // The little-endian files are written by Lucene, and the upgrade to Lucene 9 switched the byte order from big to little.
-        switch (indexComponent)
+        switch (indexComponentType)
         {
             case META:
             case GROUP_META:

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -47,7 +47,6 @@ import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyWithSource;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
@@ -95,13 +94,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     public V2VectorIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
                                  PerIndexFiles perIndexFiles,
                                  SegmentMetadata segmentMetadata,
-                                 IndexDescriptor indexDescriptor,
                                  IndexContext indexContext) throws IOException
     {
         this(primaryKeyMapFactory,
              perIndexFiles,
              segmentMetadata,
-             indexDescriptor,
              indexContext,
              new CassandraOnDiskHnsw(segmentMetadata.componentMetadatas, perIndexFiles, indexContext));
     }
@@ -109,11 +106,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     protected V2VectorIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
                                     PerIndexFiles perIndexFiles,
                                     SegmentMetadata segmentMetadata,
-                                    IndexDescriptor indexDescriptor,
                                     IndexContext indexContext,
                                     JVectorLuceneOnDiskGraph graph)
     {
-        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexDescriptor, indexContext);
+        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexContext);
         this.graph = graph;
         this.keyFactory = PrimaryKey.factory(indexContext.comparator(), indexContext.indexFeatureSet());
         cachedBits = ThreadLocal.withInitial(SparseBits::new);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -36,7 +36,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.vector.JVectorLuceneOnDiskGraph;
@@ -76,12 +76,12 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         similarityFunction = context.getIndexWriterConfig().getSimilarityFunction();
 
         vectorsFile = indexFiles.vectors();
-        long vectorsSegmentOffset = this.componentMetadatas.get(IndexComponent.VECTOR).offset;
+        long vectorsSegmentOffset = this.componentMetadatas.get(IndexComponentType.VECTOR).offset;
 
-        SegmentMetadata.ComponentMetadata postingListsMetadata = this.componentMetadatas.get(IndexComponent.POSTING_LISTS);
+        SegmentMetadata.ComponentMetadata postingListsMetadata = this.componentMetadatas.get(IndexComponentType.POSTING_LISTS);
         ordinalsMap = new OnDiskOrdinalsMap(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
 
-        SegmentMetadata.ComponentMetadata termsMetadata = this.componentMetadatas.get(IndexComponent.TERMS_DATA);
+        SegmentMetadata.ComponentMetadata termsMetadata = this.componentMetadatas.get(IndexComponentType.TERMS_DATA);
         hnsw = new OnDiskHnswGraph(indexFiles.termsData(), termsMetadata.offset, termsMetadata.length, OFFSET_CACHE_MIN_BYTES);
         vectors = new OnDiskVectors(vectorsFile, vectorsSegmentOffset);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
@@ -26,6 +26,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import com.google.common.base.Preconditions;
 
 import io.micrometer.core.lang.NonNull;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.disk.v1.MetadataWriter;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesWriter;
@@ -74,7 +75,7 @@ public class SortedTermsWriter implements Closeable
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
 
     private final IncrementalTrieWriter<Long> trieWriter;
-    private final IndexOutput trieOutput;
+    private final IndexOutputWriter trieOutput;
     private final IndexOutput termsOutput;
     private final NumericValuesWriter offsetsWriter;
     private final String componentName;
@@ -94,26 +95,24 @@ public class SortedTermsWriter implements Closeable
      * It does not own the components, so you must close the components by yourself
      * after you're done with the writer.
      *
-     * @param componentName the component name for the SortedTermsMeta
+     * @param termsDataComponent component builder for the prefix-compressed terms data
      * @param metadataWriter the MetadataWriter for storing the SortedTermsMeta
-     * @param termsData where to write the prefix-compressed terms data
      * @param termsDataBlockOffsets  where to write the offsets of each block of terms data
-     * @param trieWriter where to write the trie that maps the terms to point ids
+     * @param trieComponent component where to write the trie that maps the terms to point ids
      */
-    public SortedTermsWriter(@NonNull String componentName,
+    public SortedTermsWriter(@NonNull IndexComponent.ForWrite termsDataComponent,
                              @NonNull MetadataWriter metadataWriter,
-                             @Nonnull IndexOutput termsData,
                              @Nonnull NumericValuesWriter termsDataBlockOffsets,
-                             @Nonnull IndexOutputWriter trieWriter) throws IOException
+                             @Nonnull IndexComponent.ForWrite trieComponent) throws IOException
     {
-        this.componentName = componentName;
+        this.componentName = termsDataComponent.fileNamePart();
         this.metadataWriter = metadataWriter;
-        this.trieOutput = trieWriter;
+        this.trieOutput = trieComponent.openOutput();
         SAICodecUtils.writeHeader(this.trieOutput);
-        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieWriter.asSequentialWriter(), ByteComparable.Version.OSS41);
-        SAICodecUtils.writeHeader(termsData);
-        this.termsOutput = termsData;
-        this.bytesStartFP = termsData.getFilePointer();
+        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieOutput.asSequentialWriter(), ByteComparable.Version.OSS41);
+        this.termsOutput = termsDataComponent.openOutput();
+        SAICodecUtils.writeHeader(termsOutput);
+        this.bytesStartFP = termsOutput.getFilePointer();
         this.offsetsWriter = termsDataBlockOffsets;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -44,7 +44,7 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.vector.AutoResumingNodeScoreIterator;
@@ -89,13 +89,13 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
 
         similarityFunction = context.getIndexWriterConfig().getSimilarityFunction();
 
-        SegmentMetadata.ComponentMetadata termsMetadata = this.componentMetadatas.get(IndexComponent.TERMS_DATA);
+        SegmentMetadata.ComponentMetadata termsMetadata = this.componentMetadatas.get(IndexComponentType.TERMS_DATA);
         graphHandle = indexFiles.termsData();
         var rawGraph = OnDiskGraphIndex.load(graphHandle::createReader, termsMetadata.offset);
         features = rawGraph.getFeatureSet();
         graph = V3OnDiskFormat.ENABLE_EDGES_CACHE ? cachingGraphFor(rawGraph) : rawGraph;
 
-        long pqSegmentOffset = this.componentMetadatas.get(IndexComponent.PQ).offset;
+        long pqSegmentOffset = this.componentMetadatas.get(IndexComponentType.PQ).offset;
         try (var pqFile = indexFiles.pq();
              var reader = pqFile.createReader())
         {
@@ -151,7 +151,7 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
             }
         }
 
-        SegmentMetadata.ComponentMetadata postingListsMetadata = this.componentMetadatas.get(IndexComponent.POSTING_LISTS);
+        SegmentMetadata.ComponentMetadata postingListsMetadata = this.componentMetadatas.get(IndexComponentType.POSTING_LISTS);
         ordinalsMap = new OnDiskOrdinalsMap(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
 
         searchers = ExplicitThreadLocal.withInitial(() -> new GraphSearcher(graph));

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -93,12 +93,12 @@ public class V3OnDiskFormat extends V2OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
     {
         // VSTODO add checksums and actual validation
         if (indexContext.isVector())
             return VECTOR_COMPONENTS_V3;
-        return super.perIndexComponents(indexContext);
+        return super.perIndexComponentTypes(indexContext);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
@@ -54,11 +54,11 @@ public class V3OnDiskFormat extends V2OnDiskFormat
 
     public static final V3OnDiskFormat instance = new V3OnDiskFormat();
 
-    public static final Set<IndexComponent> VECTOR_COMPONENTS_V3 = EnumSet.of(IndexComponent.COLUMN_COMPLETION_MARKER,
-                                                                              IndexComponent.META,
-                                                                              IndexComponent.PQ,
-                                                                              IndexComponent.TERMS_DATA,
-                                                                              IndexComponent.POSTING_LISTS);
+    public static final Set<IndexComponentType> VECTOR_COMPONENTS_V3 = EnumSet.of(IndexComponentType.COLUMN_COMPLETION_MARKER,
+                                                                                  IndexComponentType.META,
+                                                                                  IndexComponentType.PQ,
+                                                                                  IndexComponentType.TERMS_DATA,
+                                                                                  IndexComponentType.POSTING_LISTS);
 
     private static final IndexFeatureSet v3IndexFeatureSet = new IndexFeatureSet()
     {
@@ -88,12 +88,12 @@ public class V3OnDiskFormat extends V2OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 
     @Override
-    public Set<IndexComponent> perIndexComponents(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponents(IndexContext indexContext)
     {
         // VSTODO add checksums and actual validation
         if (indexContext.isVector())

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3VectorIndexSearcher.java
@@ -35,10 +35,9 @@ public class V3VectorIndexSearcher extends V2VectorIndexSearcher
     public V3VectorIndexSearcher(PrimaryKeyMap.Factory primaryKeyMapFactory,
                                  PerIndexFiles perIndexFiles,
                                  SegmentMetadata segmentMetadata,
-                                 IndexDescriptor indexDescriptor,
                                  IndexContext indexContext) throws IOException
     {
-        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexDescriptor, indexContext, new CassandraDiskAnn(segmentMetadata.componentMetadatas, perIndexFiles, indexContext));
+        super(primaryKeyMapFactory, perIndexFiles, segmentMetadata, indexContext, new CassandraDiskAnn(segmentMetadata.componentMetadatas, perIndexFiles, indexContext));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.disk.vector;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,15 +74,15 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.Segment;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.v3.CassandraDiskAnn;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType;
-import org.apache.cassandra.index.sai.utils.IndexFileUtils;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.index.sai.utils.ScoredPrimaryKey;
 import org.apache.cassandra.io.util.SequentialWriter;
@@ -119,7 +118,6 @@ public class CassandraOnHeapGraph<T> implements Accountable
     private final NonBlockingHashMap<T, VectorFloat<?>> vectorsByKey;
     private final AtomicInteger nextOrdinal = new AtomicInteger();
     private final VectorSourceModel sourceModel;
-    private final IndexContext context;
     private final InvalidVectorBehavior invalidVectorBehavior;
     private volatile boolean hasDeletions;
 
@@ -131,7 +129,6 @@ public class CassandraOnHeapGraph<T> implements Accountable
      */
     public CassandraOnHeapGraph(IndexContext context, boolean forSearching)
     {
-        this.context = context;
         var indexConfig = context.getIndexWriterConfig();
         var termComparator = context.getValidator();
         serializer = (VectorType.VectorSerializer) termComparator.getSerializer();
@@ -331,7 +328,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         return deletedOrdinals;
     }
 
-    public SegmentMetadata.ComponentMetadataMap flush(IndexDescriptor descriptor, Set<Integer> deletedOrdinals) throws IOException
+    public SegmentMetadata.ComponentMetadataMap flush(IndexComponents.ForWrite perIndexComponents, Set<Integer> deletedOrdinals) throws IOException
     {
         int nInProgress = builder.insertsInProgress();
         assert nInProgress == 0 : String.format("Attempting to write graph while %d inserts are in progress", nInProgress);
@@ -352,14 +349,13 @@ public class CassandraOnHeapGraph<T> implements Accountable
                                                 : x -> x;
         var finalOrdinalMap = ordinalMap == null ? OnDiskGraphIndexWriter.sequentialRenumbering(builder.getGraph()) : ordinalMap;
 
-        var indexFile = descriptor.fileFor(IndexComponent.TERMS_DATA, context);
+        IndexComponent.ForWrite termsDataComponent = perIndexComponents.addOrGet(IndexComponentType.TERMS_DATA);
+        var indexFile = termsDataComponent.file();
         long termsOffset = SAICodecUtils.headerSize();
         if (indexFile.exists())
             termsOffset += indexFile.length();
-        var pqOrder = descriptor.getVersion(context).onDiskFormat().byteOrderFor(IndexComponent.PQ, context);
-        var postingsOrder = descriptor.getVersion(context).onDiskFormat().byteOrderFor(IndexComponent.POSTING_LISTS, context);
-        try (var pqOutput = IndexFileUtils.instance.openOutput(descriptor.fileFor(IndexComponent.PQ, context), pqOrder, true);
-             var postingsOutput = IndexFileUtils.instance.openOutput(descriptor.fileFor(IndexComponent.POSTING_LISTS, context), postingsOrder, true);
+        try (var pqOutput = perIndexComponents.addOrGet(IndexComponentType.PQ).openOutput(true);
+             var postingsOutput = perIndexComponents.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true);
              var indexWriter = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
                                .withVersion(JVECTOR_2_VERSION) // always write old-version format since we're not using the new features
                                .withMap(finalOrdinalMap)
@@ -375,7 +371,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
             // compute and write PQ
             long pqOffset = pqOutput.getFilePointer();
-            long pqPosition = writePQ(pqOutput.asSequentialWriter(), reverseOrdinalMapper, context);
+            long pqPosition = writePQ(pqOutput.asSequentialWriter(), reverseOrdinalMapper, perIndexComponents.context());
             long pqLength = pqPosition - pqOffset;
 
             // write postings
@@ -407,10 +403,10 @@ public class CassandraOnHeapGraph<T> implements Accountable
     static SegmentMetadata.ComponentMetadataMap createMetadataMap(long termsOffset, long termsLength, long postingsOffset, long postingsLength, long pqOffset, long pqLength)
     {
         SegmentMetadata.ComponentMetadataMap metadataMap = new SegmentMetadata.ComponentMetadataMap();
-        metadataMap.put(IndexComponent.TERMS_DATA, -1, termsOffset, termsLength, Map.of());
-        metadataMap.put(IndexComponent.POSTING_LISTS, -1, postingsOffset, postingsLength, Map.of());
+        metadataMap.put(IndexComponentType.TERMS_DATA, -1, termsOffset, termsLength, Map.of());
+        metadataMap.put(IndexComponentType.POSTING_LISTS, -1, postingsOffset, postingsLength, Map.of());
         Map<String, String> vectorConfigs = Map.of("SEGMENT_ID", ByteBufferUtil.bytesToHex(ByteBuffer.wrap(StringHelper.randomId())));
-        metadataMap.put(IndexComponent.PQ, -1, pqOffset, pqLength, vectorConfigs);
+        metadataMap.put(IndexComponentType.PQ, -1, pqOffset, pqLength, vectorConfigs);
         return metadataMap;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -50,7 +50,7 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.plan.Expression;
@@ -371,9 +371,9 @@ public class VectorMemtableIndex implements MemtableIndex
         return graph.size();
     }
 
-    public SegmentMetadata.ComponentMetadataMap writeData(IndexDescriptor indexDescriptor, Set<Integer> deletedOrdinals) throws IOException
+    public SegmentMetadata.ComponentMetadataMap writeData(IndexComponents.ForWrite perIndexComponents, Set<Integer> deletedOrdinals) throws IOException
     {
-        return graph.flush(indexDescriptor, deletedOrdinals);
+        return graph.flush(perIndexComponents, deletedOrdinals);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
+++ b/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
@@ -21,7 +21,9 @@ package org.apache.cassandra.index.sai.view;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -33,6 +35,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Pair;
 
@@ -81,7 +84,7 @@ public class IndexViewManager
         Pair<Set<SSTableIndex>, Set<SSTableContext>> indexes = context.getBuiltIndexes(newSSTableContexts, validate);
 
         View currentView, newView;
-        Collection<SSTableIndex> newViewIndexes = new HashSet<>();
+        Map<Descriptor, SSTableIndex> newViewIndexes = new HashMap<>();
         Collection<SSTableIndex> releasableIndexes = new ArrayList<>();
         Collection<SSTableReader> toRemove = new HashSet<>(oldSSTables);
         
@@ -97,21 +100,18 @@ public class IndexViewManager
                 // but different SSTableReader java objects with different start positions. So we need to release them
                 // from existing view.  see DSP-19677
                 SSTableReader sstable = sstableIndex.getSSTable();
-                if (toRemove.contains(sstable) || newViewIndexes.contains(sstableIndex))
+                if (toRemove.contains(sstable))
                     releasableIndexes.add(sstableIndex);
                 else
-                    newViewIndexes.add(sstableIndex);
+                    addOrUpdateSSTableIndex(sstableIndex, newViewIndexes, releasableIndexes);
             }
 
             for (SSTableIndex sstableIndex : indexes.left)
             {
-                if (newViewIndexes.contains(sstableIndex))
-                    releasableIndexes.add(sstableIndex);
-                else
-                    newViewIndexes.add(sstableIndex);
+                addOrUpdateSSTableIndex(sstableIndex, newViewIndexes, releasableIndexes);
             }
 
-            newView = new View(context, newViewIndexes);
+            newView = new View(context, newViewIndexes.values());
         }
         while (!view.compareAndSet(currentView, newView));
 
@@ -121,6 +121,26 @@ public class IndexViewManager
             logger.trace(context.logMessage("There are now {} active SSTable indexes."), view.get().getIndexes().size());
 
         return indexes.right;
+    }
+
+    private static void addOrUpdateSSTableIndex(SSTableIndex ssTableIndex, Map<Descriptor, SSTableIndex> addTo, Collection<SSTableIndex> toRelease)
+    {
+        var descriptor = ssTableIndex.getSSTable().descriptor;
+        SSTableIndex previous = addTo.get(descriptor);
+        if (previous != null)
+        {
+            // If the new index use the same files that the exiting one (and the previous one is still complete, meaning
+            // that the files weren't corrupted), then keep the old one (no point in changing for the same thing).
+            if (previous.usedPerIndexComponents().isComplete() && ssTableIndex.usedPerIndexComponents().hasSameVersionAndGenerationThan(previous.usedPerIndexComponents()))
+            {
+                toRelease.add(ssTableIndex);
+                return;
+            }
+
+            // Otherwise, release the old, and we'll replace by the new one below.
+            toRelease.add(previous);
+        }
+        addTo.put(descriptor, ssTableIndex);
     }
 
     public void prepareSSTablesForRebuild(Collection<SSTableReader> sstablesToRebuild)

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -347,7 +347,7 @@ public abstract class SSTable
      * @param skipMissing, skip adding the component to the returned set if the corresponding file is missing.
      * @return set of components found in the TOC
      */
-    protected static Set<Component> readTOC(Descriptor descriptor, boolean skipMissing) throws IOException
+    public static Set<Component> readTOC(Descriptor descriptor, boolean skipMissing) throws IOException
     {
         File tocFile = descriptor.fileFor(Component.TOC);
         List<String> componentNames = Files.readAllLines(tocFile.toPath());

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -84,7 +84,7 @@ public abstract class SSTable
     public static final int TOMBSTONE_HISTOGRAM_TTL_ROUND_SECONDS = Integer.valueOf(System.getProperty("cassandra.streaminghistogram.roundseconds", "60"));
 
     public final Descriptor descriptor;
-    public final Set<Component> components;
+    private volatile ImmutableSet<Component> components;
     public final boolean compression;
 
     public DecoratedKey first;
@@ -103,17 +103,15 @@ public abstract class SSTable
         assert components != null;
 
         this.descriptor = descriptor;
-        Set<Component> dataComponents = new HashSet<>(components);
-        this.compression = dataComponents.contains(Component.COMPRESSION_INFO);
-        this.components = new CopyOnWriteArraySet<>(dataComponents);
+        this.compression = components.contains(Component.COMPRESSION_INFO);
+        this.components = ImmutableSet.copyOf(components);
         this.metadata = metadata;
         this.optimizationStrategy = Objects.requireNonNull(optimizationStrategy);
     }
 
-    @VisibleForTesting
-    public Set<Component> getComponents()
+    public ImmutableSet<Component> components()
     {
-        return ImmutableSet.copyOf(components);
+        return components;
     }
 
     /**
@@ -414,18 +412,13 @@ public abstract class SSTable
     public synchronized void registerComponents(Collection<Component> newComponents, Tracker tracker)
     {
         Collection<Component> componentsToAdd = new HashSet<>(Collections2.filter(newComponents, x -> !components.contains(x)));
-        appendTOC(descriptor, componentsToAdd);
-        components.addAll(componentsToAdd);
-
-        if (tracker == null)
+        if (componentsToAdd.isEmpty())
             return;
 
-        for (Component component : componentsToAdd)
-        {
-            File file = descriptor.fileFor(component);
-            if (file.exists())
-                tracker.updateSizeTracking(file.length());
-        }
+        appendTOC(descriptor, componentsToAdd);
+        components = ImmutableSet.<Component>builder().addAll(components).addAll(componentsToAdd).build();
+
+        updateComponentsTracking(componentsToAdd, tracker, 1);
     }
 
     /**
@@ -435,15 +428,62 @@ public abstract class SSTable
      */
     public synchronized void unregisterComponents(Collection<Component> removeComponents, Tracker tracker)
     {
-        Collection<Component> componentsToRemove = new HashSet<>(Collections2.filter(removeComponents, components::contains));
-        components.removeAll(componentsToRemove);
+        Set<Component> componentsToRemove = new HashSet<>(Collections2.filter(removeComponents, components::contains));
+        components = Sets.difference(components, componentsToRemove).immutableCopy();
         rewriteTOC(descriptor, components);
 
-        for (Component component : componentsToRemove)
+        updateComponentsTracking(componentsToRemove, tracker, -1);
+    }
+
+    private void updateComponentsTracking(Collection<Component> toUpdate, Tracker tracker, long multiplier)
+    {
+        if (tracker == null)
+            return;
+
+        for (Component component : toUpdate)
         {
             File file = descriptor.fileFor(component);
             if (file.exists())
-                tracker.updateSizeTracking(-file.length());
+                tracker.updateSizeTracking(multiplier * file.length());
+        }
+    }
+
+    /**
+     * Reads components from the TOC file and update the `components` set of this object accordindly.
+     * <p>
+     * Usually, components are added/removed through {@link #addComponents}, {@link #registerComponents} or
+     * {@link #unregisterComponents}, which both update this object component and update the TOC file accordingly, and
+     * this method should not be used. But some implementation of tiered storage may add components/rewrite the TOC
+     * "externally" (one reason can be offloading index rebuild) and need those change to be reflected to this object
+     * and this is where this method comes in.
+     * <p>
+     * If the TOC file does not exist, cannot be read, or does not at least contains the minimal components that all
+     * sstables should have when this is called, this method is a no-op.
+     */
+    public synchronized void reloadComponentsFromTOC(Tracker tracker)
+    {
+        try
+        {
+            Set<Component> tocComponents = readTOC(descriptor);
+            Set<Component> requiredComponents = descriptor.formatType.info.requiredComponents();
+            if (!tocComponents.containsAll(requiredComponents))
+            {
+                logger.error("Cannot reload components from read TOC file for {}; the TOC does not contain all the required components for the sstable type and is like corrupted (components in TOC: {}, required by sstable format: {})",
+                             descriptor, tocComponents, requiredComponents);
+                return;
+            }
+
+            Set<Component> toAdd = Sets.difference(tocComponents, components);
+            Set<Component> toRemove = Sets.difference(components, tocComponents);
+            components = ImmutableSet.copyOf(tocComponents);
+
+            updateComponentsTracking(toAdd, tracker, 1);
+            updateComponentsTracking(toRemove, tracker, -1);
+
+        }
+        catch (IOException e)
+        {
+            logger.error("Failed to read TOC file for {}; ignoring component reload", descriptor, e);
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1002,7 +1002,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     private SSTableReader cloneAndReplace(DecoratedKey newFirst, OpenReason reason, IndexSummary newSummary)
     {
         SSTableReader replacement = internalOpen(descriptor,
-                                                 components,
+                                                 components(),
                                                  metadata,
                                                  ifile != null ? ifile.sharedCopy() : null,
                                                  dfile.sharedCopy(),
@@ -1030,7 +1030,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     public SSTableReader cloneAndReplace(IFilter newBloomFilter)
     {
         SSTableReader replacement = internalOpen(descriptor,
-                                                 components,
+                                                 components(),
                                                  metadata,
                                                  ifile.sharedCopy(),
                                                  dfile.sharedCopy(),
@@ -1867,7 +1867,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
     public void createLinks(String snapshotDirectoryPath, RateLimiter rateLimiter)
     {
-        createLinks(descriptor, components, snapshotDirectoryPath, rateLimiter);
+        createLinks(descriptor, components(), snapshotDirectoryPath, rateLimiter);
     }
 
     public static void createLinks(Descriptor descriptor, Set<Component> components, String snapshotDirectoryPath)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -105,7 +105,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         isInternalKeyspace = SchemaConstants.isInternalKeyspace(metadata.keyspace);
     }
 
-    private static Set<Component> indexComponents(Descriptor descriptor, TableMetadata metadata, Collection<Index.Group> indexGroups)
+    private static Set<Component> indexComponents(Collection<Index.Group> indexGroups)
     {
         if (indexGroups == null)
             return Collections.emptySet();
@@ -113,7 +113,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         Set<Component> components = new HashSet<>();
         for (Index.Group group : indexGroups)
         {
-            components.addAll(group.componentsForNewBuid(descriptor, metadata));
+            components.addAll(group.componentsForNewSSTable());
         }
 
         return components;
@@ -131,12 +131,6 @@ public abstract class SSTableWriter extends SSTable implements Transactional
                                        LifecycleNewTracker lifecycleNewTracker)
     {
         Factory writerFactory = descriptor.getFormat().getWriterFactory();
-        // For SAI, it is important that this list of components is computed before any of the new components are
-        // actually created: otherwise, said computation would see the components and consider them part of some
-        // previous aborted build, and would anticipate the wrong "generation". And some SAI components are created
-        // by the `observers(...)` call below, as the SAI flush observer is created, so effectively this
-        // `indexComponents(...)` call need to be before the `observers(...)` one.
-        Set<Component> components = indexComponents(descriptor, metadata.get(), indexGroups);
         return writerFactory.open(descriptor,
                                   keyCount,
                                   repairedAt,
@@ -147,7 +141,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
                                   header,
                                   observers(descriptor, indexGroups, lifecycleNewTracker, metadata.get(), keyCount),
                                   lifecycleNewTracker,
-                                  components);
+                                  indexComponents(indexGroups));
     }
 
     public static SSTableWriter create(Descriptor descriptor,

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
@@ -127,6 +127,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
         for (SequentialWriter writer : componentWriters.values())
             writer.finish();
 
+        SSTable.appendTOC(descriptor, components);
         return finished();
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableZeroCopyWriter.java
@@ -39,7 +39,6 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.SSTableMultiWriter;
 import org.apache.cassandra.io.util.DataInputPlus;
-import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.net.AsyncStreamingInputPlus;
@@ -127,7 +126,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
         for (SequentialWriter writer : componentWriters.values())
             writer.finish();
 
-        SSTable.appendTOC(descriptor, components);
+        SSTable.appendTOC(descriptor, components());
         return finished();
     }
 
@@ -135,7 +134,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     public Collection<SSTableReader> finished()
     {
         if (finalReader == null)
-            finalReader = descriptor.getFormat().getReaderFactory().open(descriptor, components, metadata);
+            finalReader = descriptor.getFormat().getReaderFactory().open(descriptor, components(), metadata);
 
         return ImmutableList.of(finalReader);
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -349,7 +349,7 @@ public abstract class SortedTableWriter extends SSTableWriter
             writeMetadata(descriptor, finalizeMetadata(), writerOption());
 
             // save the table of components
-            SSTable.appendTOC(descriptor, components);
+            SSTable.appendTOC(descriptor, components());
         }
 
         private void openResult()

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -202,7 +202,7 @@ public class BigTableWriter extends SortedTableWriter
         FileHandle dfile = dbuilder.bufferSize(dataBufferSize).complete(boundary.dataLength);
         invalidateCacheAtBoundary(dfile);
         SSTableReader sstable = BigTableReader.internalOpen(descriptor,
-                                                           components, metadata,
+                                                           components(), metadata,
                                                            ifile, dfile,
                                                            indexSummary,
                                                            iwriter.bf.sharedCopy(),
@@ -245,7 +245,7 @@ public class BigTableWriter extends SortedTableWriter
         FileHandle dfile = dbuilder.bufferSize(dataBufferSize).complete();
         invalidateCacheAtBoundary(dfile);
         SSTableReader sstable = SSTableReader.internalOpen(descriptor,
-                                                           components,
+                                                           components(),
                                                            metadata,
                                                            ifile,
                                                            dfile,
@@ -348,7 +348,7 @@ public class BigTableWriter extends SortedTableWriter
          */
         void flushBf()
         {
-            if (components.contains(Component.FILTER))
+            if (components().contains(Component.FILTER))
             {
                 File path = descriptor.fileFor(Component.FILTER);
                 try (FileOutputStreamPlus stream = new FileOutputStreamPlus(path))

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -137,7 +137,7 @@ public class TrieIndexSSTableReader extends SSTableReader
     private TrieIndexSSTableReader cloneInternal(DecoratedKey first, OpenReason openReason, IFilter bf)
     {
         TrieIndexSSTableReader clone = new TrieIndexSSTableReader(descriptor,
-                                                                  components,
+                                                                  components(),
                                                                   metadata,
                                                                   maxDataAge,
                                                                   sstableMetadata,

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
@@ -191,7 +191,7 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
             FileHandle dfile = dbuilder.bufferSize(dataBufferSize).complete(dataFile.getLastFlushOffset());
             invalidateCacheAtBoundary(dfile);
             SSTableReader sstable = TrieIndexSSTableReader.internalOpen(descriptor,
-                                                               components, metadata,
+                                                               components(), metadata,
                                                                ifile, dfile, partitionIndex, iwriter.bf.sharedCopy(),
                                                                maxDataAge, stats, SSTableReader.OpenReason.EARLY, header);
 
@@ -231,7 +231,7 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
         FileHandle dfile = dbuilder.bufferSize(dataBufferSize).complete();
         invalidateCacheAtBoundary(dfile);
         SSTableReader sstable = TrieIndexSSTableReader.internalOpen(descriptor,
-                                                            components,
+                                                            components(),
                                                             this.metadata,
                                                             rowIndexFile,
                                                             dfile,
@@ -361,7 +361,7 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
          */
         void flushBf()
         {
-            if (components.contains(Component.FILTER))
+            if (components().contains(Component.FILTER))
             {
                 File path = descriptor.fileFor(Component.FILTER);
                 try (SeekableByteChannel fos = Files.newByteChannel(path.toPath(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -23,9 +23,9 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.RateLimiter;
 
 import org.apache.cassandra.cache.InstrumentingCache;
@@ -706,9 +706,9 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    public Set<Component> getComponents()
+    public ImmutableSet<Component> components()
     {
-        return delegate.getComponents();
+        return delegate.components();
     }
 
     @Override

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/AbstractOnDiskBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/AbstractOnDiskBenchmark.java
@@ -33,7 +33,8 @@ import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.io.IndexInput;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
@@ -124,17 +125,17 @@ public abstract class AbstractOnDiskBenchmark
                                     metadata.keyspace,
                                     metadata.name,
                                     Util.newUUIDGen().get());
-        indexDescriptor = IndexDescriptor.createNew(descriptor, metadata.partitioner, metadata.comparator);
+        indexDescriptor = IndexDescriptor.create(descriptor, metadata);
         index = "test";
         indexContext = SAITester.createIndexContext(index, IntegerType.instance);
 
         // write per-sstable components: token and offset
         writeSSTableComponents(numRows());
-        token = indexDescriptor.createPerSSTableFileHandle(IndexComponent.TOKEN_VALUES);
+        token = indexDescriptor.perSSTableComponents().get(IndexComponentType.TOKEN_VALUES).createFileHandle();
 
         // write postings
         summaryPosition = writePostings(numPostings());
-        postings = indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext);
+        postings = indexDescriptor.perIndexComponents(indexContext).get(IndexComponentType.POSTING_LISTS).createFileHandle();
     }
 
     @TearDown(Level.Trial)
@@ -162,7 +163,7 @@ public abstract class AbstractOnDiskBenchmark
         final int[] postings = IntStream.range(0, rows).map(this::toPosting).toArray();
         final ArrayPostingList postingList = new ArrayPostingList(postings);
 
-        try (PostingsWriter writer = new PostingsWriter(indexDescriptor, indexContext))
+        try (PostingsWriter writer = new PostingsWriter(indexDescriptor.newPerIndexComponentsForWrite(indexContext)))
         {
             long summaryPosition = writer.write(postingList);
             writer.complete();
@@ -182,7 +183,7 @@ public abstract class AbstractOnDiskBenchmark
 
     private void writeSSTableComponents(int rows) throws IOException
     {
-        SSTableComponentsWriter writer = new SSTableComponentsWriter(indexDescriptor);
+        SSTableComponentsWriter writer = new SSTableComponentsWriter(indexDescriptor.newPerSSTableComponentsForWrite());
         for (int i = 0; i < rows; i++)
             writer.recordCurrentTokenOffset(toToken(i), toOffset(i));
 
@@ -191,8 +192,9 @@ public abstract class AbstractOnDiskBenchmark
 
     protected final LongArray openRowIdToTokenReader() throws IOException
     {
-        MetadataSource source = MetadataSource.loadGroupMetadata(indexDescriptor);
-        NumericValuesMeta tokensMeta = new NumericValuesMeta(source.get(indexDescriptor.componentFileName(IndexComponent.TOKEN_VALUES)));
+        IndexComponents.ForRead components = indexDescriptor.perSSTableComponents();
+        MetadataSource source = MetadataSource.loadMetadata(components);
+        NumericValuesMeta tokensMeta = new NumericValuesMeta(source.get(components.get(IndexComponentType.TOKEN_VALUES)));
         return new BlockPackedReader(token, tokensMeta).open();
     }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/AbstractOnDiskBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/AbstractOnDiskBenchmark.java
@@ -125,7 +125,7 @@ public abstract class AbstractOnDiskBenchmark
                                     metadata.keyspace,
                                     metadata.name,
                                     Util.newUUIDGen().get());
-        indexDescriptor = IndexDescriptor.create(descriptor, metadata);
+        indexDescriptor = IndexDescriptor.empty(descriptor);
         index = "test";
         indexContext = SAITester.createIndexContext(index, IntegerType.instance);
 

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -360,7 +360,7 @@ public class ColumnFamilyStoreTest
         {
             Descriptor existing = liveSSTable.descriptor;
             Descriptor desc = new Descriptor(Directories.getBackupsDirectory(existing), KEYSPACE2, CF_STANDARD1, liveSSTable.descriptor.id, liveSSTable.descriptor.formatType);
-            for (Component c : liveSSTable.components)
+            for (Component c : liveSSTable.components())
                 assertTrue("Cannot find backed-up file:" + desc.fileFor(c), desc.fileFor(c).exists());
         }
     }

--- a/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
@@ -1361,8 +1361,8 @@ public class LogTransactionTest extends AbstractTransactionalTest
      */
     static Set<File> getAllFilePaths(SSTableReader sstable, boolean existingOnly)
     {
-        Set<File> ret = new HashSet<>(sstable.getComponents().size());
-        for (Component component : sstable.getComponents())
+        Set<File> ret = new HashSet<>(sstable.components().size());
+        for (Component component : sstable.components())
         {
             File path = sstable.descriptor.fileFor(component);
 

--- a/test/unit/org/apache/cassandra/index/CustomIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/CustomIndexTest.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -1675,7 +1676,13 @@ public class CustomIndexTest extends CQLTester
             }
 
             @Override
-            public Set<Component> getComponents()
+            public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
+            {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public Set<Component> activeComponents(SSTableReader sstable)
             {
                 return Collections.emptySet();
             }

--- a/test/unit/org/apache/cassandra/index/CustomIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/CustomIndexTest.java
@@ -1676,7 +1676,7 @@ public class CustomIndexTest extends CQLTester
             }
 
             @Override
-            public Set<Component> componentsForNewBuid(Descriptor descriptor, TableMetadata metadata)
+            public Set<Component> componentsForNewSSTable()
             {
                 return Collections.emptySet();
             }

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -176,7 +176,7 @@ public class SecondaryIndexManagerTest extends CQLTester
         // unlink sstable and index context: expect no rows to be read by base and index
         cfs.clearUnsafe();
         IndexMetadata indexMetadata = cfs.metadata().indexes.iterator().next();
-        ((StorageAttachedIndex) cfs.getIndexManager().getIndex(indexMetadata)).getIndexContext().drop(sstables);
+        ((StorageAttachedIndex) cfs.getIndexManager().getIndex(indexMetadata)).getIndexContext().prepareSSTablesForRebuild(sstables);
         assertEmpty(execute("SELECT * FROM %s WHERE a=1"));
         assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -398,11 +398,8 @@ public class SAITester extends CQLTester
                     if (sstableIndex.isEmpty())
                         continue;
 
-                    // Make sure the index does use the context it should (for which we already checked the version),
-                    // but note that `SSTableIndex` uses a "sharedCopy()" of the context, so we check equality of the
-                    // pk map factory (which should be same between original and a copy).
-                    assertEquals(sstableIndex.usedPerIndexComponents(), expectedVersion);
-
+                    // Make sure the index does use components of the proper version.
+                    assertEquals(sstableIndex.usedPerIndexComponents().version(), expectedVersion);
                 }
             }
         }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -30,14 +30,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.management.AttributeNotFoundException;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -65,13 +66,15 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.index.Index;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.ResourceLeakDetector;
+import org.apache.cassandra.inject.ActionBuilder;
+import org.apache.cassandra.inject.Expression;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.io.sstable.Component;
@@ -89,6 +92,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.awaitility.Awaitility;
 
 import static org.apache.cassandra.inject.ActionBuilder.newActionBuilder;
+import static org.apache.cassandra.inject.Expression.expr;
 import static org.apache.cassandra.inject.Expression.quote;
 import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
 import static org.junit.Assert.assertEquals;
@@ -105,20 +109,29 @@ public class SAITester extends CQLTester
 
     protected static int ASSERTION_TIMEOUT_SECONDS = 15;
 
+    protected static Injections.Counter.CounterBuilder addConditions(Injections.Counter.CounterBuilder builder, Consumer<ActionBuilder.ConditionsBuilder> adder)
+    {
+        adder.accept(builder.lastActionBuilder().conditions());
+        return builder;
+    }
+
+
     protected static final Injections.Counter INDEX_BUILD_COUNTER = Injections.newCounter("IndexBuildCounter")
                                                                               .add(newInvokePoint().onClass(CompactionManager.class)
                                                                                                    .onMethod("submitIndexBuild", "SecondaryIndexBuilder", "TableOperationObserver"))
                                                                               .build();
 
-    protected static final Injections.Counter perSSTableValidationCounter = Injections.newCounter("PerSSTableValidationCounter")
-                                                                                      .add(newInvokePoint().onClass(IndexDescriptor.class)
-                                                                                                           .onMethod("validatePerSSTableComponents"))
-                                                                                      .build();
+    protected static final Injections.Counter perSSTableValidationCounter = addConditions(Injections.newCounter("PerSSTableValidationCounter")
+                                                                                      .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
+                                                                                                           .onMethod("validateComponents")),
+                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+    ).build();
 
-    protected static final Injections.Counter perColumnValidationCounter = Injections.newCounter("PerColumnValidationCounter")
-                                                                                     .add(newInvokePoint().onClass(IndexDescriptor.class)
-                                                                                                          .onMethod("validatePerIndexComponents"))
-                                                                                     .build();
+    protected static final Injections.Counter perColumnValidationCounter = addConditions(Injections.newCounter("PerColumnValidationCounter")
+                                                                                     .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
+                                                                                                          .onMethod("validateComponents")),
+                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+    ).build();
 
     protected static ColumnIdentifier V1_COLUMN_IDENTIFIER = ColumnIdentifier.getInterned("v1", true);
     protected static ColumnIdentifier V2_COLUMN_IDENTIFIER = ColumnIdentifier.getInterned("v2", true);
@@ -268,24 +281,24 @@ public class SAITester extends CQLTester
         }
     }
 
-    protected void corruptIndexComponent(IndexComponent indexComponent, CorruptionType corruptionType) throws Exception
+    protected void corruptIndexComponent(IndexComponentType indexComponentType, CorruptionType corruptionType) throws Exception
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
 
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
-            File file = IndexDescriptor.createFrom(sstable).fileFor(indexComponent);
+            File file = IndexDescriptor.create(sstable).perSSTableComponents().get(indexComponentType).file();
             corruptionType.corrupt(file);
         }
     }
 
-    protected void corruptIndexComponent(IndexComponent indexComponent, IndexContext indexContext, CorruptionType corruptionType) throws Exception
+    protected void corruptIndexComponent(IndexComponentType indexComponentType, IndexContext indexContext, CorruptionType corruptionType) throws Exception
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
 
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
-            File file = IndexDescriptor.createFrom(sstable).fileFor(indexComponent, indexContext);
+            File file = IndexDescriptor.create(sstable).perIndexComponents(indexContext).get(indexComponentType).file();
             corruptionType.corrupt(file);
         }
     }
@@ -334,10 +347,11 @@ public class SAITester extends CQLTester
 
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
-            IndexDescriptor indexDescriptor = IndexDescriptor.createFrom(sstable);
+            IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
             if (indexDescriptor.isIndexEmpty(context))
                 continue;
-            if (!indexDescriptor.validatePerSSTableComponentsChecksum() || !indexDescriptor.validatePerIndexComponentsChecksum(context))
+            if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true)
+                || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true))
                 return false;
         }
         return true;
@@ -500,6 +514,28 @@ public class SAITester extends CQLTester
         assertTrue(indexFiles().size() == 0);
     }
 
+    // Verify every sstables is indexed correctly and the components are valid.
+    protected void verifyIndexComponentFiles(@Nullable IndexContext numericIndexContext, @Nullable IndexContext stringIndexContext)
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            // We create a descriptor from scratch, to ensure this discover from disk directly.
+            IndexDescriptor descriptor = IndexDescriptor.create(sstable);
+
+            // Note that validation makes sure that all expected components exists, on top of validating those.
+            descriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true);
+            if (numericIndexContext != null)
+                descriptor.perIndexComponents(numericIndexContext).validateComponents(sstable, cfs.getTracker(), true);
+            if (stringIndexContext != null)
+                descriptor.perIndexComponents(stringIndexContext).validateComponents(sstable, cfs.getTracker(), true);
+        }
+    }
+
+
+    // Note: this assumes the checked component files are at generation 0, which is not always the case with rebuild.
+    // The `verifyIndexComponentFiles` method is probably a safer replacement overall, but many test still use this so
+    // we keep it for now.
     protected void verifyIndexFiles(IndexContext numericIndexContext, IndexContext literalIndexContext, int numericFiles, int literalFiles)
     {
         verifyIndexFiles(numericIndexContext,
@@ -511,6 +547,7 @@ public class SAITester extends CQLTester
                          literalFiles);
     }
 
+    // Same as namesake
     protected void verifyIndexFiles(IndexContext numericIndexContext,
                                     IndexContext literalIndexContext,
                                     int perSSTableFiles,
@@ -521,21 +558,22 @@ public class SAITester extends CQLTester
     {
         Set<File> indexFiles = indexFiles();
 
-        for (IndexComponent indexComponent : Version.latest().onDiskFormat().perSSTableComponents())
+        for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perSSTableComponents())
         {
-            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.latest().fileNameFormatter().format(indexComponent, null)));
+            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.latest().fileNameFormatter().format(indexComponentType, null, 0)));
             assertEquals(tableFiles.toString(), perSSTableFiles, tableFiles.size());
         }
 
         if (literalIndexContext != null)
         {
-            for (IndexComponent indexComponent : Version.latest().onDiskFormat().perIndexComponents(literalIndexContext))
+            for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perIndexComponents(literalIndexContext))
             {
                 Set<File> stringIndexFiles = componentFiles(indexFiles,
                                                             new Component(Component.Type.CUSTOM,
-                                                                          Version.latest().fileNameFormatter().format(indexComponent,
-                                                                                                                    literalIndexContext)));
-                if (isBuildCompletionMarker(indexComponent))
+                                                                          Version.latest().fileNameFormatter().format(indexComponentType,
+                                                                                                                      literalIndexContext,
+                                                                                                                      0)));
+                if (isBuildCompletionMarker(indexComponentType))
                     assertEquals(literalCompletionMarkers, stringIndexFiles.size());
                 else
                     assertEquals(stringIndexFiles.toString(), literalFiles, stringIndexFiles.size());
@@ -544,13 +582,14 @@ public class SAITester extends CQLTester
 
         if (numericIndexContext != null)
         {
-            for (IndexComponent indexComponent : Version.latest().onDiskFormat().perIndexComponents(numericIndexContext))
+            for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perIndexComponents(numericIndexContext))
             {
                 Set<File> numericIndexFiles = componentFiles(indexFiles,
                                                              new Component(Component.Type.CUSTOM,
-                                                                           Version.latest().fileNameFormatter().format(indexComponent,
-                                                                                                                     numericIndexContext)));
-                if (isBuildCompletionMarker(indexComponent))
+                                                                           Version.latest().fileNameFormatter().format(indexComponentType,
+                                                                                                                       numericIndexContext,
+                                                                                                                       0)));
+                if (isBuildCompletionMarker(indexComponentType))
                     assertEquals(numericCompletionMarkers, numericIndexFiles.size());
                 else
                     assertEquals(numericIndexFiles.toString(), numericFiles, numericIndexFiles.size());
@@ -558,35 +597,22 @@ public class SAITester extends CQLTester
         }
     }
 
-    protected boolean isBuildCompletionMarker(IndexComponent indexComponent)
+    protected boolean isBuildCompletionMarker(IndexComponentType indexComponentType)
     {
-        return (indexComponent == IndexComponent.GROUP_COMPLETION_MARKER) ||
-               (indexComponent == IndexComponent.COLUMN_COMPLETION_MARKER);
+        return (indexComponentType == IndexComponentType.GROUP_COMPLETION_MARKER) ||
+               (indexComponentType == IndexComponentType.COLUMN_COMPLETION_MARKER);
 
     }
 
     protected Set<File> indexFiles()
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        Set<Component> components = cfs.indexManager.listIndexGroups()
-                                                    .stream()
-                                                    .filter(g -> g instanceof StorageAttachedIndexGroup)
-                                                    .map(Index.Group::getComponents)
-                                                    .flatMap(Set::stream)
-                                                    .collect(Collectors.toSet());
-
-        Set<File> indexFiles = new HashSet<>();
-        for (Component component : components)
-        {
-            List<File> files = cfs.getDirectories().getCFDirectories()
-                    .stream()
-                    .flatMap(dir -> Arrays.stream(dir.tryList()))
-                    .filter(File::isFile)
-                    .filter(f -> f.name().endsWith(component.name))
-                    .collect(Collectors.toList());
-            indexFiles.addAll(files);
-        }
-        return indexFiles;
+        return cfs.getDirectories().getCFDirectories()
+                  .stream()
+                  .flatMap(dir -> Arrays.stream(dir.tryList()))
+                  .filter(File::isFile)
+                  .filter(file -> Version.tryParseFileName(file.name()).isPresent())
+                  .collect(Collectors.toSet());
     }
 
     protected ObjectName bufferSpaceObjectName(String name) throws MalformedObjectNameException
@@ -760,11 +786,11 @@ public class SAITester extends CQLTester
     private void verifySSTableComponents(String table, boolean indexComponentsExist) throws Exception
     {
         ColumnFamilyStore cfs = Objects.requireNonNull(Schema.instance.getKeyspaceInstance(KEYSPACE)).getColumnFamilyStore(table);
-        for (SSTable sstable : cfs.getLiveSSTables())
+        for (SSTableReader sstable : cfs.getLiveSSTables())
         {
             Set<Component> components = sstable.components;
             StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
-            Set<Component> ndiComponents = group == null ? Collections.emptySet() : group.getComponents();
+            Set<Component> ndiComponents = group == null ? Collections.emptySet() : group.activeComponents(sstable);
 
             Set<Component> diff = Sets.difference(ndiComponents, components);
             if (indexComponentsExist)
@@ -783,9 +809,9 @@ public class SAITester extends CQLTester
         return indexFiles.stream().filter(c -> c.name().endsWith(component.name)).collect(Collectors.toSet());
     }
 
-    protected Set<File> componentFiles(Collection<File> indexFiles, IndexComponent indexComponent, IndexContext indexContext)
+    protected Set<File> componentFiles(Collection<File> indexFiles, IndexComponentType indexComponentType, IndexContext indexContext)
     {
-        String componentName = Version.latest().fileNameFormatter().format(indexComponent, indexContext);
+        String componentName = Version.latest().fileNameFormatter().format(indexComponentType, indexContext, 0);
         return indexFiles.stream().filter(c -> c.name().endsWith(componentName)).collect(Collectors.toSet());
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.IMMUTABLE_SAI_COMPONENTS;
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractRebuildAndImmutableComponentsTest extends SAITester
+{
+     private Boolean defaultImmutableSetting;
+
+    protected abstract boolean useImmutableComponents();
+
+    @Before
+    public void setup() throws Throwable
+    {
+        defaultImmutableSetting = IMMUTABLE_SAI_COMPONENTS.getBoolean();
+        IMMUTABLE_SAI_COMPONENTS.setBoolean(useImmutableComponents());
+        requireNetwork();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (defaultImmutableSetting != null)
+            IMMUTABLE_SAI_COMPONENTS.setBoolean(defaultImmutableSetting);
+    }
+
+    @Test
+    public void rebuildCreateNewGenerationFiles() throws Throwable
+    {
+        // Setup: create index, insert data, flush, and make sure everything is correct.
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+        String name = createIndex("CREATE CUSTOM INDEX test_index ON %s(val) USING 'StorageAttachedIndex'");
+
+        IndexContext context = createIndexContext(name, UTF8Type.instance);
+
+        execute("INSERT INTO %s (id, val) VALUES ('0', 'testValue')");
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'otherValue')");
+        execute("INSERT INTO %s (id, val) VALUES ('2', 'testValue')");
+        execute("INSERT INTO %s (id, val) VALUES ('3', 'otherValue')");
+
+        flush();
+
+        assertEquals(2, execute("SELECT id FROM %s WHERE val = 'testValue'").size());
+
+        // Rebuild the index
+        rebuildIndexes(name);
+
+        assertEquals(2, execute("SELECT id FROM %s WHERE val = 'testValue'").size());
+
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        validateSSTables(cfs, context);
+    }
+
+    protected abstract void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception;
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTest.java
@@ -20,21 +20,17 @@ package org.apache.cassandra.index.sai.cql;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.IMMUTABLE_SAI_COMPONENTS;
 import static org.junit.Assert.assertEquals;
 
-/**
- * Common code for tests to validate the behavior of the {@link org.apache.cassandra.config.CassandraRelevantProperties#IMMUTABLE_SAI_COMPONENTS} property.
- * <p>
- * Implementation note: this was meant to contain the common `@Test` to both implementation of this abstract class,
- * with just the final validation of sstables being abstracted, but when doing that, something in CI (I suspect `ant`)
- * tries to run the test directly on the abstract class (which fails with an `InstantiationException`, obviously, but
- * ends up as a test failure). If there is a magic flag to make it work, I don't know it and don't care to looking for
- * it. So the concrete tests are in the subclasses, even if it's not quite DRY.
- */
 public abstract class AbstractRebuildAndImmutableComponentsTest extends SAITester
 {
      private Boolean defaultImmutableSetting;
@@ -56,12 +52,14 @@ public abstract class AbstractRebuildAndImmutableComponentsTest extends SAITeste
             IMMUTABLE_SAI_COMPONENTS.setBoolean(defaultImmutableSetting);
     }
 
-    protected String createTableWithIndexAndRebuild() throws Throwable
+    @Test
+    public void rebuildCreateNewGenerationFiles() throws Throwable
     {
         // Setup: create index, insert data, flush, and make sure everything is correct.
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
         String name = createIndex("CREATE CUSTOM INDEX test_index ON %s(val) USING 'StorageAttachedIndex'");
 
+        IndexContext context = createIndexContext(name, UTF8Type.instance);
 
         execute("INSERT INTO %s (id, val) VALUES ('0', 'testValue')");
         execute("INSERT INTO %s (id, val) VALUES ('1', 'otherValue')");
@@ -77,6 +75,9 @@ public abstract class AbstractRebuildAndImmutableComponentsTest extends SAITeste
 
         assertEquals(2, execute("SELECT id FROM %s WHERE val = 'testValue'").size());
 
-        return name;
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        validateSSTables(cfs, context);
     }
+
+    protected abstract void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception;
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AbstractRebuildAndImmutableComponentsTester.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -31,7 +32,8 @@ import org.apache.cassandra.index.sai.SAITester;
 import static org.apache.cassandra.config.CassandraRelevantProperties.IMMUTABLE_SAI_COMPONENTS;
 import static org.junit.Assert.assertEquals;
 
-public abstract class AbstractRebuildAndImmutableComponentsTest extends SAITester
+@Ignore
+public abstract class AbstractRebuildAndImmutableComponentsTester extends SAITester
 {
      private Boolean defaultImmutableSetting;
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
@@ -24,7 +24,7 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 
 import static org.junit.Assert.assertEquals;
 
@@ -43,15 +43,15 @@ public class EmptyMemtableFlushTest extends SAITester
         execute("DELETE FROM %s WHERE id = 0");
         flush();
         // After this we should have only 1 set of index files but 2 completion markers
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.KD_TREE, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.KD_TREE_POSTING_LISTS, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.META, val1IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.KD_TREE, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.KD_TREE_POSTING_LISTS, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.META, val1IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
 
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.KD_TREE, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.KD_TREE_POSTING_LISTS, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.META, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.KD_TREE, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.KD_TREE_POSTING_LISTS, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.META, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
 
         assertEquals(0, execute("SELECT * from %s WHERE val1 = 0").size());
         assertEquals(1, execute("SELECT * from %s WHERE val2 = 1").size());
@@ -69,15 +69,15 @@ public class EmptyMemtableFlushTest extends SAITester
         execute("DELETE FROM %s WHERE id = 0");
         flush();
         // After this we should have only 1 set of index files but 2 completion markers
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.TERMS_DATA, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.POSTING_LISTS, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponent.META, val1IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.TERMS_DATA, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.POSTING_LISTS, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.META, val1IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
 
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.TERMS_DATA, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.POSTING_LISTS, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.META, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponent.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.TERMS_DATA, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.POSTING_LISTS, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.META, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
 
         assertEquals(0, execute("SELECT * from %s WHERE val1 = '0'").size());
         assertEquals(1, execute("SELECT * from %s WHERE val2 = '1'").size());

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -1036,8 +1036,8 @@ public class NativeIndexDDLTest extends SAITester
             createTable(CREATE_TABLE_TEMPLATE);
             String numericIndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
             String stringIndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-            IndexContext numericIndexContext = createIndexContext(numericIndexName, Int32Type.instance);
-            IndexContext stringIndexContext = createIndexContext(stringIndexName, UTF8Type.instance);
+            IndexContext numericIndexContext = getIndexContext(numericIndexName);
+            IndexContext stringIndexContext = getIndexContext(stringIndexName);
 
             int rowCount = 2;
             execute("INSERT INTO %s (id1, v1, v2) VALUES ('0', 0, '0');");

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.io.util.PathUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTest
+public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTester
 {
     @Override
     protected boolean useImmutableComponents()

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
@@ -22,7 +22,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Test;
+
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
@@ -43,8 +47,7 @@ public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmuta
         return true;
     }
 
-    @Override
-    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception
+    private void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception
     {
         Index.Group indexGroup = StorageAttachedIndexGroup.getIndexGroup(cfs);
         assert indexGroup != null;
@@ -69,6 +72,14 @@ public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmuta
                 }
             }
         }
+    }
+
+    @Test
+    public void rebuildCreateNewGenerationFiles() throws Throwable
+    {
+        String indexName = createTableWithIndexAndRebuild();
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        validateSSTables(cfs, getIndexContext(indexName));
     }
 
     private static Set<String> allSSTableFilenames(SSTableReader sstable)

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
@@ -22,11 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
-
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
@@ -47,7 +43,8 @@ public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmuta
         return true;
     }
 
-    private void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception
+    @Override
+    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception
     {
         Index.Group indexGroup = StorageAttachedIndexGroup.getIndexGroup(cfs);
         assert indexGroup != null;
@@ -72,14 +69,6 @@ public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmuta
                 }
             }
         }
-    }
-
-    @Test
-    public void rebuildCreateNewGenerationFiles() throws Throwable
-    {
-        String indexName = createTableWithIndexAndRebuild();
-        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        validateSSTables(cfs, getIndexContext(indexName));
     }
 
     private static Set<String> allSSTableFilenames(SSTableReader sstable)

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.PathUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTest
+{
+    @Override
+    protected boolean useImmutableComponents()
+    {
+        return true;
+    }
+
+    @Override
+    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context) throws Exception
+    {
+        Index.Group indexGroup = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        assert indexGroup != null;
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            // Make sure the TOC has all the active components; this is somewhat indirectly tested by the few next
+            // assertions, but good sanity check (and somewhat test the `activeComponents` method too).
+            assertTrue(SSTable.readTOC(sstable.descriptor).containsAll(indexGroup.activeComponents(sstable)));
+
+            IndexDescriptor descriptor = IndexDescriptor.create(sstable);
+            assertEquals(1, descriptor.perSSTableComponents().generation());
+            assertEquals(1, descriptor.perIndexComponents(context).generation());
+
+            Set<String> files = allSSTableFilenames(sstable);
+            for (var components : List.of(descriptor.perSSTableComponents(), descriptor.perIndexComponents(context)))
+            {
+                for (var component : components.all())
+                {
+                    String gen0Component = components.version().fileNameFormatter().format(component.componentType(), components.context(), 0);
+                    String expectedFilename = sstable.descriptor.fileFor(new Component(Component.Type.CUSTOM, gen0Component)).name();
+                    assertTrue( "File " + expectedFilename + " not found in " + files, files.contains(expectedFilename));
+                }
+            }
+        }
+    }
+
+    private static Set<String> allSSTableFilenames(SSTableReader sstable)
+    {
+        Set<String> files = new HashSet<>();
+        PathUtils.forEach(sstable.descriptor.directory.toPath(), path -> {
+            String filename = path.getFileName().toString();
+            if (filename.startsWith(sstable.descriptor.filenamePart()))
+                files.add(filename);
+        });
+        return files;
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithImmutableComponentsTest.java
@@ -54,7 +54,7 @@ public class RebuildWithImmutableComponentsTest extends AbstractRebuildAndImmuta
             // assertions, but good sanity check (and somewhat test the `activeComponents` method too).
             assertTrue(SSTable.readTOC(sstable.descriptor).containsAll(indexGroup.activeComponents(sstable)));
 
-            IndexDescriptor descriptor = IndexDescriptor.create(sstable);
+            IndexDescriptor descriptor = IndexDescriptor.load(sstable, Set.of(context));
             assertEquals(1, descriptor.perSSTableComponents().generation());
             assertEquals(1, descriptor.perIndexComponents(context).generation());
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Set;
+
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
@@ -38,7 +40,7 @@ public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImm
     {
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
-            IndexDescriptor descriptor = IndexDescriptor.create(sstable);
+            IndexDescriptor descriptor = IndexDescriptor.load(sstable, Set.of(context));
             assertEquals(0, descriptor.perSSTableComponents().generation());
             assertEquals(0, descriptor.perIndexComponents(context).generation());
         }

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
@@ -27,7 +27,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 import static org.junit.Assert.assertEquals;
 
-public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTest
+public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTester
 {
     @Override
     protected boolean useImmutableComponents()

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
@@ -20,7 +20,10 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.Set;
 
+import org.junit.Test;
+
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -35,8 +38,7 @@ public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImm
         return false;
     }
 
-    @Override
-    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context)
+    private void validateSSTables(ColumnFamilyStore cfs, IndexContext context)
     {
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
@@ -44,5 +46,13 @@ public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImm
             assertEquals(0, descriptor.perSSTableComponents().generation());
             assertEquals(0, descriptor.perIndexComponents(context).generation());
         }
+    }
+
+    @Test
+    public void rebuildCreateNewGenerationFiles() throws Throwable
+    {
+        String indexName = createTableWithIndexAndRebuild();
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        validateSSTables(cfs, getIndexContext(indexName));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
@@ -20,10 +20,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.Set;
 
-import org.junit.Test;
-
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -38,7 +35,8 @@ public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImm
         return false;
     }
 
-    private void validateSSTables(ColumnFamilyStore cfs, IndexContext context)
+    @Override
+    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context)
     {
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
@@ -46,13 +44,5 @@ public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImm
             assertEquals(0, descriptor.perSSTableComponents().generation());
             assertEquals(0, descriptor.perIndexComponents(context).generation());
         }
-    }
-
-    @Test
-    public void rebuildCreateNewGenerationFiles() throws Throwable
-    {
-        String indexName = createTableWithIndexAndRebuild();
-        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        validateSSTables(cfs, getIndexContext(indexName));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RebuildWithoutImmutableComponentsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertEquals;
+
+public class RebuildWithoutImmutableComponentsTest extends AbstractRebuildAndImmutableComponentsTest
+{
+    @Override
+    protected boolean useImmutableComponents()
+    {
+        return false;
+    }
+
+    @Override
+    protected void validateSSTables(ColumnFamilyStore cfs, IndexContext context)
+    {
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IndexDescriptor descriptor = IndexDescriptor.create(sstable);
+            assertEquals(0, descriptor.perSSTableComponents().generation());
+            assertEquals(0, descriptor.perIndexComponents(context).generation());
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -39,15 +39,17 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndexBuilder;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter;
+import org.apache.cassandra.inject.Expression;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
 import org.apache.cassandra.schema.Schema;
 
+import static org.apache.cassandra.inject.Expression.expr;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -96,21 +98,39 @@ public class NodeStartupTest extends SAITester
                                                                      .add(InvokePointBuilder.newInvokePoint().onClass(StorageAttachedIndexBuilder.class).onMethod("build").atEntry())
                                                                      .build();
 
-    private static final Injections.Counter deletedPerSStableCounter = Injections.newCounter("deletedPrimaryKeyMapCounter")
-                                                                                 .add(InvokePointBuilder.newInvokePoint()
-                                                                                                        .onClass(IndexDescriptor.class)
-                                                                                                        .onMethod("deletePerSSTableIndexComponents")
-                                                                                                        .atEntry())
-                                                                                 .build();
+    private static final Injections.Counter deletedPerSStableCounter = addConditions(Injections.newCounter("deletedPrimaryKeyMapCounter")
+                                                                                               .add(InvokePointBuilder.newInvokePoint()
+                                                                                                                      .onInterface("ComponentGroup$Writer")
+                                                                                                                      .onMethod("deleteAllComponents")
+                                                                                                                      .atEntry()),
+                                                                                     b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args())
+    ).build();
 
-    private static final Injections.Counter deletedPerIndexCounter = Injections.newCounter("deletedColumnIndexCounter")
-                                                                               .add(InvokePointBuilder.newInvokePoint()
-                                                                                                      .onClass(IndexDescriptor.class)
-                                                                                                      .onMethod("deleteColumnIndex")
-                                                                                                      .atEntry())
-                                                                               .build();
+    private static final Injections.Counter invalidatePerSStableCounter = addConditions(Injections.newCounter("invalidatePrimaryKeyMapCounter")
+                                                                                               .add(InvokePointBuilder.newInvokePoint()
+                                                                                                                      .onClass("IndexDescriptor$IndexComponentsImpl")
+                                                                                                                      .onMethod("invalidate")
+                                                                                                                      .atEntry()),
+                                                                                     b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args())
+    ).build();
 
-    private static final Injections.Counter[] counters = new Injections.Counter[] { buildCounter, deletedPerSStableCounter, deletedPerIndexCounter };
+    private static final Injections.Counter deletedPerIndexCounter = addConditions(Injections.newCounter("deletedColumnIndexCounter")
+                                                                                             .add(InvokePointBuilder.newInvokePoint()
+                                                                                                                    .onInterface("ComponentGroup$Writer")
+                                                                                                                    .onMethod("deleteAllComponents")
+                                                                                                                    .atEntry()),
+                                                                                   b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args())
+    ).build();
+
+    private static final Injections.Counter invalidatePerIndexCounter = addConditions(Injections.newCounter("invalidateColumnIndexCounter")
+                                                                                                  .add(InvokePointBuilder.newInvokePoint()
+                                                                                                                         .onClass("IndexDescriptor$IndexComponentsImpl")
+                                                                                                                         .onMethod("invalidate")
+                                                                                                                         .atEntry()),
+                                                                                        b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args())
+    ).build();
+
+    private static final Injections.Counter[] counters = new Injections.Counter[] { buildCounter, deletedPerSStableCounter, invalidatePerSStableCounter, deletedPerIndexCounter, invalidatePerIndexCounter };
 
     private static Throwable error = null;
 
@@ -202,8 +222,12 @@ public class NodeStartupTest extends SAITester
     @Parameterized.Parameter(4)
     public int deletedPerSSTable;
     @Parameterized.Parameter(5)
-    public int deletedPerIndex;
+    public int invalidatePerSStable;
     @Parameterized.Parameter(6)
+    public int deletedPerIndex;
+    @Parameterized.Parameter(7)
+    public int invalidatePerIndex;
+    @Parameterized.Parameter(8)
     public int expectedDocuments;
 
     @SuppressWarnings("unused")
@@ -212,27 +236,27 @@ public class NodeStartupTest extends SAITester
     {
         List<Object[]> scenarios = new LinkedList<>();
 
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 1, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 1, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 2, 2, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 2, 2, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 2, 2, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 2, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 2, DOCS });
-        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 2, DOCS });
-        scenarios.add( new Object[] { Populator.NON_INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, 0 });
-        scenarios.add( new Object[] { Populator.NON_INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, 0 });
-        scenarios.add( new Object[] { Populator.TOMBSTONES, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, 0 });
-        scenarios.add( new Object[] { Populator.TOMBSTONES, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, 0 });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.ALL_EMPTY, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_INCOMPLETE, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 0, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 1, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 1, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_SSTABLE_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 1, 0, 0, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 1, 0, 0, 0, 1, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 1, 0, 0, 0, 1, DOCS });
+        scenarios.add( new Object[] { Populator.INDEXABLE_ROWS, IndexStateOnRestart.PER_COLUMN_CORRUPT, StartupTaskRunOrder.PRE_JOIN_RUNS_MID_BUILD, 1, 0, 0, 0, 1, DOCS });
+        scenarios.add( new Object[] { Populator.NON_INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, 0, 0, 0 });
+        scenarios.add( new Object[] { Populator.NON_INDEXABLE_ROWS, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, 0, 0, 0 });
+        scenarios.add( new Object[] { Populator.TOMBSTONES, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_BEFORE_BUILD, 0, 0, 0, 0, 0, 0 });
+        scenarios.add( new Object[] { Populator.TOMBSTONES, IndexStateOnRestart.VALID, StartupTaskRunOrder.PRE_JOIN_RUNS_AFTER_BUILD, 0, 0, 0, 0, 0, 0 });
 
         return scenarios;
     }
@@ -260,7 +284,9 @@ public class NodeStartupTest extends SAITester
 
         Assert.assertEquals(builds, buildCounter.get());
         Assert.assertEquals(deletedPerSSTable, deletedPerSStableCounter.get());
+        Assert.assertEquals(invalidatePerSStable, invalidatePerSStableCounter.get());
         Assert.assertEquals(deletedPerIndex, deletedPerIndexCounter.get());
+        Assert.assertEquals(invalidatePerIndex, invalidatePerIndexCounter.get());
     }
 
     public void populateIndexableRows()
@@ -317,13 +343,13 @@ public class NodeStartupTest extends SAITester
     private boolean isGroupIndexComplete() throws Exception
     {
         ColumnFamilyStore cfs = Objects.requireNonNull(Schema.instance.getKeyspaceInstance(KEYSPACE)).getColumnFamilyStore(currentTable());
-        return cfs.getLiveSSTables().stream().allMatch(sstable -> IndexDescriptor.createFrom(sstable).isPerSSTableBuildComplete());
+        return cfs.getLiveSSTables().stream().allMatch(sstable -> IndexDescriptor.create(sstable).perSSTableComponents().isComplete());
     }
 
     private boolean isColumnIndexComplete() throws Exception
     {
         ColumnFamilyStore cfs = Objects.requireNonNull(Schema.instance.getKeyspaceInstance(KEYSPACE)).getColumnFamilyStore(currentTable());
-        return cfs.getLiveSSTables().stream().allMatch(sstable -> IndexDescriptor.createFrom(sstable).isPerIndexBuildComplete(indexContext));
+        return cfs.getLiveSSTables().stream().allMatch(sstable -> IndexDescriptor.create(sstable).isPerIndexBuildComplete(indexContext));
     }
 
     private void setState(IndexStateOnRestart state)
@@ -337,21 +363,21 @@ public class NodeStartupTest extends SAITester
                 Version.latest().onDiskFormat().perIndexComponents(indexContext).forEach(c -> remove(c, indexContext));
                 break;
             case PER_SSTABLE_INCOMPLETE:
-                remove(IndexComponent.GROUP_COMPLETION_MARKER);
+                remove(IndexComponentType.GROUP_COMPLETION_MARKER);
                 break;
             case PER_COLUMN_INCOMPLETE:
-                remove(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext);
+                remove(IndexComponentType.COLUMN_COMPLETION_MARKER, indexContext);
                 break;
             case PER_SSTABLE_CORRUPT:
-                corrupt(IndexComponent.GROUP_META);
+                corrupt(IndexComponentType.GROUP_META);
                 break;
             case PER_COLUMN_CORRUPT:
-                corrupt(IndexComponent.META, indexContext);
+                corrupt(IndexComponentType.META, indexContext);
                 break;
         }
     }
 
-    private void remove(IndexComponent component)
+    private void remove(IndexComponentType component)
     {
         try
         {
@@ -364,7 +390,7 @@ public class NodeStartupTest extends SAITester
         }
     }
 
-    private void remove(IndexComponent component, IndexContext indexContext)
+    private void remove(IndexComponentType component, IndexContext indexContext)
     {
         try
         {
@@ -377,7 +403,7 @@ public class NodeStartupTest extends SAITester
         }
     }
 
-    private void corrupt(IndexComponent component)
+    private void corrupt(IndexComponentType component)
     {
         try
         {
@@ -390,7 +416,7 @@ public class NodeStartupTest extends SAITester
         }
     }
 
-    private void corrupt(IndexComponent component, IndexContext indexContext)
+    private void corrupt(IndexComponentType component, IndexContext indexContext)
     {
         try
         {

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.cassandra.index.sai.disk.format;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
 import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +39,13 @@ import static org.apache.cassandra.index.sai.SAIUtil.setLatestVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * At the time of this writing, the test of this class mostly test the "fallback-scan-disk" mode of component discovery
+ * from IndexDescriptor, because they don't create a proper sstable with a TOC, they just "touch" a bunch of the
+ * component files. The "normal" discovery path that uses the TOC is however effectively tested by pretty much
+ * every other SAI test, so it is a reasonable way to test that fallback. Besides, the test also test the parsing of
+ * of the component filename at various versions, and that code is common to both paths.
+ */
 public class IndexDescriptorTest
 {
     private TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -74,12 +78,15 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.AA);
 
+        // As mentioned in the class javadoc, we rely on the no-TOC fallback path and that only kick in if there is a
+        // data file. Otherwise, it assumes the SSTable simply does not exist at all.
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI_GroupComplete.db");
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
 
         assertEquals(Version.AA, indexDescriptor.getVersion());
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.GROUP_COMPLETION_MARKER));
+        assertTrue(indexDescriptor.perSSTableComponents().has(IndexComponentType.GROUP_COMPLETION_MARKER));
     }
 
     @Test
@@ -87,14 +94,15 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.AA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI_GroupComplete.db");
         createFileOnDisk("-SAI_test_index_ColumnComplete.db");
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
         assertEquals(Version.AA, indexDescriptor.getVersion());
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext));
+        assertTrue(indexDescriptor.perIndexComponents(indexContext).has(IndexComponentType.COLUMN_COMPLETION_MARKER));
     }
 
     @Test
@@ -102,12 +110,13 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.BA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI+ba+GroupComplete.db");
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
 
         assertEquals(Version.BA, indexDescriptor.getVersion());
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.GROUP_COMPLETION_MARKER));
+        assertTrue(indexDescriptor.perSSTableComponents().has(IndexComponentType.GROUP_COMPLETION_MARKER));
     }
 
     @Test
@@ -115,13 +124,14 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.BA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI+ba+test_index+ColumnComplete.db");
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
         assertEquals(Version.BA, indexDescriptor.getVersion());
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext));
+        assertTrue(indexDescriptor.perIndexComponents(indexContext).has(IndexComponentType.COLUMN_COMPLETION_MARKER));
     }
 
     @Test
@@ -129,17 +139,18 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.AA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI_GroupComplete.db");
         createFileOnDisk("-SAI_GroupMeta.db");
         createFileOnDisk("-SAI_TokenValues.db");
         createFileOnDisk("-SAI_OffsetsValues.db");
 
-        IndexDescriptor result = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor result = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
 
-        assertTrue(result.hasComponent(IndexComponent.GROUP_COMPLETION_MARKER));
-        assertTrue(result.hasComponent(IndexComponent.GROUP_META));
-        assertTrue(result.hasComponent(IndexComponent.TOKEN_VALUES));
-        assertTrue(result.hasComponent(IndexComponent.OFFSETS_VALUES));
+        assertTrue(result.perSSTableComponents().has(IndexComponentType.GROUP_COMPLETION_MARKER));
+        assertTrue(result.perSSTableComponents().has(IndexComponentType.GROUP_META));
+        assertTrue(result.perSSTableComponents().has(IndexComponentType.TOKEN_VALUES));
+        assertTrue(result.perSSTableComponents().has(IndexComponentType.OFFSETS_VALUES));
     }
 
     @Test
@@ -147,6 +158,7 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.AA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI_GroupComplete.db");
         createFileOnDisk("-SAI_test_index_ColumnComplete.db");
         createFileOnDisk("-SAI_test_index_Meta.db");
@@ -154,13 +166,14 @@ public class IndexDescriptorTest
         createFileOnDisk("-SAI_test_index_PostingLists.db");
 
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.META, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.TERMS_DATA, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.POSTING_LISTS, indexContext));
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(indexContext);
+        assertTrue(components.has(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(components.has(IndexComponentType.META));
+        assertTrue(components.has(IndexComponentType.TERMS_DATA));
+        assertTrue(components.has(IndexComponentType.POSTING_LISTS));
     }
 
     @Test
@@ -168,19 +181,21 @@ public class IndexDescriptorTest
     {
         setLatestVersion(Version.AA);
 
+        createFileOnDisk("-Data.db");
         createFileOnDisk("-SAI_GroupComplete.db");
         createFileOnDisk("-SAI_test_index_ColumnComplete.db");
         createFileOnDisk("-SAI_test_index_Meta.db");
         createFileOnDisk("-SAI_test_index_KDTree.db");
         createFileOnDisk("-SAI_test_index_KDTreePostingLists.db");
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(descriptor, Murmur3Partitioner.instance, SAITester.EMPTY_COMPARATOR);
         IndexContext indexContext = SAITester.createIndexContext("test_index", Int32Type.instance);
 
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.META, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.KD_TREE, indexContext));
-        assertTrue(indexDescriptor.hasComponent(IndexComponent.KD_TREE_POSTING_LISTS, indexContext));
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(indexContext);
+        assertTrue(components.has(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(components.has(IndexComponentType.META));
+        assertTrue(components.has(IndexComponentType.KD_TREE));
+        assertTrue(components.has(IndexComponentType.KD_TREE_POSTING_LISTS));
     }
 
     private void createFileOnDisk(String filename) throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.KDTreeIndexBuilder;
@@ -152,7 +153,8 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
         final IndexContext indexContext = SAITester.createIndexContext(index, UTF8Type.instance);
 
         SegmentMetadata.ComponentMetadataMap indexMetas;
-        try (InvertedIndexWriter writer = new InvertedIndexWriter(indexDescriptor, indexContext))
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        try (InvertedIndexWriter writer = new InvertedIndexWriter(components))
         {
             indexMetas = writer.writeAll(new MemtableTermsIterator(null, null, termsEnum.iterator()));
         }
@@ -167,7 +169,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
                                                                     wrap(termsEnum.get(terms - 1).left),
                                                                     indexMetas);
 
-        try (PerIndexFiles indexFiles = new PerIndexFiles(indexDescriptor, indexContext))
+        try (PerIndexFiles indexFiles = new PerIndexFiles(components))
         {
             SSTableContext sstableContext = mock(SSTableContext.class);
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -173,7 +173,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
         {
             SSTableContext sstableContext = mock(SSTableContext.class);
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);
-            when(sstableContext.indexDescriptor()).thenReturn(indexDescriptor);
+            when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
             final IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext,
                                                                                           SAITester.createIndexContext(index, UTF8Type.instance),
                                                                                           indexFiles,

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
@@ -250,12 +250,10 @@ public class KDTreeSegmentMergerTest extends SAITester
 
         MergeOneDimPointValues merger = new MergeOneDimPointValues(segmentIterators, Integer.BYTES);
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(temporaryFolder.newFolder()),
-                                                                                   "test",
-                                                                                   "test",
-                                                                                   new SequenceBasedSSTableId(20)),
-                                                                    Murmur3Partitioner.instance,
-                                                                    SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.empty(new Descriptor(new File(temporaryFolder.newFolder()),
+                                                                               "test",
+                                                                               "test",
+                                                                               new SequenceBasedSSTableId(20)));
         IndexContext indexContext = SAITester.createIndexContext("test", Int32Type.instance);
 
         IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
@@ -300,12 +298,10 @@ public class KDTreeSegmentMergerTest extends SAITester
 
     private BKDReader createReader(BKDTreeRamBuffer buffer, int maxSegmentRowId, int id) throws Throwable
     {
-        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(temporaryFolder.newFolder()),
-                                                                                   "test",
-                                                                                   "test",
-                                                                                   new SequenceBasedSSTableId(id)),
-                                                                    Murmur3Partitioner.instance,
-                                                                    SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.empty(new Descriptor(new File(temporaryFolder.newFolder()),
+                                                                               "test",
+                                                                               "test",
+                                                                               new SequenceBasedSSTableId(id)));
 
         IndexContext indexContext = SAITester.createIndexContext("test", Int32Type.instance);
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
@@ -38,7 +38,8 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.PostingList;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.BKDReader;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.BKDTreeRamBuffer;
@@ -249,7 +250,7 @@ public class KDTreeSegmentMergerTest extends SAITester
 
         MergeOneDimPointValues merger = new MergeOneDimPointValues(segmentIterators, Integer.BYTES);
 
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(new Descriptor(new File(temporaryFolder.newFolder()),
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(temporaryFolder.newFolder()),
                                                                                    "test",
                                                                                    "test",
                                                                                    new SequenceBasedSSTableId(20)),
@@ -257,19 +258,19 @@ public class KDTreeSegmentMergerTest extends SAITester
                                                                     SAITester.EMPTY_COMPARATOR);
         IndexContext indexContext = SAITester.createIndexContext("test", Int32Type.instance);
 
-        try (NumericIndexWriter indexWriter = new NumericIndexWriter(indexDescriptor,
-                                                                     indexContext,
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        try (NumericIndexWriter indexWriter = new NumericIndexWriter(components,
                                                                      Integer.BYTES,
                                                                      maxSegmentRowId,
                                                                      totalRows,
                                                                      IndexWriterConfig.defaultConfig("test")))
         {
             SegmentMetadata.ComponentMetadataMap metadata = indexWriter.writeAll(merger);
-            final long bkdPosition = metadata.get(IndexComponent.KD_TREE).root;
-            final long postingsPosition = metadata.get(IndexComponent.KD_TREE_POSTING_LISTS).root;
+            final long bkdPosition = metadata.get(IndexComponentType.KD_TREE).root;
+            final long postingsPosition = metadata.get(IndexComponentType.KD_TREE_POSTING_LISTS).root;
 
-            FileHandle kdtree = indexDescriptor.createPerIndexFileHandle(IndexComponent.KD_TREE, indexContext);
-            FileHandle kdtreePostings = indexDescriptor.createPerIndexFileHandle(IndexComponent.KD_TREE_POSTING_LISTS, indexContext);
+            FileHandle kdtree = components.get(IndexComponentType.KD_TREE).createFileHandle();
+            FileHandle kdtreePostings = components.get(IndexComponentType.KD_TREE_POSTING_LISTS).createFileHandle();
             BKDReader reader = new BKDReader(indexContext, kdtree, bkdPosition, kdtreePostings, postingsPosition);
 
             for (int term : expected.keySet())
@@ -299,7 +300,7 @@ public class KDTreeSegmentMergerTest extends SAITester
 
     private BKDReader createReader(BKDTreeRamBuffer buffer, int maxSegmentRowId, int id) throws Throwable
     {
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(new Descriptor(new File(temporaryFolder.newFolder()),
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(temporaryFolder.newFolder()),
                                                                                    "test",
                                                                                    "test",
                                                                                    new SequenceBasedSSTableId(id)),
@@ -308,19 +309,19 @@ public class KDTreeSegmentMergerTest extends SAITester
 
         IndexContext indexContext = SAITester.createIndexContext("test", Int32Type.instance);
 
-        final NumericIndexWriter writer = new NumericIndexWriter(indexDescriptor,
-                                                                 indexContext,
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        final NumericIndexWriter writer = new NumericIndexWriter(components,
                                                                  Integer.BYTES,
                                                                  maxSegmentRowId,
                                                                  buffer.numRows(),
                                                                  IndexWriterConfig.defaultConfig("test"));
 
         final SegmentMetadata.ComponentMetadataMap metadata = writer.writeAll(buffer.asPointValues());
-        final long bkdPosition = metadata.get(IndexComponent.KD_TREE).root;
-        final long postingsPosition = metadata.get(IndexComponent.KD_TREE_POSTING_LISTS).root;
+        final long bkdPosition = metadata.get(IndexComponentType.KD_TREE).root;
+        final long postingsPosition = metadata.get(IndexComponentType.KD_TREE_POSTING_LISTS).root;
 
-        FileHandle kdtree = indexDescriptor.createPerIndexFileHandle(IndexComponent.KD_TREE, indexContext);
-        FileHandle kdtreePostings = indexDescriptor.createPerIndexFileHandle(IndexComponent.KD_TREE_POSTING_LISTS, indexContext);
+        FileHandle kdtree = components.get(IndexComponentType.KD_TREE).createFileHandle();
+        FileHandle kdtreePostings = components.get(IndexComponentType.KD_TREE_POSTING_LISTS).createFileHandle();
         return new BKDReader(indexContext, kdtree, bkdPosition, kdtreePostings, postingsPosition);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.index.sai.disk.v1;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -71,6 +72,10 @@ public class LegacyOnDiskFormatTest
     private TableMetadata tableMetadata;
     private IndexDescriptor indexDescriptor;
     private SSTableReader sstable;
+    private PrimaryKey.Factory pkFactory;
+
+    private IndexContext intContext = SAITester.createIndexContext("int_index", Int32Type.instance);
+    private IndexContext textContext = SAITester.createIndexContext("text_index", UTF8Type.instance);
 
     @BeforeClass
     public static void initialise()
@@ -79,7 +84,6 @@ public class LegacyOnDiskFormatTest
         DatabaseDescriptor.setPartitionerUnsafe(Murmur3Partitioner.instance);
         StorageService.instance.setPartitionerUnsafe(Murmur3Partitioner.instance);
     }
-
 
     @Before
     public void setup() throws Throwable
@@ -93,7 +97,8 @@ public class LegacyOnDiskFormatTest
                                      .addRegularColumn("text_value", UTF8Type.instance)
                                      .build();
         sstable = TrieIndexFormat.instance.getReaderFactory().openNoValidation(descriptor, TableMetadataRef.forOfflineTools(tableMetadata));
-        indexDescriptor = IndexDescriptor.create(sstable);
+        indexDescriptor = IndexDescriptor.empty(sstable.descriptor).reload(Set.of(intContext, textContext));
+        pkFactory = indexDescriptor.perSSTableComponents().version().onDiskFormat().newPrimaryKeyFactory(tableMetadata.comparator);
     }
 
     @After
@@ -105,7 +110,7 @@ public class LegacyOnDiskFormatTest
     @Test
     public void correctlyIdentifiesPerSSTableFileVersion()
     {
-        assertEquals(Version.AA, indexDescriptor.getVersion());
+        assertEquals(Version.AA, indexDescriptor.perSSTableComponents().version());
     }
 
     @Test
@@ -126,11 +131,10 @@ public class LegacyOnDiskFormatTest
     @Test
     public void canReadPerIndexMetadata() throws Throwable
     {
-        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(SAITester.createIndexContext("int_index",
-                                                                                                        Int32Type.instance));
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(intContext);
         final MetadataSource source = MetadataSource.loadMetadata(components);
 
-        List<SegmentMetadata> metadatas = SegmentMetadata.load(source, indexDescriptor.primaryKeyFactory);
+        List<SegmentMetadata> metadatas = SegmentMetadata.load(source, pkFactory);
 
         assertEquals(1, metadatas.size());
         assertEquals(100, metadatas.get(0).numRows);
@@ -139,11 +143,12 @@ public class LegacyOnDiskFormatTest
     @Test
     public void canCreateAndUsePrimaryKeyMapWithLegacyFormat() throws Throwable
     {
-        PrimaryKeyMap.Factory primaryKeyMapFactory = indexDescriptor.newPrimaryKeyMapFactory(sstable);
+        var perSSTableComponents = indexDescriptor.perSSTableComponents();
+        PrimaryKeyMap.Factory primaryKeyMapFactory = perSSTableComponents.version().onDiskFormat().newPrimaryKeyMapFactory(perSSTableComponents, pkFactory, sstable);
 
         PrimaryKeyMap primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
 
-        PrimaryKey expected = indexDescriptor.primaryKeyFactory.createTokenOnly(Murmur3Partitioner.instance.decorateKey(Int32Type.instance.decompose(23)).getToken());
+        PrimaryKey expected = pkFactory.createTokenOnly(Murmur3Partitioner.instance.decorateKey(Int32Type.instance.decompose(23)).getToken());
 
         PrimaryKey primaryKey = primaryKeyMap.primaryKeyFromRowId(0);
 
@@ -153,20 +158,19 @@ public class LegacyOnDiskFormatTest
     @Test
     public void canSearchBDKIndex() throws Throwable
     {
-        IndexContext indexContext = SAITester.createIndexContext("int_index", Int32Type.instance);
-        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(indexContext);
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(intContext);
 
         final MetadataSource source = MetadataSource.loadMetadata(components);
 
-        List<SegmentMetadata> metadatas = SegmentMetadata.load(source, indexDescriptor.primaryKeyFactory);
+        List<SegmentMetadata> metadatas = SegmentMetadata.load(source, pkFactory);
 
-        BKDReader bkdReader = new BKDReader(indexContext,
+        BKDReader bkdReader = new BKDReader(intContext,
                                             components.get(IndexComponentType.KD_TREE).createFileHandle(),
                                             metadatas.get(0).getIndexRoot(IndexComponentType.KD_TREE),
                                             components.get(IndexComponentType.KD_TREE_POSTING_LISTS).createFileHandle(),
                                             metadatas.get(0).getIndexRoot(IndexComponentType.KD_TREE_POSTING_LISTS));
 
-        Expression expression = new Expression(indexContext).add(Operator.LT, Int32Type.instance.decompose(10));
+        Expression expression = new Expression(intContext).add(Operator.LT, Int32Type.instance.decompose(10));
         BKDReader.IntersectVisitor query = bkdQueryFrom(expression, bkdReader.getNumDimensions(), bkdReader.getBytesPerDimension());
         PostingList postingList = bkdReader.intersect(query, QueryEventListeners.NO_OP_BKD_LISTENER, new QueryContext());
         assertNotNull(postingList);
@@ -175,25 +179,24 @@ public class LegacyOnDiskFormatTest
     @Test
     public void canSearchTermsIndex() throws Throwable
     {
-        IndexContext indexContext = SAITester.createIndexContext("text_index", UTF8Type.instance);
-        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(indexContext);
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(textContext);
 
         final MetadataSource source = MetadataSource.loadMetadata(components);
 
-        SegmentMetadata metadata = SegmentMetadata.load(source, indexDescriptor.primaryKeyFactory).get(0);
+        SegmentMetadata metadata = SegmentMetadata.load(source, pkFactory).get(0);
 
         long root = metadata.getIndexRoot(IndexComponentType.TERMS_DATA);
         Map<String,String> map = metadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).attributes;
         String footerPointerString = map.get(SAICodecUtils.FOOTER_POINTER);
         long footerPointer = footerPointerString == null ? -1 : Long.parseLong(footerPointerString);
 
-        TermsReader termsReader = new TermsReader(indexContext,
+        TermsReader termsReader = new TermsReader(textContext,
                                                   components.get(IndexComponentType.TERMS_DATA).createFileHandle(),
-                                                  components.version().byteComparableVersionFor(IndexComponentType.TERMS_DATA, components.descriptor().version),
+                                                  components.byteComparableVersionFor(IndexComponentType.TERMS_DATA),
                                                   components.get(IndexComponentType.POSTING_LISTS).createFileHandle(),
                                                   root,
                                                   footerPointer);
-        Expression expression = new Expression(indexContext).add(Operator.EQ, UTF8Type.instance.decompose("10"));
+        Expression expression = new Expression(textContext).add(Operator.EQ, UTF8Type.instance.decompose("10"));
         ByteComparable term = ByteComparable.fixedLength(expression.lower.value.encoded);
 
         PostingList result = termsReader.exactMatch(term, QueryEventListeners.NO_OP_TRIE_LISTENER, new QueryContext());

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -112,9 +112,7 @@ public class SegmentFlushTest
     private void testFlushBetweenRowIds(long sstableRowId1, long sstableRowId2, int segments) throws Exception
     {
         Path tmpDir = Files.createTempDirectory("SegmentFlushTest");
-        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(tmpDir.toFile()), "ks", "cf", new SequenceBasedSSTableId(1)),
-                                                                    Murmur3Partitioner.instance,
-                                                                    SAITester.EMPTY_COMPARATOR);
+        IndexDescriptor indexDescriptor = IndexDescriptor.empty(new Descriptor(new File(tmpDir.toFile()), "ks", "cf", new SequenceBasedSSTableId(1)));
 
         ColumnMetadata column = ColumnMetadata.regularColumn("sai", "internal", "column", UTF8Type.instance);
         IndexMetadata config = IndexMetadata.fromSchemaMetadata("index_name", IndexMetadata.Kind.CUSTOM, null);
@@ -150,7 +148,7 @@ public class SegmentFlushTest
         MetadataSource source = MetadataSource.loadMetadata(components);
 
         // verify segment count
-        List<SegmentMetadata> segmentMetadatas = SegmentMetadata.load(source, indexDescriptor.primaryKeyFactory);
+        List<SegmentMetadata> segmentMetadatas = SegmentMetadata.load(source, indexContext.keyFactory());
         assertEquals(segments, segmentMetadatas.size());
 
         // verify segment metadata
@@ -194,7 +192,7 @@ public class SegmentFlushTest
 
         try (TermsReader reader = new TermsReader(components.context(),
                                                   termsData,
-                                                  components.version().byteComparableVersionFor(IndexComponentType.TERMS_DATA, components.descriptor().version),
+                                                  components.byteComparableVersionFor(IndexComponentType.TERMS_DATA),
                                                   postingLists,
                                                   segmentMetadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -45,7 +45,8 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
@@ -111,7 +112,7 @@ public class SegmentFlushTest
     private void testFlushBetweenRowIds(long sstableRowId1, long sstableRowId2, int segments) throws Exception
     {
         Path tmpDir = Files.createTempDirectory("SegmentFlushTest");
-        IndexDescriptor indexDescriptor = IndexDescriptor.createNew(new Descriptor(new File(tmpDir.toFile()), "ks", "cf", new SequenceBasedSSTableId(1)),
+        IndexDescriptor indexDescriptor = IndexDescriptor.create(new Descriptor(new File(tmpDir.toFile()), "ks", "cf", new SequenceBasedSSTableId(1)),
                                                                     Murmur3Partitioner.instance,
                                                                     SAITester.EMPTY_COMPARATOR);
 
@@ -127,7 +128,8 @@ public class SegmentFlushTest
                                                      config,
                                                      MockSchema.newCFS("ks"));
 
-        SSTableIndexWriter writer = new SSTableIndexWriter(indexDescriptor, indexContext, V1OnDiskFormat.SEGMENT_BUILD_MEMORY_LIMITER, () -> true, 2);
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        SSTableIndexWriter writer = new SSTableIndexWriter(components, V1OnDiskFormat.SEGMENT_BUILD_MEMORY_LIMITER, () -> true, 2);
 
         List<DecoratedKey> keys = Arrays.asList(dk("1"), dk("2"));
         Collections.sort(keys);
@@ -145,7 +147,7 @@ public class SegmentFlushTest
 
         writer.complete(Stopwatch.createStarted());
 
-        MetadataSource source = MetadataSource.loadColumnMetadata(indexDescriptor, indexContext);
+        MetadataSource source = MetadataSource.loadMetadata(components);
 
         // verify segment count
         List<SegmentMetadata> segmentMetadatas = SegmentMetadata.load(source, indexDescriptor.primaryKeyFactory);
@@ -163,7 +165,7 @@ public class SegmentFlushTest
         maxTerm = segments == 1 ? term2 : term1;
         numRowsPerSegment = segments == 1 ? 2 : 1;
         verifySegmentMetadata(segmentMetadata);
-        verifyStringIndex(indexDescriptor, indexContext, segmentMetadata);
+        verifyStringIndex(components, segmentMetadata);
 
         if (segments > 1)
         {
@@ -179,22 +181,22 @@ public class SegmentFlushTest
 
             segmentMetadata = segmentMetadatas.get(1);
             verifySegmentMetadata(segmentMetadata);
-            verifyStringIndex(indexDescriptor, indexContext, segmentMetadata);
+            verifyStringIndex(components, segmentMetadata);
         }
     }
 
-    private void verifyStringIndex(IndexDescriptor indexDescriptor, IndexContext indexContext, SegmentMetadata segmentMetadata) throws IOException
+    private void verifyStringIndex(IndexComponents.ForRead components, SegmentMetadata segmentMetadata) throws IOException
     {
-        FileHandle termsData = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-        FileHandle postingLists = indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext);
+        FileHandle termsData = components.get(IndexComponentType.TERMS_DATA).createFileHandle();
+        FileHandle postingLists = components.get(IndexComponentType.POSTING_LISTS).createFileHandle();
 
-        long termsFooterPointer = Long.parseLong(segmentMetadata.componentMetadatas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
+        long termsFooterPointer = Long.parseLong(segmentMetadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
-        try (TermsReader reader = new TermsReader(indexDescriptor,
-                                                  indexContext,
+        try (TermsReader reader = new TermsReader(components.context(),
                                                   termsData,
+                                                  components.version().byteComparableVersionFor(IndexComponentType.TERMS_DATA, components.descriptor().version),
                                                   postingLists,
-                                                  segmentMetadata.componentMetadatas.get(IndexComponent.TERMS_DATA).root,
+                                                  segmentMetadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))
         {
             TermsIterator iterator = reader.allTerms(0);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
@@ -85,9 +85,9 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponentType.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
-        try (TermsReader reader = new TermsReader(indexDescriptor,
-                                                  indexContext,
+        try (TermsReader reader = new TermsReader(indexContext,
                                                   termsData,
+                                                  components.byteComparableVersionFor(IndexComponentType.TERMS_DATA),
                                                   postingLists,
                                                   indexMetas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))
@@ -123,9 +123,9 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponentType.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
-        try (TermsReader reader = new TermsReader(indexDescriptor,
-                                                  indexContext,
+        try (TermsReader reader = new TermsReader(indexContext,
                                                   termsData,
+                                                  components.byteComparableVersionFor(IndexComponentType.TERMS_DATA),
                                                   postingLists,
                                                   indexMetas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
@@ -30,7 +30,8 @@ import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.trie.InvertedIndexWriter;
 import org.apache.cassandra.index.sai.metrics.QueryEventListener;
@@ -73,21 +74,22 @@ public class TermsReaderTest extends SaiRandomizedTest
         final List<Pair<ByteComparable, LongArrayList>> termsEnum = buildTermsEnum(terms, postings);
 
         SegmentMetadata.ComponentMetadataMap indexMetas;
-        try (InvertedIndexWriter writer = new InvertedIndexWriter(indexDescriptor, indexContext))
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        try (InvertedIndexWriter writer = new InvertedIndexWriter(components))
         {
             indexMetas = writer.writeAll(new MemtableTermsIterator(null, null, termsEnum.iterator()));
         }
 
-        FileHandle termsData = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-        FileHandle postingLists = indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext);
+        FileHandle termsData = components.get(IndexComponentType.TERMS_DATA).createFileHandle();
+        FileHandle postingLists = components.get(IndexComponentType.POSTING_LISTS).createFileHandle();
 
-        long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
+        long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponentType.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
         try (TermsReader reader = new TermsReader(indexDescriptor,
                                                   indexContext,
                                                   termsData,
                                                   postingLists,
-                                                  indexMetas.get(IndexComponent.TERMS_DATA).root,
+                                                  indexMetas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))
         {
             try (TermsIterator actualTermsEnum = reader.allTerms(0))
@@ -110,21 +112,22 @@ public class TermsReaderTest extends SaiRandomizedTest
         final List<Pair<ByteComparable, LongArrayList>> termsEnum = buildTermsEnum(numTerms, numPostings);
 
         SegmentMetadata.ComponentMetadataMap indexMetas;
-        try (InvertedIndexWriter writer = new InvertedIndexWriter(indexDescriptor, indexContext))
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        try (InvertedIndexWriter writer = new InvertedIndexWriter(components))
         {
             indexMetas = writer.writeAll(new MemtableTermsIterator(null, null, termsEnum.iterator()));
         }
 
-        FileHandle termsData = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-        FileHandle postingLists = indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext);
+        FileHandle termsData = components.get(IndexComponentType.TERMS_DATA).createFileHandle();
+        FileHandle postingLists = components.get(IndexComponentType.POSTING_LISTS).createFileHandle();
 
-        long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
+        long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponentType.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
         try (TermsReader reader = new TermsReader(indexDescriptor,
                                                   indexContext,
                                                   termsData,
                                                   postingLists,
-                                                  indexMetas.get(IndexComponent.TERMS_DATA).root,
+                                                  indexMetas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))
         {
             for (Pair<ByteComparable, LongArrayList> pair : termsEnum)

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -171,7 +171,7 @@ public class KDTreeIndexBuilder
         {
             SSTableContext sstableContext = mock(SSTableContext.class);
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);
-            when(sstableContext.indexDescriptor()).thenReturn(indexDescriptor);
+            when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
 
             IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
             assertThat(searcher, is(instanceOf(KDTreeIndexSearcher.class)));

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
@@ -146,8 +147,8 @@ public class KDTreeIndexBuilder
         final SegmentMetadata metadata;
 
         IndexContext indexContext = SAITester.createIndexContext("test", Int32Type.instance);
-        try (NumericIndexWriter writer = new NumericIndexWriter(indexDescriptor,
-                                                                indexContext,
+        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
+        try (NumericIndexWriter writer = new NumericIndexWriter(components,
                                                                 TypeUtil.fixedSizeOf(type),
                                                                 maxSegmentRowId,
                                                                 size,
@@ -166,7 +167,7 @@ public class KDTreeIndexBuilder
                                            indexMetas);
         }
 
-        try (PerIndexFiles indexFiles = new PerIndexFiles(indexDescriptor, SAITester.createIndexContext("test", Int32Type.instance)))
+        try (PerIndexFiles indexFiles = new PerIndexFiles(components))
         {
             SSTableContext sstableContext = mock(SSTableContext.class);
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyTest.java
@@ -42,7 +42,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForDeferredPrimaryKey()
     {
-        var factory = Version.BA.onDiskFormat().primaryKeyFactory(EMPTY_COMPARATOR);
+        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -69,7 +69,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForLoadedPrimaryKey()
     {
-        var factory = Version.BA.onDiskFormat().primaryKeyFactory(EMPTY_COMPARATOR);
+        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -91,7 +91,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     public void testHashCodeForDeferedPrimaryKeyWithClusteringColumns()
     {
         var comparator = new ClusteringComparator(Int32Type.instance);
-        var factory = Version.BA.onDiskFormat().primaryKeyFactory(comparator);
+        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
@@ -32,9 +32,10 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
-import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.disk.v1.MetadataSource;
 import org.apache.cassandra.index.sai.disk.v1.MetadataWriter;
 import org.apache.cassandra.index.sai.disk.v1.bitpack.NumericValuesMeta;
@@ -54,18 +55,15 @@ public class SortedTermsTest extends SaiRandomizedTest
     public void testLexicographicException() throws Exception
     {
         IndexDescriptor indexDescriptor = newIndexDescriptor();
-        try (MetadataWriter metadataWriter = new MetadataWriter(indexDescriptor.openPerSSTableOutput(IndexComponent.GROUP_META)))
+        IndexComponents.ForWrite components = indexDescriptor.newPerSSTableComponentsForWrite();
+        try (MetadataWriter metadataWriter = new MetadataWriter(components))
         {
-            NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
-                                                                        indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
+            NumericValuesWriter blockFPWriter = new NumericValuesWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
-            IndexOutputWriter trieWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_TRIE);
-            IndexOutputWriter bytesWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCKS);
-            try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
+            try (SortedTermsWriter writer = new SortedTermsWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
-                                                                  bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  components.addOrGet(IndexComponentType.PRIMARY_KEY_TRIE)))
             {
                 ByteBuffer buffer = Int32Type.instance.decompose(99999);
                 ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
@@ -99,18 +97,15 @@ public class SortedTermsTest extends SaiRandomizedTest
 
         primaryKeys.sort(PrimaryKey::compareTo);
 
-        try (MetadataWriter metadataWriter = new MetadataWriter(indexDescriptor.openPerSSTableOutput(IndexComponent.GROUP_META)))
+        IndexComponents.ForWrite components = indexDescriptor.newPerSSTableComponentsForWrite();
+        try (MetadataWriter metadataWriter = new MetadataWriter(components))
         {
-            IndexOutputWriter trieWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_TRIE);
-            IndexOutputWriter bytesWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCKS);
-            NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
-                                                                        indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
+            NumericValuesWriter blockFPWriter = new NumericValuesWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
-            try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
+            try (SortedTermsWriter writer = new SortedTermsWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
-                                                                  bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  components.addOrGet(IndexComponentType.PRIMARY_KEY_TRIE)))
             {
                 primaryKeys.forEach(primaryKey -> {
                     try
@@ -124,12 +119,12 @@ public class SortedTermsTest extends SaiRandomizedTest
                 });
             }
         }
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_TRIE, true));
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_TRIE, false));
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_BLOCKS, true));
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_BLOCKS, false));
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS, true));
-        assertTrue(validateComponent(indexDescriptor, IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS, false));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_TRIE, true));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_TRIE, false));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_BLOCKS, true));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_BLOCKS, false));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS, true));
+        assertTrue(validateComponent(components, IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS, false));
     }
 
     @Test
@@ -359,18 +354,15 @@ public class SortedTermsTest extends SaiRandomizedTest
 
     private void writeTerms(IndexDescriptor indexDescriptor, List<byte[]> terms) throws IOException
     {
-        try (MetadataWriter metadataWriter = new MetadataWriter(indexDescriptor.openPerSSTableOutput(IndexComponent.GROUP_META)))
+        IndexComponents.ForWrite components = indexDescriptor.newPerSSTableComponentsForWrite();
+        try (MetadataWriter metadataWriter = new MetadataWriter(components))
         {
-            IndexOutputWriter trieWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_TRIE);
-            IndexOutputWriter bytesWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCKS);
-            NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
-                                                                        indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
+            NumericValuesWriter blockFPWriter = new NumericValuesWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
-            try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
+            try (SortedTermsWriter writer = new SortedTermsWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
-                                                                  bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  components.addOrGet(IndexComponentType.PRIMARY_KEY_TRIE)))
             {
                 for (int x = 0; x < 1000 * 4; x++)
                 {
@@ -383,22 +375,20 @@ public class SortedTermsTest extends SaiRandomizedTest
                 }
             }
         }
+        components.markComplete();
     }
 
     private void writeTerms(IndexDescriptor indexDescriptor, List<ByteSource> termsMinPrefix, List<ByteSource> termsMaxPrefix, int numPerPrefix, boolean matchesData) throws IOException
     {
-        try (MetadataWriter metadataWriter = new MetadataWriter(indexDescriptor.openPerSSTableOutput(IndexComponent.GROUP_META)))
+        IndexComponents.ForWrite components = indexDescriptor.newPerSSTableComponentsForWrite();
+        try (MetadataWriter metadataWriter = new MetadataWriter(components))
         {
-            IndexOutputWriter trieWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_TRIE);
-            IndexOutputWriter bytesWriter = indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCKS);
-            NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
-                                                                        indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
+            NumericValuesWriter blockFPWriter = new NumericValuesWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
-            try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
+            try (SortedTermsWriter writer = new SortedTermsWriter(components.addOrGet(IndexComponentType.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
-                                                                  bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  components.addOrGet(IndexComponentType.PRIMARY_KEY_TRIE)))
             {
                 for (int x = 0; x < 1000 ; x++)
                 {
@@ -413,6 +403,7 @@ public class SortedTermsTest extends SaiRandomizedTest
                 }
             }
         }
+        components.markComplete();
     }
 
     private ByteSource intByteSource(int value)
@@ -435,12 +426,15 @@ public class SortedTermsTest extends SaiRandomizedTest
     private void withSortedTermsCursor(IndexDescriptor indexDescriptor,
                                        ThrowingConsumer<SortedTermsReader.Cursor> testCode) throws IOException
     {
-        MetadataSource metadataSource = MetadataSource.loadGroupMetadata(indexDescriptor);
-        NumericValuesMeta blockPointersMeta = new NumericValuesMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS)));
-        SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS)));
-        try (FileHandle trieHandle = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_TRIE);
-             FileHandle termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
-             FileHandle blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS))
+        IndexComponents.ForRead components = indexDescriptor.perSSTableComponents();
+        MetadataSource metadataSource = MetadataSource.loadMetadata(components);
+        IndexComponent.ForRead blocksComponent = components.get(IndexComponentType.PRIMARY_KEY_BLOCKS);
+        IndexComponent.ForRead blockOffsetsComponent = components.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS);
+        NumericValuesMeta blockPointersMeta = new NumericValuesMeta(metadataSource.get(blockOffsetsComponent.fileNamePart()));
+        SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(blocksComponent.fileNamePart()));
+        try (FileHandle trieHandle = components.get(IndexComponentType.PRIMARY_KEY_TRIE).createFileHandle();
+             FileHandle termsData = blocksComponent.createFileHandle();
+             FileHandle blockOffsets = blockOffsetsComponent.createFileHandle())
         {
             SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta);
             try (SortedTermsReader.Cursor cursor = reader.openCursor())
@@ -453,21 +447,24 @@ public class SortedTermsTest extends SaiRandomizedTest
     private void withSortedTermsReader(IndexDescriptor indexDescriptor,
                                        ThrowingConsumer<SortedTermsReader> testCode) throws IOException
     {
-        MetadataSource metadataSource = MetadataSource.loadGroupMetadata(indexDescriptor);
-        NumericValuesMeta blockPointersMeta = new NumericValuesMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS)));
-        SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS)));
-        try (FileHandle trieHandle = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_TRIE);
-             FileHandle termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
-             FileHandle blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS))
+        IndexComponents.ForRead components = indexDescriptor.perSSTableComponents();
+        MetadataSource metadataSource = MetadataSource.loadMetadata(components);
+        IndexComponent.ForRead blocksComponent = components.get(IndexComponentType.PRIMARY_KEY_BLOCKS);
+        IndexComponent.ForRead blockOffsetsComponent = components.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS);
+        NumericValuesMeta blockPointersMeta = new NumericValuesMeta(metadataSource.get(blockOffsetsComponent.fileNamePart()));
+        SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(blocksComponent.fileNamePart()));
+        try (FileHandle trieHandle = components.get(IndexComponentType.PRIMARY_KEY_TRIE).createFileHandle();
+             FileHandle termsData = blocksComponent.createFileHandle();
+             FileHandle blockOffsets = blockOffsetsComponent.createFileHandle())
         {
             SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta);
             testCode.accept(reader);
         }
     }
 
-    private boolean validateComponent(IndexDescriptor indexDescriptor, IndexComponent indexComponent, boolean checksum)
+    private boolean validateComponent(IndexComponents.ForRead components, IndexComponentType indexComponentType, boolean checksum)
     {
-        try (IndexInput input = indexDescriptor.openPerSSTableInput(indexComponent))
+        try (IndexInput input = components.get(indexComponentType).openInput())
         {
             if (checksum)
                 SAICodecUtils.validateChecksum(input);

--- a/test/unit/org/apache/cassandra/index/sai/functional/DropTableTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/DropTableTest.java
@@ -66,7 +66,7 @@ public class DropTableTest extends SAITester
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
         ArrayList<String> files = new ArrayList<>();
-        for (Component component : sstable.components)
+        for (Component component : sstable.components())
         {
             File file = sstable.descriptor.fileFor(component);
             if (file.exists())

--- a/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
@@ -68,7 +68,7 @@ public class FailureTest extends SAITester
         // Now verify that a restart actually repairs the index...
         simulateNodeRestart();
 
-        verifyIndexFiles(numericIndexContext, null, 2, 0);
+        verifyIndexComponentFiles(numericIndexContext, null);
         verifySSTableIndexes(numericIndexContext.getIndexName(), 2, 2);
 
         assertEquals(2, execute("SELECT id1 FROM %s WHERE v1 > 1").size());
@@ -121,7 +121,6 @@ public class FailureTest extends SAITester
         // Verify that the initial index build fails...
         verifyInitialIndexFailed(v2IndexName);
 
-        verifyNoIndexFiles();
         verifySSTableIndexes(v2IndexName, 0);
 
         // ...and then verify that, while the node is still operational, the index is not.

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -53,7 +53,7 @@ public class GroupComponentsTest extends SAITester
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
         Set<Component> components = group.activeComponents(sstable);
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() + 1, components.size());
+        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
 
         // index files are released but not removed
         cfs.invalidate(true, false);
@@ -79,7 +79,7 @@ public class GroupComponentsTest extends SAITester
 
         Set<Component> components = group.activeComponents(sstables.iterator().next());
 
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() + 1, components.size());
+        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
     }
 
     @Test
@@ -99,8 +99,8 @@ public class GroupComponentsTest extends SAITester
 
         Set<Component> components = group.activeComponents(sstables.iterator().next());
 
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() +
-                     Version.latest().onDiskFormat().perIndexComponents(indexContext).size(),
+        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() +
+                     Version.latest().onDiskFormat().perIndexComponentTypes(indexContext).size(),
                      components.size());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -18,13 +18,10 @@
 
 package org.apache.cassandra.index.sai.functional;
 
-import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterables;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -55,7 +52,7 @@ public class GroupComponentsTest extends SAITester
         StorageAttachedIndex index = (StorageAttachedIndex) group.getIndexes().iterator().next();
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
-        Set<Component> components = group.getLiveComponents(sstable, getIndexesFromGroup(group));
+        Set<Component> components = group.activeComponents(sstable);
         assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() + 1, components.size());
 
         // index files are released but not removed
@@ -80,7 +77,7 @@ public class GroupComponentsTest extends SAITester
 
         assertEquals(1, sstables.size());
 
-        Set<Component> components = group.getLiveComponents(sstables.iterator().next(), getIndexesFromGroup(group));
+        Set<Component> components = group.activeComponents(sstables.iterator().next());
 
         assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() + 1, components.size());
     }
@@ -100,15 +97,10 @@ public class GroupComponentsTest extends SAITester
 
         assertEquals(1, sstables.size());
 
-        Set<Component> components = group.getLiveComponents(sstables.iterator().next(), getIndexesFromGroup(group));
+        Set<Component> components = group.activeComponents(sstables.iterator().next());
 
         assertEquals(Version.latest().onDiskFormat().perSSTableComponents().size() +
                      Version.latest().onDiskFormat().perIndexComponents(indexContext).size(),
                      components.size());
-    }
-
-    private Collection<StorageAttachedIndex> getIndexesFromGroup(StorageAttachedIndexGroup group)
-    {
-        return group.getIndexes().stream().map(index -> (StorageAttachedIndex)index).collect(Collectors.toList());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
@@ -150,8 +150,8 @@ public class IndexBuildDeciderTest extends SAITester
     private int numericIndexFileCount()
     {
         IndexContext context = createIndexContext("v1", Int32Type.instance);
-        return V2OnDiskFormat.instance.perIndexComponents(context).size()
-               + V2OnDiskFormat.instance.perSSTableComponents().size();
+        return V2OnDiskFormat.instance.perIndexComponentTypes(context).size()
+               + V2OnDiskFormat.instance.perSSTableComponentTypes().size();
     }
 
     public static class IndexBuildDeciderWithoutInitialBuild implements IndexBuildDecider

--- a/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
@@ -102,7 +102,7 @@ public class SnapshotTest extends SAITester
 
         // Rebuild the index to verify that the index files are overridden
         rebuildIndexes(numericIndexContext.getIndexName());
-        verifyIndexFiles(numericIndexContext, null, 2, 0);
+        verifyIndexComponentFiles(numericIndexContext, null);
         assertNotEquals(snapshotLastModified, indexFilesLastModified());
         assertNumRows(2, "SELECT * FROM %%s WHERE v1 >= 0");
         assertValidationCount(2, 2); // compaction should not validate

--- a/test/unit/org/apache/cassandra/index/sai/utils/IndexInputLeakDetector.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/IndexInputLeakDetector.java
@@ -41,7 +41,7 @@ public class IndexInputLeakDetector extends TestRuleAdapter
     {
         TrackingIndexFileUtils trackingIndexFileUtils = new TrackingIndexFileUtils(sequentialWriterOption);
         trackedIndexFileUtils.add(trackingIndexFileUtils);
-        return IndexDescriptor.createNew(descriptor, tableMetadata.partitioner, tableMetadata.comparator);
+        return IndexDescriptor.create(descriptor, tableMetadata);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/utils/IndexInputLeakDetector.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/IndexInputLeakDetector.java
@@ -37,11 +37,11 @@ public class IndexInputLeakDetector extends TestRuleAdapter
 {
     private final static Set<TrackingIndexFileUtils> trackedIndexFileUtils = Collections.synchronizedSet(new HashSet<>());
 
-    public IndexDescriptor newIndexDescriptor(Descriptor descriptor, TableMetadata tableMetadata, SequentialWriterOption sequentialWriterOption)
+    public IndexDescriptor newIndexDescriptor(Descriptor descriptor, SequentialWriterOption sequentialWriterOption)
     {
         TrackingIndexFileUtils trackingIndexFileUtils = new TrackingIndexFileUtils(sequentialWriterOption);
         trackedIndexFileUtils.add(trackingIndexFileUtils);
-        return IndexDescriptor.create(descriptor, tableMetadata);
+        return IndexDescriptor.empty(descriptor);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/utils/SaiRandomizedTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SaiRandomizedTest.java
@@ -72,17 +72,10 @@ public class SaiRandomizedTest extends RandomizedTest
 
     public IndexDescriptor newIndexDescriptor() throws IOException
     {
-        String keyspace = randomSimpleString(5, 13);
-        String table = randomSimpleString(3, 17);
-        TableMetadata metadata = TableMetadata.builder(keyspace, table)
-                                              .addPartitionKeyColumn(randomSimpleString(3, 15), Int32Type.instance)
-                                              .partitioner(Murmur3Partitioner.instance)
-                                              .build();
         return indexInputLeakDetector.newIndexDescriptor(new Descriptor(new File(temporaryFolder.newFolder()),
                                                                         randomSimpleString(5, 13),
                                                                         randomSimpleString(3, 17),
                                                                         new SequenceBasedSSTableId(randomIntBetween(0, 128))),
-                                                         metadata,
                                                          SequentialWriterOption.newBuilder()
                                                                                .bufferSize(randomIntBetween(17, 1 << 13))
                                                                                .bufferType(randomBoolean() ? BufferType.ON_HEAP : BufferType.OFF_HEAP)

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -41,11 +41,11 @@ import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
-import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.utils.FBUtilities;
@@ -172,12 +172,12 @@ public class IndexViewManagerTest extends SAITester
         for (int i = 0; i < CONCURRENT_UPDATES; i++)
         {
             // mock the initial view indexes to track the number of releases
-            List<SSTableContext> initialContexts = sstables.stream().limit(2).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
+            List<SSTableContext> initialContexts = sstables.stream().limit(2).map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
             List<SSTableIndex> initialIndexes = new ArrayList<>();
 
             for (SSTableContext initialContext : initialContexts)
             {
-                MockSSTableIndex mockSSTableIndex = new MockSSTableIndex(initialContext, columnContext);
+                MockSSTableIndex mockSSTableIndex = new MockSSTableIndex(initialContext, initialContext.usedPerSSTableComponents().indexDescriptor().perIndexComponents(columnContext));
                 initialIndexes.add(mockSSTableIndex);
             }
 
@@ -185,8 +185,8 @@ public class IndexViewManagerTest extends SAITester
             View initialView = tracker.getView();
             assertEquals(2, initialView.size());
 
-            List<SSTableContext> compacted = sstables.stream().skip(2).limit(1).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
-            List<SSTableContext> flushed = sstables.stream().skip(3).limit(1).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
+            List<SSTableContext> compacted = sstables.stream().skip(2).limit(1).map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
+            List<SSTableContext> flushed = sstables.stream().skip(3).limit(1).map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
 
             // concurrently update from both flush and compaction
             Future<?> compaction = executor.submit(() -> tracker.update(initial, compacted, true));
@@ -231,9 +231,9 @@ public class IndexViewManagerTest extends SAITester
     {
         int releaseCount = 0;
 
-        MockSSTableIndex(SSTableContext group, IndexContext context) throws IOException
+        MockSSTableIndex(SSTableContext group, IndexComponents.ForRead perIndexComponents) throws IOException
         {
-            super(group, context);
+            super(group, perIndexComponents);
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -171,7 +172,7 @@ public class IndexViewManagerTest extends SAITester
         for (int i = 0; i < CONCURRENT_UPDATES; i++)
         {
             // mock the initial view indexes to track the number of releases
-            List<SSTableContext> initialContexts = sstables.stream().limit(2).map(SSTableContext::create).collect(Collectors.toList());
+            List<SSTableContext> initialContexts = sstables.stream().limit(2).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
             List<SSTableIndex> initialIndexes = new ArrayList<>();
 
             for (SSTableContext initialContext : initialContexts)
@@ -184,8 +185,8 @@ public class IndexViewManagerTest extends SAITester
             View initialView = tracker.getView();
             assertEquals(2, initialView.size());
 
-            List<SSTableContext> compacted = sstables.stream().skip(2).limit(1).map(SSTableContext::create).collect(Collectors.toList());
-            List<SSTableContext> flushed = sstables.stream().skip(3).limit(1).map(SSTableContext::create).collect(Collectors.toList());
+            List<SSTableContext> compacted = sstables.stream().skip(2).limit(1).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
+            List<SSTableContext> flushed = sstables.stream().skip(3).limit(1).map(s -> SSTableContext.create(s, IndexDescriptor.create(s))).collect(Collectors.toList());
 
             // concurrently update from both flush and compaction
             Future<?> compaction = executor.submit(() -> tracker.update(initial, compacted, true));

--- a/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
@@ -205,7 +205,7 @@ public class SegmentsSystemViewTest extends SAITester
             {
                 SSTableReader sstable = sstableIndex.getSSTable();
 
-                IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
+                IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
 
                 if (TypeUtil.isLiteral(sstableIndex.getIndexContext().getValidator()))
                 {

--- a/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
@@ -158,13 +158,13 @@ public class SegmentsSystemViewTest extends SAITester
                     final String indexType = entry.getKey();
                     final String str = entry.getValue().getOrDefault(SegmentMetadata.ComponentMetadata.LENGTH, "0");
 
-                    if (indexType.equals(IndexComponent.KD_TREE.toString()))
+                    if (indexType.equals(IndexComponentType.KD_TREE.toString()))
                     {
                         int maxPointsInLeafNode = Integer.parseInt(entry.getValue().get("max_points_in_leaf_node"));
 
                         assertEquals(1024, maxPointsInLeafNode);
                     }
-                    else if (indexType.equals(IndexComponent.KD_TREE_POSTING_LISTS.toString()))
+                    else if (indexType.equals(IndexComponentType.KD_TREE_POSTING_LISTS.toString()))
                     {
                         int numLeafPostings = Integer.parseInt(entry.getValue().get("num_leaf_postings"));
 
@@ -205,18 +205,17 @@ public class SegmentsSystemViewTest extends SAITester
             {
                 SSTableReader sstable = sstableIndex.getSSTable();
 
-                IndexDescriptor indexDescriptor = IndexDescriptor.createFrom(sstable);
-                indexDescriptor.hasComponent(IndexComponent.COLUMN_COMPLETION_MARKER, index.getIndexContext());
+                IndexDescriptor indexDescriptor = IndexDescriptor.create(sstable);
 
                 if (TypeUtil.isLiteral(sstableIndex.getIndexContext().getValidator()))
                 {
-                    addComponentSizeToMap(lengths, IndexComponent.TERMS_DATA, index.getIndexContext(), indexDescriptor);
-                    addComponentSizeToMap(lengths, IndexComponent.POSTING_LISTS, index.getIndexContext(), indexDescriptor);
+                    addComponentSizeToMap(lengths, IndexComponentType.TERMS_DATA, index.getIndexContext(), indexDescriptor);
+                    addComponentSizeToMap(lengths, IndexComponentType.POSTING_LISTS, index.getIndexContext(), indexDescriptor);
                 }
                 else
                 {
-                    addComponentSizeToMap(lengths, IndexComponent.KD_TREE, index.getIndexContext(), indexDescriptor);
-                    addComponentSizeToMap(lengths, IndexComponent.KD_TREE_POSTING_LISTS, index.getIndexContext(), indexDescriptor);
+                    addComponentSizeToMap(lengths, IndexComponentType.KD_TREE, index.getIndexContext(), indexDescriptor);
+                    addComponentSizeToMap(lengths, IndexComponentType.KD_TREE_POSTING_LISTS, index.getIndexContext(), indexDescriptor);
                 }
             }
         }
@@ -224,10 +223,10 @@ public class SegmentsSystemViewTest extends SAITester
         return lengths;
     }
 
-    private void addComponentSizeToMap(HashMap<String, Long> map, IndexComponent key, IndexContext indexContext, IndexDescriptor indexDescriptor)
+    private void addComponentSizeToMap(HashMap<String, Long> map, IndexComponentType key, IndexContext indexContext, IndexDescriptor indexDescriptor)
     {
         map.compute(key.name(), (typeName, acc) -> {
-            final long size = indexDescriptor.sizeOnDiskOfPerIndexComponent(key, indexContext);
+            final long size = indexDescriptor.perIndexComponents(indexContext).get(key).file().length();
             return acc == null ? size : size + acc;
         });
     }

--- a/test/unit/org/apache/cassandra/inject/ActionBuilder.java
+++ b/test/unit/org/apache/cassandra/inject/ActionBuilder.java
@@ -127,7 +127,7 @@ public class ActionBuilder
 
         public ConditionsBuilder not()
         {
-            if (!(elements.getLast() instanceof LogicOp))
+            if (!elements.isEmpty() && !(elements.getLast() instanceof LogicOp))
             {
                 elements.add(LogicOp.AND);
             }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -738,7 +738,7 @@ public class SSTableReaderTest
 
         // re-open the same sstable as it would be during bulk loading
         Set<Component> components = Sets.newHashSet(sstable.descriptor.getFormat().requiredComponents());
-        if (sstable.components.contains(Component.COMPRESSION_INFO))
+        if (sstable.components().contains(Component.COMPRESSION_INFO))
             components.add(Component.COMPRESSION_INFO);
         SSTableReader bulkLoaded = sstable.descriptor.getFormat().getReaderFactory().openForBatch(sstable.descriptor, components, store.metadata);
         sections = bulkLoaded.getPositionsForRanges(ranges);
@@ -896,7 +896,7 @@ public class SSTableReaderTest
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD);
         SSTableReader sstable = getNewSSTable(cfs);
         Descriptor notLiveDesc = new Descriptor(new File("/tmp"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
-        notLiveDesc.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
+        notLiveDesc.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components(), false);
     }
 
     @Test(expected = RuntimeException.class)
@@ -906,7 +906,7 @@ public class SSTableReaderTest
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD);
         SSTableReader sstable = getNewSSTable(cfs);
         Descriptor notLiveDesc = new Descriptor(new File("/tmp"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
-        sstable.descriptor.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, notLiveDesc, sstable.descriptor, sstable.components, false);
+        sstable.descriptor.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, notLiveDesc, sstable.descriptor, sstable.components(), false);
     }
 
     @Test
@@ -922,15 +922,15 @@ public class SSTableReaderTest
         SSTableId id = SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get();
         Descriptor notLiveDesc = new Descriptor(tmpdir, sstable.descriptor.ksname, sstable.descriptor.cfname, id);
         // make sure the new directory is empty and that the old files exist:
-        for (Component c : sstable.components)
+        for (Component c : sstable.components())
         {
             File f = notLiveDesc.fileFor(c);
             assertFalse(f.exists());
             assertTrue(sstable.descriptor.fileFor(c).exists());
         }
-        notLiveDesc.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
+        notLiveDesc.getFormat().getReaderFactory().moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components(), false);
         // make sure the files were moved:
-        for (Component c : sstable.components)
+        for (Component c : sstable.components())
         {
             File f = notLiveDesc.fileFor(c);
             assertTrue(f.exists());

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
@@ -239,7 +239,7 @@ public class SSTableUtils
             // mark all components for removal
             if (cleanup)
                 for (SSTableReader reader: readers)
-                    for (Component component : reader.components)
+                    for (Component component : reader.components())
                         reader.descriptor.fileFor(component).deleteOnExit();
             return readers;
         }


### PR DESCRIPTION
When a SAI index is rebuild, create new index files rather than overwriting existing files, making SAI index components
files essentially truly immutable (once initially written).

To do this, SAI index components have a new parameter, their "generation": for a given version, the component with the
highest generation is the most recently written one. That generation is added to the filename, but with the special case
that the initial generation (for a version), generation 0, is special cased and not added to the filename, and this for
backward compatibility. This means in particular that filenames are completely unchanged by this patch up until one
triggers an index rebuild that does not also correspond to a version change.

One implication is that on a rebuild, old SAI index components are not deleted anymore (previously, they were deleted at
the end of the rebuild, and the rebuild was re-creating new versions of the same files, essentially overwriting the file
but in 2 steps) and will remain on disk. The intent here is that this pave the way for allowing index "live" rebuild,
that is rebuilding an index without making the index un-queriable during the rebuild. However, this patch does *not*
implement such "live" rebuild, leaving it as a follow up. As of this patch, the old index component files are also never
deleted, though over time, compaction will get rid of them by virtue of replacing the sstables that have those
components.

Technically, the generation added is not incremented "per component", but rather per "group" of components, where
"group" means (for a particular sstable) either 1) all the per-sstable components or 2) all the components of a
particular index. As an example, suppose the components for an sstable are (where 1 is the generation, and including
only a subset of real components to keep the example shorter):
```
<sstable X>-SAI+CA+1+GroupMeta.db
<sstable X>-SAI+CA+1+TokenValues.db
<sstable X>-SAI+CA+1+PrimaryKeyTrie.db
<sstable X>-SAI+CA+1+GroupComplete.db
<sstable X>-SAI+CA+myIndex+Meta.db
<sstable X>-SAI+CA+myIndex+TermsData.db
```
In this example, the per-sstable group is complete, but not the group for `myIndex` (missing at least the
`-ColumnComplete` component). Also, the per-sstable group is at generation 1, while the `myIndex` group is at generation
0.. If a rebuild is triggered, the created components will be (assuming `CA` is the current version and again using a
subset of the actual components for simplicity):
```
<sstable X>-SAI+CA+2+GroupMeta.db
<sstable X>-SAI+CA+2+TokenValues.db
<sstable X>-SAI+CA+2+PrimaryKeyTrie.db
<sstable X>-SAI+CA+2+GroupComplete.db
<sstable X>-SAI+CA+1+myIndex+Meta.db
<sstable X>-SAI+CA+1+myIndex+TermsData.db
<sstable X>-SAI+CA+1+PostingLists.db
<sstable X>-SAI+CA+1+ColumnComplete.db
```
In other words, the generation for the per-sstable group and the `myIndex` one are independent, but the generation are
linked within a group (the `<sstable X>-SAI+CA+1+PostingLists.db` file is at generation 1 like the rest of that group
and not 0, despite there being no generation 0 file before the rebuild).

The reason generation are linked "by group" is that 1) we need to at least link the generation to the "completion
marker" components to the rest of the component of the group this is a marker for, and linking the whole group as above
feels like the cleaner solution and 2) linking the generation of *all* the SAI components of a given sstable would
prevent us from being able to rebuild a single index without rebuilding the per-sstable components/other indexes.
