### PR TITLE
SAI fix performance when selection and order by on the same column

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -195,12 +195,13 @@ public class SSTableIndex
     }
 
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+                                                                  Expression predicate,
                                                                   AbstractBounds<PartitionPosition> keyRange,
                                                                   QueryContext context,
                                                                   int limit,
                                                                   long totalRows) throws IOException
     {
-        return searchableIndex.orderBy(orderer, keyRange, context, limit, totalRows);
+        return searchableIndex.orderBy(orderer, predicate, keyRange, context, limit, totalRows);
     }
 
     public void populateSegmentView(SimpleDataSet dataSet)

--- a/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
@@ -97,7 +97,12 @@ public class EmptyIndex implements SearchableIndex
     }
 
     @Override
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext context, int limit, long totalRows) throws IOException
+    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+                                                                  Expression slice,
+                                                                  AbstractBounds<PartitionPosition> keyRange,
+                                                                  QueryContext context,
+                                                                  int limit,
+                                                                  long totalRows) throws IOException
     {
         return List.of();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -70,6 +70,7 @@ public interface SearchableIndex extends Closeable
                                 boolean defer, int limit) throws IOException;
 
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+                                                                  Expression slice,
                                                                   AbstractBounds<PartitionPosition> keyRange,
                                                                   QueryContext context,
                                                                   int limit,

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 
@@ -104,12 +103,13 @@ public abstract class IndexSearcher implements Closeable, SegmentOrdering
      * Order the on-disk index synchronously and produce an iterator in score order
      *
      * @param orderer      the object containing the ordering logic
+     * @param slice        optional predicate to get a slice of the index
      * @param keyRange     key range specific in read command, used by ANN index
      * @param queryContext to track per sstable cache and per query metrics
      * @param limit        the num of rows to returned, used by ANN index
      * @return an iterator of {@link PrimaryKeyWithSortKey} in score order
      */
-    public abstract CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException;
+    public abstract CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException;
 
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -129,7 +129,7 @@ public class InvertedIndexSearcher extends IndexSearcher implements SegmentOrder
     }
 
     @Override
-    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException
+    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException
     {
         var iter = new RowIdWithTermsIterator(reader.allTerms(orderer.isAscending()));
         return toMetaSortedIterator(iter, queryContext);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
@@ -106,9 +106,12 @@ public class KDTreeIndexSearcher extends IndexSearcher
         }
     }
 
-    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException
+    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, int limit) throws IOException
     {
-        var iter = new RowIdIterator(bkdReader.iteratorState(orderer.isAscending()));
+        var query = slice != null && slice.getOp().isEqualityOrRange()
+                    ? bkdQueryFrom(slice, bkdReader.getNumDimensions(), bkdReader.getBytesPerDimension())
+                    : null;
+        var iter = new RowIdIterator(bkdReader.iteratorState(orderer.isAscending(), query));
         return toMetaSortedIterator(iter, queryContext);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -153,9 +153,9 @@ public class Segment implements Closeable
      * @param limit      the num of rows to returned, used by ANN index
      * @return an iterator of {@link PrimaryKeyWithSortKey} in score order
      */
-    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext context, int limit) throws IOException
+    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice, AbstractBounds<PartitionPosition> keyRange, QueryContext context, int limit) throws IOException
     {
-        return index.orderBy(orderer, keyRange, context, limit);
+        return index.orderBy(orderer, slice, keyRange, context, limit);
     }
 
     public IndexSearcher getIndexSearcher()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -194,7 +194,7 @@ public class V1SearchableIndex implements SearchableIndex
     }
 
     @Override
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer, Expression slice,
                                                                   AbstractBounds<PartitionPosition> keyRange,
                                                                   QueryContext context,
                                                                   int limit,
@@ -208,7 +208,7 @@ public class V1SearchableIndex implements SearchableIndex
                 if (segment.intersects(keyRange))
                 {
                     var segmentLimit = segment.proportionalAnnLimit(limit, totalRows);
-                    iterators.add(segment.orderBy(orderer, keyRange, context, segmentLimit));
+                    iterators.add(segment.orderBy(orderer, slice, keyRange, context, segmentLimit));
                 }
             }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -169,7 +169,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     }
 
     @Override
-    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, AbstractBounds<PartitionPosition> keyRange, QueryContext context, int limit) throws IOException
+    public CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice, AbstractBounds<PartitionPosition> keyRange, QueryContext context, int limit) throws IOException
     {
         if (logger.isTraceEnabled())
             logger.trace(indexContext.logMessage("Searching on expression '{}'..."), orderer);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -199,8 +199,13 @@ public class VectorMemtableIndex implements MemtableIndex
     }
 
     @Override
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext context, Orderer orderer, AbstractBounds<PartitionPosition> keyRange, int limit)
+    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext context,
+                                                                  Orderer orderer,
+                                                                  Expression slice,
+                                                                  AbstractBounds<PartitionPosition> keyRange,
+                                                                  int limit)
     {
+        assert slice == null : "ANN does not support index slicing";
         assert orderer.isANN() : "Only ANN is supported for vector search, received " + orderer.operator;
 
         var qv = vts.createFloatVector(orderer.vector);

--- a/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
@@ -51,7 +51,7 @@ public abstract class MemoryIndex
                              LongConsumer onHeapAllocationsTracker,
                              LongConsumer offHeapAllocationsTracker);
 
-    public abstract CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer);
+    public abstract CloseableIterator<PrimaryKeyWithSortKey> orderBy(Orderer orderer, Expression slice);
 
     public abstract RangeIterator search(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -54,7 +54,6 @@ import org.apache.cassandra.index.sai.utils.PriorityQueueIterator;
 import org.apache.cassandra.index.sai.utils.RangeConcatIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
-import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Pair;
@@ -213,7 +212,11 @@ public class TrieMemtableIndex implements MemtableIndex
     }
 
     @Override
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext queryContext, Orderer orderer, AbstractBounds<PartitionPosition> keyRange, int limit)
+    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext queryContext,
+                                                                  Orderer orderer,
+                                                                  Expression slice,
+                                                                  AbstractBounds<PartitionPosition> keyRange,
+                                                                  int limit)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = keyRange.right.isMinimum() ? boundaries.shardCount() - 1 : boundaries.getShardForToken(keyRange.right.getToken());
@@ -223,7 +226,7 @@ public class TrieMemtableIndex implements MemtableIndex
         for (int shard  = startShard; shard <= endShard; ++shard)
         {
             assert rangeIndexes[shard] != null;
-            iterators.add(rangeIndexes[shard].orderBy(orderer));
+            iterators.add(rangeIndexes[shard].orderBy(orderer, slice));
         }
 
         return iterators;

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.plan;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
@@ -105,4 +106,12 @@ public class Orderer
         return ORDER_BY_OPERATORS.contains(expression.operator());
     }
 
+    @Override
+    public String toString()
+    {
+        String direction = isAscending() ? "ASC" : "DESC";
+        return isANN()
+               ? context.getColumnName() + " ANN OF " + Arrays.toString(vector) + ' ' + direction
+               : context.getColumnName() + ' ' + direction;
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryViewBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryViewBuilder.java
@@ -88,6 +88,14 @@ public class QueryViewBuilder
             view.release();
             referencedIndexes.forEach(SSTableIndex::release);
         }
+
+        /**
+         * Returns the total count of rows in all sstables in this view
+         */
+        public long getTotalSStableRows()
+        {
+            return view.sstables.stream().mapToLong(SSTableReader::getTotalRows).sum();
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -122,7 +122,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     public UnfilteredPartitionIterator search(ReadExecutionController executionController) throws RequestTimeoutException
     {
         FilterTree filterTree = analyzeFilter();
-        if (command.isTopK())
+        Plan plan = controller.buildPlan();
+
+        // Can't check for `command.isTopK()` because the planner could optimize sorting out
+        if (plan.ordering() != null)
         {
             // TopK queries require a consistent view of the sstables and memtables in order to validate overwritten
             // rows. Acquire the view before building any of the iterators.
@@ -131,7 +134,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 // TODO this is a bit of a hack, but we need to get the view from the queryView. Find better way to
                 // thread this through.
                 queryContext.view = queryView;
-                Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator();
+                Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
                 assert !(keysIterator instanceof RangeIterator);
                 var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
                 var result = new ScoreOrderedResultRetriever(queryView.view, scoredKeysIterator, filterTree, controller,
@@ -141,7 +144,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         }
         else
         {
-            Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator();
+            Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
             assert keysIterator instanceof RangeIterator;
             return new ResultRetriever((RangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
         }

--- a/src/java/org/apache/cassandra/index/sai/utils/MemtableOrdering.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/MemtableOrdering.java
@@ -20,9 +20,12 @@ package org.apache.cassandra.index.sai.utils;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
 import org.apache.cassandra.utils.CloseableIterator;
 
@@ -34,13 +37,19 @@ public interface MemtableOrdering
 
     /**
      * Order the index based on the given expression.
+     *
      * @param queryContext - the query context
-     * @param orderer - the expression to order by
-     * @param keyRange - the key range to search
-     * @param limit - can be used to inform the search, but should not be used to prematurely limit the iterator
+     * @param orderer      - the expression to order by
+     * @param slice    - the expression to restrict index search by
+     * @param keyRange     - the key range to search
+     * @param limit        - can be used to inform the search, but should not be used to prematurely limit the iterator
      * @return an iterator over the results in score order.
      */
-    List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext queryContext, Orderer orderer, AbstractBounds<PartitionPosition> keyRange, int limit);
+    List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext queryContext,
+                                                           Orderer orderer,
+                                                           Expression slice,
+                                                           AbstractBounds<PartitionPosition> keyRange,
+                                                           int limit);
 
     /**
      * Order the given list of {@link PrimaryKey} results corresponding to the given expression.

--- a/src/java/org/apache/cassandra/index/sai/utils/SegmentOrdering.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SegmentOrdering.java
@@ -47,7 +47,7 @@ import org.apache.cassandra.utils.CloseableIterator;
  *
  * Note: a segment ordering is only used when a query has both ordering and non-ordering predicates.
  * Where a query has only ordering predicates, the ordering is handled by the
- * {@link IndexSearcher#orderBy(Orderer, AbstractBounds, QueryContext, int)}.
+ * {@link IndexSearcher#orderBy(Orderer, org.apache.cassandra.index.sai.plan.Expression, AbstractBounds, QueryContext, int)}.
  */
 public interface SegmentOrdering
 {

--- a/src/java/org/apache/cassandra/index/sai/utils/TreeFormatter.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TreeFormatter.java
@@ -73,10 +73,17 @@ public class TreeFormatter<T>
             sb.append(padding);
             sb.append(hasRightSibling ? " ├─ " : " └─ ");
             padding.append(hasRightSibling ? " │  " : "    ");
-
         }
-        sb.append(toString.apply(node));
+
+        String[] nodeStr = toString.apply(node).split("\n");
+        sb.append(nodeStr[0]);
         sb.append('\n');
+        for (int i = 1; i < nodeStr.length; i++)
+        {
+            sb.append(padding);
+            sb.append(nodeStr[i]);
+            sb.append('\n');
+        }
 
         var iter = children.apply(node).iterator();
         while (iter.hasNext())

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -55,9 +55,7 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.cql.VectorTester;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
-import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
-import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithScore;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
@@ -163,7 +161,7 @@ public class VectorMemtableIndexTest extends SAITester
             long expectedResults = Math.min(limit, keysInRange.size());
 
             // execute the random ANN expression, and check that we get back as many keys as we asked for
-            var iterators = memtableIndex.orderBy(new QueryContext(), orderer, keyRange, limit);
+            var iterators = memtableIndex.orderBy(new QueryContext(), orderer, null, keyRange, limit);
             assertEquals(1, iterators.size());
             try (var iterator = iterators.get(0))
             {

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -377,7 +377,7 @@ public class PlanTest
         Plan.KeysIteration s2 = factory.indexScan(saiPred2, 30);
         Plan.KeysIteration s3 = factory.indexScan(saiPred3, 50);
         Plan.KeysIteration plan1 = factory.intersection(Lists.newArrayList(s1, s2, s3));
-        Plan plan2 = plan1.remove(s2.id);
+        Plan plan2 = plan1.removeRestriction(s2.id);
 
         assertNotSame(plan1, plan2);
         assertEquals(plan1.id, plan2.id);  // although the result plan is different object, the nodes must retain their ids
@@ -385,10 +385,10 @@ public class PlanTest
         assertEquals(Lists.newArrayList(s1.id, s3.id), ids(plan2.subplans()));
         assertNotEquals(plan1.cost(), plan2.cost());
 
-        Plan plan3 = plan2.remove(s1.id);
+        Plan plan3 = plan2.removeRestriction(s1.id);
         assertEquals(s3.id, plan3.id);
 
-        Plan plan4 = plan3.remove(s3.id);
+        Plan plan4 = plan3.removeRestriction(s3.id);
         assertTrue(plan4 instanceof Plan.Everything);
     }
 
@@ -403,7 +403,7 @@ public class PlanTest
         Plan.KeysIteration sub1 = factory.intersection(Lists.newArrayList(s1, s2));
         Plan.KeysIteration sub2 = factory.intersection(Lists.newArrayList(s3, s4));
         Plan.KeysIteration plan1 = factory.union(Lists.newArrayList(sub1, sub2));
-        Plan plan2 = plan1.remove(s2.id).remove(s3.id);
+        Plan plan2 = plan1.removeRestriction(s2.id).removeRestriction(s3.id);
 
         Plan reference = factory.union(Lists.newArrayList(s1, s4));
 
@@ -463,7 +463,7 @@ public class PlanTest
             }
 
             @Override
-            public Iterator<? extends PrimaryKey> getTopKRows(int softLimit)
+            public Iterator<? extends PrimaryKey> getTopKRows(Expression predicate, int softLimit)
             {
                 throw new UnsupportedOperationException();
             }
@@ -517,9 +517,12 @@ public class PlanTest
                      "         └─ KeysSort (keys: 3.0, cost/key: 10.0, cost: 40118.3..40148.3)\n" +
                      "             └─ Union (keys: 1999.0, cost/key: 17.0, cost: 90.0..34091.3)\n" +
                      "                 ├─ Intersection (keys: 1000.0, cost/key: 33.0, cost: 60.0..33061.3)\n" +
-                     "                 │   ├─ NumericIndexScan of pred2_idx using RANGE(pred2) (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 1.0, cost: 30.0..2030.0)\n" +
-                     "                 │   └─ NumericIndexScan of pred1_idx using RANGE(pred1) (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 15.5, cost: 30.0..31031.3)\n" +
-                     "                 └─ LiteralIndexScan of pred4_idx using RANGE(pred4) (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 1.0, cost: 30.0..1030.0)\n", prettyStr);
+                     "                 │   ├─ NumericIndexScan of pred2_idx (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 1.0, cost: 30.0..2030.0)\n" +
+                     "                 │   │  predicate: RANGE(pred2)\n" +
+                     "                 │   └─ NumericIndexScan of pred1_idx (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 15.5, cost: 30.0..31031.3)\n" +
+                     "                 │      predicate: RANGE(pred1)\n" +
+                     "                 └─ LiteralIndexScan of pred4_idx (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 1.0, cost: 30.0..1030.0)\n" +
+                     "                    predicate: RANGE(pred4)\n", prettyStr);
     }
 
     @Test
@@ -981,7 +984,7 @@ public class PlanTest
         Mockito.when(indexScan1.withAccess(Mockito.any())).thenReturn(indexScan1);
         Mockito.when(indexScan1.estimateCost()).thenReturn(new Plan.KeysIterationCost(20,0.0, 0.5));
         Mockito.when(indexScan1.estimateSelectivity()).thenReturn(0.001);
-        Mockito.when(indexScan1.description()).thenReturn("");
+        Mockito.when(indexScan1.title()).thenReturn("");
 
         Plan.KeysIteration indexScan2 = factory.indexScan(saiPred2, (long) (0.01 * factory.tableMetrics.rows));
         Plan.KeysIteration indexScan3 = factory.indexScan(saiPred3, (long) (0.5 * factory.tableMetrics.rows));

--- a/test/unit/org/apache/cassandra/index/sai/utils/TreeFormatterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/TreeFormatterTest.java
@@ -62,4 +62,25 @@ public class TreeFormatterTest
                      "     └─ child 2b\n", formattedTree);
     }
 
+    @Test
+    public void formatTreeWithMultiLineNodes() {
+        TreeNode root = new TreeNode("root line 1\nroot line 2", List.of(
+        new TreeNode("child 1\nchild 1 line 2", List.of(
+            new TreeNode("child 1a", Collections.emptyList()),
+            new TreeNode("child 1b", Collections.emptyList()))),
+        new TreeNode("child 2\nchild 2 line 2", Collections.emptyList())));
+
+        TreeFormatter<TreeNode> formatter = new TreeFormatter<>(t -> t.label, t -> t.children);
+        String formattedTree = formatter.format(root);
+
+        assertEquals("root line 1\n" +
+                     "root line 2\n" +
+                     " ├─ child 1\n" +
+                     " │  child 1 line 2\n" +
+                     " │   ├─ child 1a\n" +
+                     " │   └─ child 1b\n" +
+                     " └─ child 2\n" +
+                     "    child 2 line 2\n", formattedTree);
+    }
+
 }


### PR DESCRIPTION
Fixes [10400](https://github.com/riptano/cndb/issues/10400)


Schema:
Table with one indexed column `a` with random values ranging 0.0 to 1.0.
1M rows. 

Query:
`SELECT * FROM tab WHERE a > 0.8 ORDER BY a LIMIT 10`

Performance before: 0 req/sec (all timeouts)
Performance after: 7300 req/s (0 timeouts)