### PR TITLE
CNDB-10624: Add counter to track number of OOM errors when loading bloom filters

### DIFF
--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -51,15 +51,9 @@ public class OffHeapBitSet implements IBitSet
         long wordCount = (((numBits - 1) >>> 6) + 1);
         if (wordCount > Integer.MAX_VALUE)
             throw new UnsupportedOperationException("Bloom filter size is > 16GB, reduce the bloom_filter_fp_chance");
-        try
-        {
-            long byteCount = wordCount * 8L;
-            bytes = allocate(byteCount, memoryLimiter);
-        }
-        catch (OutOfMemoryError e)
-        {
-            throw new RuntimeException("Out of native memory occured, You can avoid it by increasing the system ram space or by increasing bloom_filter_fp_chance.");
-        }
+
+        long byteCount = wordCount * 8L;
+        bytes = allocate(byteCount, memoryLimiter); // Can possibly throw OOM, but we handle it in the caller
         // flush/clear the existing memory.
         clear();
     }


### PR DESCRIPTION
Add counter to track number of OOMs.
Alternatively we can propagate metadata information into FilterFactory to enrich counter with keyspace and table name. I went for minimal approach to avoid refactoring. 

Prometheus friendly metric is exposed through `bloom_filter_oom_errors`.