### PR TITLE
CNDB-9707 Implement RequestSensorsFactory to control sensors tracking per keyspace

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -462,7 +462,12 @@ public enum CassandraRelevantProperties
     /**
      * Allows to set custom current trie index format. This node will produce sstables in this format.
      */
-    TRIE_INDEX_FORMAT_VERSION("cassandra.trie_index_format_version", "cc");
+    TRIE_INDEX_FORMAT_VERSION("cassandra.trie_index_format_version", "cc"),
+    /**
+     * Allows custom implementation of {@link org.apache.cassandra.sensors.RequestSensorsFactory} to optionally create
+     * and configure {@link org.apache.cassandra.sensors.RequestSensors} instances.
+     */
+    REQUEST_SENSORS_FACTORY("cassandra.request_sensors_factory_class");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/CounterMutationCallback.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationCallback.java
@@ -102,7 +102,7 @@ public class CounterMutationCallback implements Runnable
             response.withCustomParam(requestBytesParam, requestBytes);
 
             // for each table in the mutation, send the global per table counter write bytes as recorded by the registry
-            Optional<Sensor> registrySensor = SensorsRegistry.instance.getOrCreateSensor(sensor.getContext(), sensor.getType());
+            Optional<Sensor> registrySensor = SensorsRegistry.instance.getSensor(sensor.getContext(), sensor.getType());
             registrySensor.ifPresent(s -> {
                 String tableBytesParam = tableParamSupplier.apply(s.getContext().getTable());
                 byte[] tableBytes = SensorsCustomParams.sensorValueAsBytes(s.getValue() * replicaMultiplier);

--- a/src/java/org/apache/cassandra/db/CounterMutationCallback.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationCallback.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.NoPayload;
 import org.apache.cassandra.net.SensorsCustomParams;
 import org.apache.cassandra.sensors.RequestSensors;
-import org.apache.cassandra.sensors.RequestTracker;
 import org.apache.cassandra.sensors.Sensor;
 import org.apache.cassandra.sensors.SensorsRegistry;
 import org.apache.cassandra.sensors.Type;
@@ -40,12 +39,14 @@ public class CounterMutationCallback implements Runnable
 {
     private final Message<CounterMutation> requestMessage;
     private final InetAddressAndPort respondToAddress;
+    private final RequestSensors requestSensors;
     private int replicaCount = 0;
 
-    public CounterMutationCallback(Message<CounterMutation> requestMessage, InetAddressAndPort respondToAddress)
+    public CounterMutationCallback(Message<CounterMutation> requestMessage, InetAddressAndPort respondToAddress, RequestSensors requestSensors)
     {
         this.requestMessage = requestMessage;
         this.respondToAddress = respondToAddress;
+        this.requestSensors = requestSensors;
     }
 
     /**
@@ -67,44 +68,44 @@ public class CounterMutationCallback implements Runnable
         MessagingService.instance().send(responseBuilder.build(), respondToAddress);
     }
 
-    private static void addSensorsToResponse(Message.Builder<NoPayload> response, Mutation mutation, int replicaMultiplier)
+    private void addSensorsToResponse(Message.Builder<NoPayload> response, Mutation mutation, int replicaMultiplier)
     {
         int tables = mutation.getTableIds().size();
 
         // Add internode bytes sensors to the response after updating each per-table sensor with the current response
         // message size: this is missing the sensor values, but it's a good enough approximation
-        Collection<Sensor> requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
+        Collection<Sensor> sensors = this.requestSensors.getSensors(Type.INTERNODE_BYTES);
         int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
-        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
-        RequestTracker.instance.get().syncAllSensors();
+        sensors.forEach(sensor -> this.requestSensors.incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
+        this.requestSensors.syncAllSensors();
         Function<String, String> requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;
         Function<String, String> tableParam = SensorsCustomParams::encodeTableInInternodeBytesTableParam;
-        addSensorsToResponse(requestSensors, requestParam, tableParam, response, replicaMultiplier);
+        addSensorsToResponse(sensors, requestParam, tableParam, response, replicaMultiplier);
 
         // Add write bytes sensors to the response
         requestParam = SensorsCustomParams::encodeTableInWriteBytesRequestParam;
         tableParam = SensorsCustomParams::encodeTableInWriteBytesTableParam;
-        requestSensors = RequestTracker.instance.get().getSensors(Type.WRITE_BYTES);
-        addSensorsToResponse(requestSensors, requestParam, tableParam, response, replicaMultiplier);
+        sensors = this.requestSensors.getSensors(Type.WRITE_BYTES);
+        addSensorsToResponse(sensors, requestParam, tableParam, response, replicaMultiplier);
     }
 
-    private static void addSensorsToResponse(Collection<Sensor> requestSensors,
+    private static void addSensorsToResponse(Collection<Sensor> sensors,
                                              Function<String, String> requestParamSupplier,
                                              Function<String, String> tableParamSupplier,
                                              Message.Builder<NoPayload> response,
                                              int replicaMultiplier)
     {
-        for (Sensor requestSensor : requestSensors)
+        for (Sensor sensor : sensors)
         {
-            String requestBytesParam = requestParamSupplier.apply(requestSensor.getContext().getTable());
-            byte[] requestBytes = SensorsCustomParams.sensorValueAsBytes(requestSensor.getValue() * replicaMultiplier);
+            String requestBytesParam = requestParamSupplier.apply(sensor.getContext().getTable());
+            byte[] requestBytes = SensorsCustomParams.sensorValueAsBytes(sensor.getValue() * replicaMultiplier);
             response.withCustomParam(requestBytesParam, requestBytes);
 
             // for each table in the mutation, send the global per table counter write bytes as recorded by the registry
-            Optional<Sensor> registrySensor = SensorsRegistry.instance.getOrCreateSensor(requestSensor.getContext(), requestSensor.getType());
-            registrySensor.ifPresent(sensor -> {
-                String tableBytesParam = tableParamSupplier.apply(sensor.getContext().getTable());
-                byte[] tableBytes = SensorsCustomParams.sensorValueAsBytes(sensor.getValue() * replicaMultiplier);
+            Optional<Sensor> registrySensor = SensorsRegistry.instance.getOrCreateSensor(sensor.getContext(), sensor.getType());
+            registrySensor.ifPresent(s -> {
+                String tableBytesParam = tableParamSupplier.apply(s.getContext().getTable());
+                byte[] tableBytes = SensorsCustomParams.sensorValueAsBytes(s.getValue() * replicaMultiplier);
                 response.withCustomParam(tableBytesParam, tableBytes);
             });
         }

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -92,7 +92,7 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
             response.withCustomParam(requestBytesParam, requestBytes);
 
             // for each table in the mutation, send the global per table write/index bytes as observed by the registry
-            Optional<Sensor> registrySensor = SensorsRegistry.instance.getOrCreateSensor(requestSensor.getContext(), requestSensor.getType());
+            Optional<Sensor> registrySensor = SensorsRegistry.instance.getSensor(requestSensor.getContext(), requestSensor.getType());
             registrySensor.ifPresent(sensor -> {
                 String tableBytesParam = tableParamSupplier.apply(sensor.getContext().getTable());
                 byte[] tableBytes = SensorsCustomParams.sensorValueAsBytes(sensor.getValue());

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.net.SensorsCustomParams;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
-import org.apache.cassandra.sensors.RequestTracker;
+import org.apache.cassandra.sensors.RequestSensorsFactory;
 import org.apache.cassandra.sensors.Sensor;
 import org.apache.cassandra.sensors.SensorsRegistry;
 import org.apache.cassandra.sensors.Type;
@@ -46,41 +46,41 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
 {
     public static final MutationVerbHandler instance = new MutationVerbHandler();
 
-    private void respond(Message<Mutation> respondTo, InetAddressAndPort respondToAddress)
+    private void respond(RequestSensors requestSensors, Message<Mutation> respondToMessage, InetAddressAndPort respondToAddress)
     {
         Tracing.trace("Enqueuing response to {}", respondToAddress);
 
-        Message.Builder<NoPayload> response = respondTo.emptyResponseBuilder();
-        addSensorsToResponse(response, respondTo.payload);
+        Message.Builder<NoPayload> response = respondToMessage.emptyResponseBuilder();
+        addSensorsToResponse(requestSensors, response, respondToMessage.payload);
 
         MessagingService.instance().send(response.build(), respondToAddress);
     }
 
-    private void addSensorsToResponse(Message.Builder<NoPayload> response, Mutation mutation)
+    private void addSensorsToResponse(RequestSensors requestSensors, Message.Builder<NoPayload> response, Mutation mutation)
     {
         int tables = mutation.getTableIds().size();
 
         // Add write bytes sensors to the response
         Function<String, String> requestParam = SensorsCustomParams::encodeTableInWriteBytesRequestParam;
         Function<String, String> tableParam = SensorsCustomParams::encodeTableInWriteBytesTableParam;
-        Collection<Sensor> requestSensors = RequestTracker.instance.get().getSensors(Type.WRITE_BYTES);
-        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
+        Collection<Sensor> sensors = requestSensors.getSensors(Type.WRITE_BYTES);
+        addSensorsToResponse(sensors, requestParam, tableParam, response);
 
         // Add index write bytes sensors to the response
         requestParam = SensorsCustomParams::encodeTableInIndexWriteBytesRequestParam;
         tableParam = SensorsCustomParams::encodeTableInIndexWriteBytesTableParam;
-        requestSensors = RequestTracker.instance.get().getSensors(Type.INDEX_WRITE_BYTES);
-        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
+        sensors = requestSensors.getSensors(Type.INDEX_WRITE_BYTES);
+        addSensorsToResponse(sensors, requestParam, tableParam, response);
 
         // Add internode bytes sensors to the response after updating each per-table sensor with the current response
         // message size: this is missing the sensor values, but it's a good enough approximation
         int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
-        requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
-        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
-        RequestTracker.instance.get().syncAllSensors();
+        sensors = requestSensors.getSensors(Type.INTERNODE_BYTES);
+        sensors.forEach(sensor -> requestSensors.incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
+        requestSensors.syncAllSensors();
         requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;
         tableParam = SensorsCustomParams::encodeTableInInternodeBytesTableParam;
-        addSensorsToResponse(requestSensors, requestParam, tableParam, response);
+        addSensorsToResponse(sensors, requestParam, tableParam, response);
     }
 
     private void addSensorsToResponse(Collection<Sensor> requestSensors, Function<String, String> requestParamSupplier, Function<String, String> tableParamSupplier, Message.Builder<NoPayload> response)
@@ -125,19 +125,20 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
         try
         {
             // Initialize the sensor and set ExecutorLocals
-            Collection<TableMetadata> tables = message.payload.getPartitionUpdates().stream().map(PartitionUpdate::metadata).collect(Collectors.toList());
-            RequestSensors requestSensors = new RequestSensors();
+            RequestSensors requestSensors = RequestSensorsFactory.instance.create(message.payload.getKeyspaceName());
             ExecutorLocals locals = ExecutorLocals.create(requestSensors);
             ExecutorLocals.set(locals);
 
             // Initialize internode bytes with the inbound message size:
-            tables.forEach(tm -> {
+            Collection<TableMetadata> tables = message.payload.getPartitionUpdates().stream().map(PartitionUpdate::metadata).collect(Collectors.toList());
+            for (TableMetadata tm : tables)
+            {
                 Context context = Context.from(tm);
                 requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
                 requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
-            });
+            }
 
-            message.payload.applyFuture(WriteOptions.DEFAULT).thenAccept(o -> respond(message, respondToAddress)).exceptionally(wto -> {
+            message.payload.applyFuture(WriteOptions.DEFAULT).thenAccept(o -> respond(requestSensors, message, respondToAddress)).exceptionally(wto -> {
                 failed();
                 return null;
             });

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db;
 
 import java.util.Optional;
 
-import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,10 +32,9 @@ import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.SensorsCustomParams;
-import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
-import org.apache.cassandra.sensors.RequestTracker;
+import org.apache.cassandra.sensors.RequestSensorsFactory;
 import org.apache.cassandra.sensors.Sensor;
 import org.apache.cassandra.sensors.SensorsRegistry;
 import org.apache.cassandra.sensors.Type;
@@ -62,18 +60,15 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         validateTransientStatus(message);
 
         // Initialize the sensor and set ExecutorLocals
+        RequestSensors requestSensors = RequestSensorsFactory.instance.create(command.metadata().keyspace);
         Context context = Context.from(command);
-        ImmutableSet<TableMetadata> tables = ImmutableSet.of(command.metadata());
-        RequestSensors requestSensors = new RequestSensors();
         requestSensors.registerSensor(context, Type.READ_BYTES);
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
         // Initialize internode bytes with the inbound message size:
-        tables.forEach(tm -> {
-            requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
-            requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
-        });
+        requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
+        requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
 
         long timeout = message.expiresAtNanos() - message.createdAtNanos();
         command.setMonitoringTime(message.createdAtNanos(), message.isCrossNode(), timeout, DatabaseDescriptor.getSlowQueryTimeout(NANOSECONDS));
@@ -93,20 +88,21 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         }
 
         Message.Builder<ReadResponse> reply = message.responseWithBuilder(response);
-        int size = reply.currentPayloadSize(MessagingService.current_version);
-        RequestTracker.instance.get().incrementSensor(context, Type.INTERNODE_BYTES, size);
-        RequestTracker.instance.get().syncAllSensors();
 
-        addInternodeSensorToResponse(reply, context);
+        addInternodeSensorToResponse(requestSensors, context, reply);
         SensorsCustomParams.addReadSensorToResponse(reply, requestSensors, context);
 
         Tracing.trace("Enqueuing response to {}", message.from());
         MessagingService.instance().send(reply.build(), message.from());
     }
 
-    private void addInternodeSensorToResponse(Message.Builder<ReadResponse> reply, Context context)
+    private void addInternodeSensorToResponse(RequestSensors requestSensors, Context context, Message.Builder<ReadResponse> reply)
     {
-        Optional<Sensor> requestSensor = RequestTracker.instance.get().getSensor(context, Type.INTERNODE_BYTES);
+        int size = reply.currentPayloadSize(MessagingService.current_version);
+        requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, size);
+        requestSensors.syncAllSensors();
+
+        Optional<Sensor> requestSensor = requestSensors.getSensor(context, Type.INTERNODE_BYTES);
         requestSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> {
             reply.withCustomParam(SensorsCustomParams.encodeTableInInternodeBytesRequestParam(context.getTable()),
                                      bytes);

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -108,7 +108,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
                                      bytes);
         });
 
-        Optional<Sensor> tableSensor = SensorsRegistry.instance.getOrCreateSensor(context, Type.INTERNODE_BYTES);
+        Optional<Sensor> tableSensor = SensorsRegistry.instance.getSensor(context, Type.INTERNODE_BYTES);
         tableSensor.map(s -> SensorsCustomParams.sensorValueAsBytes(s.getValue())).ifPresent(bytes -> {
             reply.withCustomParam(SensorsCustomParams.encodeTableInInternodeBytesTableParam(context.getTable()),
                                   bytes);

--- a/src/java/org/apache/cassandra/net/SensorsCustomParams.java
+++ b/src/java/org/apache/cassandra/net/SensorsCustomParams.java
@@ -22,6 +22,8 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.function.Function;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.sensors.Sensor;
@@ -139,6 +141,10 @@ public final class SensorsCustomParams
      */
     public static <T> void addWriteSensorToResponse(Message.Builder<T> response, RequestSensors sensors, Context context)
     {
+        Preconditions.checkNotNull(response);
+        Preconditions.checkNotNull(sensors);
+        Preconditions.checkNotNull(context);
+
         addSensorToResponse(response, sensors, context, Type.WRITE_BYTES,
                             (sensor) -> SensorsCustomParams.encodeTableInWriteBytesRequestParam(sensor.getContext().getTable()),
                             (sensor) -> SensorsCustomParams.encodeTableInWriteBytesTableParam(sensor.getContext().getTable()));
@@ -149,6 +155,10 @@ public final class SensorsCustomParams
      */
     public static <T> void addReadSensorToResponse(Message.Builder<T> response, RequestSensors sensors, Context context)
     {
+        Preconditions.checkNotNull(response);
+        Preconditions.checkNotNull(sensors);
+        Preconditions.checkNotNull(context);
+
         addSensorToResponse(response, sensors, context, Type.READ_BYTES,
                             (ignored) -> SensorsCustomParams.READ_BYTES_REQUEST,
                             (ignored) -> SensorsCustomParams.READ_BYTES_TABLE);

--- a/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
@@ -29,6 +29,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Groups {@link Sensor}s associated to a given request/response and related {@link Context}: this is the main entry
  * point to create and modify sensors. More specifically:
@@ -42,6 +44,8 @@ import javax.annotation.Nullable;
  * there is no automatic synchronization or coordination across sensor values belonging to different
  * {@link RequestSensors} objects, hence {@link #syncAllSensors()} MUST be invoked to propagate the sensors values
  * at a global level to the {@link SensorsRegistry}.
+ * <br/>
+ * Please note instances of this class should be created via the configured {@link RequestSensorsFactory}.
  */
 public class ActiveRequestSensors implements RequestSensors
 {
@@ -53,11 +57,13 @@ public class ActiveRequestSensors implements RequestSensors
 
     private final Map<Sensor, Double> latestSyncedValuePerSensor = new HashMap<>();
 
+    @VisibleForTesting
     public ActiveRequestSensors()
     {
         this(() -> SensorsRegistry.instance);
     }
 
+    @VisibleForTesting
     public ActiveRequestSensors(Supplier<SensorsRegistry> sensorsRegistry)
     {
         this.sensorsRegistry = sensorsRegistry;

--- a/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Groups {@link Sensor}s associated to a given request/response and related {@link Context}: this is the main entry
+ * point to create and modify sensors. More specifically:
+ * <ul>
+ *     <li>Create a new sensor associated to the request/response via {@link #registerSensor(Context, Type)}.</li>
+ *     <li>Increment the sensor value for the request/response via {@link #incrementSensor(Context, Type, double)}.</li>
+ *     <li>Sync this request/response sensor value to the {@link SensorsRegistry} via {@link #syncAllSensors()}.</li>
+ * </ul>
+ * Sensor values related to a given request/response are isolated from other sensors, and the "same" sensor
+ * (for a given context and type) registered to different requests/responses will have a different value: in other words,
+ * there is no automatic synchronization or coordination across sensor values belonging to different
+ * {@link RequestSensors} objects, hence {@link #syncAllSensors()} MUST be invoked to propagate the sensors values
+ * at a global level to the {@link SensorsRegistry}.
+ */
+public class ActiveRequestSensors implements RequestSensors
+{
+    private final Supplier<SensorsRegistry> sensorsRegistry;
+
+    // Using Map of array values for performance reasons to avoid wrapping key into another Object (.eg. Pair(context,type)).
+    // Note that array values can contain NULL so be careful to filter NULLs when iterating over array
+    private final HashMap<Context, Sensor[]> sensors = new LinkedHashMap<>();
+
+    private final Map<Sensor, Double> latestSyncedValuePerSensor = new HashMap<>();
+
+    public ActiveRequestSensors()
+    {
+        this(() -> SensorsRegistry.instance);
+    }
+
+    public ActiveRequestSensors(Supplier<SensorsRegistry> sensorsRegistry)
+    {
+        this.sensorsRegistry = sensorsRegistry;
+    }
+
+    public synchronized void registerSensor(Context context, Type type)
+    {
+        Sensor[] typeSensors = sensors.computeIfAbsent(context, key ->
+        {
+            Sensor[] newTypeSensors = new Sensor[Type.values().length];
+            newTypeSensors[type.ordinal()] = new Sensor(context, type);
+            return newTypeSensors;
+        });
+        if (typeSensors[type.ordinal()] == null)
+            typeSensors[type.ordinal()] = new Sensor(context, type);
+    }
+
+    public synchronized Optional<Sensor> getSensor(Context context, Type type)
+    {
+        return Optional.ofNullable(getSensorFast(context, type));
+    }
+
+    public synchronized Set<Sensor> getSensors(Type type)
+    {
+        return sensors.values().stream().flatMap(Arrays::stream).filter(Objects::nonNull).filter(s -> s.getType() == type).collect(Collectors.toSet());
+    }
+
+    public synchronized void incrementSensor(Context context, Type type, double value)
+    {
+        Sensor sensor = getSensorFast(context, type);
+        if (sensor != null)
+            sensor.increment(value);
+    }
+
+    public synchronized void syncAllSensors()
+    {
+        sensors.values().forEach(types -> {
+            for (int i = 0; i < types.length; i++)
+            {
+                if (types[i] != null)
+                {
+                    Sensor sensor = types[i];
+                    double current = latestSyncedValuePerSensor.getOrDefault(sensor, 0d);
+                    double update = sensor.getValue() - current;
+                    if (update == 0d)
+                        continue;
+
+                    latestSyncedValuePerSensor.put(sensor, sensor.getValue());
+                    sensorsRegistry.get().incrementSensor(sensor.getContext(), sensor.getType(), update);
+                }
+            }
+        });
+    }
+
+    /**
+     * To get best perfromance we are not returning Optional here
+     */
+    @Nullable
+    private Sensor getSensorFast(Context context, Type type)
+    {
+        Sensor[] typeSensors = sensors.get(context);
+        if (typeSensors != null)
+            return typeSensors[type.ordinal()];
+
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ActiveRequestSensors other = (ActiveRequestSensors) o;
+        return Objects.equals(sensors, other.sensors);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sensors);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ActiveRequestSensors{" +
+               "sensors=" + sensors +
+               '}';
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/ActiveRequestSensorsFactory.java
+++ b/src/java/org/apache/cassandra/sensors/ActiveRequestSensorsFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+/**
+ * Implementation of the {@link RequestSensorsFactory} that creates a new instance of {@link ActiveRequestSensors}
+ * enabled for all keyspaces.
+ */
+public class ActiveRequestSensorsFactory implements RequestSensorsFactory
+{
+    @Override
+    public RequestSensors create(String keyspace)
+    {
+        return new ActiveRequestSensors();
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/NoOpRequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/NoOpRequestSensors.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * No-op implementation of {@link RequestSensors}. This is used when sensors are disabled.
+ */
+public class NoOpRequestSensors implements RequestSensors
+{
+    public static final NoOpRequestSensors instance = new NoOpRequestSensors();
+
+    @Override
+    public void registerSensor(Context context, Type type)
+    {
+
+    }
+
+    @Override
+    public Optional<Sensor> getSensor(Context context, Type type)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<Sensor> getSensors(Type type)
+    {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public void incrementSensor(Context context, Type type, double value)
+    {
+
+    }
+
+    @Override
+    public void syncAllSensors()
+    {
+
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/RequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/RequestSensors.java
@@ -18,132 +18,53 @@
 
 package org.apache.cassandra.sensors;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * Groups {@link Sensor}s associated to a given request/response and related {@link Context}: this is the main entry
- * point to create and modify sensors. More specifically:
- * <ul>
- *     <li>Create a new sensor associated to the request/response via {@link #registerSensor(Context, Type)}.</li>
- *     <li>Increment the sensor value for the request/response via {@link #incrementSensor(Context, Type, double)}.</li>
- *     <li>Sync this request/response sensor value to the {@link SensorsRegistry} via {@link #syncAllSensors()}.</li>
- * </ul>
- * Sensor values related to a given request/response are isolated from other sensors, and the "same" sensor
- * (for a given context and type) registered to different requests/responses will have a different value: in other words,
- * there is no automatic synchronization or coordination across sensor values belonging to different
- * {@link RequestSensors} objects, hence {@link #syncAllSensors()} MUST be invoked to propagate the sensors values
- * at a global level to the {@link SensorsRegistry}.
+ * point to create and modify sensors. Actual implementations can be created via {@link RequestSensorsFactory}.
  */
-public class RequestSensors
+public interface RequestSensors
 {
-    private final Supplier<SensorsRegistry> sensorsRegistry;
-
-    // Using Map of array values for performance reasons to avoid wrapping key into another Object (.eg. Pair(context,type)).
-    // Note that array values can contain NULL so be careful to filter NULLs when iterating over array
-    private final HashMap<Context, Sensor[]> sensors = new LinkedHashMap<>();
-
-    private final Map<Sensor, Double> latestSyncedValuePerSensor = new HashMap<>();
-
-    public RequestSensors()
-    {
-        this(() -> SensorsRegistry.instance);
-    }
-
-    public RequestSensors(Supplier<SensorsRegistry> sensorsRegistry)
-    {
-        this.sensorsRegistry = sensorsRegistry;
-    }
-
-    public synchronized void registerSensor(Context context, Type type)
-    {
-        Sensor[] typeSensors = sensors.computeIfAbsent(context, key ->
-        {
-            Sensor[] newTypeSensors = new Sensor[Type.values().length];
-            newTypeSensors[type.ordinal()] = new Sensor(context, type);
-            return newTypeSensors;
-        });
-        if (typeSensors[type.ordinal()] == null)
-            typeSensors[type.ordinal()] = new Sensor(context, type);
-    }
-
-    public synchronized Optional<Sensor> getSensor(Context context, Type type)
-    {
-        return Optional.ofNullable(getSensorFast(context, type));
-    }
-
-    public synchronized Set<Sensor> getSensors(Type type)
-    {
-        return sensors.values().stream().flatMap(Arrays::stream).filter(Objects::nonNull).filter(s -> s.getType() == type).collect(Collectors.toSet());
-    }
-
-    public synchronized void incrementSensor(Context context, Type type, double value)
-    {
-        Sensor sensor = getSensorFast(context, type);
-        if (sensor != null)
-            sensor.increment(value);
-    }
-
-    public synchronized void syncAllSensors()
-    {
-        sensors.values().forEach(types -> {
-            for (int i = 0; i < types.length; i++)
-            {
-                if (types[i] != null)
-                {
-                    Sensor sensor = types[i];
-                    double current = latestSyncedValuePerSensor.getOrDefault(sensor, 0d);
-                    double update = sensor.getValue() - current;
-                    if (update == 0d)
-                        continue;
-
-                    latestSyncedValuePerSensor.put(sensor, sensor.getValue());
-                    sensorsRegistry.get().incrementSensor(sensor.getContext(), sensor.getType(), update);
-                }
-            }
-        });
-    }
+    /**
+     * Register a new sensor associated to the given context and type. It is up to the implementation to decide the
+     * idempotency of this operation.
+     *
+     * @param context the sensor context associated with the request/response
+     * @param type    the type of the sensor
+     */
+    void registerSensor(Context context, Type type);
 
     /**
-     * To get best perfromance we are not returning Optional here
+     * Returns the sensor associated to the given context and type, if any.
+     *
+     * @param context the sensor context associated with the request/response
+     * @param type    the type of the sensor
+     * @return the sensor associated to the given context and type, if any
      */
-    @Nullable
-    private Sensor getSensorFast(Context context, Type type)
-    {
-        Sensor[] typeSensors = sensors.get(context);
-        if (typeSensors != null)
-            return typeSensors[type.ordinal()];
-        return null;
-    }
+    Optional<Sensor> getSensor(Context context, Type type);
 
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RequestSensors sensors1 = (RequestSensors) o;
-        return Objects.equals(sensors, sensors1.sensors);
-    }
+    /**
+     * Returns all the sensors associated to the given type.
+     *
+     * @param type the type of the sensors
+     * @return all the sensors associated to the given type
+     */
+    Collection<Sensor> getSensors(Type type);
 
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(sensors);
-    }
+    /**
+     * Increment the sensor value associated to the given context and type by the given value.
+     *
+     * @param context the sensor context associated with the request/response
+     * @param type    the type of the sensor
+     * @param value   the value to increment the sensor by
+     */
+    void incrementSensor(Context context, Type type, double value);
 
-    @Override
-    public String toString()
-    {
-        return "RequestSensors{" +
-               "sensors=" + sensors +
-               '}';
-    }
+    /**
+     * Sync all the sensors values tracked for this request to the global {@link SensorsRegistry}. This method
+     * will be called at least once per request/response so it is recommended to make the implementation idempotent.
+     */
+    void syncAllSensors();
 }

--- a/src/java/org/apache/cassandra/sensors/RequestSensorsFactory.java
+++ b/src/java/org/apache/cassandra/sensors/RequestSensorsFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.REQUEST_SENSORS_FACTORY;
+
+/**
+ * Provides a customizable factory to create a {@link RequestSensors} to track sensors per user request.
+ * Configured via the {@link REQUEST_SENSORS_FACTORY} system property, if unset a {@link NoOpRequestSensors} will be used.
+ * To activate tracking of request sensors, use {@link ActiveRequestSensors}.
+ */
+public interface RequestSensorsFactory
+{
+    RequestSensorsFactory instance = REQUEST_SENSORS_FACTORY.getString() == null ?
+                                   new RequestSensorsFactory() {} :
+                                   FBUtilities.construct(CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.getString(), "requests sensors factory");
+
+    /**
+     * Creates a {@link RequestSensors} for the given keyspace. Implementations should be very efficient because this method is potentially invoked on each verb handler serving a user request.
+     *
+     * @param keyspace the keyspace of the request
+     * @return a {@link RequestSensors} instance. The default implementation returns a singleton no-op instance.
+     */
+    default RequestSensors create(String keyspace)
+    {
+        return NoOpRequestSensors.instance;
+    }
+}

--- a/src/java/org/apache/cassandra/sensors/RequestSensorsFactory.java
+++ b/src/java/org/apache/cassandra/sensors/RequestSensorsFactory.java
@@ -25,8 +25,8 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.REQUEST_SE
 
 /**
  * Provides a customizable factory to create a {@link RequestSensors} to track sensors per user request.
- * Configured via the {@link REQUEST_SENSORS_FACTORY} system property, if unset a {@link NoOpRequestSensors} will be used.
- * To activate tracking of request sensors, use {@link ActiveRequestSensors}.
+ * Configured via the {@link CassandraRelevantProperties#REQUEST_SENSORS_FACTORY} system property, if unset a {@link NoOpRequestSensors} will be used.
+ * To activate tracking of request sensors, use {@link ActiveRequestSensorsFactory}.
  */
 public interface RequestSensorsFactory
 {

--- a/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,16 +7,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
 package org.apache.cassandra.service.paxos;
 
@@ -28,6 +28,7 @@ import org.apache.cassandra.net.NoPayload;
 import org.apache.cassandra.net.SensorsCustomParams;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.RequestSensorsFactory;
 import org.apache.cassandra.sensors.Type;
 import org.apache.cassandra.service.MutatorProvider;
 import org.apache.cassandra.tracing.Tracing;
@@ -39,7 +40,7 @@ public class CommitVerbHandler implements IVerbHandler<Commit>
     public void doVerb(Message<Commit> message)
     {
         // Initialize the sensor and set ExecutorLocals
-        RequestSensors sensors = new RequestSensors();
+        RequestSensors sensors = RequestSensorsFactory.instance.create(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
         sensors.registerSensor(context, Type.WRITE_BYTES);
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.SensorsCustomParams;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.RequestSensorsFactory;
 import org.apache.cassandra.sensors.Type;
 
 public class PrepareVerbHandler implements IVerbHandler<Commit>
@@ -40,8 +41,9 @@ public class PrepareVerbHandler implements IVerbHandler<Commit>
     public void doVerb(Message<Commit> message)
     {
         // Initialize the sensor and set ExecutorLocals
+        RequestSensors sensors = RequestSensorsFactory.instance.create(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
-        RequestSensors sensors = new RequestSensors();
+
         // Prepare phase incorporates a read to check the cas condition, so a read sensor is registered in addition to the write sensor
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);

--- a/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.SensorsCustomParams;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.RequestSensorsFactory;
 import org.apache.cassandra.sensors.Type;
 
 public class ProposeVerbHandler implements IVerbHandler<Commit>
@@ -40,8 +41,9 @@ public class ProposeVerbHandler implements IVerbHandler<Commit>
     public void doVerb(Message<Commit> message)
     {
         // Initialize the sensor and set ExecutorLocals
-        RequestSensors sensors = new RequestSensors();
+        RequestSensors sensors = RequestSensorsFactory.instance.create(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
+
         // Propose phase consults the Paxos table for more recent promises, so a read sensor is registered in addition to the write sensor
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);

--- a/test/microbench/org/apache/cassandra/test/microbench/RequestSensorBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/RequestSensorBench.java
@@ -31,6 +31,7 @@ import org.apache.commons.math3.distribution.ZipfDistribution;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.sensors.ActiveRequestSensors;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.sensors.SensorsRegistry;
@@ -89,7 +90,7 @@ public class RequestSensorBench
         }
 
         IntStream.range(0, THREADS).forEach(t -> {
-            requestSensorsPool[t] = new RequestSensors();
+            requestSensorsPool[t] = new ActiveRequestSensors();
             Pair<Context, Type> contextTypePair = contextFixtures.get(zipfDistributionContext.sample());
             IntStream.range(0, SENSORS_PER_THREAD).forEach(s -> fixtures[t][s] = new Fixture(contextTypePair.left, contextTypePair.right));
         });

--- a/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
+++ b/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.sensors.Context;
+import org.apache.cassandra.sensors.ActiveRequestSensorsFactory;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.sensors.SensorsRegistry;
 import org.apache.cassandra.sensors.Type;
@@ -42,6 +43,8 @@ import static org.junit.Assert.assertTrue;
 
 public class SensorsCustomParamsTest
 {
+    private static final ActiveRequestSensorsFactory requestSensorsFactory = new ActiveRequestSensorsFactory();
+
     @BeforeClass
     public static void setUpClass() throws Exception
     {
@@ -156,7 +159,7 @@ public class SensorsCustomParamsTest
 
     private void testAddSensorToResponse(Type sensorType, Function<Context, String> requestParamSupplier, Function<Context, String> tableParamSupplier)
     {
-        RequestSensors sensors = new RequestSensors();
+        RequestSensors sensors = requestSensorsFactory.create("ks1");
         UUID tableId = UUID.randomUUID();
         KeyspaceMetadata ksm = KeyspaceMetadata.create("ks1", null);
         TableMetadata tm = TableMetadata.builder("ks1", "t1", TableId.fromString(tableId.toString()))

--- a/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsFactoryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsFactoryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ActiveRequestSensorsFactoryTest
+{
+    @Test
+    public void testCreate()
+    {
+        ActiveRequestSensorsFactory factory = new ActiveRequestSensorsFactory();
+        RequestSensors sensors = factory.create("ks1");
+        assertThat(sensors).isNotNull();
+        assertThat(sensors).isInstanceOf(ActiveRequestSensors.class);
+        RequestSensors anotherSensors = factory.create("ks1");
+        assertThat(sensors).isNotSameAs(anotherSensors);
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsFactoryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsFactoryTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class ActiveRequestSensorsFactoryTest
 {
     @Test
-    public void testCreate()
+    public void testCreateActiveRequestSensors()
     {
         ActiveRequestSensorsFactory factory = new ActiveRequestSensorsFactory();
         RequestSensors sensors = factory.create("ks1");

--- a/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ActiveRequestSensorsTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class RequestSensorsTest
+public class ActiveRequestSensorsTest
 {
     private Context context1;
     private Type type1;
@@ -51,9 +51,9 @@ public class RequestSensorsTest
         context2 = new Context("ks2", "t2", "id2");
         type2 = Type.WRITE_BYTES;
 
-        context1Sensors = new RequestSensors(() -> sensorsRegistry);
-        context2Sensors = new RequestSensors(() -> sensorsRegistry);
-        sensors = new RequestSensors(() -> sensorsRegistry);
+        context1Sensors = new ActiveRequestSensors(() -> sensorsRegistry);
+        context2Sensors = new ActiveRequestSensors(() -> sensorsRegistry);
+        sensors = new ActiveRequestSensors(() -> sensorsRegistry);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/sensors/DisabledSensorsTest.java
+++ b/test/unit/org/apache/cassandra/sensors/DisabledSensorsTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import java.util.HashMap;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.statements.schema.IndexTarget;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.CounterMutationVerbHandler;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.MutationVerbHandler;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.ReadCommandVerbHandler;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.exceptions.WriteTimeoutException;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.schema.Indexes;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.CommitVerbHandler;
+import org.apache.cassandra.service.paxos.PrepareVerbHandler;
+import org.apache.cassandra.service.paxos.ProposeVerbHandler;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.UUIDGen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that sensors are not tracked when disabled. Please note that sensor tracking is and opt-in feature so any existing
+ * test that exercise the {@link org.apache.cassandra.net.IVerbHandler#doVerb(Message)} would surface functionality regression (e.g. NPEs).
+ * Here we make sure that sensors are indeed not tracked when disabled and for that it suffices to cover a happy case verb handler invocation scenario.
+ */
+public class DisabledSensorsTest
+{
+    public static final String KEYSPACE1 = "SensorsReadTest";
+    public static final String CF_STANDARD = "Standard";
+    public static final String CF_STANDARD_SAI = "StandardSAI";
+    private static final String CF_COUTNER = "Counter";
+
+    private ColumnFamilyStore store;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception
+    {
+        CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.setString(SensorsTestUtil.NoOpRequestSensorsFactory.class.getName());
+
+        // build SAI indexes
+        Indexes.Builder saiIndexes = Indexes.builder();
+        saiIndexes.add(IndexMetadata.fromSchemaMetadata(CF_STANDARD_SAI + "_val", IndexMetadata.Kind.CUSTOM, new HashMap<>()
+        {{
+            put(IndexTarget.CUSTOM_INDEX_OPTION_NAME, StorageAttachedIndex.class.getName());
+            put(IndexTarget.TARGET_OPTION_NAME, "val");
+        }}));
+
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE1,
+                                    KeyspaceParams.simple(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD,
+                                                              1, AsciiType.instance, AsciiType.instance, null),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD_SAI,
+                                                              1, AsciiType.instance, AsciiType.instance, null)
+                                                .partitioner(Murmur3Partitioner.instance)
+                                                .indexes(saiIndexes.build()),
+                                    SchemaLoader.counterCFMD(KEYSPACE1, CF_COUTNER));
+
+        CompactionManager.instance.disableAutoCompaction();
+        DatabaseDescriptor.setPartitionerUnsafe(Murmur3Partitioner.instance);
+    }
+
+    @After
+    public void afterTest()
+    {
+        Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD).truncateBlocking();
+        Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD_SAI).truncateBlocking();
+        Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_COUTNER).truncateBlocking();
+    }
+
+    @Test
+    public void testSensorsForReadVerbHandler()
+    {
+        store = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD);
+
+        new RowUpdateBuilder(store.metadata(), 0, "0")
+        .add("val", ByteBufferUtil.EMPTY_BYTE_BUFFER)
+        .build()
+        .applyUnsafe();
+
+        DecoratedKey key = store.getPartitioner().decorateKey(ByteBufferUtil.bytes("4"));
+        ReadCommand command = Util.cmd(store, key).build();
+        handleReadCommand(command);
+
+        assertSensorsAreNotTracked();
+    }
+
+    @Test
+    public void testSensorsForMutationVerbHandler()
+    {
+        store = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD);
+
+        Mutation m = new RowUpdateBuilder(store.metadata(), 0, "0")
+                     .add("val", "0")
+                     .build();
+        handleMutation(m);
+
+        assertSensorsAreNotTracked();
+    }
+
+    @Test
+    public void testSensorsForMutationVerbHandlerWithSAI()
+    {
+        store = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD_SAI);
+        Mutation saiMutation = new RowUpdateBuilder(store.metadata(), 0, "0")
+                               .add("val", "hi there")
+                               .build();
+        handleMutation(saiMutation);
+        assertSensorsAreNotTracked();
+    }
+
+    @Test
+    public void testSensorsForCounterMutationVerbHandler() throws WriteTimeoutException
+    {
+        store = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_COUTNER);
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_COUTNER);
+        cfs.truncateBlocking();
+
+        Mutation mutation = new RowUpdateBuilder(cfs.metadata(), 5, "key1")
+                            .clustering("cc")
+                            .add("val", 1L).build();
+
+        CounterMutation counterMutation = new CounterMutation(mutation, ConsistencyLevel.ANY);
+        handleCounterMutation(counterMutation);
+
+        assertSensorsAreNotTracked();
+    }
+
+    @Test
+    public void testLWTSensors()
+    {
+        store = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD);
+        PartitionUpdate update = new RowUpdateBuilder(store.metadata(), 0, "0")
+                                 .add("val", "0")
+                                 .buildUpdate();
+        Commit commit = Commit.newPrepare(update.partitionKey(), store.metadata(), UUIDGen.getTimeUUID());
+        handlePaxosPrepare(commit);
+        handlePaxosPropose(commit);
+        handlePaxosCommit(commit);
+
+        assertSensorsAreNotTracked();
+    }
+
+    private static void handleReadCommand(ReadCommand command)
+    {
+        ReadCommandVerbHandler.instance.doVerb(Message.builder(Verb.READ_REQ, command).build());
+    }
+
+    private static void handleMutation(Mutation mutation)
+    {
+        MutationVerbHandler.instance.doVerb(Message.builder(Verb.MUTATION_REQ, mutation).build());
+    }
+
+    private static void handleCounterMutation(CounterMutation mutation)
+    {
+        CounterMutationVerbHandler.instance.doVerb(Message.builder(Verb.COUNTER_MUTATION_REQ, mutation).build());
+    }
+
+    private static void handlePaxosPrepare(Commit prepare)
+    {
+        PrepareVerbHandler.instance.doVerb(Message.builder(Verb.PAXOS_PREPARE_REQ, prepare).build());
+    }
+
+    private static void handlePaxosPropose(Commit proposal)
+    {
+        ProposeVerbHandler.instance.doVerb(Message.builder(Verb.PAXOS_PROPOSE_REQ, proposal).build());
+    }
+
+    private static void handlePaxosCommit(Commit commit)
+    {
+        CommitVerbHandler.instance.doVerb(Message.builder(Verb.PAXOS_COMMIT_REQ, commit).build());
+    }
+
+    private static void assertSensorsAreNotTracked()
+    {
+        assertThat(RequestTracker.instance.get()).isInstanceOf(NoOpRequestSensors.class);
+        for (Type type : Type.values())
+        {
+            assertThat(SensorsRegistry.instance.getSensorsByType(type)).isEmpty();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/RequestSensorsFactoryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/RequestSensorsFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class RequestSensorsFactoryTest
+{
+    @Test
+    public void testCreate()
+    {
+        RequestSensorsFactory factory = new RequestSensorsFactory() {};
+        RequestSensors sensors = factory.create("ks1");
+        assertThat(sensors).isInstanceOf(NoOpRequestSensors.class);
+        RequestSensors anotherSensors = factory.create("k2");
+        assertThat(anotherSensors).isSameAs(sensors);
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/RequestSensorsFactoryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/RequestSensorsFactoryTest.java
@@ -28,9 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RequestSensorsFactoryTest
 {
     @Test
-    public void testCreate()
+    public void testCreateUsesNoOpByDefault()
     {
-        RequestSensorsFactory factory = new RequestSensorsFactory() {};
+        RequestSensorsFactory factory = RequestSensorsFactory.instance;
         RequestSensors sensors = factory.create("ks1");
         assertThat(sensors).isInstanceOf(NoOpRequestSensors.class);
         RequestSensors anotherSensors = factory.create("k2");

--- a/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
@@ -28,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -64,6 +65,8 @@ public class SensorsIndexWriteTest
     @BeforeClass
     public static void defineSchema() throws Exception
     {
+        CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.setString(ActiveRequestSensorsFactory.class.getName());
+
         SchemaLoader.prepareServer();
 
         // build SAI indexes

--- a/test/unit/org/apache/cassandra/sensors/SensorsInternodeTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsInternodeTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
@@ -69,6 +70,8 @@ public class SensorsInternodeTest
     @BeforeClass
     public static void beforeClass() throws Exception
     {
+        CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.setString(ActiveRequestSensorsFactory.class.getName());
+
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE1,
                                     KeyspaceParams.simple(1),

--- a/test/unit/org/apache/cassandra/sensors/SensorsReadTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsReadTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.Operator;
@@ -74,6 +75,8 @@ public class SensorsReadTest
     @BeforeClass
     public static void defineSchema() throws Exception
     {
+        CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.setString(ActiveRequestSensorsFactory.class.getName());
+
         // build SAI indexes
         Indexes.Builder saiIndexes = Indexes.builder();
         saiIndexes.add(IndexMetadata.fromSchemaMetadata(CF_STANDARD_SAI + "_val", IndexMetadata.Kind.CUSTOM, new HashMap<>()

--- a/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
@@ -220,7 +220,7 @@ public class SensorsRegistryTest
         SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
         SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
 
-        RequestSensors requestSensors = new RequestSensors(() -> SensorsRegistry.instance);
+        RequestSensors requestSensors = new ActiveRequestSensors(() -> SensorsRegistry.instance);
         requestSensors.registerSensor(context1, type1);
 
         requestSensors.incrementSensor(context1, type1, 1.0);

--- a/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
@@ -234,4 +234,46 @@ public class SensorsRegistryTest
         requestSensors.syncAllSensors();
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(2.0));
     }
+
+    @Test
+    public void testRemoveSensorByKeyspace()
+    {
+        SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
+        SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
+        SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF2).metadata());
+
+        SensorsRegistry.instance.getOrCreateSensor(context1, type1);
+        SensorsRegistry.instance.getOrCreateSensor(context2, type1);
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isPresent();
+        assertThat(SensorsRegistry.instance.getSensor(context2, type1)).isPresent();
+
+        SensorsRegistry.instance.removeSensorsByKeyspace(context1.getKeyspace());
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isEmpty();
+        assertThat(SensorsRegistry.instance.getSensor(context2, type1)).isEmpty();
+
+        SensorsRegistry.instance.getOrCreateSensor(context1, type1);
+        SensorsRegistry.instance.getOrCreateSensor(context2, type1);
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isPresent();
+        assertThat(SensorsRegistry.instance.getSensor(context2, type1)).isPresent();
+    }
+
+    @Test
+    public void testRemoveSensorByTableId()
+    {
+        SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
+        SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
+        SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF2).metadata());
+
+        SensorsRegistry.instance.getOrCreateSensor(context1, type1);
+        SensorsRegistry.instance.getOrCreateSensor(context2, type1);
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isPresent();
+        assertThat(SensorsRegistry.instance.getSensor(context2, type1)).isPresent();
+
+        SensorsRegistry.instance.removeSensorsByTableId(context1.getKeyspace(), context1.getTableId());
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isEmpty();
+        assertThat(SensorsRegistry.instance.getSensor(context2, type1)).isPresent();
+
+        SensorsRegistry.instance.getOrCreateSensor(context1, type1);
+        assertThat(SensorsRegistry.instance.getSensor(context1, type1)).isPresent();
+    }
 }

--- a/test/unit/org/apache/cassandra/sensors/SensorsTestUtil.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsTestUtil.java
@@ -31,6 +31,13 @@ import org.apache.cassandra.net.MessagingService;
 
 public final class SensorsTestUtil
 {
+    /**
+     * Returns the default implementation of the {@link RequestSensorsFactory}
+     */
+    public static class NoOpRequestSensorsFactory implements RequestSensorsFactory
+    {
+    }
+    
     private SensorsTestUtil()
     {
     }

--- a/test/unit/org/apache/cassandra/sensors/SensorsWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsWriteTest.java
@@ -29,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
@@ -72,6 +73,8 @@ public class SensorsWriteTest
     @BeforeClass
     public static void defineSchema() throws Exception
     {
+        CassandraRelevantProperties.REQUEST_SENSORS_FACTORY.setString(ActiveRequestSensorsFactory.class.getName());
+
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE1,
                                     KeyspaceParams.simple(1),


### PR DESCRIPTION
Addresses: https://github.com/riptano/cndb/issues/9707

Adds `RequestSensorsFactory` that can be provided from upstream dependents to effectively enable/disable sensors tracking per ks