### PR TITLE
CNDB-9681: Use rerankk as limit and disable cassandra.sai.reduce_topk_across_sstables by default

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -195,7 +195,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         {
             // not restricted
             if (RangeUtil.coversFullRing(keyRange))
-                return graph.search(queryVector, limit, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
+                return graph.search(queryVector, rerankK, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
 
             PrimaryKey firstPrimaryKey = keyFactory.createTokenOnly(keyRange.left.getToken());
 
@@ -211,7 +211,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
             // if it covers entire segment, skip bit set
             if (minSSTableRowId <= metadata.minSSTableRowId && maxSSTableRowId >= metadata.maxSSTableRowId)
-                return graph.search(queryVector, limit, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
+                return graph.search(queryVector, rerankK, rerankK, threshold, Bits.ALL, context, context::addAnnNodesVisited);
 
             minSSTableRowId = Math.max(minSSTableRowId, metadata.minSSTableRowId);
             maxSSTableRowId = min(maxSSTableRowId, metadata.maxSSTableRowId);
@@ -257,7 +257,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             if (cardinality == 0)
                 return CloseableIterator.emptyIterator();
 
-            return graph.search(queryVector, limit, rerankK, threshold, bits, context, visited -> {
+            return graph.search(queryVector, rerankK, rerankK, threshold, bits, context, visited -> {
                 betterCostEstimate.updateStatistics(visited);
                 context.addAnnNodesVisited(visited);
             });
@@ -503,7 +503,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         }
         // else ask the index to perform a search limited to the bits we created
         var queryVector = vts.createFloatVector(exp.lower.value.vector);
-        var results = graph.search(queryVector, limit, rerankK, 0, bits, context, cost::updateStatistics);
+        var results = graph.search(queryVector, rerankK, rerankK, 0, bits, context, cost::updateStatistics);
         return toScoreOrderedIterator(results, context);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -41,7 +41,8 @@ import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
  */
 public class V3OnDiskFormat extends V2OnDiskFormat
 {
-    public static final boolean REDUCE_TOPK_ACROSS_SSTABLES = Boolean.parseBoolean(System.getProperty("cassandra.sai.reduce_topk_across_sstables", "true"));
+    // Default is set to false because it is not yet ready for production (see https://github.com/riptano/cndb/issues/9681)
+    public static final boolean REDUCE_TOPK_ACROSS_SSTABLES = Boolean.parseBoolean(System.getProperty("cassandra.sai.reduce_topk_across_sstables", "false"));
     public static final boolean ENABLE_RERANK_FLOOR = Boolean.parseBoolean(System.getProperty("cassandra.sai.rerank_floor", "true"));
     public static final boolean ENABLE_EDGES_CACHE = Boolean.parseBoolean(System.getProperty("cassandra.sai.enable_edges_cache", "false"));
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -74,7 +74,7 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         if (nodeScores.hasNext())
             return nodeScores.next();
 
-        var nextResult = searcher.resume(limit, rerankK);
+        var nextResult = searcher.resume(rerankK, rerankK);
         maybeLogTrace(nextResult);
         cumulativeNodesVisited += nextResult.getVisitedCount();
         // If the next result is empty, we are done searching.


### PR DESCRIPTION
This is a temporary hack to mitigate a regression introduced with
https://github.com/datastax/cassandra/pull/1107


`reduce_topk_across_sstables` sounds like a good improvement but it is actually introducing a performance regression in the workload used in https://github.com/riptano/cndb/issues/9681

The effect of disabling reduce_topk_across_sstables in the first case further improves hybrid performance. In the previous prod image, we would always ask for rerank results from JVector (so, 100 gets turned into something like 299). Now, we search for 299 but only return the 100 best across the boundary. This is designed to improve performance in the case where all results are permitted, with the idea that the penalty of asking for more is quite small. It seems we underestimated this penalty. This means we need dramatically more requeries in the hybrid case, compounded by reduce_topk_across_sstables, which reduces the limit proportionally to the size of the sstable/total sstables.


The patch is originally contributed by @jkni 