### PR TITLE
Prevent closing PartitionIterator twice for LWT

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -678,8 +678,7 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         SinglePartitionReadQuery readCommand = request.readCommand(nowInSeconds);
         FilteredPartition current;
         try (ReadExecutionController executionController = readCommand.executionController();
-             PartitionIterator iter = readCommand.executeInternal(executionController);
-             RowIterator row = PartitionIterators.getOnlyElement(iter, readCommand);)
+             RowIterator row = PartitionIterators.getOnlyElement(readCommand.executeInternal(executionController), readCommand))
         {
             // FilteredPartition consumes the row but does not close the iterator
             current = FilteredPartition.create(row);


### PR DESCRIPTION
@jacek-lewandowski pointed out that the original solution in https://github.com/datastax/cassandra/pull/1103 double closes the `PartitionIterator` https://github.com/apache/cassandra/pull/3296#discussion_r1595218736. This change ensures we close it once.