### PR TITLE
DSP-24228: Configurable ByteComparable.Version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -543,7 +543,7 @@
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.15"/>
           <dependency groupId="commons-io" artifactId="commons-io" version="2.6" scope="test"/>
-          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.11"/>
+          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.14.0"/>
           <dependency groupId="org.apache.commons" artifactId="commons-math3" version="3.2"/>
           <dependency groupId="org.antlr" artifactId="antlr" version="3.5.2" scope="provided">
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -55,6 +55,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.util.IOUtils;
@@ -199,6 +200,15 @@ public class IndexDescriptor
             // this is called by flush while creating new index files, as well as loading files that already exist
             return Version.latest();
         });
+    }
+
+    /**
+     * Returns the byte-comparable version used to encode keys in the trie-based components of the index.
+     * @see OnDiskFormat#byteComparableVersionFor(IndexComponent, IndexDescriptor)
+     */
+    public ByteComparable.Version byteComparableVersionFor(IndexComponent component)
+    {
+        return getVersion().onDiskFormat().byteComparableVersionFor(component, this);
     }
 
     /**
@@ -439,7 +449,8 @@ public class IndexDescriptor
      */
     private ChecksumIndexInput checksumIndexInput(IndexContext context, IndexInput indexInput)
     {
-        return getVersion(context) == Version.AA
+        Version version = getVersion(context);
+        return version == Version.AA || version == Version.AB
                ? new EndiannessReverserChecksumIndexInput(indexInput)
                : new BufferedChecksumIndexInput(indexInput);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 /**
  * An interface to the on-disk format of an index. This provides format agnostics methods
@@ -212,4 +213,10 @@ public interface OnDiskFormat
      * @return The {@link ByteOrder} for the file associated with the {@link IndexComponent}
      */
     public ByteOrder byteOrderFor(IndexComponent component, IndexContext context);
+
+
+    /**
+     * Return the ByteComparable encoding version used by the index tries.
+     */
+    ByteComparable.Version byteComparableVersionFor(IndexComponent component, IndexDescriptor descriptor);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -37,6 +37,8 @@ public class Version
 {
     // 6.8 formats
     public static final Version AA = new Version("aa", V1OnDiskFormat.instance, Version::aaFileNameFormat);
+    // version AB is the same as AA, but always uses ByteComparable.Version.LEGACY encoding (see DSP-24228)
+    public static final Version AB = new Version("ab", V1OnDiskFormat.instance, (c, i) -> stargazerFileNameFormat(c, i, "ab"));
     // Stargazer
     public static final Version BA = new Version("ba", V2OnDiskFormat.instance, (c, i) -> stargazerFileNameFormat(c, i, "ba"));
     // Converged Cassandra with JVector
@@ -44,7 +46,7 @@ public class Version
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
     // are more likely to match the latest version so we want to test that one first.
-    public static final List<Version> ALL = Lists.newArrayList(CA, BA, AA);
+    public static final List<Version> ALL = Lists.newArrayList(CA, BA, AB, AA);
 
     public static final Version EARLIEST = AA;
     public static final Version VECTOR_EARLIEST = BA;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -71,7 +71,9 @@ public class InvertedIndexSearcher extends IndexSearcher
         reader = new TermsReader(indexContext,
                                  indexFiles.termsData(),
                                  indexFiles.postingLists(),
-                                 root, footerPointer);
+                                 root,
+                                 footerPointer,
+                                 indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -162,7 +162,8 @@ public class MemtableIndexWriter implements PerIndexWriter
                                                                     Integer.MAX_VALUE,
                                                                     indexContext.getIndexWriterConfig()))
             {
-                indexMetas = writer.writeAll(ImmutableOneDimPointValues.fromTermEnum(terms, termComparator));
+                ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.KD_TREE);
+                indexMetas = writer.writeAll(ImmutableOneDimPointValues.fromTermEnum(terms, termComparator, version));
                 numRows = writer.getPointCount();
             }
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -53,6 +53,7 @@ import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.store.IndexInput;
 
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
@@ -163,8 +164,8 @@ public class V1OnDiskFormat implements OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isLiteral())
-            return new InvertedIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
-        return new KDTreeIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new InvertedIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
+        return new KDTreeIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
     }
 
     @Override
@@ -305,6 +306,34 @@ public class V1OnDiskFormat implements OnDiskFormat
     public ByteOrder byteOrderFor(IndexComponent indexComponent, IndexContext context)
     {
         return ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    public ByteComparable.Version byteComparableVersionFor(IndexComponent component, IndexDescriptor descriptor)
+    {
+        if (component == IndexComponent.KD_TREE)
+            return ByteComparable.Version.OSS41;
+
+        // DSP-24228
+        //
+        // Accidentally, we deployed a version of Converged Cassandra that had a bug to production.
+        // That version, which uses sstables in version CC, incorrectly uses OSS41 bytecomparables to
+        // read and write V1 SAI indexes. Fixing the bytecomparables to the correct LEGACY version for all SAI AA
+        // indexes would cause the "incorrect" indexes written by the unpached version to be misinterpreted.
+        // Hence, we make this special case exception here - for legacy SAI indexes in version AA created for sstables
+        // in version CC we stick to the new encoding to keep consistency with whatever was written to disk.
+        // Using different encoding does not cause any trouble as long as it is consistent
+        // for reading (querying) and writing; the problem only happens if bytecomprables of different versions
+        // are compared to each other.
+        //
+        // Additionally, we introduce a new SAI version AB, which is essentially the same as AA, but for which we
+        // will use the correct LEGACY encoding regardless of the sstable version so that those indexes are
+        // fully compatible with DSE 6.8.
+        String sstableVersion =  descriptor.descriptor.version.getVersion();
+        Version indexVersion = descriptor.getVersion();
+        return sstableVersion.startsWith("c") && indexVersion.equals(Version.AA)
+                ? ByteComparable.Version.OSS41
+                : ByteComparable.Version.LEGACY;
     }
 
     protected boolean isBuildCompletionMarker(IndexComponent indexComponent)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
@@ -39,16 +39,22 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
 {
     private final TermsIterator termEnum;
     private final byte[] scratch;
+    private final ByteComparable.Version version;
 
-    private ImmutableOneDimPointValues(TermsIterator termEnum, AbstractType<?> termComparator)
+    private ImmutableOneDimPointValues(TermsIterator termEnum,
+                                       AbstractType<?> termComparator,
+                                       ByteComparable.Version version)
     {
         this.termEnum = termEnum;
         this.scratch = new byte[TypeUtil.fixedSizeOf(termComparator)];
+        this.version = version;
     }
 
-    public static ImmutableOneDimPointValues fromTermEnum(TermsIterator termEnum, AbstractType<?> termComparator)
+    public static ImmutableOneDimPointValues fromTermEnum(TermsIterator termEnum,
+                                                          AbstractType<?> termComparator,
+                                                          ByteComparable.Version version)
     {
-        return new ImmutableOneDimPointValues(termEnum, termComparator);
+        return new ImmutableOneDimPointValues(termEnum, termComparator, version);
     }
 
     @Override
@@ -56,7 +62,7 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
     {
         while (termEnum.hasNext())
         {
-            ByteBufferUtil.toBytes(termEnum.next().asComparableBytes(ByteComparable.Version.OSS41), scratch);
+            ByteBufferUtil.toBytes(termEnum.next().asComparableBytes(version), scratch);
             try (final PostingList postings = termEnum.postings())
             {
                 long segmentRowId;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
@@ -33,9 +33,9 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
  */
 public class ReverseTrieTermsDictionaryReader extends ReverseValueIterator<ReverseTrieTermsDictionaryReader> implements Iterator<Pair<ByteComparable, Long>>
 {
-    public ReverseTrieTermsDictionaryReader(Rebufferer rebufferer, long root)
+    public ReverseTrieTermsDictionaryReader(Rebufferer rebufferer, long root, ByteComparable.Version version)
     {
-        super(rebufferer, root, true, ByteComparable.Version.OSS41);
+        super(rebufferer, root, true, version);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryWriter.java
@@ -50,8 +50,10 @@ public class TrieTermsDictionaryWriter implements Closeable
         startOffset = termDictionaryOutput.getFilePointer();
 
         SAICodecUtils.writeHeader(termDictionaryOutput);
+        ByteComparable.Version byteComparableVersion = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
+
         // we pass the output as SequentialWriter, but we keep IndexOutputWriter around to write footer on flush
-        termsDictionaryWriter = IncrementalTrieWriter.open(TrieTermsDictionaryReader.trieSerializer, termDictionaryOutput.asSequentialWriter(), ByteComparable.Version.OSS41);
+        termsDictionaryWriter = IncrementalTrieWriter.open(TrieTermsDictionaryReader.trieSerializer, termDictionaryOutput.asSequentialWriter(), byteComparableVersion);
     }
 
     public void add(ByteComparable term, long postingListOffset) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/SSTableComponentsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/SSTableComponentsWriter.java
@@ -59,11 +59,13 @@ public class SSTableComponentsWriter implements PerSSTableWriter
         this.blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                      indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                      metadataWriter, true);
+
         this.sortedTermsWriter = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
                                                        metadataWriter,
                                                        bytesWriter,
                                                        blockFPWriter,
-                                                       trieWriter);
+                                                       trieWriter,
+                                                       indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.store.IndexInput;
 
 /**
@@ -110,7 +111,7 @@ public class V2OnDiskFormat extends V1OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 
@@ -189,5 +190,11 @@ public class V2OnDiskFormat extends V1OnDiskFormat
             default:
                 return ByteOrder.BIG_ENDIAN;
         }
+    }
+
+    @Override
+    public ByteComparable.Version byteComparableVersionFor(IndexComponent component, IndexDescriptor descriptor)
+    {
+        return ByteComparable.Version.OSS41;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -73,6 +73,7 @@ public class SortedTermsReader
     private final SortedTermsMeta meta;
     private final FileHandle termsTrie;
     private final LongArray.Factory blockOffsetsFactory;
+    private final ByteComparable.Version termsTrieByteComparableVersion;
 
     /**
      * Creates a new reader based on its data components.
@@ -89,7 +90,8 @@ public class SortedTermsReader
                              @Nonnull FileHandle termsDataBlockOffsets,
                              @Nonnull FileHandle termsTrie,
                              @Nonnull SortedTermsMeta meta,
-                             @Nonnull NumericValuesMeta blockOffsetsMeta) throws IOException
+                             @Nonnull NumericValuesMeta blockOffsetsMeta,
+                             @Nonnull ByteComparable.Version termsTrieByteComparableVersion) throws IOException
     {
         this.termsData = termsData;
         this.termsTrie = termsTrie;
@@ -99,6 +101,7 @@ public class SortedTermsReader
         }
         this.meta = meta;
         this.blockOffsetsFactory = new MonotonicBlockPackedReader(termsDataBlockOffsets, blockOffsetsMeta);
+        this.termsTrieByteComparableVersion = termsTrieByteComparableVersion;
     }
 
     /**
@@ -153,7 +156,7 @@ public class SortedTermsReader
             this.termsDataFp = this.termsData.getFilePointer();
             this.blockOffsets = new LongArray.DeferredLongArray(blockOffsetsFactory::open);
             this.currentTerm = new BytesRef(Math.max(meta.maxTermLength, 0));  // maxTermLength can be negative if meta.count == 0
-            this.reader = new TrieTermsDictionaryReader(termsTrie.instantiateRebufferer(), meta.trieFP, ByteComparable.Version.OSS41);
+            this.reader = new TrieTermsDictionaryReader(termsTrie.instantiateRebufferer(), meta.trieFP, termsTrieByteComparableVersion);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
@@ -79,6 +79,8 @@ public class SortedTermsWriter implements Closeable
     private final NumericValuesWriter offsetsWriter;
     private final String componentName;
     private final MetadataWriter metadataWriter;
+    private final ByteComparable.Version trieByteComparableVersion;
+
 
     private BytesRefBuilder prevTerm = new BytesRefBuilder();
     private BytesRefBuilder tempTerm = new BytesRefBuilder();
@@ -104,17 +106,19 @@ public class SortedTermsWriter implements Closeable
                              @NonNull MetadataWriter metadataWriter,
                              @Nonnull IndexOutput termsData,
                              @Nonnull NumericValuesWriter termsDataBlockOffsets,
-                             @Nonnull IndexOutputWriter trieWriter) throws IOException
+                             @Nonnull IndexOutputWriter trieWriter,
+                             ByteComparable.Version trieByteComparableVersion) throws IOException
     {
         this.componentName = componentName;
         this.metadataWriter = metadataWriter;
         this.trieOutput = trieWriter;
         SAICodecUtils.writeHeader(this.trieOutput);
-        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieWriter.asSequentialWriter(), ByteComparable.Version.OSS41);
+        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieWriter.asSequentialWriter(), trieByteComparableVersion);
         SAICodecUtils.writeHeader(termsData);
         this.termsOutput = termsData;
         this.bytesStartFP = termsData.getFilePointer();
         this.offsetsWriter = termsDataBlockOffsets;
+        this.trieByteComparableVersion = trieByteComparableVersion;
     }
 
     /**
@@ -199,7 +203,7 @@ public class SortedTermsWriter implements Closeable
      */
     private void copyBytes(ByteComparable source, BytesRefBuilder dest)
     {
-        ByteSource byteSource = source.asComparableBytes(ByteComparable.Version.OSS41);
+        ByteSource byteSource = source.asComparableBytes(trieByteComparableVersion);
         int val;
         while ((val = byteSource.next()) != ByteSource.END_OF_STREAM)
             dest.append((byte) val);

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 /**
  * Different vector components compared to V2OnDiskFormat (supporting DiskANN/jvector instead of HNSW/lucene).
@@ -88,7 +89,7 @@ public class V3OnDiskFormat extends V2OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 

--- a/src/java/org/apache/cassandra/io/tries/IncrementalDeepTrieWriterPageAware.java
+++ b/src/java/org/apache/cassandra/io/tries/IncrementalDeepTrieWriterPageAware.java
@@ -35,13 +35,18 @@ class IncrementalDeepTrieWriterPageAware<VALUE> extends IncrementalTrieWriterPag
 {
     private final int maxRecursionDepth;
 
-    IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer, DataOutputPlus dest, int maxRecursionDepth, ByteComparable.Version version)
+     IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer,
+                                        DataOutputPlus dest,
+                                        int maxRecursionDepth,
+                                        ByteComparable.Version version)
     {
         super(trieSerializer, dest, version);
         this.maxRecursionDepth = maxRecursionDepth;
     }
 
-    IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer, DataOutputPlus dest, ByteComparable.Version version)
+     IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer,
+                                        DataOutputPlus dest,
+                                        ByteComparable.Version version)
     {
         this(trieSerializer, dest, 64, version);
     }

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -49,7 +49,12 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
         initializeNoRightBound(root, NOT_AT_LIMIT, LeftBoundTreatment.GREATER);
     }
 
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, ByteComparable.Version version)
+    protected ReverseValueIterator(Rebufferer source,
+                                   long root,
+                                   ByteComparable start,
+                                   ByteComparable end,
+                                   LeftBoundTreatment admitPrefix,
+                                   ByteComparable.Version version)
     {
         this(source, root, start, end, admitPrefix, false, version);
     }
@@ -65,7 +70,13 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
      * </ul>
      * This behaviour is shared with the forward counterpart {@link ValueIterator}.
      */
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, boolean collecting, ByteComparable.Version version)
+    protected ReverseValueIterator(Rebufferer source,
+                                   long root,
+                                   ByteComparable start,
+                                   ByteComparable end,
+                                   LeftBoundTreatment admitPrefix,
+                                   boolean collecting,
+                                   ByteComparable.Version version)
     {
         super(source, root, start != null ? start.asComparableBytes(version) : null, collecting, version);
 

--- a/src/java/org/apache/cassandra/io/tries/ValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ValueIterator.java
@@ -46,7 +46,12 @@ public class ValueIterator<CONCRETE extends ValueIterator<CONCRETE>> extends Bas
         initializeNoLeftBound(root, 256);
     }
 
-    protected ValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, ByteComparable.Version version)
+    protected ValueIterator(Rebufferer source,
+                            long root,
+                            ByteComparable start,
+                            ByteComparable end,
+                            LeftBoundTreatment admitPrefix,
+                            ByteComparable.Version version)
     {
         this(source, root, start, end, admitPrefix, false, version);
     }
@@ -63,12 +68,18 @@ public class ValueIterator<CONCRETE extends ValueIterator<CONCRETE>> extends Bas
      * </ul>
      * This behaviour is shared with the reverse counterpart {@link ReverseValueIterator}.
      */
-    protected ValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, boolean collecting, ByteComparable.Version version)
+    protected ValueIterator(Rebufferer source,
+                            long root,
+                            ByteComparable start,
+                            ByteComparable end,
+                            LeftBoundTreatment admitPrefix,
+                            boolean collecting,
+                            ByteComparable.Version version)
     {
         super(source, root, end != null ? end.asComparableBytes(version) : null, collecting, version);
 
         if (start != null)
-            initializeWithLeftBound(root, start.asComparableBytes(byteComparableVersion), admitPrefix, limit != null);
+            initializeWithLeftBound(root, start.asComparableBytes(version), admitPrefix, limit != null);
         else
             initializeNoLeftBound(root, limit != null ? limit.next() : 256);
     }

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
@@ -123,7 +123,8 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
                                                               metadataWriter,
                                                               bytesWriter,
                                                               blockFPWriter,
-                                                              trieWriter))
+                                                              trieWriter,
+                                                              ByteComparable.Version.OSS41))
         {
             for (int x = 0; x < NUM_ROWS; x++)
             {
@@ -175,7 +176,7 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
         termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
         blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS);
 
-        sortedTermsReader = new SortedTermsReader(termsData,blockOffsets, trieFile, sortedTermsMeta, blockOffsetMeta);
+        sortedTermsReader = new SortedTermsReader(termsData, blockOffsets, trieFile, sortedTermsMeta, blockOffsetMeta, ByteComparable.Version.OSS41);
 
         luceneReader = DirectoryReader.open(directory);
         LeafReaderContext context = luceneReader.leaves().get(0);

--- a/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
@@ -127,7 +127,8 @@ public interface DataModel
                                                        "1896, " + NORMAL_COLUMN_DATA.get(12),
                                                        "1896, " + NORMAL_COLUMN_DATA.get(13),
                                                        "1845, " + NORMAL_COLUMN_DATA.get(14),
-                                                       "1845, " + NORMAL_COLUMN_DATA.get(15));
+                                                       "1845, " + NORMAL_COLUMN_DATA.get(15)
+    );
 
     static AtomicInteger seq = new AtomicInteger();
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
@@ -61,7 +61,7 @@ public class VersionTest
     public void unsupportedOrInvalidVersionsDoNotParse()
     {
         assertThatThrownBy(() -> Version.parse(null)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Version.parse("ab")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Version.parse("ac")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("a")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("abc")).isInstanceOf(IllegalArgumentException.class);
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -190,7 +190,8 @@ public class LegacyOnDiskFormatTest
                                                   indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext),
                                                   indexDescriptor.createPerIndexFileHandle(IndexComponent.POSTING_LISTS, indexContext),
                                                   root,
-                                                  footerPointer);
+                                                  footerPointer,
+                                                  ByteComparable.Version.LEGACY);
         Expression expression = new Expression(indexContext).add(Operator.EQ, UTF8Type.instance.decompose("10"));
         ByteComparable term = ByteComparable.fixedLength(expression.lower.value.encoded);
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -194,7 +194,8 @@ public class SegmentFlushTest
                                                   termsData,
                                                   postingLists,
                                                   segmentMetadata.componentMetadatas.get(IndexComponent.TERMS_DATA).root,
-                                                  termsFooterPointer))
+                                                  termsFooterPointer,
+                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA)))
         {
             TermsIterator iterator = reader.allTerms(0);
             assertEquals(minTerm, iterator.getMinTerm());

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
@@ -83,11 +83,13 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
+        ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
         try (TermsReader reader = new TermsReader(indexContext,
                                                   termsData,
                                                   postingLists,
                                                   indexMetas.get(IndexComponent.TERMS_DATA).root,
-                                                  termsFooterPointer))
+                                                  termsFooterPointer,
+                                                  version))
         {
             try (TermsIterator actualTermsEnum = reader.allTerms(0))
             {
@@ -95,7 +97,7 @@ public class TermsReaderTest extends SaiRandomizedTest
                 for (ByteComparable term = actualTermsEnum.next(); term != null; term = actualTermsEnum.next())
                 {
                     final ByteComparable expected = termsEnum.get(i++).left;
-                    assertEquals(0, ByteComparable.compare(expected, term, ByteComparable.Version.OSS41));
+                    assertEquals(0, ByteComparable.compare(expected, term, version));
                 }
             }
         }
@@ -119,15 +121,18 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
+
+        ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
         try (TermsReader reader = new TermsReader(indexContext,
                                                   termsData,
                                                   postingLists,
                                                   indexMetas.get(IndexComponent.TERMS_DATA).root,
-                                                  termsFooterPointer))
+                                                  termsFooterPointer,
+                                                  version))
         {
             for (Pair<ByteComparable, LongArrayList> pair : termsEnum)
             {
-                final byte[] bytes = ByteSourceInverse.readBytes(pair.left.asComparableBytes(ByteComparable.Version.OSS41));
+                final byte[] bytes = ByteSourceInverse.readBytes(pair.left.asComparableBytes(version));
                 try (PostingList actualPostingList = reader.exactMatch(ByteComparable.fixedLength(bytes),
                                                                        (QueryEventListener.TrieIndexEventListener)NO_OP_TRIE_LISTENER,
                                                                        new QueryContext()))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
@@ -46,7 +46,7 @@ public class ImmutableOneDimPointValuesTest
         final int minTerm = 0, maxTerm = 10;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                .fromTermEnum(termEnum, Int32Type.instance);
+                .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         pointValues.intersect(assertingVisitor(minTerm));
     }
@@ -57,7 +57,7 @@ public class ImmutableOneDimPointValuesTest
         final int minTerm = 3, maxTerm = 13;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                .fromTermEnum(termEnum, Int32Type.instance);
+                .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         expectedException.expect(IllegalStateException.class);
         pointValues.swap(0, 1);
@@ -68,7 +68,7 @@ public class ImmutableOneDimPointValuesTest
     {
         final int minTerm = 2, maxTerm = 7;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
-        final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues.fromTermEnum(termEnum, Int32Type.instance);
+        final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues.fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         MutablePointsReaderUtils.sort(2, Int32Type.instance.valueLengthIfFixed(), pointValues, 0, Math.toIntExact(pointValues.size()));
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -136,7 +136,7 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
         final int maxSegmentRowId = 100;
         final TermsIterator termEnum = buildTermEnum(0, maxSegmentRowId);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                                                       .fromTermEnum(termEnum, Int32Type.instance);
+                                                       .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         SegmentMetadata.ComponentMetadataMap indexMetas;
         try (NumericIndexWriter writer = new NumericIndexWriter(indexDescriptor,

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/trie/TrieTermsDictionaryTest.java
@@ -47,11 +47,10 @@ import static org.apache.cassandra.utils.bytecomparable.ByteComparable.compare;
 
 public class TrieTermsDictionaryTest extends SaiRandomizedTest
 {
-    public final static ByteComparable.Version VERSION = OSS41;
-
     private IndexDescriptor indexDescriptor;
     private String index;
     private IndexContext indexContext;
+    private ByteComparable.Version byteComparableVersion;
 
     @Before
     public void setup() throws Throwable
@@ -59,6 +58,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         indexDescriptor = newIndexDescriptor();
         index = newIndex();
         indexContext = SAITester.createIndexContext(index, UTF8Type.instance);
+        byteComparableVersion = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             assertEquals(NOT_FOUND, reader.exactMatch(asByteComparable.apply("a")));
             assertEquals(0, reader.exactMatch(asByteComparable.apply("ab")));
@@ -165,7 +165,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             assertEquals(0, reader.ceiling(asByteComparable.apply("a")));
             assertEquals(2, reader.ceiling(asByteComparable.apply("abc")));
@@ -245,7 +245,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
     private void readAndAssertCeiling(long root, long expected, ByteComparable key)
     {
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), root, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), root, byteComparableVersion))
         {
             assertEquals(expected, reader.ceiling(key));
         }
@@ -274,7 +274,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             assertEquals(NOT_FOUND, reader.floor(asByteComparable.apply("a")));
             assertEquals(7, reader.floor(asByteComparable.apply("z")));
@@ -312,7 +312,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             // Validate token only searches
             assertEquals(NOT_FOUND, reader.floor(primaryKey(asByteComparable, "a", ByteSource.GT_NEXT_COMPONENT)));
@@ -363,8 +363,8 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader iterator = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION);
-             ReverseTrieTermsDictionaryReader reverseIterator = new ReverseTrieTermsDictionaryReader(input.instantiateRebufferer(), fp))
+             TrieTermsDictionaryReader iterator = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion);
+             ReverseTrieTermsDictionaryReader reverseIterator = new ReverseTrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             verifyOrder(iterator, byteComparables, true);
             Collections.reverse(byteComparables);
@@ -408,7 +408,7 @@ public class TrieTermsDictionaryTest extends SaiRandomizedTest
         }
 
         try (FileHandle input = indexDescriptor.createPerIndexFileHandle(IndexComponent.TERMS_DATA, indexContext);
-             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, VERSION))
+             TrieTermsDictionaryReader reader = new TrieTermsDictionaryReader(input.instantiateRebufferer(), fp, byteComparableVersion))
         {
             final ByteComparable expectedMaxTerm = byteComparables.get(byteComparables.size() - 1);
             final ByteComparable actualMaxTerm = reader.getMaxTerm();

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
@@ -54,6 +54,7 @@ public class SortedTermsTest extends SaiRandomizedTest
     public void testLexicographicException() throws Exception
     {
         IndexDescriptor indexDescriptor = newIndexDescriptor();
+        ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
         try (MetadataWriter metadataWriter = new MetadataWriter(indexDescriptor.openPerSSTableOutput(IndexComponent.GROUP_META)))
         {
             NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
@@ -66,16 +67,16 @@ public class SortedTermsTest extends SaiRandomizedTest
                                                                   bytesWriter,
                                                                   blockFPWriter,
                                                                   trieWriter,
-                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
+                                                                  version))
             {
                 ByteBuffer buffer = Int32Type.instance.decompose(99999);
-                ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
+                ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, version);
                 byte[] bytes1 = ByteSourceInverse.readBytes(byteSource);
 
                 writer.add(ByteComparable.fixedLength(bytes1));
 
                 buffer = Int32Type.instance.decompose(444);
-                byteSource = Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
+                byteSource = Int32Type.instance.asComparableBytes(buffer, version);
                 byte[] bytes2 = ByteSourceInverse.readBytes(byteSource);
 
                 assertThrows(IllegalArgumentException.class, () -> writer.add(ByteComparable.fixedLength(bytes2)));
@@ -249,6 +250,7 @@ public class SortedTermsTest extends SaiRandomizedTest
     public void testAdvance() throws IOException
     {
         IndexDescriptor descriptor = newIndexDescriptor();
+        ByteComparable.Version version = descriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
 
         List<byte[]> terms = new ArrayList<>();
         writeTerms(descriptor, terms);
@@ -260,7 +262,7 @@ public class SortedTermsTest extends SaiRandomizedTest
             {
                 ByteComparable term = cursor.term();
 
-                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(ByteComparable.Version.OSS41));
+                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(version));
                 assertArrayEquals(terms.get(x), bytes);
 
                 x++;
@@ -277,6 +279,7 @@ public class SortedTermsTest extends SaiRandomizedTest
     public void testReset() throws Exception
     {
         IndexDescriptor descriptor = newIndexDescriptor();
+        ByteComparable.Version version = descriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
 
         List<byte[]> terms = new ArrayList<>();
         writeTerms(descriptor, terms);
@@ -285,11 +288,11 @@ public class SortedTermsTest extends SaiRandomizedTest
         {
             assertTrue(cursor.advance());
             assertTrue(cursor.advance());
-            String term1 = cursor.term().byteComparableAsString(ByteComparable.Version.OSS41);
+            String term1 = cursor.term().byteComparableAsString(version);
             cursor.reset();
             assertTrue(cursor.advance());
             assertTrue(cursor.advance());
-            String term2 = cursor.term().byteComparableAsString(ByteComparable.Version.OSS41);
+            String term2 = cursor.term().byteComparableAsString(version);
             assertEquals(term1, term2);
             assertEquals(1, cursor.pointId());
         });
@@ -299,6 +302,7 @@ public class SortedTermsTest extends SaiRandomizedTest
     public void testSeekToPointId() throws Exception
     {
         IndexDescriptor descriptor = newIndexDescriptor();
+        ByteComparable.Version version = descriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
 
         List<byte[]> terms = new ArrayList<>();
         writeTerms(descriptor, terms);
@@ -311,7 +315,7 @@ public class SortedTermsTest extends SaiRandomizedTest
                 cursor.seekToPointId(x);
                 ByteComparable term = cursor.term();
 
-                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(ByteComparable.Version.OSS41));
+                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(version));
                 assertArrayEquals(terms.get(x), bytes);
             }
         });
@@ -324,7 +328,7 @@ public class SortedTermsTest extends SaiRandomizedTest
                 cursor.seekToPointId(x);
                 ByteComparable term = cursor.term();
 
-                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(ByteComparable.Version.OSS41));
+                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(version));
                 assertArrayEquals(terms.get(x), bytes);
             }
         });
@@ -338,7 +342,7 @@ public class SortedTermsTest extends SaiRandomizedTest
                 cursor.seekToPointId(target);
                 ByteComparable term = cursor.term();
 
-                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(ByteComparable.Version.OSS41));
+                byte[] bytes = ByteSourceInverse.readBytes(term.asComparableBytes(version));
                 assertArrayEquals(terms.get(target), bytes);
             }
         });
@@ -368,17 +372,18 @@ public class SortedTermsTest extends SaiRandomizedTest
             NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
+            ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
             try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
                                                                   trieWriter,
-                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
+                                                                  version))
             {
                 for (int x = 0; x < 1000 * 4; x++)
                 {
                     ByteBuffer buffer = Int32Type.instance.decompose(x);
-                    ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
+                    ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, version);
                     byte[] bytes = ByteSourceInverse.readBytes(byteSource);
                     terms.add(bytes);
 
@@ -397,12 +402,13 @@ public class SortedTermsTest extends SaiRandomizedTest
             NumericValuesWriter blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                                         metadataWriter, true);
+            ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
             try (SortedTermsWriter writer = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
                                                                   trieWriter,
-                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
+                                                                  version))
             {
                 for (int x = 0; x < 1000 ; x++)
                 {
@@ -410,25 +416,25 @@ public class SortedTermsTest extends SaiRandomizedTest
                     for (int i = 0; i < numPerPrefix; i++)
                     {
                         String component2 = "v" + i;
-                        termsMinPrefix.add(ByteSource.withTerminator(ByteSource.LT_NEXT_COMPONENT, intByteSource(component1 + (matchesData ? 0 : 1))));
-                        termsMaxPrefix.add(ByteSource.withTerminator(ByteSource.GT_NEXT_COMPONENT, intByteSource(component1 + (matchesData ? 0 : 1))));
-                        writer.add(v -> ByteSource.withTerminator(ByteSource.TERMINATOR, intByteSource(component1), utfByteSource(component2)));
+                        termsMinPrefix.add(ByteSource.withTerminator(ByteSource.LT_NEXT_COMPONENT, intByteSource(component1 + (matchesData ? 0 : 1), version)));
+                        termsMaxPrefix.add(ByteSource.withTerminator(ByteSource.GT_NEXT_COMPONENT, intByteSource(component1 + (matchesData ? 0 : 1), version)));
+                        writer.add(v -> ByteSource.withTerminator(ByteSource.TERMINATOR, intByteSource(component1, version), utfByteSource(component2, version)));
                     }
                 }
             }
         }
     }
 
-    private ByteSource intByteSource(int value)
+    private ByteSource intByteSource(int value, ByteComparable.Version version)
     {
         ByteBuffer buffer = Int32Type.instance.decompose(value);
-        return Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
+        return Int32Type.instance.asComparableBytes(buffer, version);
     }
 
-    private ByteSource utfByteSource(String value)
+    private ByteSource utfByteSource(String value, ByteComparable.Version version)
     {
         ByteBuffer buffer = UTF8Type.instance.decompose(value);
-        return UTF8Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
+        return UTF8Type.instance.asComparableBytes(buffer, version);
     }
 
     @FunctionalInterface

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsTest.java
@@ -65,7 +65,8 @@ public class SortedTermsTest extends SaiRandomizedTest
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  trieWriter,
+                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
             {
                 ByteBuffer buffer = Int32Type.instance.decompose(99999);
                 ByteSource byteSource = Int32Type.instance.asComparableBytes(buffer, ByteComparable.Version.OSS41);
@@ -110,7 +111,8 @@ public class SortedTermsTest extends SaiRandomizedTest
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  trieWriter,
+                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
             {
                 primaryKeys.forEach(primaryKey -> {
                     try
@@ -370,7 +372,8 @@ public class SortedTermsTest extends SaiRandomizedTest
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  trieWriter,
+                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
             {
                 for (int x = 0; x < 1000 * 4; x++)
                 {
@@ -398,7 +401,8 @@ public class SortedTermsTest extends SaiRandomizedTest
                                                                   metadataWriter,
                                                                   bytesWriter,
                                                                   blockFPWriter,
-                                                                  trieWriter))
+                                                                  trieWriter,
+                                                                  indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE)))
             {
                 for (int x = 0; x < 1000 ; x++)
                 {
@@ -442,7 +446,8 @@ public class SortedTermsTest extends SaiRandomizedTest
              FileHandle termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
              FileHandle blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS))
         {
-            SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta);
+            ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
+            SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta, version);
             try (SortedTermsReader.Cursor cursor = reader.openCursor())
             {
                 testCode.accept(cursor);
@@ -460,7 +465,8 @@ public class SortedTermsTest extends SaiRandomizedTest
              FileHandle termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
              FileHandle blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS))
         {
-            SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta);
+            ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE);
+            SortedTermsReader reader = new SortedTermsReader(termsData, blockOffsets, trieHandle, sortedTermsMeta, blockPointersMeta, version);
             testCode.accept(reader);
         }
     }

--- a/test/unit/org/apache/cassandra/io/tries/TrieBuilderTest.java
+++ b/test/unit/org/apache/cassandra/io/tries/TrieBuilderTest.java
@@ -18,12 +18,17 @@
 package org.apache.cassandra.io.tries;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.TailOverridingRebufferer;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
Astra on DSE 6.8 uses DSE6 byte-comparable encoding in SAI tries and SSTable indexes, denoted by `ByteComparableVersion.LEGACY`. Hence, in order to read and write those legacy indexes we must use that byte-comparable encoding version, instead of the default `OSS41` version.

Unfortunately the code in `org.apache.cassandra.io.tries` is used by both SAI and sstable indexes and had a hardcoded OSS41 version of byte-comparables.

This commit makes the byte-comparable versions
used in `io.tries` configurable by the caller so a proper version can be selected depending on the type and version of the index and the sstable:

* v1 (AA) SAI indexes on legacy SSTables (A*, B*) - LEGACY 
* v1 (AA) SAI indexes on current SSTables (C*) - OSS41* 
* v1 (AA) SAI indexes on any future SSTables (D*) - LEGACY 
* v1 (AB) SAI indexes - LEGACY**
* v2 and newer SAI indexes - OSS41

*) Because we already deployed a version of Cassandra without this patch to production, the AA indexes on CC SSTables must exceptionally use the OSS41 encoding.

**) This commit also introduces a new version of legacy SAI index: AB, which is the same as AA, but always uses the LEGACY byte-comparable encoding. This new version is intended to allow easy downgrades to DSE 6.8.