### PR TITLE
CNDB-9827: Online sorting and trimming of CQL result rows

### DIFF
--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -94,19 +94,6 @@ public class ResultSet
         Collections.reverse(rows);
     }
 
-    public void trim(int limit, int offset)
-    {
-        while (offset-- > 0 && !rows.isEmpty())
-            rows.remove(0);
-
-        int toRemove = rows.size() - limit;
-        if (toRemove > 0)
-        {
-            for (int i = 0; i < toRemove; i++)
-                rows.remove(rows.size() - 1);
-        }
-    }
-
     @Override
     public String toString()
     {

--- a/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.selection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+import org.apache.cassandra.index.Index;
+
+/**
+ * Builds a list of query result rows applying the specified order, limit and offset.
+ * </p>
+ * It's functionally equivalent to adding all the rows to a list, sorting it based on the specified order, removing the
+ * first offset elements, and then removing the last elements until the list size satisfies the limit.
+ * </p>
+ * The advantage of this class is that it doesn't need to keep all the rows in memory. If the order is based on
+ * insertion order, it won't keep more than {@code limit} rows in memory. If the order is based on a comparator or an
+ * {@link Index.Scorer}, it won't keep more than {@code limit + offset} rows in memory.
+ */
+public abstract class SortedRowsBuilder
+{
+    protected final int limit;
+    protected final int offset;
+
+    private SortedRowsBuilder(int limit, int offset)
+    {
+        assert limit > 0 && offset >= 0;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    /**
+     * Adds the specified row to this builder. The row might be ignored if it's over the specified limit and offset.
+     *
+     * @param row the row to add
+     */
+    public abstract void add(List<ByteBuffer> row);
+
+    /**
+     * @return a list of query result rows based on the specified order, limit and offset.
+     */
+    public abstract List<List<ByteBuffer>> build();
+
+    /**
+     * Returns a new row builder that keeps insertion order.
+     *
+     * @return a rows builder that keeps insertion order.
+     */
+    public static SortedRowsBuilder create()
+    {
+        return new WithInsertionOrder(Integer.MAX_VALUE, 0);
+    }
+
+    /**
+     * Returns a new row builder that keeps insertion order.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @return a rows builder that keeps insertion order.
+     */
+    public static SortedRowsBuilder create(int limit, int offset)
+    {
+        return new WithInsertionOrder(limit, offset);
+    }
+
+    /**
+     * Returns a new row builder that orders the added rows based on the specified {@link Comparator}.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @param comparator the comparator to use for ordering
+     * @return a rows builder that orders results based on a comparator.
+     */
+    public static SortedRowsBuilder create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+    {
+        return new WithComparator(limit, offset, comparator);
+    }
+
+    /**
+     * Returns a new row builder that orders the added rows based on the specified {@link Index.Scorer}.
+     *
+     * @param limit the query limit
+     * @param offset the query offset
+     * @param scorer the index scorer to use for ordering
+     * {@link SortedRowsBuilder} that orders results based on a secondary index scorer.
+     */
+    public static SortedRowsBuilder create(int limit, int offset, Index.Scorer scorer)
+    {
+        return new WithScore(limit, offset, scorer);
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that keeps insertion order.
+     * </p>
+     * It keeps at most {@code limit} rows in memory.
+     */
+    private static class WithInsertionOrder extends SortedRowsBuilder
+    {
+        private final List<List<ByteBuffer>> rows = new ArrayList<>();
+        private int toSkip = offset;
+
+        private WithInsertionOrder(int limit, int offset)
+        {
+            super(limit, offset);
+        }
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            if (toSkip-- <= 0 && rows.size() < limit)
+                rows.add(row);
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            return rows;
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that orders the added rows based on a {@link Comparator}.
+     */
+    private static class WithComparator extends WithCompare<WithCompare.DecoratedRow>
+    {
+        private final Comparator<List<ByteBuffer>> comparator;
+
+        private WithComparator(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+        {
+            super(limit, offset);
+            this.comparator = comparator;
+        }
+
+        @Override
+        DecoratedRow decorate(List<ByteBuffer> row, int id)
+        {
+            return new DecoratedRow(row, id);
+        }
+
+        @Override
+        public int compare(DecoratedRow one, DecoratedRow other)
+        {
+            return comparator.compare(one.row, other.row);
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that orders the added rows based on a {@link Index.Scorer}.
+     * </p>
+     * The rows are decorated with their scores, so we don't have to recompute them while sorting.
+     */
+    private static class WithScore extends WithCompare<WithScore.ScoredRow>
+    {
+        private final Index.Scorer scorer;
+
+        private WithScore(int limit, int offset, Index.Scorer scorer)
+        {
+            super(limit, offset);
+            this.scorer = scorer;
+        }
+
+        @Override
+        ScoredRow decorate(List<ByteBuffer> row, int id)
+        {
+            return new ScoredRow(row, id, scorer.score(row));
+        }
+
+        @Override
+        public int compare(ScoredRow one, ScoredRow other)
+        {
+            return scorer.reversed()
+                   ? Float.compare(other.score, one.score)
+                   : Float.compare(one.score, other.score);
+        }
+
+        static final class ScoredRow extends DecoratedRow
+        {
+            private final float score;
+
+            ScoredRow(List<ByteBuffer> row, int id, float score)
+            {
+                super(row, id);
+                this.score = score;
+            }
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that orders rows based on the {@link #compare(DecoratedRow, DecoratedRow)} method.
+     * </p>
+     * It's possible for {@link #compare(DecoratedRow, DecoratedRow)} to produce ties. To deal with these ties, the rows
+     * are decorated with their position in the sequence of calls to {@link #add(List)}, so we can use that identifying
+     * position to solve ties by favoring the row that was inserted first.
+     * </p>
+     * It keeps at most {@code limit + offset} rows in memory.
+     */
+    private static abstract class WithCompare<T extends WithCompare.DecoratedRow> extends SortedRowsBuilder
+    {
+        private final PriorityQueue<T> queue = new PriorityQueue<>(this::compareReversedWithIdx);
+        private int numAddedRows = 0;
+        private boolean built = false;
+
+        private WithCompare(int limit, int offset)
+        {
+            super(limit, offset);
+        }
+
+        abstract T decorate(List<ByteBuffer> row, int id);
+
+        private int compareReversedWithIdx(T one, T other)
+        {
+            int cmp = compare(other, one);
+            return cmp != 0 ? cmp : Integer.compare(other.id, one.id);
+        }
+
+        abstract int compare(T indexedRow, T other);
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            assert !built : "Cannot add more rows after calling build()";
+            T candidate = decorate(row, numAddedRows++);
+            queue.offer(candidate);
+            if (queue.size() > limit + offset)
+                queue.poll();
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            built = true;
+
+            int toPeek = queue.size() - offset;
+            if (toPeek <= 0)
+                return Collections.emptyList();
+
+            ArrayList<List<ByteBuffer>> rows = new ArrayList<>(toPeek);
+            while (!queue.isEmpty() && toPeek-- > 0)
+                rows.add(queue.poll().row);
+
+            Collections.reverse(rows);
+            return rows;
+        }
+
+        /**
+         * A row decorated with its position in the sequence of calls to {@link #add(List)},
+         * so we can use it to solve ties in {@link #compareReversedWithIdx(DecoratedRow, DecoratedRow)}.
+         */
+        static class DecoratedRow
+        {
+            protected final List<ByteBuffer> row;
+            protected final int id;
+
+            DecoratedRow(List<ByteBuffer> row, int id)
+            {
+                this.row = row;
+                this.id = id;
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -411,8 +411,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             }
 
             // We don't support offset for top-k queries.
-            int offset = getOffset(options);
-            checkFalse(offset > 0, String.format(TOPK_OFFSET_ERROR, offset));
+            checkFalse(userOffset > 0, String.format(TOPK_OFFSET_ERROR, userOffset));
         }
 
         return query;

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1129,7 +1129,9 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      */
     public SortedRowsBuilder sortedRowsBuilder(int limit, int offset, QueryOptions options)
     {
-        assert (orderingComparator != null) == needsPostQueryOrdering();
+        assert (orderingComparator != null) == needsPostQueryOrdering()
+                : String.format("orderingComparator: %s, needsPostQueryOrdering: %s",
+                                orderingComparator, needsPostQueryOrdering());
 
         if (orderingComparator == null)
         {

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1129,7 +1129,9 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      */
     public SortedRowsBuilder sortedRowsBuilder(int limit, int offset, QueryOptions options)
     {
-        if (!needsPostQueryOrdering() || orderingComparator == null)
+        assert (orderingComparator != null) == needsPostQueryOrdering();
+
+        if (orderingComparator == null)
         {
             return SortedRowsBuilder.create(limit, offset);
         }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -447,16 +447,34 @@ public interface Index
     public RowFilter getPostIndexQueryFilter(RowFilter filter);
 
     /**
-     * Reorder query result before sending to client
+     * Returns a {@link Scorer} to give a similarity/proximity score to CQL result rows, so they can be ordered by the
+     * coordinator before sending them to client.
      *
-     * @param cqlRows     result set from a query
      * @param restriction restriction that requires current index
      * @param columnIndex idx of the indexed column in returned row
      * @param options     query options
+     * @return a scorer to score the rows
      */
-    default void postQuerySort(ResultSet cqlRows, Restriction restriction, int columnIndex, QueryOptions options)
+    default Scorer postQueryScorer(Restriction restriction, int columnIndex, QueryOptions options)
     {
         throw new NotImplementedException();
+    }
+
+    /**
+     * Gives a similarity/proximity score to CQL result rows.
+     */
+    interface Scorer
+    {
+        /**
+         * @param row a CQL result row
+         * @return the similarity/proximity score for the row
+         */
+        float score(List<ByteBuffer> row);
+
+        /**
+         * @return {@code true} if higher scores are considered better, {@code false} otherwise
+         */
+        boolean reversed();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.selection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.index.Index;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests for {@link SortedRowsBuilder}.
+ */
+public class SortedRowsBuilderTest
+{
+    private static final Comparator<List<ByteBuffer>> comparator = (o1, o2) -> Int32Type.instance.compare(o1.get(0), o2.get(0));
+    private static final Comparator<List<ByteBuffer>> reverseComparator = comparator.reversed();
+
+    @Test
+    public void testRowBuilder()
+    {
+        test();
+        test(0);
+        test(0, 0, 0, 0);
+        test(0, 1, 2, 3, 5, 6, 7, 8);
+        test(8, 7, 6, 5, 3, 2, 1, 0);
+        test(1, 6, 2, 0, 7, 3, 5, 4);
+        test(1, 6, 2, 0, 7, 3, 5, 4, 4, 5, 3, 7, 0, 2, 6, 1);
+    }
+
+    private static void test(int... values)
+    {
+        List<List<ByteBuffer>> rows = toRows(values);
+
+        for (int limit = 1; limit <= values.length + 1; limit++)
+        {
+            for (int offset = 0; offset <= values.length + 1; offset++)
+            {
+                // with insertion order
+                test(rows, SortedRowsBuilder.create(limit, offset), null, limit, offset);
+
+                // with comparator
+                test(rows, SortedRowsBuilder.create(limit, offset, comparator), comparator, limit, offset);
+                test(rows, SortedRowsBuilder.create(limit, offset, reverseComparator), reverseComparator, limit, offset);
+
+                // with index scorer
+                test(rows, SortedRowsBuilder.create(limit, offset, scorer(false)), comparator, limit, offset);
+                test(rows, SortedRowsBuilder.create(limit, offset, scorer(true)), reverseComparator, limit, offset);
+            }
+        }
+    }
+
+    private static void test(List<List<ByteBuffer>> rows,
+                             SortedRowsBuilder builder,
+                             @Nullable Comparator<List<ByteBuffer>> comparator,
+                             int limit,
+                             int offset)
+    {
+        // get the expected values...
+        List<List<ByteBuffer>> expecetedRows = new ArrayList<>(rows);
+        if (comparator != null)
+            expecetedRows.sort(comparator);
+        expecetedRows = expecetedRows.subList(Math.min(offset, expecetedRows.size()),
+                                              Math.min(offset + limit, expecetedRows.size()));
+        List<Integer> expectedValues = fromRows(expecetedRows);
+
+        // get the actual values...
+        rows.forEach(builder::add);
+        List<Integer> actualValues = fromRows(builder.build());
+
+        // ...and compare
+        Assertions.assertThat(actualValues).isEqualTo(expectedValues);
+    }
+
+    private static List<List<ByteBuffer>> toRows(int... values)
+    {
+        List<List<ByteBuffer>> rows = new ArrayList<>();
+        for (int value : values)
+            rows.add(Collections.singletonList(Int32Type.instance.decompose(value)));
+        return rows;
+    }
+
+    private static List<Integer> fromRows(List<List<ByteBuffer>> rows)
+    {
+        List<Integer> values = new ArrayList<>();
+        for (List<ByteBuffer> row : rows)
+            values.add(Int32Type.instance.compose(row.get(0)));
+        return values;
+    }
+
+    private static Index.Scorer scorer(boolean reversed)
+    {
+        return new Index.Scorer()
+        {
+            @Override
+            public float score(List<ByteBuffer> row)
+            {
+                return Int32Type.instance.compose(row.get(0));
+            }
+
+            @Override
+            public boolean reversed()
+            {
+                return reversed;
+            }
+        };
+    }
+}


### PR DESCRIPTION
When using `ORDER BY` or `ANN`, `SELECT` queries collect all the rows found in each replica into a `ResultSet`, then order them, and finally trim the first `LIMIT` results. This can be seen [here](https://github.com/datastax/cassandra/blob/d45360170795aa4a535a410b0c754a9f5c94d2c8/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java#L918-L934).

For index-based sorting, it means that the `ResultSet` holds up to num_replicas\*LIMIT in memory. If we were also using an `OFFSET`, it would hold num_replicas*(LIMIT+OFFSET) rows.

This PR uses online sorting in the `ResultSetBuilder` to limit its memory usage to just LIMIT rows, or LIMIT+OFFSET rows if we use an offset.