### PR TITLE
CNDB-9441: fix SAI rebuild order to complete transaction first

### DIFF
--- a/src/java/org/apache/cassandra/index/internal/CollatedViewIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/internal/CollatedViewIndexBuilder.java
@@ -24,11 +24,11 @@ import java.util.UUID;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexBuilder;
 import org.apache.cassandra.io.sstable.ReducingKeyIterator;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.UUIDGen;
 
@@ -66,6 +66,9 @@ public class CollatedViewIndexBuilder extends SecondaryIndexBuilder
     {
         try
         {
+            for (SSTableReader sstable : sstables)
+                SSTableWatcher.instance.onIndexBuild(sstable);
+
             PageSize pageSize = cfs.indexManager.calculateIndexingPageSize();
             while (iter.hasNext())
             {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -21,6 +21,7 @@
 
 package org.apache.cassandra.index.sai;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -50,6 +51,7 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
 import org.apache.cassandra.io.sstable.SSTableSimpleIterator;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -143,6 +145,8 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
             return false;
         }
 
+        SSTableWatcher.instance.onIndexBuild(sstable);
+
         IndexDescriptor indexDescriptor = group.descriptorFor(sstable);
         Set<Component> replacedComponents = new HashSet<>();
 
@@ -214,8 +218,7 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
                     previousKeyPosition = dataPosition;
                 }
 
-                completeSSTable(indexWriter, sstable, indexes, perSSTableFileLock, replacedComponents);
-                txn.trackNewAttachedIndexFiles(sstable);
+                completeSSTable(txn, indexWriter, sstable, indexes, perSSTableFileLock, replacedComponents);
             }
             logger.debug("Completed indexing sstable {}", sstable.descriptor);
 
@@ -308,11 +311,12 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
             components.forWrite().forceDeleteAllComponents();
     }
 
-    private void completeSSTable(StorageAttachedIndexWriter indexWriter,
+    private void completeSSTable(LifecycleTransaction txn,
+                                 StorageAttachedIndexWriter indexWriter,
                                  SSTableReader sstable,
                                  Set<StorageAttachedIndex> indexes,
                                  CountDownLatch latch,
-                                 Set<Component> replacedComponents) throws InterruptedException
+                                 Set<Component> replacedComponents) throws InterruptedException, IOException
     {
         indexWriter.complete(sstable);
 
@@ -343,8 +347,16 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
         sstable.registerComponents(group.activeComponents(sstable), tracker);
         if (!replacedComponents.isEmpty())
             sstable.unregisterComponents(replacedComponents, tracker);
-        Set<StorageAttachedIndex> incomplete = group.onSSTableChanged(Collections.emptyList(), Collections.singleton(sstable), existing, false);
 
+        /**
+         * During memtable flush, it completes the transaction first which opens the flushed sstable,
+         * and then notify the new sstable to SAI. Here we should do the same.
+         */
+        txn.trackNewAttachedIndexFiles(sstable);
+        // there is nothing to commit. Close() effectively abort the transaction.
+        txn.close();
+
+        Set<StorageAttachedIndex> incomplete = group.onSSTableChanged(Collections.emptyList(), Collections.singleton(sstable), existing, false);
         if (!incomplete.isEmpty())
         {
             // If this occurs during an initial index build, there is only one index in play, and

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
@@ -54,13 +54,13 @@ public interface IndexComponent
 
         /**
          * Opens a file handle for the provided index component similarly to {@link #createFileHandle()},
-         * but this method shoud be called instead of the aforemented one if the access is done "as part of flushing", that is
+         * but this method shoud be called instead of the aforemented one if the access is done during index building, that is
          * before the full index that this is a part of has been finalized.
          * <p>
          * The use of this method can allow specific storage providers, typically tiered storage ones, to distinguish accesses
-         * that happen "at flush time" from other accesses, as the related file may be in different tier of storage.
+         * that happen "at index building time" from other accesses, as the related file may be in different tier of storage.
          */
-        FileHandle createFlushTimeFileHandle();
+        FileHandle createIndexBuildTimeFileHandle();
 
         IndexInput openInput();
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -613,9 +613,9 @@ public class IndexDescriptor
             }
 
             @Override
-            public FileHandle createFlushTimeFileHandle()
+            public FileHandle createIndexBuildTimeFileHandle()
             {
-                try (final FileHandle.Builder builder = StorageProvider.instance.flushTimeFileHandleBuilderFor(this))
+                try (final FileHandle.Builder builder = StorageProvider.instance.indexBuildTimeFileHandleBuilderFor(this))
                 {
                     return builder.order(byteOrder()).complete();
                 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
@@ -171,7 +171,7 @@ public class NumericIndexWriter implements Closeable
             components.put(IndexComponentType.KD_TREE, bkdPosition, bkdOffset, bkdLength, attributes);
         }
 
-        try (TraversingBKDReader reader = new TraversingBKDReader(this.components.get(IndexComponentType.KD_TREE).createFlushTimeFileHandle(), bkdPosition);
+        try (TraversingBKDReader reader = new TraversingBKDReader(this.components.get(IndexComponentType.KD_TREE).createIndexBuildTimeFileHandle(), bkdPosition);
              IndexOutput postingsOutput = this.components.addOrGet(IndexComponentType.KD_TREE_POSTING_LISTS).openOutput(true))
         {
             final long postingsOffset = postingsOutput.getFilePointer();

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.SecondaryIndexBuilder;
@@ -37,6 +36,7 @@ import org.apache.cassandra.index.sasi.conf.ColumnIndex;
 import org.apache.cassandra.index.sasi.disk.PerSSTableIndexWriter;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -75,6 +75,7 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
             SSTableReader sstable = e.getKey();
             Map<ColumnMetadata, ColumnIndex> indexes = e.getValue();
 
+            SSTableWatcher.instance.onIndexBuild(sstable);
             try (RandomAccessReader dataFile = sstable.openDataReader())
             {
                 PerSSTableIndexWriter indexWriter = SASIIndex.newWriter(keyValidator, sstable.descriptor, indexes, OperationType.COMPACTION);

--- a/src/java/org/apache/cassandra/io/sstable/SSTableWatcher.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableWatcher.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.io.sstable;
 
 import java.util.Set;
 
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_SSTABLE_WATCHER;
@@ -52,5 +53,12 @@ public interface SSTableWatcher
     default Set<Component> discoverComponents(Descriptor descriptor, Set<Component> existing)
     {
         return existing;
+    }
+
+    /**
+     * Called before executing index build on existing sstable
+     */
+    default void onIndexBuild(SSTableReader sstable)
+    {
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.SerializationHeader;
+import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.Descriptor;
@@ -104,6 +105,11 @@ public abstract class SSTableReaderBuilder
     public static FileHandle.Builder defaultIndexHandleBuilder(Descriptor descriptor, Component component)
     {
         return StorageProvider.instance.fileHandleBuilderFor(descriptor, component);
+    }
+
+    public static FileHandle.Builder primaryIndexWriteTimeBuilder(Descriptor descriptor, Component component, OperationType operationType)
+    {
+        return StorageProvider.instance.primaryIndexWriteTimeFileHandleBuilderFor(descriptor, component, operationType);
     }
 
     @SuppressWarnings("resource")

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.SerializationHeader;
+import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.FSWriteError;
@@ -70,6 +71,7 @@ public class BigTableWriter extends SortedTableWriter
     private final ColumnIndex columnIndexWriter;
     private final IndexWriter iwriter;
     private final TransactionalProxy txnProxy;
+    private final OperationType operationType;
 
     private static final SequentialWriterOption WRITER_OPTION = SequentialWriterOption.newBuilder()
                                                                                       .trickleFsync(DatabaseDescriptor.getTrickleFsync())
@@ -94,6 +96,7 @@ public class BigTableWriter extends SortedTableWriter
         this.rowIndexEntrySerializer = new BigTableRowIndexEntry.Serializer(descriptor.version, header);
         columnIndexWriter = new ColumnIndex(this.header, dataFile, descriptor.version, this.observers, rowIndexEntrySerializer.indexInfoSerializer());
         txnProxy = new TransactionalProxy();
+        operationType = lifecycleNewTracker.opType();
     }
 
     private static Set<Component> components(TableMetadata metadata, Collection<Component> indexComponents)
@@ -308,7 +311,7 @@ public class BigTableWriter extends SortedTableWriter
         IndexWriter(long keyCount)
         {
             indexFile = new SequentialWriter(descriptor.fileFor(Component.PRIMARY_INDEX), WRITER_OPTION);
-            builder = SSTableReaderBuilder.defaultIndexHandleBuilder(descriptor, Component.PRIMARY_INDEX);
+            builder = SSTableReaderBuilder.primaryIndexWriteTimeBuilder(descriptor, Component.PRIMARY_INDEX, operationType);
             summary = new IndexSummaryBuilder(keyCount, metadata().params.minIndexInterval, Downsampling.BASE_SAMPLING_LEVEL);
             bf = FilterFactory.getFilter(keyCount, metadata().params.bloomFilterFpChance);
             // register listeners to be alerted when the data files are flushed


### PR DESCRIPTION
- Add SSTableWatcher#onIndexRebuild to be called before index rebuild

- Add primary index write time file handle builder for row index and partiton index when creating sstable

- Overwrite TOC directly instead of deleting then appending