### PR TITLE
Opinionated changes to internode tracking

### DIFF
--- a/src/java/org/apache/cassandra/db/CounterMutationCallback.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationCallback.java
@@ -74,7 +74,7 @@ public class CounterMutationCallback implements Runnable
         // Add internode bytes sensors to the response after updating each per-table sensor with the current response
         // message size: this is missing the sensor values, but it's a good enough approximation
         Collection<Sensor> requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
-        int perSensorSize = response.currentSize(MessagingService.current_version) / tables;
+        int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
         requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
         RequestTracker.instance.get().syncAllSensors();
         Function<String, String> requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;

--- a/src/java/org/apache/cassandra/db/CounterMutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationVerbHandler.java
@@ -28,8 +28,11 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.Type;
 import org.apache.cassandra.service.StorageProxy;
 
 public class CounterMutationVerbHandler implements IVerbHandler<CounterMutation>
@@ -45,11 +48,17 @@ public class CounterMutationVerbHandler implements IVerbHandler<CounterMutation>
         logger.trace("Applying forwarded {}", cm);
 
         // Initialize the sensor and set ExecutorLocals
-        String keyspace = cm.getKeyspaceName();
         Collection<TableMetadata> tables = message.payload.getPartitionUpdates().stream().map(PartitionUpdate::metadata).collect(Collectors.toSet());
-        RequestSensors requestSensors = new RequestSensors(keyspace, tables);
+        RequestSensors requestSensors = new RequestSensors();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
+
+        // Initialize internode bytes with the inbound message size:
+        tables.forEach(tm -> {
+            Context context = Context.from(tm);
+            requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
+            requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.serializedSize(MessagingService.current_version) / tables.size());
+        });
 
         String localDataCenter = DatabaseDescriptor.getEndpointSnitch().getLocalDatacenter();
         // We should not wait for the result of the write in this thread,
@@ -61,7 +70,7 @@ public class CounterMutationVerbHandler implements IVerbHandler<CounterMutation>
         // it's own in that case.
         StorageProxy.applyCounterMutationOnLeader(cm,
                                                   localDataCenter,
-                                                  new CounterMutationCallback(message, message.from(), requestSensors),
+                                                  new CounterMutationCallback(message, message.from()),
                                                   queryStartNanoTime);
     }
 }

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -74,7 +74,7 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
 
         // Add internode bytes sensors to the response after updating each per-table sensor with the current response
         // message size: this is missing the sensor values, but it's a good enough approximation
-        int perSensorSize = response.currentSize(MessagingService.current_version) / tables;
+        int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
         requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
         requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
         RequestTracker.instance.get().syncAllSensors();

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -61,38 +61,29 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
         // Add write bytes sensors to the response
         Function<String, String> requestParam = SensorsCustomParams::encodeTableInWriteBytesRequestParam;
         Function<String, String> tableParam = SensorsCustomParams::encodeTableInWriteBytesTableParam;
-        Collection<Sensor> sensors = RequestTracker.instance.get().getSensors(Type.WRITE_BYTES);
-        addSensorsToResponse(sensors, requestParam, tableParam, response);
+        Collection<Sensor> requestSensors = RequestTracker.instance.get().getSensors(Type.WRITE_BYTES);
+        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
 
         // Add index write bytes sensors to the response
         requestParam = SensorsCustomParams::encodeTableInIndexWriteBytesRequestParam;
         tableParam = SensorsCustomParams::encodeTableInIndexWriteBytesTableParam;
-        sensors = RequestTracker.instance.get().getSensors(Type.INDEX_WRITE_BYTES);
-        addSensorsToResponse(sensors, requestParam, tableParam, response);
+        requestSensors = RequestTracker.instance.get().getSensors(Type.INDEX_WRITE_BYTES);
+        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
 
-        // Add internode message sensors to the response
-        for (PartitionUpdate update : mutation.getPartitionUpdates())
-        {
-            Context context = Context.from(update.metadata());
-            Optional<Sensor> internodeBytes = SensorsRegistry.instance.getSensor(context, Type.INTERNODE_MSG_BYTES);
-            internodeBytes.ifPresent(sensor -> {
-                byte[] bytes = SensorsCustomParams.sensorValueAsBytes(sensor.getValue());
-                String internodeBytesTableParam = SensorsCustomParams.encodeTableInInternodeBytesTableParam(context.getTable());
-                response.withCustomParam(internodeBytesTableParam, bytes);
-            });
-
-            Optional<Sensor> internodeCount = SensorsRegistry.instance.getSensor(context, Type.INTERNODE_MSG_COUNT);
-            internodeCount.ifPresent(sensor -> {
-                byte[] count = SensorsCustomParams.sensorValueAsBytes(sensor.getValue());
-                String internodeCountTableParam = SensorsCustomParams.encodeTableInInternodeCountTableParam(context.getTable());
-                response.withCustomParam(internodeCountTableParam, count);
-            });
-        }
+        // Add internode bytes sensors to the response after updating each per-table sensor with the current response
+        // message size: this is missing the sensor values, but it's a good enough approximation
+        int perSensorSize = response.currentSize(MessagingService.current_version) / requestSensors.size();
+        requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
+        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
+        RequestTracker.instance.get().syncAllSensors();
+        requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;
+        tableParam = SensorsCustomParams::encodeTableInInternodeBytesTableParam;
+        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
     }
 
-    private void addSensorsToResponse(Collection<Sensor> sensors, Function<String, String> requestParamSupplier, Function<String, String> tableParamSupplier, Message.Builder<NoPayload> response)
+    private void addSensorsToResponse(Collection<Sensor> requestSensors, Function<String, String> requestParamSupplier, Function<String, String> tableParamSupplier, Message.Builder<NoPayload> response)
     {
-        for (Sensor requestSensor : sensors)
+        for (Sensor requestSensor : requestSensors)
         {
             String requestBytesParam = requestParamSupplier.apply(requestSensor.getContext().getTable());
             byte[] requestBytes = SensorsCustomParams.sensorValueAsBytes(requestSensor.getValue());
@@ -132,11 +123,17 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
         try
         {
             // Initialize the sensor and set ExecutorLocals
-            String keyspace = message.payload.getKeyspaceName();
             Collection<TableMetadata> tables = message.payload.getPartitionUpdates().stream().map(PartitionUpdate::metadata).collect(Collectors.toList());
-            RequestSensors sensors = new RequestSensors(keyspace, tables);
-            ExecutorLocals locals = ExecutorLocals.create(sensors);
+            RequestSensors requestSensors = new RequestSensors();
+            ExecutorLocals locals = ExecutorLocals.create(requestSensors);
             ExecutorLocals.set(locals);
+
+            // Initialize internode bytes with the inbound message size:
+            tables.forEach(tm -> {
+                Context context = Context.from(tm);
+                requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
+                requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.serializedSize(MessagingService.current_version) / tables.size());
+            });
 
             message.payload.applyFuture(WriteOptions.DEFAULT).thenAccept(o -> respond(message, respondToAddress)).exceptionally(wto -> {
                 failed();

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -93,7 +93,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         }
 
         Message.Builder<ReadResponse> reply = message.responseWithBuilder(response);
-        int size = reply.currentSize(MessagingService.current_version);
+        int size = reply.currentPayloadSize(MessagingService.current_version);
         RequestTracker.instance.get().incrementSensor(context, Type.INTERNODE_BYTES, size);
         RequestTracker.instance.get().syncAllSensors();
 

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -112,7 +112,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
                                      bytes);
         });
 
-        Optional<Sensor> tableSensor = SensorsRegistry.instance.getSensor(context, Type.INTERNODE_BYTES);
+        Optional<Sensor> tableSensor = SensorsRegistry.instance.getOrCreateSensor(context, Type.INTERNODE_BYTES);
         tableSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> {
             reply.withCustomParam(SensorsCustomParams.encodeTableInInternodeBytesTableParam(context.getTable()),
                                   bytes);
@@ -133,7 +133,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         readRequestSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue()))
                          .ifPresent(bytes -> reply.withCustomParam(requestBytesParam, bytes));
 
-        Optional<Sensor> readTableSensor = SensorsRegistry.instance.getSensor(context, type);
+        Optional<Sensor> readTableSensor = SensorsRegistry.instance.getOrCreateSensor(context, type);
         readTableSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue()))
                        .ifPresent(bytes -> reply.withCustomParam(tableBytesParam, bytes));
     }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -604,7 +604,25 @@ public class Message<T>
             if (payload == null)
                 throw new IllegalArgumentException();
 
-            return new Message<>(new Header(hasId ? id : nextId(), verb, from, createdAtNanos, expiresAtNanos, flags, params), payload);
+            return doBuild(hasId ? id : nextId());
+        }
+
+        public int currentSize(int version)
+        {
+            // use dummy id just for the sake of computing the serialized size
+            return doBuild(0).serializedSize(version);
+        }
+
+        private Message<T> doBuild(long id)
+        {
+            if (verb == null)
+                throw new IllegalArgumentException();
+            if (from == null)
+                throw new IllegalArgumentException();
+            if (payload == null)
+                throw new IllegalArgumentException();
+
+            return new Message<>(new Header(id, verb, from, createdAtNanos, expiresAtNanos, flags, params), payload);
         }
     }
 

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -40,11 +40,6 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.metrics.MessagingMetrics;
 import org.apache.cassandra.nodes.Nodes;
-import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.sensors.Context;
-import org.apache.cassandra.sensors.RequestSensors;
-import org.apache.cassandra.sensors.RequestTracker;
-import org.apache.cassandra.sensors.Type;
 import org.apache.cassandra.service.AbstractWriteResponseHandler;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
@@ -625,37 +620,10 @@ public class MessagingService extends MessagingServiceMBeanImpl
     public void listen()
     {
         inboundSockets.open();
-        outboundSink.add(this::trackOutboundMessages);
     }
 
     public void waitUntilListening() throws InterruptedException
     {
         inboundSockets.open().await();
-    }
-
-    private boolean trackOutboundMessages(Message<?> message, InetAddressAndPort ignored)
-    {
-        RequestSensors requestSensors = RequestTracker.instance.get();
-        if (requestSensors == null)
-            return true;
-
-        String keyspace = requestSensors.getKeyspace();
-        double size = message.serializedSize(MessagingService.current_version);
-        // split the internode message bytes and count into between tables in the mutation
-        int tablesCount = requestSensors.getTables().size();
-        double internodeBytesPerTable = size / tablesCount;
-        double internodeCountPerTable = 1.0d / tablesCount;
-
-        for (TableMetadata tm : requestSensors.getTables())
-        {
-            Context context = new Context(keyspace, tm.name, tm.id.toString());
-            requestSensors.registerSensor(context, Type.INTERNODE_MSG_BYTES);
-            requestSensors.registerSensor(context, Type.INTERNODE_MSG_COUNT);
-            requestSensors.incrementSensor(context, Type.INTERNODE_MSG_BYTES, internodeBytesPerTable);
-            requestSensors.incrementSensor(context, Type.INTERNODE_MSG_COUNT, internodeCountPerTable);
-        }
-        requestSensors.syncAllSensors();
-
-        return true;
     }
 }

--- a/src/java/org/apache/cassandra/net/SensorsCustomParams.java
+++ b/src/java/org/apache/cassandra/net/SensorsCustomParams.java
@@ -65,15 +65,15 @@ public final class SensorsCustomParams
      */
     public static final String INDEX_WRITE_BYTES_TABLE_TEMPLATE = "INDEX_WRITE_BYTES_TABLE.%s";
     /**
-     * The total internode message bytes received by the writer or coordinator for a given keyspace.
-     * To support batch writes, table name is encoded in the following format: INTERNODE_MSG_BYTES.<table>
+     * The per-request internode message bytes received and sent by the writer for a given keyspace and table.
+     * To support batch writes, table name is encoded in the following format: INTERNODE_MSG_BYTES_REQUEST.<table>
+     */
+    public static final String INTERNODE_MSG_BYTES_REQUEST_TEMPLATE = "INTERNODE_MSG_BYTES_REQUEST.%s";
+    /**
+     * The total internode message bytes received by the writer or coordinator for a given keyspace and table.
+     * To support batch writes, table name is encoded in the following format: INTERNODE_MSG_BYTES_TABLE.<table>
      */
     public static final String INTERNODE_MSG_BYTES_TABLE_TEMPLATE = "INTERNODE_MSG_BYTES_TABLE.%s";
-    /**
-     * The total internode message count received by the writer or coordinator for a given keyspace.
-     * To support batch writes, table name is encoded in the following format: INTERNODE_MSG_COUNT.<table>
-     */
-    public static final String INTERNODE_MSG_COUNT_TABLE_TEMPLATE = "INTERNODE_MSG_COUNT_TABLE.%s";
 
     private SensorsCustomParams()
     {
@@ -118,13 +118,13 @@ public final class SensorsCustomParams
         return String.format(INDEX_WRITE_BYTES_TABLE_TEMPLATE, tableName);
     }
 
+    public static String encodeTableInInternodeBytesRequestParam(String tableName)
+    {
+        return String.format(INTERNODE_MSG_BYTES_REQUEST_TEMPLATE, tableName);
+    }
+
     public static String encodeTableInInternodeBytesTableParam(String tableName)
     {
         return String.format(INTERNODE_MSG_BYTES_TABLE_TEMPLATE, tableName);
-    }
-
-    public static String encodeTableInInternodeCountTableParam(String tableName)
-    {
-        return String.format(INTERNODE_MSG_COUNT_TABLE_TEMPLATE, tableName);
     }
 }

--- a/src/java/org/apache/cassandra/sensors/RequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/RequestSensors.java
@@ -18,21 +18,16 @@
 
 package org.apache.cassandra.sensors;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableSet;
-
-import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.Pair;
 
 /**
@@ -53,19 +48,17 @@ public class RequestSensors
 {
     private final Supplier<SensorsRegistry> sensorsRegistry;
     private final ConcurrentMap<Pair<Context, Type>, Sensor> sensors = new ConcurrentHashMap<>();
-    private final String keyspace;
-    private final Collection<TableMetadata> tables;
+    private final ConcurrentMap<Sensor, Double> latestSyncedValuePerSensor = new ConcurrentHashMap<>();
+    private final ReadWriteLock updateLock = new ReentrantReadWriteLock();
 
-    public RequestSensors(String keyspace, Collection<TableMetadata> tables)
+    public RequestSensors()
     {
-        this(() -> SensorsRegistry.instance, keyspace, tables);
+        this(() -> SensorsRegistry.instance);
     }
 
-    public RequestSensors(Supplier<SensorsRegistry> sensorsRegistry, String keyspace, Collection<TableMetadata> tables)
+    public RequestSensors(Supplier<SensorsRegistry> sensorsRegistry)
     {
         this.sensorsRegistry = sensorsRegistry;
-        this.keyspace = keyspace;
-        this.tables = tables;
     }
 
     public void registerSensor(Context context, Type type)
@@ -85,22 +78,33 @@ public class RequestSensors
 
     public void incrementSensor(Context context, Type type, double value)
     {
-        Optional.ofNullable(sensors.get(Pair.create(context, type))).ifPresent(s -> s.increment(value));
-    }
-
-    public String getKeyspace()
-    {
-        return keyspace;
-    }
-
-    public Collection<TableMetadata> getTables()
-    {
-        return tables;
+        updateLock.readLock().lock();
+        try
+        {
+            Optional.ofNullable(sensors.get(Pair.create(context, type))).ifPresent(s -> s.increment(value));
+        }
+        finally
+        {
+            updateLock.readLock().unlock();
+        }
     }
 
     public void syncAllSensors()
     {
-        sensors.values().forEach(s -> sensorsRegistry.get().updateSensor(s.getContext(), s.getType(), s.getValue()));
+        updateLock.writeLock().lock();
+        try
+        {
+            sensors.values().forEach(sensor -> {
+                double current = latestSyncedValuePerSensor.getOrDefault(sensor, 0d);
+                double update = sensor.getValue() - current;
+                latestSyncedValuePerSensor.put(sensor, sensor.getValue());
+                sensorsRegistry.get().incrementSensor(sensor.getContext(), sensor.getType(), update);
+            });
+        }
+        finally
+        {
+            updateLock.writeLock().unlock();
+        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -54,8 +54,8 @@ import org.apache.cassandra.utils.concurrent.Timer;
  * </ul>
  * The returned sensors are global, meaning that their value spans across requests/responses, but cannot be modified either
  * directly or indirectly via this class (whose update methods are package protected). In order to modify a sensor value,
- * it must be registered to a request/response via {@link RequestSensors#registerSensor(Type)} and incremented via
- * {@link RequestSensors#incrementSensor(Type, double)}, then synced via {@link RequestSensors#syncAllSensors()}, which
+ * it must be registered to a request/response via {@link RequestSensors#registerSensor(Context, Type)} and incremented via
+ * {@link RequestSensors#incrementSensor(Context, Type, double)}, then synced via {@link RequestSensors#syncAllSensors()}, which
  * will update the related global sensors.
  * <br/><br/>
  * Given sensors are tied to a context, that is to a given keyspace and table, their global instance will be deleted
@@ -146,16 +146,16 @@ public class SensorsRegistry implements SchemaChangeListener
         }
     }
 
-    protected void updateSensor(Context context, Type type, double value)
+    protected void incrementSensor(Context context, Type type, double value)
     {
         getOrCreateSensor(context, type).ifPresent(s -> s.increment(value));
     }
 
-    protected Future<Void> updateSensorAsync(Context context, Type type, double value, long delay, TimeUnit unit)
+    protected Future<Void> incrementSensorAsync(Context context, Type type, double value, long delay, TimeUnit unit)
     {
         return asyncUpdater.onTimeout(() ->
-                               getOrCreateSensor(context, type).ifPresent(s -> s.increment(value)),
-                               delay, unit);
+                                      getOrCreateSensor(context, type).ifPresent(s -> s.increment(value)),
+                                      delay, unit);
     }
 
     public Set<Sensor> getSensorsByKeyspace(String keyspace)

--- a/src/java/org/apache/cassandra/sensors/Type.java
+++ b/src/java/org/apache/cassandra/sensors/Type.java
@@ -23,9 +23,7 @@ package org.apache.cassandra.sensors;
  */
 public enum Type
 {
-    CLIENT_BYTES,
-    INTERNODE_MSG_BYTES,
-    INTERNODE_MSG_COUNT,
+    INTERNODE_BYTES,
 
     READ_BYTES,
 

--- a/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
+++ b/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -120,9 +119,8 @@ public class CounterMutationCallbackTest
         // dummy mutation
         TableMetadata metadata = MockSchema.newTableMetadata(KEYSPACE1, CF_COUTNER);
         Mutation mutation = new Mutation(PartitionUpdate.simpleBuilder(metadata, "").build());
-        CounterMutation counterMutation = new CounterMutation(mutation, null);
-        Message<CounterMutation> msg =
-        Message.builder(Verb.COUNTER_MUTATION_REQ, counterMutation)
+        CounterMutation counterMutation = new CounterMutation(mutation, ConsistencyLevel.ANY); // CL here just for serialization, otherwise ignored
+        Message<CounterMutation> msg = Message.builder(Verb.COUNTER_MUTATION_REQ, counterMutation)
                .withId(1)
                .from(FBUtilities.getLocalAddressAndPort())
                .withCreatedAt(approxTime.now())
@@ -130,15 +128,17 @@ public class CounterMutationCallbackTest
                .withFlag(MessageFlag.CALL_BACK_ON_FAILURE)
                .withParam(TRACE_SESSION, UUID.randomUUID())
                .build();
+        int responseSize = msg.emptyResponseBuilder().currentSize(MessagingService.current_version);
 
-        RequestSensors requestSensors = new RequestSensors(KEYSPACE1, ImmutableSet.of(metadata));
+        RequestSensors requestSensors = new RequestSensors();
         RequestTracker.instance.set(requestSensors);
 
         Context context = Context.from(Keyspace.open(KEYSPACE1).getMetadata().tables.get(CF_COUTNER).get());
+        requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
         requestSensors.incrementSensor(context, Type.WRITE_BYTES, COUNTER_MUTATION_BYTES); // mimic a counter mutation of size 56 bytes on the leader node
         requestSensors.syncAllSensors();
-        CounterMutationCallback callback = new CounterMutationCallback(msg, FBUtilities.getLocalAddressAndPort(), requestSensors);
+        CounterMutationCallback callback = new CounterMutationCallback(msg, FBUtilities.getLocalAddressAndPort());
         Integer replicaCount = replicaCountAndExpectedSensorValue.left;
         callback.setReplicaCount(replicaCount);
 
@@ -149,9 +149,12 @@ public class CounterMutationCallbackTest
         assertThat(localSensor.getValue()).isEqualTo(COUNTER_MUTATION_BYTES);
         Sensor registerSensor = SensorsRegistry.instance.getSensor(context, Type.WRITE_BYTES).get();
         assertThat(registerSensor.getValue()).isEqualTo(COUNTER_MUTATION_BYTES);
+        localSensor = SensorsTestUtil.getThreadLocalRequestSensor(context, Type.INTERNODE_BYTES);
+        assertThat(localSensor.getValue()).isEqualTo(responseSize);
+        registerSensor = SensorsRegistry.instance.getSensor(context, Type.INTERNODE_BYTES).get();
+        assertThat(registerSensor.getValue()).isEqualTo(responseSize);
 
         // verify custom headers have the sensors values adjusted for the replica count
-        assertThat(localSensor.getValue()).isEqualTo(COUNTER_MUTATION_BYTES);
         assertThat(capturedOutboundMessages).size().isEqualTo(1);
         Map<String, byte[]> customParam = capturedOutboundMessages.get(0).header.customParams();
         assertThat(customParam).isNotNull();
@@ -165,6 +168,16 @@ public class CounterMutationCallbackTest
                                                    v -> {
                                                        double actual = SensorsCustomParams.sensorValueFromBytes(v);
                                                        assertThat(actual).isEqualTo(expectedSensorValue);
+                                                   });
+        assertThat(customParam).hasEntrySatisfying("INTERNODE_MSG_BYTES_REQUEST.Counter",
+                                                   v -> {
+                                                       double actual = SensorsCustomParams.sensorValueFromBytes(v);
+                                                       assertThat(actual).isEqualTo(responseSize * Math.max(replicaCount, 1));
+                                                   });
+        assertThat(customParam).hasEntrySatisfying("INTERNODE_MSG_BYTES_TABLE.Counter",
+                                                   v -> {
+                                                       double actual = SensorsCustomParams.sensorValueFromBytes(v);
+                                                       assertThat(actual).isEqualTo(responseSize * Math.max(replicaCount, 1));
                                                    });
     }
 }

--- a/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
+++ b/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
@@ -128,7 +128,7 @@ public class CounterMutationCallbackTest
                .withFlag(MessageFlag.CALL_BACK_ON_FAILURE)
                .withParam(TRACE_SESSION, UUID.randomUUID())
                .build();
-        int responseSize = msg.emptyResponseBuilder().currentSize(MessagingService.current_version);
+        int responseSize = msg.emptyResponseBuilder().currentPayloadSize(MessagingService.current_version);
 
         RequestSensors requestSensors = new RequestSensors();
         RequestTracker.instance.set(requestSensors);

--- a/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
+++ b/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
@@ -97,20 +97,20 @@ public class SensorsCustomParamsTest
     }
 
     @Test
+    public void testEncodeTableInInternodeBytesRequestParam()
+    {
+        String table = "t1";
+        String expectedParam = String.format("INTERNODE_MSG_BYTES_REQUEST.%s", table);
+        String actualParam = SensorsCustomParams.encodeTableInInternodeBytesRequestParam(table);
+        assertEquals(expectedParam, actualParam);
+    }
+
+    @Test
     public void testEncodeTableInInternodeBytesTableParam()
     {
         String table = "t1";
         String expectedParam = String.format("INTERNODE_MSG_BYTES_TABLE.%s", table);
         String actualParam = SensorsCustomParams.encodeTableInInternodeBytesTableParam(table);
-        assertEquals(expectedParam, actualParam);
-    }
-
-    @Test
-    public void testEncodeTableInInternodeCountTableParam()
-    {
-        String table = "t1";
-        String expectedParam = String.format("INTERNODE_MSG_COUNT_TABLE.%s", "t1");
-        String actualParam = SensorsCustomParams.encodeTableInInternodeCountTableParam(table);
         assertEquals(expectedParam, actualParam);
     }
 }

--- a/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
@@ -134,22 +134,22 @@ public class SensorsRegistryTest
     }
 
     @Test
-    public void testUpdateSensor()
+    public void testIncrementSensor()
     {
         SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
         SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
 
-        SensorsRegistry.instance.updateSensor(context1, type1, 1.0);
+        SensorsRegistry.instance.incrementSensor(context1, type1, 1.0);
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
     }
 
     @Test
-    public void testUpdateSensorAsync() throws ExecutionException, InterruptedException, TimeoutException
+    public void testIncrementSensorAsync() throws ExecutionException, InterruptedException, TimeoutException
     {
         SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
         SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
 
-        SensorsRegistry.instance.updateSensorAsync(context1, type1, 1.0, 1, TimeUnit.MILLISECONDS).get(1, TimeUnit.SECONDS);
+        SensorsRegistry.instance.incrementSensorAsync(context1, type1, 1.0, 1, TimeUnit.MILLISECONDS).get(1, TimeUnit.SECONDS);
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
     }
 
@@ -212,5 +212,23 @@ public class SensorsRegistryTest
 
         verify(listener, never()).onSensorCreated(any());
         verify(listener, never()).onSensorRemoved(any());
+    }
+
+    @Test
+    public void testUpdateAndSyncSensorViaRequestSensors()
+    {
+        SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
+        SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
+
+        RequestSensors requestSensors = new RequestSensors(() -> SensorsRegistry.instance);
+        requestSensors.registerSensor(context1, type1);
+
+        requestSensors.incrementSensor(context1, type1, 1.0);
+        requestSensors.syncAllSensors();
+        assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
+
+        requestSensors.incrementSensor(context1, type1, 1.0);
+        requestSensors.syncAllSensors();
+        assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(2.0));
     }
 }


### PR DESCRIPTION
* Removed message count as bytes should really be the most important/accurate.
* Tracked both inbound and outbound bytes, as writes take up inbound bytes, while reads take up outbound bytes.
* Added internode sensors to custom params in the same place where we add the other sensors.
* Added internode sensors for request.