### PR TITLE
enable fused adc and use VectorCompression and ProductQuantization instead of PQVectors

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.7" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.9" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -30,7 +30,6 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.jbellis.jvector.pq.PQVectors;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Row;
@@ -41,6 +40,7 @@ import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -328,12 +328,11 @@ public class SSTableIndexWriter implements PerIndexWriter
         {
             // if we have a PQ instance available, we can use it to build a CompactionGraph;
             // otherwise, build on heap (which will create PQ for next time, if we have enough vectors)
-            var cvi = CassandraOnHeapGraph.getCompressedVectorsIfPresent(indexContext, cv1 -> cv1 instanceof PQVectors);
-            if (cvi == null || cvi.unitVectors.isEmpty() || !V3OnDiskFormat.ENABLE_LTM_CONSTRUCTION) {
+            var pqi = CassandraOnHeapGraph.getPqIfPresent(indexContext, vc -> vc.type == VectorCompression.CompressionType.PRODUCT_QUANTIZATION);
+            if (pqi == null || pqi.unitVectors.isEmpty() || !V3OnDiskFormat.ENABLE_LTM_CONSTRUCTION) {
                 builder = new SegmentBuilder.VectorOnHeapSegmentBuilder(indexDescriptor, indexContext, rowIdOffset, keyCount, limiter);
             } else {
-                var pq = ((PQVectors) cvi.cv).getProductQuantization();
-                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(indexDescriptor, indexContext, rowIdOffset, keyCount, limiter, pq, cvi.unitVectors.get());
+                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(indexDescriptor, indexContext, rowIdOffset, keyCount, limiter, pqi.pq, pqi.unitVectors.get());
             }
         }
         else if (indexContext.isLiteral())

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/hnsw/CassandraOnDiskHnsw.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.index.sai.disk.vector.NodeScoreToScoredRowIdIterator
 import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.disk.vector.OrdinalsView;
 import org.apache.cassandra.index.sai.disk.vector.ScoredRowId;
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
 import org.apache.cassandra.index.sai.disk.vector.VectorValidation;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -183,6 +184,14 @@ public class CassandraOnDiskHnsw extends JVectorLuceneOnDiskGraph
     public VectorSupplier getVectorSupplier()
     {
         return new HNSWVectorSupplier(vectors);
+    }
+
+    @Override
+    public VectorCompression getCompression()
+    {
+        return new VectorCompression(VectorCompression.CompressionType.NONE,
+                                     vectors.dimension() * Float.BYTES,
+                                     vectors.dimension() * Float.BYTES);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -25,9 +25,7 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +34,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
@@ -310,7 +307,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var searcher = searchers.get();
         var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
-        var rerankK = sourceModel.rerankKFor(limit, null);
+        var rerankK = sourceModel.rerankKFor(limit, VectorCompression.NO_COMPRESSION);
         var result = searcher.search(ssf, limit, rerankK, threshold, 0.0f, bits);
         Tracing.trace("ANN search visited {} in-memory nodes to return {} results", result.getVisitedCount(), result.getNodes().length);
         context.addAnnNodesVisited(result.getVisitedCount());
@@ -421,14 +418,14 @@ public class CassandraOnHeapGraph<T> implements Accountable
      * "Best" means the most recent one that hits the row count target of {@link ProductQuantization#MAX_PQ_TRAINING_SET_SIZE},
      * or the one with the most rows if none are larger than that.
      */
-    public static CompressedVectorInfo getCompressedVectorsIfPresent(IndexContext indexContext, Function<CompressedVectors, Boolean> matcher)
+    public static PqInfo getPqIfPresent(IndexContext indexContext, Function<VectorCompression, Boolean> matcher)
     {
         // Retrieve the first compressed vectors for a segment with at least MAX_PQ_TRAINING_SET_SIZE rows
-        // or the one with the most rows if none are larger than MAX_PQ_TRAINING_SET_SIZE
+        // or the one with the most rows if none reach that size
         var indexes = new ArrayList<>(indexContext.getView().getIndexes());
         indexes.sort(Comparator.comparing(SSTableIndex::getSSTable, CompactionSSTable.maxTimestampDescending));
 
-        CompressedVectorInfo cvi = null;
+        PqInfo cvi = null;
         long maxRows = 0;
         for (SSTableIndex index : indexes)
         {
@@ -437,13 +434,12 @@ public class CassandraOnHeapGraph<T> implements Accountable
                 if (segment.metadata.numRows < maxRows)
                     continue;
 
-                var searcher = segment.getIndexSearcher();
-                var v2Searcher = (V2VectorIndexSearcher) searcher;
-                var cv = v2Searcher.getCompressedVectors();
+                var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+                var cv = searcher.getCompression();
                 if (matcher.apply(cv))
                 {
                     // We can exit now because we won't find a better candidate
-                    var candidate = new CompressedVectorInfo(cv, v2Searcher.containsUnitVectors());
+                    var candidate = new PqInfo(searcher.getPQ(), searcher.containsUnitVectors());
                     if (segment.metadata.numRows >= ProductQuantization.MAX_PQ_TRAINING_SET_SIZE)
                         return candidate;
 
@@ -500,8 +496,8 @@ public class CassandraOnHeapGraph<T> implements Accountable
             // build encoder (expensive for PQ, cheaper for BQ)
             if (preferredCompression.type == CompressionType.PRODUCT_QUANTIZATION)
             {
-                var cvi = getCompressedVectorsIfPresent(indexContext, preferredCompression::matches);
-                var previousCV = cvi == null ? null : cvi.cv;
+                var cvi = getPqIfPresent(indexContext, preferredCompression::equals);
+                var previousCV = cvi == null ? null : cvi.pq;
                 compressor = computeOrRefineFrom(previousCV, preferredCompression);
             }
             else
@@ -550,23 +546,23 @@ public class CassandraOnHeapGraph<T> implements Accountable
         writer.writeByte(type.ordinal());
     }
 
-    VectorCompressor<?> computeOrRefineFrom(CompressedVectors previousCV, VectorCompression preferredCompression)
+    VectorCompressor<?> computeOrRefineFrom(ProductQuantization previousPQ, VectorCompression preferredCompression)
     {
         // refining an existing codebook is much faster than starting from scratch
         VectorCompressor<?> compressor;
-        if (previousCV == null)
+        if (previousPQ == null)
         {
             if (vectorValues.size() < MIN_PQ_ROWS)
                 compressor = null;
             else
-                compressor = ProductQuantization.compute(vectorValues, preferredCompression.compressToBytes, 256, false);
+                compressor = ProductQuantization.compute(vectorValues, preferredCompression.getCompressedSize(), 256, false);
         }
         else
         {
             if (vectorValues.size() < MIN_PQ_ROWS)
-                compressor = previousCV.getCompressor();
+                compressor = previousPQ;
             else
-                compressor = ((ProductQuantization) previousCV.getCompressor()).refine(vectorValues);
+                compressor = previousPQ.refine(vectorValues);
         }
         return compressor;
     }
@@ -613,15 +609,15 @@ public class CassandraOnHeapGraph<T> implements Accountable
         FAIL
     }
 
-    public static class CompressedVectorInfo
+    public static class PqInfo
     {
-        public final CompressedVectors cv;
+        public final ProductQuantization pq;
         /** an empty Optional indicates that the index was written with an older version that did not record this information */
         public final Optional<Boolean> unitVectors;
 
-        public CompressedVectorInfo(CompressedVectors cv, Optional<Boolean> unitVectors)
+        public PqInfo(ProductQuantization pq, Optional<Boolean> unitVectors)
         {
-            this.cv = cv;
+            this.pq = pq;
             this.unitVectors = unitVectors;
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.EnumMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.disk.Feature;
 import io.github.jbellis.jvector.graph.disk.FeatureId;
+import io.github.jbellis.jvector.graph.disk.FusedADC;
 import io.github.jbellis.jvector.graph.disk.InlineVectorValues;
 import io.github.jbellis.jvector.graph.disk.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
@@ -60,6 +61,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
+import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.vector.VectorPostings.CompactionVectorPostings;
 import org.apache.cassandra.index.sai.utils.IndexFileUtils;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
@@ -144,12 +146,19 @@ public class CompactionGraph implements Closeable, Accountable
         var indexFile = descriptor.fileFor(IndexComponent.TERMS_DATA, context);
         termsOffset = (indexFile.exists() ? indexFile.length() : 0)
                       + SAICodecUtils.headerSize();
-        writer = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
-                 .withVersion(JVECTOR_2_VERSION) // VSTODO old version until we add LVQ
-                 .withStartOffset(termsOffset)
-                 .with(new InlineVectors(dimension))
-                 .withMapper(new OnDiskGraphIndexWriter.IdentityMapper())
-                 .build();
+        var writerBuilder = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
+                            .withStartOffset(termsOffset)
+                            .with(new InlineVectors(dimension))
+                            .withMapper(new OnDiskGraphIndexWriter.IdentityMapper());
+        if (V3OnDiskFormat.WRITE_JVECTOR3_FORMAT)
+        {
+            writerBuilder = writerBuilder.with(new FusedADC(indexConfig.getMaximumNodeConnections(), compressor));
+        }
+        else
+        {
+            writerBuilder = writerBuilder.withVersion(JVECTOR_2_VERSION);
+        }
+        writer = writerBuilder.build();
         writer.getOutput().seek(indexFile.length()); // position at the end of the previous segment before writing our own header
         SAICodecUtils.writeHeader(SAICodecUtils.toLuceneOutput(writer.getOutput()));
         inlineVectors = new InlineVectorValues(dimension, writer);
@@ -244,8 +253,12 @@ public class CompactionGraph implements Closeable, Accountable
                                                                               pqVectors.count(), builder.getGraph().size());
         assert postingsMap.keySet().size() == builder.getGraph().size() : String.format("postings map entry count %d != vector count %d",
                                                                                         postingsMap.keySet().size(), builder.getGraph().size());
-        logger.debug("Writing graph with {} rows and {} distinct vectors",
-                     postingsMap.values().stream().mapToInt(VectorPostings::size).sum(), builder.getGraph().size());
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Writing graph with {} rows and {} distinct vectors",
+                         postingsMap.values().stream().mapToInt(VectorPostings::size).sum(), builder.getGraph().size());
+            logger.debug("Estimated size is {} + {}", pqVectors.ramBytesUsed(), builder.getGraph().ramBytesUsed());
+        }
 
         var pqOrder = descriptor.getVersion(context).onDiskFormat().byteOrderFor(IndexComponent.PQ, context);
         var postingsOrder = descriptor.getVersion(context).onDiskFormat().byteOrderFor(IndexComponent.POSTING_LISTS, context);
@@ -258,10 +271,11 @@ public class CompactionGraph implements Closeable, Accountable
             // write PQ
             long pqOffset = pqOutput.getFilePointer();
             CassandraOnHeapGraph.writePqHeader(pqOutput.asSequentialWriter(), unitVectors, VectorCompression.CompressionType.PRODUCT_QUANTIZATION);
-            pqVectors.write(pqOutput.asSequentialWriter(), JVECTOR_2_VERSION); // VSTODO old version until we add LVQ
+            pqVectors.write(pqOutput.asSequentialWriter(), JVECTOR_2_VERSION); // VSTODO old version until we add APQ
             long pqLength = pqOutput.getFilePointer() - pqOffset;
 
             // write postings
+            // VSTODO make this async?  it's i/o bound and cleanup next step is cpu bound
             long postingsOffset = postingsOutput.getFilePointer();
             long postingsPosition = new VectorPostingsWriter<Integer>(postingsOneToOne, i -> i)
                                             .writePostings(postingsOutput.asSequentialWriter(), inlineVectors, postingsMap, Set.of());
@@ -271,7 +285,18 @@ public class CompactionGraph implements Closeable, Accountable
             builder.cleanup();
 
             var start = System.nanoTime();
-            writer.write(new EnumMap<>(FeatureId.class));
+            if (writer.getFeatureSet().contains(FeatureId.FUSED_ADC))
+            {
+                try (var view = builder.getGraph().getView())
+                {
+                    var supplier = Feature.singleStateFactory(FeatureId.FUSED_ADC, ordinal -> new FusedADC.State(view, pqVectors, ordinal));
+                    writer.write(supplier);
+                }
+            }
+            else
+            {
+                writer.write(Map.of());
+            }
             SAICodecUtils.writeFooter(writer.getOutput(), writer.checksum());
             logger.info("Writing graph took {}ms", (System.nanoTime() - start) / 1_000_000);
             long termsLength = writer.getOutput().position() - termsOffset;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorLuceneOnDiskGraph.java
@@ -58,6 +58,8 @@ public abstract class JVectorLuceneOnDiskGraph implements AutoCloseable
     public abstract OrdinalsView getOrdinalsView() throws IOException;
     public abstract VectorSupplier getVectorSupplier() throws IOException;
 
+    public abstract VectorCompression getCompression();
+
     /** returns null if no compression was performed */
     public abstract CompressedVectors getCompressedVectors();
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
@@ -25,13 +25,13 @@ public class VectorCompression
     public static final VectorCompression NO_COMPRESSION = new VectorCompression(CompressionType.NONE, -1, -1);
 
     public final CompressionType type;
-    private final int originalSize;
-    private final int compressedSize;
+    private final int originalSize; // in bytes
+    private final int compressedSize; // in bytes
 
-    public VectorCompression(CompressionType type, int originalSize, double ratio)
+    public VectorCompression(CompressionType type, int dimension, double ratio)
     {
         this.type = type;
-        this.originalSize = originalSize;
+        this.originalSize = dimension * Float.BYTES;
         this.compressedSize = (int) (originalSize * ratio);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
@@ -61,7 +61,7 @@ public class VectorCompression
 
     public String toString()
     {
-        return String.format("VectorCompression(%s, %d)", type, getCompressedSize());
+        return String.format("VectorCompression(%s, %d->%d)", type, originalSize, compressedSize);
     }
 
     public int getOriginalSize()

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
@@ -18,42 +18,64 @@
 
 package org.apache.cassandra.index.sai.disk.vector;
 
-import io.github.jbellis.jvector.pq.BQVectors;
-import io.github.jbellis.jvector.pq.CompressedVectors;
-import io.github.jbellis.jvector.pq.PQVectors;
+import java.util.Objects;
 
 public class VectorCompression
 {
-    public final CompressionType type;
-    public final int compressToBytes;
+    public static final VectorCompression NO_COMPRESSION = new VectorCompression(CompressionType.NONE, -1, -1);
 
-    public VectorCompression(CompressionType type, int compressToBytes)
+    public final CompressionType type;
+    private final int originalSize;
+    private final int compressedSize;
+
+    public VectorCompression(CompressionType type, int originalSize, double ratio)
     {
         this.type = type;
-        this.compressToBytes = compressToBytes;
+        this.originalSize = originalSize;
+        this.compressedSize = (int) (originalSize * ratio);
     }
 
-    /**
-     * @return true if the given CompressedVectors implements a matching compression type and size
-     */
-    public boolean matches(CompressedVectors cv)
+    public VectorCompression(CompressionType type, int originalSize, int compressedSize)
     {
+        this.type = type;
+        this.originalSize = originalSize;
+        this.compressedSize = compressedSize;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VectorCompression that = (VectorCompression) o;
         if (type == CompressionType.NONE)
-            return cv == null;
-        if (cv == null)
-            return false;
+            return that.type == CompressionType.NONE;
+        return originalSize == that.originalSize && compressedSize == that.compressedSize && type == that.type;
+    }
 
-        if (type == CompressionType.PRODUCT_QUANTIZATION)
-            return cv instanceof PQVectors && cv.getCompressedSize() == compressToBytes;
-
-        assert type == CompressionType.BINARY_QUANTIZATION;
-        // BQ algorithm is the same no matter what the size is
-        return cv instanceof BQVectors;
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, getOriginalSize(), getCompressedSize());
     }
 
     public String toString()
     {
-        return String.format("VectorCompression(%s, %d)", type, compressToBytes);
+        return String.format("VectorCompression(%s, %d)", type, getCompressedSize());
+    }
+
+    public int getOriginalSize()
+    {
+        if (type == CompressionType.NONE)
+            throw new UnsupportedOperationException();
+        return originalSize;
+    }
+
+    public int getCompressedSize()
+    {
+        if (type == CompressionType.NONE)
+            throw new UnsupportedOperationException();
+        return compressedSize;
     }
 
     public enum CompressionType

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -22,25 +22,25 @@ import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import io.github.jbellis.jvector.pq.BinaryQuantization;
-import io.github.jbellis.jvector.pq.CompressedVectors;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
 import static io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE;
 import static io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
 import static java.lang.Math.max;
 import static java.lang.Math.pow;
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.BINARY_QUANTIZATION;
+import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.NONE;
 import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
 
 public enum VectorSourceModel
 {
-    ADA002((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 8), 1.5),
-    OPENAI_V3_SMALL((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 16), 1.5),
-    OPENAI_V3_LARGE((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 16), 1.5),
-    BERT((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 4), 1.0),
-    GECKO((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 8), 1.5),
-    NV_QA_4((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 8), 1.5),
-    COHERE_V3((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension / 16), 1.25),
+    ADA002((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.125), 1.5),
+    OPENAI_V3_SMALL((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.5),
+    OPENAI_V3_LARGE((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.5),
+    BERT((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.25), 1.0),
+    GECKO((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.125), 1.5),
+    NV_QA_4((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.125), 1.5),
+    COHERE_V3((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.25),
 
     OTHER(COSINE, VectorSourceModel::genericCompression, VectorSourceModel::genericOverquery);
 
@@ -56,7 +56,7 @@ public enum VectorSourceModel
      * Factor by which to multiply the top K requested by to search deeper in the graph.
      * This is IN ADDITION to the tapered 2x applied by OverqueryUtils.
      */
-    public final Function<CompressedVectors, Double> overqueryProvider;
+    public final Function<VectorCompression, Double> overqueryProvider;
 
     VectorSourceModel(Function<Integer, VectorCompression> compressionProvider, double overqueryFactor)
     {
@@ -65,7 +65,7 @@ public enum VectorSourceModel
 
     VectorSourceModel(VectorSimilarityFunction defaultSimilarityFunction,
                       Function<Integer, VectorCompression> compressionProvider,
-                      Function<CompressedVectors, Double> overqueryProvider)
+                      Function<VectorCompression, Double> overqueryProvider)
     {
         this.defaultSimilarityFunction = defaultSimilarityFunction;
         this.compressionProvider = compressionProvider;
@@ -80,7 +80,7 @@ public enum VectorSourceModel
     private static VectorCompression genericCompression(int originalDimension)
     {
         // Model is unspecified / unknown, so we guess.
-        return new VectorCompression(PRODUCT_QUANTIZATION, defaultPQBytesFor(originalDimension));
+        return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension, defaultPQBytesFor(originalDimension));
     }
 
     private static int defaultPQBytesFor(int originalDimension)
@@ -123,13 +123,13 @@ public enum VectorSourceModel
         return compressedBytes;
     }
 
-    private static double genericOverquery(CompressedVectors cv)
+    private static double genericOverquery(VectorCompression vc)
     {
-        assert cv != null;
+        assert vc != null;
         // we compress extra-large vectors more aggressively, so we need to bump up the limit for those.
-        if (cv instanceof BinaryQuantization)
+        if (vc.type == BINARY_QUANTIZATION)
             return 2.0;
-        else if ((double) cv.getOriginalSize() / cv.getCompressedSize() > 16.0)
+        else if ((double) vc.getOriginalSize() / vc.getCompressedSize() > 16.0)
             return 1.5;
         else
             return 1.0;
@@ -137,16 +137,16 @@ public enum VectorSourceModel
 
     /**
      * @param limit the number of results the user asked for
-     * @param cv the compressed vectors being queried.  Null if uncompressed.
+     * @param vc compression information about vectors being queried
      * @return the topK >= `limit` results to ask the index to search for, forcing
      * the greedy search deeper into the graph.  This serves two purposes:
      * 1. Smoothes out the relevance difference between small LIMIT and large
      * 2. Compensates for using lossily-compressed vectors during the search
      */
-    public int rerankKFor(int limit, CompressedVectors cv)
+    public int rerankKFor(int limit, VectorCompression vc)
     {
         // if the vectors are uncompressed, bump up the limit a bit to start with but decay it rapidly
-        if (cv == null)
+        if (vc.type == NONE)
         {
             var n = max(1.0, 0.979 + 4.021 * pow(limit, -0.761)); // f(1) =  5.0, f(100) = 1.1, f(1000) = 1.0
             return (int) (n * limit);
@@ -158,16 +158,16 @@ public enum VectorSourceModel
         var n = tapered2x(limit);
 
         // per-model adjustment on top of the ~2x factor
-        int originalDimension = cv.getOriginalSize() / 4;
-        if (compressionProvider.apply(originalDimension).matches(cv))
+        int originalDimension = vc.getOriginalSize() / 4;
+        if (compressionProvider.apply(originalDimension).equals(vc))
         {
-            n *= overqueryProvider.apply(cv);
+            n *= overqueryProvider.apply(vc);
         }
         else
         {
             // we're using an older CV that wasn't created with the currently preferred parameters,
             // so use the generic defaults instead
-            n *= OTHER.overqueryProvider.apply(cv);
+            n *= OTHER.overqueryProvider.apply(vc);
         }
 
         return (int) (n * limit);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -42,7 +42,7 @@ public enum VectorSourceModel
     NV_QA_4((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.125), 1.5),
     COHERE_V3((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.25),
 
-    OTHER(COSINE, VectorSourceModel::genericCompression, VectorSourceModel::genericOverquery);
+    OTHER(COSINE, VectorSourceModel::genericCompressionFor, VectorSourceModel::genericOverquery);
 
     /**
      * Default similarity function for this model.
@@ -77,10 +77,10 @@ public enum VectorSourceModel
         return valueOf(value.toUpperCase());
     }
 
-    private static VectorCompression genericCompression(int originalDimension)
+    private static VectorCompression genericCompressionFor(int dimension)
     {
         // Model is unspecified / unknown, so we guess.
-        return new VectorCompression(PRODUCT_QUANTIZATION, originalDimension, defaultPQBytesFor(originalDimension));
+        return new VectorCompression(PRODUCT_QUANTIZATION, dimension * Float.BYTES, defaultPQBytesFor(dimension));
     }
 
     private static int defaultPQBytesFor(int originalDimension)

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
@@ -102,7 +102,7 @@ public class VectorCompressionTest extends VectorTester
     {
         // with fewer than MIN_PQ_ROWS we expect to observe no compression no matter
         // what the source model would prefer
-        testOne(1, VectorSourceModel.OTHER, 200, new VectorCompression(NONE, 200 * Float.BYTES));
+        testOne(1, VectorSourceModel.OTHER, 200, new VectorCompression(NONE, 200 * Float.BYTES, 1.0));
     }
 
     private void testOne(VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
@@ -139,14 +139,13 @@ public class VectorCompressionTest extends VectorTester
         try (var segment = segments.iterator().next();
              var searcher = (V3VectorIndexSearcher) segment.getIndexSearcher())
         {
-            var cv = searcher.getCompressedVectors();
-            var msg = String.format("Expected %s but got %s", expectedCompression,
-                                    cv == null ? "NONE" : cv.getClass().getSimpleName() + '@' + cv.getCompressedSize());
-            assertTrue(msg, expectedCompression.matches(cv));
-            if (cv != null)
+            var vc = searcher.getCompression();
+            var msg = String.format("Expected %s but got %s@%s", expectedCompression, vc.type, vc.getCompressedSize());
+            assertEquals(msg, expectedCompression, vc);
+            if (vc.type != NONE)
             {
-                assertEquals((int) (100 * VectorSourceModel.tapered2x(100) * model.overqueryProvider.apply(cv)),
-                             model.rerankKFor(100, cv));
+                assertEquals((int) (100 * VectorSourceModel.tapered2x(100) * model.overqueryProvider.apply(vc)),
+                             model.rerankKFor(100, vc));
             }
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
@@ -102,7 +102,7 @@ public class VectorCompressionTest extends VectorTester
     {
         // with fewer than MIN_PQ_ROWS we expect to observe no compression no matter
         // what the source model would prefer
-        testOne(1, VectorSourceModel.OTHER, 200, new VectorCompression(NONE, 200 * Float.BYTES, 1.0));
+        testOne(1, VectorSourceModel.OTHER, 200, VectorCompression.NO_COMPRESSION);
     }
 
     private void testOne(VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
@@ -140,7 +140,7 @@ public class VectorCompressionTest extends VectorTester
              var searcher = (V3VectorIndexSearcher) segment.getIndexSearcher())
         {
             var vc = searcher.getCompression();
-            var msg = String.format("Expected %s but got %s@%s", expectedCompression, vc.type, vc.getCompressedSize());
+            var msg = String.format("Expected %s but got %s", expectedCompression, vc);
             assertEquals(msg, expectedCompression, vc);
             if (vc.type != NONE)
             {


### PR DESCRIPTION
Enabling fused adc is easy (this is done in CassandraDiskANN) but there's a bunch of code churn because we need to load PQ codebooks (ProductQuantization instance) and metadata (VectorCompression instance) into memory without loading the compressed vectors (CompressedVectors = PQVectors instances). 