### PR TITLE
Limit the number of intersection loops by the number of keys available

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1071,9 +1071,12 @@ abstract public class Plan
         private ArrayList<KeysIteration> propagateAccess(List<KeysIteration> subplans)
         {
             double loops = isEffectivelyZero(selectivity()) ? 1.0 : subplans.get(0).selectivity() / selectivity();
-
             ArrayList<KeysIteration> newSubplans = new ArrayList<>(subplans.size());
-            newSubplans.add(subplans.get(0).withAccess(access.scaleDistance(loops).convolute(loops, 1.0)));
+            KeysIteration s0 = subplans.get(0).withAccess(access.scaleDistance(loops).convolute(loops, 1.0));
+            newSubplans.add(s0);
+
+            // We may run out of keys while iterating the first iterator, and then we just break the loop early
+            loops = Math.min(s0.expectedKeys(), loops);
 
             double matchProbability = 1.0;
             for (int i = 1; i < subplans.size(); i++)

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -148,11 +148,14 @@ public class PlanTest
     public void intersectionWithEmpty()
     {
         Plan.KeysIteration a1 = factory.indexScan(saiPred1, 0);
-        Plan.KeysIteration a2 = factory.indexScan(saiPred2, (long)(0.01 * factory.tableMetrics.rows));
+        Plan.KeysIteration a2 = factory.indexScan(saiPred2, (long)(0.5 * factory.tableMetrics.rows));
         Plan.KeysIteration plan = factory.intersection(Lists.newArrayList(a1, a2));
         assertEquals(0.0, plan.selectivity(), 0.0001);
         assertEquals(0.0, plan.expectedKeys(), 0.0001);
-        assertTrue(plan.fullCost() <= 2 * factory.tableMetrics.sstables * SAI_OPEN_COST + SAI_KEY_COST * 2);
+
+        // There should be no cost of iterating the iterator a2,
+        // because there are no keyst to match on the left side (a1) and the intersection loop would exit early
+        assertEquals(plan.fullCost(), 2 * factory.tableMetrics.sstables * SAI_OPEN_COST, 0.0001);
     }
 
     @Test


### PR DESCRIPTION
This commit fixes a minor bug in SAI cost estimation code that caused the cost of intersections to be sometimes overestimated. The estimation code didn't account for the fact that we may reach the end of the iterator before finding a matching key.