### PR TITLE
Improvements to LTM vector compaction

### DIFF
--- a/conf/jvm11-server.options
+++ b/conf/jvm11-server.options
@@ -4,6 +4,9 @@
 # See jvm-server.options. This file is specific for Java 11 and newer.    #
 ###########################################################################
 
+-XX:ThreadPriorityPolicy=1
+-XX:+UseThreadPriorities
+
 #################
 #  GC SETTINGS  #
 #################

--- a/conf/jvm17-server.options
+++ b/conf/jvm17-server.options
@@ -4,6 +4,9 @@
 # See jvm-server.options. This file is specific for Java 11 and newer.    #
 ###########################################################################
 
+-XX:ThreadPriorityPolicy=1
+-XX:+UseThreadPriorities
+
 #################
 #  GC SETTINGS  #
 #################

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.index.sai.disk.v1.kdtree.NumericIndexWriter;
 import org.apache.cassandra.index.sai.disk.v1.trie.InvertedIndexWriter;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
+import org.apache.cassandra.index.sai.utils.LowPriorityThreadFactory;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -67,6 +68,12 @@ import static org.apache.cassandra.utils.FBUtilities.busyWaitWhile;
 public abstract class SegmentBuilder
 {
     private static final Logger logger = LoggerFactory.getLogger(SegmentBuilder.class);
+
+    /** for parallelism within a single compaction */
+    public static final ForkJoinPool compactionFjp = new ForkJoinPool(Runtime.getRuntime().availableProcessors(),
+                                                                      new LowPriorityThreadFactory(),
+                                                                      null,
+                                                                      false);
 
     // Served as safe net in case memory limit is not triggered or when merger merges small segments..
     public static final long LAST_VALID_SEGMENT_ROW_ID = ((long)Integer.MAX_VALUE / 2) - 1L;
@@ -256,7 +263,7 @@ public abstract class SegmentBuilder
                 return result.bytesUsed;
 
             updatesInFlight.incrementAndGet();
-            ForkJoinPool.commonPool().submit(() -> {
+            compactionFjp.submit(() -> {
                 try
                 {
                     long bytesAdded = result.bytesUsed + graphIndex.addGraphNode(result);
@@ -344,7 +351,7 @@ public abstract class SegmentBuilder
         protected long addInternalAsync(ByteBuffer term, int segmentRowId)
         {
             updatesInFlight.incrementAndGet();
-            ForkJoinPool.commonPool().submit(() -> {
+            compactionFjp.submit(() -> {
                 try
                 {
                     long bytesAdded = addInternal(term, segmentRowId);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -55,6 +55,7 @@ import net.openhft.chronicle.hash.serialization.BytesReader;
 import net.openhft.chronicle.hash.serialization.BytesWriter;
 import net.openhft.chronicle.map.ChronicleMap;
 import net.openhft.chronicle.map.ChronicleMapBuilder;
+import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -275,7 +276,7 @@ public class CompactionGraph implements Closeable, Accountable
             // write postings asynchronously while we run cleanup().  this requires the index header to be present
             writer.writeHeader();
             long postingsOffset = postingsOutput.getFilePointer();
-            var es = Executors.newSingleThreadExecutor();
+            var es = Executors.newSingleThreadExecutor(new NamedThreadFactory("CompactionGraphPostingsWriter"));
             var indexHandle = perIndexComponents.get(IndexComponentType.TERMS_DATA).createFileHandle();
             var index = OnDiskGraphIndex.load(indexHandle::createReader, termsOffset);
             var postingsFuture = es.submit(() -> {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,10 +61,10 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
-import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.vector.VectorPostings.CompactionVectorPostings;
+import org.apache.cassandra.index.sai.utils.LowPriorityThreadFactory;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
@@ -77,6 +78,11 @@ public class CompactionGraph implements Closeable, Accountable
 {
     private static final Logger logger = LoggerFactory.getLogger(CompactionGraph.class);
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private static final ForkJoinPool compactionFjp = new ForkJoinPool(Runtime.getRuntime().availableProcessors(),
+                                                                       new LowPriorityThreadFactory(),
+                                                                       null,
+                                                                       false);
 
     private final GraphIndexBuilder builder;
     private final VectorType.VectorSerializer serializer;
@@ -142,7 +148,7 @@ public class CompactionGraph implements Closeable, Accountable
                                         indexConfig.getConstructionBeamWidth(),
                                         1.2f,
                                         dimension > 3 ? 1.2f : 1.4f,
-                                        SegmentBuilder.compactionFjp, SegmentBuilder.compactionFjp);
+                                        compactionFjp, compactionFjp);
 
         var indexFile = perIndexComponents.addOrGet(IndexComponentType.TERMS_DATA).file();
         termsOffset = (indexFile.exists() ? indexFile.length() : 0)

--- a/src/java/org/apache/cassandra/index/sai/utils/LowPriorityThreadFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/LowPriorityThreadFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+
+public class LowPriorityThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory
+{
+    @Override
+    public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+        ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+        worker.setPriority(Thread.MIN_PRIORITY);
+        return worker;
+    }
+}


### PR DESCRIPTION
the FJP change is the big one, switching to a bounded queue can prevent OOM