### PR TITLE
Re-applying CNDB-7178: Keep track of failed segments when applying mutations (#1228)

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -52,7 +52,6 @@ import org.apache.cassandra.io.util.SimpleCachedBufferPool;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WrappedRunnable;
 import org.apache.cassandra.utils.concurrent.WaitQueue;
 
@@ -418,9 +417,9 @@ public abstract class AbstractCommitLogSegmentManager
         handleReplayedSegment(file, false);
     }
 
-    void handleReplayedSegment(final File file, boolean hasInvalidMutations)
+    void handleReplayedSegment(final File file, boolean hasInvalidOrFailedMutations)
     {
-        if (!hasInvalidMutations)
+        if (!hasInvalidOrFailedMutations)
         {
             // (don't decrease managed size, since this was never a "live" segment)
             logger.trace("(Unopened) segment {} is no longer needed and will be deleted now", file);
@@ -428,7 +427,7 @@ public abstract class AbstractCommitLogSegmentManager
         }
         else
         {
-            logger.debug("File {} should not be deleted as it contains invalid mutations", file.name());
+            logger.debug("File {} should not be deleted as it contains invalid or failed mutations", file.name());
         }
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -24,12 +24,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -69,8 +72,11 @@ import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.WrappedRunnable;
 import org.jctools.maps.NonBlockingHashMap;
+import org.jctools.maps.NonBlockingHashSet;
 
 /**
  * Replays commit logs (reads commit logs and flushes new sstables).
@@ -87,10 +93,13 @@ public class CommitLogReplayer implements CommitLogReadHandler
     public static MutationInitiator mutationInitiator = new MutationInitiator();
     static final String IGNORE_REPLAY_ERRORS_PROPERTY = Config.PROPERTY_PREFIX + "commitlog.ignorereplayerrors";
     private static final Logger logger = LoggerFactory.getLogger(CommitLogReplayer.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 10, TimeUnit.SECONDS);
     private static final int MAX_OUTSTANDING_REPLAY_COUNT = Integer.getInteger(Config.PROPERTY_PREFIX + "commitlog_max_outstanding_replay_count", 1024);
 
     private final Map<Keyspace, AtomicInteger> keyspacesReplayed;
     private final Queue<Future<Integer>> futures;
+
+    private final Set<String> segmentsWithFailedMutations;
 
     private final Map<TableId, IntervalSet<CommitLogPosition>> cfPersisted;
     private final CommitLogPosition globalPosition;
@@ -116,6 +125,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
     {
         this.keyspacesReplayed = new NonBlockingHashMap<>();
         this.futures = new ArrayDeque<>();
+        this.segmentsWithFailedMutations = new NonBlockingHashSet<>();
         this.cfPersisted = cfPersisted;
         this.globalPosition = globalPosition;
         this.replayFilter = replayFilter;
@@ -300,11 +310,13 @@ public class CommitLogReplayer implements CommitLogReadHandler
             logger.debug("Invalid mutation detected for table id {}", id);
         }
 
-        protected Future<Integer> initiateMutation(final Mutation mutation,
-                                                   final long segmentId,
-                                                   final int serializedSize,
-                                                   final int entryLocation,
-                                                   final CommitLogReplayer commitLogReplayer)
+        protected void onFailedMutation(String keyspace, Collection<TableId> tableIds) {}
+
+        protected CompletableFuture<Integer> initiateMutation(final Mutation mutation,
+                                                              final CommitLogDescriptor desc,
+                                                              final int serializedSize,
+                                                              final int entryLocation,
+                                                              final CommitLogReplayer commitLogReplayer)
         {
             Runnable runnable = new WrappedRunnable()
             {
@@ -332,13 +344,13 @@ public class CommitLogReplayer implements CommitLogReadHandler
 
                         // replay if current segment is newer than last flushed one or,
                         // if it is the last known segment, if we are after the commit log segment position
-                        if (shouldReplay(update.metadata().id, commitLogReplayer, segmentId, entryLocation))
+                        if (shouldReplay(update.metadata().id, commitLogReplayer, desc.id, entryLocation))
                         {
                             if (newPUCollector == null)
                                 newPUCollector = new Mutation.PartitionUpdateCollector(mutation.getKeyspaceName(), mutation.key());
                             newPUCollector.add(update);
                             replayedCount++;
-                            updatesAndPositions.add(Triple.of(update, segmentId, entryLocation));
+                            updatesAndPositions.add(Triple.of(update, desc.id, entryLocation));
                         }
                         else
                         {
@@ -360,7 +372,13 @@ public class CommitLogReplayer implements CommitLogReadHandler
                     }
                 }
             };
-            return Stage.MUTATION.submit(runnable, serializedSize);
+            return Stage.MUTATION.submit(runnable, serializedSize).exceptionally( ex ->
+                             {
+                                 noSpamLogger.warn("Failed applying mutation for keyspace {}", mutation.getKeyspaceName(), ex);
+                                 onFailedMutation(mutation.getKeyspaceName(), mutation.getTableIds());
+                                 commitLogReplayer.segmentsWithFailedMutations.add(desc.fileName());
+                                 throw Throwables.throwAsUncheckedException(ex.getCause());
+                             });
         }
 
         /**
@@ -548,9 +566,11 @@ public class CommitLogReplayer implements CommitLogReadHandler
         return false;
     }
 
-    public Set<String> getSegmentsWithInvalidMutations()
+    public Set<String> getSegmentWithInvalidOrFailedMutations()
     {
-        return commitLogReader.getSegmentsWithInvalidMutations();
+        Set<String> union = new HashSet<>(segmentsWithFailedMutations);
+        union.addAll(commitLogReader.getSegmentsWithInvalidMutations());
+        return union;
     }
 
     public void handleInvalidMutation(TableId id)
@@ -565,7 +585,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
 
         pendingMutationBytes += size;
         futures.offer(mutationInitiator.initiateMutation(m,
-                                                         desc.id,
+                                                         desc,
                                                          size,
                                                          entryLocation,
                                                          this));

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
@@ -49,6 +50,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.commitlog.CommitLogArchiver;
+import org.apache.cassandra.db.commitlog.CommitLogDescriptor;
 import org.apache.cassandra.db.commitlog.CommitLogReplayer;
 import org.apache.cassandra.db.context.CounterContext;
 import org.apache.cassandra.db.rows.*;
@@ -346,18 +348,18 @@ public class RecoveryManagerTest
         final Semaphore blocked = new Semaphore(0);
 
         @Override
-        protected Future<Integer> initiateMutation(final Mutation mutation,
-                final long segmentId,
-                final int serializedSize,
-                final int entryLocation,
-                final CommitLogReplayer clr)
+        protected CompletableFuture<Integer> initiateMutation(final Mutation mutation,
+                                                              final CommitLogDescriptor desc,
+                                                              final int serializedSize,
+                                                              final int entryLocation,
+                                                              final CommitLogReplayer clr)
         {
-            final Future<Integer> toWrap = super.initiateMutation(mutation,
-                                                                  segmentId,
+            final CompletableFuture<Integer> toWrap = super.initiateMutation(mutation,
+                                                                  desc,
                                                                   serializedSize,
                                                                   entryLocation,
                                                                   clr);
-            return new Future<Integer>()
+            return new CompletableFuture<>()
             {
 
                 @Override

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogReplayerTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogReplayerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Mutation;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(BMUnitRunner.class)
+public class CommitLogReplayerTest
+{
+    @BeforeClass
+    public static void before()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+    @Test
+    @BMRules(rules = { @BMRule(name = "Fail applying mutation",
+            targetClass = "org.apache.cassandra.concurrent.Stage",
+            targetMethod = "submit",
+            action = "return CompletableFuture.failedFuture(new RuntimeException(\"mutation failed\"));") } )
+    public void testTrackingSegmentsWhenMutationFails()
+    {
+        CommitLogReplayer.MutationInitiator mutationInitiator = new CommitLogReplayer.MutationInitiator();
+        CommitLogReplayer replayer = new CommitLogReplayer(CommitLog.instance, CommitLogPosition.NONE, null, CommitLogReplayer.ReplayFilter.create());
+        CommitLogDescriptor descriptor = mock(CommitLogDescriptor.class);
+        String failedSegment = "failedSegment";
+        when(descriptor.fileName()).thenReturn(failedSegment);
+        CompletableFuture<Integer> mutationFuture = mutationInitiator.initiateMutation(mock(Mutation.class), descriptor, 0, 0, replayer);
+        Assert.assertThrows(ExecutionException.class, () -> mutationFuture.get());
+        Assert.assertTrue(!replayer.getSegmentWithInvalidOrFailedMutations().isEmpty());
+        Assert.assertTrue(replayer.getSegmentWithInvalidOrFailedMutations().contains(failedSegment));
+    }
+}


### PR DESCRIPTION
Re-applying https://github.com/datastax/cassandra/commit/9fe9211f1213d9b342ea1f81d1c7740abb9db11d introduced in https://github.com/datastax/cassandra/pull/1228

CNDB change is approved so we need to get this in.
