### PR TITLE
CNDB-10647: Fix EQ queries on analyzed columns

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -42,7 +42,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
     /**
      * The composite type.
      */
-    protected final ClusteringComparator comparator;
+    private final ClusteringComparator comparator;
 
     private ClusteringColumnRestrictions(ClusteringComparator comparator,
                                          RestrictionSet restrictionSet)
@@ -189,7 +189,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
                 SingleRestriction lastRestriction = restrictions.lastRestriction();
                 ColumnMetadata lastRestrictionStart = lastRestriction.getFirstColumn();
                 ColumnMetadata newRestrictionStart = newRestriction.getFirstColumn();
-                restrictions.addRestriction(newRestriction, isDisjunction);
+                restrictions.addRestriction(newRestriction, isDisjunction, indexRegistry);
 
                 checkFalse(lastRestriction.isSlice() && newRestrictionStart.position() > lastRestrictionStart.position(),
                            "Clustering column \"%s\" cannot be restricted (preceding column \"%s\" is restricted by a non-EQ relation)",
@@ -203,7 +203,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             }
             else
             {
-                restrictions.addRestriction(newRestriction, isDisjunction);
+                restrictions.addRestriction(newRestriction, isDisjunction, indexRegistry);
             }
 
             return this;

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeyRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeyRestrictions.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.restrictions;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.Bound;
@@ -31,7 +32,7 @@ import org.apache.cassandra.service.QueryState;
  */
 interface PartitionKeyRestrictions extends Restrictions
 {
-    public PartitionKeyRestrictions mergeWith(Restriction restriction);
+    public PartitionKeyRestrictions mergeWith(Restriction restriction, IndexRegistry indexRegistry);
 
     public List<ByteBuffer> values(QueryOptions options, QueryState queryState);
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
@@ -29,11 +29,10 @@ import org.apache.cassandra.db.MultiClusteringBuilder;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.index.IndexRegistry;
-import org.apache.cassandra.service.QueryState;
 
 /**
  * A set of single restrictions on the partition key.
- * <p>This class can only contains <code>SingleRestriction</code> instances. Token restrictions will be handled by
+ * <p>This class can only contain <code>SingleRestriction</code> instances. Token restrictions will be handled by
  * <code>TokenRestriction</code> class or by the <code>TokenFilter</code> class if the query contains a mix of token
  * restrictions and single column restrictions on the partition key.
  */
@@ -42,7 +41,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     /**
      * The composite type.
      */
-    protected final ClusteringComparator comparator;
+    private final ClusteringComparator comparator;
 
     private PartitionKeySingleRestrictionSet(RestrictionSet restrictionSet, ClusteringComparator comparator)
     {
@@ -51,7 +50,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     }
 
     @Override
-    public PartitionKeyRestrictions mergeWith(Restriction restriction)
+    public PartitionKeyRestrictions mergeWith(Restriction restriction, IndexRegistry indexRegistry)
     {
         if (restriction.isOnToken())
         {
@@ -69,7 +68,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             builder.addRestriction(r);
         }
         return builder.addRestriction(restriction)
-                      .build();
+                      .build(indexRegistry);
     }
 
     @Override
@@ -162,7 +161,8 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
 
         private final List<Restriction> restrictions = new ArrayList<>();
 
-        private Builder(ClusteringComparator clusteringComparator) {
+        private Builder(ClusteringComparator clusteringComparator)
+        {
             this.clusteringComparator = clusteringComparator;
         }
 
@@ -172,36 +172,38 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             return this;
         }
 
-        public PartitionKeyRestrictions build()
+        public PartitionKeyRestrictions build(IndexRegistry indexRegistry)
         {
-            return build(false);
+            return build(indexRegistry, false);
         }
 
-        public PartitionKeyRestrictions build(boolean isDisjunction)
+        public PartitionKeyRestrictions build(IndexRegistry indexRegistry, boolean isDisjunction)
         {
             RestrictionSet.Builder restrictionSet = RestrictionSet.builder();
 
-            for (int i = 0; i < restrictions.size(); i++) {
+            for (int i = 0; i < restrictions.size(); i++)
+            {
                 Restriction restriction = restrictions.get(i);
 
                 // restrictions on tokens are handled in a special way
                 if (restriction.isOnToken())
-                    return buildWithTokens(restrictionSet, i);
+                    return buildWithTokens(restrictionSet, i, indexRegistry);
 
-                restrictionSet.addRestriction((SingleRestriction) restriction, isDisjunction);
+                restrictionSet.addRestriction((SingleRestriction) restriction, isDisjunction, indexRegistry);
             }
 
             return buildPartitionKeyRestrictions(restrictionSet);
         }
 
-        private PartitionKeyRestrictions buildWithTokens(RestrictionSet.Builder restrictionSet, int i)
+        private PartitionKeyRestrictions buildWithTokens(RestrictionSet.Builder restrictionSet, int i, IndexRegistry indexRegistry)
         {
             PartitionKeyRestrictions merged = buildPartitionKeyRestrictions(restrictionSet);
 
-            for (; i < restrictions.size(); i++) {
+            for (; i < restrictions.size(); i++)
+            {
                 Restriction restriction = restrictions.get(i);
 
-                merged = merged.mergeWith(restriction);
+                merged = merged.mergeWith(restriction, indexRegistry);
             }
 
             return merged;

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.cql3.restrictions;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
@@ -411,7 +413,7 @@ public abstract class RestrictionSet implements Restrictions
         {
         }
 
-        public void addRestriction(SingleRestriction restriction, boolean isDisjunction)
+        public void addRestriction(SingleRestriction restriction, boolean isDisjunction, IndexRegistry indexRegistry)
         {
             List<ColumnMetadata> columnDefs = restriction.getColumnDefs();
 
@@ -420,24 +422,42 @@ public abstract class RestrictionSet implements Restrictions
                 // If this restriction is part of a disjunction query then we don't want
                 // to merge the restrictions (if that is possible), we just add the
                 // restriction to the set of restrictions for the column.
-                addRestrictionForColumns(columnDefs, restriction, false);
+                addRestrictionForColumns(columnDefs, restriction, null);
             }
             else
             {
+                // In some special cases such as EQ in analyzed index we need to skip merging the restriction,
+                // so we can send multiple EQ restrictions to the index.
+                if (restriction.skipMerge(indexRegistry))
+                {
+                    addRestrictionForColumns(columnDefs, restriction, null);
+                    return;
+                }
+
                 // If this restriction isn't part of a disjunction then we need to get
                 // the set of existing restrictions for the column and merge them with the
                 // new restriction
                 Set<SingleRestriction> existingRestrictions = getRestrictions(newRestrictions, columnDefs);
 
                 SingleRestriction merged = restriction;
-                for (SingleRestriction existing : existingRestrictions)
-                    merged = existing.mergeWith(merged);
+                Set<SingleRestriction> replacedRestrictions = new HashSet<>();
 
-                addRestrictionForColumns(merged.getColumnDefs(), merged, true);
+                for (SingleRestriction existing : existingRestrictions)
+                {
+                    if (!existing.skipMerge(indexRegistry))
+                    {
+                        merged = existing.mergeWith(merged);
+                        replacedRestrictions.add(existing);
+                    }
+                }
+
+                addRestrictionForColumns(merged.getColumnDefs(), merged, replacedRestrictions);
             }
         }
 
-        private void addRestrictionForColumns(List<ColumnMetadata> columnDefs, SingleRestriction restriction, boolean replace)
+        private void addRestrictionForColumns(List<ColumnMetadata> columnDefs,
+                                              SingleRestriction restriction,
+                                              @Nullable Set<SingleRestriction> replacedRestrictions)
         {
             for (int i = 0; i < columnDefs.size(); i++)
             {
@@ -449,8 +469,12 @@ public abstract class RestrictionSet implements Restrictions
                 }
                 // If the restriction is a merger of new restriction and existing restrictions then
                 // we need to remove the existing restrictions for the column before adding it
-                if (replace)
-                    newRestrictions.removeAll(column);
+                if (replacedRestrictions != null)
+                {
+                    for (SingleRestriction r : replacedRestrictions)
+                        newRestrictions.remove(column, r);
+                }
+
                 newRestrictions.put(column, restriction);
             }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -146,6 +146,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
 
     public static final class EQRestriction extends SingleColumnRestriction
     {
+        public static final String CANNOT_BE_MERGED_ERROR = "%s cannot be restricted by more than one relation if it includes an Equal";
+
         private final Term term;
 
         public EQRestriction(ColumnMetadata columnDef, Term term)
@@ -197,9 +199,27 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
+        public boolean skipMerge(IndexRegistry indexRegistry)
+        {
+            // We should skip merging this EQ if there is an analyzed index for this column that supports EQ,
+            // so there can be multiple EQs for the same column.
+
+            if (indexRegistry == null)
+                return false;
+
+            for (Index index : indexRegistry.listIndexes())
+            {
+                if (index.supportsExpression(columnDef, Operator.ANALYZER_MATCHES) &&
+                    index.supportsExpression(columnDef, Operator.EQ))
+                    return true;
+            }
+            return false;
+        }
+
+        @Override
         public SingleRestriction doMergeWith(SingleRestriction otherRestriction)
         {
-            throw invalidRequest("%s cannot be restricted by more than one relation if it includes an Equal", columnDef.name);
+            throw invalidRequest(CANNOT_BE_MERGED_ERROR, columnDef.name);
         }
 
         @Override
@@ -880,12 +900,6 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public boolean isEQ()
-        {
-            return false;
-        }
-
-        @Override
         public boolean isLIKE()
         {
             return true;
@@ -1252,6 +1266,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
 
     public static final class AnalyzerMatchesRestriction extends SingleColumnRestriction
     {
+        public static final String CANNOT_BE_MERGED_ERROR = "%s cannot be restricted by other operators if it includes analyzer match (:)";
         private final List<Term> values;
 
         public AnalyzerMatchesRestriction(ColumnMetadata columnDef, Term value)
@@ -1264,6 +1279,12 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         {
             super(columnDef);
             this.values = values;
+        }
+
+        @Override
+        public boolean isAnalyzerMatches()
+        {
+            return true;
         }
 
         List<Term> getValues()
@@ -1315,15 +1336,15 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public SingleRestriction doMergeWith(SingleRestriction otherRestriction)
         {
-            if (!(otherRestriction instanceof AnalyzerMatchesRestriction))
-                throw new UnsupportedOperationException();
+            if (!(otherRestriction.isAnalyzerMatches()))
+                throw invalidRequest(CANNOT_BE_MERGED_ERROR, columnDef.name);
+
             List<Term> otherValues = ((AnalyzerMatchesRestriction) otherRestriction).getValues();
             List<Term> newValues = new ArrayList<>(values.size() + otherValues.size());
             newValues.addAll(values);
             newValues.addAll(otherValues);
             return new AnalyzerMatchesRestriction(columnDef, newValues);
         }
-
 
         @Override
         protected boolean isSupportedBy(Index index)

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleRestriction.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.restrictions;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.Bound;
 import org.apache.cassandra.db.MultiClusteringBuilder;
+import org.apache.cassandra.index.IndexRegistry;
 
 /**
  * A single restriction/clause on one or multiple column.
@@ -32,6 +33,11 @@ public interface SingleRestriction extends Restriction
     }
 
     public default boolean isEQ()
+    {
+        return false;
+    }
+
+    public default boolean isAnalyzerMatches()
     {
         return false;
     }
@@ -89,6 +95,17 @@ public interface SingleRestriction extends Restriction
     public default boolean isInclusive(Bound b)
     {
         return true;
+    }
+
+    /**
+     * Checks if this restriction shouldn't be merged with other restrictions.
+     *
+     * @param indexRegistry the index registry
+     * @return {@code true} if this shouldn't be merged with other restrictions
+     */
+    default boolean skipMerge(IndexRegistry indexRegistry)
+    {
+        return false;
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -35,7 +35,6 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.DecimalType;
 import org.apache.cassandra.db.marshal.IntegerType;
-import org.apache.cassandra.db.marshal.SimpleDateType;
 import org.apache.cassandra.dht.*;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
@@ -152,7 +151,8 @@ public class StatementRestrictions
     private StatementRestrictions(TableMetadata table, boolean allowFiltering)
     {
         this.table = table;
-        this.partitionKeyRestrictions = PartitionKeySingleRestrictionSet.builder(table.partitionKeyAsClusteringComparator()).build();
+        this.partitionKeyRestrictions = PartitionKeySingleRestrictionSet.builder(table.partitionKeyAsClusteringComparator())
+                                                                        .build(IndexRegistry.obtain(table));
         this.clusteringColumnsRestrictions = ClusteringColumnRestrictions.builder(table, allowFiltering).build();
         this.nonPrimaryKeyRestrictions = RestrictionSet.builder().build();
         this.notNullColumns = ImmutableSet.of();
@@ -440,12 +440,12 @@ public class StatementRestrictions
                     }
                     else
                     {
-                        nonPrimaryKeyRestrictionSet.addRestriction((SingleRestriction) restriction, element.isDisjunction());
+                        nonPrimaryKeyRestrictionSet.addRestriction((SingleRestriction) restriction, element.isDisjunction(), indexRegistry);
                     }
                 }
             }
 
-            PartitionKeyRestrictions partitionKeyRestrictions = partitionKeyRestrictionSet.build();
+            PartitionKeyRestrictions partitionKeyRestrictions = partitionKeyRestrictionSet.build(indexRegistry);
             ClusteringColumnRestrictions clusteringColumnsRestrictions = clusteringColumnsRestrictionSet.build();
             RestrictionSet nonPrimaryKeyRestrictions = nonPrimaryKeyRestrictionSet.build();
             ImmutableSet<ColumnMetadata> notNullColumns = notNullColumnsBuilder.build();
@@ -696,7 +696,7 @@ public class StatementRestrictions
                     throw new InvalidRequestException(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE,
                                                                     restriction.getFirstColumn()));
                 }
-                receiver.addRestriction(restriction, false);
+                receiver.addRestriction(restriction, false, indexRegistry);
             }
         }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -178,12 +178,12 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
-    public PartitionKeyRestrictions mergeWith(Restriction restriction) throws InvalidRequestException
+    public PartitionKeyRestrictions mergeWith(Restriction restriction, IndexRegistry indexRegistry) throws InvalidRequestException
     {
         if (restriction.isOnToken())
-            return TokenFilter.create(restrictions, (TokenRestriction) tokenRestriction.mergeWith(restriction));
+            return TokenFilter.create(restrictions, (TokenRestriction) tokenRestriction.mergeWith(restriction, indexRegistry));
 
-        return TokenFilter.create(restrictions.mergeWith(restriction), tokenRestriction);
+        return TokenFilter.create(restrictions.mergeWith(restriction, indexRegistry), tokenRestriction);
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -163,10 +163,10 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
-    public final PartitionKeyRestrictions mergeWith(Restriction otherRestriction) throws InvalidRequestException
+    public final PartitionKeyRestrictions mergeWith(Restriction otherRestriction, IndexRegistry indexRegistry) throws InvalidRequestException
     {
         if (!otherRestriction.isOnToken())
-            return TokenFilter.create(toPartitionKeyRestrictions(otherRestriction), this);
+            return TokenFilter.create(toPartitionKeyRestrictions(otherRestriction, indexRegistry), this);
 
         return doMergeWith((TokenRestriction) otherRestriction);
     }
@@ -184,14 +184,14 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
      * @return a <code>PartitionKeyRestrictions</code>
      * @throws InvalidRequestException if a problem occurs while converting the restriction
      */
-    private PartitionKeyRestrictions toPartitionKeyRestrictions(Restriction restriction) throws InvalidRequestException
+    private PartitionKeyRestrictions toPartitionKeyRestrictions(Restriction restriction, IndexRegistry indexRegistry) throws InvalidRequestException
     {
         if (restriction instanceof PartitionKeyRestrictions)
             return (PartitionKeyRestrictions) restriction;
 
         return PartitionKeySingleRestrictionSet.builder(metadata.partitionKeyAsClusteringComparator())
                                                .addRestriction(restriction)
-                                               .build();
+                                               .build(indexRegistry);
     }
 
     public static final class EQRestriction extends TokenRestriction

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -604,6 +604,14 @@ public class IndexContext
     }
 
     /**
+     * @return whether the column is analyzed, meaning it uses an analyzer that isn't no-op.
+     */
+    public boolean isAnalyzed()
+    {
+        return isAnalyzed;
+    }
+
+    /**
      * Called when index is dropped. Mark all {@link SSTableIndex} as released and per-column index files
      * will be removed when in-flight queries completed and {@code obsolete} is true.
      *
@@ -635,6 +643,10 @@ public class IndexContext
         // Analyzed columns store the indexed result, so we are unable to compute raw equality.
         // The only supported operator is ANALYZER_MATCHES.
         if (op == Operator.ANALYZER_MATCHES) return isAnalyzed;
+
+        // If the column is analyzed and the operator is EQ, we need to check if the analyzer supports it.
+        if (op == Operator.EQ && isAnalyzed && !analyzerFactory.supportsEquals())
+            return false;
 
         // ANN is only supported against vectors.
         // BOUNDED_ANN is only supported against vectors with a Euclidean similarity function.

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -91,6 +91,7 @@ import org.apache.cassandra.index.SecondaryIndexBuilder;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.TargetParser;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
+import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.index.sai.analyzer.LuceneAnalyzer;
 import org.apache.cassandra.index.sai.analyzer.NonTokenizingOptions;
 import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
@@ -207,7 +208,8 @@ public class StorageAttachedIndex implements Index
                                                                      IndexWriterConfig.SOURCE_MODEL,
                                                                      IndexWriterConfig.OPTIMIZE_FOR,
                                                                      LuceneAnalyzer.INDEX_ANALYZER,
-                                                                     LuceneAnalyzer.QUERY_ANALYZER);
+                                                                     LuceneAnalyzer.QUERY_ANALYZER,
+                                                                     AnalyzerEqOperatorSupport.OPTION);
 
     // this does not include vectors because each Vector declaration is a separate type instance
     public static final Set<CQL3Type> SUPPORTED_TYPES = ImmutableSet.of(CQL3Type.Native.ASCII, CQL3Type.Native.BIGINT, CQL3Type.Native.DATE,

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.analyzer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.service.ClientWarn;
+
+/**
+ * Index config property for defining the behaviour of the equals operator (=) when the index is analyzed.
+ * </p>
+ * Analyzers transform the indexed value, so EQ queries using an analyzed index can return results different to those of
+ * an equivalent query without indexes. Having EQ queries returning different results depending on if/how the column is
+ * indexed can be confusing for users, so probably the safest approach is to reject EQ queries on analyzed indexes, and
+ * let users use the analyzer matches operator (:) instead. However, for backwards compatibility reasons, we should
+ * allow users to let equality queries behave same as match queries through this index config property. We use an enum
+ * value rather than a boolean to allow for future extensions.
+ */
+public class AnalyzerEqOperatorSupport
+{
+    public static final String OPTION = "equals_behaviour_when_analyzed";
+    public static final Value DEFAULT = Value.MATCH; // default to : behaviour for backwards compatibility
+
+    @VisibleForTesting
+    static final String NOT_ANALYZED_ERROR = "The behaviour of the equals operator (=) cannot be " +
+                                             "defined with the '" + OPTION + "' index option because " +
+                                             "the index is not analyzed.";
+
+    @VisibleForTesting
+    static final String WRONG_OPTION_ERROR = String.format("Invalid value for '%s' option. " +
+                                                           "Possible values are %s but found ",
+                                                           OPTION, Arrays.toString(Value.values()));
+
+    public static final String EQ_RESTRICTION_ON_ANALYZED_WARNING =
+    String.format("Columns [%%s] are restricted by '=' and have analyzed indexes [%%s] able to process those restrictions. " +
+                  "Analyzed indexes might process '=' restrictions in a way that is inconsistent with non-indexed queries. " +
+                  "While '=' is still supported on analyzed indexes for backwards compatibility, " +
+                  "it is recommended to use the ':' operator instead to prevent the ambiguity. " +
+                  "Future versions will remove support for '=' on analyzed indexes. " +
+                  "If you want to forbid the use of '=' on analyzed indexes now, " +
+                  "please use '%s':'%s' in the index options.",
+                  OPTION, Value.UNSUPPORTED.toString().toLowerCase());
+
+    public enum Value
+    {
+        /**
+         * The index won't support equality (=) expressions on analyzed indexes.
+         */
+        UNSUPPORTED,
+        /**
+         * Allow equality (=) expressions on analyzed indexes. They will behave same as match queries (:).
+         */
+        MATCH
+    }
+
+    public static boolean supportsEqualsFromOptions(Map<String, String> options)
+    {
+        return fromMap(options) == Value.MATCH;
+    }
+
+    public static Value fromMap(Map<String, String> options)
+    {
+        if (options == null || !options.containsKey(OPTION))
+            return DEFAULT;
+
+        if (!AbstractAnalyzer.isAnalyzed(options))
+            throw new InvalidRequestException(NOT_ANALYZED_ERROR);
+
+        String option = options.get(OPTION).toUpperCase();
+        try
+        {
+            return Value.valueOf(option);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new InvalidRequestException(WRONG_OPTION_ERROR + option);
+        }
+    }
+
+    /**
+     * Emits a client warning if the filter contains EQ restrictions on columns having an analyzed index.
+     *
+     * @param filter the filter to check
+     * @param indexes the existing indexes
+     */
+    public static void maybeWarn(RowFilter filter, Set<Index> indexes)
+    {
+        Warner warner = new Warner(indexes);
+        maybeWarn(filter.root(), warner);
+        warner.maybeWarn();
+    }
+
+    private static void maybeWarn(RowFilter.FilterElement element, Warner warner)
+    {
+        for (RowFilter.Expression expression : element.expressions())
+        {
+            if (expression.operator() == Operator.EQ)
+                warner.addEqRestriction(expression.column());
+        }
+
+        for (RowFilter.FilterElement child : element.children())
+        {
+            maybeWarn(child, warner);
+        }
+    }
+
+    /**
+     * Class for emitting a client warning when a query has EQ restrictions on columns having an analyzed index.
+     */
+    private static class Warner
+    {
+        private final Set<Index> allIndexes;
+
+        private Set<ColumnMetadata> columns;
+        private Set<Index> indexes;
+
+        private Warner(Set<Index> allIndexes)
+        {
+            this.allIndexes = allIndexes;
+        }
+
+        private void addEqRestriction(ColumnMetadata column)
+        {
+            for (Index index : allIndexes)
+            {
+                if (index.supportsExpression(column, Operator.EQ) &&
+                    index.supportsExpression(column, Operator.ANALYZER_MATCHES))
+                {
+                    if (columns == null)
+                        columns = new HashSet<>();
+                    columns.add(column);
+
+                    if (indexes == null)
+                        indexes = new HashSet<>();
+                    indexes.add(index);
+                }
+            }
+        }
+
+        private void maybeWarn()
+        {
+            if (columns == null || indexes == null)
+                return;
+
+            StringJoiner columnNames = new StringJoiner(", ");
+            StringJoiner indexNames = new StringJoiner(", ");
+            columns.forEach(column -> columnNames.add(column.name.toString()));
+            indexes.forEach(index -> indexNames.add(index.getIndexMetadata().name));
+
+            ClientWarn.instance.warn(String.format(EQ_RESTRICTION_ON_ANALYZED_WARNING, columnNames, indexNames));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -103,9 +103,11 @@ public class Operation
                 switch (e.operator())
                 {
                     case EQ:
-                        // EQ operator will always be a multiple expression because it is being used by
-                        // map entries
+                        // EQ operator will always be a multiple expression because it is being used by map entries
                         isMultiExpression = indexContext.isNonFrozenCollection();
+
+                        // EQ wil behave like ANALYZER_MATCHES for analyzed columns if the analyzer supports EQ queries
+                        isMultiExpression |= indexContext.isAnalyzed() && analyzerFactory.supportsEquals();
                         break;
                     case CONTAINS:
                     case CONTAINS_KEY:
@@ -279,22 +281,22 @@ public class Operation
 
         abstract Plan.KeysIteration plan(QueryController controller);
 
-        static Node buildTree(List<RowFilter.Expression> expressions, List<RowFilter.FilterElement> children, boolean isDisjunction)
+        static Node buildTree(QueryController controller, List<RowFilter.Expression> expressions, List<RowFilter.FilterElement> children, boolean isDisjunction)
         {
             OperatorNode node = isDisjunction ? new OrNode() : new AndNode();
             for (RowFilter.Expression expression : expressions)
-                node.add(buildExpression(expression, isDisjunction));
+                node.add(buildExpression(controller, expression, isDisjunction));
             for (RowFilter.FilterElement child : children)
-                node.add(buildTree(child));
+                node.add(buildTree(controller, child));
             return node;
         }
 
-        static Node buildTree(RowFilter.FilterElement filterOperation)
+        static Node buildTree(QueryController controller, RowFilter.FilterElement filterOperation)
         {
-            return buildTree(filterOperation.expressions(), filterOperation.children(), filterOperation.isDisjunction());
+            return buildTree(controller, filterOperation.expressions(), filterOperation.children(), filterOperation.isDisjunction());
         }
 
-        static Node buildExpression(RowFilter.Expression expression, boolean isDisjunction)
+        static Node buildExpression(QueryController controller, RowFilter.Expression expression, boolean isDisjunction)
         {
             if (expression.operator() == Operator.IN)
             {
@@ -317,7 +319,8 @@ public class Operation
                     return new EmptyNode();
                 return node;
             }
-            else if (expression.operator() == Operator.ANALYZER_MATCHES && isDisjunction)
+            else if (isDisjunction && (expression.operator() == Operator.ANALYZER_MATCHES ||
+                                       expression.operator() == Operator.EQ && controller.getContext(expression).isAnalyzed()))
             {
                 OperatorNode node = new AndNode();
                 node.add(new ExpressionNode(expression));

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -322,6 +322,9 @@ public class Operation
             else if (isDisjunction && (expression.operator() == Operator.ANALYZER_MATCHES ||
                                        expression.operator() == Operator.EQ && controller.getContext(expression).isAnalyzed()))
             {
+                // In case of having a tokenizing query_analyzer (such as NGram) with OR, we need to split the
+                // expression into multiple expressions and intersect them.
+                // The additional node in case of no tokenization will be taken care of in Plan.Factory#intersection()
                 OperatorNode node = new AndNode();
                 node.add(new ExpressionNode(expression));
                 return node;

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -384,7 +384,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     {
         // Remove the ORDER BY filter expression from the filter tree, as it is added below.
         var filterElement = filterOperation().filter(e -> !Orderer.isFilterExpressionOrderer(e));
-        Plan.KeysIteration keysIterationPlan = Operation.Node.buildTree(filterElement)
+        Plan.KeysIteration keysIterationPlan = Operation.Node.buildTree(this, filterElement)
                                                              .analyzeTree(this)
                                                              .plan(this);
 
@@ -440,7 +440,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
     public FilterTree buildFilter()
     {
-        return Operation.Node.buildTree(filterOperation()).analyzeTree(this).filterTree();
+        return Operation.Node.buildTree(this, filterOperation()).analyzeTree(this).filterTree();
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -33,8 +33,10 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 
@@ -193,6 +195,16 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     public boolean shouldEstimateInitialConcurrency()
     {
         return false;
+    }
+
+    @Override
+    public void validate(ReadCommand command) throws InvalidRequestException
+    {
+        // Maybe warn about EQ restrictions on analyzed columns
+        AnalyzerEqOperatorSupport.maybeWarn(command.rowFilter(), indexes);
+
+        // Validate index by index
+        Index.QueryPlan.super.validate(command);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sasi/conf/ColumnIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/conf/ColumnIndex.java
@@ -221,6 +221,9 @@ public class ColumnIndex
         if (op == Operator.LIKE)
             return isLiteral();
 
+        if (op == Operator.ANALYZER_MATCHES)
+            return false;
+
         Op operator = Op.valueOf(op);
         return !(isTokenized && operator == Op.EQ) // EQ is only applicable to non-tokenized indexes
                && !(isTokenized && mode.mode == OnDiskIndexBuilder.Mode.CONTAINS && operator == Op.PREFIX) // PREFIX not supported on tokenized CONTAINS mode indexes

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -261,6 +261,7 @@ public abstract class CQLTester
     private List<String> types = new ArrayList<>();
     private List<String> functions = new ArrayList<>();
     private List<String> aggregates = new ArrayList<>();
+    private List<String> indexes = new ArrayList<>();
     private User user;
 
     // We don't use USE_PREPARED_VALUES in the code below so some test can foce value preparation (if the result
@@ -789,6 +790,13 @@ public abstract class CQLTester
         return keyspaces.get(keyspaces.size() - 1);
     }
 
+    protected String currentIndex()
+    {
+        if (indexes.isEmpty())
+            return null;
+        return indexes.get(indexes.size() - 1);
+    }
+
     protected Collection<String> currentTables()
     {
         if (tables == null || tables.isEmpty())
@@ -1010,6 +1018,7 @@ public abstract class CQLTester
     {
         logger.info(formattedQuery);
         String indexName = getCreateIndexName(formattedQuery);
+        indexes.add(indexName);
         schemaChange(formattedQuery);
         return indexName;
     }

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.analyzer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.service.ClientWarn;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport.EQ_RESTRICTION_ON_ANALYZED_WARNING;
+
+/**
+ * Tests for {@link AnalyzerEqOperatorSupport}.
+ */
+public class AnalyzerEqOperatorSupportTest extends SAITester
+{
+    @Before
+    public void createTable()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+    }
+
+    private void populateTable()
+    {
+        execute("INSERT INTO %s (k, v) VALUES (1, 'Quick fox')");
+        execute("INSERT INTO %s (k, v) VALUES (2, 'Lazy fox')");
+    }
+
+    @Test
+    public void testWithoutAnyIndex()
+    {
+        populateTable();
+
+        // equals (=)
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox' ALLOW FILTERING", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox' ALLOW FILTERING");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'fox' ALLOW FILTERING");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox' ALLOW FILTERING", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox' ALLOW FILTERING");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy' ALLOW FILTERING");
+        assertInvalidMessage("v cannot be restricted by more than one relation if it includes an Equal",
+                             "SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox' ALLOW FILTERING");
+
+        // matches (:)
+        assertInvalidMessage(": restriction is only supported on properly indexed columns. v : 'Quick fox' is not valid.",
+                             "SELECT k FROM %s WHERE v : 'Quick fox' ALLOW FILTERING");
+    }
+
+    @Test
+    public void testWithLegacyIndex()
+    {
+        populateTable();
+
+        createIndex("CREATE INDEX ON %s(v)");
+        waitForIndexQueryable();
+
+        // equals (=)
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'fox'");
+        assertInvalidMessage("v cannot be restricted by more than one relation if it includes an Equal",
+                             "SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'");
+        assertInvalidMessage(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION,
+                             "SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'");
+
+        // matches (:)
+        assertInvalidMessage(format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'v'),
+                             "SELECT k FROM %s WHERE v : 'Quick fox'");
+    }
+
+    @Test
+    public void testNonAnalyzedIndexWithDefaults()
+    {
+        assertIndexQueries("{}", () -> {
+
+            // equals (=)
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox'");
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'fox'");
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'");
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'");
+            assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'");
+            assertInvalidMessage("v cannot be restricted by more than one relation if it includes an Equal",
+                                 "SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'");
+
+            // matches (:)
+            assertIndexDoesNotSupportMatches();
+        });
+    }
+
+    @Test
+    public void testNonAnalyzedIndexWithMatch()
+    {
+        assertIndexThrowsNotAnalyzedError("{'equals_behaviour_when_analyzed': 'MATCH'}");
+    }
+
+    @Test
+    public void testNonAnalyzedIndexWithUnsupported()
+    {
+        assertIndexThrowsNotAnalyzedError("{'equals_behaviour_when_analyzed': 'UNSUPPORTED'}");
+    }
+
+    @Test
+    public void testNonAnalyzedIndexWithWrongValue()
+    {
+        assertIndexThrowsNotAnalyzedError("{'equals_behaviour_when_analyzed': 'WRONG'}");
+    }
+
+    @Test
+    public void testNonTokenizedIndexWithDefaults()
+    {
+        assertIndexQueries("{'case_sensitive': 'false'}", () -> {
+            assertNonTokenizedIndexSupportsEquality();
+            assertNonTokenizedIndexSupportsMatches();
+            assertNonTokenizedIndexSupportsMixedEqualityAndMatches();
+        });
+    }
+
+    @Test
+    public void testNonTokenizedIndexWithMatch()
+    {
+        assertIndexQueries("{'case_sensitive': 'false', 'equals_behaviour_when_analyzed': 'MATCH'}", () -> {
+            assertNonTokenizedIndexSupportsEquality();
+            assertNonTokenizedIndexSupportsMatches();
+            assertNonTokenizedIndexSupportsMixedEqualityAndMatches();
+        });
+    }
+
+    @Test
+    public void testNonTokenizedIndexWithUnsupported()
+    {
+        assertIndexQueries("{'case_sensitive': 'false', 'equals_behaviour_when_analyzed': 'UNSUPPORTED'}", () -> {
+            assertIndexDoesNotSupportEquals();
+            assertNonTokenizedIndexSupportsMatches();
+        });
+    }
+
+    @Test
+    public void testNonTokenizedIndexWithWrongValue()
+    {
+        assertIndexThrowsUnrecognizedOptionError("{'case_sensitive': 'false', 'equals_behaviour_when_analyzed': 'WRONG'}");
+    }
+
+    private void assertNonTokenizedIndexSupportsEquality()
+    {
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'");
+    }
+
+    private void assertNonTokenizedIndexSupportsMatches()
+    {
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'fox'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' OR v : 'Lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' OR v : 'lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' AND v : 'fox'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' AND v : 'fox'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' AND v : 'Lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' AND v : 'lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'dog'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'Lazy'");
+    }
+
+    private void assertNonTokenizedIndexSupportsMixedEqualityAndMatches()
+    {
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'");
+
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'");
+    }
+
+    @Test
+    public void testTokenizedIndexWithDefaults()
+    {
+        assertIndexQueries("{'index_analyzer': 'standard'}", () -> {
+            assertTokenizedIndexSupportsEquality();
+            assertTokenizedIndexSupportsMatches();
+            assertTokenizedIndexSupportsMixedEqualityAndMatches();
+        });
+    }
+
+    @Test
+    public void testTokenizedIndexWithMatch()
+    {
+        assertIndexQueries("{'index_analyzer': 'standard', 'equals_behaviour_when_analyzed': 'MATCH'}", () -> {
+            assertTokenizedIndexSupportsEquality();
+            assertTokenizedIndexSupportsMatches();
+            assertTokenizedIndexSupportsMixedEqualityAndMatches();
+        });
+    }
+
+    @Test
+    public void testTokenizedIndexWithUnsupported()
+    {
+        assertIndexQueries("{'index_analyzer': 'standard', 'equals_behaviour_when_analyzed': 'UNSUPPORTED'}", () -> {
+            assertIndexDoesNotSupportEquals();
+            assertTokenizedIndexSupportsMatches();
+        });
+    }
+
+    @Test
+    public void testTokenizedIndexWithWrongValue()
+    {
+        assertIndexThrowsUnrecognizedOptionError("{'index_analyzer': 'standard', 'equals_behaviour_when_analyzed': 'WRONG'}");
+    }
+
+    private void assertTokenizedIndexSupportsEquality()
+    {
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'", row(1), row(2));
+    }
+
+    private void assertTokenizedIndexSupportsMatches()
+    {
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'fox'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' OR v : 'Lazy'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' OR v : 'lazy'", row(1), row(2));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' AND v : 'fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' AND v : 'fox'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' AND v : 'Lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' AND v : 'lazy'");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'dog'", row(1));
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'Lazy'", row(1), row(2));
+    }
+
+    private void assertTokenizedIndexSupportsMixedEqualityAndMatches()
+    {
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'", row(1), row(2));
+
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'", row(1), row(2));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'", row(1));
+        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'", row(1), row(2));
+    }
+
+    private void assertIndexDoesNotSupportEquals()
+    {
+        // the EQ query should not be supported by the index
+        String query = "SELECT k FROM %s WHERE v = 'Quick fox'";
+        assertInvalidMessage("Column 'v' has an index but does not support the operators specified in the query", query);
+
+        // the EQ query should stil be supported with filtering without index intervention
+        assertRowsWithoutWarning(query + " ALLOW FILTERING", row(1));
+
+        // the EQ query should not use any kind of transformation when filtered without index intervention
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'quick fox' ALLOW FILTERING");
+        assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'fox' ALLOW FILTERING");
+    }
+
+    private void assertIndexDoesNotSupportMatches()
+    {
+        String query = "SELECT k FROM %s WHERE v : 'Quick fox'";
+        String errorMessage = "Index on column v does not support ':' restrictions.";
+        assertInvalidMessage(errorMessage, query);
+        assertInvalidMessage(errorMessage, query + " ALLOW FILTERING");
+    }
+
+    private void assertIndexThrowsNotAnalyzedError(String indexOptions)
+    {
+        assertInvalidMessage(AnalyzerEqOperatorSupport.NOT_ANALYZED_ERROR,
+                             "CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS =" + indexOptions);
+    }
+
+    private void assertIndexThrowsUnrecognizedOptionError(String indexOptions)
+    {
+        assertInvalidMessage(AnalyzerEqOperatorSupport.WRONG_OPTION_ERROR,
+                             "CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS =" + indexOptions);
+    }
+
+    private void assertIndexQueries(String indexOptions, Runnable queries)
+    {
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = " + indexOptions);
+        waitForIndexQueryable();
+        populateTable();
+
+        queries.run();
+        flush();
+        queries.run();
+    }
+
+    private void assertRowsWithoutWarning(String query, Object[]... rows)
+    {
+        assertRows(query, rows).isNullOrEmpty();
+    }
+
+    private void assertRowsWithWarning(String query, Object[]... rows)
+    {
+        assertRows(query, rows).hasSize(1).contains(format(EQ_RESTRICTION_ON_ANALYZED_WARNING, 'v', currentIndex()));
+    }
+
+    private ListAssert<String> assertRows(String query, Object[]... rows)
+    {
+        ClientWarn.instance.captureWarnings();
+        CQLTester.disablePreparedReuseForTest();
+        assertRows(execute(query), rows);
+        ListAssert<String> assertion = Assertions.assertThat(ClientWarn.instance.getWarnings());
+        ClientWarn.instance.resetWarnings();
+        return assertion;
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -165,7 +165,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStandardAnalyzerWithFullConfig() throws Throwable
+    public void testStandardAnalyzerWithFullConfig()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -179,7 +179,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStandardAnalyzerWithBuiltInName() throws Throwable
+    public void testStandardAnalyzerWithBuiltInName()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -189,7 +189,8 @@ public class LuceneAnalyzerTest extends SAITester
         standardAnalyzerTest();
     }
 
-    private void standardAnalyzerTest() throws Throwable {
+    private void standardAnalyzerTest()
+    {
         waitForIndexQueryable();
         execute("INSERT INTO %s (id, val) VALUES ('1', 'The quick brown fox jumps over the lazy DOG.')");
 
@@ -209,6 +210,8 @@ public class LuceneAnalyzerTest extends SAITester
         assertEquals(1, execute("SELECT * FROM %s WHERE val : 'dog' OR (val : 'quick' AND val : 'missing')").size());
         assertEquals(1, execute("SELECT * FROM %s WHERE val : 'missing' OR (val : 'quick' AND val : 'dog')").size());
         assertEquals(0, execute("SELECT * FROM %s WHERE val : 'missing' OR (val : 'quick' AND val : 'missing')").size());
+        assertEquals(1, execute("SELECT * FROM %s WHERE val : 'missing cat' OR val : 'dog'").size());
+        assertEquals(0, execute("SELECT * FROM %s WHERE val : 'missing cat' OR val : 'missing dog'").size());
 
         // EQ operator support is reintroduced for analyzed columns, it should work as ':' operator
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'dog'").size());


### PR DESCRIPTION
Adds a new `equals_behaviour_when_analyzed` index config property allowing to define the behaviour of the `=` operator on analyzed indexes. Values are:
* `REJECT`: Reject the query
* `MATCH`: Behave the same as the `:` operator.

I think `REJECT` should be the ideal behaviour, but `MATCH` is the default for compatibility reasons.

Here is an example showing how it works:
```
CREATE TABLE t (k int PRIMARY KEY, v text);
INSERT INTO t (k, v) VALUES (1, 'Quick fox');
INSERT INTO t (k, v) VALUES (2, 'Lazy fox');

-- with defaults
CREATE CUSTOM INDEX idx ON t(v) USING 'StorageAttachedIndex'
WITH OPTIONS = { 'index_analyzer': 'standard' };
SELECT k FROM t WHERE v = 'Quick fox'; -- returns row 1
SELECT k FROM t WHERE v : 'Quick fox'; -- returns row 1

-- with MATCH
DROP INDEX idx;
CREATE CUSTOM INDEX idx ON t(v) USING 'StorageAttachedIndex'
WITH OPTIONS = {
   'index_analyzer': 'standard', 
   'equals_behaviour_when_analyzed': 'match'
   };
SELECT k FROM t WHERE v = 'Quick fox'; -- returns row 1
SELECT k FROM t WHERE v : 'Quick fox'; -- returns row 1

-- with REJECT
DROP INDEX idx;
CREATE CUSTOM INDEX idx ON t(v) USING 'StorageAttachedIndex'
WITH OPTIONS = {
   'index_analyzer': 'standard', 
   'equals_behaviour_when_analyzed': 'reject'
   };
SELECT k FROM t WHERE v = 'Quick fox'; -- fails asking for ALLOW FILTERING
SELECT k FROM t WHERE v : 'Quick fox'; -- returns row 1
```
Not sure about the name of the property, though. Perhaps it could be just `equals_behaviour`, although it's rejected if the index isn't analyzed.

I'm using an enum for the value, instead of a boolean, to allow us to add new behaviours if necessary.