### PR TITLE
Fix TOC including non-existing files when flushing empty SAI index

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -322,7 +322,7 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
                                  CountDownLatch latch,
                                  Set<Component> replacedComponents) throws InterruptedException
     {
-        indexWriter.complete();
+        indexWriter.complete(sstable);
 
         if (indexWriter.isAborted())
             throw new RuntimeException(String.format("Index build for %s with indexes %s is aborted", sstable.descriptor, indexes));

--- a/src/java/org/apache/cassandra/index/sai/disk/PerIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PerIndexWriter.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 
 import com.google.common.base.Stopwatch;
 
-import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 
 /**
@@ -31,6 +31,11 @@ import org.apache.cassandra.index.sai.utils.PrimaryKey;
  */
 public interface PerIndexWriter
 {
+    /**
+     * The index components written on disk by this disk.
+     */
+    IndexComponents.ForWrite writtenComponents();
+
     /**
      * Adds a row to this index.
      */

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -262,17 +262,6 @@ public interface IndexComponents
         IndexComponent.ForWrite addOrGet(IndexComponentType component);
 
         /**
-         * Adds to this writer all the components that the version of this writer defines.
-         *
-         * @return this writer (for chaining purposes).
-         */
-        default ForWrite addAllComponentsForVersion()
-        {
-            expectedComponentsForVersion().forEach(this::addOrGet);
-            return this;
-        }
-
-        /**
          * Delete the files of all the components in this writer (and remove them so that the group will be empty
          * afterward).
          */

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -140,6 +140,13 @@ public class IndexDescriptor
         return new IndexComponentsImpl(context, Version.latest(), -1);
     }
 
+    /**
+     * The set of components _expected_ to be written for a newly flushed sstable given the provided set of indices.
+     * This includes both per-sstable and per-index components.
+     * <p>
+     * Please note that the final sstable may not contain all of these components, as some may be empty or not written
+     * due to the specific of the flush, but this should be a superset of the components written.
+     */
     public static Set<Component> componentsForNewlyFlushedSSTable(Collection<StorageAttachedIndex> indices)
     {
         Version version = Version.latest();
@@ -148,12 +155,25 @@ public class IndexDescriptor
             components.add(customComponentFor(version, component, null, 0));
 
         for (StorageAttachedIndex index : indices)
-        {
-            IndexContext context = index.getIndexContext();
-            for (IndexComponentType component : version.onDiskFormat().perIndexComponentTypes(context))
-                components.add(customComponentFor(version, component, context, 0));
-        }
+            addPerIndexComponentsForNewlyFlushedSSTable(components, version, index.getIndexContext());
         return components;
+    }
+
+    /**
+     * The set of per-index components _expected_ to be written for a newly flushed sstable for the provided index.
+     * <p>
+     * This is a subset of {@link #componentsForNewlyFlushedSSTable(Collection)} and has the same caveats.
+     */
+    public static Set<Component> perIndexComponentsForNewlyFlushedSSTable(IndexContext context)
+    {
+        return addPerIndexComponentsForNewlyFlushedSSTable(new HashSet<>(), Version.latest(), context);
+    }
+
+    private static Set<Component> addPerIndexComponentsForNewlyFlushedSSTable(Set<Component> addTo, Version version, IndexContext context)
+    {
+        for (IndexComponentType component : version.onDiskFormat().perIndexComponentTypes(context))
+            addTo.add(customComponentFor(version, component, context, 0));
+        return addTo;
     }
 
     private static Component customComponentFor(Version version, IndexComponentType componentType, @Nullable IndexContext context, int generation)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -80,6 +80,12 @@ public class MemtableIndexWriter implements PerIndexWriter
     }
 
     @Override
+    public IndexComponents.ForWrite writtenComponents()
+    {
+        return perIndexComponents;
+    }
+
+    @Override
     public void addRow(PrimaryKey key, Row row, long sstableRowId)
     {
         // Memtable indexes are flushed directly to disk with the aid of a mapping between primary

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionT
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 
@@ -88,6 +89,12 @@ public class SSTableIndexWriter implements PerIndexWriter
     public IndexContext indexContext()
     {
         return indexContext;
+    }
+
+    @Override
+    public IndexComponents.ForWrite writtenComponents()
+    {
+        return perIndexComponents;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
@@ -134,7 +134,7 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
 
     private void completeSSTable(PerSSTableIndexWriter indexWriter, SSTableReader sstable, Collection<ColumnIndex> indexes)
     {
-        indexWriter.complete();
+        indexWriter.complete(sstable);
 
         for (ColumnIndex index : indexes)
         {

--- a/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.index.sasi.utils.CombinedTermIterator;
 import org.apache.cassandra.index.sasi.utils.TypeUtil;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
@@ -142,7 +143,7 @@ public class PerSSTableIndexWriter implements SSTableFlushObserver
         });
     }
 
-    public void complete()
+    public void complete(SSTable sstable)
     {
         if (isComplete)
             return;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFlushObserver.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFlushObserver.java
@@ -22,6 +22,7 @@ import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.io.sstable.SSTable;
 
 /**
  * Observer for events in the lifecycle of writing out an sstable.
@@ -103,7 +104,7 @@ public interface SSTableFlushObserver
     /**
      * Called when all data is written to the file and it's ready to be finished up.
      */
-    void complete();
+    void complete(SSTable sstable);
 
     /**
      * Clean up resources on error. There should be no side effects if called multiple times.

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -321,7 +321,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         if (openResult)
             openResult();
         txnProxy().commit();
-        observers.forEach(SSTableFlushObserver::complete);
+        observers.forEach(obs -> obs.complete(this));
         return finished();
     }
 
@@ -341,8 +341,8 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         finally
         {
             // need to generate all index files before commit, so they will be included in txn log
-            observers.forEach(SSTableFlushObserver::complete);
-        }
+            observers.forEach(obs -> obs.complete(this));
+         }
     }
 
     public final Throwable commit(Throwable accumulate)

--- a/test/unit/org/apache/cassandra/index/CustomIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/CustomIndexTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
@@ -1271,7 +1272,7 @@ public class CustomIndexTest extends CQLTester
                 }
 
                 @Override
-                public void complete()
+                public void complete(SSTable sstable)
                 {
                     completeFlushCalls.incrementAndGet();
                 }
@@ -1667,10 +1668,10 @@ public class CustomIndexTest extends CQLTester
                     }
 
                     @Override
-                    public void complete()
+                    public void complete(SSTable sstable)
                     {
                         completeFlushCalls.incrementAndGet();
-                        observers.forEach(SSTableFlushObserver::complete);
+                        observers.forEach(obs -> obs.complete(sstable));
                     }
                 };
             }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -98,6 +98,7 @@ import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SAITester extends CQLTester
 {
@@ -661,6 +662,32 @@ public class SAITester extends CQLTester
                   .filter(File::isFile)
                   .filter(file -> Version.tryParseFileName(file.name()).isPresent())
                   .collect(Collectors.toSet());
+    }
+
+    /**
+     * Checks that the set of all SAI index files in the TOC for all sstables (of the {@link #currentTable()}) are
+     * exactly the provided files.
+     *
+     * @param files expected SAI index files (typically the result of {@link #indexFiles()} above). Should not contain
+     *              non-SAI sstable files (or the test will fail).
+     */
+    protected void assertIndexFilesInToc(Set<File> files) throws IOException
+    {
+        Set<String> found = files.stream().map(File::name).collect(Collectors.toSet());
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            for (Component component : SSTable.readTOC(sstable.descriptor, false))
+            {
+                if (component.type != Component.Type.CUSTOM || !component.name.startsWith(Version.SAI_DESCRIPTOR))
+                    continue;
+
+                String tocFile = sstable.descriptor.fileFor(component).name();
+                if (!found.remove(tocFile))
+                    fail(String.format("TOC of %s contains unexpected SAI index file %s (all expected: %s)", sstable, tocFile, files));
+            }
+        }
+        assertTrue("The following files could not be found in the sstable TOC files: " + found, found.isEmpty());
     }
 
     protected ObjectName bufferSpaceObjectName(String name) throws MalformedObjectNameException

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Set;
+
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -25,6 +27,7 @@ import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.io.util.File;
 
 import static org.junit.Assert.assertEquals;
 
@@ -43,18 +46,21 @@ public class EmptyMemtableFlushTest extends SAITester
         execute("DELETE FROM %s WHERE id = 0");
         flush();
         // After this we should have only 1 set of index files but 2 completion markers
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.KD_TREE, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.KD_TREE_POSTING_LISTS, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.META, val1IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
+        Set<File> indexFiles = indexFiles();
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.KD_TREE, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.KD_TREE_POSTING_LISTS, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.META, val1IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
 
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.KD_TREE, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.KD_TREE_POSTING_LISTS, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.META, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.KD_TREE, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.KD_TREE_POSTING_LISTS, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.META, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
 
         assertEquals(0, execute("SELECT * from %s WHERE val1 = 0").size());
         assertEquals(1, execute("SELECT * from %s WHERE val2 = 1").size());
+
+        assertIndexFilesInToc(indexFiles);
     }
 
     @Test
@@ -69,17 +75,20 @@ public class EmptyMemtableFlushTest extends SAITester
         execute("DELETE FROM %s WHERE id = 0");
         flush();
         // After this we should have only 1 set of index files but 2 completion markers
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.TERMS_DATA, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.POSTING_LISTS, val1IndexContext).size());
-        assertEquals(0, componentFiles(indexFiles(), IndexComponentType.META, val1IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
+        Set<File> indexFiles = indexFiles();
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.TERMS_DATA, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.POSTING_LISTS, val1IndexContext).size());
+        assertEquals(0, componentFiles(indexFiles, IndexComponentType.META, val1IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.COLUMN_COMPLETION_MARKER, val1IndexContext).size());
 
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.TERMS_DATA, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.POSTING_LISTS, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.META, val2IndexContext).size());
-        assertEquals(1, componentFiles(indexFiles(), IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.TERMS_DATA, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.POSTING_LISTS, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.META, val2IndexContext).size());
+        assertEquals(1, componentFiles(indexFiles, IndexComponentType.COLUMN_COMPLETION_MARKER, val2IndexContext).size());
 
         assertEquals(0, execute("SELECT * from %s WHERE val1 = '0'").size());
         assertEquals(1, execute("SELECT * from %s WHERE val2 = '1'").size());
+
+        assertIndexFilesInToc(indexFiles);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/functional/FlushingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FlushingTest.java
@@ -50,6 +50,8 @@ public class FlushingTest extends SAITester
 
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
         assertEquals(1, rows.all().size());
+
+        assertIndexFilesInToc(indexFiles());
     }
 
     @Test
@@ -66,6 +68,8 @@ public class FlushingTest extends SAITester
             flush();
         }
 
+        assertIndexFilesInToc(indexFiles());
+
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1 >= 0");
         assertEquals(0, rows.all().size());
         verifyIndexFiles(numericIndexContext, null, sstables, 0, 0, sstables, 0);
@@ -77,5 +81,7 @@ public class FlushingTest extends SAITester
         rows = executeNet("SELECT id1 FROM %s WHERE v1 >= 0");
         assertEquals(0, rows.all().size());
         verifySSTableIndexes(numericIndexContext.getIndexName(), 1, 1);
+
+        assertIndexFilesInToc(indexFiles());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriterTest.java
@@ -136,8 +136,8 @@ public class PerSSTableIndexWriterTest extends SchemaLoader
 
         String indexFile = indexWriter.indexes.get(column).filename(true);
 
-        // final flush
-        indexWriter.complete();
+        // final flush (not: the `sstable` is not used by SASI, so passing `null` is fine)
+        indexWriter.complete(null);
 
         for (String segment : segments)
             Assert.assertFalse(new File(segment).exists());
@@ -234,7 +234,8 @@ public class PerSSTableIndexWriterTest extends SchemaLoader
         for (String segment : segments)
             Assert.assertTrue(new File(segment).exists());
 
-        indexWriter.complete();
+        // The sstable argument is not used by SASI
+        indexWriter.complete(null);
 
         // make sure that individual segments have been cleaned up
         for (String segment : segments)

--- a/test/unit/org/apache/cassandra/io/sstable/format/SSTableFlushObserverTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/SSTableFlushObserverTest.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.util.File;
@@ -451,7 +452,7 @@ public class SSTableFlushObserverTest
         }
 
         @Override
-        public void complete()
+        public void complete(SSTable sstable)
         {
             isComplete = true;
             if (pendingHeader)


### PR DESCRIPTION
On flush, index components are registered early, before the actual start of the flush, and so we register all the components we expect to have on a successful build. But when an index for a particular sstable is empty (meaning that the memtable has nothing to index for that particular index), only the completion marker is written for that index but no other components, so the TOC file for the sstable ended up including components that don't actually exists.

Technically, this wasn't "breaking" anything as while the SAI code now uses the TOC to discover components, it detects this case and fallback to scanning disk (which will discover the right components). However this fallback is less efficient, particulary in CNDB, so it is worth avoiding it (besides, having the TOC file be incorrect is at a minimum confusing).