### PR TITLE
Use precomputed PQ score functions for ANN search on both index and brute force paths

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -304,7 +304,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         var approximateScores = new PriorityQueue<BruteForceRowIdIterator.RowWithApproximateScore>(segmentRowIds.size(),
                                                                                                    (a, b) -> Float.compare(b.getApproximateScore(), a.getApproximateScore()));
         var similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
-        var scoreFunction = cv.scoreFunctionFor(queryVector, similarityFunction);
+        var scoreFunction = cv.precomputedScoreFunctionFor(queryVector, similarityFunction);
 
         try (var ordinalsView = graph.getOrdinalsView())
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -240,7 +240,7 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
             var sf = pqUnitVectors && similarityFunction == VectorSimilarityFunction.DOT_PRODUCT
                      ? VectorSimilarityFunction.COSINE
                      : similarityFunction;
-            var asf = compressedVectors.scoreFunctionFor(queryVector, sf);
+            var asf = compressedVectors.precomputedScoreFunctionFor(queryVector, sf);
             var rr = view.rerankerFor(queryVector, sf);
             ssp = new SearchScoreProvider(asf, rr);
         }


### PR DESCRIPTION
This is a regression introduced when adopting the new version of JVector in #1084. As noted in the JVector commit https://github.com/jbellis/jvector/commit/040baecee8041180691407c03ccae3fd757b8268, the deprecated `approximateScoreFunctionFor` API was replaced by two new APIs: `precomputedScoreFunctionFor` (which behaves the same as the deprecated `approximateScoreFunctionFor`) and `scoreFunctionFor`. In these cases, we did not replace with the equivalent API but instead the new API, which is designed for cases like parts of incremental graph construction, when only a small amount of scores will be computed.