### PR TITLE
CNDB-10625: Set reduce_topk_across_sstables and enable_jvector_deletes to false by default

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -41,10 +41,10 @@ import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
  */
 public class V3OnDiskFormat extends V2OnDiskFormat
 {
-    public static final boolean REDUCE_TOPK_ACROSS_SSTABLES = Boolean.parseBoolean(System.getProperty("cassandra.sai.reduce_topk_across_sstables", "true"));
+    public static final boolean REDUCE_TOPK_ACROSS_SSTABLES = Boolean.parseBoolean(System.getProperty("cassandra.sai.reduce_topk_across_sstables", "false"));
     public static final boolean ENABLE_RERANK_FLOOR = Boolean.parseBoolean(System.getProperty("cassandra.sai.rerank_floor", "true"));
     public static final boolean ENABLE_EDGES_CACHE = Boolean.parseBoolean(System.getProperty("cassandra.sai.enable_edges_cache", "false"));
-    public static final boolean ENABLE_JVECTOR_DELETES = Boolean.parseBoolean(System.getProperty("cassandra.sai.enable_jvector_deletes", "true"));
+    public static final boolean ENABLE_JVECTOR_DELETES = Boolean.parseBoolean(System.getProperty("cassandra.sai.enable_jvector_deletes", "false"));
 
     public static volatile boolean WRITE_JVECTOR3_FORMAT = Boolean.parseBoolean(System.getProperty("cassandra.sai.write_jv3_format", "false"));
     public static final boolean ENABLE_LTM_CONSTRUCTION = Boolean.parseBoolean(System.getProperty("cassandra.sai.ltm_construction", "true"));


### PR DESCRIPTION

This is only for the following hotfix:
https://github.com/riptano/cndb/issues/10596.
They should be turned back on when we fix the issues.