### PR TITLE
CNDB-10748: Do not persist (and fsync) to disk the list of peers when Cassandra runs on CNDB

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -387,6 +387,9 @@ public enum CassandraRelevantProperties
     CURSORS_ENABLED("cassandra.allow_cursor_compaction", "true"),
 
     SYNC_LAG_FACTOR("cassandra.commitlog_sync_block_lag_factor", "1.5"),
+    // When the list of peers is stored to an alternative metadata service (like etcd) we don't need to store
+    // it locally on disk.
+    PERSIST_PEER_NODES_TO_DISK("cassandra.persist_peer_nodes_to_disk", "true"),
 
     CDC_STREAMING_ENABLED("cassandra.cdc.enable_streaming", "true"),
     // Default metric aggegration strategy for tables without aggregation explicitly set.


### PR DESCRIPTION
This is a POC - DO NOT MERGE

Summary for the changes:
Add a system property to skip persisting to disk the list of peers. 

It is not possible to apply the same change to the "local" node info, because it contains metadata about truncation and other stuff that must be persistent when the node restarts

Links to: https://github.com/riptano/cndb/issues/10748