### PR TITLE
Fix flaky CompactionTest.testAbortCompactionWithEarlyOpenSSTables

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -161,6 +161,7 @@ public class CompactionTest extends AbstractMetricsTest
         createTable(CREATE_TABLE_TEMPLATE);
         String v1IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+        waitForIndexQueryable();
 
         int sstables = 2;
         int num = 10;


### PR DESCRIPTION
CompactionTest.testAbortCompactionWithEarlyOpenSSTables must wait for index to be queryable, as otherwise, a delayed index initial build task can cause an unanticipated flush that violates test assertions.