### PR TITLE
Use vector index node count estimates when planning TopK queries

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -1070,7 +1070,10 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                 default:
                     break;
             }
-            return String.format("%s %s %s", column.name, operator, type.getString(value));
+            var valueString = type.getString(value);
+            if (valueString.length() > 9)
+                valueString = valueString.substring(0, 6) + "...";
+            return String.format("%s %s %s", column.name, operator, valueString);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
@@ -199,5 +200,14 @@ public class Segment implements Closeable, SegmentOrdering
     public String toString()
     {
         return String.format("Segment{metadata=%s}", metadata);
+    }
+
+    public int estimateAnnNodesVisited(int limit, int candidates)
+    {
+        IndexSearcher searcher = getIndexSearcher();
+        if (!(searcher instanceof V2VectorIndexSearcher))
+            throw new UnsupportedOperationException("Not a vector index segment");
+
+        return ((V2VectorIndexSearcher) searcher).estimateNodesVisited(limit, candidates);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -202,12 +202,17 @@ public class Segment implements Closeable, SegmentOrdering
         return String.format("Segment{metadata=%s}", metadata);
     }
 
+    /**
+     * Estimate how many nodes the index will visit to find the top `limit` results
+     * given the number of candidates that match other predicates and taking into
+     * account the size of the index itself.  (The smaller
+     * the number of candidates, the more nodes we expect to visit just to find
+     * results that are in that set.)
+     */
     public int estimateAnnNodesVisited(int limit, int candidates)
     {
         IndexSearcher searcher = getIndexSearcher();
-        if (!(searcher instanceof V2VectorIndexSearcher))
-            throw new UnsupportedOperationException("Not a vector index segment");
-
+        assert searcher instanceof V2VectorIndexSearcher : searcher;
         return ((V2VectorIndexSearcher) searcher).estimateNodesVisited(limit, candidates);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -434,6 +434,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         }
     }
 
+    public int estimateNodesVisited(int limit, int candidates)
+    {
+        return estimateCost(limit, candidates).expectedNodesVisited;
+    }
+
     private CostEstimate estimateCost(int limit, int candidates)
     {
         int rawExpectedNodes = getRawExpectedNodes(limit, candidates);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -335,6 +335,11 @@ public class VectorMemtableIndex implements MemtableIndex
         return (int) min(max(limit, Plan.memoryToDiskFactor() * expectedComparisons), GLOBAL_BRUTE_FORCE_ROWS);
     }
 
+    public int estimateAnnNodesVisited(int limit, int nPermittedOrdinals)
+    {
+        return expectedNodesVisited(limit, nPermittedOrdinals, graph.size());
+    }
+
     /**
      * All parameters must be greater than zero.  nPermittedOrdinals may be larger than graphSize.
      */

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -392,6 +392,7 @@ abstract public class Plan
     {
         if (selectivity == -1)
             selectivity = estimateSelectivity();
+        assert 0.0 <= selectivity && selectivity <= 1.0 : "Invalid selectivity: " + selectivity;
         return selectivity;
     }
 
@@ -1794,6 +1795,8 @@ abstract public class Plan
         Access scaleCount(double factor)
         {
             assert !Double.isNaN(factor) : "Count multiplier must not be NaN";
+            if (Double.isInfinite(factor))
+                return EMPTY;
 
             double[] counts = Arrays.copyOf(this.counts, this.counts.length);
             double[] skipDistances = Arrays.copyOf(this.distances, this.distances.length);
@@ -1809,6 +1812,8 @@ abstract public class Plan
         Access scaleDistance(double factor)
         {
             assert !Double.isNaN(factor) : "Distance multiplier must not be NaN";
+            if (Double.isInfinite(factor))
+                return EMPTY;
 
             double[] counts = Arrays.copyOf(this.counts, this.counts.length);
             double[] skipDistances = Arrays.copyOf(this.distances, this.distances.length);

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1151,7 +1151,7 @@ abstract public class Plan
             // occurs that we collected enough rows. keysCount() gives us the
             // average expected number of rows that will be needed but
             // many queries will need fewer than that.
-            return executor.getTopKRows(ordering, keysCount() / 10);
+            return executor.getTopKRows(ordering, max(1, keysCount() / 10));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1146,7 +1146,11 @@ abstract public class Plan
         @Override
         protected Iterator<? extends PrimaryKey> execute(Executor executor)
         {
-            return executor.getTopKRows(ordering, keysCount());
+            // Divide soft limit by 10, so we can terminate search earlier if it
+            // occurs that we collected enough rows. keysCount() gives us the
+            // average expected number of rows that will be needed but
+            // many queries will need fewer than that.
+            return executor.getTopKRows(ordering, keysCount() / 10);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1147,11 +1147,11 @@ abstract public class Plan
         @Override
         protected Iterator<? extends PrimaryKey> execute(Executor executor)
         {
-            // Divide soft limit by 10, so we can terminate search earlier if it
+            // Divide soft limit by 2, so we can terminate search earlier if it
             // occurs that we collected enough rows. keysCount() gives us the
             // average expected number of rows that will be needed but
             // many queries will need fewer than that.
-            return executor.getTopKRows(ordering, max(1, keysCount() / 10));
+            return executor.getTopKRows(ordering, max(1, keysCount() / 2));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1645,7 +1645,7 @@ abstract public class Plan
     public static class CostCoefficients
     {
         /** The constant cost of performing skipTo on posting lists returned from range scans */
-        public final static double RANGE_SCAN_SKIP_COST = 0.3;
+        public final static double RANGE_SCAN_SKIP_COST = 0.2;
 
         /** The coefficient controlling the increase of the skip cost with the distance of the skip. */
         public final static double RANGE_SCAN_SKIP_COST_DISTANCE_FACTOR = 0.1;
@@ -1656,7 +1656,7 @@ abstract public class Plan
         public final static double RANGE_SCAN_SKIP_COST_POSTINGS_COUNT_EXPONENT = 0.33;
 
         /** The constant cost of performing skipTo on literal indexes */
-        public final static double POINT_LOOKUP_SKIP_COST = 0.8;
+        public final static double POINT_LOOKUP_SKIP_COST = 0.5;
 
         /** The coefficient controlling the increase of the skip cost with the total size of the posting list for point lookup queries. */
         public final static double POINT_LOOKUP_SKIP_COST_DISTANCE_FACTOR = 0.1;
@@ -1672,7 +1672,7 @@ abstract public class Plan
         public final static double ANN_OPEN_COST = 10.0;
 
         /** Additional overhead needed by processing each input key fed to the ANN index searcher */
-        public final static double ANN_INPUT_KEY_COST = 5.0;
+        public final static double ANN_INPUT_KEY_COST = 3.0;
 
         /** Cost to get a scored key from DiskANN */
         public final static double ANN_SCORED_KEY_COST = 10.0;
@@ -1681,7 +1681,7 @@ abstract public class Plan
         public final static double ANN_NODE_COST = 20.0;
 
         /** Cost to fetch one row from storage */
-        public final static double ROW_COST = 200.0;
+        public final static double ROW_COST = 80.0;
 
         /** Additional cost added to row fetch cost per each row cell */
         public final static double ROW_CELL_COST = 0.4;

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -131,7 +131,9 @@ abstract public class Plan
      */
     final Access access;
 
-
+    /**
+     * Lazily caches the estimated fraction of the table data that the result of this plan is expected to match.
+     */
     private double selectivity = -1;
 
 
@@ -800,7 +802,6 @@ abstract public class Plan
             return Objects.equals(this.access, access)
                    ? this
                    : new LiteralIndexScan(factory, id, predicate, matchingKeysCount, this.access);
-
         }
     }
 
@@ -1159,7 +1160,6 @@ abstract public class Plan
             return Objects.equals(access, this.access)
                    ? this
                    : new AnnScan(factory, id, ordering, access);
-
         }
 
         @Override
@@ -1243,7 +1243,6 @@ abstract public class Plan
         @Override
         protected RowsIterationCost estimateCost()
         {
-
             double rowFetchCost = CostCoefficients.ROW_COST
                                   + CostCoefficients.ROW_CELL_COST * factory.tableMetrics.avgCellsPerRow
                                   + CostCoefficients.ROW_BYTE_COST * factory.tableMetrics.avgBytesPerRow;
@@ -1261,7 +1260,6 @@ abstract public class Plan
             return Objects.equals(access, this.access)
                 ? this
                 : new Fetch(factory, id, source.orig, access);
-
         }
     }
 
@@ -1636,8 +1634,9 @@ abstract public class Plan
         /**
          * Returns the expected number of ANN index nodes that must be visited to get the list of candidates for top K.
          *
-         * @param ordering allows to identify the proper index
-         * @param limit    number of expected
+         * @param ordering   allows to identify the proper index
+         * @param limit      number of rows to fetch
+         * @param candidates number of candidate rows that satisfy the expression predicates
          */
         int estimateAnnNodesVisited(RowFilter.Expression ordering, int limit, long candidates);
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -281,6 +281,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         if (Tracing.isTracing())
         {
+            Tracing.trace("Query execution plan:\n" + optimizedPlan.toStringRecursive());
             List<Plan.IndexScan> origIndexScans = keysIterationPlan.nodesOfType(Plan.IndexScan.class);
             List<Plan.IndexScan> selectedIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
             Tracing.trace("Selecting {} {} of {} out of {} indexes",

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -490,14 +490,14 @@ public class PlanTest
 
         String prettyStr = limit.toStringRecursive();
 
-        assertEquals("Limit 3 (rows: 3.0, cost/row: 213.4, cost: 58616.9..59257.2)\n" +
-                     " └─ Filter pred1 < X AND pred2 < X AND pred3 < X (sel: 1.000000000) (rows: 3.0, cost/row: 213.4, cost: 58616.9..59257.2)\n" +
-                     "     └─ Fetch (rows: 3.0, cost/row: 213.4, cost: 58616.9..59257.2)\n" +
-                     "         └─ AnnSort (keys: 3.0, cost/key: 10.0, cost: 58616.9..58646.9)\n" +
-                     "             └─ Union (keys: 1999.0, cost/key: 24.3, cost: 90.0..48591.9)\n" +
-                     "                 ├─ Intersection (keys: 1000.0, cost/key: 47.5, cost: 60.0..47561.9)\n" +
+        assertEquals("Limit 3 (rows: 3.0, cost/row: 93.4, cost: 40118.3..40398.6)\n" +
+                     " └─ Filter pred1 < X AND pred2 < X AND pred3 < X (sel: 1.000000000) (rows: 3.0, cost/row: 93.4, cost: 40118.3..40398.6)\n" +
+                     "     └─ Fetch (rows: 3.0, cost/row: 93.4, cost: 40118.3..40398.6)\n" +
+                     "         └─ AnnSort (keys: 3.0, cost/key: 10.0, cost: 40118.3..40148.3)\n" +
+                     "             └─ Union (keys: 1999.0, cost/key: 17.0, cost: 90.0..34091.3)\n" +
+                     "                 ├─ Intersection (keys: 1000.0, cost/key: 33.0, cost: 60.0..33061.3)\n" +
                      "                 │   ├─ NumericIndexScan of pred2_idx using RANGE(pred2) (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 1.0, cost: 30.0..2030.0)\n" +
-                     "                 │   └─ NumericIndexScan of pred1_idx using RANGE(pred1) (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 22.8, cost: 30.0..45531.9)\n" +
+                     "                 │   └─ NumericIndexScan of pred1_idx using RANGE(pred1) (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 15.5, cost: 30.0..31031.3)\n" +
                      "                 └─ LiteralIndexScan of pred3_idx using RANGE(pred3) (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 1.0, cost: 30.0..1030.0)\n", prettyStr);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -940,7 +940,8 @@ public class PlanTest
     {
         Plan.KeysIteration indexScan1 = Mockito.mock(Plan.KeysIteration.class);
         Mockito.when(indexScan1.withAccess(Mockito.any())).thenReturn(indexScan1);
-        Mockito.when(indexScan1.estimateCost()).thenReturn(new Plan.KeysIterationCost(20, 0.01, 0.0, 0.5));
+        Mockito.when(indexScan1.estimateCost()).thenReturn(new Plan.KeysIterationCost(20,0.0, 0.5));
+        Mockito.when(indexScan1.estimateSelectivity()).thenReturn(0.001);
         Mockito.when(indexScan1.description()).thenReturn("");
 
         Plan.KeysIteration indexScan2 = factory.numericIndexScan(saiPred2, (long) (0.01 * factory.tableMetrics.rows));
@@ -951,8 +952,8 @@ public class PlanTest
         Plan.RowsIteration origPlan = factory.limit(postFilter, 3);
         origPlan.cost();
 
-        Mockito.verify(indexScan1, Mockito.atMost(2)).withAccess(Mockito.any());
-        Mockito.verify(indexScan1, Mockito.atMost(1)).estimateCost();
+        Mockito.verify(indexScan1, Mockito.times(1)).withAccess(Mockito.any());
+        Mockito.verify(indexScan1, Mockito.times(1)).estimateCost();
     }
 
     private List<Integer> ids(List<? extends Plan> subplans)


### PR DESCRIPTION
This commit introduces a new interface: `Plan.CostEstimator`. This allows to plug external cost estimators into the query planner. Therefore, the code in `Plan` is decoupled from the actual storage / indexing machinery and can be easily tested. We also don't leak index-specific stuff to the Plan.

Currently, `CostEstimator` implementation estimates the expected number of visited DiskANN index nodes, depending on the limit and total number of indexed rows. This is achieved by iterating through all vector indexes involved in the query and summing their estimates.