### PR TITLE
Fix hybrid vector query bug when sstable has rows with null vectors

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -585,9 +585,11 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                 // Increment here to simplify the sstableRowId < 0 logic.
                 i++;
 
-                // these should still be true based on our computation of keysInRange
-                assert sstableRowId >= metadata.minSSTableRowId : String.format("sstableRowId %d < minSSTableRowId %d", sstableRowId, metadata.minSSTableRowId);
-                assert sstableRowId <= metadata.maxSSTableRowId : String.format("sstableRowId %d > maxSSTableRowId %d", sstableRowId, metadata.maxSSTableRowId);
+                // During compaction, the SegmentMetadata is written based on the rows with vector values. Therefore,
+                // we can find a row that has a row id but is outside the min/max range of the segment. We can ignore
+                // these rows here and skip the row id to ordinal conversion that would result in a -1 ordinal.
+                if (sstableRowId < metadata.minSSTableRowId || sstableRowId > metadata.maxSSTableRowId)
+                    continue;
 
                 // convert the global row id to segment row id and from segment row id to graph ordinal
                 int segmentRowId = metadata.toSegmentRowId(sstableRowId);

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1935,8 +1935,9 @@ public abstract class CQLTester
     }
 
     /**
-     * Runs the given function before and after a flush of sstables.  This is useful for checking that behavior is
-     * the same whether data is in memtables or sstables.
+     * Runs the given function before a flush, after a flush, and finally after a compaction of the table. This is
+     * useful for checking that behavior is the same whether data is in memtables, memtable-flushed-sstbales,
+     * compaction-built-sstables.
      * @param runnable
      * @throws Throwable
      */

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1934,6 +1934,28 @@ public abstract class CQLTester
         }
     }
 
+    /**
+     * Runs the given function before and after a flush of sstables.  This is useful for checking that behavior is
+     * the same whether data is in memtables or sstables.
+     * @param runnable
+     * @throws Throwable
+     */
+    public void runThenFlushThenCompact(CheckedFunction runnable) throws Throwable
+    {
+        beforeAndAfterFlush(runnable);
+
+        compact();
+
+        try
+        {
+            runnable.apply();
+        }
+        catch (Throwable t)
+        {
+            throw new AssertionError("Test failed after compact:\n" + t, t);
+        }
+    }
+
     private static String replaceValues(String query, Object[] values)
     {
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/10810

We hit:

```
java.lang.AssertionError: sstableRowId 315407 > maxSSTableRowId 315406
     	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.flatmapPrimaryKeysToBitsAndRows(V2VectorIndexSearcher.java:615)
     	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.orderResultsBy(V2VectorIndexSearcher.java:509)
     	at org.apache.cassandra.index.sai.disk.v1.Segment.orderResultsBy(Segment.java:183)
     	at org.apache.cassandra.index.sai.disk.v1.V1SearchableIndex.orderResultsBy(V1SearchableIndex.java:213)
     	at org.apache.cassandra.index.sai.SSTableIndex.orderResultsBy(SSTableIndex.java:292)
     	at org.apache.cassandra.index.sai.plan.QueryController.lambda$orderSstables$10(QueryController.java:623)
     	... 23 common frames omitted
```

Notably, this bug happened after compaction, not just after flush. I added a new utility method to make it easier to test compaction code path.