### PR TITLE
Utilize PriorityQueue's O(N) constructor in several SAI use cases

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.disk;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.PriorityQueue;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.utils.Throwables;
@@ -77,7 +78,11 @@ public interface PostingList extends Closeable
         return new PeekablePostingList(this);
     }
 
-    class PeekablePostingList implements PostingList
+    /**
+     * Note: this class has a natural ordering that is inconsistent with equals in order to
+     * use {@link PriorityQueue}'s O(N) constructor.
+     */
+    class PeekablePostingList implements PostingList, Comparable<PeekablePostingList>
     {
         private final PostingList wrapped;
 
@@ -152,6 +157,12 @@ public interface PostingList extends Closeable
         public void close() throws IOException
         {
             wrapped.close();
+        }
+
+        @Override
+        public int compareTo(PeekablePostingList o)
+        {
+            return Long.compare(peek(), o.peek());
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingList.java
@@ -162,6 +162,9 @@ public interface PostingList extends Closeable
         @Override
         public int compareTo(PeekablePostingList o)
         {
+            // we are comparing over some mutable state: this should not generally work
+            // in this case it works because this method is used ONLY
+            // while constructing a PriorityQueue
             return Long.compare(peek(), o.peek());
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingList.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/MergePostingList.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.index.sai.disk.v1.postings;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.PriorityQueue;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -34,8 +33,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 @NotThreadSafe
 public class MergePostingList implements PostingList
 {
-    private static final Comparator<PeekablePostingList> COMPARATOR = Comparator.comparingLong(PostingList.PeekablePostingList::peek);
-
     final ArrayList<PeekablePostingList> postingLists;
     // (Intersection code just calls advance(long), so don't create this until we need it)
     PriorityQueue<PeekablePostingList> pq;
@@ -75,8 +72,8 @@ public class MergePostingList implements PostingList
             if (postingLists.isEmpty())
                 return PostingList.END_OF_STREAM;
 
-            pq = new PriorityQueue<>(postingLists.size(), COMPARATOR);
-            pq.addAll(postingLists);
+            // Leverage PQ's O(N) heapify time complexity
+            pq = new PriorityQueue<>(postingLists);
         }
 
         while (!pq.isEmpty())

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
@@ -42,7 +42,11 @@ import org.apache.cassandra.utils.AbstractIterator;
  */
 public class BruteForceRowIdIterator extends AbstractIterator<ScoredRowId>
 {
-    public static class RowWithApproximateScore
+    /**
+     * Note: this class has a natural ordering that is inconsistent with equals in order to
+     * use {@link PriorityQueue}'s O(N) constructor.
+     */
+    public static class RowWithApproximateScore implements Comparable<RowWithApproximateScore>
     {
         private final int rowId;
         private final int ordinal;
@@ -55,9 +59,11 @@ public class BruteForceRowIdIterator extends AbstractIterator<ScoredRowId>
             this.appoximateScore = appoximateScore;
         }
 
-        public float getApproximateScore()
+        @Override
+        public int compareTo(RowWithApproximateScore o)
         {
-            return appoximateScore;
+            // Inverted comparison to sort in descending order
+            return Float.compare(o.appoximateScore, appoximateScore);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/ScoredRowId.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/ScoredRowId.java
@@ -18,7 +18,13 @@
 
 package org.apache.cassandra.index.sai.disk.vector;
 
-public class ScoredRowId
+import java.util.PriorityQueue;
+
+/**
+ * Note: this class has a natural ordering that is inconsistent with equals in order to
+ * use {@link PriorityQueue}'s O(N) constructor.
+ */
+public class ScoredRowId implements Comparable<ScoredRowId>
 {
     final int segmentRowId;
     final float score;
@@ -37,5 +43,12 @@ public class ScoredRowId
     public int getSegmentRowId()
     {
         return segmentRowId;
+    }
+
+    @Override
+    public int compareTo(ScoredRowId o)
+    {
+        // Inverted comparison to sort in descending order
+        return Float.compare(o.score, score);
     }
 }


### PR DESCRIPTION
In order to leverage this logic, I made
several utility objects comparable. These
objects have very limited use cases, so
I propose that it is acceptable that the
classes have different logic for equality
and for comparison. If that is not generally
accepted, we will need to tweak the PR.