### PR TITLE
CNDB-9541 main: Support LIMIT/OFFSET paging for Data API

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1596,3 +1596,9 @@ enable_drop_compact_storage: false
   # Default -1 to disable and use the physically available disk size of data directories during calculations.
   # may differ if emulate_dbaas_defaults is enabled
   # disk_usage_max_disk_size_in_gb: -1
+
+  # Guardrail to warn or fail when using LIMIT/OFFSET paging skipping more rows than threshold.
+  # Default offset_rows_warn_threshold is 10000, may differ if emulate_dbaas_defaults is enabled
+  # Default offset_rows_failure_threshold is 20000, may differ if emulate_dbaas_defaults is enabled
+  # offset_rows_warn_threshold: 10000
+  # offset_rows_failure_threshold: 20000

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -1071,7 +1071,7 @@ bc(syntax)..
                   ( GROUP BY <group-by>)?
                   ( ORDER BY <order-by> )?
                   ( PER PARTITION LIMIT <integer> )?
-                  ( LIMIT <integer> )?
+                  ( LIMIT <integer> ( OFFSET <integer> )? )?
                   ( ALLOW FILTERING )?
 
 <select-clause> ::= DISTINCT? <selection-list>
@@ -1206,9 +1206,9 @@ Aggregate functions will produce a separate value for each group. If no @GROUP B
 
 If a column is selected without an aggregate function, in a statement with a @GROUP BY@, the first value encounter in each group will be returned.
 
-h4(#selectLimit). @LIMIT@ and @PER PARTITION LIMIT@
+h4(#selectLimit). @LIMIT@, @OFFSET@ and @PER PARTITION LIMIT@
 
-The @LIMIT@ option to a @SELECT@ statement limits the number of rows returned by a query, while the @PER PARTITION LIMIT@ option limits the number of rows returned for a given partition by the query. Note that both type of limit can used in the same statement.
+The @LIMIT@ option in a @SELECT@ statement limits the number of rows returned by a query. The @LIMIT@ option can include an @OFFSET@ option to skip the first rows of the query result. The @PER PARTITION LIMIT@ option limits the number of rows returned for a given partition by the query. Note that both type of limit can used in the same statement.
 
 h4(#selectAllowFiltering). @ALLOW FILTERING@
 

--- a/doc/modules/cassandra/examples/BNF/select_statement.bnf
+++ b/doc/modules/cassandra/examples/BNF/select_statement.bnf
@@ -4,7 +4,7 @@ select_statement::= SELECT [ JSON | DISTINCT ] ( select_clause | '*' )
 	[ GROUP BY `group_by_clause` ]  
 	[ ORDER BY `ordering_clause` ]  
 	[ PER PARTITION LIMIT (`integer` | `bind_marker`) ]  
-	[ LIMIT (`integer` | `bind_marker`) ]  
+	[ LIMIT (`integer` | `bind_marker`) [ OFFSET (`integer` | `bind_marker`) ] ]
 	[ ALLOW FILTERING ]
 select_clause::= `selector` [ AS `identifier` ] ( ',' `selector` [ AS `identifier` ] ) 
 selector::== `column_name` 

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -1623,7 +1623,7 @@ FROM  +
 ( GROUP BY )? +
 ( ORDER BY )? +
 ( PER PARTITION LIMIT )? +
-( LIMIT )? +
+( LIMIT ( OFFSET )? )? +
 ( ALLOW FILTERING )?
 
 ::= DISTINCT?
@@ -1842,12 +1842,12 @@ with a `GROUP BY`, the first value encounter in each group will be
 returned.
 
 [[selectLimit]]
-===== `LIMIT` and `PER PARTITION LIMIT`
+===== `LIMIT`, `OFFSET` and `PER PARTITION LIMIT`
 
-The `LIMIT` option to a `SELECT` statement limits the number of rows
-returned by a query, while the `PER PARTITION LIMIT` option limits the
-number of rows returned for a given partition by the query. Note that
-both type of limit can used in the same statement.
+The `LIMIT` option in a `SELECT` statement limits the number of rows returned by a query.
+The `LIMIT` option can include an `OFFSET` option to skip the first rows of the query result.
+The `PER PARTITION LIMIT` option limits the number of rows returned for a given partition by the query.
+Note that both types of limits can used in the same statement.
 
 [[selectAllowFiltering]]
 ===== `ALLOW FILTERING`

--- a/doc/modules/cassandra/pages/cql/dml.adoc
+++ b/doc/modules/cassandra/pages/cql/dml.adoc
@@ -210,9 +210,10 @@ or the reverse
 [[limit-clause]]
 === Limiting results
 
-The `LIMIT` option to a `SELECT` statement limits the number of rows
-returned by a query. The `PER PARTITION LIMIT` option limits the
-number of rows returned for a given partition by the query. Both types of limits can used in the same statement.
+The `LIMIT` option in a `SELECT` statement limits the number of rows returned by a query.
+The `LIMIT` option can include an `OFFSET` option to skip the first rows of the query result.
+The `PER PARTITION LIMIT` option limits the number of rows returned for a given partition by the query.
+Note that both types of limits can used in the same statement.
 
 [[allow-filtering]]
 === Allowing filtering

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -714,7 +714,7 @@ syntax_rules += r'''
                           ( "GROUP" "BY" <groupByClause> ( "," <groupByClause> )* )?
                           ( "ORDER" "BY" <orderByClause> ( "," <orderByClause> )* )?
                           ( "PER" "PARTITION" "LIMIT" perPartitionLimit=<wholenumber> )?
-                          ( "LIMIT" limit=<wholenumber> )?
+                          ( "LIMIT" limit=<wholenumber> ( "OFFSET" offset=<wholenumber> )? )?
                           ( "ALLOW" "FILTERING" )?
                     ;
 <whereClause> ::= <relation> ( "AND" <relation> )*

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -837,3 +837,11 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('ALTER KEYSPACE system_trac', "es WITH replication = {'class': '")
         self.trycompletions("ALTER KEYSPACE system_traces WITH replication = {'class': '", '',
                             choices=['NetworkTopologyStrategy', 'SimpleStrategy'])
+
+    def test_complete_in_select_limit_clause(self):
+        self.trycompletions('SELECT * FROM system.peers LI', immediate='MIT ')
+        self.trycompletions('SELECT * FROM system.peers LIMIT', choices=['<wholenumber>'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 ', choices=[';', 'ALLOW', 'OFFSET'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OF', immediate='FSET ')
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET', choices=['<wholenumber>'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET 1 ', choices=[';', 'ALLOW'])

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -72,6 +72,7 @@ K_INSERT:      I N S E R T;
 K_UPDATE:      U P D A T E;
 K_WITH:        W I T H;
 K_LIMIT:       L I M I T;
+K_OFFSET:      O F F S E T;
 K_PER:         P E R;
 K_PARTITION:   P A R T I T I O N;
 K_USING:       U S I N G;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -255,6 +255,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
     @init {
         Term.Raw limit = null;
         Term.Raw perPartitionLimit = null;
+        Term.Raw offset = null;
         List<Ordering.Raw> orderings = new ArrayList<>();
         List<ColumnIdentifier> groups = new ArrayList<>();
         boolean allowFiltering = false;
@@ -268,7 +269,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
       ( K_GROUP K_BY groupByClause[groups] ( ',' groupByClause[groups] )* )?
       ( K_ORDER K_BY orderByClause[orderings] ( ',' orderByClause[orderings] )* )?
       ( K_PER K_PARTITION K_LIMIT rows=intValue { perPartitionLimit = rows; } )?
-      ( K_LIMIT rows=intValue { limit = rows; } )?
+      ( K_LIMIT rows=intValue { limit = rows; } ( K_OFFSET rows=intValue { offset = rows; } )? )?
       ( K_ALLOW K_FILTERING  { allowFiltering = true; } )?
       {
           SelectStatement.Parameters params = new SelectStatement.Parameters(orderings,
@@ -277,7 +278,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
                                                                              allowFiltering,
                                                                              isJson);
           WhereClause where = wclause == null ? WhereClause.empty() : wclause.build();
-          $expr = new SelectStatement.RawStatement(cf, params, $sclause.selectors, where, limit, perPartitionLimit);
+          $expr = new SelectStatement.RawStatement(cf, params, $sclause.selectors, where, limit, perPartitionLimit, offset);
       }
     ;
 
@@ -1966,5 +1967,6 @@ basic_unreserved_keyword returns [String str]
         | K_COLUMN
         | K_RECORD
         | K_ANN_OF
+        | K_OFFSET
         ) { $str = $k.text; }
     ;

--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -94,16 +94,6 @@ public class ResultSet
         Collections.reverse(rows);
     }
 
-    public void trim(int limit)
-    {
-        int toRemove = rows.size() - limit;
-        if (toRemove > 0)
-        {
-            for (int i = 0; i < toRemove; i++)
-                rows.remove(rows.size() - 1);
-        }
-    }
-
     @Override
     public String toString()
     {

--- a/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.selection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.cassandra.index.Index;
+
+/**
+ * Builds a list of query result rows applying the specified order, limit and offset.
+ */
+public abstract class SortedRowsBuilder
+{
+    public final int limit;
+    public final int offset;
+
+    private SortedRowsBuilder(int limit, int offset)
+    {
+        assert limit > 0 && offset >= 0;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    /**
+     * Adds the specified row to this builder. The row might be ignored if it's over the specified limit and offset.
+     *
+     * @param row the row to add
+     */
+    public abstract void add(List<ByteBuffer> row);
+
+    /**
+     * @return a list of query result rows based on the specified order, limit and offset.
+     */
+    public abstract List<List<ByteBuffer>> build();
+
+    /**
+     * Returns a new row builder that keeps insertion order.
+     *
+     * @return a rows builder that keeps insertion order.
+     */
+    public static SortedRowsBuilder create()
+    {
+        return new WithInsertionOrder(Integer.MAX_VALUE, 0);
+    }
+
+    /**
+     * Returns a new row builder that keeps insertion order.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @return a rows builder that keeps insertion order.
+     */
+    public static SortedRowsBuilder create(int limit, int offset)
+    {
+        return new WithInsertionOrder(limit, offset);
+    }
+
+    /**
+     * Returns a new row builder that orders the added rows based on the specified {@link Comparator}.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @param comparator the comparator to use for ordering
+     * @return a rows builder that orders results based on a comparator.
+     */
+    public static SortedRowsBuilder create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+    {
+        return WithListSort.create(limit, offset, comparator);
+    }
+
+    /**
+     * Returns a new row builder that orders the added rows based on the specified {@link Index.Scorer}.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @param scorer the index scorer to use for ordering
+     * {@link SortedRowsBuilder} that orders results based on a secondary index scorer.
+     */
+    public static SortedRowsBuilder create(int limit, int offset, Index.Scorer scorer)
+    {
+        return WithListSort.create(limit, offset, scorer);
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that keeps insertion order.
+     * </p>
+     * It keeps at most {@code limit} rows in memory.
+     */
+    private static class WithInsertionOrder extends SortedRowsBuilder
+    {
+        private final List<List<ByteBuffer>> rows = new ArrayList<>();
+        private int toSkip = offset;
+
+        private WithInsertionOrder(int limit, int offset)
+        {
+            super(limit, offset);
+        }
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            if (toSkip-- <= 0 && rows.size() < limit)
+                rows.add(row);
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            return rows;
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that orders rows based on the provided comparator.
+     * </p>
+     * It simply stores all the rows in a list, and sorts and trims it when {@link #build()} is called. As such, it can
+     * consume a bunch of resources if the number of rows is high. However, it has good performance for cases where the
+     * number of rows is close to {@code limit + offset}, as it's the case of partition-directed queries.
+     * </p>
+     * The rows can be decorated with any other value used for the comparator, so it doesn't need to recalculate that
+     * value in every comparison.
+     */
+    public static class WithListSort<T> extends SortedRowsBuilder
+    {
+        private final List<T> rows = new ArrayList<>();
+        private final Function<List<ByteBuffer>, T> decorator;
+        private final Function<T, List<ByteBuffer>> undecorator;
+        private final Comparator<T> comparator;
+
+        public static WithListSort<List<ByteBuffer>> create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+        {
+            return new WithListSort<>(limit, offset, r -> r, r -> r, comparator);
+        }
+
+        public static WithListSort<RowWithScore> create(int limit, int offset, Index.Scorer scorer)
+        {
+            return new WithListSort<>(limit, offset,
+                                  r -> new RowWithScore(r, scorer.score(r)),
+                                  rs -> rs.row,
+                                      (x, y) -> scorer.reversed()
+                                            ? Float.compare(y.score, x.score)
+                                            : Float.compare(x.score, y.score));
+        }
+
+        private WithListSort(int limit,
+                             int offset,
+                             Function<List<ByteBuffer>, T> decorator,
+                             Function<T, List<ByteBuffer>> undecorator,
+                             Comparator<T> comparator)
+        {
+            super(limit, offset);
+            this.comparator = comparator;
+            this.decorator = decorator;
+            this.undecorator = undecorator;
+        }
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            rows.add(decorator.apply(row));
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            rows.sort(comparator);
+
+            // trim the results and undecorate them
+            List<List<ByteBuffer>> result = new ArrayList<>();
+            for (int i = offset; i < Math.min(limit + offset, rows.size()); i++)
+            {
+                result.add(undecorator.apply(rows.get(i)));
+            }
+
+            return result;
+        }
+
+        /**
+         * A row decorated with its score assigned by a {@link Index.Scorer},
+         * so we don't need to recalculate that score in every comparison.
+         */
+        private static final class RowWithScore
+        {
+            private final List<ByteBuffer> row;
+            private final float score;
+
+            private RowWithScore(List<ByteBuffer> row, float score)
+            {
+                this.row = row;
+                this.score = score;
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.restrictions.ExternalRestriction;
 import org.apache.cassandra.cql3.restrictions.Restrictions;
 import org.apache.cassandra.cql3.restrictions.SingleRestriction;
+import org.apache.cassandra.cql3.selection.SortedRowsBuilder;
 import org.apache.cassandra.db.marshal.MultiCellCapableType;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.index.Index;
@@ -108,6 +109,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     public static final String TOPK_CONSISTENCY_LEVEL_WARNING = "Top-K queries can only be run with consistency level ONE " +
                                                                 "/ LOCAL_ONE / NODE_LOCAL. Consistency level %s was requested. " +
                                                                 "Downgrading the consistency level to %s.";
+    public static final String TOPK_OFFSET_ERROR = "Top-K queries cannot be run with an offset. Offset was set to %d.";
 
     private final String rawCQLStatement;
     public final VariableSpecifications bindVariables;
@@ -116,6 +118,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     private final Selection selection;
     private final Term limit;
     private final Term perPartitionLimit;
+    private final Term offset;
 
     private final StatementRestrictions restrictions;
 
@@ -148,7 +151,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            AggregationSpecification aggregationSpec,
                            ColumnComparator<List<ByteBuffer>> orderingComparator,
                            Term limit,
-                           Term perPartitionLimit)
+                           Term perPartitionLimit,
+                           Term offset)
     {
         this.rawCQLStatement = queryString;
         this.table = table;
@@ -161,6 +165,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         this.parameters = parameters;
         this.limit = limit;
         this.perPartitionLimit = perPartitionLimit;
+        this.offset = offset;
     }
 
     @Override
@@ -225,6 +230,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                    null,
                                    null,
                                    null,
+                                   null,
                                    null);
     }
 
@@ -274,7 +280,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                    aggregationSpec,
                                    orderingComparator,
                                    limit,
-                                   perPartitionLimit);
+                                   perPartitionLimit,
+                                   offset);
     }
 
     /**
@@ -295,7 +302,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                    aggregationSpec,
                                    orderingComparator,
                                    limit,
-                                   perPartitionLimit);
+                                   perPartitionLimit,
+                                   offset);
     }
 
     private void validateQueryOptions(QueryState queryState, QueryOptions options)
@@ -331,34 +339,17 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         int nowInSec = options.getNowInSeconds(queryState);
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
+        int userOffset = getOffset(options);
         PageSize pageSize = options.getPageSize();
 
         Selectors selectors = selection.newSelectors(options);
-        ReadQuery query = getQuery(queryState, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, pageSize);
-
-        // Handle additional validation for topK queries
-        if (query.isTopK()) {
-                // We aren't going to allow SERIAL at all, so we can error out on those.
-                checkFalse(options.getConsistency() == ConsistencyLevel.LOCAL_SERIAL ||
-                           options.getConsistency() == ConsistencyLevel.SERIAL,
-                           String.format(TOPK_CONSISTENCY_LEVEL_ERROR, options.getConsistency()));
-
-                if (options.getConsistency() != ConsistencyLevel.ONE &&
-                    options.getConsistency() != ConsistencyLevel.LOCAL_ONE &&
-                    options.getConsistency() != ConsistencyLevel.NODE_LOCAL)
-                {
-                    ConsistencyLevel supplied = options.getConsistency();
-                    ConsistencyLevel downgrade = supplied.isDatacenterLocal() ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE;
-                    options.updateConsistency(downgrade);
-                    ClientWarn.instance.warn(String.format(TOPK_CONSISTENCY_LEVEL_WARNING, supplied, downgrade));
-                }
-        }
+        ReadQuery query = getQuery(queryState, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, userOffset);
 
         if (query.limits().isGroupByLimit() && pageSize != null && pageSize.isDefined() && pageSize.getUnit() == PageSize.PageUnit.BYTES)
             throw new InvalidRequestException("Paging in bytes cannot be specified for aggregation queries");
 
         if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize, query.isTopK()))
-            return execute(query, options, queryState, selectors, nowInSec, userLimit, queryStartNanoTime);
+            return execute(query, options, queryState, selectors, nowInSec, userLimit, userOffset, queryStartNanoTime);
 
         QueryPager pager = getPager(query, options);
 
@@ -368,6 +359,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                        pageSize,
                        nowInSec,
                        userLimit,
+                       userOffset,
                        queryStartNanoTime);
     }
 
@@ -380,7 +372,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                         nowInSec,
                         getLimit(options),
                         getPerPartitionLimit(options),
-                        options.getPageSize());
+                        getOffset(options));
     }
 
     public ReadQuery getQuery(QueryState queryState,
@@ -389,16 +381,40 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                               int nowInSec,
                               int userLimit,
                               int perPartitionLimit,
-                              PageSize pageSize)
+                              int userOffset)
     {
         boolean isPartitionRangeQuery = restrictions.isKeyRange() || restrictions.usesSecondaryIndexing() || restrictions.isDisjunction();
 
-        DataLimits limit = getDataLimits(queryState, userLimit, perPartitionLimit);
+        DataLimits dataLimits = getDataLimits(queryState, userLimit, perPartitionLimit, userOffset);
 
-        if (isPartitionRangeQuery)
-            return getRangeCommand(options, columnFilter, limit, nowInSec, queryState);
+        ReadQuery query = isPartitionRangeQuery
+                        ? getRangeCommand(options, columnFilter, dataLimits, nowInSec, queryState)
+                        : getSliceCommands(queryState, options, columnFilter, dataLimits, nowInSec);
 
-        return getSliceCommands(queryState, options, columnFilter, limit, nowInSec);
+        // Handle additional validation for topK queries
+        if (query.isTopK())
+        {
+            // We aren't going to allow SERIAL at all, so we can error out on those.
+            checkFalse(options.getConsistency() == ConsistencyLevel.LOCAL_SERIAL ||
+                       options.getConsistency() == ConsistencyLevel.SERIAL,
+                       String.format(TOPK_CONSISTENCY_LEVEL_ERROR, options.getConsistency()));
+
+            // Consistency levels with more than one replica are downgraded to ONE/LOCAL_ONE.
+            if (options.getConsistency() != ConsistencyLevel.ONE &&
+                options.getConsistency() != ConsistencyLevel.LOCAL_ONE &&
+                options.getConsistency() != ConsistencyLevel.NODE_LOCAL)
+            {
+                ConsistencyLevel supplied = options.getConsistency();
+                ConsistencyLevel downgrade = supplied.isDatacenterLocal() ? ConsistencyLevel.LOCAL_ONE : ConsistencyLevel.ONE;
+                options.updateConsistency(downgrade);
+                ClientWarn.instance.warn(String.format(TOPK_CONSISTENCY_LEVEL_WARNING, supplied, downgrade));
+            }
+
+            // We don't support offset for top-k queries.
+            checkFalse(userOffset > 0, String.format(TOPK_OFFSET_ERROR, userOffset));
+        }
+
+        return query;
     }
 
     private ResultMessage.Rows execute(ReadQuery query,
@@ -406,11 +422,13 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        QueryState queryState,
                                        Selectors selectors,
                                        int nowInSec,
-                                       int userLimit, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
+                                       int userLimit,
+                                       int userOffset,
+                                       long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
     {
         try (PartitionIterator data = query.execute(options.getConsistency(), queryState, queryStartNanoTime))
         {
-            return processResults(data, options, selectors, nowInSec, userLimit);
+            return processResults(data, options, selectors, nowInSec, userLimit, userOffset);
         }
     }
 
@@ -452,6 +470,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         public abstract PartitionIterator fetchPage(PageSize pageSize, long queryStartNanoTime);
 
+        public abstract PartitionIterator readAll(PageSize pageSize, long queryStartNanoTime);
+
         public static class NormalPager extends Pager
         {
             private final ConsistencyLevel consistency;
@@ -464,9 +484,16 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                 this.queryState = queryState;
             }
 
+            @Override
             public PartitionIterator fetchPage(PageSize pageSize, long queryStartNanoTime)
             {
                 return pager.fetchPage(pageSize, consistency, queryState, queryStartNanoTime);
+            }
+
+            @Override
+            public PartitionIterator readAll(PageSize pageSize, long queryStartNanoTime)
+            {
+                return pager.readAll(pageSize, consistency, queryState, queryStartNanoTime);
             }
         }
 
@@ -480,9 +507,16 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                 this.executionController = executionController;
             }
 
+            @Override
             public PartitionIterator fetchPage(PageSize pageSize, long queryStartNanoTime)
             {
                 return pager.fetchPageInternal(pageSize, executionController);
+            }
+
+            @Override
+            public PartitionIterator readAll(PageSize pageSize, long queryStartNanoTime)
+            {
+                return pager.readAllInternal(pageSize, executionController);
             }
         }
     }
@@ -493,6 +527,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        PageSize pageSize,
                                        int nowInSec,
                                        int userLimit,
+                                       int userOffset,
                                        long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
     {
         if (aggregationSpec != null)
@@ -517,10 +552,16 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                   "Cannot page queries with both ORDER BY and a IN restriction on the partition key;"
                   + " you must either remove the ORDER BY or the IN and sort client side, or disable paging for this query");
 
+        // If the query has an offset we silently ignore user-facing paging and return all the rows specified by the
+        // limit/offset constraints in one go, since regular key-based paging is not supported when using limit/offest
+        // paging. However, we still use the query fetch size to internally page the rows. We do that to avoid loading
+        // in memory all the rows that will be discarded by the offset.
         ResultMessage.Rows msg;
-        try (PartitionIterator page = pager.fetchPage(pageSize, queryStartNanoTime))
+        try (PartitionIterator partitions = userOffset > 0
+                                          ? pager.readAll(pageSize, queryStartNanoTime)
+                                          : pager.fetchPage(pageSize, queryStartNanoTime))
         {
-            msg = processResults(page, options, selectors, nowInSec, userLimit);
+            msg = processResults(partitions, options, selectors, nowInSec, userLimit, userOffset);
         }
 
         // Please note that the isExhausted state of the pager only gets updated when we've closed the page, so this
@@ -541,9 +582,10 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                               QueryOptions options,
                                               Selectors selectors,
                                               int nowInSec,
-                                              int userLimit) throws RequestValidationException
+                                              int userLimit,
+                                              int userOffset) throws RequestValidationException
     {
-        ResultSet rset = process(partitions, options, selectors, nowInSec, userLimit);
+        ResultSet rset = process(partitions, options, selectors, nowInSec, userLimit, userOffset);
         return new ResultMessage.Rows(rset);
     }
 
@@ -556,10 +598,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     {
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
+        int userOffset = getOffset(options);
         PageSize pageSize = options.getPageSize();
 
         Selectors selectors = selection.newSelectors(options);
-        ReadQuery query = getQuery(state, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, pageSize);
+        ReadQuery query = getQuery(state, options, selectors.getColumnFilter(), nowInSec, userLimit, userPerPartitionLimit, userOffset);
 
         try (ReadExecutionController executionController = query.executionController())
         {
@@ -567,7 +610,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             {
                 try (PartitionIterator data = query.executeInternal(executionController))
                 {
-                    return processResults(data, options, selectors, nowInSec, userLimit);
+                    return processResults(data, options, selectors, nowInSec, userLimit, userOffset);
                 }
             }
 
@@ -579,6 +622,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            pageSize,
                            nowInSec,
                            userLimit,
+                           userOffset,
                            queryStartNanoTime);
         }
     }
@@ -598,7 +642,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     {
         QueryOptions options = QueryOptions.DEFAULT;
         Selectors selectors = selection.newSelectors(options);
-        return process(partitions, options, selectors, nowInSec, getLimit(options));
+        return process(partitions, options, selectors, nowInSec, getLimit(options), getOffset(options));
     }
 
     @Override
@@ -794,8 +838,14 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         return builder.build();
     }
 
-    private DataLimits getDataLimits(QueryState queryState, int userLimit, int perPartitionLimit)
+    private DataLimits getDataLimits(QueryState queryState, int userLimit, int perPartitionLimit, int userOffset)
     {
+        assert userOffset == 0 || userLimit != NO_LIMIT : "Cannot use OFFSET without LIMIT";
+
+        if (userOffset > 0)
+            Guardrails.offsetRows.guard(userOffset, "Select query", false, queryState);
+
+        int fetchLimit = userLimit == NO_LIMIT ? userLimit : userLimit + userOffset;
         int cqlRowLimit = NO_LIMIT;
         int cqlPerPartitionLimit = NO_LIMIT;
 
@@ -803,7 +853,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         if (aggregationSpec != AggregationSpecification.AGGREGATE_EVERYTHING)
         {
             if (!needsToSkipUserLimit())
-                cqlRowLimit = userLimit;
+                cqlRowLimit = fetchLimit;
             cqlPerPartitionLimit = perPartitionLimit;
         }
 
@@ -891,6 +941,31 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         return userLimit;
     }
 
+    private int getOffset(QueryOptions options)
+    {
+        int userOffset = 0;
+
+        if (offset != null)
+        {
+            ByteBuffer b = checkNotNull(offset.bindAndGet(options), "Invalid null value of offset");
+            // treat UNSET limit value as zero
+            if (b != UNSET_BYTE_BUFFER)
+            {
+                try
+                {
+                    Int32Type.instance.validate(b);
+                    userOffset = Int32Type.instance.compose(b);
+                    checkTrue(userOffset >= 0, "Offset must be positive");
+                }
+                catch (MarshalException e)
+                {
+                    throw new InvalidRequestException("Invalid offset value");
+                }
+            }
+        }
+        return userOffset;
+    }
+
     private NavigableSet<Clustering<?>> getRequestedRows(QueryOptions options, QueryState queryState) throws InvalidRequestException
     {
         // Note: getRequestedColumns don't handle static columns, but due to CASSANDRA-5762
@@ -912,10 +987,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                               QueryOptions options,
                               Selectors selectors,
                               int nowInSec,
-                              int userLimit) throws InvalidRequestException
+                              int userLimit,
+                              int userOffset) throws InvalidRequestException
     {
         GroupMaker groupMaker = aggregationSpec == null ? null : aggregationSpec.newGroupMaker();
-        ResultSetBuilder result = new ResultSetBuilder(getResultMetadata(), selectors, groupMaker);
+        SortedRowsBuilder rows = sortedRowsBuilder(userLimit, userOffset, options);
+        ResultSetBuilder result = new ResultSetBuilder(getResultMetadata(), selectors, groupMaker, rows);
 
         while (partitions.hasNext())
         {
@@ -925,36 +1002,16 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             }
         }
 
-        ResultSet cqlRows = result.build();
-
         ColumnFamilyStore store = cfs();
         if (store != null)
-            store.metric.coordinatorReadSize.update(calculateSize(cqlRows.rows));
+            store.metric.coordinatorReadSize.update(result.readRowsSize());
 
-        orderResults(cqlRows, options);
-
-        cqlRows.trim(userLimit);
-
-        return cqlRows;
+        return result.build();
     }
 
     public ColumnFamilyStore cfs()
     {
         return Schema.instance.getColumnFamilyStoreInstance(table.id);
-    }
-
-    private int calculateSize(List<List<ByteBuffer>> rows)
-    {
-        int size = 0;
-        for (List<ByteBuffer> row : rows)
-        {
-            for (int i = 0, isize = row.size(); i < isize; i++)
-            {
-                ByteBuffer value = row.get(i);
-                size += value != null ? value.remaining() : 0;
-            }
-        }
-        return size;
     }
 
     public static ByteBuffer[] getComponents(TableMetadata metadata, DecoratedKey dk)
@@ -1069,27 +1126,30 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     /**
      * Orders results when multiple keys are selected (using IN)
      */
-    public void orderResults(ResultSet cqlRows, QueryOptions options)
+    public SortedRowsBuilder sortedRowsBuilder(int limit, int offset, QueryOptions options)
     {
-        if (cqlRows.size() == 0 || !needsPostQueryOrdering())
-            return;
+        assert (orderingComparator != null) == needsPostQueryOrdering()
+                : String.format("orderingComparator: %s, needsPostQueryOrdering: %s",
+                                orderingComparator, needsPostQueryOrdering());
 
-        if (orderingComparator != null)
+        if (orderingComparator == null)
         {
-            if (orderingComparator instanceof IndexColumnComparator)
-            {
-                SingleRestriction restriction = ((IndexColumnComparator<?>) orderingComparator).restriction;
-                int columnIndex = ((IndexColumnComparator<?>) orderingComparator).columnIndex;
+            return SortedRowsBuilder.create(limit, offset);
+        }
+        else if (orderingComparator instanceof IndexColumnComparator)
+        {
+            SingleRestriction restriction = ((IndexColumnComparator<?>) orderingComparator).restriction;
+            int columnIndex = ((IndexColumnComparator<?>) orderingComparator).columnIndex;
 
-                Index index = restriction.findSupportingIndex(IndexRegistry.obtain(table));
-                assert index != null;
+            Index index = restriction.findSupportingIndex(IndexRegistry.obtain(table));
+            assert index != null;
 
-                index.postQuerySort(cqlRows, restriction, columnIndex, options);
-            }
-            else
-            {
-                Collections.sort(cqlRows.rows, orderingComparator);
-            }
+            Index.Scorer scorer = index.postQueryScorer(restriction, columnIndex, options);
+            return SortedRowsBuilder.create(limit, offset, scorer);
+        }
+        else
+        {
+            return SortedRowsBuilder.create(limit, offset, orderingComparator);
         }
     }
 
@@ -1100,13 +1160,15 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         public final WhereClause whereClause;
         public final Term.Raw limit;
         public final Term.Raw perPartitionLimit;
+        public final Term.Raw offset;
 
         public RawStatement(QualifiedName cfName,
                             Parameters parameters,
                             List<RawSelector> selectClause,
                             WhereClause whereClause,
                             Term.Raw limit,
-                            Term.Raw perPartitionLimit)
+                            Term.Raw perPartitionLimit,
+                            Term.Raw offset)
         {
             super(cfName);
             this.parameters = parameters;
@@ -1114,6 +1176,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             this.whereClause = whereClause;
             this.limit = limit;
             this.perPartitionLimit = perPartitionLimit;
+            this.offset = offset;
         }
 
         @Override
@@ -1187,7 +1250,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        aggregationSpec,
                                        orderingComparator,
                                        prepareLimit(bindVariables, limit, ks, limitReceiver()),
-                                       prepareLimit(bindVariables, perPartitionLimit, ks, perPartitionLimitReceiver()));
+                                       prepareLimit(bindVariables, perPartitionLimit, ks, perPartitionLimitReceiver()),
+                                       prepareLimit(bindVariables, offset, ks, offsetReceiver()));
         }
 
         private Set<ColumnMetadata> getResultSetOrdering(StatementRestrictions restrictions, Map<ColumnMetadata, Ordering> orderingColumns)
@@ -1513,6 +1577,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         private ColumnSpecification perPartitionLimitReceiver()
         {
             return new ColumnSpecification(keyspace(), name(), new ColumnIdentifier("[per_partition_limit]", true), Int32Type.instance);
+        }
+
+        private ColumnSpecification offsetReceiver()
+        {
+            return new ColumnSpecification(keyspace(), name(), new ColumnIdentifier("[offset]", true), Int32Type.instance);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/view/View.java
+++ b/src/java/org/apache/cassandra/db/view/View.java
@@ -174,6 +174,7 @@ public class View
                                                  selectClause(),
                                                  definition.whereClause,
                                                  null,
+                                                 null,
                                                  null);
 
             rawSelect.setBindVariables(Collections.emptyList());

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -254,6 +254,17 @@ public abstract class Guardrails
                                                     "atomicity, or asynchronous writes for performance.",
                                                     v, what.contains(", ") ? "s" : "", what));
 
+    /**
+     * Guardrail on the number of rows that a SELECT query with LIMIT/OFFSET can skip.
+     */
+    public static final Threshold offsetRows =
+    factory.threshold("offset_rows",
+                      () -> config.offset_rows_warn_threshold,
+                      () -> config.offset_rows_failure_threshold,
+                      (isWarning, what, value, threshold) ->
+                      format("%s requested to skip %s rows, this exceeds the %s threshold of %s.",
+                             what, value, isWarning ? "warning" : "failure", threshold));
+
     private static String formatSize(long size)
     {
         return Units.toString(size, SizeUnit.BYTES);

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -141,6 +141,10 @@ public class GuardrailsConfig
 
     public volatile Integer partition_size_warn_threshold_in_mb;
 
+    // Limit the offset used in SELECT queries
+    public volatile Integer offset_rows_warn_threshold;
+    public volatile Integer offset_rows_failure_threshold;
+
     /**
      * If {@link DatabaseDescriptor#isEmulateDbaasDefaults()} is true, apply cloud defaults to guardrails settings that
      * are not specified in yaml; otherwise, apply on-prem defaults to guardrails settings that are not specified in yaml;
@@ -227,6 +231,9 @@ public class GuardrailsConfig
         if (overrideTotalFailureThreshold != UNSET)
             sai_indexes_total_failure_threshold = overrideTotalFailureThreshold;
         enforceDefault(sai_indexes_total_failure_threshold, v -> sai_indexes_total_failure_threshold = v, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD);
+
+        enforceDefault(offset_rows_warn_threshold, v -> offset_rows_warn_threshold = v, 10000, 10000);
+        enforceDefault(offset_rows_failure_threshold, v -> offset_rows_failure_threshold = v, 20000, 20000);
     }
 
     /**
@@ -289,6 +296,10 @@ public class GuardrailsConfig
                                                         + "'%s' does not parse as a Consistency Level", rawCL));
             }
         }
+
+        validateStrictlyPositiveInteger(offset_rows_warn_threshold, "offset_rows_warn_threshold");
+        validateStrictlyPositiveInteger(offset_rows_failure_threshold, "offset_rows_failure_threshold");
+        validateWarnLowerThanFail(offset_rows_warn_threshold, offset_rows_failure_threshold, "offset_rows_threshold");
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -448,16 +448,37 @@ public interface Index
     public RowFilter getPostIndexQueryFilter(RowFilter filter);
 
     /**
-     * Reorder query result before sending to client
+     * Returns a {@link Scorer} to give a similarity/proximity score to CQL result rows, so they can be ordered by the
+     * coordinator before sending them to client.
      *
-     * @param cqlRows     result set from a query
      * @param restriction restriction that requires current index
      * @param columnIndex idx of the indexed column in returned row
      * @param options     query options
+     * @return a scorer to score the rows
      */
-    default void postQuerySort(ResultSet cqlRows, Restriction restriction, int columnIndex, QueryOptions options)
+    default Scorer postQueryScorer(Restriction restriction, int columnIndex, QueryOptions options)
     {
         throw new NotImplementedException();
+    }
+
+    /**
+     * Gives a similarity/proximity score to CQL result rows.
+     */
+    interface Scorer
+    {
+        /**
+         * @param row a CQL result row
+         * @return the similarity/proximity score for the row
+         */
+        float score(List<ByteBuffer> row);
+
+        /**
+         * @return {@code true} if higher scores are considered better, {@code false} otherwise
+         */
+        default boolean reversed()
+        {
+            return false;
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/pager/PagedPartitionIterator.java
+++ b/src/java/org/apache/cassandra/service/pager/PagedPartitionIterator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.service.pager;
+
+import org.apache.cassandra.cql3.PageSize;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.ReadExecutionController;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.service.QueryState;
+
+/**
+ * A partition iterator that reads its rows from a provided {@link QueryPager}, consuming it until it's exhausted.
+ */
+abstract class PagedPartitionIterator implements PartitionIterator
+{
+    protected final QueryPager pager;
+    protected final PageSize pageSize;
+    protected PartitionIterator current;
+
+    protected PagedPartitionIterator(QueryPager pager, PageSize pageSize)
+    {
+        this.pager = pager;
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    public void close()
+    {
+        if (current != null)
+        {
+            current.close();
+            current = null;
+        }
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        maybeFetch();
+        return current != null && current.hasNext();
+    }
+
+    @Override
+    public RowIterator next()
+    {
+        maybeFetch();
+        return current.next();
+    }
+
+    private void maybeFetch()
+    {
+        if (current == null || !current.hasNext())
+        {
+            if (current != null)
+            {
+                current.close();
+                current = null;
+            }
+
+            if (!pager.isExhausted())
+                current = fetch();
+        }
+    }
+
+    protected abstract PartitionIterator fetch();
+
+    /**
+     * {@link PagedPartitionIterator} that for local queries.
+     */
+    public static class Internal extends PagedPartitionIterator
+    {
+        private final ReadExecutionController controller;
+
+        public Internal(QueryPager pager, PageSize pageSize, ReadExecutionController controller)
+        {
+            super(pager, pageSize);
+            this.controller = controller;
+        }
+
+        @Override
+        protected PartitionIterator fetch()
+        {
+            return pager.fetchPageInternal(pageSize, controller);
+        }
+    }
+
+    /**
+     * {@link PagedPartitionIterator} that for distributed queries.
+     */
+    public static class Distributed extends PagedPartitionIterator
+    {
+        private final ConsistencyLevel consistency;
+        private final QueryState state;
+        private final long queryStartNanoTime;
+
+        public Distributed(QueryPager pager,
+                           PageSize pageSize,
+                           ConsistencyLevel consistency,
+                           QueryState state,
+                           long queryStartNanoTime)
+        {
+            super(pager, pageSize);
+            this.consistency = consistency;
+            this.state = state;
+            this.queryStartNanoTime = queryStartNanoTime;
+        }
+
+        @Override
+        protected PartitionIterator fetch()
+        {
+            return pager.fetchPage(pageSize, consistency, state, queryStartNanoTime);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/service/pager/QueryPager.java
+++ b/src/java/org/apache/cassandra/service/pager/QueryPager.java
@@ -157,4 +157,36 @@ public interface QueryPager
     {
         return false;
     }
+
+    /**
+     * Reads all the rows in this pager using paging internally.
+     * </p>
+     * Pages will be lazily fetched according to the provided page size as the returned {@link PartitionIterator} is
+     * consumed.
+     *
+     * @param pageSize the maximum number of elements to be fetched on each internal page.
+     * @param consistency the consistency level to achieve for the query.
+     * @param queryState the {@code QueryState} for the query. In practice, this can be null unless {@code consistency}
+     * is a serial consistency.
+     * @return all the rows in this pager.
+     */
+    default PartitionIterator readAll(PageSize pageSize, ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime)
+    {
+        return new PagedPartitionIterator.Distributed(this, pageSize, consistency, queryState, queryStartNanoTime);
+    }
+
+    /**
+     * Reads all the rows in this pager using paging internally, using local queries.
+     * </p>
+     * Pages will be lazily fetched according to the provided page size as the returned {@link PartitionIterator} is
+     * consumed.
+     *
+     * @param pageSize the maximum number of elements to be fetched on each internal page.
+     * @param executionController the {@code ReadExecutionController} protecting the read.
+     * @return all the rows in this pager.
+     */
+    default PartitionIterator readAllInternal(PageSize pageSize, ReadExecutionController executionController)
+    {
+        return new PagedPartitionIterator.Internal(this, pageSize, executionController);
+    }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.selection.SortedRowsBuilder;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.index.Index;
+import org.openjdk.jmh.annotations.*;
+
+/**
+ * Benchmarks each implementation of {@link SortedRowsBuilder}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 2) // seconds
+@Measurement(iterations = 5, time = 2) // seconds
+@Fork(value = 4)
+@Threads(4)
+@State(Scope.Benchmark)
+public class SortedRowsBuilderBench extends CQLTester
+{
+    private static final int NUM_COLUMNS = 10;
+    private static final int SORTED_COLUMN_CARDINALITY = 1000;
+    private static final Index.Scorer SCORER = row -> Int32Type.instance.compose(row.get(0));
+    private static final Comparator<List<ByteBuffer>> COMPARATOR = (o1, o2) -> Int32Type.instance.compare(o1.get(0), o2.get(0));
+    private static final Random RANDOM = new Random();
+
+    @Param({ "1", "2", "3", "4", "6", "8", "16" })
+    public int nodes;
+
+    @Param({ "100", "10000" })
+    public int limit;
+
+    @Param({ "0", "0.1", "0.5", "1" })
+    public float offsetRatio;
+
+    private int offset;
+
+    private List<List<ByteBuffer>> rows;
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable
+    {
+        int rowsPerNode = limit + offset;
+        int rowsPerCoordinator = rowsPerNode * nodes;
+        offset = (int) (rowsPerNode * offsetRatio);
+        rows = new ArrayList<>(rowsPerCoordinator);
+        for (int r = 0; r < rowsPerCoordinator; r++)
+        {
+            rows.add(randomRow());
+        }
+    }
+
+    @Benchmark
+    public Object insertion()
+    {
+        return test(SortedRowsBuilder.create(limit, offset));
+    }
+
+    @Benchmark
+    public Object comparator()
+    {
+        return test(SortedRowsBuilder.create(limit, offset, COMPARATOR));
+    }
+
+    @Benchmark
+    public Object scorer()
+    {
+        return test(SortedRowsBuilder.create(limit, offset, SCORER));
+    }
+
+    private List<List<ByteBuffer>> test(SortedRowsBuilder builder)
+    {
+        rows.forEach(builder::add);
+        return builder.build();
+    }
+
+    private static List<ByteBuffer> randomRow()
+    {
+        List<ByteBuffer> row = new ArrayList<>(NUM_COLUMNS);
+        for (int c = 0; c < NUM_COLUMNS; c++)
+        {
+            row.add(Int32Type.instance.decompose(RANDOM.nextInt(SORTED_COLUMN_CARDINALITY)));
+        }
+        return row;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/WhereClauseMutationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/WhereClauseMutationTest.java
@@ -91,7 +91,8 @@ public class WhereClauseMutationTest extends CQLTester
                                                                         rawStatement.selectClause,
                                                                         rawStatement.whereClause.mutateRelations(r -> mutateRelation(r)),
                                                                         rawStatement.limit,
-                                                                        rawStatement.perPartitionLimit);
+                                                                        rawStatement.perPartitionLimit,
+                                                                        null);
 
                         selectStatement = rawStatement.prepare(queryState.getClientState());
                         return selectStatement.execute(queryState, options, queryStartNanoTime);

--- a/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.selection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.index.Index;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests for {@link SortedRowsBuilder}.
+ */
+public class SortedRowsBuilderTest
+{
+    private static final Comparator<List<ByteBuffer>> comparator = (o1, o2) -> Int32Type.instance.compare(o1.get(0), o2.get(0));
+    private static final Comparator<List<ByteBuffer>> reverseComparator = comparator.reversed();
+
+    @Test
+    public void testRowBuilder()
+    {
+        test();
+        test(0);
+        test(0, 0, 0, 0);
+        test(0, 1, 2, 3, 5, 6, 7, 8);
+        test(8, 7, 6, 5, 3, 2, 1, 0);
+        test(1, 6, 2, 0, 7, 3, 5, 4);
+        test(1, 6, 2, 0, 7, 3, 5, 4, 4, 5, 3, 7, 0, 2, 6, 1);
+    }
+
+    private static void test(int... values)
+    {
+        List<List<ByteBuffer>> rows = toRows(values);
+
+        for (int limit = 1; limit <= values.length + 1; limit++)
+        {
+            for (int offset = 0; offset <= values.length + 1; offset++)
+            {
+                // with insertion order
+                test(rows, SortedRowsBuilder.create(limit, offset), null);
+
+                // with comparator
+                test(rows, SortedRowsBuilder.create(limit, offset, comparator), comparator);
+                test(rows, SortedRowsBuilder.create(limit, offset, reverseComparator), reverseComparator);
+
+                // with index scorer
+                test(rows, SortedRowsBuilder.create(limit, offset, scorer(false)), comparator);
+                test(rows, SortedRowsBuilder.create(limit, offset, scorer(true)), reverseComparator);
+            }
+        }
+    }
+
+    private static void test(List<List<ByteBuffer>> rows,
+                             SortedRowsBuilder builder,
+                             @Nullable Comparator<List<ByteBuffer>> comparator)
+    {
+        int limit = builder.limit;
+        int offset = builder.offset;
+
+        // get the expected values...
+        List<List<ByteBuffer>> expecetedRows = new ArrayList<>(rows);
+        if (comparator != null)
+            expecetedRows.sort(comparator);
+        expecetedRows = expecetedRows.subList(Math.min(offset, expecetedRows.size()),
+                                              Math.min(offset + limit, expecetedRows.size()));
+        List<Integer> expectedValues = fromRows(expecetedRows);
+
+        // get the actual values...
+        rows.forEach(builder::add);
+        List<Integer> actualValues = fromRows(builder.build());
+
+        // ...and compare
+        Assertions.assertThat(actualValues).isEqualTo(expectedValues);
+    }
+
+    private static List<List<ByteBuffer>> toRows(int... values)
+    {
+        List<List<ByteBuffer>> rows = new ArrayList<>();
+        for (int value : values)
+            rows.add(Collections.singletonList(Int32Type.instance.decompose(value)));
+        return rows;
+    }
+
+    private static List<Integer> fromRows(List<List<ByteBuffer>> rows)
+    {
+        List<Integer> values = new ArrayList<>();
+        for (List<ByteBuffer> row : rows)
+            values.add(Int32Type.instance.compose(row.get(0)));
+        return values;
+    }
+
+    private static Index.Scorer scorer(boolean reversed)
+    {
+        return new Index.Scorer()
+        {
+            @Override
+            public float score(List<ByteBuffer> row)
+            {
+                return Int32Type.instance.compose(row.get(0));
+            }
+
+            @Override
+            public boolean reversed()
+            {
+                return reversed;
+            }
+        };
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.validation.operations;
+
+import java.util.Arrays;
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.SyntaxException;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests for {@code SELECT} queries with {@code LIMIT} and {@code OFFSET}.
+ */
+public class SelectOffsetTest extends CQLTester
+{
+    public static final Object[][] EMPTY_ROWS = new Object[0][];
+
+    private static final Logger logger = LoggerFactory.getLogger(SelectOffsetTest.class);
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        requireNetwork();
+    }
+
+    @Test
+    public void testParseAndValidate() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+
+        // with LIMIT
+        execute("SELECT * FROM %s LIMIT 4 OFFSET 0");
+        execute("SELECT * FROM %s LIMIT 4 OFFSET 1");
+        assertRejectsNegativeOffset("SELECT * FROM %s LIMIT 4 OFFSET -1");
+        assertRejectsOffsetWithoutLimit("SELECT * FROM %s OFFSET 1");
+
+        // with PER PARTITION LIMIT
+        execute("SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 10 OFFSET 0");
+        execute("SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 10 OFFSET 1");
+        assertRejectsNegativeOffset("SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 10 OFFSET -1");
+        assertRejectsOffsetWithoutLimit("SELECT * FROM %s PER PARTITION LIMIT 2 OFFSET 1");
+
+        // with ALLOW FILTERING
+        execute("SELECT * FROM %s WHERE v=0 LIMIT 10 OFFSET 0 ALLOW FILTERING");
+        execute("SELECT * FROM %s WHERE v=0 LIMIT 10 OFFSET 1 ALLOW FILTERING");
+        assertRejectsNegativeOffset("SELECT * FROM %s WHERE v=0 LIMIT 10 OFFSET -1 ALLOW FILTERING");
+        assertRejectsOffsetWithoutLimit("SELECT * FROM %s WHERE v=0 OFFSET 1 ALLOW FILTERING");
+    }
+
+    private void assertRejectsNegativeOffset(String query) throws Throwable
+    {
+        assertInvalidThrowMessage("Offset must be positive",
+                                  InvalidRequestException.class,
+                                  query);
+    }
+
+    private void assertRejectsOffsetWithoutLimit(String query) throws Throwable
+    {
+        assertInvalidThrowMessage("[OFFSET]",
+                                  SyntaxException.class,
+                                  query);
+    }
+
+    @Test
+    public void testSkinnyTable() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+
+        // test with empty table
+        testLimitAndOffset("SELECT * FROM %s");
+        testLimitAndOffset("SELECT * FROM %s WHERE k=2");
+        testLimitAndOffset("SELECT * FROM %s WHERE v=30");
+        testLimitAndOffset("SELECT k, v, sum(v) FROM %s", row(null, null, 0));
+
+        // write some data
+        execute("INSERT INTO %s (k, v) VALUES (1, 10)");
+        execute("INSERT INTO %s (k, v) VALUES (2, 20)");
+        execute("INSERT INTO %s (k, v) VALUES (3, 30)");
+        execute("INSERT INTO %s (k, v) VALUES (4, 40)");
+
+        testLimitAndOffset("SELECT * FROM %s", row(1, 10), row(2, 20), row(4, 40), row(3, 30));
+        testLimitAndOffset("SELECT * FROM %s WHERE k=2", row(2, 20));
+        testLimitAndOffset("SELECT * FROM %s WHERE k<2", row(1, 10));
+        testLimitAndOffset("SELECT * FROM %s WHERE k>2", row(4, 40), row(3, 30));
+        testLimitAndOffset("SELECT * FROM %s WHERE v=30", row(3, 30));
+        testLimitAndOffset("SELECT * FROM %s WHERE v<30", row(1, 10), row(2, 20));
+        testLimitAndOffset("SELECT * FROM %s WHERE v>30", row(4, 40));
+        testLimitAndOffset("SELECT k, v, sum(v) FROM %s", row(1, 10, 100));
+    }
+
+    @Test
+    public void testWideTable() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2))");
+
+        // test with empty table
+        testLimitAndOffset("SELECT * FROM %s");
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 3");
+        testLimitAndOffset("SELECT * FROM %s GROUP BY k, c1");
+        testLimitAndOffset("SELECT k, c1, c2, sum(v) FROM %s GROUP BY k, c1");
+        testLimitAndOffset("SELECT k, c1, c2, sum(v) FROM %s", row(null, null, null, 0));
+
+        // write some data
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, 0, 0)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, 1, 1)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, 2, 2)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 1, 0, 3)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 1, 1, 4)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (0, 1, 2, 5)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 0, 0, 6)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 0, 1, 7)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 0, 2, 8)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 1, 0, 9)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 1, 1, 10)");
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (1, 1, 2, 11)");
+
+        testLimitAndOffset("SELECT * FROM %s",
+                           row(1, 0, 0, 6),
+                           row(1, 0, 1, 7),
+                           row(1, 0, 2, 8),
+                           row(1, 1, 0, 9),
+                           row(1, 1, 1, 10),
+                           row(1, 1, 2, 11),
+                           row(0, 0, 0, 0),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 2, 2),
+                           row(0, 1, 0, 3),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 2, 5));
+
+        // With filtering restrictions
+        testLimitAndOffset("SELECT * FROM %s WHERE k=0",
+                           row(0, 0, 0, 0),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 2, 2),
+                           row(0, 1, 0, 3),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 2, 5));
+        testLimitAndOffset("SELECT * FROM %s WHERE k=0 AND c1=1",
+                           row(0, 1, 0, 3),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 2, 5));
+        testLimitAndOffset("SELECT * FROM %s WHERE v>2 AND v<8",
+                           row(1, 0, 0, 6),
+                           row(1, 0, 1, 7),
+                           row(0, 1, 0, 3),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 2, 5));
+        testLimitAndOffset("SELECT * FROM %s WHERE v<=2 OR v>=8",
+                           row(1, 0, 2, 8),
+                           row(1, 1, 0, 9),
+                           row(1, 1, 1, 10),
+                           row(1, 1, 2, 11),
+                           row(0, 0, 0, 0),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 2, 2));
+
+        // With PER PARTITION LIMIT
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 3",
+                           row(1, 0, 0, 6),
+                           row(1, 0, 1, 7),
+                           row(1, 0, 2, 8),
+                           row(0, 0, 0, 0),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 2, 2));
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 1",
+                           row(1, 0, 0, 6),
+                           row(0, 0, 0, 0));
+
+        // With aggregation
+        testLimitAndOffset("SELECT k, c1, c2, sum(v) FROM %s", row(1, 0, 0, 66));
+        testLimitAndOffset("SELECT count(*) FROM %s", row(12L));
+
+        // With GROUP BY
+        testLimitAndOffset("SELECT * FROM %s GROUP BY k, c1",
+                           row(1, 0, 0, 6),
+                           row(1, 1, 0, 9),
+                           row(0, 0, 0, 0),
+                           row(0, 1, 0, 3));
+        testLimitAndOffset("SELECT k, c1, c2, sum(v) FROM %s GROUP BY k, c1",
+                           row(1, 0, 0, 21),
+                           row(1, 1, 0, 30),
+                           row(0, 0, 0, 3),
+                           row(0, 1, 0, 12));
+
+        // With ORDER BY
+        testLimitAndOffset("SELECT * FROM %s WHERE k = 0 ORDER BY c1 DESC",
+                           row(0, 1, 2, 5),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 0, 3),
+                           row(0, 0, 2, 2),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 0, 0));
+        testLimitAndOffset("SELECT * FROM %s WHERE k = 0 ORDER BY c1 DESC PER PARTITION LIMIT 4",
+                           row(0, 1, 2, 5),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 0, 3),
+                           row(0, 0, 2, 2));
+        testLimitAndOffset("SELECT * FROM %s WHERE k = 0 ORDER BY c1 DESC PER PARTITION LIMIT 1",
+                           row(0, 1, 2, 5));
+
+        // With keys IN
+        testLimitAndOffset("SELECT * FROM %s WHERE k IN (1, 0)",
+                           row(0, 0, 0, 0),
+                           row(0, 0, 1, 1),
+                           row(0, 0, 2, 2),
+                           row(0, 1, 0, 3),
+                           row(0, 1, 1, 4),
+                           row(0, 1, 2, 5),
+                           row(1, 0, 0, 6),
+                           row(1, 0, 1, 7),
+                           row(1, 0, 2, 8),
+                           row(1, 1, 0, 9),
+                           row(1, 1, 1, 10),
+                           row(1, 1, 2, 11));
+        testLimitAndOffsetWithoutPaging("SELECT * FROM %s WHERE k IN (1, 0) ORDER BY c1, c2",
+                                        row(0, 0, 0, 0),
+                                        row(1, 0, 0, 6),
+                                        row(0, 0, 1, 1),
+                                        row(1, 0, 1, 7),
+                                        row(0, 0, 2, 2),
+                                        row(1, 0, 2, 8),
+                                        row(0, 1, 0, 3),
+                                        row(1, 1, 0, 9),
+                                        row(0, 1, 1, 4),
+                                        row(1, 1, 1, 10),
+                                        row(0, 1, 2, 5),
+                                        row(1, 1, 2, 11));
+        testLimitAndOffsetWithoutPaging("SELECT * FROM %s WHERE k IN (1, 0) ORDER BY c1 DESC, c2 DESC",
+                                        row(0, 1, 2, 5),
+                                        row(1, 1, 2, 11),
+                                        row(0, 1, 1, 4),
+                                        row(1, 1, 1, 10),
+                                        row(0, 1, 0, 3),
+                                        row(1, 1, 0, 9),
+                                        row(0, 0, 2, 2),
+                                        row(1, 0, 2, 8),
+                                        row(0, 0, 1, 1),
+                                        row(1, 0, 1, 7),
+                                        row(0, 0, 0, 0),
+                                        row(1, 0, 0, 6));
+    }
+
+    @Test
+    public void testWideTableWithStatic() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v int, s int static, PRIMARY KEY (k, c))");
+
+        // test with empty table
+        testLimitAndOffset("SELECT * FROM %s");
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 1");
+
+        // write some data
+        execute("INSERT INTO %s (k, s) VALUES (0, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 0)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 2, 0)");
+        execute("INSERT INTO %s (k, s) VALUES (1, 0)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 0)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 2, 1)");
+
+        testLimitAndOffset("SELECT * FROM %s",
+                           row(1, 0, 0, 1),
+                           row(1, 1, 0, 0),
+                           row(1, 2, 0, 1),
+                           row(0, 0, 1, 0),
+                           row(0, 1, 1, 1),
+                           row(0, 2, 1, 0));
+        testLimitAndOffset("SELECT k, s FROM %s",
+                           row(1, 0),
+                           row(1, 0),
+                           row(1, 0),
+                           row(0, 1),
+                           row(0, 1),
+                           row(0, 1));
+        testLimitAndOffset("SELECT s FROM %s",
+                           row(0),
+                           row(0),
+                           row(0),
+                           row(1),
+                           row(1),
+                           row(1));
+
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 2",
+                           row(1, 0, 0, 1),
+                           row(1, 1, 0, 0),
+                           row(0, 0, 1, 0),
+                           row(0, 1, 1, 1));
+        testLimitAndOffset("SELECT * FROM %s PER PARTITION LIMIT 1",
+                           row(1, 0, 0, 1),
+                           row(0, 0, 1, 0));
+    }
+
+    @Test
+    public void testANN()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        execute("INSERT INTO %s (k, v) VALUES (1, [1])");
+        execute("INSERT INTO %s (k, v) VALUES (2, [4])");
+        execute("INSERT INTO %s (k, v) VALUES (3, [2])");
+        execute("INSERT INTO %s (k, v) VALUES (4, [3])");
+        execute("INSERT INTO %s (k, v) VALUES (5, [2])");
+
+        // offset 0 is equivalent to no offset, so it's allowed
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 10 OFFSET 0"),
+                   row(1, vector(1f)),
+                   row(5, vector(2f)),
+                   row(3, vector(2f)),
+                   row(4, vector(3f)),
+                   row(2, vector(4f)));
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 5 OFFSET 0"),
+                   row(1, vector(1f)),
+                   row(5, vector(2f)),
+                   row(3, vector(2f)),
+                   row(4, vector(3f)),
+                   row(2, vector(4f)));
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 4 OFFSET 0"),
+                   row(1, vector(1f)),
+                   row(5, vector(2f)),
+                   row(3, vector(2f)),
+                   row(4, vector(3f)));
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 3 OFFSET 0"),
+                   row(1, vector(1f)),
+                   row(5, vector(2f)),
+                   row(3, vector(2f)));
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 2 OFFSET 0"),
+                   row(1, vector(1f)),
+                   row(3, vector(2f)));
+        assertRows(execute("SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 1 OFFSET 0"),
+                   row(1, vector(1f)));
+
+        // offset > 0 is not allowed
+        String query = "SELECT * FROM %s ORDER BY v ANN OF [0] LIMIT 10 OFFSET 1";
+        String error = String.format(SelectStatement.TOPK_OFFSET_ERROR, 1);
+        Assertions.assertThatThrownBy(() -> execute(query))
+                  .isInstanceOf(InvalidRequestException.class)
+                  .hasMessage(error);
+        Assertions.assertThatThrownBy(() -> executeNet(query))
+                  .isInstanceOf(InvalidQueryException.class)
+                  .hasMessage(error);
+    }
+
+    @SafeVarargs
+    protected static <T> Vector<T> vector(T... values)
+    {
+        return new Vector<>(values);
+    }
+
+    private void testLimitAndOffset(String select, Object[]... rows) throws Throwable
+    {
+        testLimitAndOffset(select, true, rows);
+    }
+
+    private void testLimitAndOffsetWithoutPaging(String select, Object[]... rows) throws Throwable
+    {
+        testLimitAndOffset(select, false, rows);
+    }
+
+    private void testLimitAndOffset(String select, boolean paging, Object[]... rows) throws Throwable
+    {
+        for (int limit = 1; limit <= rows.length + 1; limit++)
+        {
+            for (int offset = 0; offset <= rows.length + 1; offset++)
+            {
+                testLimitAndOffset(select, limit, offset, paging, rows);
+            }
+            testLimitAndOffset(select, limit, null, paging, rows);
+        }
+    }
+
+    private void testLimitAndOffset(String query, int limit, @Nullable Integer offset, boolean paging, Object[]... rows) throws Throwable
+    {
+        // append the specified limit and offset to the unrestricted query
+        StringBuilder sb = new StringBuilder(query);
+        sb.append(" LIMIT ").append(limit);
+        if (offset != null)
+            sb.append(" OFFSET ").append(offset);
+        sb.append(" ALLOW FILTERING");
+        String queryWithLimitAndOffset = sb.toString();
+
+        // trim the unrestricted query results according to the specified limit and offset
+        rows = trimRows(limit, offset, rows);
+
+        // test without paging
+        logger.debug("Executing test query without paging: {}", query);
+        assertRows(execute(queryWithLimitAndOffset), rows);
+
+        // test with paging (not all queries support it)
+        if (paging)
+        {
+            int numRows = rows.length;
+            for (int pageSize : ImmutableSet.of(Integer.MAX_VALUE, numRows + 1, numRows, numRows - 1, 1))
+            {
+                logger.debug("Executing test query with page size {}: {}", pageSize, query);
+                ResultSet rs = executeNetWithPaging(queryWithLimitAndOffset, pageSize);
+
+                // key-based paging should be disabled when limit/offset paging is used
+                if (offset != null && offset > 0)
+                {
+                    Assert.assertTrue(rs.isFullyFetched());
+                    Assert.assertNull(rs.getExecutionInfo().getPagingState());
+                }
+
+                assertRowsNet(rs, rows);
+            }
+        }
+
+        // test with bind markers
+        sb = new StringBuilder(query);
+        sb.append(" LIMIT ?");
+        if (offset != null)
+            sb.append(" OFFSET ?");
+        sb.append(" ALLOW FILTERING");
+        String queryWithBindMarkers = sb.toString();
+        assertRows(offset == null
+                   ? execute(queryWithBindMarkers, limit)
+                   : execute(queryWithBindMarkers, limit, offset),
+                   rows);
+    }
+
+    private static Object[][] trimRows(Integer limit, @Nullable Integer offset, Object[]... rows)
+    {
+        offset = offset == null ? 0 : offset;
+        limit = limit == null ? rows.length : limit;
+
+        if (offset >= rows.length)
+            return EMPTY_ROWS;
+
+        return Arrays.copyOfRange(rows, offset, Math.min(offset + limit, rows.length));
+    }
+}

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailOffsetLimitRowsTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailOffsetLimitRowsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.lang.String.format;
+
+/**
+ * Tests the guardrail for the number of rows that a LIMIT/OFFSET SELECT query can skip, {@link Guardrails#offsetRows}.
+ */
+public class GuardrailOffsetLimitRowsTest extends GuardrailTester
+{
+    private static final int WARN_THRESHOLD = 2;
+    private static final int FAIL_THRESHOLD = 4;
+
+    private int defaultWarnThreshold;
+    private int defaultFailThreshold;
+
+    @Before
+    public void before()
+    {
+        defaultWarnThreshold = config().offset_rows_warn_threshold;
+        defaultFailThreshold = config().offset_rows_failure_threshold;
+        config().offset_rows_warn_threshold = WARN_THRESHOLD;
+        config().offset_rows_failure_threshold = FAIL_THRESHOLD;
+    }
+
+    @After
+    public void after()
+    {
+        config().offset_rows_warn_threshold = defaultWarnThreshold;
+        config().offset_rows_failure_threshold = defaultFailThreshold;
+    }
+
+    @Test
+    public void testConfigValidation()
+    {
+        config().offset_rows_failure_threshold = -1;
+        testValidationOfStrictlyPositiveProperty((c, v) -> c.offset_rows_warn_threshold = v.intValue(),
+                                                 "offset_rows_warn_threshold");
+
+        config().offset_rows_warn_threshold = -1;
+        testValidationOfStrictlyPositiveProperty((c, v) -> c.offset_rows_failure_threshold = v.intValue(),
+                                                 "offset_rows_failure_threshold");
+    }
+
+    @Test
+    public void testOffset() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2))");
+
+        testGuardrail("SELECT * FROM %s LIMIT 100 OFFSET %d");
+        testGuardrail("SELECT * FROM %s PER PARTITION LIMIT 3 LIMIT 100 OFFSET %d");
+        testGuardrail("SELECT * FROM %s GROUP BY k, c1 LIMIT 100 OFFSET %d");
+        testGuardrail("SELECT k, c1, c2, sum(v) FROM %s GROUP BY k, c1 LIMIT 100 OFFSET %d");
+        testGuardrail("SELECT k, c1, c2, sum(v) FROM %s LIMIT 100 OFFSET %d");
+    }
+
+    @Test
+    public void testExcludedUsers() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2))");
+        int offset = FAIL_THRESHOLD + 1;
+        testExcludedUsers(() -> formatQuery("SELECT * FROM %s LIMIT 100 OFFSET %d", offset),
+                          () -> formatQuery("SELECT * FROM %s PER PARTITION LIMIT 3 LIMIT 100 OFFSET %d", offset),
+                          () -> formatQuery("SELECT * FROM %s GROUP BY k, c1 LIMIT 100 OFFSET %d", offset),
+                          () -> formatQuery("SELECT k, c1, c2, sum(v) FROM %s GROUP BY k, c1 LIMIT 100 OFFSET %d", offset),
+                          () -> formatQuery("SELECT k, c1, c2, sum(v) FROM %s LIMIT 100 OFFSET %d", offset));
+    }
+
+    private void testGuardrail(String query) throws Throwable
+    {
+        assertValid(query, 1);
+        assertValid(query, WARN_THRESHOLD);
+        assertWarns(query, WARN_THRESHOLD + 1);
+        assertWarns(query, FAIL_THRESHOLD);
+        assertFails(query, FAIL_THRESHOLD + 1);
+        assertFails(query, Integer.MAX_VALUE);
+    }
+
+    private String formatQuery(String query, int offset)
+    {
+        return format(query, currentTable(), offset);
+    }
+
+    private void assertValid(String query, int offset) throws Throwable
+    {
+        super.assertValid(formatQuery(query, offset));
+    }
+
+    private void assertWarns(String query, int offset) throws Throwable
+    {
+        assertWarns(format("Select query requested to skip %s rows, this exceeds the warning threshold of %s.",
+                           offset, WARN_THRESHOLD),
+                    formatQuery(query, offset));
+    }
+
+    private void assertFails(String query, int offset) throws Throwable
+    {
+        assertFails(format("Select query requested to skip %s rows, this exceeds the failure threshold of %s.",
+                           offset, FAIL_THRESHOLD),
+                    formatQuery(query, offset));
+    }
+}


### PR DESCRIPTION
Add an optional `OFFSET` to CQL `SELECT` queries.

This can be used to do `LIMIT`/`OFFSET` paging.

The implementation involves the coordinator requesting offset+limit rows to
the replicas and then skipping the first offset rows. This way, large offsets
might be problematic performance-wise.

The offset is part of the limit clause, so it's not possible to use an offset
without a limit.

Using an offset disables regular key-based paging for the client, although
key-based paging will still be internally used if possible to reduce memory
pressure.

A new `offset_rows_warn_threshold`/`offset_rows_failure_threshold` guardrail
can be used to forbid problematically large offsets.