### PR TITLE
ModificationStatement#casInternal must close rows iterator

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -678,9 +678,11 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         SinglePartitionReadQuery readCommand = request.readCommand(nowInSeconds);
         FilteredPartition current;
         try (ReadExecutionController executionController = readCommand.executionController();
-             PartitionIterator iter = readCommand.executeInternal(executionController))
+             PartitionIterator iter = readCommand.executeInternal(executionController);
+             RowIterator row = PartitionIterators.getOnlyElement(iter, readCommand);)
         {
-            current = FilteredPartition.create(PartitionIterators.getOnlyElement(iter, readCommand));
+            // FilteredPartition consumes the row but does not close the iterator
+            current = FilteredPartition.create(row);
         }
 
         if (!request.appliesTo(current))


### PR DESCRIPTION
Fix for flaky test `MapEntriesIndexTest#testLWTConditionalUpdate`. It was flaky, and not always failing, because there was a garbage collection race such that we loaded chunks into the chunk cache, and the test only failed if GC happened before the test framework checked if any reference counted objects were leaked.

The other caller of `PartitionIterators#getOnlyElement` ultimately does the following, providing further validation for this solution:

https://github.com/datastax/cassandra/blob/233b9a4588f53c4c45a037476af481754a89c530/src/java/org/apache/cassandra/service/StorageProxy.java#L481-L484

Note that it doesn't look like the `Close` class defined in the `PartitionIterators#getOnlyElement` method is ever called. I'm not sure if that's an issue or not. However, I added some basic logging to the chunk cache during my testing, and I can see that this PR's change fixes a reference leak.

https://github.com/datastax/cassandra/blob/0cf63a3d0b6d501600c36d6b793dde750e9f428b/src/java/org/apache/cassandra/db/partitions/PartitionIterators.java#L45-L70

Additional analysis for reference:

The stack from the reference counting tooling was:

```
[junit-timeout] ERROR [Reference-Reaper] 2024-05-03 15:07:10,025 Ref.java:248 - LEAK DETECTED: a reference (org.apache.cassandra.utils.concurrent.Ref$State@18c9f8b) to @1486334689 was not released before the reference was garbage collected
[junit-timeout] ERROR [Reference-Reaper] 2024-05-03 15:07:10,029 Ref.java:271 - Allocate trace org.apache.cassandra.utils.concurrent.Ref$State@18c9f8b:
[junit-timeout] Thread[main,5,main]
[junit-timeout] 	at java.base/java.lang.Thread.getStackTrace(Thread.java:1602)
[junit-timeout] 	at org.apache.cassandra.utils.concurrent.Ref$Debug.<init>(Ref.java:261)
[junit-timeout] 	at org.apache.cassandra.utils.concurrent.Ref$State.<init>(Ref.java:184)
[junit-timeout] 	at org.apache.cassandra.utils.concurrent.Ref.<init>(Ref.java:101)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$Chunk.setAttachment(BufferPool.java:1298)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$Chunk.set(BufferPool.java:1438)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$Chunk.get(BufferPool.java:1428)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$MicroQueueOfChunks.get(BufferPool.java:618)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGetInternal(BufferPool.java:946)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.tryGet(BufferPool.java:929)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.get(BufferPool.java:889)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool$LocalPool.get(BufferPool.java:879)
[junit-timeout] 	at org.apache.cassandra.utils.memory.BufferPool.get(BufferPool.java:203)
[junit-timeout] 	at org.apache.cassandra.cache.ChunkCache.load(ChunkCache.java:269)
[junit-timeout] 	at org.apache.cassandra.cache.ChunkCache$CachingRebufferer.rebuffer(ChunkCache.java:410)
[junit-timeout] 	at org.apache.cassandra.io.util.RandomAccessReader.reBufferAt(RandomAccessReader.java:74)
[junit-timeout] 	at org.apache.cassandra.io.util.RandomAccessReader.seek(RandomAccessReader.java:353)
[junit-timeout] 	at org.apache.cassandra.io.util.FileHandle.createReader(FileHandle.java:156)
[junit-timeout] 	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableReader.getExactPosition(TrieIndexSSTableReader.java:369)
[junit-timeout] 	at org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableReader.iterator(TrieIndexSSTableReader.java:608)
[junit-timeout] 	at org.apache.cassandra.db.rows.UnfilteredRowIteratorWithLowerBound.initializeIterator(UnfilteredRowIteratorWithLowerBound.java:131)
[junit-timeout] 	at org.apache.cassandra.db.rows.LazilyInitializedUnfilteredRowIterator.maybeInit(LazilyInitializedUnfilteredRowIterator.java:50)
[junit-timeout] 	at org.apache.cassandra.db.rows.LazilyInitializedUnfilteredRowIterator.computeNext(LazilyInitializedUnfilteredRowIterator.java:101)
[junit-timeout] 	at org.apache.cassandra.db.rows.UnfilteredRowIteratorWithLowerBound.computeNext(UnfilteredRowIteratorWithLowerBound.java:169)
[junit-timeout] 	at org.apache.cassandra.db.rows.UnfilteredRowIteratorWithLowerBound.computeNext(UnfilteredRowIteratorWithLowerBound.java:48)
[junit-timeout] 	at org.apache.cassandra.utils.AbstractIterator.hasNext(AbstractIterator.java:47)
[junit-timeout] 	at org.apache.cassandra.db.rows.UnfilteredRowIterator.isEmpty(UnfilteredRowIterator.java:67)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadCommand.withSSTablesIterated(SinglePartitionReadCommand.java:805)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadCommand.withSSTablesIterated(SinglePartitionReadCommand.java:795)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadCommand.queryMemtableAndDiskInternal(SinglePartitionReadCommand.java:721)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadCommand.queryMemtableAndDisk(SinglePartitionReadCommand.java:577)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadCommand.queryStorage(SinglePartitionReadCommand.java:410)
[junit-timeout] 	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:409)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadQuery$Group.executeLocally(SinglePartitionReadQuery.java:242)
[junit-timeout] 	at org.apache.cassandra.db.SinglePartitionReadQuery$Group.executeInternal(SinglePartitionReadQuery.java:216)
[junit-timeout] 	at org.apache.cassandra.cql3.statements.SelectStatement.executeInternal(SelectStatement.java:568)
[junit-timeout] 	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:552)
[junit-timeout] 	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:103)
[junit-timeout] 	at org.apache.cassandra.cql3.QueryProcessor.executeInternal(QueryProcessor.java:489)
[junit-timeout] 	at org.apache.cassandra.cql3.CQLTester.executeFormattedQuery(CQLTester.java:1390)
[junit-timeout] 	at org.apache.cassandra.cql3.CQLTester.execute(CQLTester.java:1378)
[junit-timeout] 	at org.apache.cassandra.index.sai.cql.MapEntriesIndexTest.testLWTConditionalUpdate(MapEntriesIndexTest.java:437)
[junit-timeout] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[junit-timeout] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[junit-timeout] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[junit-timeout] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[junit-timeout] 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
[junit-timeout] 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
[junit-timeout] 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
[junit-timeout] 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
[junit-timeout] 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
[junit-timeout] 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
[junit-timeout] 	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
[junit-timeout] 	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
[junit-timeout] 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
[junit-timeout] 	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
[junit-timeout] 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
[junit-timeout] 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
[junit-timeout] 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
[junit-timeout] 	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
[junit-timeout] 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
[junit-timeout] 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
[junit-timeout] 	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
[junit-timeout] 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
[junit-timeout] 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
[junit-timeout] 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
[junit-timeout] 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
[junit-timeout] 	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
[junit-timeout] 	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:50)
[junit-timeout] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:535)
[junit-timeout] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1197)
[junit-timeout] 	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:1042)
```

Because it was in the chunk cache and was a result of an unclosed iterator, I found it less than straight forward to debug. However, eventually I realized that the allocation method pointed to the first of these lines:

```java
        var row3 = execute("SELECT item_cost FROM %s WHERE partition = 3");
        assertEquals("{apple=10000, orange=1}", row3.one().getMap("item_cost", UTF8Type.instance, Int32Type.instance).toString());

        // Attempt to update rows, but only one of the updates is successful in updating the value of apple
        execute("UPDATE %s SET item_cost['apple'] = 3 WHERE partition = 2 IF item_cost['apple'] > 100");
        execute("UPDATE %s SET item_cost['apple'] = 3 WHERE partition = 3 IF item_cost['apple'] > 100");
```

Then, it was the last line where we accessed partition 3 that referenced the chunk cache without releasing the reference.

The key takeaway: pay more attention to the stack trace. It took me too long to realize it was consistently pointing at the same line in a test, and once I figured that out, it was fairly straight forward to solve.