### PR TITLE
CNDB-9987: Fix GuardrailNonPartitionRestrictedQueryTest

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -1242,20 +1242,10 @@ public class RowFilter implements Iterable<RowFilter.Expression>
                 default:
                     break;
             }
-            if (cql)
-            {
-                var cqlValueString = type.toCQLString(value);
-                if (cqlValueString.length() > 9)
-                    cqlValueString = cqlValueString.substring(0, 6) + "...";
-                return String.format("%s %s %s", column.name.toCQLString(), operator, cqlValueString);
-            }
-            else
-            {
-                var valueString = type.getString(value);
-                if (valueString.length() > 9)
-                    valueString = valueString.substring(0, 6) + "...";
-                return String.format("%s %s %s", column.name.toString(), operator, valueString);
-            }
+
+            return cql
+                   ? String.format("%s %s %s", column.name.toCQLString(), operator, type.toCQLString(value, true))
+                   : String.format("%s %s %s", column.name.toString(), operator, type.getString(value, true));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -205,9 +205,26 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return getString(bytes, ByteBufferAccessor.instance);
     }
 
+    public final String getString(ByteBuffer bytes, boolean truncate)
+    {
+        String s = getString(bytes);
+        return truncate ? truncateString(s) : s;
+    }
+
     public String toCQLString(ByteBuffer bytes)
     {
         return asCQL3Type().toCQLLiteral(bytes);
+    }
+
+    public String toCQLString(ByteBuffer bytes, boolean truncate)
+    {
+        String s = toCQLString(bytes);
+        return truncate ? truncateString(s) : s;
+    }
+
+    private static String truncateString(String valueString)
+    {
+        return valueString.length() <= 9 ? valueString : valueString.substring(0, 6) + "...";
     }
 
     /** get a byte representation of the given string. */

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.MessageParams;
 import org.apache.cassandra.db.MultiRangeReadCommand;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
@@ -56,6 +57,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
 import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CollectionType;
@@ -89,6 +91,7 @@ import org.apache.cassandra.index.sai.view.View;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.net.ParamType;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -762,6 +765,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                     }
                 }
 
+                maybeTriggerReferencedIndexesGuardrail(referencedIndexes.size());
+
                 if (failed)
                 {
                     // TODO: This might be a good candidate for a table/index group metric in the future...
@@ -776,6 +781,25 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         finally
         {
             Tracing.trace("Querying storage-attached indexes {}", indexNames);
+        }
+    }
+
+    void maybeTriggerReferencedIndexesGuardrail(int numReferencedIndexes)
+    {
+        if (Guardrails.saiSSTableIndexesPerQuery.failsOn(numReferencedIndexes, null))
+        {
+            String msg = String.format("Query %s attempted to read from too many indexes (%s) but max allowed is %s; " +
+                                       "query aborted (see sai_sstable_indexes_per_query_fail_threshold)",
+                                       command.toCQLString(),
+                                       numReferencedIndexes,
+                                       Guardrails.CONFIG_PROVIDER.getOrCreate(null).getSaiSSTableIndexesPerQueryFailThreshold());
+            Tracing.trace(msg);
+            MessageParams.add(ParamType.TOO_MANY_REFERENCED_INDEXES_FAIL, numReferencedIndexes);
+            throw new QueryReferencingTooManyIndexesException(msg);
+        }
+        else if (Guardrails.saiSSTableIndexesPerQuery.warnsOn(numReferencedIndexes, null))
+        {
+            MessageParams.add(ParamType.TOO_MANY_REFERENCED_INDEXES_WARN, numReferencedIndexes);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -129,6 +129,8 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             // rows. Acquire the view before building any of the iterators.
             try (var queryView = new QueryViewBuilder(cfs, controller.getOrderer(), controller.mergeRange(), queryContext).build())
             {
+                controller.maybeTriggerReferencedIndexesGuardrail(queryView.referencedIndexes.size());
+
                 // TODO this is a bit of a hack, but we need to get the view from the queryView. Find better way to
                 // thread this through.
                 queryContext.view = queryView;
@@ -147,7 +149,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             return new ResultRetriever((RangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
         }
     }
-
 
     /**
      * Converts expressions into filter tree (which is currently just a single AND).

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -261,12 +261,12 @@ public class Message<T>
      * Used by the {@code MultiRangeReadCommand} to split multi-range responses from a replica
      * into single-range responses.
      */
-    public static <T> Message<T> remoteResponse(InetAddressAndPort from, Verb verb, T payload)
+    public static <T> Message<T> remoteResponse(InetAddressAndPort from, Verb verb, Map<ParamType, Object> params, T payload)
     {
         assert verb.isResponse();
         long createdAtNanos = approxTime.now();
         long expiresAtNanos = verb.expiresAtNanos(createdAtNanos);
-        return new Message<>(new Header(0, verb, from, createdAtNanos, expiresAtNanos, 0, NO_PARAMS), payload);
+        return new Message<>(new Header(0, verb, from, createdAtNanos, expiresAtNanos, 0, params), payload);
     }
 
     /** Builds a response Message with provided payload, and all the right fields inferred from request Message */
@@ -329,7 +329,7 @@ public class Message<T>
         return new Message<>(header.withParams(values), payload);
     }
 
-    private static final EnumMap<ParamType, Object> NO_PARAMS = new EnumMap<>(ParamType.class);
+    public static final EnumMap<ParamType, Object> NO_PARAMS = new EnumMap<>(ParamType.class);
 
     private static Map<ParamType, Object> buildParams(ParamType type, Object value)
     {

--- a/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/EndpointGroupingCoordinator.java
@@ -258,7 +258,7 @@ public class EndpointGroupingCoordinator
 
                     // extract subrange response in token order
                     ReadResponse subrangeResponse = multiRangeResponse.subrangeResponse(multiRangeCommand, range);
-                    handler.onResponse(Message.remoteResponse(response.header.from, Verb.RANGE_RSP, subrangeResponse));
+                    handler.onResponse(Message.remoteResponse(response.header.from, Verb.RANGE_RSP, response.header.params(), subrangeResponse));
                 }
             }
 

--- a/test/unit/org/apache/cassandra/schema/MigrationCoordinatorTest.java
+++ b/test/unit/org/apache/cassandra/schema/MigrationCoordinatorTest.java
@@ -205,7 +205,7 @@ public class MigrationCoordinatorTest
         Pair<InetAddressAndPort, RequestCallback<Collection<Mutation>>> request2 = wrapper.requests.poll();
         Assert.assertEquals(EP2, request2.left);
         Assert.assertFalse(coordinator.awaitSchemaRequests(1));
-        request2.right.onResponse(Message.remoteResponse(request2.left, Verb.SCHEMA_PULL_RSP, Collections.emptyList()));
+        request2.right.onResponse(Message.remoteResponse(request2.left, Verb.SCHEMA_PULL_RSP, Message.NO_PARAMS, Collections.emptyList()));
         Assert.assertEquals(EP2, Iterables.getOnlyElement(wrapper.mergedSchemasFrom));
         Assert.assertTrue(coordinator.awaitSchemaRequests(1));
 
@@ -317,7 +317,7 @@ public class MigrationCoordinatorTest
 
         getUnchecked(wrapper.coordinator.reportEndpointVersion(EP3, V2));
         Pair<InetAddressAndPort, RequestCallback<Collection<Mutation>>> cb = wrapper.requests.remove();
-        cb.right.onResponse(Message.remoteResponse(cb.left, Verb.SCHEMA_PULL_RSP, Collections.emptyList()));
+        cb.right.onResponse(Message.remoteResponse(cb.left, Verb.SCHEMA_PULL_RSP, Message.NO_PARAMS, Collections.emptyList()));
 
         getUnchecked(wrapper.coordinator.reportEndpointVersion(EP1, V1));
         getUnchecked(wrapper.coordinator.reportEndpointVersion(EP2, V1));
@@ -352,7 +352,7 @@ public class MigrationCoordinatorTest
 
         // a single success should unblock startup though
         cb = wrapper.requests.remove();
-        cb.right.onResponse(Message.remoteResponse(cb.left, Verb.SCHEMA_PULL_RSP, Collections.emptyList()));
+        cb.right.onResponse(Message.remoteResponse(cb.left, Verb.SCHEMA_PULL_RSP, Message.NO_PARAMS, Collections.emptyList()));
         Assert.assertTrue(wrapper.coordinator.awaitSchemaRequests(1));
     }
 
@@ -440,7 +440,7 @@ public class MigrationCoordinatorTest
 
             assertThat(msg.verb()).isEqualTo(Verb.SCHEMA_PULL_REQ);
             assertThat(endpoint).isEqualTo(regularNode1);
-            callback.onResponse(Message.remoteResponse(regularNode1, Verb.SCHEMA_PULL_RSP, mutations));
+            callback.onResponse(Message.remoteResponse(regularNode1, Verb.SCHEMA_PULL_RSP, Message.NO_PARAMS, mutations));
             return null;
         }).when(wrapper.messagingService).sendWithCallback(any(Message.class), any(InetAddressAndPort.class), any(RequestCallback.class));
         wrapper.coordinator.reset();


### PR DESCRIPTION
This includes:
* Adding the missing call to the tested guardrail, Guardrails.saiSSTableIndexesPerQuery, which was missed on rebase.
* Fixes for the test itself, since row filter expression values are truncated at printing (CC-only behaviour).
* Fixes to make track warnings work with MultiRangeReadCommand. The former was ASF-only, whereas the latter was CC-only.