### PR TITLE
CNDB-9804: Remove duplicated closing of postings IndexInput's

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -289,6 +289,7 @@ public class BKDReaderTest extends SaiRandomizedTest
         assertEquals(PostingList.END_OF_STREAM, intersection.advance(numRows + 1));
 
         intersection.close();
+        reader.close();
     }
 
     @Test
@@ -309,9 +310,12 @@ public class BKDReaderTest extends SaiRandomizedTest
         }
 
         final BKDReader reader = finishAndOpenReaderOneDim(50, buffer);
-
         final PostingList intersection = reader.intersect(buildQuery(1017, 1096), (QueryEventListener.BKDIndexEventListener)NO_OP_BKD_LISTENER, new QueryContext());
+
         assertEquals(PostingList.EMPTY, intersection);
+
+        intersection.close();
+        reader.close();
     }
 
     private BKDReader.IntersectVisitor buildQuery(int queryMin, int queryMax)


### PR DESCRIPTION
Remove unnecessary closing of postings in `BKDReader.Intersection#mergePostings`.

The posting readers created by `BKDReader.Intersection#initPostingReader` already close their `IndexInput` on close.