### PR TITLE
CNDB-10731: Add support for index analyzers to RowFilter

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.marshal.*;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -407,8 +406,7 @@ public enum Operator
         @Override
         public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            if (analyzer == null)
-                throw new InvalidRequestException(": operation can only be computed by an indexed column with a configured analyzer");
+            assert analyzer != null : ": operation can only be computed by an indexed column with a configured analyzer";
 
             List<ByteBuffer> leftTokens = analyzer.analyze(leftOperand);
             List<ByteBuffer> rightTokens = analyzer.analyze(rightOperand);

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -21,11 +21,16 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 public enum Operator
@@ -39,8 +44,11 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
+            if (analyzer != null)
+                return ANALYZER_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
+
             return type.compareForCQL(leftOperand, rightOperand) == 0;
         }
     },
@@ -53,7 +61,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return type.compareForCQL(leftOperand, rightOperand) < 0;
         }
@@ -67,7 +75,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return type.compareForCQL(leftOperand, rightOperand) <= 0;
         }
@@ -81,7 +89,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return type.compareForCQL(leftOperand, rightOperand) >= 0;
         }
@@ -95,7 +103,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return type.compareForCQL(leftOperand, rightOperand) > 0;
         }
@@ -108,7 +116,7 @@ public enum Operator
             return "IN";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             List<?> inValues = ListType.getInstance(type, false).getSerializer().deserialize(rightOperand);
             return inValues.contains(type.getSerializer().deserialize(leftOperand));
@@ -123,7 +131,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             switch(((CollectionType<?>) type).kind)
             {
@@ -153,7 +161,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             MapType<?, ?> mapType = (MapType<?, ?>) type;
             Map<?, ?> map = mapType.getSerializer().deserialize(leftOperand);
@@ -170,7 +178,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return type.compareForCQL(leftOperand, rightOperand) != 0;
 
@@ -185,7 +193,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             throw new UnsupportedOperationException();
         }
@@ -199,7 +207,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return ByteBufferUtil.startsWith(leftOperand, rightOperand);
         }
@@ -213,7 +221,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return ByteBufferUtil.endsWith(leftOperand, rightOperand);
         }
@@ -227,7 +235,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return ByteBufferUtil.contains(leftOperand, rightOperand);
         }
@@ -240,7 +248,7 @@ public enum Operator
             return "LIKE '<term>'";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return ByteBufferUtil.contains(leftOperand, rightOperand);
         }
@@ -254,7 +262,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             throw new UnsupportedOperationException();
         }
@@ -268,7 +276,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             return true;
         }
@@ -281,9 +289,9 @@ public enum Operator
             return "NOT IN";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !IN.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !IN.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_CONTAINS(17)
@@ -295,9 +303,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
 
     },
@@ -310,9 +318,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !CONTAINS_KEY.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !CONTAINS_KEY.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_LIKE_PREFIX(19)
@@ -324,9 +332,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !LIKE_PREFIX.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !LIKE_PREFIX.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_LIKE_SUFFIX(20)
@@ -338,9 +346,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !LIKE_SUFFIX.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !LIKE_SUFFIX.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_LIKE_CONTAINS(21)
@@ -352,9 +360,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !LIKE_CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !LIKE_CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_LIKE_MATCHES(22)
@@ -365,9 +373,9 @@ public enum Operator
             return "NOT LIKE '<term>'";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !LIKE_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !LIKE_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
     NOT_LIKE(23)
@@ -379,9 +387,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            return !LIKE.isSatisfiedBy(type, leftOperand, rightOperand);
+            return !LIKE.isSatisfiedBy(type, leftOperand, rightOperand, analyzer);
         }
     },
 
@@ -396,14 +404,33 @@ public enum Operator
             return ":";
         }
 
-        /**
-         * This method is not supported for this operator. The operator itself does not have the context to know
-         * the correct result because an analyzed column can be analyzed in different ways. Therefore, this operator
-         * relies on the index implementation to perform to determine satisfaction.
-         */
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            throw new UnsupportedOperationException(": operation can only be computed by an indexed column with a configured analyzer");
+            if (analyzer == null)
+                throw new InvalidRequestException(": operation can only be computed by an indexed column with a configured analyzer");
+
+            List<ByteBuffer> leftTokens = analyzer.analyze(leftOperand);
+            List<ByteBuffer> rightTokens = analyzer.analyze(rightOperand);
+
+            Iterator<ByteBuffer> it = rightTokens.iterator();
+
+            do {
+                if (!it.hasNext())
+                    return true;
+            } while (hasToken(type, leftTokens, it.next()));
+
+            return false;
+        }
+
+        private boolean hasToken(AbstractType<?> type, List<ByteBuffer> tokens, ByteBuffer token)
+        {
+            for (ByteBuffer t : tokens)
+            {
+                if (type.compareForCQL(t, token) == 0)
+                    return true;
+            }
+            return false;
         }
     },
     /**
@@ -411,7 +438,7 @@ public enum Operator
      * that all result vectors are within a given distance of the query vector. The notable difference between this
      * operator and {@link #ANN} is that it does not introduce an arbitrary limit on the number of results returned,
      * and as a consequence, it can be logically combined with other predicates and even unioned with other
-     * {@link #BOUNDED_ANN} predicates.
+     * {@code #BOUNDED_ANN} predicates.
      */
     BOUNDED_ANN(101)
     {
@@ -422,7 +449,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             throw new UnsupportedOperationException();
         }
@@ -437,7 +464,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             throw new UnsupportedOperationException();
         }
@@ -451,7 +478,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             throw new UnsupportedOperationException();
         }
@@ -466,7 +493,7 @@ public enum Operator
      * Creates a new <code>Operator</code> with the specified binary representation.
      * @param b the binary representation of this <code>Enum</code> value
      */
-    private Operator(int b)
+    Operator(int b)
     {
         this.b = b;
     }
@@ -506,8 +533,14 @@ public enum Operator
 
     /**
      * Whether 2 values satisfy this operator (given the type they should be compared with).
+     *
+     * @param type the type of the values to compare.
+     * @param leftOperand the left operand of the comparison.
+     * @param rightOperand the right operand of the comparison.
+     * @param analyzer an index-provided function to transform the compared values before comparison, or {@code null} if
+     * the values don't need to be transformed.
      */
-    public abstract boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand);
+    public abstract boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer);
 
     public int serializedSize()
     {

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -415,10 +415,12 @@ public enum Operator
 
             Iterator<ByteBuffer> it = rightTokens.iterator();
 
-            do {
+            do
+            {
                 if (!it.hasNext())
                     return true;
-            } while (hasToken(type, leftTokens, it.next()));
+            }
+            while (hasToken(type, leftTokens, it.next()));
 
             return false;
         }

--- a/src/java/org/apache/cassandra/cql3/conditions/AbstractConditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/AbstractConditions.java
@@ -17,8 +17,13 @@
  */
 package org.apache.cassandra.cql3.conditions;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.functions.Function;
 
@@ -32,9 +37,16 @@ abstract class AbstractConditions implements Conditions
     {
     }
 
+    @Override
     public Iterable<ColumnMetadata> getColumns()
     {
         return null;
+    }
+
+    @Override
+    public Set<ColumnMetadata> getAnalyzedColumns(IndexRegistry indexRegistry)
+    {
+        return Collections.emptySet();
     }
 
     public boolean isEmpty()

--- a/src/java/org/apache/cassandra/cql3/conditions/AbstractConditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/AbstractConditions.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.functions.Function;

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -255,7 +255,7 @@ public abstract class ColumnCondition
                 // the condition value is not null, so only NEQ can return true
                 return operator == Operator.NEQ;
             }
-            return operator.isSatisfiedBy(type, otherValue, value);
+            return operator.isSatisfiedBy(type, otherValue, value, null); // We don't use any analyzers in LWT, see CNDB-11658
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -41,6 +41,8 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.*;
  */
 public abstract class ColumnCondition
 {
+    public static final String ANALYZER_MATCHES_ERROR = "LWT Conditions do not support the : operator";
+
     public final ColumnMetadata column;
     public final Operator operator;
     private final Terms terms;
@@ -783,7 +785,7 @@ public abstract class ColumnCondition
 
             // Analyzer matches operator is only supported on SAI indexes for now
             if (operator == Operator.ANALYZER_MATCHES)
-                throw invalidRequest("LWT Conditions do not support the : operator");
+                throw invalidRequest(ANALYZER_MATCHES_ERROR);
 
             if (collectionElement != null)
             {

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnConditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnConditions.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,6 +29,7 @@ import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.CQL3CasRequest;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -75,6 +77,15 @@ public final class ColumnConditions extends AbstractConditions
         return Stream.concat(columnConditions.stream(), staticConditions.stream())
                      .map(e -> e.column)
                      .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<ColumnMetadata> getAnalyzedColumns(IndexRegistry indexRegistry)
+    {
+        return Stream.concat(columnConditions.stream(), staticConditions.stream())
+                     .filter(c -> indexRegistry.getAnalyzerFor(c.column, c.operator).isPresent())
+                     .map(c -> c.column)
+                     .collect(Collectors.toSet());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/conditions/Conditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/Conditions.java
@@ -17,12 +17,17 @@
  */
 package org.apache.cassandra.cql3.conditions;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.CQL3CasRequest;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 
 /**
@@ -56,7 +61,13 @@ public interface Conditions
      * Returns the column definitions to which apply the conditions.
      * @return the column definitions to which apply the conditions.
      */
+    @Nullable
     Iterable<ColumnMetadata> getColumns();
+
+    /**
+     * @return the column definitions of the conditions supported by a {@link org.apache.cassandra.index.Index.Analyzer}.
+     */
+    Set<ColumnMetadata> getAnalyzedColumns(IndexRegistry indexRegistry);
 
     /**
      * Checks if this <code>Conditions</code> is empty.

--- a/src/java/org/apache/cassandra/cql3/conditions/Conditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/Conditions.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.cql3.conditions;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -75,6 +75,8 @@ public class StatementRestrictions
     public static final String INDEX_DOES_NOT_SUPPORT_DISJUNCTION =
     "An index involved in this query does not support disjunctive queries using the OR operator";
 
+    public static final String RESTRICTION_REQUIRES_INDEX_MESSAGE = "%s restriction is only supported on properly indexed columns. %s is not valid.";
+
     public static final String PARTITION_KEY_RESTRICTION_MUST_BE_TOP_LEVEL =
     "Restriction on partition key column %s must not be nested under OR operator";
 
@@ -391,7 +393,7 @@ public class StatementRestrictions
                     {
                         if (getColumnsWithUnsupportedIndexRestrictions(table, ImmutableList.of(restriction)).isEmpty())
                         {
-                            throw invalidRequest("LIKE restriction is only supported on properly indexed columns. %s is not valid.", relation.toString());
+                            throw invalidRequest(RESTRICTION_REQUIRES_INDEX_MESSAGE, relation.operator(), relation.toString());
                         }
                         else
                         {
@@ -408,7 +410,7 @@ public class StatementRestrictions
                         {
                             if (getColumnsWithUnsupportedIndexRestrictions(table, ImmutableList.of(restriction)).isEmpty())
                             {
-                                throw invalidRequest(": restriction is only supported on properly indexed columns. %s is not valid.", relation.toString());
+                                throw invalidRequest(RESTRICTION_REQUIRES_INDEX_MESSAGE, relation.operator(), relation.toString());
                             }
                             else
                             {
@@ -988,7 +990,7 @@ public class StatementRestrictions
         if (filterRestrictions.isEmpty() && children.isEmpty())
             return RowFilter.NONE;
 
-        return RowFilter.builder().buildFromRestrictions(this, indexManager, table, options);
+        return RowFilter.builder(indexManager).buildFromRestrictions(this, table, options);
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.cql3.statements;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Iterables;
@@ -285,8 +284,9 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         Set<ColumnMetadata> analyzedColumns = conditions.getAnalyzedColumns(indexRegistry);
         if (!analyzedColumns.isEmpty())
         {
-            ClientWarn.instance.warn(String.format(AnalyzerEqOperatorSupport.LWT_CONDITION_ON_ANALYZED_WARNING,
-                                                   analyzedColumns.stream().map(c -> c.name.toString()).collect(Collectors.joining(", "))));
+            StringJoiner joiner = new StringJoiner(", ");
+            analyzedColumns.forEach(c -> joiner.add(c.name.toString()));
+            ClientWarn.instance.warn(String.format(AnalyzerEqOperatorSupport.LWT_CONDITION_ON_ANALYZED_WARNING, joiner));
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.statements;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Iterables;
@@ -27,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.index.IndexRegistry;
+import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
@@ -49,6 +52,7 @@ import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.StorageService;
@@ -275,6 +279,15 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         // there are system queries with USING TIMESTAMP, e.g. SchemaKeyspace#saveSystemKeyspacesSchema
         if (SchemaConstants.isUserKeyspace(metadata.keyspace) && attrs.isTimestampSet())
             Guardrails.userTimestampsEnabled.ensureEnabled(state);
+
+        // Warn but otherwise accept conditions on analyzed columns. The analyzers won't be used (see CNDB-11658).
+        IndexRegistry indexRegistry = IndexRegistry.obtain(metadata);
+        Set<ColumnMetadata> analyzedColumns = conditions.getAnalyzedColumns(indexRegistry);
+        if (!analyzedColumns.isEmpty())
+        {
+            ClientWarn.instance.warn(String.format(AnalyzerEqOperatorSupport.LWT_CONDITION_ON_ANALYZED_WARNING,
+                                                   analyzedColumns.stream().map(c -> c.name.toString()).collect(Collectors.joining(", "))));
+        }
     }
 
     public RegularAndStaticColumns updatedColumns()

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -761,7 +761,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             PartitionRangeReadQuery.create(table, nowInSec, columnFilter, rowFilter, limit, new DataRange(keyBounds, clusteringIndexFilter));
 
         // If there's a secondary index that the command can use, have it validate the request parameters.
-        command.maybeValidateIndex();
+        command.maybeValidateIndexes();
 
         return command;
     }

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -269,6 +269,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      * @param indexRestrictions the index restrictions to add
      * @return a new {@code SelectStatement} instance with the added index restrictions
      */
+    @SuppressWarnings("unused") // this is used by DSE and CNDB to add authorization restrictions
     public SelectStatement addIndexRestrictions(Restrictions indexRestrictions)
     {
         return new SelectStatement(rawCQLStatement,

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -379,6 +379,7 @@ public abstract class ReadCommand extends AbstractReadQuery
      * validation method to check that nothing in this command's parameters
      * violates the implementation specific validation rules.
      */
+    @Override
     public void maybeValidateIndexes()
     {
         IndexRegistry.obtain(metadata()).validate(rowFilter());

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -62,6 +62,8 @@ import org.apache.cassandra.guardrails.DefaultGuardrail;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.guardrails.Threshold;
 import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.IndexRegistry;
+import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -378,8 +380,10 @@ public abstract class ReadCommand extends AbstractReadQuery
      * validation method to check that nothing in this command's parameters
      * violates the implementation specific validation rules.
      */
-    public void maybeValidateIndex()
+    public void maybeValidateIndexes()
     {
+        IndexRegistry.obtain(metadata()).validate(rowFilter());
+
         if (null != indexQueryPlan)
             indexQueryPlan.validate(this);
     }

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -63,7 +63,6 @@ import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.guardrails.Threshold;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
-import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus;

--- a/src/java/org/apache/cassandra/db/ReadQuery.java
+++ b/src/java/org/apache/cassandra/db/ReadQuery.java
@@ -251,7 +251,7 @@ public interface ReadQuery
      * validation method to check that nothing in this query's parameters
      * violates the implementation specific validation rules.
      */
-    default void maybeValidateIndex()
+    default void maybeValidateIndexes()
     {
     }
 

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -25,11 +25,12 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.index.sai.utils.GeoUtil;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -72,13 +74,13 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNu
  * be handled by a 2ndary index, and the rest is simply filtered out from the
  * result set (the later can only happen if the query was using ALLOW FILTERING).
  */
-public abstract class RowFilter implements Iterable<RowFilter.Expression>
+public class RowFilter implements Iterable<RowFilter.Expression>
 {
     private static final Logger logger = LoggerFactory.getLogger(RowFilter.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
     public static final Serializer serializer = new Serializer();
-    public static final RowFilter NONE = CQLFilter.NONE;
+    public static final RowFilter NONE = new RowFilter(FilterElement.NONE);
 
     protected final FilterElement root;
 
@@ -99,17 +101,10 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
     }
 
     /**
-     * @return *all* the expressions from the RowFilter tree in pre-order.
-     */
-    public Stream<Expression> getExpressionsPreOrder()
-    {
-        return root.getExpressionsPreOrder();
-    }
-
-    /**
      * Checks if some of the expressions apply to clustering or regular columns.
      * @return {@code true} if some of the expressions apply to clustering or regular columns, {@code false} otherwise.
      */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean hasExpressionOnClusteringOrRegularColumns()
     {
         warnIfFilterIsATree();
@@ -122,7 +117,55 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         return false;
     }
 
-    protected abstract Transformation<BaseRowIterator<?>> filter(TableMetadata metadata, int nowInSec);
+    protected Transformation<BaseRowIterator<?>> filter(TableMetadata metadata, int nowInSec)
+    {
+        FilterElement partitionLevelOperation = root.partitionLevelTree();
+        FilterElement rowLevelOperation = root.rowLevelTree();
+
+        final boolean filterNonStaticColumns = rowLevelOperation.size() > 0;
+
+        return new Transformation<>()
+        {
+            DecoratedKey pk;
+
+            protected BaseRowIterator<?> applyToPartition(BaseRowIterator<?> partition)
+            {
+                pk = partition.partitionKey();
+
+                // Short-circuit all partitions that won't match based on static and partition keys
+                if (!partitionLevelOperation.isSatisfiedBy(metadata, partition.partitionKey(), partition.staticRow()))
+                {
+                    partition.close();
+                    return null;
+                }
+
+                BaseRowIterator<?> iterator = partition instanceof UnfilteredRowIterator
+                                              ? Transformation.apply((UnfilteredRowIterator) partition, this)
+                                              : Transformation.apply((RowIterator) partition, this);
+
+                if (filterNonStaticColumns && !iterator.hasNext())
+                {
+                    iterator.close();
+                    return null;
+                }
+
+                return iterator;
+            }
+
+            @Override
+            public Row applyToRow(Row row)
+            {
+                Row purged = row.purge(DeletionPurger.PURGE_ALL, nowInSec, metadata.enforceStrictLiveness());
+                if (purged == null)
+                    return null;
+
+                if (!rowLevelOperation.isSatisfiedBy(metadata, pk, purged))
+                    return null;
+
+                return row;
+            }
+        };
+    }
 
     /**
      * Filters the provided iterator so that only the row satisfying the expression of this filter
@@ -170,7 +213,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
     }
 
     /**
-     * Returns true if all of the expressions within this filter that apply to the partition key are satisfied by
+     * Returns true if all the expressions within this filter that apply to the partition key are satisfied by
      * the given key, false otherwise.
      */
     public boolean partitionKeyRestrictionsAreSatisfiedBy(DecoratedKey key, AbstractType<?> keyValidator)
@@ -184,14 +227,14 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             ByteBuffer value = keyValidator instanceof CompositeType
                              ? ((CompositeType) keyValidator).split(key.getKey())[e.column.position()]
                              : key.getKey();
-            if (!e.operator().isSatisfiedBy(e.column.type, value, e.value))
+            if (!e.operator().isSatisfiedBy(e.column.type, value, e.value, e.analyzer()))
                 return false;
         }
         return true;
     }
 
     /**
-     * Returns true if all of the expressions within this filter that apply to the clustering key are satisfied by
+     * Returns true if all the expressions within this filter that apply to the clustering key are satisfied by
      * the given Clustering, false otherwise.
      */
     public boolean clusteringKeyRestrictionsAreSatisfiedBy(Clustering<?> clustering)
@@ -202,10 +245,8 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             if (!e.column.isClusteringColumn())
                 continue;
 
-            if (!e.operator().isSatisfiedBy(e.column.type, clustering.bufferAt(e.column.position()), e.value))
-            {
+            if (!e.operator().isSatisfiedBy(e.column.type, clustering.bufferAt(e.column.position()), e.value, e.analyzer()))
                 return false;
-            }
         }
         return true;
     }
@@ -221,7 +262,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         if (root.size() == 1)
             return RowFilter.NONE;
 
-        return new CQLFilter(root.filter(e -> !e.equals(expression)));
+        return new RowFilter(root.filter(e -> !e.equals(expression)));
     }
 
     public RowFilter withoutExpressions()
@@ -231,7 +272,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
 
     public RowFilter restrict(Predicate<Expression> filter)
     {
-        return new CQLFilter(root.filter(filter));
+        return new RowFilter(root.filter(filter));
     }
 
     public boolean isEmpty()
@@ -239,6 +280,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         return root.isEmpty();
     }
 
+    @Override
     public Iterator<Expression> iterator()
     {
         warnIfFilterIsATree();
@@ -255,42 +297,55 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
     {
         if (!root.children.isEmpty())
         {
-            noSpamLogger.warn("RowFilter is a tree, but we're using it as a list of top-levels expressions", new Exception("stacktrace of a potential misuse"));
+            noSpamLogger.warn("RowFilter is a tree, but we're using it as a list of top-levels expressions",
+                              new Exception("stacktrace of a potential misuse"));
         }
     }
 
     public static Builder builder()
     {
-        return new Builder();
+        return new Builder(null);
+    }
+
+    public static Builder builder(IndexRegistry indexRegistry)
+    {
+        return new Builder(indexRegistry);
     }
 
     public static class Builder
     {
         private FilterElement.Builder current = new FilterElement.Builder(false);
 
+        private final IndexRegistry indexRegistry;
+
+        public Builder(IndexRegistry indexRegistry)
+        {
+            this.indexRegistry = indexRegistry;
+        }
+
         public RowFilter build()
         {
-            return new CQLFilter(current.build());
+            return new RowFilter(current.build());
         }
 
-        public RowFilter buildFromRestrictions(StatementRestrictions restrictions, IndexRegistry indexManager, TableMetadata table, QueryOptions options)
+        public RowFilter buildFromRestrictions(StatementRestrictions restrictions, TableMetadata table, QueryOptions options)
         {
-            return new CQLFilter(doBuild(restrictions, indexManager, table, options));
+            return new RowFilter(doBuild(restrictions, table, options));
         }
 
-        private FilterElement doBuild(StatementRestrictions restrictions, IndexRegistry indexManager, TableMetadata table, QueryOptions options)
+        private FilterElement doBuild(StatementRestrictions restrictions, TableMetadata table, QueryOptions options)
         {
             FilterElement.Builder element = new FilterElement.Builder(restrictions.isDisjunction());
             this.current = element;
 
             for (Restrictions restrictionSet : restrictions.filterRestrictions().getRestrictions())
-                restrictionSet.addToRowFilter(this, indexManager, options);
+                restrictionSet.addToRowFilter(this, indexRegistry, options);
 
             for (ExternalRestriction expression : restrictions.filterRestrictions().getExternalExpressions())
                 addAllAsConjunction(b -> expression.addToRowFilter(b, table, options));
 
             for (StatementRestrictions child : restrictions.children())
-                element.children.add(doBuild(child, indexManager, table, options));
+                element.children.add(doBuild(child, table, options));
 
             // Optimize out any conjunctions / disjunctions with TRUE.
             // This is not needed for correctness.
@@ -329,7 +384,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             {
                 // If we're in disjunction mode, we must not pass the current builder to addToRowFilter.
                 // We create a new conjunction sub-builder instead and add all expressions there.
-                var builder = new Builder();
+                var builder = new Builder(indexRegistry);
                 addToRowFilterDelegate.accept(builder);
 
                 if (builder.current.expressions.size() == 1 && builder.current.children.isEmpty())
@@ -365,14 +420,20 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
 
         public SimpleExpression add(ColumnMetadata def, Operator op, ByteBuffer value)
         {
-            SimpleExpression expression = new SimpleExpression(def, op, value);
+            SimpleExpression expression = new SimpleExpression(def, op, value, analyzer(def, op));
             add(expression);
             return expression;
         }
 
         public void addMapComparison(ColumnMetadata def, ByteBuffer key, Operator op, ByteBuffer value)
         {
-            add(new MapComparisonExpression(def, key, op, value));
+            add(new MapComparisonExpression(def, key, op, value, analyzer(def, op)));
+        }
+
+        @Nullable
+        private Index.Analyzer analyzer(ColumnMetadata def, Operator op)
+        {
+            return indexRegistry == null ? null : indexRegistry.getAnalyzerFor(def, op).orElse(null);
         }
 
         public void addGeoDistanceExpression(ColumnMetadata def, ByteBuffer point, Operator op, ByteBuffer distance)
@@ -434,7 +495,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
 
         public static final FilterElement NONE = new FilterElement(false, Collections.emptyList(), Collections.emptyList());
 
-        private boolean isDisjunction;
+        private final boolean isDisjunction;
 
         private final List<Expression> expressions;
 
@@ -457,6 +518,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             return expressions;
         }
 
+        @Override
         public Iterator<Expression> iterator()
         {
             List<Expression> allExpressions = new ArrayList<>(expressions);
@@ -469,9 +531,9 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         {
             FilterElement.Builder builder = new Builder(isDisjunction);
 
-            expressions.stream().filter(filter).forEach(e -> builder.expressions.add(e));
+            expressions.stream().filter(filter).forEach(builder.expressions::add);
 
-            children.stream().map(c -> c.filter(filter)).forEach(c -> builder.children.add(c));
+            children.stream().map(c -> c.filter(filter)).forEach(builder.children::add);
 
             return builder.build();
         }
@@ -563,22 +625,16 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             {
                 if (sb.length() > 0)
                     sb.append(isDisjunction ? " OR " : " AND ");
-                sb.append("(");
+                sb.append('(');
                 sb.append(children.get(i));
-                sb.append(")");
+                sb.append(')');
             }
             return sb.toString();
         }
 
-        public Stream<Expression> getExpressionsPreOrder()
-        {
-            return Stream.concat(expressions.stream(),
-                                 children.stream().flatMap(FilterElement::getExpressionsPreOrder));
-        }
-
         public static class Builder
         {
-            private boolean isDisjunction;
+            private final boolean isDisjunction;
             private final List<Expression> expressions = new ArrayList<>();
             private final List<FilterElement> children = new ArrayList<>();
 
@@ -649,66 +705,6 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         }
     }
 
-    private static class CQLFilter extends RowFilter
-    {
-        private static final CQLFilter NONE = new CQLFilter(FilterElement.NONE);
-
-        private CQLFilter(FilterElement operation)
-        {
-            super(operation);
-        }
-
-        protected Transformation<BaseRowIterator<?>> filter(TableMetadata metadata, int nowInSec)
-        {
-            FilterElement partitionLevelOperation = root.partitionLevelTree();
-            FilterElement rowLevelOperation = root.rowLevelTree();
-
-            final boolean filterNonStaticColumns = rowLevelOperation.size() > 0;
-
-            return new Transformation<BaseRowIterator<?>>()
-            {
-                DecoratedKey pk;
-
-                @SuppressWarnings("resource")
-                protected BaseRowIterator<?> applyToPartition(BaseRowIterator<?> partition)
-                {
-                    pk = partition.partitionKey();
-
-                    // Short-circuit all partitions that won't match based on static and partition keys
-                    if (!partitionLevelOperation.isSatisfiedBy(metadata, partition.partitionKey(), partition.staticRow()))
-                    {
-                        partition.close();
-                        return null;
-                    }
-
-                    BaseRowIterator<?> iterator = partition instanceof UnfilteredRowIterator
-                                                  ? Transformation.apply((UnfilteredRowIterator) partition, this)
-                                                  : Transformation.apply((RowIterator) partition, this);
-
-                    if (filterNonStaticColumns && !iterator.hasNext())
-                    {
-                        iterator.close();
-                        return null;
-                    }
-
-                    return iterator;
-                }
-
-                public Row applyToRow(Row row)
-                {
-                    Row purged = row.purge(DeletionPurger.PURGE_ALL, nowInSec, metadata.enforceStrictLiveness());
-                    if (purged == null)
-                        return null;
-
-                    if (!rowLevelOperation.isSatisfiedBy(metadata, pk, purged))
-                        return null;
-
-                    return row;
-                }
-            };
-        }
-    }
-
     public static abstract class Expression
     {
         public static final Serializer serializer = new Serializer();
@@ -718,7 +714,8 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         // (we could clean those on a major protocol update, but it's not worth
         // the trouble for now)
         // VECTOR
-        protected enum Kind {
+        protected enum Kind
+        {
             SIMPLE(0), MAP_COMPARISON(1), UNUSED1(2), CUSTOM(3), USER(4), VECTOR_RADIUS(100);
             private final int val;
             Kind(int v) { val = v; }
@@ -739,6 +736,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         }
 
         protected abstract Kind kind();
+
         protected final ColumnMetadata column;
         protected final Operator operator;
         protected final ByteBuffer value;
@@ -768,6 +766,12 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         public Operator operator()
         {
             return operator;
+        }
+
+        @Nullable
+        public Index.Analyzer analyzer()
+        {
+            return null;
         }
 
         /**
@@ -817,8 +821,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         /**
          * Returns whether the provided row satisfied this expression or not.
          *
-         *
-         * @param metadata
+         * @param metadata the metadata of the queried table
          * @param partitionKey the partition key for row to check.
          * @param row the row to check. It should *not* contain deleted cells
          * (i.e. it should come from a RowIterator).
@@ -853,9 +856,9 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
 
             Expression that = (Expression)o;
 
-            return Objects.equal(this.kind(), that.kind())
+            return this.kind() == that.kind()
+                && this.operator == that.operator
                 && Objects.equal(this.column.name, that.column.name)
-                && Objects.equal(this.operator, that.operator)
                 && Objects.equal(this.value, that.value);
         }
 
@@ -926,6 +929,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                 ByteBuffer name = ByteBufferUtil.readWithShortLength(in);
                 Operator operator = Operator.readFrom(in);
                 ColumnMetadata column = metadata.getColumn(name);
+                Index.Analyzer analyzer = IndexRegistry.obtain(metadata).getAnalyzerFor(column, operator).orElse(null);
 
                 // Compact storage tables, when used with thrift, used to allow falling through this withouot throwing an
                 // exception. However, since thrift was removed in 4.0, this behaviour was not restored in CASSANDRA-16217
@@ -935,11 +939,11 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                 switch (kind)
                 {
                     case SIMPLE:
-                        return new SimpleExpression(column, operator, ByteBufferUtil.readWithShortLength(in));
+                        return new SimpleExpression(column, operator, ByteBufferUtil.readWithShortLength(in), analyzer);
                     case MAP_COMPARISON:
                         ByteBuffer key = ByteBufferUtil.readWithShortLength(in);
                         ByteBuffer value = ByteBufferUtil.readWithShortLength(in);
-                        return new MapComparisonExpression(column, key, operator, value);
+                        return new MapComparisonExpression(column, key, operator, value, analyzer);
                     case VECTOR_RADIUS:
                         Operator boundaryOperator = Operator.readFrom(in);
                         ByteBuffer distance = ByteBufferUtil.readWithShortLength(in);
@@ -962,7 +966,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                 switch (expression.kind())
                 {
                     case SIMPLE:
-                        size += ByteBufferUtil.serializedSizeWithShortLength(((SimpleExpression)expression).value);
+                        size += ByteBufferUtil.serializedSizeWithShortLength((expression).value);
                         break;
                     case MAP_COMPARISON:
                         MapComparisonExpression mexpr = (MapComparisonExpression)expression;
@@ -989,15 +993,37 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
     }
 
     /**
-     * An expression of the form 'column' 'op' 'value'.
+     * An expression that can be associated with an {@link Index.Analyzer}.
      */
-    public static class SimpleExpression extends Expression
+    public abstract static class AnalyzableExpression extends Expression
     {
-        public SimpleExpression(ColumnMetadata column, Operator operator, ByteBuffer value)
+        @Nullable
+        protected final Index.Analyzer analyzer;
+
+        public AnalyzableExpression(ColumnMetadata column, Operator operator, ByteBuffer value, @Nullable Index.Analyzer analyzer)
         {
             super(column, operator, value);
+            this.analyzer = analyzer;
         }
 
+        @Nullable
+        public final Index.Analyzer analyzer()
+        {
+            return analyzer;
+        }
+    }
+
+    /**
+     * An expression of the form 'column' 'op' 'value'.
+     */
+    public static class SimpleExpression extends AnalyzableExpression
+    {
+        public SimpleExpression(ColumnMetadata column, Operator operator, ByteBuffer value, @Nullable Index.Analyzer analyzer)
+        {
+            super(column, operator, value, analyzer);
+        }
+
+        @Override
         public boolean isSatisfiedBy(TableMetadata metadata, DecoratedKey partitionKey, Row row)
         {
             // We support null conditions for LWT (in ColumnCondition) but not for RowFilter.
@@ -1025,13 +1051,13 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                                 return false;
 
                             ByteBuffer counterValue = LongType.instance.decompose(CounterContext.instance().total(foundValue, ByteBufferAccessor.instance));
-                            return operator.isSatisfiedBy(LongType.instance, counterValue, value);
+                            return operator.isSatisfiedBy(LongType.instance, counterValue, value, analyzer);
                         }
                         else
                         {
                             // Note that CQL expression are always of the form 'x < 4', i.e. the tested value is on the left.
                             ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                            return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value);
+                            return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value, analyzer);
                         }
                     }
                 case NEQ:
@@ -1039,12 +1065,13 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                 case LIKE_SUFFIX:
                 case LIKE_CONTAINS:
                 case LIKE_MATCHES:
+                case ANALYZER_MATCHES:
                 case ANN:
                     {
                         assert !column.isComplex() : "Only CONTAINS and CONTAINS_KEY are supported for 'complex' types";
                         ByteBuffer foundValue = getValue(metadata, partitionKey, row);
                         // Note that CQL expression are always of the form 'x < 4', i.e. the tested value is on the left.
-                        return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value);
+                        return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value, analyzer);
                     }
                 case CONTAINS:
                     return contains(metadata, partitionKey, row);
@@ -1166,14 +1193,18 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
      * supported when 'column' is a map) and where the operator can be {@link Operator#EQ}, {@link Operator#NEQ},
      * {@link Operator#LT}, {@link Operator#LTE}, {@link Operator#GT}, or {@link Operator#GTE}.
      */
-    public static class MapComparisonExpression extends Expression
+    public static class MapComparisonExpression extends AnalyzableExpression
     {
         private final ByteBuffer key;
         private ByteBuffer indexValue = null;
 
-        public MapComparisonExpression(ColumnMetadata column, ByteBuffer key, Operator operator, ByteBuffer value)
+        public MapComparisonExpression(ColumnMetadata column,
+                                       ByteBuffer key,
+                                       Operator operator,
+                                       ByteBuffer value,
+                                       @Nullable Index.Analyzer analyzer)
         {
-            super(column, operator, value);
+            super(column, operator, value, analyzer);
             assert column.type instanceof MapType && (operator == Operator.EQ || operator == Operator.NEQ || operator.isSlice());
             this.key = key;
         }
@@ -1199,12 +1230,14 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
          * Returns whether the provided row satisfies this expression. For equality, it validates that the row contains
          * the exact key/value pair. For inequalities, it validates that the row contains the key, then that the value
          * satisfies the inequality.
-         * @param metadata
+         *
+         * @param metadata the metadata of the queried table
          * @param partitionKey the partition key for row to check.
          * @param row the row to check. It should *not* contain deleted cells
          * (i.e. it should come from a RowIterator).
          * @return whether the row is satisfied by this expression.
          */
+        @Override
         public boolean isSatisfiedBy(TableMetadata metadata, DecoratedKey partitionKey, Row row)
         {
             return isSatisfiedByEq(metadata, partitionKey, row) ^ (operator == Operator.NEQ);
@@ -1276,7 +1309,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             MapComparisonExpression that = (MapComparisonExpression)o;
 
             return Objects.equal(this.column.name, that.column.name)
-                && Objects.equal(this.operator, that.operator)
+                && this.operator == that.operator
                 && Objects.equal(this.key, that.key)
                 && Objects.equal(this.value, that.value);
         }
@@ -1336,7 +1369,6 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         }
     }
 
-
     public static class GeoDistanceExpression extends Expression
     {
         private final ByteBuffer distance;
@@ -1373,9 +1405,8 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         }
 
         /**
-         * Build a new {@link GeoDistanceExpression} that is shifted by 360 degrees and can correctly search
+         * @return a new {@link GeoDistanceExpression} that is shifted by 360 degrees and can correctly search
          * on the opposite side of the antimeridian.
-         * @return
          */
         public GeoDistanceExpression buildShiftedExpression()
         {
@@ -1448,7 +1479,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             GeoDistanceExpression that = (GeoDistanceExpression)o;
 
             return Objects.equal(this.column.name, that.column.name)
-                   && Objects.equal(this.distanceOperator, that.distanceOperator)
+                   && this.distanceOperator == that.distanceOperator
                    && Objects.equal(this.distance, that.distance)
                    && Objects.equal(this.value, that.value);
         }
@@ -1506,6 +1537,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             return value;
         }
 
+        @Override
         public String toString()
         {
             return String.format("expr(%s, %s)",
@@ -1516,12 +1548,14 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                                          .customExpressionValueType());
         }
 
+        @Override
         protected Kind kind()
         {
             return Kind.CUSTOM;
         }
 
         // Filtering by custom expressions isn't supported yet, so just accept any row
+        @Override
         public boolean isSatisfiedBy(TableMetadata metadata, DecoratedKey partitionKey, Row row)
         {
             return true;
@@ -1540,7 +1574,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
      * is important, new types should registered last and obsoleted types should still be registered (
      * or dummy implementations registered in their place) to preserve consistent identifiers across
      * the cluster).
-     *
+     * </p>
      * During serialization, the identifier for the Deserializer implementation is prepended to the
      * implementation specific payload. To deserialize, the identifier is read first to obtain the
      * Deserializer, which then provides the concrete expression instance.
@@ -1613,6 +1647,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             super(column, operator, value);
         }
 
+        @Override
         protected Kind kind()
         {
             return Kind.USER;
@@ -1634,14 +1669,13 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         {
             in.readBoolean(); // Unused
             FilterElement operation = FilterElement.serializer.deserialize(in, version, metadata);
-            return new CQLFilter(operation);
+            return new RowFilter(operation);
         }
 
         public long serializedSize(RowFilter filter, int version)
         {
-            long size = 1 // unused boolean
-                        + FilterElement.serializer.serializedSize(filter.root, version);
-            return size;
+            return 1 // unused boolean
+                   + FilterElement.serializer.serializedSize(filter.root, version);
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -127,6 +127,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
         {
             DecoratedKey pk;
 
+            @Override
             protected BaseRowIterator<?> applyToPartition(BaseRowIterator<?> partition)
             {
                 pk = partition.partitionKey();

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -104,7 +104,6 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      * Checks if some of the expressions apply to clustering or regular columns.
      * @return {@code true} if some of the expressions apply to clustering or regular columns, {@code false} otherwise.
      */
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean hasExpressionOnClusteringOrRegularColumns()
     {
         warnIfFilterIsATree();

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -102,6 +102,11 @@ public interface IndexRegistry
         public void validate(PartitionUpdate update)
         {
         }
+
+        @Override
+        public void validate(RowFilter filter)
+        {
+        }
     };
 
     /**
@@ -288,7 +293,11 @@ public interface IndexRegistry
 
         public void validate(PartitionUpdate update)
         {
+        }
 
+        @Override
+        public void validate(RowFilter filter)
+        {
         }
     };
 
@@ -303,6 +312,20 @@ public interface IndexRegistry
     Index getIndex(IndexMetadata indexMetadata);
     Collection<Index> listIndexes();
 
+    default Optional<Index.Analyzer> getAnalyzerFor(ColumnMetadata column, Operator operator)
+    {
+        for (Index index : listIndexes())
+        {
+            if (index.supportsExpression(column, operator))
+            {
+                Optional<Index.Analyzer> analyzer = index.getAnalyzer();
+                if (analyzer.isPresent())
+                    return analyzer;
+            }
+        }
+        return Optional.empty();
+    }
+
     Optional<Index> getBestIndexFor(RowFilter.Expression expression);
 
     /**
@@ -315,6 +338,8 @@ public interface IndexRegistry
      * @param update PartitionUpdate containing the values to be validated by registered Index implementations
      */
     void validate(PartitionUpdate update);
+
+    void validate(RowFilter filter);
 
     /**
      * Returns the {@code IndexRegistry} associated to the specified table.

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -106,6 +106,7 @@ public interface IndexRegistry
         @Override
         public void validate(RowFilter filter)
         {
+            // no-op since it's an empty registry
         }
     };
 
@@ -298,6 +299,7 @@ public interface IndexRegistry
         @Override
         public void validate(RowFilter filter)
         {
+            // no-op since it's an empty registry
         }
     };
 

--- a/src/java/org/apache/cassandra/index/RowFilterValidator.java
+++ b/src/java/org/apache/cassandra/index/RowFilterValidator.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/java/org/apache/cassandra/index/RowFilterValidator.java
+++ b/src/java/org/apache/cassandra/index/RowFilterValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.service.ClientWarn;
+
+/**
+ * Class for validating the index-related aspects of a {@link RowFilter}, without considering what index is actually used.
+ * </p>
+ * It will emit a client warning when a query has EQ restrictions on columns having an analyzed index.
+ */
+class RowFilterValidator
+{
+    private final Iterable<Index> allIndexes;
+
+    private Set<ColumnMetadata> columns;
+    private Set<Index> indexes;
+
+    private RowFilterValidator(Iterable<Index> allIndexes)
+    {
+        this.allIndexes = allIndexes;
+    }
+
+    private void addEqRestriction(ColumnMetadata column)
+    {
+        for (Index index : allIndexes)
+        {
+            if (index.supportsExpression(column, Operator.EQ) &&
+                index.supportsExpression(column, Operator.ANALYZER_MATCHES))
+            {
+                if (columns == null)
+                    columns = new HashSet<>();
+                columns.add(column);
+
+                if (indexes == null)
+                    indexes = new HashSet<>();
+                indexes.add(index);
+            }
+        }
+    }
+
+    private void validate()
+    {
+        if (columns == null || indexes == null)
+            return;
+
+        StringJoiner columnNames = new StringJoiner(", ");
+        StringJoiner indexNames = new StringJoiner(", ");
+        columns.forEach(column -> columnNames.add(column.name.toString()));
+        indexes.forEach(index -> indexNames.add(index.getIndexMetadata().name));
+
+        ClientWarn.instance.warn(String.format(AnalyzerEqOperatorSupport.EQ_RESTRICTION_ON_ANALYZED_WARNING, columnNames, indexNames));
+    }
+
+    /**
+     * Emits a client warning if the filter contains EQ restrictions on columns having an analyzed index.
+     *
+     * @param filter the filter to validate
+     * @param indexes the existing indexes
+     */
+    public static void validate(RowFilter filter, Iterable<Index> indexes)
+    {
+        RowFilterValidator validator = new RowFilterValidator(indexes);
+        validate(filter.root(), validator);
+        validator.validate();
+    }
+
+    private static void validate(RowFilter.FilterElement element, RowFilterValidator validator)
+    {
+        for (RowFilter.Expression expression : element.expressions())
+        {
+            if (expression.operator() == Operator.EQ)
+                validator.addEqRestriction(expression.column());
+        }
+
+        for (RowFilter.FilterElement child : element.children())
+        {
+            validate(child, validator);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1277,6 +1277,12 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
             index.validate(update);
     }
 
+    @Override
+    public void validate(RowFilter filter)
+    {
+        RowFilterValidator.validate(filter, indexes.values());
+    }
+
     /*
      * IndexRegistry methods
      */

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -645,6 +645,29 @@ public class StorageAttachedIndex implements Index
     }
 
     @Override
+    public Optional<Analyzer> getAnalyzer()
+    {
+        if (!indexContext.isAnalyzed())
+            return Optional.empty();
+
+        return Optional.of(value -> {
+            List<ByteBuffer> tokens = new ArrayList<>();
+            AbstractAnalyzer analyzer = indexContext.getQueryAnalyzerFactory().create();
+            try
+            {
+                analyzer.reset(value);
+                while (analyzer.hasNext())
+                    tokens.add(analyzer.next());
+            }
+            finally
+            {
+                analyzer.end();
+            }
+            return tokens;
+        });
+    }
+
+    @Override
     public RowFilter getPostIndexQueryFilter(RowFilter filter)
     {
         // it should be executed from the SAI query plan, this is only used by the singleton index query plan

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
@@ -17,19 +17,11 @@
 package org.apache.cassandra.index.sai.analyzer;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import java.util.StringJoiner;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.cassandra.cql3.Operator;
-import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.index.Index;
-import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.service.ClientWarn;
 
 /**
  * Index config property for defining the behaviour of the equals operator (=) when the index is analyzed.
@@ -99,80 +91,6 @@ public class AnalyzerEqOperatorSupport
         catch (IllegalArgumentException e)
         {
             throw new InvalidRequestException(WRONG_OPTION_ERROR + option);
-        }
-    }
-
-    /**
-     * Emits a client warning if the filter contains EQ restrictions on columns having an analyzed index.
-     *
-     * @param filter the filter to check
-     * @param indexes the existing indexes
-     */
-    public static void maybeWarn(RowFilter filter, Set<Index> indexes)
-    {
-        Warner warner = new Warner(indexes);
-        maybeWarn(filter.root(), warner);
-        warner.maybeWarn();
-    }
-
-    private static void maybeWarn(RowFilter.FilterElement element, Warner warner)
-    {
-        for (RowFilter.Expression expression : element.expressions())
-        {
-            if (expression.operator() == Operator.EQ)
-                warner.addEqRestriction(expression.column());
-        }
-
-        for (RowFilter.FilterElement child : element.children())
-        {
-            maybeWarn(child, warner);
-        }
-    }
-
-    /**
-     * Class for emitting a client warning when a query has EQ restrictions on columns having an analyzed index.
-     */
-    private static class Warner
-    {
-        private final Set<Index> allIndexes;
-
-        private Set<ColumnMetadata> columns;
-        private Set<Index> indexes;
-
-        private Warner(Set<Index> allIndexes)
-        {
-            this.allIndexes = allIndexes;
-        }
-
-        private void addEqRestriction(ColumnMetadata column)
-        {
-            for (Index index : allIndexes)
-            {
-                if (index.supportsExpression(column, Operator.EQ) &&
-                    index.supportsExpression(column, Operator.ANALYZER_MATCHES))
-                {
-                    if (columns == null)
-                        columns = new HashSet<>();
-                    columns.add(column);
-
-                    if (indexes == null)
-                        indexes = new HashSet<>();
-                    indexes.add(index);
-                }
-            }
-        }
-
-        private void maybeWarn()
-        {
-            if (columns == null || indexes == null)
-                return;
-
-            StringJoiner columnNames = new StringJoiner(", ");
-            StringJoiner indexNames = new StringJoiner(", ");
-            columns.forEach(column -> columnNames.add(column.name.toString()));
-            indexes.forEach(index -> indexNames.add(index.getIndexMetadata().name));
-
-            ClientWarn.instance.warn(String.format(EQ_RESTRICTION_ON_ANALYZED_WARNING, columnNames, indexNames));
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
@@ -48,26 +48,18 @@ public class AnalyzerEqOperatorSupport
                                                            "Possible values are %s but found ",
                                                            OPTION, Arrays.toString(Value.values()));
 
-    public static final String DEPRECATION_WARNING =
-    String.format("Future versions will remove support for '=' on analyzed indexes preventing this ambiguity. " +
-                  "If you want to forbid the use of '=' on analyzed indexes now and prevent this warning, " +
-                  "please use '%s':'%s' in the index options.",
-                  AnalyzerEqOperatorSupport.OPTION,
-                  AnalyzerEqOperatorSupport.Value.UNSUPPORTED.toString().toLowerCase());
-
     public static final String EQ_RESTRICTION_ON_ANALYZED_WARNING =
-    "Columns [%s] are restricted by '=' and have analyzed indexes [%s] able to process those restrictions. " +
-    "Analyzed indexes might process '=' restrictions in a way that is inconsistent with non-indexed queries. " +
-    "While '=' is still supported on analyzed indexes for backwards compatibility, " +
-    "it is recommended to use the ':' operator instead to prevent the ambiguity. " +
-    DEPRECATION_WARNING;
+    String.format("Columns [%%s] are restricted by '=' and have analyzed indexes [%%s] able to process those restrictions. " +
+                  "Analyzed indexes might process '=' restrictions in a way that is inconsistent with non-indexed queries. " +
+                  "While '=' is still supported on analyzed indexes for backwards compatibility, " +
+                  "it is recommended to use the ':' operator instead to prevent the ambiguity. " +
+                  "Future versions will remove support for '=' on analyzed indexes. " +
+                  "If you want to forbid the use of '=' on analyzed indexes now, " +
+                  "please use '%s':'%s' in the index options.",
+                  OPTION, Value.UNSUPPORTED.toString().toLowerCase());
 
     public static final String LWT_CONDITION_ON_ANALYZED_WARNING =
-    "Index analyzers not applied to LWT conditions on columns [%s]. " +
-    "The LWT conditions use the '=' operator on columns supported by analyzed indexes " +
-    "that process the '=' operator same as the ':' operator in SELECT queries for backwards compatibility. " +
-    "This means that '=' has different meaning in LWT writes (not analyzed) than in SELECT queries (analyzed). " +
-    DEPRECATION_WARNING;
+    "Index analyzers not applied to LWT conditions on columns [%s].";
 
     public enum Value
     {

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupport.java
@@ -48,15 +48,26 @@ public class AnalyzerEqOperatorSupport
                                                            "Possible values are %s but found ",
                                                            OPTION, Arrays.toString(Value.values()));
 
-    public static final String EQ_RESTRICTION_ON_ANALYZED_WARNING =
-    String.format("Columns [%%s] are restricted by '=' and have analyzed indexes [%%s] able to process those restrictions. " +
-                  "Analyzed indexes might process '=' restrictions in a way that is inconsistent with non-indexed queries. " +
-                  "While '=' is still supported on analyzed indexes for backwards compatibility, " +
-                  "it is recommended to use the ':' operator instead to prevent the ambiguity. " +
-                  "Future versions will remove support for '=' on analyzed indexes. " +
-                  "If you want to forbid the use of '=' on analyzed indexes now, " +
+    public static final String DEPRECATION_WARNING =
+    String.format("Future versions will remove support for '=' on analyzed indexes preventing this ambiguity. " +
+                  "If you want to forbid the use of '=' on analyzed indexes now and prevent this warning, " +
                   "please use '%s':'%s' in the index options.",
-                  OPTION, Value.UNSUPPORTED.toString().toLowerCase());
+                  AnalyzerEqOperatorSupport.OPTION,
+                  AnalyzerEqOperatorSupport.Value.UNSUPPORTED.toString().toLowerCase());
+
+    public static final String EQ_RESTRICTION_ON_ANALYZED_WARNING =
+    "Columns [%s] are restricted by '=' and have analyzed indexes [%s] able to process those restrictions. " +
+    "Analyzed indexes might process '=' restrictions in a way that is inconsistent with non-indexed queries. " +
+    "While '=' is still supported on analyzed indexes for backwards compatibility, " +
+    "it is recommended to use the ':' operator instead to prevent the ambiguity. " +
+    DEPRECATION_WARNING;
+
+    public static final String LWT_CONDITION_ON_ANALYZED_WARNING =
+    "Index analyzers not applied to LWT conditions on columns [%s]. " +
+    "The LWT conditions use the '=' operator on columns supported by analyzed indexes " +
+    "that process the '=' operator same as the ':' operator in SELECT queries for backwards compatibility. " +
+    "This means that '=' has different meaning in LWT writes (not analyzed) than in SELECT queries (analyzed). " +
+    DEPRECATION_WARNING;
 
     public enum Value
     {

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -310,7 +310,8 @@ public class Operation
                                                                                ListSerializer.readValue(expression.getIndexValue(),
                                                                                                         ByteBufferAccessor.instance,
                                                                                                         offset,
-                                                                                                        ProtocolVersion.V3))));
+                                                                                                        ProtocolVersion.V3),
+                                                                               expression.analyzer())));
                     offset += TypeSizes.INT_SIZE + ByteBufferAccessor.instance.getInt(expression.getIndexValue(), offset);
                 }
                 if (node.children().size() == 1)

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -33,10 +33,8 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
-import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 
@@ -195,16 +193,6 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     public boolean shouldEstimateInitialConcurrency()
     {
         return false;
-    }
-
-    @Override
-    public void validate(ReadCommand command) throws InvalidRequestException
-    {
-        // Maybe warn about EQ restrictions on analyzed columns
-        AnalyzerEqOperatorSupport.maybeWarn(command.rowFilter(), indexes);
-
-        // Validate index by index
-        Index.QueryPlan.super.validate(command);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.plan;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -39,13 +38,9 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadExecutionController;
-import org.apache.cassandra.db.RegularAndStaticColumns;
-import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.rows.AbstractUnfilteredRowIterator;
 import org.apache.cassandra.db.rows.Row;
-import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
@@ -54,7 +49,6 @@ import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
-import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
@@ -91,27 +85,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     public ReadCommand command()
     {
         return command;
-    }
-
-    @Override
-    public PartitionIterator filterReplicaFilteringProtection(PartitionIterator fullResponse)
-    {
-        for (RowFilter.Expression expression : controller.filterOperation())
-        {
-            AbstractAnalyzer analyzer = controller.getContext(expression).getAnalyzerFactory().create();
-            try
-            {
-                if (analyzer.transformValue())
-                    return applyIndexFilter(fullResponse, analyzeFilter(), queryContext);
-            }
-            finally
-            {
-                analyzer.end();
-            }
-        }
-
-        // if no analyzer does transformation
-        return Index.Searcher.super.filterReplicaFilteringProtection(fullResponse);
     }
 
     @Override
@@ -699,112 +672,5 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             super.close();
             rows.close();
         }
-    }
-
-    /**
-     * Used by {@link StorageAttachedIndexSearcher#filterReplicaFilteringProtection} to filter rows for columns that
-     * have transformations so won't get handled correctly by the row filter.
-     */
-    @SuppressWarnings("resource")
-    private static PartitionIterator applyIndexFilter(PartitionIterator response, FilterTree tree, QueryContext queryContext)
-    {
-        return new PartitionIterator()
-        {
-            @Override
-            public void close()
-            {
-                response.close();
-            }
-
-            @Override
-            public boolean hasNext()
-            {
-                return response.hasNext();
-            }
-
-            @Override
-            public RowIterator next()
-            {
-                RowIterator delegate = response.next();
-                Row staticRow = delegate.staticRow();
-
-                return new RowIterator()
-                {
-                    Row next;
-
-                    @Override
-                    public TableMetadata metadata()
-                    {
-                        return delegate.metadata();
-                    }
-
-                    @Override
-                    public boolean isReverseOrder()
-                    {
-                        return delegate.isReverseOrder();
-                    }
-
-                    @Override
-                    public RegularAndStaticColumns columns()
-                    {
-                        return delegate.columns();
-                    }
-
-                    @Override
-                    public DecoratedKey partitionKey()
-                    {
-                        return delegate.partitionKey();
-                    }
-
-                    @Override
-                    public Row staticRow()
-                    {
-                        return staticRow;
-                    }
-
-                    @Override
-                    public void close()
-                    {
-                        delegate.close();
-                    }
-
-                    private Row computeNext()
-                    {
-                        while (delegate.hasNext())
-                        {
-                            Row row = delegate.next();
-                            queryContext.addRowsFiltered(1);
-                            if (tree.isSatisfiedBy(delegate.partitionKey(), row, staticRow))
-                                return row;
-                        }
-                        return null;
-                    }
-
-                    private Row loadNext()
-                    {
-                        if (next == null)
-                            next = computeNext();
-                        return next;
-                    }
-
-                    @Override
-                    public boolean hasNext()
-                    {
-                        return loadNext() != null;
-                    }
-
-                    @Override
-                    public Row next()
-                    {
-                        Row result = loadNext();
-                        next = null;
-
-                        if (result == null)
-                            throw new NoSuchElementException();
-                        return result;
-                    }
-                };
-            }
-        };
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/DataResolver.java
+++ b/src/java/org/apache/cassandra/service/reads/DataResolver.java
@@ -292,13 +292,7 @@ public class DataResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
 
     private  UnaryOperator<PartitionIterator> preCountFilterForReplicaFilteringProtection()
     {
-        return results -> {
-            Index.Searcher searcher = command.indexSearcher();
-            // in case of "ALLOW FILTERING" without index
-            if (searcher == null)
-                return command.rowFilter().filter(results, command.metadata(), command.nowInSec());
-            return searcher.filterReplicaFilteringProtection(results);
-        };
+        return results -> command.rowFilter().filter(results, command.metadata(), command.nowInSec());
     }
 
     @SuppressWarnings("resource")

--- a/test/unit/org/apache/cassandra/cql3/OperatorTest.java
+++ b/test/unit/org/apache/cassandra/cql3/OperatorTest.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/unit/org/apache/cassandra/cql3/OperatorTest.java
+++ b/test/unit/org/apache/cassandra/cql3/OperatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.Index;
+import org.assertj.core.api.Assertions;
+
+public class OperatorTest
+{
+    @Test
+    public void testAnalyzer()
+    {
+        // test with a text-based case-insensitive analyzer
+        UTF8Type utf8Type = UTF8Type.instance;
+        Index.Analyzer analyzer = value -> Collections.singletonList(utf8Type.decompose(utf8Type.compose(value).toUpperCase()));
+        testAnalyzer(utf8Type, utf8Type.decompose("FOO"), utf8Type.decompose("FOO"), analyzer, true);
+        testAnalyzer(utf8Type, utf8Type.decompose("FOO"), utf8Type.decompose("foo"), analyzer, true);
+        testAnalyzer(utf8Type, utf8Type.decompose("foo"), utf8Type.decompose("foo"), analyzer, true);
+        testAnalyzer(utf8Type, utf8Type.decompose("foo"), utf8Type.decompose("FOO"), analyzer, true);
+        testAnalyzer(utf8Type, utf8Type.decompose("foo"), utf8Type.decompose("abc"), analyzer, false);
+
+        // test with an int-based analyzer that decomposes an integer into its digits
+        Int32Type intType = Int32Type.instance;
+        analyzer = value -> intType.compose(value)
+                                   .toString()
+                                   .chars()
+                                   .boxed()
+                                   .map(intType::decompose)
+                                   .collect(Collectors.toList());
+        testAnalyzer(intType, intType.decompose(123), intType.decompose(123), analyzer, true);
+        testAnalyzer(intType, intType.decompose(123), intType.decompose(1), analyzer, true);
+        testAnalyzer(intType, intType.decompose(123), intType.decompose(2), analyzer, true);
+        testAnalyzer(intType, intType.decompose(123), intType.decompose(3), analyzer, true);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(4), analyzer, false);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(12), analyzer, true);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(23), analyzer, true);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(13), analyzer, true);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(321), analyzer, true);
+        testAnalyzer(utf8Type, intType.decompose(123), intType.decompose(1234), analyzer, false);
+    }
+
+    private static void testAnalyzer(AbstractType<?> type,
+                                     ByteBuffer left,
+                                     ByteBuffer right,
+                                     Index.Analyzer analyzer,
+                                     boolean shouldBeSatisfied)
+    {
+        // test that EQ and ANALYZER_MATCHES are satisfied by the same value with an analyzer
+        for (Operator operator : Arrays.asList(Operator.EQ, Operator.ANALYZER_MATCHES))
+            Assertions.assertThat(operator.isSatisfiedBy(type, left, right, analyzer)).isEqualTo(shouldBeSatisfied);
+
+        // test that EQ without an analyzer behaves as type-based identity
+        Assertions.assertThat(Operator.EQ.isSatisfiedBy(type, left, right, null))
+                  .isEqualTo(type.compareForCQL(left, right) == 0);
+
+        // test that ANALYZER_MATCHES throws an exception when no analyzer is provided
+        Assertions.assertThatThrownBy(() -> Operator.ANALYZER_MATCHES.isSatisfiedBy(type, left, right, null))
+                  .isInstanceOf(AssertionError.class)
+                  .hasMessageContaining(": operation can only be computed by an indexed column with a configured analyzer");
+
+        // test that all other operators ignore the analyzer
+        for (Operator operator : Operator.values())
+        {
+            if (operator == Operator.EQ || operator == Operator.ANALYZER_MATCHES)
+                continue;
+
+            boolean supported = false;
+            try
+            {
+                shouldBeSatisfied = operator.isSatisfiedBy(type, left, right, null);
+                supported = true;
+            }
+            catch (Exception e)
+            {
+                Assertions.assertThatThrownBy(() -> operator.isSatisfiedBy(type, left, right, analyzer))
+                          .isInstanceOf(e.getClass())
+                          .hasMessage(e.getMessage());
+            }
+
+            if (supported)
+            {
+                Assertions.assertThat(operator.isSatisfiedBy(type, left, right, analyzer))
+                          .isEqualTo(shouldBeSatisfied);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/filter/RowFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/RowFilterTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.db.filter;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
@@ -49,9 +48,8 @@ import org.apache.cassandra.utils.btree.BTree;
 
 public class RowFilterTest
 {
-
     @Test
-    public void testCQLFilterClose()
+    public void testRowFilterClose()
     {
         // CASSANDRA-15126
         TableMetadata metadata = TableMetadata.builder("testks", "testcf")

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
@@ -415,7 +415,7 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
 
     private void assertRowsWithLWTWarning(String query, Object[]... rows)
     {
-        assertRows(query, rows).hasSize(1).contains(format(LWT_CONDITION_ON_ANALYZED_WARNING, 'v', currentIndex()));
+        assertRows(query, rows).hasSize(1).contains(format(LWT_CONDITION_ON_ANALYZED_WARNING, 'v'));
     }
 
     private ListAssert<String> assertRows(String query, Object[]... rows)

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.conditions.ColumnCondition;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.service.ClientWarn;
@@ -28,6 +29,7 @@ import org.assertj.core.api.ListAssert;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport.EQ_RESTRICTION_ON_ANALYZED_WARNING;
+import static org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport.LWT_CONDITION_ON_ANALYZED_WARNING;
 
 /**
  * Tests for {@link AnalyzerEqOperatorSupport}.
@@ -64,6 +66,11 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
         // matches (:)
         assertInvalidMessage(": restriction is only supported on properly indexed columns. v : 'Quick fox' is not valid.",
                              "SELECT k FROM %s WHERE v : 'Quick fox' ALLOW FILTERING");
+
+        // LWT
+        assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'Quick fox'", row(true));
+        assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'fox'", row(false, "Quick fox"));
+        assertInvalidMessage(ColumnCondition.ANALYZER_MATCHES_ERROR, "UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v : 'Quick fox'");
     }
 
     @Test
@@ -85,6 +92,11 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
         // matches (:)
         assertInvalidMessage(format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'v'),
                              "SELECT k FROM %s WHERE v : 'Quick fox'");
+
+        // LWT
+        assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'Quick fox'", row(true));
+        assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'fox'", row(false, "Quick fox"));
+        assertInvalidMessage(ColumnCondition.ANALYZER_MATCHES_ERROR, "UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v : 'Quick fox'");
     }
 
     @Test
@@ -105,6 +117,11 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
 
             // matches (:)
             assertIndexDoesNotSupportMatches();
+
+            // LWT
+            assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'Quick fox'", row(true));
+            assertRowsWithoutWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'fox'", row(false, "Quick fox"));
+            assertInvalidMessage(ColumnCondition.ANALYZER_MATCHES_ERROR, "UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v : 'Quick fox'");
         });
     }
 
@@ -163,19 +180,23 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
 
     private void assertNonTokenizedIndexSupportsEquality()
     {
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'");
+
+        // LWT
+        assertRowsWithLWTWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'Quick fox'", row(true));
+        assertRowsWithLWTWarning("UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'fox'", row(false, "Quick fox"));
     }
 
     private void assertNonTokenizedIndexSupportsMatches()
@@ -193,31 +214,38 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
         assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'quick' AND v : 'lazy'");
         assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'dog'");
         assertRowsWithoutWarning("SELECT k FROM %s WHERE (v : 'quick' AND v : 'fox') OR v : 'Lazy'");
+
+        // LWT
+        assertInvalidMessage(ColumnCondition.ANALYZER_MATCHES_ERROR, "UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v : 'Quick fox'");
     }
 
     private void assertNonTokenizedIndexSupportsMixedEqualityAndMatches()
     {
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'");
 
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'");
+
+        // LWT
+        assertInvalidMessage(ColumnCondition.ANALYZER_MATCHES_ERROR,
+                             "UPDATE %s SET v = 'Quick fox' WHERE k = 1 IF v = 'Quick fox' AND v : 'Quick fox'");
     }
 
     @Test
@@ -265,20 +293,20 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
 
     private void assertTokenizedIndexSupportsEquality()
     {
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' OR v = 'lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'dog'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v = 'fox') OR v = 'Lazy'", row(1), row(2));
     }
 
     private void assertTokenizedIndexSupportsMatches()
@@ -301,34 +329,34 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
 
     private void assertTokenizedIndexSupportsMixedEqualityAndMatches()
     {
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick fox' OR v : 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick fox' OR v : 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' OR v : 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' OR v : 'lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' AND v : 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'quick' AND v : 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'dog'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v = 'quick' AND v : 'fox') OR v = 'Lazy'", row(1), row(2));
 
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'", row(1), row(2));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'", row(1));
-        assertRowsWithWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick fox' OR v = 'Lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick fox' OR v = 'lazy fox'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' OR v = 'Lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' OR v = 'lazy'", row(1), row(2));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'fox'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'Quick' AND v = 'Lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v : 'quick' AND v = 'lazy'");
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'dog'", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE (v : 'quick' AND v = 'fox') OR v : 'Lazy'", row(1), row(2));
 
         // test mixed with another non-indexed column
         String errorMsg = ": restriction is only supported on properly indexed columns";
         assertInvalidMessage(errorMsg, "SELECT k FROM %s WHERE v : 'Quick' OR f : 'Lazy' ALLOW FILTERING");
         assertRowsWithoutWarning("SELECT k FROM %s WHERE v : 'Quick' OR f = 'Lazy' ALLOW FILTERING", row(1));
         assertInvalidMessage(errorMsg, "SELECT k FROM %s WHERE v = 'Quick' OR f : 'Lazy' ALLOW FILTERING");
-        assertRowsWithWarning("SELECT k FROM %s WHERE v = 'Quick' OR f = 'Lazy' ALLOW FILTERING", row(1));
+        assertRowsWithSelectWarning("SELECT k FROM %s WHERE v = 'Quick' OR f = 'Lazy' ALLOW FILTERING", row(1));
     }
 
     private void assertIndexDoesNotSupportEquals()
@@ -380,9 +408,14 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
         assertRows(query, rows).isNullOrEmpty();
     }
 
-    private void assertRowsWithWarning(String query, Object[]... rows)
+    private void assertRowsWithSelectWarning(String query, Object[]... rows)
     {
         assertRows(query, rows).hasSize(1).contains(format(EQ_RESTRICTION_ON_ANALYZED_WARNING, 'v', currentIndex()));
+    }
+
+    private void assertRowsWithLWTWarning(String query, Object[]... rows)
+    {
+        assertRows(query, rows).hasSize(1).contains(format(LWT_CONDITION_ON_ANALYZED_WARNING, 'v', currentIndex()));
     }
 
     private ListAssert<String> assertRows(String query, Object[]... rows)

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -654,14 +654,12 @@ public class LuceneAnalyzerTest extends SAITester
         Assertions.assertThatThrownBy(() -> execute(disjunctionQueryMatchEq))
                   .isInstanceOf(InvalidRequestException.class)
                   .hasMessageContaining(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
-        // TODO: this last test is affected by CNDB-10731. We should enable it once that is fixed.
-        // assertRows(execute(disjunctionQueryMatchEq + "ALLOW FILTERING"), row("1"));
+         assertRows(execute(disjunctionQueryMatchEq + "ALLOW FILTERING"), row("1"));
 
         Assertions.assertThatThrownBy(() -> execute(disjunctionQueryEqMatch))
                   .isInstanceOf(InvalidRequestException.class)
                   .hasMessageContaining(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
-        // TODO: this last test is affected by CNDB-10731. We should enable it once that is fixed.
-        // assertRows(execute(disjunctionQueryEqMatch + "ALLOW FILTERING"), row("1"));
+         assertRows(execute(disjunctionQueryEqMatch + "ALLOW FILTERING"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.index.sai.cql;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.cql3.conditions.ColumnCondition;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 
@@ -58,7 +59,7 @@ public class LuceneUpdateDeleteTest extends SAITester
         // UPDATE with LWT fails (different error message because it fails at a different point)
         assertThatThrownBy(() -> execute("UPDATE %s SET val = 'something new' WHERE id = 0 IF val : 'dog'"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessageContaining("LWT Conditions do not support the : operator");
+        .hasMessageContaining(ColumnCondition.ANALYZER_MATCHES_ERROR);
     }
 
     // No flushes

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterClientTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterClientTest.java
@@ -43,6 +43,7 @@ public class CQLSSTableWriterClientTest
     {
         this.testDirectory = new File(Files.createTempDir());
         DatabaseDescriptor.daemonInitialization();
+        Keyspace.setInitialized();
         CommitLog.instance.start();
     }
 


### PR DESCRIPTION
Make `RowFilter` aware of index analyzers, so `:` and `=` CQL operators can operate according to any underlying analyzers even if the index is not selected.

This can happen for example with `OR` expressions where one expression has an analyzing index and the other doesn't have any index:
```
CREATE TABLE t (k int PRIMARY KEY, x int, y text);
CREATE CUSTOM INDEX ON t(y) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard'};
INSERT INTO t (k, x, y) VALUES (0, 0, 'a');
SELECT * FROM t WHERE x=1 OR y:'a' ALLOW FILTERING;
```
In this case, the index won't be used and both restrictions will be filtered. When the `RowFilter` sees the `ANALYZER_MATCHES` expression on the `y` column it fails because the CQL operator cannot work without knowledge of the index.

This PR adds a new `Index.getAnalyzer` method that the CQL operators can use. That way the `ANALYZER_MATCHES` operator can work without direct index intervention.

As a bonus, this mechanism can also be used by replica filtering protection to re-apply the row filter in the coordinator when there are conflicting results coming from the replica. So this would supersede the mechanism provided by [`Index.Searcher#filterReplicaFilteringProtection`](https://github.com/datastax/cassandra/blob/b1382eabc637912fc02c51f71585e9dc92f73c4d/src/java/org/apache/cassandra/service/reads/DataResolver.java#L300).

Please note that the general assumption here is that when we create an analyzed index in a column we are redefining how the `:` and `=` operators work when querying those columns, regardless of whether the index data structures are used or not.
