### PR TITLE
CNDB-10386: SAI sstable intersection logic in row estimate

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
+import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.index.sai.utils.ScoredPrimaryKey;
 import org.apache.cassandra.index.sai.utils.SegmentOrdering;
 import org.apache.cassandra.io.util.FileUtils;
@@ -119,18 +120,7 @@ public class Segment implements Closeable, SegmentOrdering
      */
     public boolean intersects(AbstractBounds<PartitionPosition> keyRange)
     {
-        if (keyRange instanceof Range && ((Range<?>)keyRange).isWrapAround())
-            return keyRange.contains(minKeyBound) || keyRange.contains(maxKeyBound);
-
-        int cmp = keyRange.right.compareTo(minKeyBound);
-        // if right is minimum, it means right is the max token and bigger than maxKey.
-        // if right bound is less than minKeyBound, no intersection
-        if (!keyRange.right.isMinimum() && (!keyRange.inclusiveRight() && cmp == 0 || cmp < 0))
-            return false;
-
-        cmp = keyRange.left.compareTo(maxKeyBound);
-        // if left bound is bigger than maxKeyBound, no intersection
-        return (keyRange.isStartInclusive() || cmp != 0) && cmp <= 0;
+        return RangeUtil.intersects(minKeyBound, maxKeyBound, keyRange);
     }
 
     public long indexFileCacheSize()

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -61,8 +61,6 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
-import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -80,6 +78,7 @@ import org.apache.cassandra.index.sai.utils.RangeIntersectionIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.MergeScoredPrimaryKeyIterator;
 import org.apache.cassandra.index.sai.utils.ScoredPrimaryKey;
+import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.index.sai.utils.SoftLimitUtil;
 import org.apache.cassandra.index.sai.utils.TermIterator;
 import org.apache.cassandra.index.sai.view.View;
@@ -886,15 +885,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         for (Memtable memtable : cfs.getAllMemtables())
             rows += estimateMemtableRowCount(memtable);
 
-        List<Range<Token>> tokenRanges = ranges.stream()
-                                               .map(r -> new Range<>(r.startKey().getToken(), r.stopKey().getToken()))
-                                               .collect(Collectors.toList());
-
         for (SSTableReader sstable : cfs.getLiveSSTables())
-        {
-            if (sstable.intersects(tokenRanges))
-                rows += sstable.getTotalRows();
-        }
+            for (DataRange range : ranges)
+                if (RangeUtil.intersects(sstable, range.keyRange()))
+                    rows += sstable.getTotalRows();
 
         return rows;
     }

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeUtil.java
@@ -21,7 +21,9 @@ package org.apache.cassandra.index.sai.utils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 public class RangeUtil
 {
@@ -30,5 +32,39 @@ public class RangeUtil
     public static boolean coversFullRing(AbstractBounds<PartitionPosition> keyRange)
     {
         return keyRange.left.equals(MIN_KEY_BOUND) && keyRange.right.equals(MIN_KEY_BOUND);
+    }
+
+    /**
+     * Check if the provided {@link SSTableReader} intersects with the provided key range.
+     * @param reader SSTableReader
+     * @param keyRange key range
+     * @return true the key range intersects with the min/max key bounds
+     */
+    public static boolean intersects(SSTableReader reader, AbstractBounds<PartitionPosition> keyRange)
+    {
+        return intersects(reader.first.getToken().minKeyBound(), reader.last.getToken().maxKeyBound(), keyRange);
+    }
+
+    /**
+     * Check if the min/max key bounds intersects with the keyRange
+     * @param minKeyBound min key bound
+     * @param maxKeyBound max key bound
+     * @param keyRange key range
+     * @return true the key range intersects with the min/max key bounds
+     */
+    public static boolean intersects(Token.KeyBound minKeyBound, Token.KeyBound maxKeyBound, AbstractBounds<PartitionPosition> keyRange)
+    {
+        if (keyRange instanceof Range && ((Range<?>)keyRange).isWrapAround())
+            return keyRange.contains(minKeyBound) || keyRange.contains(maxKeyBound);
+
+        int cmp = keyRange.right.compareTo(minKeyBound);
+        // if right is minimum, it means right is the max token and bigger than maxKey.
+        // if right bound is less than minKeyBound, no intersection
+        if (!keyRange.right.isMinimum() && (!keyRange.inclusiveRight() && cmp == 0 || cmp < 0))
+            return false;
+
+        cmp = keyRange.left.compareTo(maxKeyBound);
+        // if left bound is bigger than maxKeyBound, no intersection
+        return (keyRange.isStartInclusive() || cmp != 0) && cmp <= 0;
     }
 }


### PR DESCRIPTION
The underlying problem is how bounds are handled in the `Range` class, which has exclusive bounds. This change centralizes the SAI logic for intersection in an SAI utility so that a segment and the `estimateTotalAvailableRows` both have the same logic.

It seems like it would be better to centralize this logic further, but I'm not quite sure what would be best.

This PR fixes the following failure in the `VectorTypeTest.rangeSearchTest`:

```
java.lang.AssertionError: 0

	at org.apache.cassandra.index.sai.disk.v1.Segment.proportionalAnnLimit(Segment.java:241)
	at org.apache.cassandra.index.sai.plan.QueryController.estimateAnnNodesVisited(QueryController.java:945)
	at org.apache.cassandra.index.sai.plan.Plan$AnnScan.estimateCost(Plan.java:1174)
	at org.apache.cassandra.index.sai.plan.Plan$KeysIteration.cost(Plan.java:556)
	at org.apache.cassandra.index.sai.plan.Plan$KeysIteration.expectedKeys(Plan.java:577)
	at org.apache.cassandra.index.sai.plan.Plan$Fetch.estimateCost(Plan.java:1287)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.cost(Plan.java:1227)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.cost(Plan.java:1214)
	at org.apache.cassandra.index.sai.plan.Plan.initCost(Plan.java:382)
	at org.apache.cassandra.index.sai.plan.Plan$Filter.estimateCost(Plan.java:1357)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.cost(Plan.java:1227)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.expectedRows(Plan.java:1242)
	at org.apache.cassandra.index.sai.plan.Plan$Limit.estimateCost(Plan.java:1415)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.cost(Plan.java:1227)
	at org.apache.cassandra.index.sai.plan.Plan$RowsIteration.cost(Plan.java:1214)
	at org.apache.cassandra.index.sai.plan.Plan.fullCost(Plan.java:396)
	at org.apache.cassandra.index.sai.plan.Plan.optimize(Plan.java:325)
	at org.apache.cassandra.index.sai.plan.QueryController.buildPlan(QueryController.java:312)
	at org.apache.cassandra.index.sai.plan.QueryController.buildIterator(QueryController.java:369)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:124)
	at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:512)
	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:410)
	at org.apache.cassandra.db.ReadCommand.executeInternal(ReadCommand.java:537)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeInternal(SelectStatement.java:615)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:598)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:105)
	at org.apache.cassandra.cql3.QueryProcessor.executeInternal(QueryProcessor.java:489)
	at org.apache.cassandra.cql3.CQLTester.executeFormattedQuery(CQLTester.java:1391)
	at org.apache.cassandra.cql3.CQLTester.execute(CQLTester.java:1379)
```