### PR TITLE
reduce compaction performance penalty

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.6-SNAPSHOT" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.6" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.3" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.6-SNAPSHOT" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -27,6 +27,8 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 
+import static java.lang.Math.max;
+
 /**
  * Tracks state relevant to the execution of a single query, including metrics and timeout monitoring.
  */
@@ -58,6 +60,7 @@ public class QueryContext
     private final LongAdder queryTimeouts = new LongAdder();
 
     private final LongAdder annNodesVisited = new LongAdder();
+    private float annRerankFloor = 0.0f; // only called from single-threaded setup code
 
     private final LongAdder shadowedPrimaryKeyCount = new LongAdder();
 
@@ -227,6 +230,17 @@ public class QueryContext
     public long getShadowedPrimaryKeyCount()
     {
         return shadowedPrimaryKeyCount.longValue();
+    }
+
+    public float getAnnRerankFloor()
+    {
+        return annRerankFloor;
+    }
+
+    public void updateAnnRerankFloor(float observedFloor)
+    {
+        if (observedFloor < Float.POSITIVE_INFINITY)
+            annRerankFloor = max(annRerankFloor, observedFloor);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -157,10 +157,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         if (exp.getOp() != Expression.Op.ANN)
             throw new IllegalArgumentException(indexContext.logMessage("Unsupported expression during ANN index query: " + exp));
 
-        int topK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
+        int rerankK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
         var queryVector = vts.createFloatVector(exp.lower.value.vector);
 
-        var result = searchInternal(keyRange, context, queryVector, limit, topK, 0);
+        var result = searchInternal(keyRange, context, queryVector, limit, rerankK, 0);
         return toScoreOrderedIterator(result, context);
     }
 
@@ -171,7 +171,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
      * @param context the query context
      * @param queryVector the query vector
      * @param limit the limit for the query
-     * @param topK the amplified limit for the query to get more accurate results
+     * @param rerankK the amplified limit for the query to get more accurate results
      * @param threshold the threshold for the query. When the threshold is greater than 0 and brute force logic is used,
      *                  the results will be filtered by the threshold.
      */
@@ -179,14 +179,14 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                                                           QueryContext context,
                                                           VectorFloat<?> queryVector,
                                                           int limit,
-                                                          int topK,
+                                                          int rerankK,
                                                           float threshold) throws IOException
     {
         try (PrimaryKeyMap primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap())
         {
             // not restricted
             if (RangeUtil.coversFullRing(keyRange))
-                return graph.search(queryVector, topK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
+                return graph.search(queryVector, limit, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
 
             PrimaryKey firstPrimaryKey = keyFactory.createTokenOnly(keyRange.left.getToken());
 
@@ -202,16 +202,16 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             // if it covers entire segment, skip bit set
             if (minSSTableRowId <= metadata.minSSTableRowId && maxSSTableRowId >= metadata.maxSSTableRowId)
-                return graph.search(queryVector, topK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
+                return graph.search(queryVector, limit, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
 
             minSSTableRowId = Math.max(minSSTableRowId, metadata.minSSTableRowId);
             maxSSTableRowId = min(maxSSTableRowId, metadata.maxSSTableRowId);
 
             // Upper-bound cost based on maximum possible rows included
             int nRows = Math.toIntExact(maxSSTableRowId - minSSTableRowId + 1);
-            var initialCostEstimate = estimateCost(topK, nRows);
+            var initialCostEstimate = estimateCost(rerankK, nRows);
             Tracing.logAndTrace(logger, "Search range covers {} rows; expected nodes visited is {} for sstable index with {} nodes, LIMIT {}",
-                                nRows, initialCostEstimate.expectedNodesVisited, graph.size(), topK);
+                                nRows, initialCostEstimate.expectedNodesVisited, graph.size(), rerankK);
             // if we have a small number of results then let TopK processor do exact NN computation
             if (initialCostEstimate.shouldUseBruteForce())
             {
@@ -224,7 +224,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                 if (threshold > 0)
                     return filterByBruteForce(queryVector, segmentRowIds, threshold);
                 else
-                    return orderByBruteForce(queryVector, segmentRowIds, limit, topK);
+                    return orderByBruteForce(queryVector, segmentRowIds, limit, rerankK);
             }
 
             // create a bitset of ordinals corresponding to the rows in the given key range
@@ -243,12 +243,12 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             int cardinality = bits instanceof SparseBits ? ((SparseBits) bits).cardinality() : ((BitSet) bits).cardinality();
             // We can make a more accurate cost estimate now
-            var betterCostEstimate = estimateCost(topK, cardinality);
+            var betterCostEstimate = estimateCost(rerankK, cardinality);
 
             if (cardinality == 0)
                 return CloseableIterator.emptyIterator();
 
-            return graph.search(queryVector, topK, threshold, bits, context, visited -> {
+            return graph.search(queryVector, limit, rerankK, threshold, bits, context, visited -> {
                 betterCostEstimate.updateStatistics(visited);
                 context.addAnnNodesVisited(visited);
             });
@@ -476,13 +476,13 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         if (keysInRange.isEmpty())
             return CloseableIterator.emptyIterator();
 
-        int topK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
+        int rerankK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
         // Convert PKs to segment row ids and then to ordinals, skipping any that don't exist in this segment
         var bitsAndRows = flatmapPrimaryKeysToBitsAndRows(keysInRange);
         var bits = bitsAndRows.left;
         var rowIds = bitsAndRows.right;
         var numRows = rowIds.size();
-        final CostEstimate cost = estimateCost(topK, numRows);
+        final CostEstimate cost = estimateCost(rerankK, numRows);
         Tracing.logAndTrace(logger, "{} rows relevant to current sstable out of {} in range; expected nodes visited is {} for index with {} nodes, LIMIT {}",
                             numRows, keysInRange.size(), cost.expectedNodesVisited, graph.size(), limit);
         if (numRows == 0)
@@ -492,11 +492,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         {
             // brute force using the in-memory compressed vectors to cut down the number of results returned
             var queryVector = vts.createFloatVector(exp.lower.value.vector);
-            return toScoreOrderedIterator(this.orderByBruteForce(queryVector, rowIds, limit, topK), context);
+            return toScoreOrderedIterator(this.orderByBruteForce(queryVector, rowIds, limit, rerankK), context);
         }
         // else ask the index to perform a search limited to the bits we created
         var queryVector = vts.createFloatVector(exp.lower.value.vector);
-        var results = graph.search(queryVector, topK, 0, bits, context, cost::updateStatistics);
+        var results = graph.search(queryVector, limit, rerankK, 0, bits, context, cost::updateStatistics);
         return toScoreOrderedIterator(results, context);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -157,7 +157,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         if (exp.getOp() != Expression.Op.ANN)
             throw new IllegalArgumentException(indexContext.logMessage("Unsupported expression during ANN index query: " + exp));
 
-        int topK = indexContext.getIndexWriterConfig().getSourceModel().topKFor(limit, graph.getCompressedVectors());
+        int topK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
         var queryVector = vts.createFloatVector(exp.lower.value.vector);
 
         var result = searchInternal(keyRange, context, queryVector, limit, topK, 0);
@@ -476,7 +476,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         if (keysInRange.isEmpty())
             return CloseableIterator.emptyIterator();
 
-        int topK = indexContext.getIndexWriterConfig().getSourceModel().topKFor(limit, graph.getCompressedVectors());
+        int topK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompressedVectors());
         // Convert PKs to segment row ids and then to ordinals, skipping any that don't exist in this segment
         var bitsAndRows = flatmapPrimaryKeysToBitsAndRows(keysInRange);
         var bits = bitsAndRows.left;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -101,7 +101,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
      * @return Row IDs associated with the topK vectors near the query
      */
     @Override
-    public CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, int rerankK, float threshold, Bits acceptBits, QueryContext context, IntConsumer nodesVisited)
+    public CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int limit, int rerankK, float threshold, Bits acceptBits, QueryContext context, IntConsumer nodesVisited)
     {
         if (threshold > 0)
             throw new InvalidRequestException("Geo queries are not supported for legacy SAI indexes -- drop the index and recreate it to enable these");

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -101,7 +101,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
      * @return Row IDs associated with the topK vectors near the query
      */
     @Override
-    public CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, float threshold, Bits acceptBits, QueryContext context, IntConsumer nodesVisited)
+    public CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, int rerankK, float threshold, Bits acceptBits, QueryContext context, IntConsumer nodesVisited)
     {
         if (threshold > 0)
             throw new InvalidRequestException("Geo queries are not supported for legacy SAI indexes -- drop the index and recreate it to enable these");
@@ -112,7 +112,7 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
         try (var view = hnsw.getView(context))
         {
             queue = HnswGraphSearcher.search(((ArrayVectorFloat) queryVector).get(),
-                                             topK,
+                                             rerankK,
                                              vectors,
                                              VectorEncoding.FLOAT32,
                                              LuceneCompat.vsf(similarityFunction),

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -188,7 +188,8 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
             var rr = view.rerankerFor(queryVector, sf);
             ssp = new SearchScoreProvider(asf, rr);
         }
-        var result = searcher.search(ssp, topK, rerankK, threshold, 0.0f, ordinalsMap.ignoringDeleted(acceptBits));
+        var result = searcher.search(ssp, topK, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));
+        context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
         Tracing.trace("DiskANN search visited {} nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
         // Threshold based searches are comprehensive and do not need to resume the search.
         if (threshold > 0)

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -189,7 +189,8 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
             ssp = new SearchScoreProvider(asf, rr);
         }
         var result = searcher.search(ssp, topK, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));
-        context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
+        if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
+            context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
         Tracing.trace("DiskANN search visited {} nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
         // Threshold based searches are comprehensive and do not need to resume the search.
         if (threshold > 0)

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -150,18 +150,18 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
 
     /**
      * @param queryVector the query vector
-     * @param topK the number of results to look for in the index (>= limit)
+     * @param limit the number of results to look for in the index (>= limit)
      * @param rerankK the number of results to look for in the index (>= limit)
      * @param threshold the minimum similarity score to accept
      * @param acceptBits a Bits indicating which row IDs are acceptable, or null if no constraints
      * @param context unused (vestige from HNSW, retained in signature to allow calling both easily)
      * @param nodesVisitedConsumer a consumer that will be called with the number of nodes visited during the search
-     * @return Row IDs associated with the topK vectors near the query. If a threshold is specified, only vectors with
-     * a similarity score >= threshold will be returned.
+     * @return Iterator of Row IDs associated with the vectors near the query. If a threshold is specified, only vectors
+     * with a similarity score >= threshold will be returned.
      */
     @Override
     public CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector,
-                                                 int topK,
+                                                 int limit,
                                                  int rerankK,
                                                  float threshold,
                                                  Bits acceptBits,
@@ -188,7 +188,7 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
             var rr = view.rerankerFor(queryVector, sf);
             ssp = new SearchScoreProvider(asf, rr);
         }
-        var result = searcher.search(ssp, topK, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));
+        var result = searcher.search(ssp, limit, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));
         if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
             context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
         Tracing.trace("DiskANN search visited {} nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
@@ -201,7 +201,7 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
         }
         else
         {
-            var nodeScores = new AutoResumingNodeScoreIterator(searcher, result, nodesVisitedConsumer, topK, rerankK, false);
+            var nodeScores = new AutoResumingNodeScoreIterator(searcher, result, nodesVisitedConsumer, limit, rerankK, false);
             return new NodeScoreToScoredRowIdIterator(nodeScores, ordinalsMap.getRowIdsView());
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -40,6 +40,9 @@ import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
  */
 public class V3OnDiskFormat extends V2OnDiskFormat
 {
+    public static final boolean REDUCE_TOPK_ACROSS_SSTABLES = Boolean.parseBoolean(System.getProperty("cassandra.sai.reduce_topk_across_sstables", "true"));
+    public static final boolean ENABLE_RERANK_FLOOR = Boolean.parseBoolean(System.getProperty("cassandra.sai.rerank_floor", "true"));
+
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static final V3OnDiskFormat instance = new V3OnDiskFormat();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -35,6 +35,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
 {
     private final GraphSearcher searcher;
     private final int topK;
+    private final int rerankK;
     private final boolean inMemory;
     private final IntConsumer nodesVisitedConsumer;
     private Iterator<SearchResult.NodeScore> nodeScores;
@@ -54,6 +55,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
                                          SearchResult result,
                                          IntConsumer nodesVisitedConsumer,
                                          int topK,
+                                         int rerankK,
                                          boolean inMemory)
     {
         this.searcher = searcher;
@@ -61,6 +63,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         this.cumulativeNodesVisited = result.getVisitedCount();
         this.nodesVisitedConsumer = nodesVisitedConsumer;
         this.topK = topK;
+        this.rerankK = rerankK;
         this.inMemory = inMemory;
     }
 
@@ -70,7 +73,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         if (nodeScores.hasNext())
             return nodeScores.next();
 
-        var nextResult = searcher.resume(topK);
+        var nextResult = searcher.resume(topK, rerankK);
         maybeLogTrace(nextResult);
         cumulativeNodesVisited += nextResult.getVisitedCount();
         // If the next result is empty, we are done searching.

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -34,7 +34,7 @@ import org.apache.cassandra.utils.AbstractIterator;
 public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult.NodeScore>
 {
     private final GraphSearcher searcher;
-    private final int topK;
+    private final int limit;
     private final int rerankK;
     private final boolean inMemory;
     private final IntConsumer nodesVisitedConsumer;
@@ -48,13 +48,14 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
      * @param searcher the {@link GraphSearcher} to use to resume search.
      * @param result the first {@link SearchResult} to iterate over
      * @param nodesVisitedConsumer a consumer that accepts the total number of nodes visited
-     * @param topK the limit to pass to the {@link GraphSearcher} when resuming search
+     * @param limit the limit to pass to the {@link GraphSearcher} when resuming search
+     * @param rerankK the rerankK to pass to the {@link GraphSearcher} when resuming search
      * @param inMemory whether the graph is in memory or on disk (used for trace logging)
      */
     public AutoResumingNodeScoreIterator(GraphSearcher searcher,
                                          SearchResult result,
                                          IntConsumer nodesVisitedConsumer,
-                                         int topK,
+                                         int limit,
                                          int rerankK,
                                          boolean inMemory)
     {
@@ -62,7 +63,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         this.nodeScores = Arrays.stream(result.getNodes()).iterator();
         this.cumulativeNodesVisited = result.getVisitedCount();
         this.nodesVisitedConsumer = nodesVisitedConsumer;
-        this.topK = topK;
+        this.limit = limit;
         this.rerankK = rerankK;
         this.inMemory = inMemory;
     }
@@ -73,7 +74,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         if (nodeScores.hasNext())
             return nodeScores.next();
 
-        var nextResult = searcher.resume(topK, rerankK);
+        var nextResult = searcher.resume(limit, rerankK);
         maybeLogTrace(nextResult);
         cumulativeNodesVisited += nextResult.getVisitedCount();
         // If the next result is empty, we are done searching.

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -300,7 +300,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var searcher = searchers.get();
         var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
-        var topK = sourceModel.topKFor(limit, null);
+        var topK = sourceModel.rerankKFor(limit, null);
         var result = searcher.search(ssf, topK, threshold, bits);
         Tracing.trace("ANN search visited {} in-memory nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
         context.addAnnNodesVisited(result.getVisitedCount());

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -300,13 +300,13 @@ public class CassandraOnHeapGraph<T> implements Accountable
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var searcher = searchers.get();
         var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
-        var topK = sourceModel.rerankKFor(limit, null);
-        var result = searcher.search(ssf, topK, threshold, bits);
+        var rerankK = sourceModel.rerankKFor(limit, null);
+        var result = searcher.search(ssf, limit, rerankK, threshold, 0.0f, bits);
         Tracing.trace("ANN search visited {} in-memory nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
         context.addAnnNodesVisited(result.getVisitedCount());
         // Threshold based searches do not support resuming the search.
         return threshold > 0 ? CloseableIterator.wrap(Arrays.stream(result.getNodes()).iterator())
-                             : new AutoResumingNodeScoreIterator(searcher, result, context::addAnnNodesVisited, topK, true);
+                             : new AutoResumingNodeScoreIterator(searcher, result, context::addAnnNodesVisited, limit, rerankK, true);
     }
 
     public Set<Integer> computeDeletedOrdinals(Function<T, Integer> postingTransformer)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
@@ -64,7 +64,7 @@ public abstract class JVectorLuceneOnDiskGraph implements AutoCloseable
     /**
      * See CassandraDiskANN::search
      */
-    public abstract CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, int rerankK, float threshold, Bits bits, QueryContext context, IntConsumer nodesVisited);
+    public abstract CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int limit, int rerankK, float threshold, Bits bits, QueryContext context, IntConsumer nodesVisited);
 
     public abstract void close() throws IOException;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
@@ -64,7 +64,7 @@ public abstract class JVectorLuceneOnDiskGraph implements AutoCloseable
     /**
      * See CassandraDiskANN::search
      */
-    public abstract CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, float threshold, Bits bits, QueryContext context, IntConsumer nodesVisited);
+    public abstract CloseableIterator<ScoredRowId> search(VectorFloat<?> queryVector, int topK, int rerankK, float threshold, Bits bits, QueryContext context, IntConsumer nodesVisited);
 
     public abstract void close() throws IOException;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -143,7 +143,7 @@ public enum VectorSourceModel
      * 1. Smoothes out the relevance difference between small LIMIT and large
      * 2. Compensates for using lossily-compressed vectors during the search
      */
-    public int topKFor(int limit, CompressedVectors cv)
+    public int rerankKFor(int limit, CompressedVectors cv)
     {
         // if the vectors are uncompressed, bump up the limit a bit to start with but decay it rapidly
         if (cv == null)

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -534,9 +534,6 @@ public class QueryController implements Plan.Executor
         {
             // We expect the number of top results found in each sstable to be proportional to its number of rows
             // we don't pad this number more because resuming a search if we guess too low is very very inexpensive.
-            //
-            // Note that this is only used for calls to `orderBy`, i.e., vanilla ANN with no other predicates;
-            // `orderResultsBy` does not know how to auto-resume.
             int sstableLimit = V3OnDiskFormat.REDUCE_TOPK_ACROSS_SSTABLES
                                ? max(1, (int) (limit * ((double) sstable.getTotalRows() / totalRows)))
                                : limit;
@@ -547,7 +544,7 @@ public class QueryController implements Plan.Executor
                 assert expressions.size() == 1 : "only one index is expected in ANN expression, found " + expressions.size() + " in " + expressions;
                 annIndexExpression = expressions.get(0);
                 var iterators = sourceKeys.isEmpty() ? annIndexExpression.index.orderBy(annIndexExpression.expression, mergeRange, queryContext, sstableLimit)
-                                                     : annIndexExpression.index.orderResultsBy(queryContext, sourceKeys, annIndexExpression.expression, limit);
+                                                     : annIndexExpression.index.orderResultsBy(queryContext, sourceKeys, annIndexExpression.expression, sstableLimit);
                 results.addAll(iterators);
             }
             catch (Throwable ex)

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -65,6 +65,7 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
+import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.index.sai.utils.OrderingFilterRangeIterator;
@@ -536,7 +537,9 @@ public class QueryController implements Plan.Executor
             //
             // Note that this is only used for calls to `orderBy`, i.e., vanilla ANN with no other predicates;
             // `orderResultsBy` does not know how to auto-resume.
-            int sstableLimit = max(1, (int) (limit * ((double) sstable.getTotalRows() / totalRows)));
+            int sstableLimit = V3OnDiskFormat.REDUCE_TOPK_ACROSS_SSTABLES
+                               ? max(1, (int) (limit * ((double) sstable.getTotalRows() / totalRows)))
+                               : limit;
 
             QueryViewBuilder.IndexExpression annIndexExpression = null;
             try

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -92,11 +92,11 @@ public class VectorSiftSmallTest extends VectorTester
             flush();
         }
         double memoryRecall = testRecall(queryVectors, groundTruth);
-        assertTrue("Memory recall is " + memoryRecall, memoryRecall > 0.975);
+        assertTrue("Pre-compaction recall is " + memoryRecall, memoryRecall > 0.975);
 
         compact();
         var diskRecall = testRecall(queryVectors, groundTruth);
-        assertTrue("Disk recall is " + diskRecall, diskRecall > 0.975);
+        assertTrue("Post-compaction recall is " + diskRecall, diskRecall > 0.975);
     }
 
     public static ArrayList<float[]> readFvecs(String filePath) throws IOException

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
@@ -26,12 +26,8 @@ import org.junit.Test;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.cql.VectorTester;
 import org.apache.cassandra.index.sai.disk.v3.V3VectorIndexSearcher;
-import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
-import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
 
-import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.BINARY_QUANTIZATION;
 import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.NONE;
-import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -150,7 +146,7 @@ public class VectorCompressionTest extends VectorTester
             if (cv != null)
             {
                 assertEquals((int) (100 * VectorSourceModel.tapered2x(100) * model.overqueryProvider.apply(cv)),
-                             model.topKFor(100, cv));
+                             model.rerankKFor(100, cv));
             }
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -140,7 +140,7 @@ public class VectorMemtableIndexTest extends SAITester
             Set<Integer> foundKeys = new HashSet<>();
             int limit = getRandom().nextIntBetween(1, 100);
 
-            long expectedNumResults = Math.min(VectorSourceModel.OTHER.topKFor(limit, null), keysInRange.size());
+            long expectedNumResults = Math.min(VectorSourceModel.OTHER.rerankKFor(limit, null), keysInRange.size());
 
             try (var iterator = memtableIndex.orderBy(new QueryContext(), expression, keyRange, limit))
             {

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -140,7 +140,7 @@ public class VectorMemtableIndexTest extends SAITester
             Set<Integer> foundKeys = new HashSet<>();
             int limit = getRandom().nextIntBetween(1, 100);
 
-            long expectedNumResults = Math.min(VectorSourceModel.OTHER.rerankKFor(limit, null), keysInRange.size());
+            long expectedNumResults = Math.min(limit, keysInRange.size());
 
             try (var iterator = memtableIndex.orderBy(new QueryContext(), expression, keyRange, limit))
             {


### PR DESCRIPTION
- don't need to search as deep in any given index when we are combining results from multiple indexes
- enable rerankFloor to leverage information from previously searched indexes to tell us which candidates are most likely not worth doing the expensive rerank with

these have no effect when the table is perfectly compacted to a single sstable / single index segment; as the number of sstables grows, they help reduce the performance penalty without materially affecting recall.

for example, for the SIFT1M dataset we get about 93% recall in a single sstable, 95% when split across 5.

this patch saves ~50% of rerank effort in the 5-sstable case for ~0.3% degradation of recall and ~0.5% more calls to resume()

(so, recall is still significantly above the perfectly compacted base rate)