### PR TITLE
CNDB-10801: Fix bug in SAI index ordering

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithByteComparable.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithByteComparable.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
@@ -47,7 +48,8 @@ public class PrimaryKeyWithByteComparable extends PrimaryKeyWithSortKey
         {
             ByteSource byteSource = byteComparable.asComparableBytes(ByteComparable.Version.OSS50);
             byte[] indexedValue = ByteSourceInverse.readBytes(byteSource);
-            return Arrays.compare(indexedValue, value.array()) == 0;
+            byte[] liveValue = ByteBufferUtil.getArray(value);
+            return Arrays.compare(indexedValue, liveValue) == 0;
         }
         else
         {


### PR DESCRIPTION
This fixes an issue reading cell values in `ORDER BY`. It fixes multiple tests:
* GenericOrderByTest
* LiteralOrderTest
* StaticColumnIndexTest
* AsciiTest
* TextTest
