### PR TITLE
Backport datastax/cassandra#1194

### DIFF
--- a/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
@@ -205,6 +205,62 @@ public class TrackerTest
     }
 
     @Test
+    public void testLateSubscribers()
+    {
+        boolean backups = DatabaseDescriptor.isIncrementalBackupsEnabled();
+        DatabaseDescriptor.setIncrementalBackupsEnabled(false);
+        try
+        {
+            ColumnFamilyStore cfs = MockSchema.newCFS();
+            Tracker tracker = cfs.getTracker();
+
+            OrderTestingMockListener listener1 = new OrderTestingMockListener("l1");
+            OrderTestingMockListener listener2 = new OrderTestingMockListener("l2");
+            OrderTestingMockListener lateListener1 = new OrderTestingMockListener("ll1");
+            OrderTestingMockListener lateListener2 = new OrderTestingMockListener("ll2");
+
+            int initialCount = OrderTestingMockListener.counter.get();
+
+            tracker.subscribeLateConsumer(lateListener1);
+            tracker.subscribe(listener1);
+            tracker.subscribeLateConsumer(lateListener2);
+            tracker.subscribe(listener2);
+
+            List<SSTableReader> readers = ImmutableList.of(MockSchema.sstable(0, 17, cfs));
+            tracker.addSSTables(copyOf(readers), OperationType.UNKNOWN);
+
+            Assert.assertEquals(initialCount, listener1.captured);
+            Assert.assertEquals(initialCount + 1, listener2.captured);
+            Assert.assertEquals(initialCount + 2, lateListener1.captured);
+            Assert.assertEquals(initialCount + 3, lateListener2.captured);
+        }
+        finally
+        {
+            DatabaseDescriptor.setIncrementalBackupsEnabled(backups);
+        }
+    }
+
+    // Mock listener that let us test the order of notifications by capturing and incrementing a common counter.
+    // Please note that this only capture the counter value for the first time a notification is triggered
+    private static final class OrderTestingMockListener implements INotificationConsumer
+    {
+        static final AtomicInteger counter = new AtomicInteger();
+        volatile int captured = -1;
+        private final String name;
+
+        OrderTestingMockListener(String name)
+        {
+            this.name = name;
+        }
+
+        public void handleNotification(INotification notification, Object sender)
+        {
+            if (captured < 0)
+                captured = counter.getAndIncrement();
+        }
+    }
+
+    @Test
     public void testDropSSTables()
     {
         testDropSSTables(false);


### PR DESCRIPTION
Allows to register `Tracker` subscribers that fire later than other ones (#1194)

The `INotificationConsumer` subscribers of `Tracker` fire in the order they are registered. For CNDB however, we want to register subscribers that fire only after all the internal subscribers of C* have fired, as some of those do important jobs (like the `SAIGroup` one, which essentially make built index visible on flush) that we want to make sure happen first.

This patch adds a new `Tracker.subscribeLaterConsumer`, which is similar to the existing `Tracker.subscribe`, but the former guarantees that the consumers it registers all fire after the ones registered by the later.