### PR TITLE
Include checksums in CorruptBlockException when relevant

### DIFF
--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -310,8 +310,10 @@ public class CompressedSequentialWriter extends SequentialWriter
             crcCheckBuffer.clear();
             readChannel.read(crcCheckBuffer);
             crcCheckBuffer.flip();
-            if (crcCheckBuffer.getInt() != (int) checksum.getValue())
-                throw new CorruptBlockException(getFile().toString(), chunkOffset, chunkSize);
+            int storedChecksum = crcCheckBuffer.getInt();
+            int computedChecksum = (int) checksum.getValue();
+            if (storedChecksum != computedChecksum)
+                throw new CorruptBlockException(getFile().toString(), chunkOffset, chunkSize, storedChecksum, computedChecksum);
         }
         catch (CorruptBlockException e)
         {

--- a/src/java/org/apache/cassandra/io/compress/CorruptBlockException.java
+++ b/src/java/org/apache/cassandra/io/compress/CorruptBlockException.java
@@ -40,4 +40,16 @@ public class CorruptBlockException extends IOException
     {
         super(String.format("(%s): corruption detected, chunk at %d of length %d.", filePath, offset, length), cause);
     }
+
+    public CorruptBlockException(String filePath, CompressionMetadata.Chunk chunk, int storedChecksum, int calculatedChecksum)
+    {
+        this(filePath, chunk.offset, chunk.length, storedChecksum, calculatedChecksum);
+    }
+
+    public CorruptBlockException(String filePath, long offset, int length, int storedChecksum, int calculatedChecksum)
+    {
+        super(String.format("(%s): corruption detected, chunk at %d of length %d has mismatched checksums. Expected %d, but calculated %d",
+                            filePath, offset, length, storedChecksum, calculatedChecksum));
+    }
+
 }

--- a/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
@@ -138,8 +138,9 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                         int checksum = (int) ChecksumType.CRC32.of(compressed);
 
                         compressed.limit(length);
-                        if (compressed.getInt() != checksum)
-                            throw new CorruptBlockException(channel.filePath(), chunk);
+                        int storedChecksum = compressed.getInt();
+                        if (storedChecksum != checksum)
+                            throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
 
                         compressed.position(0).limit(chunk.length);
                     }
@@ -166,9 +167,11 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
 
                         ByteBuffer scratch = bufferHolder.getBuffer(Integer.BYTES);
 
-                        if (channel.read(scratch, chunkOffset + chunk.length) != Integer.BYTES
-                                || scratch.getInt(0) != checksum)
+                        if (channel.read(scratch, chunkOffset + chunk.length) != Integer.BYTES)
                             throw new CorruptBlockException(channel.filePath(), chunk);
+                        int storedChecksum = scratch.getInt(0);
+                        if (storedChecksum != checksum)
+                            throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
                     }
                 }
                 uncompressed.flip();
@@ -231,8 +234,9 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                         int checksum = (int) ChecksumType.CRC32.of(compressedChunk);
 
                         compressedChunk.limit(compressedChunk.capacity());
-                        if (compressedChunk.getInt() != checksum)
-                            throw new CorruptBlockException(channel.filePath(), chunk);
+                        int storedChecksum = compressedChunk.getInt();
+                        if (storedChecksum != checksum)
+                            throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
 
                         compressedChunk.position(chunkOffsetInSegment).limit(chunkOffsetInSegment + chunk.length);
                     }


### PR DESCRIPTION
This additional metadata is somewhat valuable in the context of troubleshooting. Recently, we had an issue where the checksum itself was not (over)written and so it was stored as 0. In many cases, this won't be helpful, but since it is cheap and could be helpful, I propose adding some additional metadata when checksums don't match.