### PR TITLE
CNDB-9698: fix LCS partialCompactionsAcceptable when removing L0 sstable from L0/L1 compaction task for limited space

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -915,9 +915,9 @@ public class CompactionTask extends AbstractCompactionTask
                 // but we can still compact expired SSTables
                 if(partialCompactionsAcceptable() && fullyExpiredSSTables.size() > 0 )
                 {
-                    // sanity check to make sure we compact only fully expired SSTables.
-                    assert transaction.originals().equals(fullyExpiredSSTables);
-                    break;
+                    // if all remaining sstables are fully expired, we can still start compaction; otherwise throw
+                    if (transaction.originals().equals(fullyExpiredSSTables))
+                        break;
                 }
 
                 String msg = String.format("Not enough space for compaction, estimated sstables = %d, expected write size = %d", estimatedSSTables, expectedWriteSize);

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
@@ -65,7 +65,8 @@ public class LeveledCompactionTask extends CompactionTask
     @Override
     protected boolean partialCompactionsAcceptable()
     {
-        throw new UnsupportedOperationException("This is now handled in reduceScopeForLimitedSpace");
+        // LCS allows removing L0 sstable from compaction for limited disk space. It's handled in #reduceScopeForLimitedSpace
+        return level <= 1;
     }
 
     protected int getLevel()

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
@@ -65,7 +65,7 @@ public class LeveledCompactionTask extends CompactionTask
     @Override
     protected boolean partialCompactionsAcceptable()
     {
-        // LCS allows removing L0 sstable from compaction for limited disk space. It's handled in #reduceScopeForLimitedSpace
+        // LCS allows removing L0 sstable from L0/L1 compaction task for limited disk space. It's handled in #reduceScopeForLimitedSpace
         return level <= 1;
     }
 


### PR DESCRIPTION
issue: https://github.com/riptano/cndb/issues/9698