### PR TITLE
CNDB-10702: use indexBuildTimeFileHandleBuilderFor for vector PQ during index build

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -51,6 +51,7 @@ import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionT
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 
@@ -394,7 +395,9 @@ public class SSTableIndexWriter implements PerIndexWriter
         // No PQ instance available in completed indexes, so check if we just wrote one
         var pqComponent = perIndexComponents.get(IndexComponentType.PQ);
         assert pqComponent != null; // we always have a PQ component even if it's not actually PQ compression
-        try (var fh = pqComponent.createFileHandle();
+
+        try (var fhBuilder = StorageProvider.instance.indexBuildTimeFileHandleBuilderFor(pqComponent);
+             var fh = fhBuilder.complete();
              var reader = fh.createReader())
         {
             var sm = segments.get(segments.size() - 1);

--- a/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.index.sai.disk.io.IndexInput;
 import org.apache.cassandra.index.sai.disk.io.IndexInputReader;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.RandomAccessReader;
@@ -132,7 +133,7 @@ public class IndexFileUtils
             if (!file.exists())
                 return;
 
-            try(FileChannel ch = FileChannel.open(file.toPath(), StandardOpenOption.READ))
+            try(FileChannel ch = StorageProvider.instance.writeTimeReadFileChannelFor(file))
             {
                 if (ch.size() == 0)
                     return;


### PR DESCRIPTION
- use writeTimeReadFileChannelFor() for recalculateChecksum on appending index segment