### PR TITLE
CNDB-9360 Allow to set custom trie index format

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -438,7 +438,11 @@ public enum CassandraRelevantProperties
     /**
      * Whether to enable the use of {@link EndpointGroupingRangeCommandIterator}
      */
-    RANGE_READ_ENDPOINT_GROUPING_ENABLED("cassandra.range_read_endpoint_grouping_enabled", "true");
+    RANGE_READ_ENDPOINT_GROUPING_ENABLED("cassandra.range_read_endpoint_grouping_enabled", "true"),
+    /**
+     * Allows to set custom current trie index format. This node will produce sstables in this format.
+     */
+    TRIE_INDEX_FORMAT_VERSION("cassandra.trie_index_format_version", "cc");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -289,7 +290,7 @@ public class TrieIndexFormat implements SSTableFormat
     //
     static class TrieIndexVersion extends Version
     {
-        public static final String current_version = "cc";
+        public static final String current_version = CassandraRelevantProperties.TRIE_INDEX_FORMAT_VERSION.getString();
         public static final String earliest_supported_version = "aa";
 
         // aa (DSE 6.0): trie index format

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
@@ -26,6 +26,9 @@ import java.util.UUID;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.SerializationHeader;
@@ -290,7 +293,15 @@ public class TrieIndexFormat implements SSTableFormat
     //
     static class TrieIndexVersion extends Version
     {
+        private static final Logger logger = LoggerFactory.getLogger(TrieIndexVersion.class);
+
         public static final String current_version = CassandraRelevantProperties.TRIE_INDEX_FORMAT_VERSION.getString();
+
+        static
+        {
+            logger.info("Trie index format current version: {}", current_version);
+        }
+
         public static final String earliest_supported_version = "aa";
 
         // aa (DSE 6.0): trie index format


### PR DESCRIPTION
Non-native Vector kubes will set it to cb.


The migration tests uncovered an sstable incompatibility. DSE code is not compatible with cc sstable format produced by vector. To make DSE -> Vector migration and rollback possible, Vector will be pinned to cb format compatible with DSE code. Obviously, the cb format will be used only in "CC Vector" kubes, not actual Vector kubes.