### PR TITLE
CNDB-10324: Prevent overflows when calculating LIMIT+OFFSET

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.math.IntMath;
 
 import org.apache.cassandra.cql3.Ordering;
 import org.apache.cassandra.cql3.restrictions.*;
@@ -848,7 +849,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         if (userOffset != NO_OFFSET)
             Guardrails.offsetRows.guard(userOffset, "Select query", false, queryState);
 
-        int fetchLimit = userLimit == NO_LIMIT || userOffset == NO_OFFSET ? userLimit : userLimit + userOffset;
+        int fetchLimit = userLimit == NO_LIMIT || userOffset == NO_OFFSET ? userLimit : IntMath.saturatedAdd(userLimit, userOffset);
         int cqlRowLimit = NO_LIMIT;
         int cqlPerPartitionLimit = NO_LIMIT;
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectOffsetTest.java
@@ -16,9 +16,13 @@
 package org.apache.cassandra.cql3.validation.operations;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.math.IntMath;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -46,6 +51,10 @@ public class SelectOffsetTest extends CQLTester
     public static void beforeClass()
     {
         requireNetwork();
+
+        // disable offset guardrails for this test
+        DatabaseDescriptor.getGuardrailsConfig().offset_rows_warn_threshold = -1;
+        DatabaseDescriptor.getGuardrailsConfig().offset_rows_failure_threshold = -1;
     }
 
     @Test
@@ -388,13 +397,25 @@ public class SelectOffsetTest extends CQLTester
 
     private void testLimitAndOffset(String select, boolean paging, Object[]... rows) throws Throwable
     {
-        for (int limit = 1; limit <= rows.length + 1; limit++)
+        List<Integer> limits = IntStream.range(1, rows.length + 1).boxed().collect(Collectors.toList());
+        limits.add(Integer.MAX_VALUE);
+        limits.add(Integer.MAX_VALUE - 1);
+
+        List<Integer> offsets = IntStream.range(0, rows.length).boxed().collect(Collectors.toList());
+        offsets.add(Integer.MAX_VALUE);
+        offsets.add(Integer.MAX_VALUE - 1);
+        offsets.add(null);
+
+        for (int limit : limits)
         {
-            for (int offset = 0; offset <= rows.length + 1; offset++)
+            for (Integer offset : offsets)
             {
+                // skip offset without limit, which is forbidden and tested in testParseAndValidate
+                if (limit == Integer.MAX_VALUE && offset != null)
+                    continue;
+
                 testLimitAndOffset(select, limit, offset, paging, rows);
             }
-            testLimitAndOffset(select, limit, null, paging, rows);
         }
     }
 
@@ -451,14 +472,15 @@ public class SelectOffsetTest extends CQLTester
                    rows);
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     private static Object[][] trimRows(Integer limit, @Nullable Integer offset, Object[]... rows)
     {
         offset = offset == null ? 0 : offset;
-        limit = limit == null ? rows.length : limit;
-
         if (offset >= rows.length)
             return EMPTY_ROWS;
 
-        return Arrays.copyOfRange(rows, offset, Math.min(offset + limit, rows.length));
+        int fetchLimit = Math.min(IntMath.saturatedAdd(limit, offset), rows.length);
+
+        return Arrays.copyOfRange(rows, offset, fetchLimit);
     }
 }


### PR DESCRIPTION
The patch adding offset paging (CNDB-9541) and its follow-up for improving coordinator-side row sorting (CNDB-9827) contain additions of offset and limit that can overflow. 

For example, `SELECT * FROM t LIMIT 2147483646 OFFSET 2` will hit an overflow that will return wrong results (the limit is `Integer.MAX_VALUE - 1`). However, it won't happen if the limit is `Integer.MAX_VALUE` because `Integer.MAX_VALUE` means no limit, and that has special treatment.

This PR uses saturated addition for adding limit+offset, so it never exceeds `Integer.MAX_VALUE`.