### PR TITLE
CNDB-10221: use int for SAI postings

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/IndexSearcherContext.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/IndexSearcherContext.java
@@ -63,7 +63,7 @@ public class IndexSearcherContext
         return segmentRowIdOffset;
     }
 
-    long count()
+    int count()
     {
         return postingList.size();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
@@ -26,26 +26,25 @@ import org.apache.cassandra.utils.Throwables;
 /**
  * Interface for advancing on and consuming a posting list.
  */
-//TODO Need to check int and long usage throughout this post DSP-19608
 @NotThreadSafe
 public interface PostingList extends Closeable
 {
     PostingList EMPTY = new EmptyPostingList();
 
-    long OFFSET_NOT_FOUND = -1;
-    long END_OF_STREAM = Long.MAX_VALUE;
+    int OFFSET_NOT_FOUND = -1;
+    int END_OF_STREAM = Integer.MAX_VALUE;
 
     @Override
     default void close() throws IOException {}
 
     /**
-     * Retrieves the next segment row ID, not including row IDs that have been returned by {@link #advance(long)}.
+     * Retrieves the next segment row ID, not including row IDs that have been returned by {@link #advance(int)}.
      *
      * @return next segment row ID
      */
-    long nextPosting() throws IOException;
+    int nextPosting() throws IOException;
 
-    long size();
+    int size();
 
     /**
      * @return {@code true} if this posting list contains no postings
@@ -67,7 +66,7 @@ public interface PostingList extends Closeable
      *
      * @return first segment row ID which is >= the target row ID or {@link PostingList#END_OF_STREAM} if one does not exist
      */
-    long advance(long targetRowID) throws IOException;
+    int advance(int targetRowID) throws IOException;
 
     /**
      * @return peekable wrapper of current posting list
@@ -82,14 +81,14 @@ public interface PostingList extends Closeable
         private final PostingList wrapped;
 
         private boolean peeked = false;
-        private long next;
+        private int next;
 
         public PeekablePostingList(PostingList wrapped)
         {
             this.wrapped = wrapped;
         }
 
-        public long peek()
+        public int peek()
         {
             if (peeked)
                 return next;
@@ -105,7 +104,7 @@ public interface PostingList extends Closeable
             }
         }
 
-        public long advanceWithoutConsuming(long targetRowID) throws IOException
+        public int advanceWithoutConsuming(int targetRowID) throws IOException
         {
             if (peek() == END_OF_STREAM)
                 return END_OF_STREAM;
@@ -119,7 +118,7 @@ public interface PostingList extends Closeable
         }
 
         @Override
-        public long nextPosting() throws IOException
+        public int nextPosting() throws IOException
         {
             if (peeked)
             {
@@ -130,13 +129,13 @@ public interface PostingList extends Closeable
         }
 
         @Override
-        public long size()
+        public int size()
         {
             return wrapped.size();
         }
 
         @Override
-        public long advance(long targetRowID) throws IOException
+        public int advance(int targetRowID) throws IOException
         {
             if (peeked && next >= targetRowID)
             {
@@ -158,19 +157,19 @@ public interface PostingList extends Closeable
     class EmptyPostingList implements PostingList
     {
         @Override
-        public long nextPosting() throws IOException
+        public int nextPosting() throws IOException
         {
             return END_OF_STREAM;
         }
 
         @Override
-        public long size()
+        public int size()
         {
             return 0;
         }
 
         @Override
-        public long advance(long targetRowID) throws IOException
+        public int advance(int targetRowID) throws IOException
         {
             return END_OF_STREAM;
         }
@@ -206,19 +205,19 @@ public interface PostingList extends Closeable
         }
 
         @Override
-        public long size()
+        public int size()
         {
             return delegate.size();
         }
 
         @Override
-        public long advance(long targetRowID) throws IOException
+        public int advance(int targetRowID) throws IOException
         {
             return delegate.advance(targetRowID);
         }
 
         @Override
-        public long nextPosting() throws IOException
+        public int nextPosting() throws IOException
         {
             return delegate.nextPosting();
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListRangeIterator.java
@@ -167,23 +167,23 @@ public class PostingListRangeIterator extends RangeIterator
         long segmentRowId;
         if (needsSkipping)
         {
-            long targetRowID;
+            long targetSstableRowId;
             if (skipToToken instanceof PrimaryKeyWithSource
                 && ((PrimaryKeyWithSource) skipToToken).getSourceSstableId().equals(primaryKeyMap.getSSTableId()))
             {
-                targetRowID = ((PrimaryKeyWithSource) skipToToken).getSourceRowId();
+                targetSstableRowId = ((PrimaryKeyWithSource) skipToToken).getSourceRowId();
             }
             else
             {
-                targetRowID = primaryKeyMap.ceiling(skipToToken);
+                targetSstableRowId = primaryKeyMap.ceiling(skipToToken);
                 // skipToToken is larger than max token in token file
-                if (targetRowID < 0)
+                if (targetSstableRowId < 0)
                 {
                     return PostingList.END_OF_STREAM;
                 }
             }
-
-            segmentRowId = postingList.advance(targetRowID - searcherContext.getSegmentRowIdOffset());
+            int targetSegmentRowId = Math.toIntExact(targetSstableRowId - searcherContext.getSegmentRowIdOffset());
+            segmentRowId = postingList.advance(targetSegmentRowId);
             needsSkipping = false;
         }
         else

--- a/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
@@ -50,7 +50,7 @@ class RAMPostingSlices
         return new PostingList()
         {
             @Override
-            public long nextPosting() throws IOException
+            public int nextPosting() throws IOException
             {
                 if (reader.eof())
                 {
@@ -64,13 +64,13 @@ class RAMPostingSlices
             }
 
             @Override
-            public long size()
+            public int size()
             {
                 return sizes[termID];
             }
 
             @Override
-            public long advance(long targetRowID)
+            public int advance(int targetRowID)
             {
                 throw new UnsupportedOperationException();
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -27,7 +27,7 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Row;
@@ -125,7 +125,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             }
             else
             {
-                final Iterator<Pair<ByteComparable, LongArrayList>> iterator = rowMapping.merge(memtableIndex);
+                final Iterator<Pair<ByteComparable, IntArrayList>> iterator = rowMapping.merge(memtableIndex);
 
                 try (MemtableTermsIterator terms = new MemtableTermsIterator(memtableIndex.getMinTerm(), memtableIndex.getMaxTerm(), iterator))
                 {
@@ -144,7 +144,7 @@ public class MemtableIndexWriter implements PerIndexWriter
         }
     }
 
-    private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, long maxSegmentRowId) throws IOException
+    private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
         long numRows;
         SegmentMetadata.ComponentMetadataMap indexMetas;
@@ -215,7 +215,7 @@ public class MemtableIndexWriter implements PerIndexWriter
         SegmentMetadata.ComponentMetadataMap metadataMap = vectorIndex.writeData(perIndexComponents, deletedOrdinals);
 
         SegmentMetadata metadata = new SegmentMetadata(0,
-                                                       rowMapping.size(),
+                                                       rowMapping.size(), // TODO this isn't the right size metric.
                                                        0,
                                                        rowMapping.maxSegmentRowId,
                                                        pkFactory.createPartitionKeyOnly(minKey),

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MergeOneDimPointValues.java
@@ -93,7 +93,7 @@ public class MergeOneDimPointValues extends MutableOneDimPointValues
             while (queue.size() != 0)
             {
                 final BKDReader.IteratorState reader = queue.top();
-                final long rowID = reader.next();
+                final int rowID = reader.next();
 
                 minRowID = Math.min(minRowID, rowID);
                 maxRowID = Math.max(maxRowID, rowID);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -95,7 +95,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
                            ByteBuffer maxTerm,
                            ComponentMetadataMap componentMetadatas)
     {
-        assert numRows < Integer.MAX_VALUE;
+        // numRows can exceed Integer.MAX_VALUE because it is the count of unique term and segmentRowId pairs.
         Objects.requireNonNull(minKey);
         Objects.requireNonNull(maxKey);
         Objects.requireNonNull(minTerm);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReader.java
@@ -34,7 +34,7 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.agrona.collections.LongArrayList;
+import org.agrona.collections.IntArrayList;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
@@ -92,7 +92,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
 
     public interface DocMapper
     {
-        long oldToNew(long rowID);
+        int oldToNew(int rowID);
     }
 
     @VisibleForTesting
@@ -106,15 +106,15 @@ public class BKDReader extends TraversingBKDReader implements Closeable
         return new IteratorState(docMapper);
     }
 
-    public class IteratorState extends AbstractIterator<Long> implements Comparable<IteratorState>, Closeable
+    public class IteratorState extends AbstractIterator<Integer> implements Comparable<IteratorState>, Closeable
     {
         public final byte[] scratch;
 
         private final IndexInput bkdInput;
         private final IndexInput bkdPostingsInput;
         private final byte[] packedValues = new byte[maxPointsInLeafNode * packedBytesLength];
-        private final LongArrayList tempPostings = new LongArrayList();
-        private final long[] postings = new long[maxPointsInLeafNode];
+        private final IntArrayList tempPostings = new IntArrayList();
+        private final int[] postings = new int[maxPointsInLeafNode];
         private final DocMapper docMapper;
         private final Iterator<Map.Entry<Long,Integer>> iterator;
 
@@ -161,7 +161,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
         }
 
         @Override
-        protected Long computeNext()
+        protected Integer computeNext()
         {
             while (true)
             {
@@ -228,8 +228,8 @@ public class BKDReader extends TraversingBKDReader implements Closeable
                         final IndexInput bkdInput,
                         final byte[] packedValues,
                         final IndexInput bkdPostingsInput,
-                        long[] postings,
-                        LongArrayList tempPostings) throws IOException
+                        int[] postings,
+                        IntArrayList tempPostings) throws IOException
     {
         bkdInput.seek(filePointer);
         final int count = bkdInput.readVInt();
@@ -297,7 +297,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
             // gather the postings into tempPostings
             while (true)
             {
-                final long rowid = postingsReader.nextPosting();
+                final int rowid = postingsReader.nextPosting();
                 if (rowid == PostingList.END_OF_STREAM) break;
                 tempPostings.add(rowid);
             }
@@ -306,7 +306,7 @@ public class BKDReader extends TraversingBKDReader implements Closeable
             for (int x = 0; x < tempPostings.size(); x++)
             {
                 int idx = origIndex[x];
-                final long rowid = tempPostings.get(idx);
+                final int rowid = tempPostings.get(idx);
 
                 postings[x] = rowid;
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
@@ -280,7 +280,7 @@ public class BKDWriter implements Closeable
     public static class RowIDAndIndex
     {
         public int valueOrderIndex;
-        public long rowID;
+        public int rowID;
 
         @Override
         public String toString()
@@ -299,7 +299,7 @@ public class BKDWriter implements Closeable
         final List<Long> leafBlockFPs = new ArrayList<>();
         final List<byte[]> leafBlockStartValues = new ArrayList<>();
         final byte[] leafValues = new byte[maxPointsInLeafNode * packedBytesLength];
-        final long[] leafDocs = new long[maxPointsInLeafNode];
+        final int[] leafDocs = new int[maxPointsInLeafNode];
         private long valueCount;
         private int leafCount;
         final RowIDAndIndex[] rowIDAndIndexes = new RowIDAndIndex[maxPointsInLeafNode];
@@ -334,7 +334,7 @@ public class BKDWriter implements Closeable
         final byte[] lastPackedValue;
         private long lastDocID;
 
-        void add(byte[] packedValue, long docID) throws IOException
+        void add(byte[] packedValue, int docID) throws IOException
         {
             assert valueInOrder(valueCount + leafCount,
                                 0, lastPackedValue, packedValue, 0, docID, lastDocID);
@@ -998,7 +998,7 @@ public class BKDWriter implements Closeable
 
     // only called from assert
     private boolean valuesInOrderAndBounds(int count, int sortedDim, byte[] minPackedValue, byte[] maxPackedValue,
-                                           IntFunction<BytesRef> values, long[] docs, int docsOffset) throws IOException
+                                           IntFunction<BytesRef> values, int[] docs, int docsOffset) throws IOException
     {
         byte[] lastPackedValue = new byte[packedBytesLength];
         long lastDoc = -1;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
@@ -59,7 +59,7 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
             ByteBufferUtil.toBytes(termEnum.next().asComparableBytes(ByteComparable.Version.OSS41), scratch);
             try (final PostingList postings = termEnum.postings())
             {
-                long segmentRowId;
+                int segmentRowId;
                 while ((segmentRowId = postings.nextPosting()) != PostingList.END_OF_STREAM)
                 {
                     visitor.visit(segmentRowId, scratch);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/MutableOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/MutableOneDimPointValues.java
@@ -95,7 +95,7 @@ public abstract class MutableOneDimPointValues extends MutablePointValues
          *  should scrutinize the packedValue to decide whether to accept it.  In the 1D case,
          *  values are visited in increasing order, and in the case of ties, in increasing
          *  docID order. */
-        void visit(long docID, byte[] packedValue) throws IOException;
+        void visit(int docID, byte[] packedValue) throws IOException;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
@@ -61,8 +61,8 @@ public class NumericIndexWriter implements Closeable
      */
     public NumericIndexWriter(IndexComponents.ForWrite components,
                               int bytesPerDim,
-                              long maxSegmentRowId,
-                              long numRows,
+                              int maxSegmentRowId,
+                              int numRows,
                               IndexWriterConfig config) throws IOException
     {
         this(components, MAX_POINTS_IN_LEAF_NODE, bytesPerDim, maxSegmentRowId, numRows, config);
@@ -71,8 +71,8 @@ public class NumericIndexWriter implements Closeable
     public NumericIndexWriter(IndexComponents.ForWrite components,
                               int maxPointsInLeafNode,
                               int bytesPerDim,
-                              long maxSegmentRowId,
-                              long numRows,
+                              int maxSegmentRowId,
+                              int numRows,
                               IndexWriterConfig config) throws IOException
     {
         checkArgument(maxSegmentRowId >= 0,
@@ -86,7 +86,7 @@ public class NumericIndexWriter implements Closeable
         this.components = components;
         this.bytesPerDim = bytesPerDim;
         this.config = config;
-        this.writer = new BKDWriter(maxSegmentRowId + 1,
+        this.writer = new BKDWriter(maxSegmentRowId + 1L,
                                     1,
                                     bytesPerDim,
                                     maxPointsInLeafNode,

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/FilteringPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/FilteringPostingList.java
@@ -57,11 +57,11 @@ public class FilteringPostingList implements PostingList
      * @return the segment row ID of the next match
      */
     @Override
-    public long nextPosting() throws IOException
+    public int nextPosting() throws IOException
     {
         while (true)
         {
-            long segmentRowId = delegate.nextPosting();
+            int segmentRowId = delegate.nextPosting();
 
             if (segmentRowId == PostingList.END_OF_STREAM)
             {
@@ -76,15 +76,15 @@ public class FilteringPostingList implements PostingList
     }
 
     @Override
-    public long size()
+    public int size()
     {
         return cardinality;
     }
 
     @Override
-    public  long advance(long targetRowID) throws IOException
+    public int advance(int targetRowID) throws IOException
     {
-        long segmentRowId = delegate.advance(targetRowID);
+        int segmentRowId = delegate.advance(targetRowID);
 
         if (segmentRowId == PostingList.END_OF_STREAM)
         {
@@ -92,7 +92,7 @@ public class FilteringPostingList implements PostingList
         }
 
         // these are always for leaf kdtree postings so the max is 1024
-        position = (int)delegate.getOrdinal();
+        position = delegate.getOrdinal();
 
         // If the ordinal of the ID we just read satisfies the filter, just return it...
         if (filter.get(position - 1))

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/OrdinalPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/OrdinalPostingList.java
@@ -25,5 +25,5 @@ public interface OrdinalPostingList extends PostingList
      *
      * @return the ordinal of the posting that will be returned on the next call to {@link #nextPosting()}
      */
-    long getOrdinal();
+    int getOrdinal();
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PackedLongsPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PackedLongsPostingList.java
@@ -37,11 +37,12 @@ public class PackedLongsPostingList implements PostingList
     }
 
     @Override
-    public long nextPosting()
+    public int nextPosting()
     {
         if (iterator.hasNext())
         {
-            return iterator.next();
+            // TODO possibly unsafe conversion?
+            return Math.toIntExact(iterator.next());
         }
         else
         {
@@ -50,13 +51,14 @@ public class PackedLongsPostingList implements PostingList
     }
 
     @Override
-    public long size()
+    public int size()
     {
-        return values.size();
+        // TODO possibly unsafe conversion?
+        return Math.toIntExact(values.size());
     }
 
     @Override
-    public long advance(long targetRowID) throws IOException
+    public int advance(int targetRowID) throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PackedLongsPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PackedLongsPostingList.java
@@ -41,7 +41,8 @@ public class PackedLongsPostingList implements PostingList
     {
         if (iterator.hasNext())
         {
-            // TODO possibly unsafe conversion?
+            // This is assumed to be safe because we only insert segment row ids, which are always integers,
+            // into the packed longs object
             return Math.toIntExact(iterator.next());
         }
         else
@@ -53,7 +54,7 @@ public class PackedLongsPostingList implements PostingList
     @Override
     public int size()
     {
-        // TODO possibly unsafe conversion?
+        // We know that the size of the packed longs object is less than or equal to Integer.MAX_VALUE
         return Math.toIntExact(values.size());
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsWriter.java
@@ -107,6 +107,8 @@ public class PostingsWriter implements Closeable
     private int bufferUpto;
     private long lastSegmentRowId;
     private long maxDelta;
+    // This number is the count of row ids written to the postings for this segment. Because a segment row id can be in
+    // multiple postings list for the segment, this number could exceed Integer.MAX_VALUE, so we use a long.
     private long totalPostings;
 
     public PostingsWriter(IndexComponents.ForWrite components) throws IOException
@@ -183,7 +185,7 @@ public class PostingsWriter implements Closeable
         blockOffsets.clear();
         blockMaxIDs.clear();
 
-        long segmentRowId;
+        int segmentRowId;
         // When postings list are merged, we don't know exact size, just an upper bound.
         // We need to count how many postings we added to the block ourselves.
         int size = 0;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/ScanningPostingsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/ScanningPostingsReader.java
@@ -37,7 +37,7 @@ public class ScanningPostingsReader extends PostingsReader
     }
 
     @Override
-    public long advance(long targetRowId)
+    public int advance(int targetRowId)
     {
         throw new UnsupportedOperationException("Cannot advance a scanning postings reader");
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/VectorPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/VectorPostingList.java
@@ -35,6 +35,7 @@ public class VectorPostingList implements PostingList
 
     public VectorPostingList(CloseableIterator<ScoredRowId> source)
     {
+        // TODO find int specific data structure?
         segmentRowIds = new LongHeap(32);
         int n = 0;
         // Once the source is consumed, we have to close it.
@@ -50,23 +51,23 @@ public class VectorPostingList implements PostingList
     }
 
     @Override
-    public long nextPosting() throws IOException
+    public int nextPosting() throws IOException
     {
         if (segmentRowIds.size() == 0)
             return PostingList.END_OF_STREAM;
-        return segmentRowIds.pop();
+        return (int) segmentRowIds.pop();
     }
 
     @Override
-    public long size()
+    public int size()
     {
         return size;
     }
 
     @Override
-    public long advance(long targetRowID) throws IOException
+    public int advance(int targetRowID) throws IOException
     {
-        long rowId;
+        int rowId;
         do
         {
             rowId = nextPosting();

--- a/src/java/org/apache/cassandra/index/sai/memory/RowMapping.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/RowMapping.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.index.sai.memory;
 import java.util.Collections;
 import java.util.Iterator;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
 import org.apache.cassandra.db.rows.Row;
@@ -44,7 +44,7 @@ public class RowMapping
     public static final RowMapping DUMMY = new RowMapping()
     {
         @Override
-        public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index) { return Collections.emptyIterator(); }
+        public Iterator<Pair<ByteComparable, IntArrayList>> merge(MemtableIndex index) { return Collections.emptyIterator(); }
 
         @Override
         public void complete() {}
@@ -65,14 +65,14 @@ public class RowMapping
         }
     };
 
-    private final MemtableTrie<Long> rowMapping = new MemtableTrie<>(BufferType.OFF_HEAP);
+    private final MemtableTrie<Integer> rowMapping = new MemtableTrie<>(BufferType.OFF_HEAP);
 
     private volatile boolean complete = false;
 
     public PrimaryKey minKey;
     public PrimaryKey maxKey;
 
-    public long maxSegmentRowId = -1;
+    public int maxSegmentRowId = -1;
 
     public int count;
 
@@ -97,32 +97,32 @@ public class RowMapping
      *
      * @return iterator of index term to postings mapping exists in the sstable
      */
-    public Iterator<Pair<ByteComparable, LongArrayList>> merge(MemtableIndex index)
+    public Iterator<Pair<ByteComparable, IntArrayList>> merge(MemtableIndex index)
     {
         assert complete : "RowMapping is not built.";
 
         Iterator<Pair<ByteComparable, Iterator<PrimaryKey>>> iterator = index.iterator(minKey.partitionKey(), maxKey.partitionKey());
-        return new AbstractIterator<Pair<ByteComparable, LongArrayList>>()
+        return new AbstractIterator<Pair<ByteComparable, IntArrayList>>()
         {
             @Override
-            protected Pair<ByteComparable, LongArrayList> computeNext()
+            protected Pair<ByteComparable, IntArrayList> computeNext()
             {
                 while (iterator.hasNext())
                 {
                     Pair<ByteComparable, Iterator<PrimaryKey>> pair = iterator.next();
 
-                    LongArrayList postings = null;
+                    IntArrayList postings = null;
                     Iterator<PrimaryKey> primaryKeys = pair.right;
 
                     while (primaryKeys.hasNext())
                     {
                         PrimaryKey primaryKey = primaryKeys.next();
                         ByteComparable byteComparable = v -> primaryKey.asComparableBytes(v);
-                        Long segmentRowId = rowMapping.get(byteComparable);
+                        Integer segmentRowId = rowMapping.get(byteComparable);
 
                         if (segmentRowId != null)
                         {
-                            postings = postings == null ? new LongArrayList() : postings;
+                            postings = postings == null ? new IntArrayList() : postings;
                             postings.add(segmentRowId);
                         }
                     }
@@ -150,10 +150,17 @@ public class RowMapping
     {
         assert !complete : "Cannot modify built RowMapping.";
 
-        ByteComparable byteComparable = v -> key.asComparableBytes(v);
-        rowMapping.apply(Trie.singleton(byteComparable, sstableRowId), (existing, neww) -> neww);
+        if (sstableRowId > Integer.MAX_VALUE)
+            throw new IllegalArgumentException("RowId must be less than or equal to Integer.MAX_VALUE");
 
-        maxSegmentRowId = Math.max(maxSegmentRowId, sstableRowId);
+        // We only build this mapping for memtables, and because those only have a single segment, we know
+        // that the segment row id is the same as the sstable row id.
+        int segmentRowId = (int) sstableRowId;
+
+        ByteComparable byteComparable = v -> key.asComparableBytes(v);
+        rowMapping.apply(Trie.singleton(byteComparable, segmentRowId), (existing, neww) -> neww);
+
+        maxSegmentRowId = Math.max(maxSegmentRowId, segmentRowId);
 
         // data is written in token sorted order
         if (minKey == null)
@@ -164,8 +171,8 @@ public class RowMapping
 
     public int get(PrimaryKey key)
     {
-        Long sstableRowId = rowMapping.get(v -> key.asComparableBytes(v));
-        return sstableRowId == null ? -1 : Math.toIntExact(sstableRowId);
+        Integer sstableRowId = rowMapping.get(v -> key.asComparableBytes(v));
+        return sstableRowId == null ? -1 : sstableRowId;
     }
 
     public int size()

--- a/src/java/org/apache/cassandra/index/sai/utils/ArrayPostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/ArrayPostingList.java
@@ -34,13 +34,13 @@ public class ArrayPostingList implements OrdinalPostingList
     }
 
     @Override
-    public long getOrdinal()
+    public int getOrdinal()
     {
         return idx;
     }
 
     @Override
-    public long nextPosting()
+    public int nextPosting()
     {
         if (idx >= postings.length)
         {
@@ -50,13 +50,13 @@ public class ArrayPostingList implements OrdinalPostingList
     }
 
     @Override
-    public long size()
+    public int size()
     {
         return postings.length;
     }
 
     @Override
-    public long advance(long targetRowID)
+    public int advance(int targetRowID)
     {
         for (int i = idx; i < postings.length; ++i)
         {

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexBuilder.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -33,7 +33,7 @@ import static java.util.stream.Collectors.toList;
 
 public class InvertedIndexBuilder
 {
-    public static List<Pair<ByteComparable, LongArrayList>> buildStringTermsEnum(int terms, int postings, Supplier<String> termsGenerator, IntSupplier postingsGenerator)
+    public static List<Pair<ByteComparable, IntArrayList>> buildStringTermsEnum(int terms, int postings, Supplier<String> termsGenerator, IntSupplier postingsGenerator)
     {
         final List<ByteComparable> sortedTerms = Stream.generate(termsGenerator)
                                                        .distinct()
@@ -43,10 +43,10 @@ public class InvertedIndexBuilder
                                                        .map(ByteComparable::fixedLength)
                                                        .collect(toList());
 
-        final List<Pair<ByteComparable, LongArrayList>> termsEnum = new ArrayList<>();
+        final List<Pair<ByteComparable, IntArrayList>> termsEnum = new ArrayList<>();
         for (ByteComparable term : sortedTerms)
         {
-            final LongArrayList postingsList = new LongArrayList();
+            final IntArrayList postingsList = new IntArrayList();
 
             IntStream.generate(postingsGenerator)
                      .distinct()

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -72,7 +72,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
     private void doTestEqQueriesAgainstStringIndex() throws Exception
     {
         final int numTerms = randomIntBetween(64, 512), numPostings = randomIntBetween(256, 1024);
-        final List<Pair<ByteComparable, LongArrayList>> termsEnum = buildTermsEnum(numTerms, numPostings);
+        final List<Pair<ByteComparable, IntArrayList>> termsEnum = buildTermsEnum(numTerms, numPostings);
 
         try (IndexSearcher searcher = buildIndexAndOpenSearcher(numTerms, numPostings, termsEnum))
         {
@@ -130,7 +130,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
     public void testUnsupportedOperator() throws Exception
     {
         final int numTerms = randomIntBetween(5, 15), numPostings = randomIntBetween(5, 20);
-        final List<Pair<ByteComparable, LongArrayList>> termsEnum = buildTermsEnum(numTerms, numPostings);
+        final List<Pair<ByteComparable, IntArrayList>> termsEnum = buildTermsEnum(numTerms, numPostings);
 
         try (IndexSearcher searcher = buildIndexAndOpenSearcher(numTerms, numPostings, termsEnum))
         {
@@ -145,7 +145,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
         }
     }
 
-    private IndexSearcher buildIndexAndOpenSearcher(int terms, int postings, List<Pair<ByteComparable, LongArrayList>> termsEnum) throws IOException
+    private IndexSearcher buildIndexAndOpenSearcher(int terms, int postings, List<Pair<ByteComparable, IntArrayList>> termsEnum) throws IOException
     {
         final int size = terms * postings;
         final IndexDescriptor indexDescriptor = newIndexDescriptor();
@@ -183,7 +183,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
         }
     }
 
-    private List<Pair<ByteComparable, LongArrayList>> buildTermsEnum(int terms, int postings)
+    private List<Pair<ByteComparable, IntArrayList>> buildTermsEnum(int terms, int postings)
     {
         return InvertedIndexBuilder.buildStringTermsEnum(terms, postings, () -> randomSimpleString(3, 5), () -> nextInt(0, Integer.MAX_VALUE));
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -150,7 +150,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
     public void testUnsupportedOperator() throws Exception
     {
         final int numTerms = randomIntBetween(5, 15), numPostings = randomIntBetween(5, 20);
-        final List<InvertedIndexBuilder.TermsEnum> termsEnum = buildTermsEnum(Version.latest(), numTerms, numPostings);
+        final List<InvertedIndexBuilder.TermsEnum> termsEnum = buildTermsEnum(version, numTerms, numPostings);
 
         try (IndexSearcher searcher = buildIndexAndOpenSearcher(numTerms, numPostings, termsEnum))
         {
@@ -195,10 +195,10 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             SSTableContext sstableContext = mock(SSTableContext.class);
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);
             when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
-            final IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext,
-                                                                                            indexContext,
-                                                                                            indexFiles,
-                                                                                            segmentMetadata);
+            final IndexSearcher searcher = version.onDiskFormat().newIndexSearcher(sstableContext,
+                                                                                   indexContext,
+                                                                                   indexFiles,
+                                                                                   segmentMetadata);
             assertThat(searcher, is(instanceOf(InvertedIndexSearcher.class)));
             return searcher;
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/KDTreeSegmentMergerTest.java
@@ -63,8 +63,8 @@ import static org.junit.Assert.assertThrows;
 public class KDTreeSegmentMergerTest extends SAITester
 {
     private TemporaryFolder temporaryFolder = new TemporaryFolder();
-    private Map<Integer, List<Long>> expected;
-    private Map<Integer, List<Long>> actual;
+    private Map<Integer, List<Integer>> expected;
+    private Map<Integer, List<Integer>> actual;
 
     @BeforeClass
     public static void dbSetup() throws Throwable
@@ -169,7 +169,7 @@ public class KDTreeSegmentMergerTest extends SAITester
                 NumericUtils.intToSortableBytes(value, scratch, 0);
                 buffer.addPackedValue(docID, new BytesRef(scratch));
                 maxSegmentRowId = docID;
-                List<Long> postings;
+                List<Integer> postings;
                 if (expected.containsKey(value))
                     postings = expected.get(value);
                 else
@@ -177,7 +177,7 @@ public class KDTreeSegmentMergerTest extends SAITester
                     postings = new ArrayList<>();
                     expected.put(value, postings);
                 }
-                postings.add((long) docID);
+                postings.add(docID);
                 docID++;
             }
             BKDReader segmentReader = createReader(buffer, maxSegmentRowId, generation);
@@ -191,7 +191,7 @@ public class KDTreeSegmentMergerTest extends SAITester
 
         merger.intersect((rowId, packedValue) -> {
             int value = NumericUtils.sortableBytesToInt(packedValue, 0);
-            List<Long> postings;
+            List<Integer> postings;
             if (actual.containsKey(value))
                 postings = actual.get(value);
             else
@@ -228,7 +228,7 @@ public class KDTreeSegmentMergerTest extends SAITester
                 NumericUtils.intToSortableBytes(value, scratch, 0);
                 buffer.addPackedValue(docID, new BytesRef(scratch));
                 maxSegmentRowId = docID;
-                List<Long> postings;
+                List<Integer> postings;
                 if (expected.containsKey(value))
                     postings = expected.get(value);
                 else
@@ -236,7 +236,7 @@ public class KDTreeSegmentMergerTest extends SAITester
                     postings = new ArrayList<>();
                     expected.put(value, postings);
                 }
-                postings.add((long) docID);
+                postings.add(docID);
                 totalRows++;
                 docID++;
             }
@@ -277,10 +277,10 @@ public class KDTreeSegmentMergerTest extends SAITester
 
                 while (true)
                 {
-                    long rowId = postingList.nextPosting();
+                    int rowId = postingList.nextPosting();
                     if (rowId == PostingList.END_OF_STREAM)
                         break;
-                    List<Long> postings;
+                    List<Integer> postings;
                     if (actual.containsKey(term))
                         postings = actual.get(term);
                     else

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -197,7 +197,7 @@ public class SegmentFlushTest
                                                   segmentMetadata.componentMetadatas.get(IndexComponentType.TERMS_DATA).root,
                                                   termsFooterPointer))
         {
-            TermsIterator iterator = reader.allTerms(0);
+            TermsIterator iterator = reader.allTerms();
             assertEquals(minTerm, iterator.getMinTerm());
             assertEquals(maxTerm, iterator.getMaxTerm());
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -129,10 +129,10 @@ public class BKDReaderTest extends SaiRandomizedTest
         it1.close();
 
         // Next test that an intersection only returns the query values
-        List<Long> expected = Lists.list(8L, 9L);
+        List<Integer> expected = Lists.list(8, 9);
         int expectedCount = 0;
         PostingList intersection = reader1.intersect(buildQuery(8, 9), (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
-        for (Long id = intersection.nextPosting(); id != PostingList.END_OF_STREAM; id = intersection.nextPosting())
+        for (Integer id = intersection.nextPosting(); id != PostingList.END_OF_STREAM; id = intersection.nextPosting())
         {
             assertEquals(expected.get(expectedCount++), id);
         }
@@ -140,7 +140,7 @@ public class BKDReaderTest extends SaiRandomizedTest
         reader1.close();
 
         // Finally test that merger returns the correct values
-        expected = Lists.list(8L, 9L, 18L, 19L);
+        expected = Lists.list(8, 9, 18, 19);
         expectedCount = 0;
 
         reader1 = createReader(10);
@@ -155,7 +155,7 @@ public class BKDReaderTest extends SaiRandomizedTest
 
         intersection = reader.intersect(buildQuery(queryMin, queryMax), (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
 
-        for (Long id = intersection.nextPosting(); id != PostingList.END_OF_STREAM; id = intersection.nextPosting())
+        for (Integer id = intersection.nextPosting(); id != PostingList.END_OF_STREAM; id = intersection.nextPosting())
         {
             assertEquals(expected.get(expectedCount++), id);
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -121,10 +121,10 @@ public class BKDReaderTest extends SaiRandomizedTest
         // Start by testing that the iteratorState returns rowIds in order
         BKDReader reader1 = createReader(10);
         BKDReader.IteratorState it1 = reader1.iteratorState();
-        Long expectedRowId = 0L;
+        int expectedRowId = 0;
         while (it1.hasNext())
         {
-            assertEquals(expectedRowId++, it1.next());
+            assertEquals(expectedRowId++, (int) it1.next());
         }
         it1.close();
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
@@ -83,7 +83,7 @@ public class ImmutableOneDimPointValuesTest
             int postingCounter = 0;
 
             @Override
-            public void visit(long docID, byte[] packedValue)
+            public void visit(int docID, byte[] packedValue)
             {
                 final ByteComparable actualTerm = ByteComparable.fixedLength(packedValue);
                 final ByteComparable expectedTerm = ByteComparable.of(term);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.index.sai.disk.MemtableTermsIterator;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
@@ -109,19 +109,19 @@ public class ImmutableOneDimPointValuesTest
         final ByteBuffer minTerm = Int32Type.instance.decompose(from);
         final ByteBuffer maxTerm = Int32Type.instance.decompose(to);
 
-        final AbstractIterator<Pair<ByteComparable, LongArrayList>> iterator = new AbstractIterator<Pair<ByteComparable, LongArrayList>>()
+        final AbstractIterator<Pair<ByteComparable, IntArrayList>> iterator = new AbstractIterator<Pair<ByteComparable, IntArrayList>>()
         {
             private int currentTerm = from;
 
             @Override
-            protected Pair<ByteComparable, LongArrayList> computeNext()
+            protected Pair<ByteComparable, IntArrayList> computeNext()
             {
                 if (currentTerm <= to)
                 {
                     return endOfData();
                 }
                 final ByteBuffer term = Int32Type.instance.decompose(currentTerm++);
-                LongArrayList postings = new LongArrayList();
+                IntArrayList postings = new IntArrayList();
                 postings.add(0, 1, 2);
                 return Pair.create(ByteComparable.fixedLength(term), postings);
             }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 
 import org.junit.Assert;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.DecimalType;
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -119,14 +119,14 @@ public class KDTreeIndexBuilder
 
     private final IndexDescriptor indexDescriptor;
     private final AbstractType<?> type;
-    private final AbstractIterator<Pair<ByteComparable, LongArrayList>> terms;
+    private final AbstractIterator<Pair<ByteComparable, IntArrayList>> terms;
     private final int size;
     private final int minSegmentRowId;
     private final int maxSegmentRowId;
 
     public KDTreeIndexBuilder(IndexDescriptor indexDescriptor,
                               AbstractType<?> type,
-                              AbstractIterator<Pair<ByteComparable, LongArrayList>> terms,
+                              AbstractIterator<Pair<ByteComparable, IntArrayList>> terms,
                               int size,
                               int minSegmentRowId,
                               int maxSegmentRowId)
@@ -273,22 +273,22 @@ public class KDTreeIndexBuilder
      * Returns inverted index where each posting list contains exactly one element equal to the terms ordinal number +
      * given offset.
      */
-    public static AbstractIterator<Pair<ByteComparable, LongArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
+    public static AbstractIterator<Pair<ByteComparable, IntArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
     {
-        return new AbstractIterator<Pair<ByteComparable, LongArrayList>>()
+        return new AbstractIterator<Pair<ByteComparable, IntArrayList>>()
         {
             private long currentTerm = 0;
             private int currentSegmentRowId = segmentRowIdOffset;
 
             @Override
-            protected Pair<ByteComparable, LongArrayList> computeNext()
+            protected Pair<ByteComparable, IntArrayList> computeNext()
             {
                 if (currentTerm++ >= size)
                 {
                     return endOfData();
                 }
 
-                LongArrayList postings = new LongArrayList();
+                IntArrayList postings = new IntArrayList();
                 postings.add(currentSegmentRowId++);
                 assertTrue(terms.hasNext());
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -190,20 +190,20 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
         final ByteBuffer minTerm = Int32Type.instance.decompose(startTermInclusive);
         final ByteBuffer maxTerm = Int32Type.instance.decompose(endTermExclusive);
 
-        final AbstractIterator<Pair<ByteComparable, LongArrayList>> iterator = new AbstractIterator<Pair<ByteComparable, LongArrayList>>()
+        final AbstractIterator<Pair<ByteComparable, IntArrayList>> iterator = new AbstractIterator<Pair<ByteComparable, IntArrayList>>()
         {
             private int currentTerm = startTermInclusive;
             private int currentRowId = 0;
 
             @Override
-            protected Pair<ByteComparable, LongArrayList> computeNext()
+            protected Pair<ByteComparable, IntArrayList> computeNext()
             {
                 if (currentTerm >= endTermExclusive)
                 {
                     return endOfData();
                 }
                 final ByteBuffer term = Int32Type.instance.decompose(currentTerm++);
-                final LongArrayList postings = new LongArrayList();
+                final IntArrayList postings = new IntArrayList();
                 postings.add(currentRowId++);
                 final ByteSource encoded = Int32Type.instance.asComparableBytes(term, ByteComparable.Version.OSS41);
                 return Pair.create(v -> encoded, postings);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/PostingsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/postings/PostingsTest.java
@@ -161,7 +161,7 @@ public class PostingsTest extends SaiRandomizedTest
             input = postingLists.openInput();
             try (PostingsReader reader = new PostingsReader(input, postingPointers[i], listener))
             {
-                long tokenToAdvance = -1;
+                int tokenToAdvance = -1;
                 expectedPostingList.reset();
                 for (int p = 0; p < numPostings - 7; ++p)
                 {


### PR DESCRIPTION
After careful examination of the SAI code base, it is clear that we have a restriction that a single segment can have at most `Integer.MAX_VALUE` rows, and therefore, we can safely use `int` instead of `long` for postings. This PR proposes changes to make the code consistent, which should improve readability and future design, assuming that we want to continue to rely on having `Integer.MAX_VALUE` as the upper bound on number of rows in a segment.

The PR removes the `OffsetPostingList` because it incorrectly applies the segment offset in the `PostingList`, which should not happen.

Note that I was able to make all of the `long` to `int` conversions with only a handful of actual type conversions. I used `Math.toIntExact` to ensure we don't introduce any regressions. Additionally, I documented special cases that I thought were notable.

In the second commit, I updated part of the kd tree logic to account for the fact that doc ids (row ids) are always integers. We still use the `PackedLongValues` object though. Perhaps there is another data structure we could use?