### PR TITLE
Only map rows to ordinals once for hybrid vector queries

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -39,6 +39,7 @@ import io.github.jbellis.jvector.util.SparseBits;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.IntArrayList;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.PartitionPosition;
@@ -233,26 +234,29 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             Tracing.logAndTrace(logger, "Search range covers {} rows in index of {} nodes; estimate for LIMIT {} is {}",
                                 nRows, graph.size(), rerankK, initialCostEstimate);
             // if the range spans a small number of rows, then generate scores from the sstable rows instead of searching the index
+            int startSegmentRowId = metadata.toSegmentRowId(minSSTableRowId);
+            int endSegmentRowId = metadata.toSegmentRowId(maxSSTableRowId);
             if (initialCostEstimate.shouldUseBruteForce())
             {
-                var segmentRowIds = new IntArrayList(nRows, 0);
-                for (long i = minSSTableRowId; i <= maxSSTableRowId; i++)
-                    segmentRowIds.add(metadata.toSegmentRowId(i));
+                var maxSize = endSegmentRowId - startSegmentRowId + 1;
+                var segmentToOrdinalMap = new Int2IntHashMap(maxSize, 0.65f, -1);
+                try (var ordinalsView = graph.getOrdinalsView())
+                {
+                    ordinalsView.forEachOrdinalInRange(startSegmentRowId, endSegmentRowId, segmentToOrdinalMap::put);
+                }
 
                 // When we have a threshold, we only need to filter the results, not order them, because it means we're
                 // evaluating a boolean predicate in the SAI pipeline that wants to collate by PK
                 if (threshold > 0)
-                    return filterByBruteForce(queryVector, segmentRowIds, threshold);
+                    return filterByBruteForce(queryVector, segmentToOrdinalMap, threshold);
                 else
-                    return orderByBruteForce(queryVector, segmentRowIds, limit, rerankK);
+                    return orderByBruteForce(queryVector, segmentToOrdinalMap, limit, rerankK);
             }
 
             // create a bitset of ordinals corresponding to the rows in the given key range
             final Bits bits;
             try (var ordinalsView = graph.getOrdinalsView())
             {
-                int startSegmentRowId = metadata.toSegmentRowId(minSSTableRowId);
-                int endSegmentRowId = metadata.toSegmentRowId(maxSSTableRowId);
                 bits = ordinalsView.buildOrdinalBits(startSegmentRowId, endSegmentRowId, this::bitSetForSearch);
             }
             // the set of ordinals may be empty if no rows in the range had a vector associated with them
@@ -275,13 +279,13 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         }
     }
 
-    private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, IntArrayList segmentRowIds, int limit, int rerankK) throws IOException
+    private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, Int2IntHashMap segmentToOrdinalMap, int limit, int rerankK) throws IOException
     {
         // If we use compressed vectors, we still have to order rerankK results using full resolution similarity
         // scores, so only use the compressed vectors when there are enough vectors to make it worthwhile.
-        if (graph.getCompressedVectors() != null && segmentRowIds.size() - rerankK > Plan.memoryToDiskFactor() * segmentRowIds.size())
-            return orderByBruteForce(graph.getCompressedVectors(), queryVector, segmentRowIds, limit, rerankK);
-        return orderByBruteForce(queryVector, segmentRowIds);
+        if (graph.getCompressedVectors() != null && segmentToOrdinalMap.size() - rerankK > Plan.memoryToDiskFactor() * segmentToOrdinalMap.size())
+            return orderByBruteForce(graph.getCompressedVectors(), queryVector, segmentToOrdinalMap, limit, rerankK);
+        return orderByBruteForce(queryVector, segmentToOrdinalMap);
     }
 
     /**
@@ -291,27 +295,18 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
      */
     private CloseableIterator<RowIdWithScore> orderByBruteForce(CompressedVectors cv,
                                                                 VectorFloat<?> queryVector,
-                                                                IntArrayList segmentRowIds,
+                                                                Int2IntHashMap segmentToOrdinalMap,
                                                                 int limit,
                                                                 int rerankK) throws IOException
     {
-        var approximateScores = new ArrayList<BruteForceRowIdIterator.RowWithApproximateScore>(segmentRowIds.size());
+        var approximateScores = new ArrayList<BruteForceRowIdIterator.RowWithApproximateScore>(segmentToOrdinalMap.size());
         var similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
         var scoreFunction = cv.precomputedScoreFunctionFor(queryVector, similarityFunction);
 
-        try (var ordinalsView = graph.getOrdinalsView())
-        {
-            for (int i = 0; i < segmentRowIds.size(); i++)
-            {
-                int segmentRowId = segmentRowIds.getInt(i);
-                int ordinal = ordinalsView.getOrdinalForRowId(segmentRowId);
-                if (ordinal < 0)
-                    continue;
-
-                var score = scoreFunction.similarityTo(ordinal);
-                approximateScores.add(new BruteForceRowIdIterator.RowWithApproximateScore(segmentRowId, ordinal, score));
-            }
-        }
+        segmentToOrdinalMap.forEach((segmentRowId, ordinal) -> {
+            var score = scoreFunction.similarityTo(ordinal);
+            approximateScores.add(new BruteForceRowIdIterator.RowWithApproximateScore(segmentRowId, ordinal, score));
+        });
         // Leverage PQ's O(N) heapify time complexity
         var approximateScoresQueue = new PriorityQueue<>(approximateScores);
         var reranker = new JVectorLuceneOnDiskGraph.CloseableReranker(similarityFunction, queryVector, graph.getVectorSupplier());
@@ -323,10 +318,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
      * vectors, read all vectors and put them into a priority queue to rank them lazily. It is assumed that the whole
      * PQ will often not be needed.
      */
-    private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, IntArrayList segmentRowIds) throws IOException
+    private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, Int2IntHashMap segmentToOrdinalMap) throws IOException
     {
-        var scoredRowIds = new ArrayList<RowIdWithScore>(segmentRowIds.size());
-        addScoredRowIdsToCollector(queryVector, segmentRowIds, 0, scoredRowIds);
+        var scoredRowIds = new ArrayList<RowIdWithScore>(segmentToOrdinalMap.size());
+        addScoredRowIdsToCollector(queryVector, segmentToOrdinalMap, 0, scoredRowIds);
         return new PriorityQueueIterator<>(new PriorityQueue<>(scoredRowIds));
     }
 
@@ -336,35 +331,28 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
      * NOTE: because the threshold is not used for ordering, the result is returned in PK order, not score order.
      */
     private CloseableIterator<RowIdWithScore> filterByBruteForce(VectorFloat<?> queryVector,
-                                                                 IntArrayList segmentRowIds,
+                                                                 Int2IntHashMap segmentToOrdinalMap,
                                                                  float threshold) throws IOException
     {
-        var results = new ArrayList<RowIdWithScore>(segmentRowIds.size());
-        addScoredRowIdsToCollector(queryVector, segmentRowIds, threshold, results);
+        var results = new ArrayList<RowIdWithScore>(segmentToOrdinalMap.size());
+        addScoredRowIdsToCollector(queryVector, segmentToOrdinalMap, threshold, results);
         return CloseableIterator.wrap(results.iterator());
     }
 
     private void addScoredRowIdsToCollector(VectorFloat<?> queryVector,
-                                            IntArrayList segmentRowIds,
+                                            Int2IntHashMap segmentToOrdinalMap,
                                             float threshold,
                                             Collection<RowIdWithScore> collector) throws IOException
     {
         var similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
-        try (var ordinalsView = graph.getOrdinalsView();
-             var vectorsView = graph.getVectorSupplier())
+        try (var vectorsView = graph.getVectorSupplier())
         {
             var esf = vectorsView.getScoreFunction(queryVector, similarityFunction);
-            for (int i = 0; i < segmentRowIds.size(); i++)
-            {
-                int segmentRowId = segmentRowIds.getInt(i);
-                int ordinal = ordinalsView.getOrdinalForRowId(segmentRowId);
-                if (ordinal < 0)
-                    continue;
-
+            segmentToOrdinalMap.forEach((segmentRowId, ordinal) -> {
                 var score = esf.similarityTo(ordinal);
                 if (score >= threshold)
                     collector.add(new RowIdWithScore(segmentRowId, score));
-            }
+            });
         }
     }
 
@@ -475,11 +463,9 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
             return CloseableIterator.emptyIterator();
 
         int rerankK = indexContext.getIndexWriterConfig().getSourceModel().rerankKFor(limit, graph.getCompression());
-        // Convert PKs to segment row ids and then to ordinals, skipping any that don't exist in this segment
-        var bitsAndRows = flatmapPrimaryKeysToBitsAndRows(keys);
-        var bits = bitsAndRows.left;
-        var rowIds = bitsAndRows.right;
-        var numRows = rowIds.size();
+        // Convert PKs to segment row ids and map to ordinals, skipping any that don't exist in this segment
+        var segmentToOrdinalMap = flatmapPrimaryKeysToBitsAndRows(keys);
+        var numRows = segmentToOrdinalMap.size();
         final CostEstimate cost = estimateCost(rerankK, numRows);
         Tracing.logAndTrace(logger, "{} relevant rows out of {} in range in index of {} nodes; estimate for LIMIT {} is {}",
                             numRows, keys.size(), graph.size(), limit, cost);
@@ -490,21 +476,28 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
         {
             // brute force using the in-memory compressed vectors to cut down the number of results returned
             var queryVector = vts.createFloatVector(orderer.vector);
-            return toMetaSortedIterator(this.orderByBruteForce(queryVector, rowIds, limit, rerankK), context);
+            return toMetaSortedIterator(this.orderByBruteForce(queryVector, segmentToOrdinalMap, limit, rerankK), context);
         }
+        // Create bits from the mapping
+        var bits = bitSetForSearch();
+        segmentToOrdinalMap.values().forEach(bits::set);
         // else ask the index to perform a search limited to the bits we created
         var queryVector = vts.createFloatVector(orderer.vector);
         var results = graph.search(queryVector, limit, rerankK, 0, bits, context, cost::updateStatistics);
         return toMetaSortedIterator(results, context);
     }
 
-    private Pair<SparseBits, IntArrayList> flatmapPrimaryKeysToBitsAndRows(List<PrimaryKey> keysInRange) throws IOException
+
+    /**
+     * Build a mapping of segment row id to ordinal for the given primary keys, skipping any that don't exist in this
+     * segment.
+     * @param keysInRange the primary keys to map
+     * @return a mapping of segment row id to ordinal
+     * @throws IOException
+     */
+    private Int2IntHashMap flatmapPrimaryKeysToBitsAndRows(List<PrimaryKey> keysInRange) throws IOException
     {
-        // if we are brute forcing the similarity search, we want to build a list of segment row ids,
-        // but if not, we want to build a bitset of ordinals corresponding to the rows.
-        // We won't know which path to take until we have an accurate key count.
-        var bits = bitSetForSearch();
-        IntArrayList rowIds = new IntArrayList();
+        var segmentToOrdinalMap = new Int2IntHashMap(keysInRange.size(), 0.65f, -1);
         try (var primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
              var ordinalsView = graph.getOrdinalsView())
         {
@@ -588,13 +581,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                 int segmentRowId = metadata.toSegmentRowId(sstableRowId);
                 int ordinal = ordinalsView.getOrdinalForRowId(segmentRowId);
                 if (ordinal >= 0)
-                {
-                    rowIds.add(segmentRowId);
-                    bits.set(ordinal);
-                }
+                    segmentToOrdinalMap.put(segmentRowId, ordinal);
             }
         }
-        return Pair.create(bits, rowIds);
+        return segmentToOrdinalMap;
     }
 
     public static double logBase2(double number) {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OrdinalsView.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OrdinalsView.java
@@ -21,8 +21,6 @@ package org.apache.cassandra.index.sai.disk.vector;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import io.github.jbellis.jvector.util.Bits;
 import io.github.jbellis.jvector.util.SparseBits;
 
@@ -40,7 +38,6 @@ public interface OrdinalsView extends AutoCloseable
      * iterates over all ordinals in the view.  order of iteration is undefined. Only calls consumer for valid mappings
      * from row id to ordinal.
      */
-    @VisibleForTesting
     void forEachOrdinalInRange(int startRowId, int endRowId, OrdinalConsumer consumer) throws IOException;
 
     default Bits buildOrdinalBits(int startRowId, int endRowId, Supplier<SparseBits> bitsSupplier) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OrdinalsView.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OrdinalsView.java
@@ -30,14 +30,15 @@ public interface OrdinalsView extends AutoCloseable
 {
     interface OrdinalConsumer
     {
-        void accept(long rowId, int ordinal) throws IOException;
+        void accept(int rowId, int ordinal) throws IOException;
     }
 
     /** return the vector ordinal associated with the given row, or -1 if no vectors are associated with it */
     int getOrdinalForRowId(int rowId) throws IOException;
 
     /**
-     * iterates over all ordinals in the view.  order of iteration is undefined.
+     * iterates over all ordinals in the view.  order of iteration is undefined. Only calls consumer for valid mappings
+     * from row id to ordinal.
      */
     @VisibleForTesting
     void forEachOrdinalInRange(int startRowId, int endRowId, OrdinalConsumer consumer) throws IOException;

--- a/src/java/org/apache/cassandra/index/sai/utils/IntIntPairArray.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IntIntPairArray.java
@@ -52,7 +52,7 @@ public class IntIntPairArray
     public void add(int x, int y)
     {
         if (size == capacity)
-            throw new IllegalStateException("Array is full");
+            throw new IndexOutOfBoundsException(size);
         array[size * 2] = x;
         array[size * 2 + 1] = y;
         size++;

--- a/src/java/org/apache/cassandra/index/sai/utils/IntIntPairArray.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IntIntPairArray.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.function.IntConsumer;
+
+import org.agrona.collections.IntIntConsumer;
+
+/**
+ * A simple array of int pairs that avoids boxing. Implemented as an alternative to the
+ * {@link org.agrona.collections.Int2IntHashMap} for uses that do not require lookups.
+ */
+public class IntIntPairArray
+{
+    private final int capacity;
+    private int size;
+    private final int[] array;
+
+    /**
+     * Create a new IntIntPairArray with the given capacity.
+     * @param capacity
+     */
+    public IntIntPairArray(int capacity)
+    {
+        assert capacity < Integer.MAX_VALUE / 2 : "capacity is too large " + capacity;
+        this.capacity = capacity;
+        this.size = 0;
+        this.array = new int[capacity * 2];
+    }
+
+    /**
+     * Add a pair to the array.
+     * @param x the first value
+     * @param y the second value
+     */
+    public void add(int x, int y)
+    {
+        if (size == capacity)
+            throw new IllegalStateException("Array is full");
+        array[size * 2] = x;
+        array[size * 2 + 1] = y;
+        size++;
+    }
+
+    /**
+     * The number of pairs in the array.
+     * @return the number of pairs in the array
+     */
+    public int size()
+    {
+        return size;
+    }
+
+    /**
+     * Iterate over the pairs in the array, calling the consumer for each pair.
+     * @param consumer the consumer to call for each pair
+     */
+    public void forEachIntPair(IntIntConsumer consumer)
+    {
+        for (int i = 0; i < size; i++)
+            consumer.accept(array[i * 2], array[i * 2 + 1]);
+    }
+
+    /**
+     * Calls the consumer for each right value in each pair of the array.
+     * @param consumer the consumer to call for each right value
+     */
+    public void forEachRightInt(IntConsumer consumer)
+    {
+        for (int i = 0; i < size; i++)
+            consumer.accept(array[i * 2 + 1]);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/utils/IntIntPairArrayTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/IntIntPairArrayTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntIntPairArrayTest
+{
+    @Test
+    public void testOperationsOnIntIntPairArray()
+    {
+        IntIntPairArray array = new IntIntPairArray(2);
+        assertEquals(0, array.size());
+        array.add(1, 2);
+        array.add(3, 4);
+        assertEquals(2, array.size());
+
+        // Validate the iteration
+        var accumulator = new AtomicInteger();
+        array.forEachRightInt(accumulator::addAndGet);
+        assertEquals(6, accumulator.get());
+
+        accumulator.set(0);
+        array.forEachIntPair((x,y) -> {
+            accumulator.addAndGet(x);
+            accumulator.addAndGet(y);
+        });
+        assertEquals(10, accumulator.get());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddToFullArray()
+    {
+        IntIntPairArray array = new IntIntPairArray(1);
+        array.add(1, 2);
+        array.add(3, 4);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testCapacityTooLarge()
+    {
+        new IntIntPairArray(Integer.MAX_VALUE / 2 + 1);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/utils/IntIntPairArrayTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/IntIntPairArrayTest.java
@@ -48,7 +48,7 @@ public class IntIntPairArrayTest
         assertEquals(10, accumulator.get());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testAddToFullArray()
     {
         IntIntPairArray array = new IntIntPairArray(1);


### PR DESCRIPTION
In the brute force code path, we currently map row ids to ordinals twice. This is expensive and can easily be reduced to once, as shown in this PR. We can also defer building the `bits` object until we know we need it.