### PR TITLE
Update JVector dependency to 3.0.0-beta.10

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.9" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0-beta.10" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">


### PR DESCRIPTION
Pick up bug fix affecting larger-than-memory vector index construction in JVector 3.0.0-beta.10