### PR TITLE
CNDB-9854: Enable cosine Fused ADC

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/CassandraDiskAnn.java
@@ -224,7 +224,6 @@ public class CassandraDiskAnn extends JVectorLuceneOnDiskGraph
         SearchScoreProvider ssp;
         if (features.contains(FeatureId.FUSED_ADC))
         {
-            assert similarityFunction != VectorSimilarityFunction.COSINE; // FIXME not yet supported
             var asf = view.approximateScoreFunctionFor(queryVector, similarityFunction);
             var rr = view.rerankerFor(queryVector, similarityFunction);
             ssp = new SearchScoreProvider(asf, rr);


### PR DESCRIPTION
This is now supported by JVector. Feature still off by default.