### PR TITLE
Compact tracing mode for cqlsh

### DIFF
--- a/pylib/cqlshlib/cqlshhandling.py
+++ b/pylib/cqlshlib/cqlshhandling.py
@@ -178,7 +178,7 @@ cqlsh_help_cmd_syntax_rules = r'''
 '''
 
 cqlsh_tracing_cmd_syntax_rules = r'''
-<tracingCommand> ::= "TRACING" ( switch=( "ON" | "OFF" ) )?
+<tracingCommand> ::= "TRACING" ( switch=( "ON" | "OFF" | "FULL" | "COMPACT" ) )?
                    ;
 '''
 

--- a/pylib/cqlshlib/tracing.py
+++ b/pylib/cqlshlib/tracing.py
@@ -45,9 +45,9 @@ def print_trace(shell, tracing_mode, trace):
 def format_trace(activity):
     """
     Format a trace activity, without the control-character mangling we use for other strings.
-    (Trace activity can contain newlines.)
+    (Trace activity can contain internal newlines that we want to preserve.)
     """
-    return colorme(activity, None, 'text')
+    return colorme(activity.rstrip(), None, 'text')
 
 
 def print_trace_full(shell, trace):

--- a/pylib/cqlshlib/tracing.py
+++ b/pylib/cqlshlib/tracing.py
@@ -22,7 +22,7 @@ from cqlshlib.displaying import colorme, MAGENTA
 from cqlshlib.formatting import CqlType
 
 
-def print_trace_session(shell, session, session_id, partial_session=False):
+def print_trace_session(shell, tracing_mode, session, session_id, partial_session=False):
     """
     Lookup a trace by session and trace session ID, then print it.
     """
@@ -33,7 +33,13 @@ def print_trace_session(shell, session, session_id, partial_session=False):
     except TraceUnavailable:
         shell.printerr("Session %s wasn't found." % session_id)
     else:
-        print_trace(shell, trace)
+        print_trace(shell, tracing_mode, trace)
+
+
+def print_trace(shell, tracing_mode, trace):
+    assert tracing_mode in {'full', 'compact'}
+    trace_fn = print_trace_full if tracing_mode == 'full' else print_trace_compact
+    trace_fn(shell, trace)
 
 
 def format_trace(activity):
@@ -44,11 +50,11 @@ def format_trace(activity):
     return colorme(activity, None, 'text')
 
 
-def print_trace(shell, trace):
+def print_trace_full(shell, trace):
     """
-    Print an already populated cassandra.query.QueryTrace instance.
+    Print a populated cassandra.query.QueryTrace instance.
     """
-    rows = make_trace_rows(trace)
+    rows = make_trace_rows(trace, 'full')
     if not rows:
         shell.printerr("No rows for session %s found." % (trace.trace_id,))
         return
@@ -61,11 +67,51 @@ def print_trace(shell, trace):
     shell.writeresult('Tracing session: ', color=MAGENTA, newline=False)
     shell.writeresult(trace.trace_id)
     shell.writeresult('')
-    shell.print_formatted_result(formatted_names, formatted_values, with_header=True, tty=shell.tty)
+    shell.print_formatted_result(formatted_names, formatted_values, True, shell.tty)
     shell.writeresult('')
 
 
-def make_trace_rows(trace):
+def print_trace_compact(shell, trace):
+    """
+    Print a populated cassandra.query.QueryTrace instance.
+    """
+    rows = make_trace_rows(trace, 'compact')
+    if not rows:
+        shell.printerr("No rows for session %s found." % (trace.trace_id,))
+        return
+
+    # Transform the full trace into 3 compact columns: src, elapsed, activity
+    # The original source column is a string version of an ipv4 address, e.g. 192.168.1.121;
+    # We want to generate a "key" mapping those addresses to "A", "B", "C", etc.
+    unique_sources = sorted(set(row[2] for row in rows))
+    if len(unique_sources) > 26:
+        shell.writeresult('Too many sources for compact mode; showing full instead')
+        print_trace_full(shell, trace)
+        return
+    source_mapping = {src: chr(65 + idx) for idx, src in enumerate(unique_sources)}
+
+    names = ['src', 'elapsed', 'activity']
+    formatted_names = list(map(shell.myformat_colname, names))
+    formatted_values = [[shell.myformat_value(source_mapping[row[2]]),
+                         shell.myformat_value(row[3]),
+                         format_trace(row[0])] for row in rows]
+
+    shell.writeresult('')
+    shell.writeresult('Tracing session: ', color=MAGENTA, newline=False)
+    shell.writeresult(trace.trace_id)
+    shell.writeresult('')
+
+    # Write mapping of sources to keys
+    shell.writeresult('Source mapping:', color=MAGENTA)
+    for src, key in source_mapping.items():
+        shell.writeresult(f"  {key} -> {src}")
+    shell.writeresult('')
+
+    shell.print_formatted_result(formatted_names, formatted_values, True, shell.tty, justify_last=False)
+    shell.writeresult('')
+
+
+def make_trace_rows(trace, tracing_mode):
     if not trace.events:
         return []
 
@@ -73,7 +119,7 @@ def make_trace_rows(trace):
 
     # append main rows (from events table).
     for event in trace.events:
-        rows.append(["%s [%s]" % (event.description, event.thread_name),
+        rows.append(["%s [%s]" % (event.description, event.thread_name) if tracing_mode == 'full' else event.description,
                      str(datetime_from_utc_to_local(event.datetime)),
                      event.source,
                      total_micro_seconds(event.source_elapsed),


### PR DESCRIPTION
Sample output:
```
cqlsh> tracing compact;
Tracing set to COMPACT.
cqlsh> select passage from coherebench.embeddings_table order by embedding ann of random_float_vector(1024, -1, 1) limit 1;

 passage
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 She was then sailed on Lake Wendouree, Ballarat, and presented with a new set of sails by local yachtsmen, before travelling to Geelong to be returned to the sea.

(1 rows)

Tracing session: fa8921c0-3e33-11ef-ba0d-9b64a7fb6e4b

Source mapping:
  A -> 127.0.0.1

 src | elapsed | activity
-----+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   A |       0 | Execute CQL3 query
   A |     464 | Parsing select passage from coherebench.embeddings_table order by embedding ann of random_float_vector(1024, -1, 1) limit 1;
   A |    1006 | Preparing statement
   A |    3049 | Index mean cardinalities are embeddings_table_embedding_idx:-9223372036854775808. Scanning with embeddings_table_embedding_idx.
   A |    3776 | Computing ranges to query
   A |    4798 | Enqueuing request to localhost/127.0.0.1:7000
   A |    5158 | Submitted scanning all ranges requests to 1 nodes
   A |    5398 | Sending RANGE_REQ message to localhost/127.0.0.1:7000 message size 4309 bytes
   A |    7038 | RANGE_REQ message received from /127.0.0.1:7000
   A |    7717 | Executing read on coherebench.embeddings_table using index embeddings_table_embedding_idx
   A |    8934 | Query execution plan:
Limit 1 (rows: 1.0, cost/row: 114.9, cost: 2050.0..2164.9)
 └─ Filter embedding ANN 3d8b99... (sel: 1.000000000) (rows: 1.0, cost/row: 114.9, cost: 2050.0..2164.9)
     └─ Fetch (rows: 1.0, cost/row: 114.9, cost: 2050.0..2164.9)
         └─ AnnScan (keys: 1.0, cost/key: 10.0, cost: 2050.0..2060.0)

   A |    9241 | Selecting 0 index with cardinality of  out of 0 indexes
   A |   10472 | Querying storage-attached indexes embeddings_table_embedding_idx (1 sstables)
   A |   27917 | DiskANN search for 1/12 visited 448 nodes and reranked 12 to return 1 results
   A |   28944 | DiskANN resumed search for 1/12 visited 0 nodes and reranked 1 to return 1 results
   A |   30938 | Index query accessed memtable indexes, 0 SSTable indexes, and 0 segments, post-filtered 1 row in 1 partition, and took 23352 microseconds.
   A |   31334 | Read 1 live rows and 0 tombstone ones
   A |   31455 | Enqueuing response to /127.0.0.1:7000
   A |   31831 | Sending RANGE_RSP message to localhost/127.0.0.1:7000 message size 4361 bytes
   A |   32699 | RANGE_RSP message received from /127.0.0.1:7000
   A |   32988 | Processing response from /127.0.0.1:7000
   A |   34396 | Request complete
```