### PR TITLE
Trigger flush of RAMStringSegmentBuilder/BKDTreeRamBuffer when backing ByteBlockPools hit maximum size

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
@@ -65,8 +65,11 @@ public class RAMStringIndexer
 
     public boolean requiresFlush()
     {
-        // termsPool can't handle more than Integer.MAX_VALUE bytes. These are allocated in chunks, which means
-        // the last allocated chunk should put estimatedBytesUsed() at Integer.MAX_VALUE + 1.
+        // ByteBlockPool can't handle more than Integer.MAX_VALUE bytes. These are allocated in fixed-size chunks,
+        // and additions are guaranteed to be smaller than the chunks. This means that the last chunk allocation will
+        // be triggered by an addition, and the rest of the space in the final chunk will be wasted, as the bytesUsed
+        // counters track block allocation, not the size of additions. This means that we can't pass this check and then
+        // fail to add a term.
         return termsBytesUsed.get() >= Integer.MAX_VALUE || slicesBytesUsed.get() >= Integer.MAX_VALUE;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.index.sai.disk;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
@@ -35,6 +37,8 @@ import org.apache.lucene.util.Counter;
  */
 public class RAMStringIndexer
 {
+    @VisibleForTesting
+    public static int MAX_BLOCK_BYTE_POOL_SIZE = Integer.MAX_VALUE;
     private final AbstractType<?> termComparator;
     private final BytesRefHash termsHash;
     private final RAMPostingSlices slices;
@@ -70,7 +74,7 @@ public class RAMStringIndexer
         // be triggered by an addition, and the rest of the space in the final chunk will be wasted, as the bytesUsed
         // counters track block allocation, not the size of additions. This means that we can't pass this check and then
         // fail to add a term.
-        return termsBytesUsed.get() >= Integer.MAX_VALUE || slicesBytesUsed.get() >= Integer.MAX_VALUE;
+        return termsBytesUsed.get() >= MAX_BLOCK_BYTE_POOL_SIZE || slicesBytesUsed.get() >= MAX_BLOCK_BYTE_POOL_SIZE;
     }
 
     public boolean isEmpty()

--- a/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
@@ -60,6 +60,13 @@ public class RAMStringIndexer
         return bytesUsed.get();
     }
 
+    public boolean requiresFlush()
+    {
+        // termsPool can't handle more than Integer.MAX_VALUE bytes. These are allocated in chunks, which means
+        // the last allocated chunk should put estimatedBytesUsed() at Integer.MAX_VALUE + 1.
+        return estimatedBytesUsed() >= Integer.MAX_VALUE;
+    }
+
     public boolean isEmpty()
     {
         return rowCount == 0;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -155,6 +155,12 @@ public abstract class SegmentBuilder
                 return writer.writeAll(kdTreeRamBuffer.asPointValues());
             }
         }
+
+        @Override
+        public boolean requiresFlush()
+        {
+            return kdTreeRamBuffer.requiresFlush();
+        }
     }
 
     public static class RAMStringSegmentBuilder extends SegmentBuilder

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -192,6 +192,12 @@ public abstract class SegmentBuilder
                 return writer.writeAll(ramIndexer.getTermsWithPostings());
             }
         }
+
+        @Override
+        public boolean requiresFlush()
+        {
+            return ramIndexer.requiresFlush();
+        }
     }
 
     public static class VectorOffHeapSegmentBuilder extends SegmentBuilder

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.disk.v1.kdtree;
 
 import java.io.IOException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.index.sai.disk.oldlucene.MutablePointValues;
@@ -34,6 +35,8 @@ import org.apache.lucene.util.packed.PackedLongValues;
  */
 public class BKDTreeRamBuffer implements Accountable
 {
+    @VisibleForTesting
+    public static int MAX_BLOCK_BYTE_POOL_SIZE = Integer.MAX_VALUE;
     // This counter should not be used to track any other allocations, as we use it to prevent block pool overflow
     private final Counter blockBytesUsed;
     private final ByteBlockPool bytes;
@@ -73,7 +76,7 @@ public class BKDTreeRamBuffer implements Accountable
         // be triggered by an addition, and the rest of the space in the final chunk will be wasted, as the bytesUsed
         // counters track block allocation, not the size of additions. This means that we can't pass this check and then
         // fail to add a term.
-        return blockBytesUsed.get() >= Integer.MAX_VALUE;
+        return blockBytesUsed.get() >= MAX_BLOCK_BYTE_POOL_SIZE;
     }
 
     public int numRows()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
@@ -68,6 +68,11 @@ public class BKDTreeRamBuffer implements Accountable
 
     public boolean requiresFlush()
     {
+        // ByteBlockPool can't handle more than Integer.MAX_VALUE bytes. These are allocated in fixed-size chunks,
+        // and additions are guaranteed to be smaller than the chunks. This means that the last chunk allocation will
+        // be triggered by an addition, and the rest of the space in the final chunk will be wasted, as the bytesUsed
+        // counters track block allocation, not the size of additions. This means that we can't pass this check and then
+        // fail to add a term.
         return blockBytesUsed.get() >= Integer.MAX_VALUE;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -109,5 +110,23 @@ public class RAMStringIndexerTest extends SaiRandomizedTest
         }
 
         assertEquals(numTerms, termOrd);
+    }
+
+    @Test
+    public void testRequiresFlush()
+    {
+        // primary behavior we're testing is that exceptions aren't thrown due to overflowing backing structures
+        RAMStringIndexer indexer = new RAMStringIndexer(UTF8Type.instance);
+
+        Assert.assertFalse(indexer.requiresFlush());
+        for (int i = 0; i < Integer.MAX_VALUE; i++)
+        {
+            if (indexer.requiresFlush())
+                break;
+            indexer.add(new BytesRef(String.format("%5000d", i)), i);
+        }
+        // If we don't require a flush before MAX_VALUE, the implementation of RAMStringIndexer has sufficiently
+        // changed to warrant changes to the test.
+        Assert.assertTrue(indexer.requiresFlush());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBufferTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBufferTest.java
@@ -76,4 +76,24 @@ public class BKDTreeRamBufferTest
             Assert.assertEquals(202 + i, NumericUtils.sortableBytesToInt(ref.bytes, ref.offset));
         }
     }
+
+    @Test
+    public void testRequiresFlush()
+    {
+        // primary behavior we're testing is that exceptions aren't thrown due to overflowing backing structures
+        final BKDTreeRamBuffer buffer = new BKDTreeRamBuffer(1, Integer.BYTES);
+
+        Assert.assertFalse(buffer.requiresFlush());
+        for (int i = 0; i < Integer.MAX_VALUE; i++)
+        {
+            if (buffer.requiresFlush())
+                break;
+            byte[] scratch = new byte[Integer.BYTES];
+            NumericUtils.intToSortableBytes(i, scratch, 0);
+            buffer.addPackedValue(i, new BytesRef(scratch));
+        }
+        // If we don't require a flush before MAX_VALUE, the implementation of BKDTreeRamBuffer has sufficiently
+        // changed to warrant changes to the test.
+        Assert.assertTrue(buffer.requiresFlush());
+    }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBufferTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBufferTest.java
@@ -80,20 +80,29 @@ public class BKDTreeRamBufferTest
     @Test
     public void testRequiresFlush()
     {
-        // primary behavior we're testing is that exceptions aren't thrown due to overflowing backing structures
-        final BKDTreeRamBuffer buffer = new BKDTreeRamBuffer(1, Integer.BYTES);
-
-        Assert.assertFalse(buffer.requiresFlush());
-        for (int i = 0; i < Integer.MAX_VALUE; i++)
+        int maxByteBlockPoolSize = BKDTreeRamBuffer.MAX_BLOCK_BYTE_POOL_SIZE;
+        try
         {
-            if (buffer.requiresFlush())
-                break;
-            byte[] scratch = new byte[Integer.BYTES];
-            NumericUtils.intToSortableBytes(i, scratch, 0);
-            buffer.addPackedValue(i, new BytesRef(scratch));
+            BKDTreeRamBuffer.MAX_BLOCK_BYTE_POOL_SIZE = 1024 * 1024 * 100;
+            // primary behavior we're testing is that exceptions aren't thrown due to overflowing backing structures
+            final BKDTreeRamBuffer buffer = new BKDTreeRamBuffer(1, Integer.BYTES);
+
+            Assert.assertFalse(buffer.requiresFlush());
+            for (int i = 0; i < Integer.MAX_VALUE; i++)
+            {
+                if (buffer.requiresFlush())
+                    break;
+                byte[] scratch = new byte[Integer.BYTES];
+                NumericUtils.intToSortableBytes(i, scratch, 0);
+                buffer.addPackedValue(i, new BytesRef(scratch));
+            }
+            // If we don't require a flush before MAX_VALUE, the implementation of BKDTreeRamBuffer has sufficiently
+            // changed to warrant changes to the test.
+            Assert.assertTrue(buffer.requiresFlush());
         }
-        // If we don't require a flush before MAX_VALUE, the implementation of BKDTreeRamBuffer has sufficiently
-        // changed to warrant changes to the test.
-        Assert.assertTrue(buffer.requiresFlush());
+        finally
+        {
+            BKDTreeRamBuffer.MAX_BLOCK_BYTE_POOL_SIZE = maxByteBlockPoolSize;
+        }
     }
 }


### PR DESCRIPTION
This PR forces RAMStringSegmentBuilder to flush when the associated RAMStringIndexer hits maximum size of 2 GiB. Without this, if segment size is increased beyond the default config and the cardinality of postings is sufficiently high, index build can repeatably fail if the RAMStringSegmentBuilder tries to add terms beyond the maximum.