### PR TITLE
CNDB-10536 main: Fix race between vector deletion and filter-then-sort queries

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -169,9 +169,13 @@ public class CassandraOnHeapGraph<T> implements Accountable
         return postingsMap.values().stream().allMatch(VectorPostings::isEmpty);
     }
 
+    /**
+     * @return the ordinal of the vector in the graph, or -1 if the vector is not in the graph
+     */
     public int getOrdinal(VectorFloat<?> vector)
     {
-        return postingsMap.get(vector).getOrdinal();
+        VectorPostings<T> postings = postingsMap.get(vector);
+        return postings == null ? -1 : postings.getOrdinal();
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -283,6 +283,10 @@ public class VectorMemtableIndex implements MemtableIndex
             if (v == null)
                 return;
             var i = graph.getOrdinal(v);
+            if (i < 0)
+                // might happen if the vector and/or its postings have been removed in the meantime between getting the
+                // vector and getting the ordinal (graph#vectorForKey and graph#getOrdinal are not synchronized)
+                return;
             keysInGraph.add(k);
             relevantOrdinals.add(i);
         });

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -23,9 +23,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -46,6 +50,8 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.tracing.TracingTestImpl;
@@ -1214,5 +1220,44 @@ public class VectorTypeTest extends VectorTester
 
         // Confirm we can query the data
         assertRowCount(execute("SELECT * FROM %s ORDER BY vec ANN OF [1,2] LIMIT 1"), 1);
+    }
+
+    /**
+     * Tests a filter-then-sort query with a concurrent vector deletion. See CNDB-10536 for details.
+     */
+    @Test
+    public void testFilterThenSortQueryWithConcurrentVectorDeletion() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>, c int)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        waitForIndexQueryable();
+
+        // write into memtable
+        execute("INSERT INTO %s (k, v, c) VALUES (1, [1, 1], 1)");
+        execute("INSERT INTO %s (k, v, c) VALUES (2, [2, 2], 1)");
+
+        // prepare an injected barrier to block CassandraOnHeapGraph#getOrdinal
+        Injections.Barrier barrier = Injections.newBarrier("block_get_ordinal", 2, false)
+                                               .add(InvokePointBuilder.newInvokePoint()
+                                                                      .onClass(CassandraOnHeapGraph.class)
+                                                                      .onMethod("getOrdinal")
+                                                                      .atEntry())
+                                               .build();
+        Injections.inject(barrier);
+
+        // start a filter-then-sort query asynchronously that will get blocked in the injected barrier
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        String select = "SELECT k FROM %s WHERE c=1 ORDER BY v ANN OF [1, 1] LIMIT 100";
+        Future<UntypedResultSet> future = executor.submit(() -> execute(select));
+
+        // once the query is blocked, delete one of the vectors and flush, so the postings for the vector are removed
+        waitForAssert(() -> Assert.assertEquals(1, barrier.getCount()));
+        execute("DELETE v FROM %s WHERE k = 1");
+        flush();
+
+        // release the barrier to resume the query, which should succeed
+        barrier.countDown();
+        assertRows(future.get(), row(2));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -1237,7 +1237,7 @@ public class VectorTypeTest extends VectorTester
         execute("INSERT INTO %s (k, v, c) VALUES (1, [1, 1], 1)");
         execute("INSERT INTO %s (k, v, c) VALUES (2, [2, 2], 1)");
 
-        // prepare an injected barrier to block CassandraOnHeapGraph#getOrdinal
+        // inject a barrier to block CassandraOnHeapGraph#getOrdinal
         Injections.Barrier barrier = Injections.newBarrier("block_get_ordinal", 2, false)
                                                .add(InvokePointBuilder.newInvokePoint()
                                                                       .onClass(CassandraOnHeapGraph.class)
@@ -1259,5 +1259,7 @@ public class VectorTypeTest extends VectorTester
         // release the barrier to resume the query, which should succeed
         barrier.countDown();
         assertRows(future.get(), row(2));
+
+        assertEquals(0, executor.shutdownNow().size());
     }
 }


### PR DESCRIPTION
Fixes a race condition when a filter-then-sort query gets intertwined with a deletion (or upsert) and a flush, only with `DC`/v5 format:
* The relevant part of the query: https://github.com/datastax/cassandra/tree/9fe9211f1213d9b342ea1f81d1c7740abb9db11d/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java#L282-L285
* The deletion of postings on flush: https://github.com/datastax/cassandra/tree/9fe9211f1213d9b342ea1f81d1c7740abb9db11d/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java#L374

If the deletion of postings happens between getting the vector and getting the postings, [`CassandraOnHeapGraph#getOrdinal`](https://github.com/datastax/cassandra/blob/9fe9211f1213d9b342ea1f81d1c7740abb9db11d/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java#L172-L175) can hit a NPE:
```
java.util.concurrent.ExecutionException: java.lang.NullPointerException

	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.apache.cassandra.index.sai.cql.VectorTypeTest.testFilterThenSortQueryWithConcurrentVectorDeletion(VectorTypeTest.java:1261)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.NullPointerException
	at org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.getOrdinal(Unknown Source)
	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.lambda$orderResultsBy$2(VectorMemtableIndex.java:280)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.WhileOps$1$1.accept(WhileOps.java:99)
	at java.base/java.util.stream.WhileOps$1Op$1OpSink.accept(WhileOps.java:386)
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1632)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.orderResultsBy(VectorMemtableIndex.java:275)
	at org.apache.cassandra.index.sai.plan.QueryController.lambda$getTopKRows$8(QueryController.java:587)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1603)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:588)
	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:570)
	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:103)
	at org.apache.cassandra.index.sai.plan.Plan$KeysSort.execute(Plan.java:1221)
	at org.apache.cassandra.index.sai.plan.QueryController.buildIterator(QueryController.java:425)
	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:134)
	at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:512)
	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:410)
	at org.apache.cassandra.db.ReadCommand.executeInternal(ReadCommand.java:537)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeInternal(SelectStatement.java:615)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:598)
	at org.apache.cassandra.cql3.statements.SelectStatement.executeLocally(SelectStatement.java:105)
	at org.apache.cassandra.cql3.QueryProcessor.executeInternal(QueryProcessor.java:489)
	at org.apache.cassandra.cql3.CQLTester.executeFormattedQuery(CQLTester.java:1391)
	at org.apache.cassandra.cql3.CQLTester.execute(CQLTester.java:1379)
	at org.apache.cassandra.index.sai.cql.VectorTypeTest.lambda$testFilterThenSortQueryWithConcurrentVectorDeletion$17(VectorTypeTest.java:1252)
```
This has been seen also in pre-v5 versions, but most probably with a similar cause:
```
Uncaught exception on thread Thread[#5257,ReadStage-92,5,main]
     java.lang.NullPointerException: Cannot invoke "org.apache.cassandra.index.sai.disk.vector.VectorPostings.getOrdinal()" because the return value of "java.util.concurrent.ConcurrentMap.get(Object)" is null
     	at org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.getOrdinal(CassandraOnHeapGraph.java:172)
     	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.lambda$orderResultsBy$2(VectorMemtableIndex.java:269)
     	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
     	at java.base/java.util.stream.WhileOps$1$1.accept(WhileOps.java:98)
     	at java.base/java.util.stream.WhileOps$1Op$1OpSink.accept(WhileOps.java:382)
     	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1686)
     	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:144)
     	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:574)
     	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:560)
     	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
     	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
     	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
     	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
     	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:611)
     	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.orderResultsBy(VectorMemtableIndex.java:264)
     	at org.apache.cassandra.index.sai.IndexContext.orderResultsBy(IndexContext.java:478)
     	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:566)
     	at org.apache.cassandra.index.sai.plan.QueryController.lambda$getTopKRows$8(QueryController.java:538)
     	at org.apache.cassandra.index.sai.utils.OrderingFilterRangeIterator.next(OrderingFilterRangeIterator.java:74)
     	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:541)
     	at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:98)
     	at org.apache.cassandra.index.sai.plan.Plan$AnnSort.execute(Plan.java:1144)
     	at org.apache.cassandra.index.sai.plan.QueryController.buildIterator(QueryController.java:388)
     	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:124)
     	at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:512)
     	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:410)
     	at org.apache.cassandra.db.ReadCommandVerbHandler.doVerb(ReadCommandVerbHandler.java:58)
     	at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:79)
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:98)
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)
     	at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)
     	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
     	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
     	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
     	at java.base/java.lang.Thread.run(Thread.java:1570)
```
The fix is simply considering that the postings might be empty. Trying to synchronize `vectorsByKey` and `postingsMap` for this seems overkill. 

A repro test is included.