### PR TITLE
Take post-filtering into account in the limit passed to TopK search

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1381,6 +1381,7 @@ abstract public class Plan
         {
             return String.format("%s (sel: %.9f)", filter, selectivity() / source.get().selectivity());
         }
+
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIntersectionIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.RangeUnionIterator;
@@ -569,7 +568,7 @@ abstract public class Plan
          * @param softLimit the number of keys likely to be requested from the returned iterator;
          *                  this is a hint only - it does not change the result set, but may change performance
          */
-        protected abstract Iterator<? extends PrimaryKey> execute(Executor executor, int softLimit);
+        protected abstract Iterator<?> execute(Executor executor, int softLimit);
 
         protected abstract KeysIteration withAccess(Access patterns);
 
@@ -784,7 +783,7 @@ abstract public class Plan
         }
 
         @Override
-        protected Iterator<? extends PrimaryKey> execute(Executor executor, int softLimit)
+        protected Iterator<?> execute(Executor executor, int softLimit)
         {
             return executor.getKeysFromIndex(predicate);
         }
@@ -1144,7 +1143,7 @@ abstract public class Plan
         }
 
         @Override
-        protected Iterator<? extends PrimaryKey> execute(Executor executor, int softLimit)
+        protected Iterator<?> execute(Executor executor, int softLimit)
         {
             // soft limit for fetching the keys from source is MAX_VALUE because we need to know
             // all keys to pick the top K.
@@ -1670,9 +1669,9 @@ abstract public class Plan
      */
     public interface Executor
     {
-        Iterator<? extends PrimaryKey> getKeysFromIndex(Expression predicate);
-        Iterator<? extends PrimaryKey> getTopKRows(RowFilter.Expression ordering, int softLimit);
-        Iterator<? extends PrimaryKey> getTopKRows(RangeIterator keys, RowFilter.Expression ordering, int softLimit);
+        Iterator<?> getKeysFromIndex(Expression predicate);
+        Iterator<?> getTopKRows(RowFilter.Expression ordering, int softLimit);
+        Iterator<?> getTopKRows(RangeIterator keys, RowFilter.Expression ordering, int softLimit);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -336,9 +336,11 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
             // If there is filtering in the plan, we may need to fetch more keys
             // from the index, so we need to reflect that in the limit.
+            // (In general, it costs more to over-fetch than under-fetch, because resume is cheap, so we don't
+            // need to use a high confidenceLevel.)
             Plan.Filter filter = plan.firstNodeOfType(Plan.Filter.class);
             int softLimit = (filter != null)
-                          ? SoftLimitUtil.softLimit(hardLimit, 0.9, filter.selectivity())
+                          ? SoftLimitUtil.softLimit(hardLimit, 0.5, filter.selectivity())
                           : hardLimit;
 
             return keysIteration.execute(this, softLimit);

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -262,7 +262,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         Plan.KeysIteration keysIterationPlan = buildKeysIterationPlan();
         Plan.RowsIteration rowsIteration = planFactory.fetch(keysIterationPlan);
         rowsIteration = planFactory.recheckFilter(command.rowFilter(), rowsIteration);
-        rowsIteration = planFactory.limit(rowsIteration, command.limits().rows());
+        rowsIteration = planFactory.limit(rowsIteration, command.limits().count());
 
         Plan optimizedPlan;
         optimizedPlan = QUERY_OPT_LEVEL > 0
@@ -319,7 +319,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         return keysIterationPlan;
     }
 
-    public Iterator<? extends PrimaryKey> buildIterator()
+    public Iterator<?> buildIterator()
     {
         try
         {

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -338,7 +338,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             // from the index, so we need to reflect that in the limit.
             Plan.Filter filter = plan.firstNodeOfType(Plan.Filter.class);
             int softLimit = (filter != null)
-                ? SoftLimitUtil.softLimit(hardLimit, 0.95, filter.selectivity())
+                ? SoftLimitUtil.softLimit(hardLimit, 0.9, filter.relativeSelectivity())
                 : hardLimit;
 
             return keysIteration.execute(this, softLimit);

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -121,7 +121,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     public UnfilteredPartitionIterator search(ReadExecutionController executionController) throws RequestTimeoutException
     {
         FilterTree filterTree = analyzeFilter();
-        Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator();
+        Iterator<?> keysIterator = controller.buildIterator();
 
         if (command.isTopK())
         {

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -121,7 +121,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     public UnfilteredPartitionIterator search(ReadExecutionController executionController) throws RequestTimeoutException
     {
         FilterTree filterTree = analyzeFilter();
-        Iterator<?> keysIterator = controller.buildIterator();
+        Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator();
 
         if (command.isTopK())
         {

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -454,7 +454,7 @@ public class PlanTest
             }
         };
 
-        RangeIterator iterator = (RangeIterator) plan.execute(executor);
+        RangeIterator iterator = (RangeIterator) plan.execute(executor, Integer.MAX_VALUE);
         assertEquals(LongIterator.convert(1L, 2L, 100L), LongIterator.convert(iterator));
     }
 


### PR DESCRIPTION
Post-filtering will reject many rows, so we need to compensate
for it by fetching more keys from the index.
