### PR TITLE
CNDB-10025 main: CQL queries with OFFSET 0 should disable paging

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -111,7 +111,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                                                 "Downgrading the consistency level to %s.";
     public static final String TOPK_OFFSET_ERROR = "Top-K queries cannot be run with an offset. Offset was set to %d.";
 
-    private static final int NO_OFFSET = -1; // sentinel value meaning no offset has been explicitlu requested
+    private static final int NO_OFFSET = -1; // sentinel value meaning no offset has been explicitly requested
 
     private final String rawCQLStatement;
     public final VariableSpecifications bindVariables;

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -111,6 +111,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                                                 "Downgrading the consistency level to %s.";
     public static final String TOPK_OFFSET_ERROR = "Top-K queries cannot be run with an offset. Offset was set to %d.";
 
+    private static final int NO_OFFSET = -1; // sentinel value meaning no offset has been explicitlu requested
+
     private final String rawCQLStatement;
     public final VariableSpecifications bindVariables;
     public final TableMetadata table;
@@ -411,7 +413,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             }
 
             // We don't support offset for top-k queries.
-            checkFalse(userOffset > 0, String.format(TOPK_OFFSET_ERROR, userOffset));
+            checkFalse(userOffset != NO_OFFSET, String.format(TOPK_OFFSET_ERROR, userOffset));
         }
 
         return query;
@@ -555,11 +557,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         // If the query has an offset we silently ignore user-facing paging and return all the rows specified by the
         // limit/offset constraints in one go, since regular key-based paging is not supported when using limit/offest
         // paging. However, we still use the query fetch size to internally page the rows. We do that to avoid loading
-        // in memory all the rows that will be discarded by the offset.
+        // in memory all the rows that will be discarded by the offset. Key-based paging is also disabled if the offset
+        // is explicitly set to zero.
         ResultMessage.Rows msg;
-        try (PartitionIterator partitions = userOffset > 0
-                                          ? pager.readAll(pageSize, queryStartNanoTime)
-                                          : pager.fetchPage(pageSize, queryStartNanoTime))
+        try (PartitionIterator partitions = userOffset == NO_OFFSET
+                                          ? pager.fetchPage(pageSize, queryStartNanoTime)
+                                          : pager.readAll(pageSize, queryStartNanoTime))
         {
             msg = processResults(partitions, options, selectors, nowInSec, userLimit, userOffset);
         }
@@ -840,12 +843,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
     private DataLimits getDataLimits(QueryState queryState, int userLimit, int perPartitionLimit, int userOffset)
     {
-        assert userOffset == 0 || userLimit != NO_LIMIT : "Cannot use OFFSET without LIMIT";
+        assert userOffset == NO_OFFSET || userLimit != NO_LIMIT : "Cannot use OFFSET without LIMIT";
 
-        if (userOffset > 0)
+        if (userOffset != NO_OFFSET)
             Guardrails.offsetRows.guard(userOffset, "Select query", false, queryState);
 
-        int fetchLimit = userLimit == NO_LIMIT ? userLimit : userLimit + userOffset;
+        int fetchLimit = userLimit == NO_LIMIT || userOffset == NO_OFFSET ? userLimit : userLimit + userOffset;
         int cqlRowLimit = NO_LIMIT;
         int cqlPerPartitionLimit = NO_LIMIT;
 
@@ -943,7 +946,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
     private int getOffset(QueryOptions options)
     {
-        int userOffset = 0;
+        int userOffset = NO_OFFSET;
 
         if (offset != null)
         {
@@ -991,7 +994,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                               int userOffset) throws InvalidRequestException
     {
         GroupMaker groupMaker = aggregationSpec == null ? null : aggregationSpec.newGroupMaker();
-        SortedRowsBuilder rows = sortedRowsBuilder(userLimit, userOffset, options);
+        SortedRowsBuilder rows = sortedRowsBuilder(userLimit, userOffset == NO_OFFSET ? 0 : userOffset, options);
         ResultSetBuilder result = new ResultSetBuilder(getResultMetadata(), selectors, groupMaker, rows);
 
         while (partitions.hasNext())

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailOffsetRowsTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailOffsetRowsTest.java
@@ -25,7 +25,7 @@ import static java.lang.String.format;
 /**
  * Tests the guardrail for the number of rows that a LIMIT/OFFSET SELECT query can skip, {@link Guardrails#offsetRows}.
  */
-public class GuardrailOffsetLimitRowsTest extends GuardrailTester
+public class GuardrailOffsetRowsTest extends GuardrailTester
 {
     private static final int WARN_THRESHOLD = 2;
     private static final int FAIL_THRESHOLD = 4;


### PR DESCRIPTION
The new `OFFSET` feature introduced by CDNB-9541 disables normal key-based paging when LIMIT/OFFSET paging is used.

However, the patch considered that queries without an explicit `OFFSET` and with `OFFSET 0` are the same. As a result, it doesn't disable key-based paging with `OFFSET 0`. Whereas the query results are perfectly correct, it can be a surprising behaviour that the first "page" of a LIMIT/OFFSET paging is also paged in a key-based way.

I think we should disable key-based paging also when `OFFSET` is explicitly set to 0.

The proposed PR uses a sentinel value to distinguish between no explicit offset and offset explicitly set to zero, and then it disables user-facing paging if the offset has been explicitly set to zero.