### PR TITLE
CNDB-9753 (main): Disallow for using duration type in maps

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -470,7 +470,17 @@ public enum CassandraRelevantProperties
     /**
      * Number of replicas required to store batchlog for atomicity, only accepts values of 1 or 2.
      */
-    REQUIRED_BATCHLOG_REPLICA_COUNT("cassandra.batchlog.required_replica_count", "2");
+    REQUIRED_BATCHLOG_REPLICA_COUNT("cassandra.batchlog.required_replica_count", "2"),
+
+    /**
+     * This property should be enabled when upgrading from the version of Cassandra that allowed to create maps with
+     * duration type as a key if the schema contains such columns. It was a bug that the validation didn't prevent
+     * from creating such maps but once they are created, we need to be able to read them - hence this property.
+     * When the check is enabled, Cassandra falls back to the old behavior and let the user load the data with such
+     * maps. When the check is disabled, Cassandra will refuse to load the data with such maps and won't start if
+     * the schema contains them.
+     */
+    DURATION_IN_MAPS_COMPATIBILITY_MODE("cassandra.types.map.duration_in_map_compatibility_mode", "false");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/SerializationHeader.java
+++ b/src/java/org/apache/cassandra/db/SerializationHeader.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -53,6 +54,8 @@ import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.AbstractTypeSerializer;
 import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.DURATION_IN_MAPS_COMPATIBILITY_MODE;
 
 public class SerializationHeader
 {
@@ -334,7 +337,7 @@ public class SerializationHeader
 
             try
             {
-                type.validateForColumn(columnName, isPrimaryKeyColumn, table.isCounter(), dropped, isForOfflineTool);
+                type.validateForColumn(columnName, isPrimaryKeyColumn, table.isCounter(), dropped, isForOfflineTool, DURATION_IN_MAPS_COMPATIBILITY_MODE.getBoolean());
                 return type;
             }
             catch (InvalidColumnTypeException e)
@@ -376,7 +379,7 @@ public class SerializationHeader
                 try
                 {
                     // Make doubly sure the fixed type is valid before returning it.
-                    fixed.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, isForOfflineTool);
+                    fixed.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, isForOfflineTool, DURATION_IN_MAPS_COMPATIBILITY_MODE.getBoolean());
                     return fixed;
                 }
                 catch (InvalidColumnTypeException e2)

--- a/src/java/org/apache/cassandra/db/marshal/DurationType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DurationType.java
@@ -83,7 +83,7 @@ public class DurationType extends AbstractType<Duration>
     }
 
     @Override
-    public boolean referencesDuration()
+    public boolean referencesDuration(boolean legacyMode)
     {
         return true;
     }

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -106,12 +106,6 @@ public class ListType<T> extends CollectionType<List<T>>
         return (ListType<?>) super.withUpdatedUserType(udt);
     }
 
-    @Override
-    public boolean referencesDuration()
-    {
-        return getElementsType().referencesDuration();
-    }
-
     @SuppressWarnings("unchecked")
     public AbstractType<T> getElementsType()
     {

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Maps;
 import org.apache.cassandra.cql3.Term;
@@ -109,10 +110,12 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
     }
 
     @Override
-    public boolean referencesDuration()
+    public boolean referencesDuration(boolean legacyMode)
     {
-        // Maps cannot be created with duration as keys
-        return getValuesType().referencesDuration();
+        if (legacyMode)
+            return getValuesType().referencesDuration(true);
+        else
+            return super.referencesDuration(false);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -368,12 +368,6 @@ public class UserType extends TupleType implements SchemaElement
     }
 
     @Override
-    public boolean referencesDuration()
-    {
-        return fieldTypes().stream().anyMatch(AbstractType::referencesDuration);
-    }
-
-    @Override
     protected String stringifyTypeParameters(boolean ignoreFreezing)
     {
         return TypeParser.stringifyUserTypeParameters(keyspace, name, fieldNames, subTypes, ignoreFreezing || !isMultiCell());

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -584,8 +584,8 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
      *
      * @param isCounterTable whether the table the column is part of is a counter table.
      */
-    public void validate(boolean isCounterTable)
+    public void validate(boolean isCounterTable, boolean durationLegacyMode)
     {
-        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable, isDropped, false);
+        type.validateForColumn(name.bytes, kind.isPrimaryKeyKind(), isCounterTable, isDropped, false, durationLegacyMode);
     }
 }

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -87,6 +87,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.cassandra.config.CassandraRelevantProperties.DURATION_IN_MAPS_COMPATIBILITY_MODE;
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
 import static org.apache.cassandra.schema.SchemaKeyspaceTables.AGGREGATES;
@@ -1044,7 +1045,7 @@ public final class SchemaKeyspace
                                             boolean isCounterTable,
                                             boolean isDroppedColumn)
     {
-        type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, false);
+        type.validateForColumn(name, isPrimaryKeyColumn, isCounterTable, isDroppedColumn, false, DURATION_IN_MAPS_COMPATIBILITY_MODE.getBoolean());
         return type;
     }
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -421,7 +421,12 @@ public class TableMetadata implements SchemaElement
         return !staticColumns().isEmpty();
     }
 
-    public void validate()
+    public final void validate()
+    {
+        validate(false);
+    }
+
+    public void validate(boolean durationLegacyMode)
     {
         if (!isNameValid(keyspace))
             except("Keyspace name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, keyspace);
@@ -431,7 +436,7 @@ public class TableMetadata implements SchemaElement
 
         params.validate();
 
-        columns().forEach(c -> c.validate(isCounter()));
+        columns().forEach(c -> c.validate(isCounter(), durationLegacyMode));
 
         // All tables should have a partition key
         if (partitionKeyColumns.isEmpty())
@@ -1597,9 +1602,10 @@ public class TableMetadata implements SchemaElement
             return compactValueColumn.type instanceof EmptyType;
         }
 
-        public void validate()
+        @Override
+        public void validate(boolean durationLegacyMode)
         {
-            super.validate();
+            super.validate(durationLegacyMode);
 
             // A compact table should always have a clustering
             if (!Flag.isCQLTable(flags) && clusteringColumns.isEmpty())


### PR DESCRIPTION
Add a flag to disable low-level check which makes it possible to load legacy data