### PR TITLE
CNDB-10850: support legacy UCSv2 settings and change the default of max_sstables_to_compact to 256 (as in DSE)

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -61,28 +61,28 @@ public class AdaptiveController extends Controller
 
     /** The minimum valid value for the scaling parameter */
     static final String MIN_SCALING_PARAMETER = "adaptive_min_scaling_parameter";
-    static private final int DEFAULT_MIN_SCALING_PARAMETER = Integer.getInteger(PREFIX + MIN_SCALING_PARAMETER, -10);
+    static private final int DEFAULT_MIN_SCALING_PARAMETER = getIntegerSystemProperty(MIN_SCALING_PARAMETER, -10);
 
     /** The maximum valid value for the scaling parameter */
     static final String MAX_SCALING_PARAMETER = "adaptive_max_scaling_parameter";
-    static private final int DEFAULT_MAX_SCALING_PARAMETER = Integer.getInteger(PREFIX + MAX_SCALING_PARAMETER, 36);
+    static private final int DEFAULT_MAX_SCALING_PARAMETER = getIntegerSystemProperty(MAX_SCALING_PARAMETER, 36);
 
     /** The interval for periodically checking the optimal value for the scaling parameter */
     static final String INTERVAL_SEC = "adaptive_interval_sec";
-    static private final int DEFAULT_INTERVAL_SEC = Integer.getInteger(PREFIX + INTERVAL_SEC, 300);
+    static private final int DEFAULT_INTERVAL_SEC = getIntegerSystemProperty(INTERVAL_SEC, 300);
 
     /** The gain is a number between 0 and 1 used to determine if a new choice of the scaling parameter is better than the current one */
     static final String THRESHOLD = "adaptive_threshold";
-    private static final double DEFAULT_THRESHOLD = Double.parseDouble(System.getProperty(PREFIX + THRESHOLD, "0.15"));
+    private static final double DEFAULT_THRESHOLD = Double.parseDouble(getSystemProperty(THRESHOLD, "0.15"));
 
     /** Below the minimum cost we don't try to optimize the scaling parameter, we consider the current scaling parameter good enough. This is necessary because the cost
      * can vanish to zero when there are neither reads nor writes and right now we don't know how to handle this case.  */
     static final String MIN_COST = "adaptive_min_cost";
-    static private final int DEFAULT_MIN_COST = Integer.getInteger(PREFIX + MIN_COST, 1000);
+    static private final int DEFAULT_MIN_COST = getIntegerSystemProperty(MIN_COST, 1000);
 
     /** The maximum number of concurrent Adaptive Compactions */
     static final String MAX_ADAPTIVE_COMPACTIONS = "max_adaptive_compactions";
-    private static final int DEFAULT_MAX_ADAPTIVE_COMPACTIONS = Integer.getInteger(PREFIX + MAX_ADAPTIVE_COMPACTIONS, 5);
+    private static final int DEFAULT_MAX_ADAPTIVE_COMPACTIONS = getIntegerSystemProperty(MAX_ADAPTIVE_COMPACTIONS, 5);
     private final int intervalSec;
     private final int minScalingParameter;
     private final int maxScalingParameter;

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -40,6 +40,9 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getIntegerSystemProperty;
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getSystemProperty;
+
 /**
  * The adaptive compaction controller dynamically calculates the optimal scaling parameter W.
  * <p/>

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -59,6 +59,8 @@ import org.apache.cassandra.utils.Overlaps;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getBooleanSystemProperty;
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getSystemProperty;
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
 /**
@@ -358,41 +360,6 @@ public abstract class Controller
                     "Set it to 'true' to enable aggressive SSTable expiration.");
         }
         this.ignoreOverlapsInExpirationCheck = ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION && ignoreOverlapsInExpirationCheck;
-    }
-
-    protected static String getSystemProperty(String option)
-    {
-        return getSystemProperty(option, null);
-    }
-
-    /**
-     * Tries to get system property with PREFIX first. If it doesn't find it,
-     * looks for system property with LEGACY_PREFIX. If both are missing it
-     * returns the default value.
-     */
-    protected static String getSystemProperty(String option, String defaultValue) {
-        String value = System.getProperty(PREFIX + option);
-        if (value == null)
-            value = System.getProperty(LEGACY_PREFIX + option, defaultValue);
-        return value;
-    }
-
-    protected static Boolean getBooleanSystemProperty(String option)
-    {
-        return Boolean.getBoolean(PREFIX + option) || Boolean.getBoolean(LEGACY_PREFIX + option);
-    }
-
-    /**
-     * Tries to get system property with PREFIX first. If it doesn't find it,
-     * looks for system property with LEGACY_PREFIX. If both are missing it
-     * returns the default value.
-     */
-    public static Integer getIntegerSystemProperty(String option, int defaultValue)
-    {
-        Integer value = Integer.getInteger(PREFIX + option);
-        if (value == null)
-            value = Integer.getInteger(LEGACY_PREFIX + option, defaultValue);
-        return value;
     }
 
     public static File getControllerConfigPath(String keyspaceName, String tableName)

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -70,6 +70,7 @@ public abstract class Controller
     private static final ConcurrentMap<TableMetadata, Controller.Metrics> allMetrics = new ConcurrentHashMap<>();
 
     static final String PREFIX = "unified_compaction.";
+    static final String LEGACY_PREFIX = "dse.unified_compaction.";
 
     /**
      * The data size in GB, it will be assumed that the node will have on disk roughly this size of data when it
@@ -80,7 +81,7 @@ public abstract class Controller
     @Deprecated
     public static final String DATASET_SIZE_OPTION_GB = "dataset_size_in_gb";
     static final long DEFAULT_DATASET_SIZE =
-        FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + DATASET_SIZE_OPTION,
+        FBUtilities.parseHumanReadableBytes(getSystemProperty(DATASET_SIZE_OPTION,
                                                               DatabaseDescriptor.getDataFileDirectoriesMinTotalSpaceInGB() + "GiB"));
 
     /**
@@ -105,7 +106,7 @@ public abstract class Controller
      * and replayers in CNDB without having to change the schema for each tenant.
      */
     @Deprecated
-    static final Optional<Integer> DEFAULT_NUM_SHARDS = Optional.ofNullable(System.getProperty(PREFIX + NUM_SHARDS_OPTION)).map(Integer::valueOf);
+    static final Optional<Integer> DEFAULT_NUM_SHARDS = Optional.ofNullable(getSystemProperty(NUM_SHARDS_OPTION)).map(Integer::valueOf);
 
     /**
      * The minimum sstable size. Sharded writers split sstables over shard only if they are at least as large as the
@@ -120,7 +121,7 @@ public abstract class Controller
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
-    static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + MIN_SSTABLE_SIZE_OPTION, "100MiB"));
+    static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */
@@ -143,7 +144,7 @@ public abstract class Controller
      * behind, higher read amplification, and other problems of that nature.
      */
     public static final String MAX_SPACE_OVERHEAD_OPTION = "max_space_overhead";
-    static final double DEFAULT_MAX_SPACE_OVERHEAD = FBUtilities.parsePercent(System.getProperty(PREFIX + MAX_SPACE_OVERHEAD_OPTION, "0.2"));
+    static final double DEFAULT_MAX_SPACE_OVERHEAD = FBUtilities.parsePercent(getSystemProperty(MAX_SPACE_OVERHEAD_OPTION, "0.2"));
     static final double MAX_SPACE_OVERHEAD_LOWER_BOUND = 0.01;
     static final double MAX_SPACE_OVERHEAD_UPPER_BOUND = 1.0;
 
@@ -155,13 +156,13 @@ public abstract class Controller
      * For others a base count of 1 is used as system tables are usually small and do not need as much compaction
      * parallelism, while having directories defined provides for parallelism in a different way.
      */
-    public static final int DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(System.getProperty(PREFIX + BASE_SHARD_COUNT_OPTION, "4"));
+    public static final int DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(getSystemProperty(BASE_SHARD_COUNT_OPTION, "4"));
 
     /**
      * The target SSTable size. This is the size of the SSTables that the controller will try to create.
      */
     static final String TARGET_SSTABLE_SIZE_OPTION = "target_sstable_size";
-    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
+    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
     static final long MIN_TARGET_SSTABLE_SIZE = 1L << 20;
 
 
@@ -191,7 +192,7 @@ public abstract class Controller
      * a growth value of 0.333, and 64 (~16GiB each) for a growth value of 0.5.
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
-    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + SSTABLE_GROWTH_OPTION, "0.5"));
+    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.5"));
 
     /**
      * Number of reserved threads to keep for each compaction level. This is used to ensure that there are always
@@ -205,7 +206,7 @@ public abstract class Controller
      * The default value is max, all compaction threads are distributed among the levels.
      */
     static final String RESERVED_THREADS_OPTION = "reserved_threads";
-    public static final int DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(System.getProperty(PREFIX + RESERVED_THREADS_OPTION, "max"));
+    public static final int DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(getSystemProperty(RESERVED_THREADS_OPTION, "max"));
 
     /**
      * Reservation type, defining whether reservations can be used by lower levels. If set to `per_level`, the
@@ -216,20 +217,20 @@ public abstract class Controller
      */
     static final String RESERVATIONS_TYPE_OPTION = "reservations_type";
     public static final Reservations.Type DEFAULT_RESERVED_THREADS_TYPE =
-        Reservations.Type.valueOf(System.getProperty(PREFIX + RESERVATIONS_TYPE_OPTION,
+        Reservations.Type.valueOf(getSystemProperty(RESERVATIONS_TYPE_OPTION,
                                                      Reservations.Type.LEVEL_OR_BELOW.name()).toUpperCase());
 
     /**
      * This parameter is intended to modify the shape of the LSM by taking into account the survival ratio of data, for now it is fixed to one.
      */
-    static final double DEFAULT_SURVIVAL_FACTOR = Double.parseDouble(System.getProperty(PREFIX + "survival_factor", "1"));
+    static final double DEFAULT_SURVIVAL_FACTOR = Double.parseDouble(getSystemProperty("survival_factor", "1"));
     static final double[] DEFAULT_SURVIVAL_FACTORS = new double[] { DEFAULT_SURVIVAL_FACTOR };
 
     /**
      * Either true or false. This parameter determines which controller will be used.
      */
     static final String ADAPTIVE_OPTION = "adaptive";
-    static final boolean DEFAULT_ADAPTIVE = Boolean.parseBoolean(System.getProperty(PREFIX + ADAPTIVE_OPTION, "false"));
+    static final boolean DEFAULT_ADAPTIVE = Boolean.parseBoolean(getSystemProperty(ADAPTIVE_OPTION, "false"));
 
     /**
      * The maximum number of sstables to compact in one operation.
@@ -271,7 +272,7 @@ public abstract class Controller
      */
     static final String OVERLAP_INCLUSION_METHOD_OPTION = "overlap_inclusion_method";
     static final Overlaps.InclusionMethod DEFAULT_OVERLAP_INCLUSION_METHOD =
-        Overlaps.InclusionMethod.valueOf(System.getProperty(PREFIX + OVERLAP_INCLUSION_METHOD_OPTION,
+        Overlaps.InclusionMethod.valueOf(getSystemProperty(OVERLAP_INCLUSION_METHOD_OPTION,
                                                           Overlaps.InclusionMethod.TRANSITIVE.toString()).toUpperCase());
 
     /**
@@ -344,7 +345,7 @@ public abstract class Controller
         this.reservedThreads = reservedThreads;
         this.reservationsType = reservationsType;
         this.maxSpaceOverhead = maxSpaceOverhead;
-        this.l0ShardsEnabled = Boolean.parseBoolean(System.getProperty(PREFIX + L0_SHARDS_ENABLED_OPTION, "false")); // FIXME VECTOR-23
+        this.l0ShardsEnabled = Boolean.parseBoolean(getSystemProperty(L0_SHARDS_ENABLED_OPTION, "false")); // FIXME VECTOR-23
 
         if (maxSSTablesToCompact <= 0)  // use half the maximum permitted compaction size as upper bound by default
             maxSSTablesToCompact = (int) (dataSetSize * this.maxSpaceOverhead * 0.5 / getMinSstableSizeBytes());
@@ -357,6 +358,41 @@ public abstract class Controller
                     "Set it to 'true' to enable aggressive SSTable expiration.");
         }
         this.ignoreOverlapsInExpirationCheck = ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION && ignoreOverlapsInExpirationCheck;
+    }
+
+    protected static String getSystemProperty(String option)
+    {
+        return getSystemProperty(option, null);
+    }
+
+    /**
+     * Tries to get system property with PREFIX first. If it doesn't find it,
+     * looks for system property with LEGACY_PREFIX. If both are missing it
+     * returns the default value.
+     */
+    protected static String getSystemProperty(String option, String defaultValue) {
+        String value = System.getProperty(PREFIX + option);
+        if (value == null)
+            value = System.getProperty(LEGACY_PREFIX + option, defaultValue);
+        return value;
+    }
+
+    protected static Boolean getBooleanSystemProperty(String option)
+    {
+        return Boolean.getBoolean(PREFIX + option) || Boolean.getBoolean(LEGACY_PREFIX + option);
+    }
+
+    /**
+     * Tries to get system property with PREFIX first. If it doesn't find it,
+     * looks for system property with LEGACY_PREFIX. If both are missing it
+     * returns the default value.
+     */
+    public static Integer getIntegerSystemProperty(String option, int defaultValue)
+    {
+        Integer value = Integer.getInteger(PREFIX + option);
+        if (value == null)
+            value = Integer.getInteger(LEGACY_PREFIX + option, defaultValue);
+        return value;
     }
 
     public static File getControllerConfigPath(String keyspaceName, String tableName)
@@ -853,7 +889,7 @@ public abstract class Controller
         double maxSpaceOverhead = options.containsKey(MAX_SPACE_OVERHEAD_OPTION)
                 ? FBUtilities.parsePercent(options.get(MAX_SPACE_OVERHEAD_OPTION))
                 : DEFAULT_MAX_SPACE_OVERHEAD;
-        int maxSSTablesToCompact = Integer.parseInt(options.getOrDefault(MAX_SSTABLES_TO_COMPACT_OPTION, "0"));
+        int maxSSTablesToCompact = Integer.parseInt(options.getOrDefault(MAX_SSTABLES_TO_COMPACT_OPTION, "256"));
         long expiredSSTableCheckFrequency = options.containsKey(EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_OPTION)
                 ? Long.parseLong(options.get(EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_OPTION))
                 : DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS;
@@ -923,7 +959,7 @@ public abstract class Controller
 
         // For remote storage, the sstables on L0 are created by the different replicas, and therefore it is likely
         // that there are RF identical copies, so here we adjust the survival factor for L0
-        double[] survivalFactors = System.getProperty(PREFIX + SHARED_STORAGE) == null || !Boolean.getBoolean(PREFIX + SHARED_STORAGE)
+        double[] survivalFactors = getSystemProperty(SHARED_STORAGE) == null || !getBooleanSystemProperty(SHARED_STORAGE)
                                    ? DEFAULT_SURVIVAL_FACTORS
                                    : new double[] { DEFAULT_SURVIVAL_FACTOR / realm.getKeyspaceReplicationStrategy().getReplicationFactor().allReplicas, DEFAULT_SURVIVAL_FACTOR };
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/CostsCalculator.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/CostsCalculator.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MovingAverage;
 
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getIntegerSystemProperty;
+
 /**
  * This class periodically retrieves delta values from the environment and stores them into exponentially weighted averages.
  * It then uses these values to calculate IO costs that are exported to {@link CompactionMetrics} and used by {@link AdaptiveController}
@@ -44,7 +46,7 @@ public class CostsCalculator
 
     /** How often values are sampled. Sampling for periods that are too short (<= 1 second) may not give good results since
      * we many not collect sufficient data. */
-    final static int samplingPeriodMs = Controller.getIntegerSystemProperty("sample_time_ms", 5000);
+    final static int samplingPeriodMs = getIntegerSystemProperty("sample_time_ms", 5000);
 
     private final Environment env;
     private final MovingAverageOfDelta partitionsReadPerPeriod;

--- a/src/java/org/apache/cassandra/db/compaction/unified/CostsCalculator.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/CostsCalculator.java
@@ -44,7 +44,7 @@ public class CostsCalculator
 
     /** How often values are sampled. Sampling for periods that are too short (<= 1 second) may not give good results since
      * we many not collect sufficient data. */
-    final static int samplingPeriodMs = Integer.getInteger(Controller.PREFIX + "sample_time_ms", 5000);
+    final static int samplingPeriodMs = Controller.getIntegerSystemProperty("sample_time_ms", 5000);
 
     private final Environment env;
     private final MovingAverageOfDelta partitionsReadPerPeriod;

--- a/src/java/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtils.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import static org.apache.cassandra.db.compaction.unified.Controller.LEGACY_PREFIX;
+import static org.apache.cassandra.db.compaction.unified.Controller.PREFIX;
+
+public class DSECompatibilityUtils
+{
+    protected static String getSystemProperty(String option)
+    {
+        return getSystemProperty(option, null);
+    }
+
+    /**
+     * Tries to get system property with PREFIX first. If it doesn't find it,
+     * looks for system property with LEGACY_PREFIX. If both are missing it
+     * returns the default value.
+     */
+    protected static String getSystemProperty(String option, String defaultValue) {
+        String value = System.getProperty(PREFIX + option);
+        if (value == null)
+            value = System.getProperty(LEGACY_PREFIX + option, defaultValue);
+        return value;
+    }
+
+    protected static Boolean getBooleanSystemProperty(String option)
+    {
+        String value = getSystemProperty(option);
+        boolean result = false;
+        try
+        {
+            result = Boolean.parseBoolean(value);
+        }
+        catch (IllegalArgumentException | NullPointerException e)
+        {
+        }
+        return result;
+    }
+
+    public static Integer getIntegerSystemProperty(String option, int defaultValue)
+    {
+        String value = getSystemProperty(option, String.valueOf(defaultValue));
+        return Integer.valueOf(value);
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtils.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtils.java
@@ -42,16 +42,7 @@ public class DSECompatibilityUtils
 
     protected static Boolean getBooleanSystemProperty(String option)
     {
-        String value = getSystemProperty(option);
-        boolean result = false;
-        try
-        {
-            result = Boolean.parseBoolean(value);
-        }
-        catch (IllegalArgumentException | NullPointerException e)
-        {
-        }
-        return result;
+        return Boolean.parseBoolean(getSystemProperty(option));
     }
 
     public static Integer getIntegerSystemProperty(String option, int defaultValue)

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -33,6 +33,8 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getSystemProperty;
+
 /**
  * The static compaction controller periodically checks the IO costs
  * that result from the current configuration of the {@link UnifiedCompactionStrategy}.

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -43,7 +43,7 @@ public class StaticController extends Controller
      * The scaling parameters W, one per bucket index and separated by a comma.
      * Higher indexes will use the value of the last index with a W specified.
      */
-    private static final String DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + SCALING_PARAMETERS_OPTION, "T4");
+    private static final String DEFAULT_STATIC_SCALING_PARAMETERS = getSystemProperty(SCALING_PARAMETERS_OPTION, "T4");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation

--- a/test/unit/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtilsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtilsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import org.junit.Test;
+
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.db.compaction.unified.AdaptiveController.MIN_COST;
+import static org.apache.cassandra.db.compaction.unified.Controller.*;
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getBooleanSystemProperty;
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getIntegerSystemProperty;
+import static org.apache.cassandra.db.compaction.unified.DSECompatibilityUtils.getSystemProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DSECompatibilityUtilsTest
+{
+    @Test
+    public void testGetSystemProperty()
+    {
+       String propValue = getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB");
+       assertEquals(DEFAULT_MIN_SSTABLE_SIZE , FBUtilities.parseHumanReadableBytes(propValue));
+
+       System.setProperty(PREFIX + MIN_SSTABLE_SIZE_OPTION, "50MiB");
+       assertEquals("50MiB", getSystemProperty(MIN_SSTABLE_SIZE_OPTION));
+
+       System.setProperty(LEGACY_PREFIX + MIN_SSTABLE_SIZE_OPTION, "1MiB");
+       // Since PREFIX is set it takes precedence
+       assertEquals("50MiB", getSystemProperty(MIN_SSTABLE_SIZE_OPTION));
+
+       System.clearProperty(PREFIX + MIN_SSTABLE_SIZE_OPTION);
+       assertEquals("1MiB", getSystemProperty(MIN_SSTABLE_SIZE_OPTION));
+    }
+
+    @Test
+    public void testGetIntegerSystemProperty()
+    {
+        int minCost = getIntegerSystemProperty(MIN_COST, 1000);
+        assertEquals(1000, minCost);
+
+        System.setProperty(PREFIX + MIN_COST, "500");
+        assertEquals(500, (int) getIntegerSystemProperty(MIN_COST, 0));
+
+        System.setProperty(LEGACY_PREFIX + MIN_COST, "100");
+        assertEquals(500, (int) getIntegerSystemProperty(MIN_COST, 0));
+
+        System.clearProperty(PREFIX + MIN_COST);
+        assertEquals(100, (int) getIntegerSystemProperty(MIN_COST, 0));
+    }
+
+    @Test
+    public void testGetBooleanSystemProperty()
+    {
+        boolean sharedStorage = getBooleanSystemProperty(SHARED_STORAGE);
+        assertFalse(sharedStorage);
+
+        System.setProperty(LEGACY_PREFIX + SHARED_STORAGE, "false");
+        assertFalse(getBooleanSystemProperty(SHARED_STORAGE));
+
+        System.setProperty(LEGACY_PREFIX + SHARED_STORAGE, "true");
+        assertTrue(getBooleanSystemProperty(SHARED_STORAGE));
+
+        System.setProperty(PREFIX + SHARED_STORAGE, "false");
+        assertFalse(getBooleanSystemProperty(SHARED_STORAGE));
+
+        System.setProperty(PREFIX + SHARED_STORAGE, "true");
+        assertTrue(getBooleanSystemProperty(SHARED_STORAGE));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtilsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/DSECompatibilityUtilsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.compaction.unified;
 
+import org.junit.After;
 import org.junit.Test;
 
 import org.apache.cassandra.utils.FBUtilities;
@@ -33,6 +34,20 @@ import static org.junit.Assert.assertTrue;
 
 public class DSECompatibilityUtilsTest
 {
+
+    /**
+     * Making sure to start each test with clean system property state
+     */
+    @After
+    public void doAfter()
+    {
+        String[] options = new String[]{MIN_SSTABLE_SIZE_OPTION, MIN_COST, SHARED_STORAGE};
+        String[] prefixes = new String[]{PREFIX, LEGACY_PREFIX};
+
+        for(String option: options)
+            for(String prefix: prefixes)
+                System.clearProperty(prefix + option);
+    }
     @Test
     public void testGetSystemProperty()
     {


### PR DESCRIPTION
Legacy prefix is considered if property is not found with existing PREFIX.
Bumps `max_sstables_to_compact` default to 256.

Closes https://github.com/riptano/cndb/issues/10850