### PR TITLE
Add property to disable opening index searcher objects (for compactors)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -479,8 +479,8 @@ public enum CassandraRelevantProperties
     DURATION_IN_MAPS_COMPATIBILITY_MODE("cassandra.types.map.duration_in_map_compatibility_mode", "false"),
 
     /**
-     * If true, the searcher object created when opening a SAI index will be replaced by a dummy object that throws
-     * if a search is attempted. This is obviously usually undesirable, but can be used if the node only compact
+     * If true, the searcher object created when opening a SAI index will be replaced by a dummy object that always
+     * return empty results. This is obviously usually undesirable, but can be used if the node only compact
      * sstables to avoid loading heavy index data structures in memory that are not used.
      */
     SAI_INDEX_READS_DISABLED("cassandra.sai.disabled_reads", "false");

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -476,7 +476,14 @@ public enum CassandraRelevantProperties
      * maps. When the check is disabled, Cassandra will refuse to load the data with such maps and won't start if
      * the schema contains them.
      */
-    DURATION_IN_MAPS_COMPATIBILITY_MODE("cassandra.types.map.duration_in_map_compatibility_mode", "false");
+    DURATION_IN_MAPS_COMPATIBILITY_MODE("cassandra.types.map.duration_in_map_compatibility_mode", "false"),
+
+    /**
+     * If true, the searcher object created when opening a SAI index will be replaced by a dummy object that throws
+     * if a search is attempted. This is obviously usually undesirable, but can be used if the node only compact
+     * sstables to avoid loading heavy index data structures in memory that are not used.
+     */
+    SAI_INDEX_READS_DISABLED("cassandra.sai.disabled_reads", "false");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -479,9 +479,9 @@ public enum CassandraRelevantProperties
     DURATION_IN_MAPS_COMPATIBILITY_MODE("cassandra.types.map.duration_in_map_compatibility_mode", "false"),
 
     /**
-     * If true, the searcher object created when opening a SAI index will be replaced by a dummy object that always
-     * return empty results. This is obviously usually undesirable, but can be used if the node only compact
-     * sstables to avoid loading heavy index data structures in memory that are not used.
+     * If true, the searcher object created when opening a SAI index will be replaced by a dummy object and index
+     * are never marked queriable (querying one will fail). This is obviously usually undesirable, but can be used if
+     * the node only compact sstables to avoid loading heavy index data structures in memory that are not used.
      */
     SAI_INDEX_READS_DISABLED("cassandra.sai.disabled_reads", "false");
 

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -70,7 +70,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.Stage;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -90,7 +89,6 @@ import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.WriteContext;
 import org.apache.cassandra.db.compaction.CompactionManager;
-import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
@@ -1858,9 +1856,6 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
     public void makeIndexQueryable(Index index, Index.Status status)
     {
-        if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
-            return;
-
         String name = index.getIndexMetadata().name;
         if (indexes.get(name) == index)
         {

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -1857,6 +1858,9 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
     public void makeIndexQueryable(Index index, Index.Status status)
     {
+        if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
+            return;
+
         String name = index.getIndexMetadata().name;
         if (indexes.get(name) == index)
         {

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -28,6 +28,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.virtual.SimpleDataSet;
@@ -55,6 +60,8 @@ import org.apache.cassandra.utils.CloseableIterator;
  */
 public class SSTableIndex
 {
+    private static final Logger logger = LoggerFactory.getLogger(SSTableIndex.class);
+
     // sort sstable index by first key then last key
     public static final Comparator<SSTableIndex> COMPARATOR = Comparator.comparing((SSTableIndex s) -> s.getSSTable().first)
                                                                         .thenComparing(s -> s.getSSTable().last)
@@ -73,11 +80,33 @@ public class SSTableIndex
     {
         assert perIndexComponents.context().getValidator() != null;
         this.perIndexComponents = perIndexComponents;
-        this.searchableIndex = perIndexComponents.version().onDiskFormat().newSearchableIndex(sstableContext, perIndexComponents);
+        this.searchableIndex = createSearchableIndex(sstableContext, perIndexComponents);
 
         this.sstableContext = sstableContext.sharedCopy(); // this line must not be before any code that may throw
         this.indexContext = perIndexComponents.context();
         this.sstable = sstableContext.sstable;
+    }
+
+    private static SearchableIndex createSearchableIndex(SSTableContext sstableContext, IndexComponents.ForRead perIndexComponents)
+    {
+        if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
+        {
+            logger.info("Creating dummy index searcher for sstable {} as SAI index reads are disabled", sstableContext.sstable.descriptor);
+            return new EmptyIndex()
+            {
+                @Override
+                public RangeIterator search(Expression expression,
+                                            AbstractBounds<PartitionPosition> keyRange,
+                                            QueryContext context,
+                                            boolean defer,
+                                            int limit) throws IOException
+                {
+                    throw new UnsupportedOperationException("SAI index reads are disabled (see '" + CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getKey() + "' property)");
+                }
+            };
+        }
+
+        return perIndexComponents.version().onDiskFormat().newSearchableIndex(sstableContext, perIndexComponents);
     }
 
     public IndexContext getIndexContext()

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -91,19 +91,8 @@ public class SSTableIndex
     {
         if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
         {
-            logger.info("Creating dummy index searcher for sstable {} as SAI index reads are disabled", sstableContext.sstable.descriptor);
-            return new EmptyIndex()
-            {
-                @Override
-                public RangeIterator search(Expression expression,
-                                            AbstractBounds<PartitionPosition> keyRange,
-                                            QueryContext context,
-                                            boolean defer,
-                                            int limit) throws IOException
-                {
-                    throw new UnsupportedOperationException("SAI index reads are disabled (see '" + CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getKey() + "' property)");
-                }
-            };
+            logger.info("Creating dummy (empty) index searcher for sstable {} as SAI index reads are disabled", sstableContext.sstable.descriptor);
+            return new EmptyIndex();
         }
 
         return perIndexComponents.version().onDiskFormat().newSearchableIndex(sstableContext, perIndexComponents);

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Operator;
@@ -714,7 +715,8 @@ public class StorageAttachedIndex implements Index
     @Override
     public boolean isQueryable(Status status)
     {
-        return status == Status.BUILD_SUCCEEDED || status == Status.UNKNOWN;
+        return !CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean()
+            && (status == Status.BUILD_SUCCEEDED || status == Status.UNKNOWN);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -256,7 +256,7 @@ public class CompactionTest extends AbstractMetricsTest
     // This test probably never worked, but initially `TestWithConcurrentVerification` was also not working properly
     // and was ignoring errors throw during the `verificationTask`, hidding the problem with this test.
     // `TestWithConcurrentVerification` was fixed, leading to this failing, and it's not immediately clear what the
-    // right fix, so for not it is ignored, but it should eventually be fixed.
+    // right fix should be, so for now it is ignored, but it should eventually be fixed.
     @Ignore
     public void testConcurrentIndexBuildWithCompaction() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -31,6 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -153,6 +154,20 @@ public class CompactionTest extends AbstractMetricsTest
 
         verifySSTableIndexes(v1IndexName, num);
         verifySSTableIndexes(v2IndexName, num);
+    }
+
+    @Test
+    public void testCompactionWithDisabledIndexReads() throws Throwable
+    {
+        CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.setBoolean(true);
+        try
+        {
+            testConcurrentQueryWithCompaction();
+        }
+        finally
+        {
+            CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.setBoolean(false);
+        }
     }
 
     @Test


### PR DESCRIPTION
The context of this is https://github.com/riptano/cndb/issues/10519.