### PR TITLE
CNDB-10210: Add missing CASSANDRA-18670 changes

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -850,7 +850,7 @@ public class IndexContext
             {
                 if (validate)
                 {
-                    if (!perIndexComponents.validateComponents(context.sstable, owner.getTracker(), false))
+                    if (!perIndexComponents.validateComponents(context.sstable, owner.getTracker(), true, false))
                     {
                         // Note that a precise warning is already logged by the validation if there is an issue.
                         invalid.add(context);

--- a/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
@@ -100,7 +100,7 @@ public class SSTableContextManager
             try
             {
                 // Only validate on restart or newly refreshed SSTable. Newly built files are unlikely to be corrupted.
-                if (validate && !sstableContexts.containsKey(sstable) && !perSSTableComponents.validateComponents(sstable, tracker, false))
+                if (validate && !sstableContexts.containsKey(sstable) && !perSSTableComponents.validateComponents(sstable, tracker, true, false))
                 {
                     // Note that the validation already log details on the problem if it fails, so no reason to log further
                     hasInvalid = true;

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -608,6 +608,12 @@ public class StorageAttachedIndex implements Index
     }
 
     @Override
+    public boolean isSSTableAttached()
+    {
+        return true;
+    }
+
+    @Override
     public Optional<ColumnFamilyStore> getBackingTable()
     {
         return Optional.empty();

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -98,7 +98,10 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
     @Override
     public void build()
     {
-        logger.debug(logMessage("Starting full index build"));
+        logger.debug(logMessage(String.format("Starting %s %s index build...",
+                                              isInitialBuild ? "initial" : "non-initial",
+                                              isFullRebuild ? "full" : "partial")));
+
         for (Map.Entry<SSTableReader, Set<StorageAttachedIndex>> e : sstables.entrySet())
         {
             SSTableReader sstable = e.getKey();
@@ -112,9 +115,7 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
             }
 
             if (indexSSTable(sstable, existing))
-            {
                 return;
-            }
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.disk.format;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -218,9 +219,10 @@ public interface IndexComponents
          *                as part of unregistering the components when they are invalid.
          * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
          *                         basic checks on the header and footers will be performed.
+         * @param rethrow whether to throw an {@link UncheckedIOException} if the group is invalid
          * @return whether the group is valid.
          */
-        boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum);
+        boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum, boolean rethrow);
 
         /**
          * Marks the group as invalid/broken.

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.disk.format;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Set;
@@ -143,9 +144,9 @@ public interface OnDiskFormat
      * @param component The component to validate
      * @param checksum {@code true} if the checksum should be tested as part of the validation
      *
-     * @return true if the component is valid
+     * @throws UncheckedIOException if there is a problem validating any on-disk component
      */
-    boolean validateIndexComponent(IndexComponent.ForRead component, boolean checksum);
+    void validateIndexComponent(IndexComponent.ForRead component, boolean checksum);
 
     /**
      * Returns the set of {@link IndexComponentType} for the per-SSTable part of an index.

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -264,8 +264,9 @@ public abstract class SSTableWriter extends SSTable implements Transactional, SS
         txnProxy.prepareToCommit();
         if (openResult)
             openResult();
-        txnProxy.commit();
+
         observers.forEach(obs -> obs.complete(this));
+        txnProxy.commit();
         return finished();
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -378,8 +378,8 @@ public class SAITester extends CQLTester
             IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
             if (indexDescriptor.isIndexEmpty(context))
                 continue;
-            if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true)
-                || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true))
+            if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true, false)
+                || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true, false))
                 return false;
         }
         return true;
@@ -563,11 +563,11 @@ public class SAITester extends CQLTester
             IndexDescriptor descriptor = loadDescriptor(sstable, cfs);
 
             // Note that validation makes sure that all expected components exists, on top of validating those.
-            descriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true);
+            descriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true, false);
             if (numericIndexContext != null)
-                descriptor.perIndexComponents(numericIndexContext).validateComponents(sstable, cfs.getTracker(), true);
+                descriptor.perIndexComponents(numericIndexContext).validateComponents(sstable, cfs.getTracker(), true, false);
             if (stringIndexContext != null)
-                descriptor.perIndexComponents(stringIndexContext).validateComponents(sstable, cfs.getTracker(), true);
+                descriptor.perIndexComponents(stringIndexContext).validateComponents(sstable, cfs.getTracker(), true, false);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Collections;
+
 import com.google.common.collect.Iterables;
 import org.junit.After;
 import org.junit.Before;
@@ -109,6 +111,17 @@ public class IndexParallelBuildTest extends SAITester
         assertEquals(1, parallelBuildCounter.get());
 
         // verify index can be read
+        assertRowCount(sstable * rowsPerSSTable, "SELECT id1 FROM %s WHERE v1>=0");
+
+        // reset the counter
+        parallelBuildCounter.reset();
+        assertEquals(0, parallelBuildCounter.get());
+
+        // verify parallel index build again, this time with a full rebuild with the sstables already loaded
+        getCurrentColumnFamilyStore().indexManager.rebuildIndexesBlocking(Collections.singleton(index));
+        assertEquals(1, parallelBuildCounter.get());
+
+        // verify index can still be read
         assertRowCount(sstable * rowsPerSSTable, "SELECT id1 FROM %s WHERE v1>=0");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -973,7 +973,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void verifyRebuildCorruptedFiles() throws Throwable
+    public void verifyRebuildCorruptedFiles() throws Throwable // TODO CNDB-10210: fix this test
     {
         // prepare schema and data
         createTable(CREATE_TABLE_TEMPLATE);
@@ -1177,7 +1177,7 @@ public class NativeIndexDDLTest extends SAITester
         try
         {
             // Create a new index, which will actuate a build compaction and fail, but leave the node running...
-            IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
+            IndexContext numericIndexContext = createIndexContext(createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
             // two index builders running in different compaction threads because of parallelised index initial build
             waitForAssert(() -> assertEquals(2, INDEX_BUILD_COUNTER.get()));
             waitForCompactionsFinished();
@@ -1212,7 +1212,7 @@ public class NativeIndexDDLTest extends SAITester
         try
         {
             // Create a new index, which will actuate a build compaction and fail, but leave the node running...
-            createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+            createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
             // two index builders running in different compaction threads because of parallelised index initial build
             waitForAssert(() -> assertEquals(2, INDEX_BUILD_COUNTER.get()));
             waitForAssert(() -> assertEquals(0, getCompactionTasks()));
@@ -1405,7 +1405,7 @@ public class NativeIndexDDLTest extends SAITester
 
         Injections.inject(delayIndexBuilderCompletion);
 
-        IndexContext numericIndexContext = getIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")));
+        IndexContext numericIndexContext = getIndexContext(createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1")));
 
         waitForAssert(() -> assertTrue(getCompactionTasks() > 0), 1000, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
Add missing CASSANDRA-18670 changes.

This fixes `ImportIndexedSSTablesTest`.

The `SIM#buildSSTableAttachedIndexesBlocking` method added by CASSANDRA-18670 is modified to build the indexes in parallel, in line with CNDB-7103.