### PR TITLE
CNDB-9967 re-enable = operator for analyzed SAI

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -607,7 +607,7 @@ public class IndexContext
         if (op.isLike() || op == Operator.LIKE) return false;
         // Analyzed columns store the indexed result, so we are unable to compute raw equality.
         // The only supported operator is ANALYZER_MATCHES.
-        if (isAnalyzed || op == Operator.ANALYZER_MATCHES) return isAnalyzed && op == Operator.ANALYZER_MATCHES;
+        if (op == Operator.ANALYZER_MATCHES) return isAnalyzed;
 
         // ANN is only supported against vectors.
         // BOUNDED_ANN is only supported against vectors with a Euclidean similarity function.

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -53,6 +53,7 @@ public class LuceneAnalyzerTest extends SAITester
         flush();
 
         assertEquals(0, execute("SELECT * FROM %s WHERE val : 'query'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val = 'query'").size());
     }
 
     @Test
@@ -203,11 +204,10 @@ public class LuceneAnalyzerTest extends SAITester
         assertEquals(1, execute("SELECT * FROM %s WHERE val : 'missing' OR (val : 'quick' AND val : 'dog')").size());
         assertEquals(0, execute("SELECT * FROM %s WHERE val : 'missing' OR (val : 'quick' AND val : 'missing')").size());
 
-        // EQ operator is not supported for analyzed columns unless ALLOW FILTERING is used
-        assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE val = 'dog'")).isInstanceOf(InvalidRequestException.class);
+        // EQ operator support is reintroduced for analyzed columns, it should work as ':' operator
+        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'The quick brown fox jumps over the lazy DOG.' ALLOW FILTERING").size());
-        // EQ is a raw equality check, so a token like 'dog' should not return any results
-        assertEquals(0, execute("SELECT * FROM %s WHERE val = 'dog' ALLOW FILTERING").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog' ALLOW FILTERING").size());
     }
 
     @Test
@@ -573,6 +573,18 @@ public class LuceneAnalyzerTest extends SAITester
 
         assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE some_num : 1"))
         .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    public void testLegacyEqQueryOnNormalizedTextColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'ascii': 'true', 'case_sensitive': 'false', 'normalize': 'true'}");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES (1, 'Aaą')");
+
+        beforeAndAfterFlush(() -> assertEquals(1, execute("SELECT * FROM %s WHERE val = 'aaa'").size()));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -316,6 +316,7 @@ public class NativeIndexDDLTest extends SAITester
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
         assertEquals(1, execute("SELECT id FROM %s WHERE val : 'camel'").size());
+        assertEquals(1, execute("SELECT id FROM %s WHERE val = 'camel'").size());
     }
 
     @Test


### PR DESCRIPTION
The operator was disabled by #702 as it may produce surprising matches. For backward compatibility, we allow this behavior.