### PR TITLE
CNDB-9477 vsearch: Fix management of syntax errors in frozen types

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1794,7 +1794,9 @@ comparatorTypeWithoutTuples returns [CQL3Type.Raw t]
     | K_FROZEN '<' f=comparatorType '>'
       {
         try {
-            $t = f.freeze();
+            // antlr might try to recover and give a null for f. It will still properly error out in the end, but we want
+            // to avoid NPE in the call to #freeze() so we should bypass this or we'll have a weird user-facing error.
+            $t = f == null ? null : f.freeze();
         } catch (InvalidRequestException e) {
             addRecognitionError(e.getMessage());
         }

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/FrozenCollectionsTest.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
 public class FrozenCollectionsTest extends CQLTester
@@ -1473,5 +1474,45 @@ public class FrozenCollectionsTest extends CQLTester
         flush();
 
         assertRows(execute("SELECT s FROM %s WHERE k = 0"), row(set(largeText, "v1", "v2")));
+    }
+
+    @Test
+    public void testInvalidSyntax() throws Throwable
+    {
+        // lists
+        assertInvalidThrowMessage("no viable alternative at input '>'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<list<>>)", KEYSPACE));
+        assertInvalidThrowMessage("mismatched input ',' expecting '>'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<list<int, int>>)", KEYSPACE));
+        assertInvalidThrowMessage("Unknown type cql_test_keyspace.list",
+                                  InvalidRequestException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<list>)", KEYSPACE));
+
+        // sets
+        assertInvalidThrowMessage("no viable alternative at input '>'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<set<>>)", KEYSPACE));
+        assertInvalidThrowMessage("mismatched input ',' expecting '>'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<set<int, int>>)", KEYSPACE));
+        assertInvalidThrowMessage("mismatched input '>' expecting '<'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<set>)", KEYSPACE));
+
+        // maps
+        assertInvalidThrowMessage("mismatched input '>' expecting ','",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<map<text>>)", KEYSPACE));
+        assertInvalidThrowMessage("no viable alternative at input '2'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<map<2>>)", KEYSPACE));
+        assertInvalidThrowMessage("no viable alternative at input '>'",
+                                  SyntaxException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<map<>>)", KEYSPACE));
+        assertInvalidThrowMessage("Unknown type cql_test_keyspace.map",
+                                  InvalidRequestException.class,
+                                  format("CREATE TABLE %s.t (k int PRIMARY KEY, v frozen<map>)", KEYSPACE));
     }
 }


### PR DESCRIPTION
When the CQL parser finds a syntax error in a type definition in `frozen<>` it produces a NPE that is caught and transformed into a `SyntaxException` [here](https://github.com/datastax/cassandra/blob/478ed37f6322128b5837ec826096bd35d56be25e/src/java/org/apache/cassandra/cql3/QueryProcessor.java#L859-L866). That emits an error warning about the NPE that can bit quite alarming, and a not too helpful error message is presented to the user.

We have seen this happening with vectors, but it can also happen with other types. For example, this will have the same behaviour: `CREATE TABLE t (k int PRIMARY KEY, v frozen<map<text>>)`

The proposed patch fixes that by preventing the NPE, with an approach identical to what is done [here](https://github.com/datastax/cassandra/blob/478ed37f6322128b5837ec826096bd35d56be25e/src/antlr/Parser.g#L1534-L1536) for function names.