### PR TITLE
CNDB-9827 main: Online sorting and trimming of CQL result rows

### DIFF
--- a/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SortedRowsBuilder.java
@@ -18,11 +18,15 @@ package org.apache.cassandra.cql3.selection;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.cassandra.index.Index;
+import org.apache.lucene.util.PriorityQueue;
 
 /**
  * Builds a list of query result rows applying the specified order, limit and offset.
@@ -83,7 +87,7 @@ public abstract class SortedRowsBuilder
      */
     public static SortedRowsBuilder create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
     {
-        return WithListSort.create(limit, offset, comparator);
+        return WithHybridSort.create(limit, offset, comparator);
     }
 
     /**
@@ -96,7 +100,7 @@ public abstract class SortedRowsBuilder
      */
     public static SortedRowsBuilder create(int limit, int offset, Index.Scorer scorer)
     {
-        return WithListSort.create(limit, offset, scorer);
+        return WithHybridSort.create(limit, offset, scorer);
     }
 
     /**
@@ -153,11 +157,11 @@ public abstract class SortedRowsBuilder
         public static WithListSort<RowWithScore> create(int limit, int offset, Index.Scorer scorer)
         {
             return new WithListSort<>(limit, offset,
-                                  r -> new RowWithScore(r, scorer.score(r)),
-                                  rs -> rs.row,
+                                      r -> new RowWithScore(r, scorer.score(r)),
+                                      rs -> rs.row,
                                       (x, y) -> scorer.reversed()
-                                            ? Float.compare(y.score, x.score)
-                                            : Float.compare(x.score, y.score));
+                                                ? Float.compare(y.score, x.score)
+                                                : Float.compare(x.score, y.score));
         }
 
         private WithListSort(int limit,
@@ -207,6 +211,211 @@ public abstract class SortedRowsBuilder
                 this.row = row;
                 this.score = score;
             }
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that orders rows based on the provided comparator.
+     * </p>
+     * It's possible for the comparison to produce ties. To deal with these ties, the rows are decorated with their
+     * position in the sequence of calls to {@link #add(List)}, so we can use that identifying position to solve ties by
+     * favoring the row that was inserted first.
+     * </p>
+     * The rows can be decorated with any other value used for the comparator, so it doesn't need to recalculate that
+     * value in every comparison.
+     * </p>
+     * It keeps at most {@code limit + offset} rows in memory.
+     */
+    public static class WithHeapSort<T extends WithHeapSort.RowWithId> extends SortedRowsBuilder
+    {
+        private final BiFunction<List<ByteBuffer>, Integer, T> decorator;
+        private final PriorityQueue<T> heap;
+        private final int heapCapacity;
+
+        private List<T> initialRows = new ArrayList<>(); // first limit+offset rows to be added with PriorityQueue#addAll
+        private int numAddedRows = 0;
+        private boolean built = false;
+
+        public static WithHeapSort<RowWithId> create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+        {
+            return new WithHeapSort<>(limit, offset,
+                                      RowWithId::new,
+                                      (x, y) -> comparator.compare(x.row, y.row));
+        }
+
+        public static WithHeapSort<RowWithIdAndScore> create(int limit, int offset, Index.Scorer scorer)
+        {
+            return new WithHeapSort<>(limit, offset,
+                                      (row, id) -> new RowWithIdAndScore(row, id, scorer.score(row)),
+                                      (x, y) -> scorer.reversed()
+                                                ? Float.compare(y.score, x.score)
+                                                : Float.compare(x.score, y.score));
+        }
+
+        private WithHeapSort(int limit,
+                             int offset,
+                             BiFunction<List<ByteBuffer>, Integer, T> decorator,
+                             Comparator<T> comparator)
+        {
+            super(limit, offset);
+            this.decorator = decorator;
+            heapCapacity = limit + offset;
+            heap = new PriorityQueue<>(limit + offset)
+            {
+                @Override
+                protected boolean lessThan(T t1, T t2)
+                {
+                    // Reverse compare rows, so the worst stays at the top of the heap.
+                    // Ties are solved by favoring the row which id indicates that it was inserted first.
+                    int cmp = comparator.compare(t1, t2);
+                    return cmp == 0 ? t1.id > t2.id : cmp > 0;
+                }
+            };
+        }
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            assert !built : "Cannot add more rows after calling build()";
+
+            T decoratedRow = decorator.apply(row, numAddedRows++);
+
+            if (initialRows != null && numAddedRows >= heapCapacity)
+                heapifyInitialRows();
+
+            if (initialRows != null)
+                initialRows.add(decoratedRow);
+            else
+                heap.insertWithOverflow(decoratedRow);
+        }
+
+        private void heapifyInitialRows()
+        {
+            heap.addAll(initialRows);
+            initialRows = null;
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            built = true;
+
+            if (initialRows != null)
+                heapifyInitialRows();
+
+            int toPeek = heap.size() - offset;
+            if (toPeek <= 0)
+                return Collections.emptyList();
+
+            ArrayList<List<ByteBuffer>> result = new ArrayList<>(toPeek);
+            while (toPeek-- > 0)
+                result.add(heap.pop().row);
+
+            Collections.reverse(result);
+            return result;
+        }
+
+        /**
+         * A row decorated with its position in the sequence of calls to {@link #add(List)},
+         * so we can use it to solve ties in comparisons.
+         */
+        private static class RowWithId
+        {
+            protected final List<ByteBuffer> row;
+            protected final int id;
+
+            private RowWithId(List<ByteBuffer> row, int id)
+            {
+                this.row = row;
+                this.id = id;
+            }
+        }
+
+        /**
+         * A {@link RowWithId} that is also decorated with a score assigned by a {@link Index.Scorer},
+         * so we don't need to recalculate that score in every comparison.
+         */
+        private static final class RowWithIdAndScore extends RowWithId
+        {
+            private final float score;
+
+            private RowWithIdAndScore(List<ByteBuffer> row, int id, float score)
+            {
+                super(row, id);
+                this.score = score;
+            }
+        }
+    }
+
+    /**
+     * {@link SortedRowsBuilder} that tries to combine the benefits of {@link WithListSort} and {@link WithHeapSort}.
+     * </p>
+     * {@link WithListSort} is faster for the first rows, but then it becomes slower than {@link WithHeapSort} as the
+     * number of rows grows. Also, {@link WithHeapSort} has constant {@code limit + offset} memory usage, whereas
+     * {@link WithListSort} memory usage grows linearly with the number of added rows.
+     * </p>
+     * This uses a {@link WithListSort} to sort the first {@code (limit + offset) * }{@link #SWITCH_FACTOR} rows,
+     * and then it switches to a {@link WithHeapSort} if more rows are added.
+     * </p>
+     * It keeps at most {@link #SWITCH_FACTOR} {@code * (limit + offset)} rows in memory.
+     */
+    public static class WithHybridSort<L, Q extends WithHeapSort.RowWithId> extends SortedRowsBuilder
+    {
+        /** Factor of {@code limit + offset} at which we switch from list to heap. */
+        public static final int SWITCH_FACTOR = 4;
+
+        private WithListSort<L> list;
+        private final Supplier<WithHeapSort<Q>> heapSupplier;
+        private final int threshold; // at what number of rows we switch from list to heap
+
+        private WithHeapSort<Q> heap;
+
+        public static SortedRowsBuilder create(int limit, int offset, Comparator<List<ByteBuffer>> comparator)
+        {
+            return new WithHybridSort<>(limit, offset,
+                                        WithListSort.create(limit, offset, comparator),
+                                        () -> WithHeapSort.create(limit, offset, comparator));
+        }
+
+        public static SortedRowsBuilder create(int limit, int offset, Index.Scorer scorer)
+        {
+            return new WithHybridSort<>(limit, offset,
+                                        WithListSort.create(limit, offset, scorer),
+                                        () -> WithHeapSort.create(limit, offset, scorer));
+        }
+
+        private WithHybridSort(int limit, int offset,
+                               WithListSort<L> list,
+                               Supplier<WithHeapSort<Q>> heapSupplier)
+        {
+            super(limit, offset);
+            this.list = list;
+            this.heapSupplier = heapSupplier;
+            this.threshold = (limit + offset) * SWITCH_FACTOR;
+        }
+
+        @Override
+        public void add(List<ByteBuffer> row)
+        {
+            // start using the heap if the list is full
+            if (list != null && list.rows.size() >= threshold)
+            {
+                heap = heapSupplier.get();
+                for (L r : list.rows)
+                    heap.add(list.undecorator.apply(r));
+                list = null;
+            }
+
+            if (list != null)
+                list.add(row);
+            else
+                heap.add(row);
+        }
+
+        @Override
+        public List<List<ByteBuffer>> build()
+        {
+            return list != null ? list.build() : heap.build();
         }
     }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
@@ -48,10 +48,10 @@ public class SortedRowsBuilderBench extends CQLTester
     private static final Comparator<List<ByteBuffer>> COMPARATOR = (o1, o2) -> Int32Type.instance.compare(o1.get(0), o2.get(0));
     private static final Random RANDOM = new Random();
 
-    @Param({ "1", "2", "3", "4", "6", "8", "16" })
+    @Param({ "1", "2", "3", "4", "5", "6", "8", "16", "32" })
     public int nodes;
 
-    @Param({ "100", "10000" })
+    @Param({ "10", "100", "1000", "10000" })
     public int limit;
 
     @Param({ "0", "0.1", "0.5", "1" })
@@ -81,15 +81,39 @@ public class SortedRowsBuilderBench extends CQLTester
     }
 
     @Benchmark
-    public Object comparator()
+    public Object comparatorWithList()
     {
-        return test(SortedRowsBuilder.create(limit, offset, COMPARATOR));
+        return test(SortedRowsBuilder.WithListSort.create(limit, offset, COMPARATOR));
     }
 
     @Benchmark
-    public Object scorer()
+    public Object comparatorWithHeap()
     {
-        return test(SortedRowsBuilder.create(limit, offset, SCORER));
+        return test(SortedRowsBuilder.WithHeapSort.create(limit, offset, COMPARATOR));
+    }
+
+    @Benchmark
+    public Object comparatorWithHybrid()
+    {
+        return test(SortedRowsBuilder.WithHybridSort.create(limit, offset, COMPARATOR));
+    }
+
+    @Benchmark
+    public Object scorerWithList()
+    {
+        return test(SortedRowsBuilder.WithListSort.create(limit, offset, SCORER));
+    }
+
+    @Benchmark
+    public Object scorerWithHeap()
+    {
+        return test(SortedRowsBuilder.WithHeapSort.create(limit, offset, SCORER));
+    }
+
+    @Benchmark
+    public Object scorerWithHybrid()
+    {
+        return test(SortedRowsBuilder.WithHybridSort.create(limit, offset, SCORER));
     }
 
     private List<List<ByteBuffer>> test(SortedRowsBuilder builder)

--- a/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
@@ -63,10 +63,22 @@ public class SortedRowsBuilderTest
                 // with comparator
                 test(rows, SortedRowsBuilder.create(limit, offset, comparator), comparator);
                 test(rows, SortedRowsBuilder.create(limit, offset, reverseComparator), reverseComparator);
+                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, comparator), comparator);
+                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, reverseComparator), reverseComparator);
+                test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, comparator), comparator);
+                test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, reverseComparator), reverseComparator);
+                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, comparator), comparator);
+                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, reverseComparator), reverseComparator);
 
                 // with index scorer
                 test(rows, SortedRowsBuilder.create(limit, offset, scorer(false)), comparator);
                 test(rows, SortedRowsBuilder.create(limit, offset, scorer(true)), reverseComparator);
+                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, scorer(false)), comparator);
+                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, scorer(true)), reverseComparator);
+                test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, scorer(false)), comparator);
+                test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, scorer(true)), reverseComparator);
+                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, scorer(false)), comparator);
+                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, scorer(true)), reverseComparator);
             }
         }
     }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
@@ -400,6 +400,9 @@ public class SelectOffsetTest extends CQLTester
 
     private void testLimitAndOffset(String query, int limit, @Nullable Integer offset, boolean paging, Object[]... rows) throws Throwable
     {
+        // test without a limit (nor offset)
+        assertRows(execute(query + " ALLOW FILTERING"), rows);
+
         // append the specified limit and offset to the unrestricted query
         StringBuilder sb = new StringBuilder(query);
         sb.append(" LIMIT ").append(limit);


### PR DESCRIPTION
Modify coordinator-side sorting of CQL result rows to use online heap-based sorting when the number of rows returned by the nodes gets to a certain size.

We use the current List#sort algorithm if the number of rows to sort is below 4*(LIMIT+OFFSET), and switch to heap sort above that number of rows.

Heap-based sort uses constant LIMIT+OFFSET memory and it's much faster with many rows, but List#sort is faster for fewer rows. Thereof the hybrid approach.