### PR TITLE
CNDB-9821 Auto sync RequestSensors increments to SensorsRegistry

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1580,7 +1580,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 {
                     Context puContext = Context.from(this.metadata.get());
                     sensors.registerSensor(puContext, Type.WRITE_BYTES);
-                    sensors.incrementSensor(puContext, Type.WRITE_BYTES, dataSize);
+                    sensors.incrementThenSyncSensor(puContext, Type.WRITE_BYTES, dataSize);
                 }
             }
         }

--- a/src/java/org/apache/cassandra/db/CounterMutationCallback.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationCallback.java
@@ -75,8 +75,7 @@ public class CounterMutationCallback implements Runnable
         // message size: this is missing the sensor values, but it's a good enough approximation
         Collection<Sensor> requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
         int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
-        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
-        RequestTracker.instance.get().syncAllSensors();
+        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementThenSyncSensor(sensor.getContext(), sensor.getType(), perSensorSize));
         Function<String, String> requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;
         Function<String, String> tableParam = SensorsCustomParams::encodeTableInInternodeBytesTableParam;
         addSensorsToResponse(requestSensors, requestParam, tableParam, response, replicaMultiplier);

--- a/src/java/org/apache/cassandra/db/CounterMutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/CounterMutationVerbHandler.java
@@ -57,7 +57,7 @@ public class CounterMutationVerbHandler implements IVerbHandler<CounterMutation>
         tables.forEach(tm -> {
             Context context = Context.from(tm);
             requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
-            requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
+            requestSensors.incrementThenSyncSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
         });
 
         String localDataCenter = DatabaseDescriptor.getEndpointSnitch().getLocalDatacenter();

--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -241,20 +241,12 @@ public class Mutation implements IMutation
     public CompletableFuture<?> applyFuture(WriteOptions writeOptions)
     {
         Keyspace ks = Keyspace.open(keyspaceName);
-        return ks.applyFuture(this, writeOptions, true).thenRun(() -> {
-            RequestSensors sensors = requestTracker.get();
-            if (sensors != null)
-                sensors.syncAllSensors();
-        });
+        return ks.applyFuture(this, writeOptions, true);
     }
 
     public void apply(WriteOptions writeOptions)
     {
         Keyspace.open(keyspaceName).apply(this, writeOptions);
-
-        RequestSensors sensors = requestTracker.get();
-        if (sensors != null)
-            sensors.syncAllSensors();
     }
 
     /*

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -76,8 +76,7 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
         // message size: this is missing the sensor values, but it's a good enough approximation
         int perSensorSize = response.currentPayloadSize(MessagingService.current_version) / tables;
         requestSensors = RequestTracker.instance.get().getSensors(Type.INTERNODE_BYTES);
-        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementSensor(sensor.getContext(), sensor.getType(), perSensorSize));
-        RequestTracker.instance.get().syncAllSensors();
+        requestSensors.forEach(sensor -> RequestTracker.instance.get().incrementThenSyncSensor(sensor.getContext(), sensor.getType(), perSensorSize));
         requestParam = SensorsCustomParams::encodeTableInInternodeBytesRequestParam;
         tableParam = SensorsCustomParams::encodeTableInInternodeBytesTableParam;
         addSensorsToResponse(requestSensors, requestParam, tableParam, response);
@@ -134,7 +133,7 @@ public class MutationVerbHandler implements IVerbHandler<Mutation>
             tables.forEach(tm -> {
                 Context context = Context.from(tm);
                 requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
-                requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
+                requestSensors.incrementThenSyncSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
             });
 
             message.payload.applyFuture(WriteOptions.DEFAULT).thenAccept(o -> respond(message, respondToAddress)).exceptionally(wto -> {

--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -72,7 +72,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         // Initialize internode bytes with the inbound message size:
         tables.forEach(tm -> {
             requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
-            requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
+            requestSensors.incrementThenSyncSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
         });
 
         long timeout = message.expiresAtNanos() - message.createdAtNanos();
@@ -94,8 +94,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
 
         Message.Builder<ReadResponse> reply = message.responseWithBuilder(response);
         int size = reply.currentPayloadSize(MessagingService.current_version);
-        RequestTracker.instance.get().incrementSensor(context, Type.INTERNODE_BYTES, size);
-        RequestTracker.instance.get().syncAllSensors();
+        RequestTracker.instance.get().incrementThenSyncSensor(context, Type.INTERNODE_BYTES, size);
 
         addInternodeSensorToResponse(reply, context);
         SensorsCustomParams.addReadSensorToResponse(reply, requestSensors, context);

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -695,8 +695,7 @@ public final class SystemKeyspace
         RequestSensors sensors = RequestTracker.instance.get();
         if (sensors != null)
             sensors.getSensor(PaxosContext, type).ifPresent(paxosSensor -> {
-                sensors.incrementSensor(Context.from(targetSensorMetadata), type, paxosSensor.getValue());
-                sensors.syncAllSensors();
+                sensors.incrementThenSyncSensor(Context.from(targetSensorMetadata), type, paxosSensor.getValue());
             });
     }
 

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
@@ -452,7 +452,7 @@ public abstract class CassandraIndex implements Index
                 {
                     sensors.registerSensor(sensorContext, Type.INDEX_WRITE_BYTES);
                     // estimate the size of the index entry as the data size of the cell before indexing
-                    sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, cell.dataSize());
+                    sensors.incrementThenSyncSensor(sensorContext, Type.INDEX_WRITE_BYTES, cell.dataSize());
                 }
             }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -57,8 +57,6 @@ import org.apache.cassandra.utils.Reducer;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
-import static java.util.function.Function.identity;
-
 public class TrieMemtableIndex implements MemtableIndex
 {
     private final ShardBoundaries boundaries;
@@ -163,13 +161,13 @@ public class TrieMemtableIndex implements MemtableIndex
                                                              memtable.markExtraOnHeapUsed(allocatedBytes, opGroup);
                                                              estimatedOnHeapMemoryUsed.add(allocatedBytes);
                                                              if (sensors != null)
-                                                                 sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
+                                                                 sensors.incrementThenSyncSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                          },
                                                          allocatedBytes -> {
                                                              memtable.markExtraOffHeapUsed(allocatedBytes, opGroup);
                                                              estimatedOffHeapMemoryUsed.add(allocatedBytes);
                                                              if (sensors != null)
-                                                                 sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
+                                                                 sensors.incrementThenSyncSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                          });
         writeCount.increment();
     }

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -54,9 +54,8 @@ import org.apache.cassandra.utils.concurrent.Timer;
  * </ul>
  * The returned sensors are global, meaning that their value spans across requests/responses, but cannot be modified either
  * directly or indirectly via this class (whose update methods are package protected). In order to modify a sensor value,
- * it must be registered to a request/response via {@link RequestSensors#registerSensor(Context, Type)} and incremented via
- * {@link RequestSensors#incrementSensor(Context, Type, double)}, then synced via {@link RequestSensors#syncAllSensors()}, which
- * will update the related global sensors.
+ * it must be registered to a request/response via {@link RequestSensors#registerSensor(Context, Type)} and incremented then synced via
+ * {@link RequestSensors#incrementThenSyncSensor(Context, Type, double)}.
  * <br/><br/>
  * Given sensors are tied to a context, that is to a given keyspace and table, their global instance will be deleted
  * if the related keyspace/table is dropped.
@@ -145,7 +144,7 @@ public class SensorsRegistry implements SchemaChangeListener
         }
     }
 
-    protected void incrementSensor(Context context, Type type, double value)
+    public void incrementSensor(Context context, Type type, double value)
     {
         getOrCreateSensor(context, type).ifPresent(s -> s.increment(value));
     }

--- a/src/java/org/apache/cassandra/sensors/read/TrackingRowIterator.java
+++ b/src/java/org/apache/cassandra/sensors/read/TrackingRowIterator.java
@@ -60,7 +60,7 @@ public class TrackingRowIterator extends Transformation<UnfilteredRowIterator>
     {
         RequestSensors sensors = requestTracker.get();
         if (sensors != null && row.isRow())
-            sensors.incrementSensor(context, Type.READ_BYTES, row.dataSize());
+            sensors.incrementThenSyncSensor(context, Type.READ_BYTES, row.dataSize());
 
         return row;
     }
@@ -69,9 +69,5 @@ public class TrackingRowIterator extends Transformation<UnfilteredRowIterator>
     protected void onClose()
     {
         super.onClose();
-
-        RequestSensors sensors = requestTracker.get();
-        if (sensors != null)
-            sensors.syncAllSensors();
     }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/sensors/RequestSensorsBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/sensors/RequestSensorsBench.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.sensors;
+
+import org.apache.cassandra.sensors.Context;
+import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.Sensor;
+import org.apache.cassandra.sensors.SensorsRegistry;
+import org.apache.cassandra.sensors.Type;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 1)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class RequestSensorsBench
+{
+    private static final RequestSensors requestSensors = new RequestSensors();
+
+    private static final int NUM_SENSORS = 1000;
+
+    @Setup
+    public void registerSensors()
+    {
+        // Register sensors
+        for (Type type : Type.values())
+        {
+            for (int i = 0; i < NUM_SENSORS; i++)
+            {
+                Context context = new Context("keyspace", "table" + i, "tableId" + i);
+                requestSensors.registerSensor(context, type);
+            }
+        }
+    }
+
+    @Benchmark
+    @Threads(50)
+    public void increment()
+    {
+        // pick a sensor at random
+        Type type = Type.values()[(int) (Math.random() * Type.values().length)];
+        int sensorIndex = (int) (Math.random() * NUM_SENSORS);
+        Context context = new Context("keyspace", "table" + sensorIndex, "tableId" + sensorIndex);
+        requestSensors.incrementThenSyncSensor(context, type, Math.random());
+        SensorsRegistry.instance.getSensor(context, type).ifPresent(Sensor::getValue);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
+++ b/test/unit/org/apache/cassandra/db/CounterMutationCallbackTest.java
@@ -136,8 +136,7 @@ public class CounterMutationCallbackTest
         Context context = Context.from(Keyspace.open(KEYSPACE1).getMetadata().tables.get(CF_COUTNER).get());
         requestSensors.registerSensor(context, Type.INTERNODE_BYTES);
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
-        requestSensors.incrementSensor(context, Type.WRITE_BYTES, COUNTER_MUTATION_BYTES); // mimic a counter mutation of size 56 bytes on the leader node
-        requestSensors.syncAllSensors();
+        requestSensors.incrementThenSyncSensor(context, Type.WRITE_BYTES, COUNTER_MUTATION_BYTES); // mimic a counter mutation of size 56 bytes on the leader node
         CounterMutationCallback callback = new CounterMutationCallback(msg, FBUtilities.getLocalAddressAndPort());
         Integer replicaCount = replicaCountAndExpectedSensorValue.left;
         callback.setReplicaCount(replicaCount);

--- a/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
+++ b/test/unit/org/apache/cassandra/net/SensorsCustomParamsTest.java
@@ -167,8 +167,7 @@ public class SensorsCustomParamsTest
 
         Context context = new Context("ks1", "t1", tableId.toString());
         sensors.registerSensor(context, sensorType);
-        sensors.incrementSensor(context, sensorType, 17.0);
-        sensors.syncAllSensors();
+        sensors.incrementThenSyncSensor(context, sensorType, 17.0);
 
         Message.Builder<NoPayload> builder =
         Message.builder(Verb._TEST_1, noPayload)

--- a/test/unit/org/apache/cassandra/sensors/RequestSensorsTest.java
+++ b/test/unit/org/apache/cassandra/sensors/RequestSensorsTest.java
@@ -116,48 +116,23 @@ public class RequestSensorsTest
     }
 
     @Test
-    public void testIncrement()
+    public void testIncrementThenSync()
     {
         context1Sensors.registerSensor(context1, type1);
-        context1Sensors.incrementSensor(context1, type1, 1.0);
+        context1Sensors.incrementThenSyncSensor(context1, type1, 1.0);
         assertThat(context1Sensors.getSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
+        verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type1), eq(1.0));
     }
 
     @Test
     public void testIncrementWithMultipleContexts()
     {
         sensors.registerSensor(context1, type1);
-        sensors.incrementSensor(context1, type1, 1.0);
+        sensors.incrementThenSyncSensor(context1, type1, 1.0);
         sensors.registerSensor(context2, type1);
-        sensors.incrementSensor(context2, type1, 2.0);
+        sensors.incrementThenSyncSensor(context2, type1, 2.0);
         assertThat(sensors.getSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
         assertThat(sensors.getSensor(context2, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(2.0));
-    }
-
-    @Test
-    public void testSyncAll()
-    {
-        context1Sensors.registerSensor(context1, type1);
-        context1Sensors.registerSensor(context1, type2);
-
-        context1Sensors.incrementSensor(context1, type1, 1.0);
-        context1Sensors.incrementSensor(context1, type2, 1.0);
-
-        context1Sensors.syncAllSensors();
-        verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type1), eq(1.0));
-        verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type2), eq(1.0));
-
-        // Syncing again doesn't update the sensor
-        context1Sensors.syncAllSensors();
-        verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type1), eq(1.0));
-        verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type2), eq(1.0));
-
-        // Unless updated:
-        context1Sensors.incrementSensor(context1, type1, 1.0);
-        context1Sensors.incrementSensor(context1, type2, 1.0);
-        context1Sensors.syncAllSensors();
-        verify(sensorsRegistry, times(2)).incrementSensor(eq(context1), eq(type1), eq(1.0));
-        verify(sensorsRegistry, times(2)).incrementSensor(eq(context1), eq(type2), eq(1.0));
     }
 
     @Test
@@ -168,12 +143,11 @@ public class RequestSensorsTest
         sensors.registerSensor(context2, type1);
         sensors.registerSensor(context2, type2);
 
-        sensors.incrementSensor(context1, type1, 1.0);
-        sensors.incrementSensor(context1, type2, 1.0);
-        sensors.incrementSensor(context2, type1, 1.0);
-        sensors.incrementSensor(context2, type2, 1.0);
+        sensors.incrementThenSyncSensor(context1, type1, 1.0);
+        sensors.incrementThenSyncSensor(context1, type2, 1.0);
+        sensors.incrementThenSyncSensor(context2, type1, 1.0);
+        sensors.incrementThenSyncSensor(context2, type2, 1.0);
 
-        sensors.syncAllSensors();
         verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type1), eq(1.0));
         verify(sensorsRegistry, times(1)).incrementSensor(eq(context1), eq(type2), eq(1.0));
         verify(sensorsRegistry, times(1)).incrementSensor(eq(context2), eq(type1), eq(1.0));

--- a/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsRegistryTest.java
@@ -215,7 +215,7 @@ public class SensorsRegistryTest
     }
 
     @Test
-    public void testUpdateAndSyncSensorViaRequestSensors()
+    public void testIncrementThenSyncSensorViaRequestSensors()
     {
         SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(KEYSPACE).getMetadata());
         SensorsRegistry.instance.onCreateTable(Keyspace.open(KEYSPACE).getColumnFamilyStore(CF1).metadata());
@@ -223,15 +223,12 @@ public class SensorsRegistryTest
         RequestSensors requestSensors = new RequestSensors(() -> SensorsRegistry.instance);
         requestSensors.registerSensor(context1, type1);
 
-        requestSensors.incrementSensor(context1, type1, 1.0);
-        requestSensors.syncAllSensors();
+        requestSensors.incrementThenSyncSensor(context1, type1, 1.0);
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(1.0));
 
-        requestSensors.incrementSensor(context1, type1, 1.0);
-        requestSensors.syncAllSensors();
+        requestSensors.incrementThenSyncSensor(context1, type1, 1.0);
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(2.0));
 
-        requestSensors.syncAllSensors();
         assertThat(SensorsRegistry.instance.getOrCreateSensor(context1, type1)).hasValueSatisfying((s) -> assertThat(s.getValue()).isEqualTo(2.0));
     }
 }


### PR DESCRIPTION
Proposal #1 for https://github.com/riptano/cndb/issues/9821

* Deprecated the `SensorsRegister#syncAllSensors`. Instead, automatically synchronize sensors increments via `RequestSensors#incrementThenSyncSensor`. 
* Use `DoubleAdder` instead of `AtomicDouble` to reduce thread contention on updates. 
* Add a simple `RequestSensorsBench` to benchmark public APIs. 

Based on benchmark results, the `RequestSensors#incrementThenSyncSensor` followed by a sensor read from the registry has the below throughout:

```
Benchmark                       Mode  Cnt       Score       Error  Units
RequestSensorsBench.increment  thrpt    5  509069.346 ± 32108.453  ops/s
``` 

It is worth noting that the switch from `AtomicDouble` to `DoubleAdder` didn't have significant improvement in terms of throughput, but it is safe to assume there is `1:M` ration between reading from and writing to sensors registry per request which is what `DoubleAdder` is meant for (however we may need `1<<M` to experience the benefits) 

However the same functionally if we were to add `SensorsRegister#syncAllSensors` (benchmark code below) is:

```
Benchmark                       Mode  Cnt     Score     Error  Units
RequestSensorsBench.increment  thrpt    5  9197.702 ± 944.301  ops/s
```

```java
@Benchmark
@Threads(50)
public void syncAllSensors()
{
    // pick a sensor at random
    Type type = Type.values()[(int) (Math.random() * Type.values().length)];
    int sensorIndex = (int) (Math.random() * NUM_SENSORS);
    Context context = new Context("keyspace", "table" + sensorIndex, "tableId" + sensorIndex);
    requestSensors.incrementSensor(context, type, Math.random());
    requestSensors.syncAllSensors();
    SensorsRegistry.instance.getSensor(context, type).ifPresent(Sensor::getValue);
}
```
