### PR TITLE
CNDB-10455: Automatically tune compaction for vector tables

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyFactory.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyFactory.java
@@ -58,7 +58,6 @@ public class CompactionStrategyFactory
     {
         // If we were called due to a metadata change but the compaction parameters are the same then
         // don't reload since we risk overriding parameters set via JMX
-        boolean hasVector = realm.metadata().hasVectorType();
         if (current != null && !current.shouldReload(compactionParams, reason))
             return current;
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyFactory.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyFactory.java
@@ -58,6 +58,7 @@ public class CompactionStrategyFactory
     {
         // If we were called due to a metadata change but the compaction parameters are the same then
         // don't reload since we risk overriding parameters set via JMX
+        boolean hasVector = realm.metadata().hasVectorType();
         if (current != null && !current.shouldReload(compactionParams, reason))
             return current;
 

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -49,6 +49,7 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
     private final CompactionParams metadataParams;
     private final UnifiedCompactionStrategy strategy;
     private final boolean enableAutoCompaction;
+    private final boolean hasVector;
 
     AtomicBoolean enabled;
 
@@ -65,6 +66,7 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
         this.strategy = new UnifiedCompactionStrategy(factory, backgroundCompactions, params.options());
         this.enabled = new AtomicBoolean(enabled);
         this.enableAutoCompaction = enableAutoCompaction;
+        this.hasVector = factory.getRealm().metadata().hasVectorType();
 
         factory.getCompactionLogger().strategyCreated(this.strategy);
 
@@ -139,6 +141,14 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
                                               ReloadReason reason)
     {
         return create(previous, factory, compactionParams, reason, enableAutoCompaction);
+    }
+
+    @Override
+    public boolean shouldReload(CompactionParams params, ReloadReason reason)
+    {
+        return reason != CompactionStrategyContainer.ReloadReason.METADATA_CHANGE
+               || !params.equals(getMetadataCompactionParams())
+               || hasVector != factory.getRealm().metadata().hasVectorType();
     }
 
     private static CompactionParams createMetadataParams(@Nullable CompactionStrategyContainer previous,

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -66,7 +66,7 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
         this.strategy = new UnifiedCompactionStrategy(factory, backgroundCompactions, params.options());
         this.enabled = new AtomicBoolean(enabled);
         this.enableAutoCompaction = enableAutoCompaction;
-        this.hasVector = factory.getRealm().metadata().hasVectorType();
+        this.hasVector = strategy.getController().hasVectorType();
 
         factory.getCompactionLogger().strategyCreated(this.strategy);
 

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
@@ -440,6 +440,10 @@ the span of the lower-density ones.
 
 UCS accepts these compaction strategy parameters:
 
+* `override_ucs_config_for_vector_tables` Allows different configurations for vector and non-vector tables.  When set
+  to `true`, if a table has a column of `VectorType`, the "vector" parameters will be used instead of the regular
+  parameters. For example, `vector_min_sstable_size` will be used, and `min_sstable_size` will be ignored.   
+  The default value is `false` which disables this feature.
 * `scaling_parameters` A list of per-level scaling parameters, specified as L*f*, T*f*, N, or an integer value
   specifying $w$ directly. If more levels are present than the length of this list, the last value is used for all
   higher levels. Often this will be a single parameter, specifying the behaviour for all levels of the
@@ -454,6 +458,8 @@ UCS accepts these compaction strategy parameters:
   compaction to be promoted to the next level) and a fan factor of 2. This can also be specified as T2 or L2.  
   The default value is T4, matching the default STCS behaviour with threshold 4. To select an equivalent of LCS
   with its default fan factor 10, use L10.
+* `vector_scaling_parameters` A list of per-level scaling parameters used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is -8 or L10.
 * `target_sstable_size` The target sstable size $t$, specified as a human-friendly size in bytes (e.g. 100 MiB =
   $100\cdot 2^{20}$ B or (10 MB = 10,000,000 B)). The strategy will split data in shards that aim to produce sstables
   of size between $t / \sqrt 2$ and $t \cdot \sqrt 2$.  
@@ -462,10 +468,14 @@ UCS accepts these compaction strategy parameters:
   Increase this if the memory pressure from the number of sstables in the system becomes too high. Also see
   `sstable_growth` below.  
   The default value is 1 GiB.
+* `vector_target_sstable_size` The target sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 5GiB.
 * `base_shard_count` The minimum number of shards $b$, used for levels with the smallest density. This gives the
   minimum compaction concurrency for the lowest levels. A low number would result in larger L0 sstables but may limit
   the overall maximum write throughput (as every piece of data has to go through L0). The base shard count only applies after `min_sstable_size` is reached.  
   The default value is 4 for all tables.
+* `vector_base_shard_count` The base shard count used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1.
 * `sstable_growth` The sstable growth component $\lambda$, applied as a factor in the shard exponent calculation.
   This is a number between 0 and 1 that controls what part of the density growth should apply to individual sstable
   size and what part should increase the number of shards. Using a value of 1 has the effect of fixing the shard
@@ -480,10 +490,14 @@ UCS accepts these compaction strategy parameters:
   two can be further tweaked by increasing $\lambda$ to get fewer but bigger sstables on the top level, and decreasing
   it to favour a higher count of smaller sstables.  
   The default value is 0.333 meaning the sstable size grows with the square root of the growth of the shard count.
+* `vector_sstable_growth` The sstable growth component used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1 which means the shard count will be fixed to the base value.
 * `min_sstable_size` The minimum sstable size $m$, applicable when the base shard count will result is sstables
   that are considered too small. If set, the strategy will split the space into fewer than the base count shards, to
   make the estimated sstables size at least as large as this value. A value of 0 disables this feature. A value of `auto` sets the minimum sstable size to the size
   of sstables resulting from flushes. The default value is 100MiB.
+* `vector_min_sstable_size` The minimum sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1024MiB.
 * `reserved_threads` Specifies the number of threads to reserve per level. Any remaining threads will take
   work according to the prioritization mechanism (i.e. higher overlap first). Higher reservations mean better
   responsiveness of the compaction strategy to new work, or smoother performance, at the expense of reducing the
@@ -491,6 +505,8 @@ UCS accepts these compaction strategy parameters:
   The default value is `max`, which spreads all threads as close to evenly between levels as possible. It is recommended
   to keep this option and the next at their defaults, which should offer a good balance between responsiveness and
   thread utilization.
+* `vector_reserved_threads` Specifies the number of threads to reserve per level for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is `max`.
 * `reservations_type` Specifies whether reservations can be used by lower levels. If set to `per_level`, the
   reservations are only used by the specific level. If set to `level_or_below`, the reservations can be used by this
   level as well as any one below it.  

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -117,6 +117,7 @@ public class AdaptiveController extends Controller
                               int reservedThreadsPerLevel,
                               Reservations.Type reservationsType,
                               Overlaps.InclusionMethod overlapInclusionMethod,
+                              boolean hasVectorType,
                               int intervalSec,
                               int minScalingParameter,
                               int maxScalingParameter,
@@ -142,7 +143,8 @@ public class AdaptiveController extends Controller
               sstableGrowthModifier,
               reservedThreadsPerLevel,
               reservationsType,
-              overlapInclusionMethod);
+              overlapInclusionMethod,
+              hasVectorType);
 
         this.scalingParameters = scalingParameters;
         this.previousScalingParameters = previousScalingParameters;
@@ -171,6 +173,7 @@ public class AdaptiveController extends Controller
                                   int reservedThreadsPerLevel,
                                   Reservations.Type reservationsType,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
+                                  boolean hasVectorType,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options)
@@ -268,6 +271,7 @@ public class AdaptiveController extends Controller
                                       reservedThreadsPerLevel,
                                       reservationsType,
                                       overlapInclusionMethod,
+                                      hasVectorType,
                                       intervalSec,
                                       minScalingParameter,
                                       maxScalingParameter,

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -315,6 +315,9 @@ public class AdaptiveController extends Controller
             parseScalingParameters(staticScalingFactors);
         else if (staticScalingParameters != null)
             parseScalingParameters(staticScalingParameters);
+        String vectorScalingParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
+        if (vectorScalingParameters != null)
+            throw new ConfigurationException(String.format("%s option is not supported with Adaptive UCS", VECTOR_SCALING_PARAMETERS_OPTION));
         s = options.remove(MIN_SCALING_PARAMETER);
         if (s != null)
             minScalingParameter = Integer.parseInt(s);

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.CompactionRealm;
 import org.apache.cassandra.db.compaction.CompactionStrategy;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileWriter;
@@ -119,11 +120,13 @@ public abstract class Controller
      * In UCS V1 mode (engaged by using "num_shards" above) the default 'auto'.
      */
     static final String MIN_SSTABLE_SIZE_OPTION = "min_sstable_size";
+    static final String VECTOR_MIN_SSTABLE_SIZE_OPTION = "vector_min_sstable_size";
     @Deprecated
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
     static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
+    static final long VECTOR_DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */
@@ -151,6 +154,7 @@ public abstract class Controller
     static final double MAX_SPACE_OVERHEAD_UPPER_BOUND = 1.0;
 
     static final String BASE_SHARD_COUNT_OPTION = "base_shard_count";
+    static final String VECTOR_BASE_SHARD_COUNT_OPTION = "vector_base_shard_count";
     /**
      * Default base shard count, used when a base count is not explicitly supplied. This value applies as long as the
      * table is not a system one, and directories are not defined.
@@ -160,11 +164,15 @@ public abstract class Controller
      */
     public static final int DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(getSystemProperty(BASE_SHARD_COUNT_OPTION, "4"));
 
+    public static final int VECTOR_DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(System.getProperty(PREFIX + VECTOR_BASE_SHARD_COUNT_OPTION, "1"));
+
     /**
      * The target SSTable size. This is the size of the SSTables that the controller will try to create.
      */
     static final String TARGET_SSTABLE_SIZE_OPTION = "target_sstable_size";
+    static final String VECTOR_TARGET_SSTABLE_SIZE_OPTION = "vector_target_sstable_size";
     public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
+    public static final long VECTOR_DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
     static final long MIN_TARGET_SSTABLE_SIZE = 1L << 20;
 
 
@@ -194,7 +202,9 @@ public abstract class Controller
      * a growth value of 0.333, and 64 (~16GiB each) for a growth value of 0.5.
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
+    static final String VECTOR_SSTABLE_GROWTH_OPTION = "vector_sstable_growth";
     static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.5"));
+    static final double VECTOR_DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + VECTOR_SSTABLE_GROWTH_OPTION, "1.0"));
 
     /**
      * Number of reserved threads to keep for each compaction level. This is used to ensure that there are always
@@ -208,7 +218,9 @@ public abstract class Controller
      * The default value is max, all compaction threads are distributed among the levels.
      */
     static final String RESERVED_THREADS_OPTION = "reserved_threads";
+    static final String VECTOR_RESERVED_THREADS_OPTION = "vector_reserved_threads";
     public static final int DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(getSystemProperty(RESERVED_THREADS_OPTION, "max"));
+    public static final int VECTOR_DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(System.getProperty(PREFIX + VECTOR_RESERVED_THREADS_OPTION, "max"));
 
     /**
      * Reservation type, defining whether reservations can be used by lower levels. If set to `per_level`, the
@@ -251,6 +263,15 @@ public abstract class Controller
     static final boolean ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = Boolean.parseBoolean(System.getProperty(ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_PROPERTY));
     static final boolean DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = false;
 
+    /**
+     * This property allows seperate configurations for vector and non-vector tables.  If this property is set to true
+     * and the table has a {@link VectorType}, the "vector" options are used over the regular options.  For instance,
+     * "vector_sstable_growth" will be used over "sstable_growth"
+     */
+    static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION = "override_ucs_config_for_vector_tables";
+    static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY = PREFIX + "override_ucs_config_for_vector_tables";
+    static final boolean DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES = Boolean.parseBoolean(System.getProperty(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY, "false"));
+
     static final int DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS = 60 * 10;
     static final String EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_OPTION = "expired_sstable_check_frequency_seconds";
 
@@ -282,6 +303,7 @@ public abstract class Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     static final String SCALING_PARAMETERS_OPTION = "scaling_parameters";
+    static final String VECTOR_SCALING_PARAMETERS_OPTION = "vector_scaling_parameters";
     @Deprecated
     static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
 
@@ -619,6 +641,7 @@ public abstract class Controller
         }
     }
 
+
     /**
      * Return the flush sstable size in bytes.
      *
@@ -850,6 +873,12 @@ public abstract class Controller
 
     public static Controller fromOptions(CompactionRealm realm, Map<String, String> options)
     {
+        boolean vectorOverride = options.containsKey(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION)
+                ? Boolean.parseBoolean(options.get(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION))
+                : DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
+        boolean useVectorOptions = realm.metadata().hasVectorType() && vectorOverride;
+        if (useVectorOptions)
+            logger.debug("Using UCS configuration optimized for vector.");
         boolean adaptive = options.containsKey(ADAPTIVE_OPTION) ? Boolean.parseBoolean(options.get(ADAPTIVE_OPTION)) : DEFAULT_ADAPTIVE;
         long dataSetSize = getSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30, DEFAULT_DATASET_SIZE);
         long flushSizeOverride = getSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20, 0);
@@ -873,19 +902,40 @@ public abstract class Controller
         {
             baseShardCount = DEFAULT_BASE_SHARD_COUNT;
         }
+        int vectorBaseShardCount;
+        if (options.containsKey(VECTOR_BASE_SHARD_COUNT_OPTION))
+        {
+            vectorBaseShardCount = Integer.parseInt(options.get(VECTOR_BASE_SHARD_COUNT_OPTION));
+        }
+        else
+        {
+            vectorBaseShardCount = VECTOR_DEFAULT_BASE_SHARD_COUNT;
+        }
 
         long targetSStableSize = options.containsKey(TARGET_SSTABLE_SIZE_OPTION)
                                  ? FBUtilities.parseHumanReadableBytes(options.get(TARGET_SSTABLE_SIZE_OPTION))
                                  : DEFAULT_TARGET_SSTABLE_SIZE;
+        long vectorTargetSStableSize = options.containsKey(VECTOR_TARGET_SSTABLE_SIZE_OPTION)
+                                 ? FBUtilities.parseHumanReadableBytes(options.get(VECTOR_TARGET_SSTABLE_SIZE_OPTION))
+                                 : VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
         long minSSTableSize = getSizeWithAltAndSpecial(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, DEFAULT_MIN_SSTABLE_SIZE);
+        long vectorMinSSTableSize = getSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
 
         double sstableGrowthModifier = DEFAULT_SSTABLE_GROWTH;
         if (options.containsKey(SSTABLE_GROWTH_OPTION))
             sstableGrowthModifier = FBUtilities.parsePercent(options.get(SSTABLE_GROWTH_OPTION));
 
+        double vectorSSTableGrowthModifier = VECTOR_DEFAULT_SSTABLE_GROWTH;
+        if (options.containsKey(VECTOR_SSTABLE_GROWTH_OPTION))
+            vectorSSTableGrowthModifier = FBUtilities.parsePercent(options.get(VECTOR_SSTABLE_GROWTH_OPTION));
+
         int reservedThreadsPerLevel = options.containsKey(RESERVED_THREADS_OPTION)
                                       ? FBUtilities.parseIntAllowingMax(options.get(RESERVED_THREADS_OPTION))
                                       : DEFAULT_RESERVED_THREADS;
+
+        int vectorReservedThreadsPerLevel = options.containsKey(VECTOR_RESERVED_THREADS_OPTION)
+                                      ? FBUtilities.parseIntAllowingMax(options.get(VECTOR_RESERVED_THREADS_OPTION))
+                                      : VECTOR_DEFAULT_RESERVED_THREADS;
         Reservations.Type reservationsType = options.containsKey(RESERVATIONS_TYPE_OPTION)
                                                   ? Reservations.Type.valueOf(options.get(RESERVATIONS_TYPE_OPTION).toUpperCase())
                                                   : DEFAULT_RESERVED_THREADS_TYPE;
@@ -938,16 +988,16 @@ public abstract class Controller
                ? AdaptiveController.fromOptions(env,
                                                 survivalFactors,
                                                 dataSetSize,
-                                                minSSTableSize,
+                                                useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
                                                 flushSizeOverride,
                                                 maxSpaceOverhead,
                                                 maxSSTablesToCompact,
                                                 expiredSSTableCheckFrequency,
                                                 ignoreOverlapsInExpirationCheck,
-                                                baseShardCount,
-                                                targetSStableSize,
-                                                sstableGrowthModifier,
-                                                reservedThreadsPerLevel,
+                                                useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                                useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
+                                                useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
+                                                useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
                                                 reservationsType,
                                                 overlapInclusionMethod,
                                                 realm.getKeyspaceName(),
@@ -956,21 +1006,22 @@ public abstract class Controller
                : StaticController.fromOptions(env,
                                               survivalFactors,
                                               dataSetSize,
-                                              minSSTableSize,
+                                              useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
                                               flushSizeOverride,
                                               maxSpaceOverhead,
                                               maxSSTablesToCompact,
                                               expiredSSTableCheckFrequency,
                                               ignoreOverlapsInExpirationCheck,
-                                              baseShardCount,
-                                              targetSStableSize,
-                                              sstableGrowthModifier,
-                                              reservedThreadsPerLevel,
+                                              useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                              useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
+                                              useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
+                                              useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
                                               reservationsType,
                                               overlapInclusionMethod,
                                               realm.getKeyspaceName(),
                                               realm.getTableName(),
-                                              options);
+                                              options,
+                                              useVectorOptions);
     }
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
@@ -984,7 +1035,9 @@ public abstract class Controller
         String s;
         boolean adaptive = DEFAULT_ADAPTIVE;
         long minSSTableSize = -1;
+        long vectorMinSSTableSize = -1;
         long targetSSTableSize = DEFAULT_TARGET_SSTABLE_SIZE;
+        long vectorTargetSSTableSize = VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
 
         s = options.remove(NUM_SHARDS_OPTION);
         if (s != null)
@@ -1025,6 +1078,7 @@ public abstract class Controller
         }
 
         minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, DEFAULT_MIN_SSTABLE_SIZE);
+        vectorMinSSTableSize = validateSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
         validateSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20);
         validateSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30);
 
@@ -1092,6 +1146,13 @@ public abstract class Controller
                                                            ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_OPTION, s));
         }
 
+        s = options.remove(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION);
+        if (s != null && !s.equalsIgnoreCase("true") && !s.equalsIgnoreCase("false"))
+        {
+            throw new ConfigurationException(String.format(booleanParseErr,
+                                                           OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, s));
+        }
+
         s = options.remove(BASE_SHARD_COUNT_OPTION);
         if (s != null)
         {
@@ -1106,6 +1167,23 @@ public abstract class Controller
             catch (NumberFormatException e)
             {
                 throw new ConfigurationException(String.format(intParseErr, s, BASE_SHARD_COUNT_OPTION), e);
+            }
+        }
+
+        s = options.remove(VECTOR_BASE_SHARD_COUNT_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                int numShards = Integer.parseInt(s);
+                if (numShards <= 0)
+                    throw new ConfigurationException(String.format(nonPositiveErr,
+                                                                   VECTOR_BASE_SHARD_COUNT_OPTION,
+                                                                   numShards));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format(intParseErr, s, VECTOR_BASE_SHARD_COUNT_OPTION), e);
             }
         }
 
@@ -1125,6 +1203,27 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
                                                                TARGET_SSTABLE_SIZE_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
+        s = options.remove(VECTOR_TARGET_SSTABLE_SIZE_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                vectorTargetSSTableSize = FBUtilities.parseHumanReadableBytes(s);
+                if (vectorTargetSSTableSize < MIN_TARGET_SSTABLE_SIZE)
+                    throw new ConfigurationException(String.format("%s %s is not acceptable, size must be at least %s",
+                                                                   VECTOR_TARGET_SSTABLE_SIZE_OPTION,
+                                                                   s,
+                                                                   FBUtilities.prettyPrintMemory(MIN_TARGET_SSTABLE_SIZE)));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
+                                                               VECTOR_TARGET_SSTABLE_SIZE_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1150,6 +1249,26 @@ public abstract class Controller
             }
         }
 
+        s = options.remove(VECTOR_SSTABLE_GROWTH_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                double targetSSTableGrowth = FBUtilities.parsePercent(s);
+                if (targetSSTableGrowth < 0 || targetSSTableGrowth > 1)
+                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
+                                                                   VECTOR_SSTABLE_GROWTH_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
+                                                               VECTOR_SSTABLE_GROWTH_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
         s = options.remove(RESERVED_THREADS_OPTION);
         if (s != null)
         {
@@ -1165,6 +1284,26 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
                                                                RESERVED_THREADS_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
+        s = options.remove(VECTOR_RESERVED_THREADS_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                int reservedThreads = FBUtilities.parseIntAllowingMax(s);
+                if (reservedThreads < 0)
+                    throw new ConfigurationException(String.format("%s %s must be an integer >= 0 or \"max\"",
+                                                                   VECTOR_RESERVED_THREADS_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
+                                                               VECTOR_RESERVED_THREADS_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1204,6 +1343,10 @@ public abstract class Controller
             throw new ConfigurationException(String.format("The minimum sstable size %s cannot be larger than the target size's lower bound %s.",
                                                            FBUtilities.prettyPrintMemory(minSSTableSize),
                                                            FBUtilities.prettyPrintMemory((long) (targetSSTableSize * INVERSE_SQRT_2))));
+        if (vectorMinSSTableSize > vectorTargetSSTableSize * INVERSE_SQRT_2)
+            throw new ConfigurationException(String.format("The vector minimum sstable size %s cannot be larger than the target size's lower bound %s.",
+                                                           FBUtilities.prettyPrintMemory(vectorMinSSTableSize),
+                                                           FBUtilities.prettyPrintMemory((long) (vectorTargetSSTableSize * INVERSE_SQRT_2))));
 
         return adaptive ? AdaptiveController.validateOptions(options) : StaticController.validateOptions(options);
     }
@@ -1224,6 +1367,17 @@ public abstract class Controller
             return specialValue;
         else
             return getSizeWithAlt(options, optionHumanReadable, optionAlt, altShift, defaultValue);
+    }
+
+    private static long getSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
+    {
+        if (specialText.equalsIgnoreCase(options.get(optionHumanReadable)))
+            return specialValue;
+        else if (options.containsKey(optionHumanReadable))
+            return FBUtilities.parseHumanReadableBytes(options.get(optionHumanReadable));
+        else
+            return defaultValue;
+
     }
 
     private static void validateSizeWithAlt(Map<String, String> options, String optionHumanReadable, String optionAlt, int altShift)
@@ -1275,6 +1429,47 @@ public abstract class Controller
         if (sizeInBytes < 0)
             throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
                                                            opt,
+                                                           s));
+        return sizeInBytes;
+    }
+
+    private static long validateSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
+    {
+        long sizeInBytes;
+        String s = null;
+        try
+        {
+            s = options.remove(optionHumanReadable);
+            if (s != null)
+            {
+                if (s.equalsIgnoreCase(specialText))
+                    return specialValue; // all good
+                sizeInBytes = FBUtilities.parseHumanReadableBytes(s);
+            }
+            else
+            {
+                return defaultValue;
+            }
+
+        }
+        catch (NumberFormatException e)
+        {
+            if (specialText != null)
+                throw new ConfigurationException(String.format("%s must be a valid size in bytes or %s for %s",
+                                                               s,
+                                                               specialText,
+                                                               optionHumanReadable),
+                                                 e);
+            else
+                throw new ConfigurationException(String.format("%s is not a valid size in bytes for %s",
+                                                               s,
+                                                               optionHumanReadable),
+                                                 e);
+        }
+
+        if (sizeInBytes < 0)
+            throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
+                                                           optionHumanReadable,
                                                            s));
         return sizeInBytes;
     }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -156,8 +156,8 @@ public abstract class Controller
     static final String BASE_SHARD_COUNT_OPTION = "base_shard_count";
     static final String VECTOR_BASE_SHARD_COUNT_OPTION = "vector_base_shard_count";
     /**
-     * Default base shard count, used when a base count is not explicitly supplied. This value applies as long as the
-     * table is not a system one, and directories are not defined.
+     * Default base shard count, used when a base count is not explicitly supplied. This value applies to all tables as
+     * long as they are larger than the minimum sstable size.
      *
      * For others a base count of 1 is used as system tables are usually small and do not need as much compaction
      * parallelism, while having directories defined provides for parallelism in a different way.

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -171,7 +171,7 @@ public abstract class Controller
      */
     static final String TARGET_SSTABLE_SIZE_OPTION = "target_sstable_size";
     static final String VECTOR_TARGET_SSTABLE_SIZE_OPTION = "vector_target_sstable_size";
-    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
+    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "1GiB"));
     public static final long VECTOR_DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
     static final long MIN_TARGET_SSTABLE_SIZE = 1L << 20;
 
@@ -203,7 +203,7 @@ public abstract class Controller
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
     static final String VECTOR_SSTABLE_GROWTH_OPTION = "vector_sstable_growth";
-    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.5"));
+    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.333"));
     static final double VECTOR_DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + VECTOR_SSTABLE_GROWTH_OPTION, "1.0"));
 
     /**

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -886,8 +886,13 @@ public abstract class Controller
                 ? Boolean.parseBoolean(options.get(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION))
                 : DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
         boolean useVectorOptions = hasVectorType && vectorOverride;
-        if (useVectorOptions)
-            logger.debug("Using UCS configuration optimized for vector.");
+        if (logger.isTraceEnabled())
+        {
+            if (useVectorOptions)
+                logger.trace("Using UCS configuration optimized for vector for {}.{}", realm.getKeyspaceName(), realm.getTableName());
+            else
+                logger.trace("Using non-vector UCS configuration for {}.{}", realm.getKeyspaceName(), realm.getTableName());
+        }
         boolean adaptive = options.containsKey(ADAPTIVE_OPTION) ? Boolean.parseBoolean(options.get(ADAPTIVE_OPTION)) : DEFAULT_ADAPTIVE;
         long dataSetSize = getSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30, DEFAULT_DATASET_SIZE);
         long flushSizeOverride = getSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20, 0);

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -46,6 +46,7 @@ public class StaticController extends Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     private static final String DEFAULT_STATIC_SCALING_PARAMETERS = getSystemProperty(SCALING_PARAMETERS_OPTION, "T4");
+    private static final String VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + VECTOR_SCALING_PARAMETERS_OPTION, "-8");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation
@@ -108,13 +109,17 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   String keyspaceName,
                                   String tableName,
-                                  Map<String, String> options)
+                                  Map<String, String> options,
+                                  boolean useVectorOptions)
     {
         int[] scalingParameters;
         if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
             scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
         else
             scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
+
+        int[] vectorScalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
+
         long currentFlushSize = flushSizeOverride;
 
         File f = getControllerConfigPath(keyspaceName, tableName);
@@ -137,7 +142,7 @@ public class StaticController extends Controller
             logger.warn("Unable to parse saved flush size. Using starting value instead:", e);
         }
         return new StaticController(env,
-                                    scalingParameters,
+                                    useVectorOptions ? vectorScalingParameters : scalingParameters,
                                     survivalFactors,
                                     dataSetSize,
                                     minSSTableSize,
@@ -167,6 +172,9 @@ public class StaticController extends Controller
             parseScalingParameters(factors);
         if (parameters != null && factors != null)
             throw new ConfigurationException(String.format("Either '%s' or '%s' should be used, not both", SCALING_PARAMETERS_OPTION, STATIC_SCALING_FACTORS_OPTION));
+        String vectorParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
+        if (vectorParameters != null)
+            parseScalingParameters(vectorParameters);
         return options;
     }
 
@@ -207,6 +215,9 @@ public class StaticController extends Controller
     @Override
     public String toString()
     {
-        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSSTableSize, Arrays.toString(survivalFactors), printScalingParameters(scalingParameters), calculator);
+        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSSTableSize,
+                             Arrays.toString(survivalFactors),
+                             printScalingParameters(scalingParameters),
+                             calculator);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -67,6 +67,7 @@ public class StaticController extends Controller
                             int reservedThreadsPerLevel,
                             Reservations.Type reservationsType,
                             Overlaps.InclusionMethod overlapInclusionMethod,
+                            boolean hasVectorType,
                             String keyspaceName,
                             String tableName)
     {
@@ -86,7 +87,8 @@ public class StaticController extends Controller
               sstableGrowthModifier,
               reservedThreadsPerLevel,
               reservationsType,
-              overlapInclusionMethod);
+              overlapInclusionMethod,
+              hasVectorType);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
         this.tableName = tableName;
@@ -107,6 +109,7 @@ public class StaticController extends Controller
                                   int reservedThreadsPerLevel,
                                   Reservations.Type reservationsType,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
+                                  boolean hasVectorType,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options,
@@ -158,6 +161,7 @@ public class StaticController extends Controller
                                     reservedThreadsPerLevel,
                                     reservationsType,
                                     overlapInclusionMethod,
+                                    hasVectorType,
                                     keyspaceName,
                                     tableName);
     }

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -421,6 +421,16 @@ public class TableMetadata implements SchemaElement
         return !staticColumns().isEmpty();
     }
 
+    public boolean hasVectorType()
+    {
+        for (ColumnMetadata column : columns.values())
+        {
+            if (column.type.isVector())
+                return true;
+        }
+        return false;
+    }
+
     public final void validate()
     {
         validate(false);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -407,6 +407,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          0,
                                                          Reservations.Type.PER_LEVEL,
                                                          overlapInclusionMethod,
+                                                         false,
                                                          updateTimeSec,
                                                          minW,
                                                          maxW,
@@ -432,6 +433,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        0,
                                                        Reservations.Type.PER_LEVEL,
                                                        overlapInclusionMethod,
+                                                       false,
                                                        "ks",
                                                        "tbl");
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -84,6 +84,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       Controller.DEFAULT_RESERVED_THREADS,
                                       Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
+                                      false,
                                       interval,
                                       minW,
                                       maxW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -151,6 +152,29 @@ public class StaticControllerTest extends ControllerTest
         addOptions(false, options);
 
         super.testValidateOptions(options, false);
+    }
+
+    @Test
+    public void testValidateVectorOptions()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put(Controller.VECTOR_BASE_SHARD_COUNT_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_SSTABLE_GROWTH_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_RESERVED_THREADS_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_MIN_SSTABLE_SIZE_OPTION, "10GiB");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_TARGET_SSTABLE_SIZE_OPTION, "-1MiB");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, "not true");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -225,6 +225,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testStartShutdown(controller);
@@ -250,6 +251,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testShutdownNotStarted(controller);
@@ -275,6 +277,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS,
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testStartAlreadyStarted(controller);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.ReplicationFactor;
 import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -40,6 +41,13 @@ import static org.mockito.Mockito.when;
 public class StaticControllerTest extends ControllerTest
 {
     static final int[] Ws = new int[] { 30, 2, 0, -6};
+    static final int[] VectorWs = new int[] {-8, -8, -8, -8};
+    static final int vectorBaseShardCount = 1;
+    static final double vectorSstableGrowthModifier = 1;
+    static final int vectorReservedThreads = Integer.MAX_VALUE;
+    static final int vectorScalingParameter = -8;
+    static final String vectorMinSSTableSize = "1024MiB";
+    static final String  vectorTargetSSTableSize = "5GiB";
 
     @Test
     public void testFromOptions()
@@ -63,6 +71,17 @@ public class StaticControllerTest extends ControllerTest
                             .collect(Collectors.joining(","));
         options.put(StaticController.SCALING_PARAMETERS_OPTION, wStr);
         options.put(Controller.SSTABLE_GROWTH_OPTION, "0");
+    }
+
+    private static void addVectorOptions(Map<String, String> options)
+    {
+        options.put(Controller.VECTOR_BASE_SHARD_COUNT_OPTION, String.valueOf(vectorBaseShardCount));
+        options.put(Controller.VECTOR_SSTABLE_GROWTH_OPTION, String.valueOf(vectorSstableGrowthModifier));
+        options.put(Controller.VECTOR_RESERVED_THREADS_OPTION, String.valueOf(vectorReservedThreads));
+        options.put(Controller.VECTOR_SCALING_PARAMETERS_OPTION, String.valueOf(vectorScalingParameter));
+        options.put(Controller.VECTOR_MIN_SSTABLE_SIZE_OPTION, vectorMinSSTableSize);
+        options.put(Controller.VECTOR_TARGET_SSTABLE_SIZE_OPTION, vectorTargetSSTableSize);
+        options.put(Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, String.valueOf(true));
     }
 
     @Test
@@ -97,6 +116,32 @@ public class StaticControllerTest extends ControllerTest
             assertEquals(Ws[i], controller.getScalingParameter(i));
 
         assertEquals(Ws[Ws.length-1], controller.getScalingParameter(Ws.length));
+    }
+
+    @Test
+    public void testFromOptionsVectorTable()
+    {
+        Map<String, String> options = new HashMap<>();
+        addOptions(false, options);
+        addVectorOptions(options);
+
+        Controller controller = testFromOptions(false, options);
+        assertTrue(controller instanceof StaticController);
+
+        for (int i = 0; i < Ws.length; i++)
+            assertEquals(Ws[i], controller.getScalingParameter(i));
+
+        assertEquals(Ws[Ws.length-1], controller.getScalingParameter(Ws.length));
+
+        controller = testFromOptionsVector(false, options);
+
+        assertEquals(vectorBaseShardCount, controller.baseShardCount);
+        assertEquals(vectorSstableGrowthModifier, controller.sstableGrowthModifier, 0.01);
+        assertEquals(FBUtilities.parseHumanReadableBytes(vectorMinSSTableSize), controller.minSSTableSize);
+        assertEquals(vectorReservedThreads, controller.getReservedThreads());
+        assertEquals(FBUtilities.parseHumanReadableBytes(vectorTargetSSTableSize), controller.getTargetSSTableSize());
+        for (int i = 0; i < Ws.length; i++)
+            assertEquals(vectorScalingParameter, controller.getScalingParameter(i));
     }
 
     @Test
@@ -198,7 +243,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
-                                                           Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
+                                                           Controller.DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
                                                            numShards,
                                                            sstableSizeMB << 20,
                                                            Controller.DEFAULT_SSTABLE_GROWTH,
@@ -223,7 +268,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
-                                                           Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
+                                                           Controller.DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
                                                            numShards,
                                                            sstableSizeMB << 20,
                                                            Controller.DEFAULT_SSTABLE_GROWTH,


### PR DESCRIPTION
Added `unified_compaction.override_ucs_config_for_vector_tables` system property.  When set, the ucs configuration will be changed to the provided (or default) vector configuration whenever a new table with a `VectorType` is created or a `VectorType` is added to an existing table.  

I've added additional options to allow for different configurations for vector vs non-vector tables.  For instance, a user can set `unified_compaction.sstable_growth=0` and `unified_compaction.vector_sstable_growth=1`.  In this case, the value of 0 will be used unless the table has a `VectorType` and `unified_compaction.override_ucs_config_for_vector_tables` is set to `true`.

CNDB issue: https://github.com/riptano/cndb/issues/10455