### PR TITLE
Double connections setting to get max degree

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -131,6 +133,16 @@ public class IndexWriterConfig
         return bkdPostingsSkip;
     }
 
+    public int getAnnMaxDegree()
+    {
+        // For historical reasons (Lucene doubled the maximum node connections for its HNSW),
+        // maximumNodeConnections represents half of the graph degree, so double it
+        return 2 * maximumNodeConnections;
+    }
+
+    /** you should probably use getAnnMaxDegree instead */
+    @VisibleForTesting
+    @Deprecated
     public int getMaximumNodeConnections()
     {
         return maximumNodeConnections;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -153,7 +153,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
         builder = new GraphIndexBuilder(vectorValues,
                                         similarityFunction,
-                                        indexConfig.getMaximumNodeConnections(),
+                                        indexConfig.getAnnMaxDegree(),
                                         indexConfig.getConstructionBeamWidth(),
                                         1.2f,
                                         dimension > 3 ? 1.2f : 2.0f);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -135,7 +135,7 @@ public class CompactionGraph implements Closeable, Accountable
 
         builder = new GraphIndexBuilder(null,
                                         dimension,
-                                        indexConfig.getMaximumNodeConnections(),
+                                        indexConfig.getAnnMaxDegree(),
                                         indexConfig.getConstructionBeamWidth(),
                                         1.2f,
                                         dimension > 3 ? 1.2f : 1.4f,

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -319,7 +319,7 @@ public class VectorMemtableIndex implements MemtableIndex
     private int maxBruteForceRows(int limit, int nPermittedOrdinals, int graphSize)
     {
         int expectedNodesVisited = expectedNodesVisited(limit, nPermittedOrdinals, graphSize);
-        int expectedComparisons = indexContext.getIndexWriterConfig().getMaximumNodeConnections() * expectedNodesVisited;
+        int expectedComparisons = indexContext.getIndexWriterConfig().getAnnMaxDegree() * expectedNodesVisited;
         // in-memory comparisons are cheaper than pulling a row off disk and then comparing
         // VSTODO this is dramatically oversimplified
         // larger dimension should increase this, because comparisons are more expensive


### PR DESCRIPTION
        // For historical reasons (Lucene doubled the maximum node connections for its HNSW),
        // maximumNodeConnections represents half of the graph degree, so double it

I'm not sure the "right" way to fix this, to be honest, since we're stuck with old-style configurations more or less permanently.