### PR TITLE
CNDB-10161: fix CompressedSequentialWriter to record proper lastFlushOffset and checksum when corruption is found and resets position

### DIFF
--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -26,6 +26,10 @@ import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
@@ -40,6 +44,8 @@ import static org.apache.cassandra.utils.Throwables.merge;
 
 public class CompressedSequentialWriter extends SequentialWriter
 {
+    protected static final Logger logger = LoggerFactory.getLogger(CompressedSequentialWriter.class);
+
     private final ChecksumWriter crcMetadata;
 
     // holds offset in the file where current chunk should be written
@@ -56,14 +62,18 @@ public class CompressedSequentialWriter extends SequentialWriter
     // holds a number of already written chunks
     private int chunkCount = 0;
 
-    private long uncompressedSize = 0, compressedSize = 0;
-
     private final MetadataCollector sstableMetadataCollector;
 
     private final ByteBuffer crcCheckBuffer = ByteBuffer.allocate(4);
     private final Optional<File> digestFile;
 
     private final int maxCompressedLength;
+
+    /**
+     * When corruption is found, the file writer is reset to previous data point but we can't reset the CRC checksum.
+     * So we have to recompute digest value.
+     */
+    private boolean recomputeChecksum = false;
 
     /**
      * Create CompressedSequentialWriter without digest file.
@@ -162,7 +172,6 @@ public class CompressedSequentialWriter extends SequentialWriter
 
         int uncompressedLength = buffer.position();
         int compressedLength = compressed.position();
-        uncompressedSize += uncompressedLength;
         ByteBuffer toWrite = compressed;
         if (compressedLength >= maxCompressedLength)
         {
@@ -182,7 +191,6 @@ public class CompressedSequentialWriter extends SequentialWriter
                 compressedLength = maxCompressedLength;
             }
         }
-        compressedSize += compressedLength;
 
         try
         {
@@ -197,7 +205,7 @@ public class CompressedSequentialWriter extends SequentialWriter
             // write corresponding checksum
             toWrite.rewind();
             crcMetadata.appendDirect(toWrite, true);
-            lastFlushOffset = uncompressedSize;
+            lastFlushOffset += uncompressedLength;
         }
         catch (IOException e)
         {
@@ -215,7 +223,7 @@ public class CompressedSequentialWriter extends SequentialWriter
     public CompressionMetadata open(long overrideLength)
     {
         if (overrideLength <= 0)
-            overrideLength = uncompressedSize;
+            overrideLength = lastFlushOffset;
         return metadataWriter.open(overrideLength, chunkOffset);
     }
 
@@ -308,7 +316,9 @@ public class CompressedSequentialWriter extends SequentialWriter
         bufferOffset = truncateTarget - buffer.position();
         chunkCount = realMark.nextChunkIndex - 1;
 
-        // truncate data and index file
+        // truncate data and index file. Unfortunately we can't reset and truncate CRC value, we have to recompute
+        // the CRC value otherwise it won't match the actual file checksum
+        recomputeChecksum = true;
         truncate(chunkOffset, bufferOffset);
         metadataWriter.resetAndTruncate(realMark.nextChunkIndex - 1);
     }
@@ -397,8 +407,9 @@ public class CompressedSequentialWriter extends SequentialWriter
         protected void doPrepare()
         {
             syncInternal();
-            digestFile.ifPresent(crcMetadata::writeFullChecksum);
-            sstableMetadataCollector.addCompressionRatio(compressedSize, uncompressedSize);
+            maybeWriteChecksum();
+
+            sstableMetadataCollector.addCompressionRatio(chunkOffset, lastFlushOffset);
             metadataWriter.finalizeLength(current(), chunkCount).prepareToCommit();
         }
 
@@ -414,6 +425,38 @@ public class CompressedSequentialWriter extends SequentialWriter
             }
 
             return accumulate;
+        }
+    }
+
+    private void maybeWriteChecksum()
+    {
+        if (digestFile.isEmpty())
+            return;
+
+        File digest = digestFile.get();
+        if (recomputeChecksum)
+        {
+            logger.info("Rescanning data file to populate digest into {} because file writer has been reset and truncated", digest);
+            try (RandomAccessReader in = RandomAccessReader.open(file))
+            {
+                CRC32 checksum = new CRC32();
+                try (CheckedInputStream checkedInputStream = new CheckedInputStream(in, checksum))
+                {
+                    byte[] chunk = new byte[64 * 1024];
+                    while (checkedInputStream.read(chunk) >= 0) {}
+
+                    long digestValue = checkedInputStream.getChecksum().getValue();
+                    ChecksumWriter.writeFullChecksum(digest, digestValue);
+                }
+            }
+            catch (IOException e)
+            {
+                throw new FSWriteError(e, digest);
+            }
+        }
+        else
+        {
+            crcMetadata.writeFullChecksum(digest);
         }
     }
 

--- a/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.io.util;
 import java.io.BufferedOutputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOError;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,6 +29,7 @@ import java.util.zip.CRC32;
 import javax.annotation.Nonnull;
 
 import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 
 public class ChecksumWriter
 {
@@ -92,10 +92,19 @@ public class ChecksumWriter
 
     public void writeFullChecksum(@Nonnull File digestFile)
     {
+        writeFullChecksum(digestFile, fullChecksum.getValue());
+    }
+
+    /**
+     * Write given checksum into the digest file. This is used when {@link CompressedSequentialWriter} is reset and truncated,
+     * and we need to recompute digest for the whole file.
+     */
+    public static void writeFullChecksum(@Nonnull File digestFile, long checksum)
+    {
         FileOutputStreamPlus fos = null;
         try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos = digestFile.newOutputStream(File.WriteMode.OVERWRITE))))
         {
-            out.write(String.valueOf(fullChecksum.getValue()).getBytes(StandardCharsets.UTF_8));
+            out.write(String.valueOf(checksum).getBytes(StandardCharsets.UTF_8));
             out.flush();
             fos.sync();
         }

--- a/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
+++ b/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
@@ -149,7 +149,9 @@ public class DataIntegrityMetadata
             long calculatedDigestValue = checkedInputStream.getChecksum().getValue();
             if (storedDigestValue != calculatedDigestValue)
             {
-                throw new IOException("Corrupted SSTable : " + descriptor.fileFor(Component.DATA));
+                throw new IOException("Corrupted SSTable : " + descriptor.fileFor(Component.DATA)
+                                      + " storedDigestValue=" + storedDigestValue
+                                      + " calculatedDigestValue=" + calculatedDigestValue);
             }
         }
 

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -814,7 +814,7 @@ public static TableMetadata.Builder clusteringSASICFMD(String ksName, String cfN
         Schema.instance.transform(SchemaTransformations.addTable(metadata, true));
     }
 
-    private static CompressionParams compressionParams(int chunkLength)
+    public static CompressionParams compressionParams(int chunkLength)
     {
         String algo = System.getProperty("cassandra.test.compression.algo", "lz4").toLowerCase();
         switch (algo)


### PR DESCRIPTION
- Rescan the full file to compute CRC checksum in case of resetAndTruncate because we can't reset CRC value to previous offset.