### PR TITLE
CNDB-10939: Make SAI index empty column values

### DIFF
--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -45,6 +45,12 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         super(ComparisonType.CUSTOM, false, subTypes);
     }
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public <VL, VR> int compareCustom(VL left, ValueAccessor<VL> accessorL, VR right, ValueAccessor<VR> accessorR)
     {
         if (accessorL.isEmpty(left) || accessorR.isEmpty(right))

--- a/src/java/org/apache/cassandra/db/marshal/AbstractGeometricType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractGeometricType.java
@@ -44,18 +44,32 @@ public abstract class AbstractGeometricType<T extends OgcGeometry> extends Abstr
         public <V> T deserialize(V value, ValueAccessor<V> accessor)
         {
             // OGCGeometry does not respect the current position of the buffer, so you need to use slice()
-            ByteBuffer byteBuffer = accessor.toBuffer(value);
-            return geoSerializer.fromWellKnownBinary(byteBuffer.slice());
+            try
+            {
+                ByteBuffer byteBuffer = accessor.toBuffer(value);
+                return geoSerializer.fromWellKnownBinary(byteBuffer.slice());
+            }
+            catch (IndexOutOfBoundsException ex)
+            {
+                throw new MarshalException("Not enough bytes to deserialize value", ex);
+            }
         }
 
         @Override
         public <V> void validate(V value, ValueAccessor<V> accessor) throws MarshalException
         {
-            ByteBuffer byteBuffer = accessor.toBuffer(value);
-            int pos = byteBuffer.position();
-            // OGCGeometry does not respect the current position of the buffer, so you need to use slice()
-            geoSerializer.fromWellKnownBinary(byteBuffer.slice()).validate();
-            byteBuffer.position(pos);
+            try
+            {
+                ByteBuffer byteBuffer = accessor.toBuffer(value);
+                int pos = byteBuffer.position();
+                // OGCGeometry does not respect the current position of the buffer, so you need to use slice()
+                geoSerializer.fromWellKnownBinary(byteBuffer.slice()).validate();
+                byteBuffer.position(pos);
+            }
+            catch (IndexOutOfBoundsException ex)
+            {
+                throw new MarshalException("Not enough bytes to deserialize value", ex);
+            }
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -552,6 +552,19 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return valueLengthIfFixed() != VARIABLE_LENGTH;
     }
 
+    /**
+     * Defines if the type allows an empty set of bytes ({@code new byte[0]}) as valid input.  The {@link #validate(Object, ValueAccessor)}
+     * and {@link #compose(Object, ValueAccessor)} methods must allow empty bytes when this returns true, and must reject empty bytes
+     * when this is false.
+     * <p/>
+     * As of this writing, the main user of this API is for testing to know what types allow empty values and what types don't,
+     * so that the data that gets generated understands when {@link ByteBufferUtil#EMPTY_BYTE_BUFFER} is allowed as valid data.
+     */
+    public boolean allowsEmpty()
+    {
+        return false;
+    }
+
     public boolean isNull(ByteBuffer bb)
     {
         return isNull(bb, ByteBufferAccessor.instance);

--- a/src/java/org/apache/cassandra/db/marshal/AsciiType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AsciiType.java
@@ -41,7 +41,7 @@ public class AsciiType extends AbstractType<String>
 
     AsciiType() {super(ComparisonType.BYTE_ORDER);} // singleton
 
-    private final FastThreadLocal<CharsetEncoder> encoder = new FastThreadLocal<CharsetEncoder>()
+    private final FastThreadLocal<CharsetEncoder> encoder = new FastThreadLocal<>()
     {
         @Override
         protected CharsetEncoder initialValue()
@@ -49,6 +49,12 @@ public class AsciiType extends AbstractType<String>
             return StandardCharsets.US_ASCII.newEncoder();
         }
     };
+
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
 
     public ByteBuffer fromString(String source)
     {

--- a/src/java/org/apache/cassandra/db/marshal/BooleanType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BooleanType.java
@@ -40,6 +40,12 @@ public class BooleanType extends AbstractType<Boolean>
 
     BooleanType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/BytesType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BytesType.java
@@ -35,6 +35,12 @@ public class BytesType extends AbstractType<ByteBuffer>
 
     BytesType() {super(ComparisonType.BYTE_ORDER);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public ByteBuffer fromString(String source)
     {
         try

--- a/src/java/org/apache/cassandra/db/marshal/CounterColumnType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CounterColumnType.java
@@ -34,6 +34,12 @@ public class CounterColumnType extends NumberType<Long>
 
     CounterColumnType() {super(ComparisonType.NOT_COMPARABLE);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/DateRangeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DateRangeType.java
@@ -45,6 +45,12 @@ public class DateRangeType extends AbstractType<DateRange>
     }
 
     @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
+    @Override
     public ByteBuffer fromString(String source) throws MarshalException
     {
         if (source.isEmpty())

--- a/src/java/org/apache/cassandra/db/marshal/DecimalType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DecimalType.java
@@ -57,6 +57,12 @@ public class DecimalType extends NumberType<BigDecimal>
 
     DecimalType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/DoubleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/DoubleType.java
@@ -37,6 +37,12 @@ public class DoubleType extends NumberType<Double>
 
     DoubleType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/EmptyType.java
+++ b/src/java/org/apache/cassandra/db/marshal/EmptyType.java
@@ -71,6 +71,12 @@ public class EmptyType extends AbstractType<Void>
     private EmptyType() {super(ComparisonType.CUSTOM);} // singleton
 
     @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
+    @Override
     public <V> ByteSource asComparableBytes(ValueAccessor<V> accessor, V data, ByteComparable.Version version)
     {
         return null;

--- a/src/java/org/apache/cassandra/db/marshal/FloatType.java
+++ b/src/java/org/apache/cassandra/db/marshal/FloatType.java
@@ -38,6 +38,12 @@ public class FloatType extends NumberType<Float>
 
     FloatType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/InetAddressType.java
+++ b/src/java/org/apache/cassandra/db/marshal/InetAddressType.java
@@ -35,6 +35,12 @@ public class InetAddressType extends AbstractType<InetAddress>
 
     InetAddressType() {super(ComparisonType.BYTE_ORDER);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/Int32Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/Int32Type.java
@@ -41,6 +41,12 @@ public class Int32Type extends NumberType<Integer>
         super(ComparisonType.CUSTOM);
     } // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/IntegerType.java
+++ b/src/java/org/apache/cassandra/db/marshal/IntegerType.java
@@ -73,6 +73,12 @@ public final class IntegerType extends NumberType<BigInteger>
 
     IntegerType() {super(ComparisonType.CUSTOM);}/* singleton */
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/LexicalUUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LexicalUUIDType.java
@@ -45,6 +45,12 @@ public class LexicalUUIDType extends AbstractType<UUID>
         super(ComparisonType.CUSTOM);
     } // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/LongType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LongType.java
@@ -38,6 +38,12 @@ public class LongType extends NumberType<Long>
 
     LongType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java
@@ -40,6 +40,12 @@ public class TimeUUIDType extends TemporalType<UUID>
         super(ComparisonType.CUSTOM);
     } // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/TimestampType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TimestampType.java
@@ -53,6 +53,12 @@ public class TimestampType extends TemporalType<Date>
 
     private TimestampType() {super(ComparisonType.CUSTOM);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -70,6 +70,12 @@ public class TupleType extends MultiCellCapableType<ByteBuffer>
     }
 
     @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
+    @Override
     public TupleType with(ImmutableList<AbstractType<?>> subTypes, boolean isMultiCell)
     {
         return new TupleType(subTypes, isMultiCell);

--- a/src/java/org/apache/cassandra/db/marshal/UTF8Type.java
+++ b/src/java/org/apache/cassandra/db/marshal/UTF8Type.java
@@ -38,6 +38,12 @@ public class UTF8Type extends AbstractType<String>
 
     UTF8Type() {super(ComparisonType.BYTE_ORDER);} // singleton
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public ByteBuffer fromString(String source)
     {
         return decompose(source);

--- a/src/java/org/apache/cassandra/db/marshal/UUIDType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UUIDType.java
@@ -54,6 +54,12 @@ public class UUIDType extends AbstractType<UUID>
         super(ComparisonType.CUSTOM);
     }
 
+    @Override
+    public boolean allowsEmpty()
+    {
+        return true;
+    }
+
     public boolean isEmptyValueMeaningless()
     {
         return true;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -233,7 +233,7 @@ public class SSTableIndexWriter implements PerIndexWriter
             currentBuilder = newSegmentBuilder(sstableRowId);
         }
 
-        if (term.remaining() == 0)
+        if (term.remaining() == 0 && !indexContext.getValidator().allowsEmpty())
             return;
 
         long allocated = currentBuilder.addAll(term, type, key, sstableRowId, analyzer, indexContext);

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -167,7 +167,7 @@ public class TrieMemtableIndex implements MemtableIndex
     @Override
     public void index(DecoratedKey key, Clustering clustering, ByteBuffer value, Memtable memtable, OpOrder.Group opGroup)
     {
-        if (value == null || value.remaining() == 0)
+        if (value == null || (value.remaining() == 0 && !validator.allowsEmpty()))
             return;
 
         RequestSensors sensors = requestTracker.get();

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.index.sai.SAITester;
+
+public class EmptyStringLifecycleTest extends SAITester
+{
+    @Test
+    public void testBeforeAndAfterFlush()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        disableCompaction(KEYSPACE);
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
+        waitForIndexQueryable();
+
+        execute("INSERT INTO %s (k, v) VALUES (0, '')");
+        execute("INSERT INTO %s (k) VALUES (1)");
+
+        UntypedResultSet rows = execute("SELECT * FROM %s WHERE v = ''");
+        assertRows(rows, row(0, ""));
+
+        flush();
+        rows = execute("SELECT * FROM %s WHERE v = ''");
+        assertRows(rows, row(0, ""));
+    }
+
+    @Test
+    public void testAfterInitialBuild()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        disableCompaction(KEYSPACE);
+
+        execute("INSERT INTO %s (k, v) VALUES (0, '')");
+        execute("INSERT INTO %s (k) VALUES (1)");
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
+        waitForIndexQueryable();
+
+        UntypedResultSet rows = execute("SELECT * FROM %s WHERE v = ''");
+        assertRows(rows, row(0, ""));
+    }
+
+    @Test
+    public void testAfterCompaction()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        disableCompaction(KEYSPACE);
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
+
+        execute("INSERT INTO %s (k, v) VALUES (0, '')");
+        execute("INSERT INTO %s (k) VALUES (1)");
+        flush();
+
+        execute("INSERT INTO %s (k, v) VALUES (1, '')");
+        flush();
+        
+        compact();
+
+        UntypedResultSet rows = execute("SELECT * FROM %s WHERE v = ''");
+        assertRows(rows, row(1, ""), row(0, ""));
+    }
+
+    @Test
+    public void testOrderBy()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        disableCompaction(KEYSPACE);
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
+
+        execute("INSERT INTO %s (k, v) VALUES (0, '')");
+
+        UntypedResultSet rows = execute("SELECT * FROM %s ORDER BY v LIMIT 10");
+        assertRows(rows, row(0, ""));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -363,18 +363,18 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void verifyEmptyStringIndexingBehaviorOnNonAnalyzedColumn() throws Throwable
+    public void verifyEmptyStringIndexingBehaviorOnNonAnalyzedColumn()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         waitForIndexQueryable();
         execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 0, "");
         flush();
-        assertRows(execute("SELECT * FROM %s WHERE v = ''"));
+        assertRows(execute("SELECT * FROM %s WHERE v = ''"), row(0, ""));
     }
 
     @Test
-    public void testEmptyQueryString() throws Throwable
+    public void verifyEmptyStringIndexingBehaviorOnAnalyzedColumn()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'standard'}");
@@ -383,6 +383,7 @@ public class LuceneAnalyzerTest extends SAITester
         execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 1, "some text to analyze");
         flush();
         assertRows(execute("SELECT * FROM %s WHERE v : ''"));
+        assertRows(execute("SELECT * FROM %s WHERE v : ' '"));
     }
 
     // The english analyzer has a default set of stop words. This test relies on "the" being one of those stop words.


### PR DESCRIPTION
Ports [CASSANDRA-19461](https://issues.apache.org/jira/browse/CASSANDRA-19461) into `main`.

Currently, SAI doesn't create an index entry for empty values. As a result, index queries such as `SELECT * FROM %s WHERE v = ''` will never find anything. However, the same query with `ALLOW FILTERING` can find rows.

The ported patch makes sure that empty values are indexed. However, existing indexes would need a rebuild to have these entries.

We need to evaluate if this can be a breaking change for some users. The only side effect I can think of is that indexes with many empty values that are never queries would become larger after this change.