### PR TITLE
Fix OR when using ANALYZER_MATCHES with ngrams

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -277,7 +277,7 @@ public class Operation
         {
             OperatorNode node = isDisjunction ? new OrNode() : new AndNode();
             for (RowFilter.Expression expression : expressions)
-                node.add(buildExpression(expression));
+                node.add(buildExpression(expression, isDisjunction));
             for (RowFilter.FilterElement child : children)
                 node.add(buildTree(child));
             return node;
@@ -288,7 +288,7 @@ public class Operation
             return buildTree(filterOperation.expressions(), filterOperation.children(), filterOperation.isDisjunction());
         }
 
-        static Node buildExpression(RowFilter.Expression expression)
+        static Node buildExpression(RowFilter.Expression expression, boolean isDisjunction)
         {
             if (expression.operator() == Operator.IN)
             {
@@ -309,6 +309,12 @@ public class Operation
                     return node.children().get(0);
                 if (node.children().isEmpty())
                     return new EmptyNode();
+                return node;
+            }
+            else if (expression.operator() == Operator.ANALYZER_MATCHES && isDisjunction)
+            {
+                OperatorNode node = new AndNode();
+                node.add(new ExpressionNode(expression));
                 return node;
             }
             else

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -462,6 +462,95 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
+    public void testEdgeNgramFilterWithOR()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"standard\", \"args\":{}}," +
+                    "\t\"filters\":[{\"name\":\"lowercase\", \"args\":{}}, " +
+                    "{\"name\":\"edgengram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"30\"}}],\n" +
+                    "\t\"charFilters\":[]" +
+                    "}'};");
+
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('3', 'FPWMCR005 Mercer High Growth Managed')");
+        execute("INSERT INTO %s (id, val) VALUES ('4', 'WFS7093AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('5', 'WFS0565AU')");
+
+        flush();
+
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
+        assertEquals(0, execute("SELECT val FROM %s WHERE val : ''").size());
+        assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : '' OR val : 'WFS2684AU'").size());
+        assertEquals(0, execute("SELECT val FROM %s WHERE val : '' AND val : 'WFS2684AU'").size());
+    }
+
+    @Test
+    public void testEdgeNgramFilterWithOrAndNoFlush()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"standard\", \"args\":{}}," +
+                    "\t\"filters\":[{\"name\":\"lowercase\", \"args\":{}}, " +
+                    "{\"name\":\"edgengram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"30\"}}],\n" +
+                    "\t\"charFilters\":[]" +
+                    "}'};");
+
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('3', 'FPWMCR005 Mercer High Growth Managed')");
+        execute("INSERT INTO %s (id, val) VALUES ('4', 'WFS7093AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('5', 'WFS0565AU')");
+
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
+        assertEquals(0, execute("SELECT val FROM %s WHERE val : ''").size());
+        assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : '' OR val : 'WFS2684AU'").size());
+        assertEquals(0, execute("SELECT val FROM %s WHERE val : '' AND val : 'WFS2684AU'").size());
+    }
+
+    @Test
+    public void testNgramFilterWithOR()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"standard\", \"args\":{}}," +
+                    "\t\"filters\":[{\"name\":\"lowercase\", \"args\":{}}, " +
+                    "{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"30\"}}],\n" +
+                    "\t\"charFilters\":[]" +
+                    "}'};");
+
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('3', 'FPWMCR005 Mercer High Growth Managed')");
+        execute("INSERT INTO %s (id, val) VALUES ('4', 'WFS7093AU')");
+        execute("INSERT INTO %s (id, val) VALUES ('5', 'WFS0565AU')");
+
+        flush();
+
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
+        assertEquals(1, execute("SELECT val FROM %s WHERE val : '268'").size());
+        assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
+        assertEquals(2, execute("SELECT val FROM %s WHERE val : '133' OR val : 'WFS2684AU'").size());
+    }
+    @Test
     public void testWhitespace() throws Throwable
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -462,7 +462,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testEdgeNgramFilterWithOR()
+    public void testEdgeNgramFilterWithOR() throws Throwable
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -482,43 +482,14 @@ public class LuceneAnalyzerTest extends SAITester
         execute("INSERT INTO %s (id, val) VALUES ('4', 'WFS7093AU')");
         execute("INSERT INTO %s (id, val) VALUES ('5', 'WFS0565AU')");
 
-        flush();
-
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
-        assertEquals(0, execute("SELECT val FROM %s WHERE val : ''").size());
-        assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : '' OR val : 'WFS2684AU'").size());
-        assertEquals(0, execute("SELECT val FROM %s WHERE val : '' AND val : 'WFS2684AU'").size());
-    }
-
-    @Test
-    public void testEdgeNgramFilterWithOrAndNoFlush()
-    {
-        createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
-
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
-                    "'index_analyzer': '{\n" +
-                    "\t\"tokenizer\":{\"name\":\"standard\", \"args\":{}}," +
-                    "\t\"filters\":[{\"name\":\"lowercase\", \"args\":{}}, " +
-                    "{\"name\":\"edgengram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"30\"}}],\n" +
-                    "\t\"charFilters\":[]" +
-                    "}'};");
-
-        waitForIndexQueryable();
-
-        execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
-        execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
-        execute("INSERT INTO %s (id, val) VALUES ('3', 'FPWMCR005 Mercer High Growth Managed')");
-        execute("INSERT INTO %s (id, val) VALUES ('4', 'WFS7093AU')");
-        execute("INSERT INTO %s (id, val) VALUES ('5', 'WFS0565AU')");
-
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
-        assertEquals(0, execute("SELECT val FROM %s WHERE val : ''").size());
-        assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
-        assertEquals(1, execute("SELECT val FROM %s WHERE val : '' OR val : 'WFS2684AU'").size());
-        assertEquals(0, execute("SELECT val FROM %s WHERE val : '' AND val : 'WFS2684AU'").size());
+        beforeAndAfterFlush(() -> {
+            assertEquals(1, execute("SELECT val FROM %s WHERE val : 'MAL0133AU'").size());
+            assertEquals(1, execute("SELECT val FROM %s WHERE val : 'WFS2684AU'").size());
+            assertEquals(0, execute("SELECT val FROM %s WHERE val : ''").size());
+            assertEquals(2, execute("SELECT val FROM %s WHERE val : 'MAL0133AU' OR val : 'WFS2684AU'").size());
+            assertEquals(1, execute("SELECT val FROM %s WHERE val : '' OR val : 'WFS2684AU'").size());
+            assertEquals(0, execute("SELECT val FROM %s WHERE val : '' AND val : 'WFS2684AU'").size());
+        });
     }
 
     @Test


### PR DESCRIPTION
Currently, we do UNION when we see OR. That breaks in cases when we use analyzers and ngrams with OR.
This PR tries to fix that by adding an AND node when we see ANALYZER_MATCHES. 