### PR TITLE
DSP-24228: Remove hardcoded Version from many places in SAI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -543,7 +543,7 @@
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.15"/>
           <dependency groupId="commons-io" artifactId="commons-io" version="2.6" scope="test"/>
-          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.11"/>
+          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.14.0"/>
           <dependency groupId="org.apache.commons" artifactId="commons-math3" version="3.2"/>
           <dependency groupId="org.antlr" artifactId="antlr" version="3.5.2" scope="provided">
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -203,6 +203,15 @@ public class IndexDescriptor
     }
 
     /**
+     * Returns the byte-comparable version used to encode keys in the trie-based components of the index.
+     * @see OnDiskFormat#byteComparableVersionFor(IndexComponent, IndexDescriptor)
+     */
+    public ByteComparable.Version byteComparableVersionFor(IndexComponent component)
+    {
+        return getVersion().onDiskFormat().byteComparableVersionFor(component, this);
+    }
+
+    /**
      * Returns true if the given component exists on disk for the given index.
      * If context is null, the component is assumed to be a per-sstable component.
      */
@@ -440,7 +449,8 @@ public class IndexDescriptor
      */
     private ChecksumIndexInput checksumIndexInput(IndexContext context, IndexInput indexInput)
     {
-        return getVersion(context) == Version.AA
+        Version version = getVersion(context);
+        return version == Version.AA
                ? new EndiannessReverserChecksumIndexInput(indexInput)
                : new BufferedChecksumIndexInput(indexInput);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 /**
  * An interface to the on-disk format of an index. This provides format agnostics methods
@@ -212,4 +213,10 @@ public interface OnDiskFormat
      * @return The {@link ByteOrder} for the file associated with the {@link IndexComponent}
      */
     public ByteOrder byteOrderFor(IndexComponent component, IndexContext context);
+
+
+    /**
+     * Return the ByteComparable encoding version used by the index tries.
+     */
+    ByteComparable.Version byteComparableVersionFor(IndexComponent component, IndexDescriptor descriptor);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -72,7 +72,8 @@ public class InvertedIndexSearcher extends IndexSearcher
                                  indexContext,
                                  indexFiles.termsData(),
                                  indexFiles.postingLists(),
-                                 root, footerPointer);
+                                 root,
+                                 footerPointer);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -162,7 +162,8 @@ public class MemtableIndexWriter implements PerIndexWriter
                                                                     Integer.MAX_VALUE,
                                                                     indexContext.getIndexWriterConfig()))
             {
-                indexMetas = writer.writeAll(ImmutableOneDimPointValues.fromTermEnum(terms, termComparator));
+                ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.KD_TREE);
+                indexMetas = writer.writeAll(ImmutableOneDimPointValues.fromTermEnum(terms, termComparator, version));
                 numRows = writer.getPointCount();
             }
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MergingIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MergingIterator.java
@@ -107,7 +107,7 @@ public final class MergingIterator implements Iterator<ByteComparable>
         top[numTop++] = queue.pop();
         // extract all subs from the queue that have the same top element
         while (queue.size() != 0
-               && ByteComparable.compare(queue.top().current, top[0].current, ByteComparable.Version.OSS41) == 0)
+               && ByteComparable.compare(queue.top().current, top[0].current) == 0)
         {
             top[numTop++] = queue.pop();
         }
@@ -153,7 +153,7 @@ public final class MergingIterator implements Iterator<ByteComparable>
         @Override
         protected boolean lessThan(SubIterator a, SubIterator b)
         {
-            final int cmp = ByteComparable.compare(a.current, b.current, ByteComparable.Version.OSS41);
+            final int cmp = ByteComparable.compare(a.current, b.current);
 
             if (cmp != 0)
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -341,7 +341,11 @@ public class SSTableIndexWriter implements PerIndexWriter
         }
         else
         {
-            builder = new SegmentBuilder.KDTreeSegmentBuilder(rowIdOffset, indexContext.getValidator(), limiter, indexContext.getIndexWriterConfig());
+            builder = new SegmentBuilder.KDTreeSegmentBuilder(rowIdOffset,
+                                                              indexContext.getValidator(),
+                                                              limiter,
+                                                              indexContext.getIndexWriterConfig(),
+                                                              indexDescriptor.byteComparableVersionFor(IndexComponent.KD_TREE));
         }
 
         long globalBytesUsed = limiter.increment(builder.totalBytesAllocated());

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -51,6 +51,7 @@ import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.metrics.QuickSlidingWindowReservoir;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 
@@ -118,8 +119,9 @@ public abstract class SegmentBuilder
         protected final byte[] buffer;
         private final BKDTreeRamBuffer kdTreeRamBuffer;
         private final IndexWriterConfig indexWriterConfig;
+        private final ByteComparable.Version version;
 
-        KDTreeSegmentBuilder(long rowIdOffset, AbstractType<?> termComparator, NamedMemoryLimiter limiter, IndexWriterConfig indexWriterConfig)
+        KDTreeSegmentBuilder(long rowIdOffset, AbstractType<?> termComparator, NamedMemoryLimiter limiter, IndexWriterConfig indexWriterConfig, ByteComparable.Version version)
         {
             super(rowIdOffset, termComparator, limiter);
 
@@ -127,6 +129,7 @@ public abstract class SegmentBuilder
             this.kdTreeRamBuffer = new BKDTreeRamBuffer(1, typeSize);
             this.buffer = new byte[typeSize];
             this.indexWriterConfig = indexWriterConfig;
+            this.version = version;
             totalBytesAllocated = kdTreeRamBuffer.ramBytesUsed();
             totalBytesAllocatedConcurrent.add(totalBytesAllocated);
         }
@@ -138,7 +141,7 @@ public abstract class SegmentBuilder
 
         protected long addInternal(ByteBuffer term, int segmentRowId)
         {
-            TypeUtil.toComparableBytes(term, termComparator, buffer);
+            TypeUtil.toComparableBytes(term, termComparator, buffer, version);
             return kdTreeRamBuffer.addPackedValue(segmentRowId, new BytesRef(buffer));
         }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
@@ -283,7 +283,7 @@ public class TermsReader implements Closeable
             do
             {
                 Pair<ByteComparable, Long> nextTriePair = reader.next();
-                ByteSource mapEntry = nextTriePair.left.asComparableBytes(ByteComparable.Version.OSS41);
+                ByteSource mapEntry = nextTriePair.left.asComparableBytes(encodingVersion);
                 long postingsOffset = nextTriePair.right;
                 byte[] nextBytes = ByteSourceInverse.readBytes(mapEntry);
 
@@ -318,8 +318,8 @@ public class TermsReader implements Closeable
         private TermsScanner(long segmentOffset)
         {
             this.termsDictionaryReader = new TrieTermsDictionaryReader(termDictionaryFile.instantiateRebufferer(), termDictionaryRoot, encodingVersion);
-            this.minTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMinTerm().asComparableBytes(ByteComparable.Version.OSS41)));
-            this.maxTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMaxTerm().asComparableBytes(ByteComparable.Version.OSS41)));
+            this.minTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMinTerm().asComparableBytes(encodingVersion)));
+            this.maxTerm = ByteBuffer.wrap(ByteSourceInverse.readBytes(termsDictionaryReader.getMaxTerm().asComparableBytes(encodingVersion)));
             this.segmentOffset = segmentOffset;
         }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
@@ -39,16 +39,22 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
 {
     private final TermsIterator termEnum;
     private final byte[] scratch;
+    private final ByteComparable.Version version;
 
-    private ImmutableOneDimPointValues(TermsIterator termEnum, AbstractType<?> termComparator)
+    private ImmutableOneDimPointValues(TermsIterator termEnum,
+                                       AbstractType<?> termComparator,
+                                       ByteComparable.Version version)
     {
         this.termEnum = termEnum;
         this.scratch = new byte[TypeUtil.fixedSizeOf(termComparator)];
+        this.version = version;
     }
 
-    public static ImmutableOneDimPointValues fromTermEnum(TermsIterator termEnum, AbstractType<?> termComparator)
+    public static ImmutableOneDimPointValues fromTermEnum(TermsIterator termEnum,
+                                                          AbstractType<?> termComparator,
+                                                          ByteComparable.Version version)
     {
-        return new ImmutableOneDimPointValues(termEnum, termComparator);
+        return new ImmutableOneDimPointValues(termEnum, termComparator, version);
     }
 
     @Override
@@ -56,7 +62,7 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
     {
         while (termEnum.hasNext())
         {
-            ByteBufferUtil.toBytes(termEnum.next().asComparableBytes(ByteComparable.Version.OSS41), scratch);
+            ByteBufferUtil.toBytes(termEnum.next().asComparableBytes(version), scratch);
             try (final PostingList postings = termEnum.postings())
             {
                 long segmentRowId;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/ReverseTrieTermsDictionaryReader.java
@@ -33,9 +33,9 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
  */
 public class ReverseTrieTermsDictionaryReader extends ReverseValueIterator<ReverseTrieTermsDictionaryReader> implements Iterator<Pair<ByteComparable, Long>>
 {
-    public ReverseTrieTermsDictionaryReader(Rebufferer rebufferer, long root)
+    public ReverseTrieTermsDictionaryReader(Rebufferer rebufferer, long root, ByteComparable.Version version)
     {
-        super(rebufferer, root, true, ByteComparable.Version.OSS41);
+        super(rebufferer, root, true, version);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/SSTableComponentsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/SSTableComponentsWriter.java
@@ -59,11 +59,13 @@ public class SSTableComponentsWriter implements PerSSTableWriter
         this.blockFPWriter = new NumericValuesWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                      indexDescriptor.openPerSSTableOutput(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS),
                                                      metadataWriter, true);
+
         this.sortedTermsWriter = new SortedTermsWriter(indexDescriptor.componentFileName(IndexComponent.PRIMARY_KEY_BLOCKS),
                                                        metadataWriter,
                                                        bytesWriter,
                                                        blockFPWriter,
-                                                       trieWriter);
+                                                       trieWriter,
+                                                       indexDescriptor.byteComparableVersionFor(IndexComponent.PRIMARY_KEY_TRIE));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.store.IndexInput;
 
 /**
@@ -110,7 +111,7 @@ public class V2OnDiskFormat extends V1OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V2VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 
@@ -189,5 +190,11 @@ public class V2OnDiskFormat extends V1OnDiskFormat
             default:
                 return ByteOrder.BIG_ENDIAN;
         }
+    }
+
+    @Override
+    public ByteComparable.Version byteComparableVersionFor(IndexComponent component, IndexDescriptor descriptor)
+    {
+        return ByteComparable.Version.OSS41;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsReader.java
@@ -73,6 +73,7 @@ public class SortedTermsReader
     private final SortedTermsMeta meta;
     private final FileHandle termsTrie;
     private final LongArray.Factory blockOffsetsFactory;
+    private final ByteComparable.Version termsTrieByteComparableVersion;
 
     /**
      * Creates a new reader based on its data components.
@@ -89,7 +90,8 @@ public class SortedTermsReader
                              @Nonnull FileHandle termsDataBlockOffsets,
                              @Nonnull FileHandle termsTrie,
                              @Nonnull SortedTermsMeta meta,
-                             @Nonnull NumericValuesMeta blockOffsetsMeta) throws IOException
+                             @Nonnull NumericValuesMeta blockOffsetsMeta,
+                             @Nonnull ByteComparable.Version termsTrieByteComparableVersion) throws IOException
     {
         this.termsData = termsData;
         this.termsTrie = termsTrie;
@@ -99,6 +101,7 @@ public class SortedTermsReader
         }
         this.meta = meta;
         this.blockOffsetsFactory = new MonotonicBlockPackedReader(termsDataBlockOffsets, blockOffsetsMeta);
+        this.termsTrieByteComparableVersion = termsTrieByteComparableVersion;
     }
 
     /**
@@ -153,7 +156,7 @@ public class SortedTermsReader
             this.termsDataFp = this.termsData.getFilePointer();
             this.blockOffsets = new LongArray.DeferredLongArray(blockOffsetsFactory::open);
             this.currentTerm = new BytesRef(Math.max(meta.maxTermLength, 0));  // maxTermLength can be negative if meta.count == 0
-            this.reader = new TrieTermsDictionaryReader(termsTrie.instantiateRebufferer(), meta.trieFP, ByteComparable.Version.OSS41);
+            this.reader = new TrieTermsDictionaryReader(termsTrie.instantiateRebufferer(), meta.trieFP, termsTrieByteComparableVersion);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
@@ -79,6 +79,8 @@ public class SortedTermsWriter implements Closeable
     private final NumericValuesWriter offsetsWriter;
     private final String componentName;
     private final MetadataWriter metadataWriter;
+    private final ByteComparable.Version trieByteComparableVersion;
+
 
     private BytesRefBuilder prevTerm = new BytesRefBuilder();
     private BytesRefBuilder tempTerm = new BytesRefBuilder();
@@ -104,17 +106,19 @@ public class SortedTermsWriter implements Closeable
                              @NonNull MetadataWriter metadataWriter,
                              @Nonnull IndexOutput termsData,
                              @Nonnull NumericValuesWriter termsDataBlockOffsets,
-                             @Nonnull IndexOutputWriter trieWriter) throws IOException
+                             @Nonnull IndexOutputWriter trieWriter,
+                             ByteComparable.Version trieByteComparableVersion) throws IOException
     {
         this.componentName = componentName;
         this.metadataWriter = metadataWriter;
         this.trieOutput = trieWriter;
         SAICodecUtils.writeHeader(this.trieOutput);
-        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieWriter.asSequentialWriter(), ByteComparable.Version.OSS41);
+        this.trieWriter = IncrementalTrieWriter.open(trieSerializer, trieWriter.asSequentialWriter(), trieByteComparableVersion);
         SAICodecUtils.writeHeader(termsData);
         this.termsOutput = termsData;
         this.bytesStartFP = termsData.getFilePointer();
         this.offsetsWriter = termsDataBlockOffsets;
+        this.trieByteComparableVersion = trieByteComparableVersion;
     }
 
     /**
@@ -199,7 +203,7 @@ public class SortedTermsWriter implements Closeable
      */
     private void copyBytes(ByteComparable source, BytesRefBuilder dest)
     {
-        ByteSource byteSource = source.asComparableBytes(ByteComparable.Version.OSS41);
+        ByteSource byteSource = source.asComparableBytes(trieByteComparableVersion);
         int val;
         while ((val = byteSource.next()) != ByteSource.END_OF_STREAM)
             dest.append((byte) val);

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 /**
  * Different vector components compared to V2OnDiskFormat (supporting DiskANN/jvector instead of HNSW/lucene).
@@ -88,7 +89,7 @@ public class V3OnDiskFormat extends V2OnDiskFormat
                                           SegmentMetadata segmentMetadata) throws IOException
     {
         if (indexContext.isVector())
-            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor, indexContext);
+            return new V3VectorIndexSearcher(sstableContext.primaryKeyMapFactory(), indexFiles, segmentMetadata, sstableContext.indexDescriptor(), indexContext);
         return super.newIndexSearcher(sstableContext, indexContext, indexFiles, segmentMetadata);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -197,7 +197,7 @@ public class TrieMemtableIndex implements MemtableIndex
         for (int i = minSubrange; i <= maxSubrange; i++)
             rangeIterators.add(rangeIndexes[i].iterator());
 
-        return MergeIterator.get(rangeIterators, (o1, o2) -> ByteComparable.compare(o1.left, o2.left, ByteComparable.Version.OSS41),
+        return MergeIterator.get(rangeIterators, (o1, o2) -> ByteComparable.compare(o1.left, o2.left),
                                  new PrimaryKeysMergeReducer(rangeIterators.size()));
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.utils.GeoUtil;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.util.SloppyMath;
 
 public class Expression

--- a/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
@@ -117,20 +117,20 @@ public class TypeUtil
 
     /**
      * Returns the lesser of two {@code ByteComparable} values, based on the result of {@link
-     * ByteComparable#compare(ByteComparable, ByteComparable, ByteComparable.Version)} comparision.
+     * ByteComparable#compare(ByteComparable, ByteComparable)} comparision.
      */
     public static ByteComparable min(ByteComparable a, ByteComparable b)
     {
-        return a == null ?  b : (b == null || ByteComparable.compare(b, a, ByteComparable.Version.OSS41) > 0) ? a : b;
+        return a == null ?  b : (b == null || ByteComparable.compare(b, a) > 0) ? a : b;
     }
 
     /**
      * Returns the greater of two {@code ByteComparable} values, based on the result of {@link
-     * ByteComparable#compare(ByteComparable, ByteComparable, ByteComparable.Version)} comparision.
+     * ByteComparable#compare(ByteComparable, ByteComparable)} comparision.
      */
     public static ByteComparable max(ByteComparable a, ByteComparable b)
     {
-        return a == null ?  b : (b == null || ByteComparable.compare(b, a, ByteComparable.Version.OSS41) < 0) ? a : b;
+        return a == null ?  b : (b == null || ByteComparable.compare(b, a) < 0) ? a : b;
     }
 
     /**
@@ -221,7 +221,7 @@ public class TypeUtil
      * @param type the type associated with the encoded {@code value} parameter
      * @param bytes this method's output
      */
-    public static void toComparableBytes(ByteBuffer value, AbstractType<?> type, byte[] bytes)
+    public static void toComparableBytes(ByteBuffer value, AbstractType<?> type, byte[] bytes, ByteComparable.Version version)
     {
         if (isInetAddress(type))
             ByteBufferUtil.arrayCopy(value, value.hasArray() ? value.arrayOffset() + value.position() : value.position(), bytes, 0, 16);
@@ -230,7 +230,7 @@ public class TypeUtil
         else if (type instanceof DecimalType)
             ByteBufferUtil.arrayCopy(value, value.hasArray() ? value.arrayOffset() + value.position() : value.position(), bytes, 0, DECIMAL_APPROXIMATION_BYTES);
         else
-            ByteBufferUtil.toBytes(type.asComparableBytes(value, ByteComparable.Version.OSS41), bytes);
+            ByteBufferUtil.toBytes(type.asComparableBytes(value, version), bytes);
     }
 
     /**
@@ -542,7 +542,9 @@ public class TypeUtil
 
     public static ByteBuffer encodeDecimal(ByteBuffer value)
     {
-        ByteSource bs = DecimalType.instance.asComparableBytes(value, ByteComparable.Version.OSS41);
+        // bytecomparable version doesn't matter for decimals, so it is set to null deliberately,
+        // so if it ever changes, this would fail the test
+        ByteSource bs = DecimalType.instance.asComparableBytes(value, null);
         bs = ByteSource.cutOrRightPad(bs, DECIMAL_APPROXIMATION_BYTES, 0);
         return ByteBuffer.wrap(ByteSourceInverse.readBytes(bs, DECIMAL_APPROXIMATION_BYTES));
     }

--- a/src/java/org/apache/cassandra/io/tries/IncrementalDeepTrieWriterPageAware.java
+++ b/src/java/org/apache/cassandra/io/tries/IncrementalDeepTrieWriterPageAware.java
@@ -35,13 +35,18 @@ class IncrementalDeepTrieWriterPageAware<VALUE> extends IncrementalTrieWriterPag
 {
     private final int maxRecursionDepth;
 
-    IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer, DataOutputPlus dest, int maxRecursionDepth, ByteComparable.Version version)
+     IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer,
+                                        DataOutputPlus dest,
+                                        int maxRecursionDepth,
+                                        ByteComparable.Version version)
     {
         super(trieSerializer, dest, version);
         this.maxRecursionDepth = maxRecursionDepth;
     }
 
-    IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer, DataOutputPlus dest, ByteComparable.Version version)
+     IncrementalDeepTrieWriterPageAware(TrieSerializer<VALUE, ? super DataOutputPlus> trieSerializer,
+                                        DataOutputPlus dest,
+                                        ByteComparable.Version version)
     {
         this(trieSerializer, dest, 64, version);
     }

--- a/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ReverseValueIterator.java
@@ -49,7 +49,12 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
         initializeNoRightBound(root, NOT_AT_LIMIT, LeftBoundTreatment.GREATER);
     }
 
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, ByteComparable.Version version)
+    protected ReverseValueIterator(Rebufferer source,
+                                   long root,
+                                   ByteComparable start,
+                                   ByteComparable end,
+                                   LeftBoundTreatment admitPrefix,
+                                   ByteComparable.Version version)
     {
         this(source, root, start, end, admitPrefix, false, version);
     }
@@ -65,7 +70,13 @@ public class ReverseValueIterator<Concrete extends ReverseValueIterator<Concrete
      * </ul>
      * This behaviour is shared with the forward counterpart {@link ValueIterator}.
      */
-    protected ReverseValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, boolean collecting, ByteComparable.Version version)
+    protected ReverseValueIterator(Rebufferer source,
+                                   long root,
+                                   ByteComparable start,
+                                   ByteComparable end,
+                                   LeftBoundTreatment admitPrefix,
+                                   boolean collecting,
+                                   ByteComparable.Version version)
     {
         super(source, root, start != null ? start.asComparableBytes(version) : null, collecting, version);
 

--- a/src/java/org/apache/cassandra/io/tries/ValueIterator.java
+++ b/src/java/org/apache/cassandra/io/tries/ValueIterator.java
@@ -46,7 +46,12 @@ public class ValueIterator<CONCRETE extends ValueIterator<CONCRETE>> extends Bas
         initializeNoLeftBound(root, 256);
     }
 
-    protected ValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, ByteComparable.Version version)
+    protected ValueIterator(Rebufferer source,
+                            long root,
+                            ByteComparable start,
+                            ByteComparable end,
+                            LeftBoundTreatment admitPrefix,
+                            ByteComparable.Version version)
     {
         this(source, root, start, end, admitPrefix, false, version);
     }
@@ -63,12 +68,18 @@ public class ValueIterator<CONCRETE extends ValueIterator<CONCRETE>> extends Bas
      * </ul>
      * This behaviour is shared with the reverse counterpart {@link ReverseValueIterator}.
      */
-    protected ValueIterator(Rebufferer source, long root, ByteComparable start, ByteComparable end, LeftBoundTreatment admitPrefix, boolean collecting, ByteComparable.Version version)
+    protected ValueIterator(Rebufferer source,
+                            long root,
+                            ByteComparable start,
+                            ByteComparable end,
+                            LeftBoundTreatment admitPrefix,
+                            boolean collecting,
+                            ByteComparable.Version version)
     {
         super(source, root, end != null ? end.asComparableBytes(version) : null, collecting, version);
 
         if (start != null)
-            initializeWithLeftBound(root, start.asComparableBytes(byteComparableVersion), admitPrefix, limit != null);
+            initializeWithLeftBound(root, start.asComparableBytes(version), admitPrefix, limit != null);
         else
             initializeNoLeftBound(root, limit != null ? limit.next() : 256);
     }

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
@@ -133,8 +133,13 @@ public interface ByteComparable
      * @return the result of the lexicographic unsigned byte comparison of the byte-comparable representations of the
      *         two arguments
      */
-    static int compare(ByteComparable bytes1, ByteComparable bytes2, Version version)
+    static int compare(ByteComparable bytes1, ByteComparable bytes2)
     {
+        // The particular version of byte comparable encoding used here shouldn't matter
+        // as long as the same version is used on both sides of the comparison.
+        // But we have to choose a version here, so we choose to use the most recent one.
+        // This version does not leak to the caller in any way.
+        ByteComparable.Version version = Version.OSS41;
         ByteSource s1 = bytes1.asComparableBytes(version);
         ByteSource s2 = bytes2.asComparableBytes(version);
 

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBenchmark.java
@@ -123,7 +123,8 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
                                                               metadataWriter,
                                                               bytesWriter,
                                                               blockFPWriter,
-                                                              trieWriter))
+                                                              trieWriter,
+                                                              ByteComparable.Version.OSS41))
         {
             for (int x = 0; x < NUM_ROWS; x++)
             {
@@ -175,7 +176,7 @@ public class SortedTermsBenchmark extends AbstractOnDiskBenchmark
         termsData = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCKS);
         blockOffsets = indexDescriptor.createPerSSTableFileHandle(IndexComponent.PRIMARY_KEY_BLOCK_OFFSETS);
 
-        sortedTermsReader = new SortedTermsReader(termsData,blockOffsets, trieFile, sortedTermsMeta, blockOffsetMeta);
+        sortedTermsReader = new SortedTermsReader(termsData, blockOffsets, trieFile, sortedTermsMeta, blockOffsetMeta, ByteComparable.Version.OSS41);
 
         luceneReader = DirectoryReader.open(directory);
         LeafReaderContext context = luceneReader.leaves().get(0);

--- a/test/unit/org/apache/cassandra/db/tries/MemtableTrieTestBase.java
+++ b/test/unit/org/apache/cassandra/db/tries/MemtableTrieTestBase.java
@@ -55,8 +55,8 @@ public abstract class MemtableTrieTestBase
 
     static final ByteComparable.Version VERSION = MemtableTrie.BYTE_COMPARABLE_VERSION;
 
-    public static final Comparator<ByteComparable> FORWARD_COMPARATOR = (bytes1, bytes2) -> ByteComparable.compare(bytes1, bytes2, VERSION);
-    public static final Comparator<ByteComparable> REVERSE_COMPARATOR = (bytes1, bytes2) -> ByteComparable.compare(invert(bytes1), invert(bytes2), VERSION);
+    public static final Comparator<ByteComparable> FORWARD_COMPARATOR = ByteComparable::compare;
+    public static final Comparator<ByteComparable> REVERSE_COMPARATOR = (bytes1, bytes2) -> ByteComparable.compare(invert(bytes1), invert(bytes2));
 
     abstract boolean usePut();
 
@@ -505,7 +505,7 @@ public abstract class MemtableTrieTestBase
         trie.forEachEntry(direction, (key, value) -> {
             Assert.assertTrue("Map exhausted first, key " + asString(key), it.hasNext());
             Map.Entry<ByteComparable, ByteBuffer> entry = it.next();
-            assertEquals(0, ByteComparable.compare(entry.getKey(), key, Trie.BYTE_COMPARABLE_VERSION));
+            assertEquals(0, ByteComparable.compare(entry.getKey(), key));
             assertEquals(entry.getValue(), value);
         });
         Assert.assertFalse("Trie exhausted first", it.hasNext());
@@ -545,7 +545,7 @@ public abstract class MemtableTrieTestBase
             Map.Entry<ByteComparable, ByteBuffer> en2 = it2.next();
             b.append(String.format("TreeSet %s:%s\n", asString(en2.getKey()), ByteBufferUtil.bytesToHex(en2.getValue())));
             b.append(String.format("Trie    %s:%s\n", asString(en1.getKey()), ByteBufferUtil.bytesToHex(en1.getValue())));
-            if (ByteComparable.compare(en1.getKey(), en2.getKey(), VERSION) != 0 || ByteBufferUtil.compareUnsigned(en1.getValue(), en2.getValue()) != 0)
+            if (ByteComparable.compare(en1.getKey(), en2.getKey()) != 0 || ByteBufferUtil.compareUnsigned(en1.getValue(), en2.getValue()) != 0)
                 failedAt.add(en1.getKey());
         }
         while (it1.hasNext())

--- a/test/unit/org/apache/cassandra/db/tries/SlicedTrieTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/SlicedTrieTest.java
@@ -82,7 +82,7 @@ public class SlicedTrieTest
     "\000\000\777",
     "\777\777"
     });
-    public static final Comparator<ByteComparable> BYTE_COMPARABLE_COMPARATOR = (bytes1, bytes2) -> ByteComparable.compare(bytes1, bytes2, Trie.BYTE_COMPARABLE_VERSION);
+    public static final Comparator<ByteComparable> BYTE_COMPARABLE_COMPARATOR = ByteComparable::compare;
     private static final int COUNT = 15000;
     Random rand = new Random();
 
@@ -95,7 +95,7 @@ public class SlicedTrieTest
     public void testIntersectRange(int count)
     {
         ByteComparable[] src1 = generateKeys(rand, count);
-        NavigableMap<ByteComparable, ByteBuffer> content1 = new TreeMap<>((bytes1, bytes2) -> ByteComparable.compare(bytes1, bytes2, Trie.BYTE_COMPARABLE_VERSION));
+        NavigableMap<ByteComparable, ByteBuffer> content1 = new TreeMap<>(ByteComparable::compare);
 
         MemtableTrie<ByteBuffer> trie1 = makeMemtableTrie(src1, content1, true);
 
@@ -106,7 +106,7 @@ public class SlicedTrieTest
         {
             ByteComparable l = rand.nextBoolean() ? MemtableTrieTestBase.generateKey(rand) : src1[rand.nextInt(src1.length)];
             ByteComparable r = rand.nextBoolean() ? MemtableTrieTestBase.generateKey(rand) : src1[rand.nextInt(src1.length)];
-            int cmp = ByteComparable.compare(l, r, Trie.BYTE_COMPARABLE_VERSION);
+            int cmp = ByteComparable.compare(l, r);
             if (cmp > 0)
             {
                 ByteComparable t = l;
@@ -132,7 +132,7 @@ public class SlicedTrieTest
     @Test
     public void testSingletonSubtrie()
     {
-        Arrays.sort(BOUNDARIES, (a, b) -> ByteComparable.compare(a, b, ByteComparable.Version.OSS41));
+        Arrays.sort(BOUNDARIES, (a, b) -> ByteComparable.compare(a, b));
         for (int li = -1; li < BOUNDARIES.length; ++li)
         {
             ByteComparable l = li < 0 ? null : BOUNDARIES[li];
@@ -147,8 +147,8 @@ public class SlicedTrieTest
 
                     for (ByteComparable key : KEYS)
                     {
-                        int cmp1 = l != null ? ByteComparable.compare(key, l, ByteComparable.Version.OSS41) : 1;
-                        int cmp2 = r != null ? ByteComparable.compare(r, key, ByteComparable.Version.OSS41) : 1;
+                        int cmp1 = l != null ? ByteComparable.compare(key, l) : 1;
+                        int cmp2 = r != null ? ByteComparable.compare(r, key) : 1;
                         Trie<Boolean> ix = new SlicedTrie<>(Trie.singleton(key, true), l, includeLeft, r, includeRight);
                         boolean expected = true;
                         if (cmp1 < 0 || cmp1 == 0 && !includeLeft)

--- a/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
@@ -127,7 +127,8 @@ public interface DataModel
                                                        "1896, " + NORMAL_COLUMN_DATA.get(12),
                                                        "1896, " + NORMAL_COLUMN_DATA.get(13),
                                                        "1845, " + NORMAL_COLUMN_DATA.get(14),
-                                                       "1845, " + NORMAL_COLUMN_DATA.get(15));
+                                                       "1845, " + NORMAL_COLUMN_DATA.get(15)
+    );
 
     static AtomicInteger seq = new AtomicInteger();
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
@@ -61,7 +61,7 @@ public class VersionTest
     public void unsupportedOrInvalidVersionsDoNotParse()
     {
         assertThatThrownBy(() -> Version.parse(null)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Version.parse("ab")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Version.parse("ac")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("a")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("abc")).isInstanceOf(IllegalArgumentException.class);
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -167,7 +167,10 @@ public class LegacyOnDiskFormatTest
                                             metadatas.get(0).getIndexRoot(IndexComponent.KD_TREE_POSTING_LISTS));
 
         Expression expression = new Expression(indexContext).add(Operator.LT, Int32Type.instance.decompose(10));
-        BKDReader.IntersectVisitor query = bkdQueryFrom(expression, bkdReader.getNumDimensions(), bkdReader.getBytesPerDimension());
+        BKDReader.IntersectVisitor query = bkdQueryFrom(expression,
+                                                        bkdReader.getNumDimensions(),
+                                                        bkdReader.getBytesPerDimension(),
+                                                        indexDescriptor.byteComparableVersionFor(IndexComponent.KD_TREE));
         PostingList postingList = bkdReader.intersect(query, QueryEventListeners.NO_OP_BKD_LISTENER, new QueryContext());
         assertNotNull(postingList);
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -217,7 +217,7 @@ public class SegmentFlushTest
         ByteComparable term = iterator.next();
         PostingList postings = iterator.postings();
 
-        assertEquals(0, ByteComparable.compare(term, ByteComparable.fixedLength(expectedTerm), ByteComparable.Version.OSS41));
+        assertEquals(0, ByteComparable.compare(term, ByteComparable.fixedLength(expectedTerm)));
         assertEquals(minSegmentRowId == maxSegmentRowId ? 1 : 2, postings.size());
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
@@ -83,6 +83,7 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
+        ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
         try (TermsReader reader = new TermsReader(indexDescriptor,
                                                   indexContext,
                                                   termsData,
@@ -96,7 +97,7 @@ public class TermsReaderTest extends SaiRandomizedTest
                 for (ByteComparable term = actualTermsEnum.next(); term != null; term = actualTermsEnum.next())
                 {
                     final ByteComparable expected = termsEnum.get(i++).left;
-                    assertEquals(0, ByteComparable.compare(expected, term, ByteComparable.Version.OSS41));
+                    assertEquals(0, ByteComparable.compare(expected, term));
                 }
             }
         }
@@ -120,6 +121,8 @@ public class TermsReaderTest extends SaiRandomizedTest
 
         long termsFooterPointer = Long.parseLong(indexMetas.get(IndexComponent.TERMS_DATA).attributes.get(SAICodecUtils.FOOTER_POINTER));
 
+
+        ByteComparable.Version version = indexDescriptor.byteComparableVersionFor(IndexComponent.TERMS_DATA);
         try (TermsReader reader = new TermsReader(indexDescriptor,
                                                   indexContext,
                                                   termsData,
@@ -129,7 +132,7 @@ public class TermsReaderTest extends SaiRandomizedTest
         {
             for (Pair<ByteComparable, LongArrayList> pair : termsEnum)
             {
-                final byte[] bytes = ByteSourceInverse.readBytes(pair.left.asComparableBytes(ByteComparable.Version.OSS41));
+                final byte[] bytes = ByteSourceInverse.readBytes(pair.left.asComparableBytes(version));
                 try (PostingList actualPostingList = reader.exactMatch(ByteComparable.fixedLength(bytes),
                                                                        (QueryEventListener.TrieIndexEventListener)NO_OP_TRIE_LISTENER,
                                                                        new QueryContext()))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDQueriesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDQueriesTest.java
@@ -39,7 +39,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
     {
         final int lowerBound = between(-10, 10);
         final Expression expression = buildExpression(Operator.GTE, lowerBound);
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertTrue(query.visit(toSortableBytes(lowerBound)));
@@ -55,7 +55,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
     {
         final int lowerBound = between(-10, 10);
         final Expression expression = buildExpression(Operator.GT, lowerBound);
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertFalse(query.visit(toSortableBytes(lowerBound)));
@@ -71,7 +71,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
     {
         final int upperBound = between(-10, 10);
         final Expression expression = buildExpression(Operator.LTE, upperBound);
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertTrue(query.visit(toSortableBytes(upperBound - 1)));
         assertTrue(query.visit(toSortableBytes(upperBound)));
@@ -87,7 +87,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
     {
         final int upper = between(-10, 10);
         final Expression expression = buildExpression(Operator.LT, upper);
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertTrue(query.visit(toSortableBytes(upper - 1)));
         assertFalse(query.visit(toSortableBytes(upper)));
@@ -105,7 +105,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
         final int upperBound = lowerBound + 5;
         final Expression expression = buildExpression(Operator.GTE, lowerBound)
                 .add(Operator.LTE, Int32Type.instance.decompose(upperBound));
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertTrue(query.visit(toSortableBytes(lowerBound)));
@@ -128,7 +128,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
         final int upperBound = lowerBound + 5;
         final Expression expression = buildExpression(Operator.GT, lowerBound)
                 .add(Operator.LT, Int32Type.instance.decompose(upperBound));
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertFalse(query.visit(toSortableBytes(lowerBound)));
@@ -151,7 +151,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
         final int upperBound = lowerBound + 5;
         final Expression expression = buildExpression(Operator.GT, lowerBound)
                 .add(Operator.LTE, Int32Type.instance.decompose(upperBound));
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertFalse(query.visit(toSortableBytes(lowerBound)));
@@ -174,7 +174,7 @@ public class BKDQueriesTest extends SaiRandomizedTest
         final int upperBound = lowerBound + 5;
         final Expression expression = buildExpression(Operator.GTE, lowerBound)
                 .add(Operator.LT, Int32Type.instance.decompose(upperBound));
-        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4);
+        final BKDReader.IntersectVisitor query = BKDQueries.bkdQueryFrom(expression, 1, 4, ByteComparable.Version.OSS41);
 
         assertFalse(query.visit(toSortableBytes(lowerBound - 1)));
         assertTrue(query.visit(toSortableBytes(lowerBound)));

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
@@ -46,7 +46,7 @@ public class ImmutableOneDimPointValuesTest
         final int minTerm = 0, maxTerm = 10;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                .fromTermEnum(termEnum, Int32Type.instance);
+                .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         pointValues.intersect(assertingVisitor(minTerm));
     }
@@ -57,7 +57,7 @@ public class ImmutableOneDimPointValuesTest
         final int minTerm = 3, maxTerm = 13;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                .fromTermEnum(termEnum, Int32Type.instance);
+                .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         expectedException.expect(IllegalStateException.class);
         pointValues.swap(0, 1);
@@ -68,7 +68,7 @@ public class ImmutableOneDimPointValuesTest
     {
         final int minTerm = 2, maxTerm = 7;
         final TermsIterator termEnum = buildDescTermEnum(minTerm, maxTerm);
-        final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues.fromTermEnum(termEnum, Int32Type.instance);
+        final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues.fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         MutablePointsReaderUtils.sort(2, Int32Type.instance.valueLengthIfFixed(), pointValues, 0, Math.toIntExact(pointValues.size()));
 
@@ -88,7 +88,7 @@ public class ImmutableOneDimPointValuesTest
                 final ByteComparable actualTerm = ByteComparable.fixedLength(packedValue);
                 final ByteComparable expectedTerm = ByteComparable.of(term);
 
-                assertEquals(0, ByteComparable.compare(actualTerm, expectedTerm, ByteComparable.Version.OSS41));
+                assertEquals(0, ByteComparable.compare(actualTerm, expectedTerm));
                 assertEquals(postingCounter, docID);
 
                 if (postingCounter >= 2)

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -136,7 +136,7 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
         final int maxSegmentRowId = 100;
         final TermsIterator termEnum = buildTermEnum(0, maxSegmentRowId);
         final ImmutableOneDimPointValues pointValues = ImmutableOneDimPointValues
-                                                       .fromTermEnum(termEnum, Int32Type.instance);
+                                                       .fromTermEnum(termEnum, Int32Type.instance, ByteComparable.Version.OSS41);
 
         SegmentMetadata.ComponentMetadataMap indexMetas;
         try (NumericIndexWriter writer = new NumericIndexWriter(indexDescriptor,
@@ -167,7 +167,7 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
                     final ByteComparable actualTerm = ByteComparable.fixedLength(packedValue);
                     final ByteComparable expectedTerm = ByteComparable.of(Math.toIntExact(visited.get()));
                     assertEquals("Point value mismatch after visiting " + visited.get() + " entries.", 0,
-                                 ByteComparable.compare(actualTerm, expectedTerm, ByteComparable.Version.OSS41));
+                                 ByteComparable.compare(actualTerm, expectedTerm));
 
                     visited.addAndGet(1);
                     return true;

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
@@ -160,7 +160,7 @@ public class TrieMemoryIndexTest
                                                           ? ByteComparable.fixedLength(decompose.apply(rowId))
                                                           : version -> type.asComparableBytes(decompose.apply(rowId), version);
             final ByteComparable actualByteComparable = pair.left;
-            assertEquals("Mismatch at: " + i, 0, ByteComparable.compare(expectedByteComparable, actualByteComparable, ByteComparable.Version.OSS41));
+            assertEquals("Mismatch at: " + i, 0, ByteComparable.compare(expectedByteComparable, actualByteComparable));
 
             i++;
         }

--- a/test/unit/org/apache/cassandra/index/sai/utils/AbstractPrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/AbstractPrimaryKeyTest.java
@@ -116,9 +116,7 @@ public class AbstractPrimaryKeyTest extends SaiRandomizedTest
 
     void assertByteComparison(PrimaryKey a, PrimaryKey b, int expected)
     {
-        assertEquals(expected, ByteComparable.compare(v -> a.asComparableBytes(v),
-                                                      v -> b.asComparableBytes(v),
-                                                      ByteComparable.Version.OSS41));
+        assertEquals(expected, ByteComparable.compare(a::asComparableBytes, b::asComparableBytes));
     }
 
     void assertCompareToAndEquals(PrimaryKey a, PrimaryKey b, int expected)

--- a/test/unit/org/apache/cassandra/io/sstable/format/trieindex/RowIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/trieindex/RowIndexTest.java
@@ -474,7 +474,7 @@ public class RowIndexTest
         for (int i = 0; i < size; i++)
         {
             assert i == 0 || comparator.compare(list.get(i - 1), list.get(i)) < 0;
-            assert i == 0 || ByteComparable.compare(comparator.asByteComparable(list.get(i - 1)), comparator.asByteComparable(list.get(i)), VERSION) < 0 :
+            assert i == 0 || ByteComparable.compare(comparator.asByteComparable(list.get(i - 1)), comparator.asByteComparable(list.get(i))) < 0 :
             String.format("%s bs %s versus %s bs %s", list.get(i - 1).clustering().clusteringString(comparator.subtypes()), comparator.asByteComparable(list.get(i - 1)), list.get(i).clustering().clusteringString(comparator.subtypes()), comparator.asByteComparable(list.get(i)));
             writer.add(list.get(i), list.get(i), new IndexInfo(i, DeletionTime.LIVE));
         }

--- a/test/unit/org/apache/cassandra/io/tries/TrieBuilderTest.java
+++ b/test/unit/org/apache/cassandra/io/tries/TrieBuilderTest.java
@@ -18,12 +18,17 @@
 package org.apache.cassandra.io.tries;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.TailOverridingRebufferer;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static org.junit.Assert.assertEquals;
 

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/AbstractTypeByteSourceTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/AbstractTypeByteSourceTest.java
@@ -99,7 +99,7 @@ public class AbstractTypeByteSourceTest
                 int compareBuffers = Integer.signum(type.compare(left, right));
                 ByteSource leftSource = type.asComparableBytes(left.duplicate(), version);
                 ByteSource rightSource = type.asComparableBytes(right.duplicate(), version);
-                int compareBytes = Integer.signum(ByteComparable.compare(v -> leftSource, v -> rightSource, version));
+                int compareBytes = Integer.signum(ByteComparable.compare(v -> leftSource, v -> rightSource));
                 Assert.assertEquals(compareBuffers, compareBytes);
             }
         }

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceComparisonTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceComparisonTest.java
@@ -342,7 +342,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
                     assertEquals(String.format("Failed comparing %s and %s, %s vs %s version %s",
                                                safeStr(c.clusteringString(comp.subtypes())),
                                                safeStr(e.clusteringString(comp.subtypes())), bsc, bse, v),
-                                 expected, Integer.signum(ByteComparable.compare(bsc, bse, v)));
+                                 expected, Integer.signum(ByteComparable.compare(bsc, bse)));
                     maybeCheck41Properties(expected, bsc, bse, v);
                     maybeAssertNotPrefix(bsc, bse, v);
 
@@ -353,7 +353,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
                     assertEquals(String.format("Failed comparing reversed %s and %s, %s vs %s version %s",
                                                safeStr(c.clusteringString(comp.subtypes())),
                                                safeStr(e.clusteringString(comp.subtypes())), bsrc, bsre, v),
-                                 expectedR, Integer.signum(ByteComparable.compare(bsrc, bsre, v)));
+                                 expectedR, Integer.signum(ByteComparable.compare(bsrc, bsre)));
                     maybeCheck41Properties(expectedR, bsrc, bsre, v);
                     maybeAssertNotPrefix(bsrc, bsre, v);
                 }
@@ -652,7 +652,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
         logger.info("{}\n{}", s1, s2);
 
         // Check that the representations compare correctly
-        Assert.assertEquals(Long.signum(kk1.compareTo(kk2)), ByteComparable.compare(kk1, kk2, version));
+        Assert.assertEquals(Long.signum(kk1.compareTo(kk2)), ByteComparable.compare(kk1, kk2));
         // s1 must not be a prefix of s2
         assertNotPrefix(s1, s2);
     }
@@ -791,7 +791,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
 
         for (Version version : Version.values())
         {
-            int actual = Integer.signum(ByteComparable.compare(bs1, bs2, version));
+            int actual = Integer.signum(ByteComparable.compare(bs1, bs2));
             assertEquals(String.format("Failed comparing %s(%s) and %s(%s)", ByteBufferUtil.bytesToHex(b1), bs1.byteComparableAsString(version), ByteBufferUtil.bytesToHex(b2), bs2.byteComparableAsString(version)),
                          expected,
                          actual);
@@ -814,7 +814,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
 
         for (Version version : Version.values())
         {
-            int actual = Integer.signum(ByteComparable.compare(k1, k2, version));
+            int actual = Integer.signum(ByteComparable.compare(k1, k2));
             assertEquals(String.format("Failed comparing %s[%s](%s) and %s[%s](%s)\npartitioner %s version %s",
                                        ByteBufferUtil.bytesToHex(b1),
                                        k1,
@@ -862,7 +862,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
         ByteComparable b1 = v -> convertor.apply(v1);
         ByteComparable b2 = v -> convertor.apply(v2);
         int expected = Integer.signum(comparator.apply(v1, v2));
-        int actual = Integer.signum(ByteComparable.compare(b1, b2, null));  // version ignored above
+        int actual = Integer.signum(ByteComparable.compare(b1, b2));
         assertEquals(String.format("Failed comparing %s and %s", v1, v2), expected, actual);
     }
 
@@ -876,7 +876,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
 
         for (Version version : Version.values())
         {
-            int actual = Integer.signum(ByteComparable.compare(bc1, bc2, version));
+            int actual = Integer.signum(ByteComparable.compare(bc1, bc2));
             if (expected != actual)
             {
                 if (type.isReversed())
@@ -885,7 +885,7 @@ public class ByteSourceComparisonTest extends ByteSourceTestBase
                     ClusteringComparator cc = new ClusteringComparator(type);
                     ByteComparable c1 = cc.asByteComparable(Clustering.make(b1));
                     ByteComparable c2 = cc.asByteComparable(Clustering.make(b2));
-                    int actualcc = Integer.signum(ByteComparable.compare(c1, c2, version));
+                    int actualcc = Integer.signum(ByteComparable.compare(c1, c2));
                     if (actualcc == expected)
                         return;
                     assertEquals(String.format("Failed comparing reversed %s(%s, %s) and %s(%s, %s) direct (%d) and as clustering", safeStr(v1), ByteBufferUtil.bytesToHex(b1), c1, safeStr(v2), ByteBufferUtil.bytesToHex(b2), c2, actual), expected, actualcc);

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceInverseTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceInverseTest.java
@@ -314,7 +314,7 @@ public class ByteSourceInverseTest
             // The best way to test the read bytes seems to be to assert that just directly using them as a
             // ByteSource (using ByteSource.fixedLength(byte[])) they compare as equal to another ByteSource obtained
             // from the same original value.
-            int compare = ByteComparable.compare(v -> originalSourceCopy, v -> ByteSource.fixedLength(bytes), version);
+            int compare = ByteComparable.compare(v -> originalSourceCopy, v -> ByteSource.fixedLength(bytes));
             Assert.assertEquals(0, compare);
         }
     }


### PR DESCRIPTION
All ByteComparable versions in SAI are now controlled by OnDiskFormat, except low number of places where it is obvious that we can hardcode a version and except in tests.

This is to make sure we don't accidentally mix versions in comparisons of bytecomparables read from disk.