### PR TITLE
SAI Update: ignore TTL when getting old row's vector value

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -391,7 +391,10 @@ public class IndexContext
         MemtableIndex target = liveMemtables.get(memtable);
         if (target == null)
             return;
-        // Use 0 for nowInSecs to get the value from the oldRow to ensure we remove the old value from the index.
+        // Use 0 for nowInSecs to get the value from the oldRow regardless of its liveness status. To get to this point,
+        // C* has already determined this is the current represntation of the oldRow in the memtable, and that means
+        // we need to add the newValue to the index and remove the oldValue from it, even if it has already expired via
+        // TTL.
         ByteBuffer oldValue = getValueOf(key, oldRow, 0);
         ByteBuffer newValue = getValueOf(key, newRow, FBUtilities.nowInSeconds());
         target.update(key, oldRow.clustering(), oldValue, newValue, memtable, opGroup);

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -391,8 +391,8 @@ public class IndexContext
         MemtableIndex target = liveMemtables.get(memtable);
         if (target == null)
             return;
-
-        ByteBuffer oldValue = getValueOf(key, oldRow, FBUtilities.nowInSeconds());
+        // Use 0 for nowInSecs to get the value from the oldRow to ensure we remove the old value from the index.
+        ByteBuffer oldValue = getValueOf(key, oldRow, 0);
         ByteBuffer newValue = getValueOf(key, newRow, FBUtilities.nowInSeconds());
         target.update(key, oldRow.clustering(), oldValue, newValue, memtable, opGroup);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -28,13 +28,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.plan.QueryController;
 
 import static org.apache.cassandra.index.sai.cql.VectorTypeTest.assertContainsInt;
 import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class VectorUpdateDeleteTest extends VectorTester
@@ -973,5 +977,32 @@ public class VectorUpdateDeleteTest extends VectorTester
         flush();
 
         verifySSTableIndexes(indexName, 1);
+    }
+
+    @Test
+    public void testTTLOverwriteHasCorrectOnDiskRowCount() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int primary key, val vector<float, 3>)");
+        var indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0, 3.0]) USING TTL 1");
+
+        // Let the ttl expire
+        Thread.sleep(1000);
+
+        execute("INSERT INTO %s (pk, val) VALUES (0, [2, 3, 4])");
+
+        var sai = (StorageAttachedIndex) Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable()).getIndexManager().getIndexByName(indexName);
+        var indexes = sai.getIndexContext().getLiveMemtables().values();
+        assertEquals("Expect just one memtable index", 1, indexes.size());
+        var vectorIndex = (VectorMemtableIndex) indexes.iterator().next();
+        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.size());
+
+        // Flush to build the on disk graph (before the fix, flush failed due to a row having two vectors)
+        flush();
+
+        // Ensure that we only have one vector
+        assertEquals("The TTL'd row is overwritten and removed during flush.", 1, sai.getIndexContext().getCellCount());
     }
 }


### PR DESCRIPTION
- Add failing test
- SAI Update: ignore TTL when getting old row's vector value

The test fails on flush with the below error:

```
java.lang.IllegalArgumentException: value already present: 0

	at com.google.common.collect.HashBiMap.put(HashBiMap.java:279)
	at com.google.common.collect.HashBiMap.put(HashBiMap.java:260)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorPostingsWriter.buildOrdinalMap(V2VectorPostingsWriter.java:195)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorPostingsWriter.remapPostings(V2VectorPostingsWriter.java:209)
	at org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.flush(CassandraOnHeapGraph.java:392)
	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.writeData(VectorMemtableIndex.java:407)
	at org.apache.cassandra.index.sai.disk.v1.MemtableIndexWriter.flushVectorIndex(MemtableIndexWriter.java:212)
	at org.apache.cassandra.index.sai.disk.v1.MemtableIndexWriter.complete(MemtableIndexWriter.java:124)
	at org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter.complete(StorageAttachedIndexWriter.java:214)
	at org.apache.cassandra.io.sstable.format.SSTableWriter.lambda$prepareToCommit$1(SSTableWriter.java:344)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:407)
	at org.apache.cassandra.io.sstable.format.SSTableWriter.prepareToCommit(SSTableWriter.java:344)
	at org.apache.cassandra.db.compaction.unified.ShardedMultiWriter.prepareToCommit(ShardedMultiWriter.java:257)
	at org.apache.cassandra.db.ColumnFamilyStore$Flush.flushMemtable(ColumnFamilyStore.java:1406)
	at org.apache.cassandra.db.ColumnFamilyStore$Flush.run(ColumnFamilyStore.java:1315)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

By passing 0 in as the `nowInSecs` parameter, we get old values even if they are TTL'd. Note that we only hit this code path if the current memtable has the oldRow and the newRow.