### PR TITLE
CNDB-10923: Fix expressions accidentally joined by OR instead of AND

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -234,7 +234,7 @@ public abstract class RestrictionSet implements Restrictions
                                    QueryOptions options) throws InvalidRequestException
         {
             for (SingleRestriction restriction : restrictionsMap.values())
-                restriction.addToRowFilter(rowFilter, indexRegistry, options);
+                rowFilter.addAllAsConjunction(b -> restriction.addToRowFilter(b, indexRegistry, options));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -719,7 +719,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         // the trouble for now)
         // VECTOR
         protected enum Kind {
-            SIMPLE(0), MAP_COMPARISON(1), UNUSED1(2), CUSTOM(3), USER(4), VECTOR_RADIUS(100), TRUE(101);
+            SIMPLE(0), MAP_COMPARISON(1), UNUSED1(2), CUSTOM(3), USER(4), VECTOR_RADIUS(100);
             private final int val;
             Kind(int v) { val = v; }
             public int getVal() { return val; }
@@ -733,7 +733,6 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                     case 3: return CUSTOM;
                     case 4: return USER;
                     case 100: return VECTOR_RADIUS;
-                    case 101: return TRUE;
                     default: throw new IllegalArgumentException("Unknown index expression kind: " + val);
                 }
             }

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -315,10 +315,9 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
          * regardless of the current mode (conjunction / disjunction) of the {@link RowFilter.Builder}.
          * <p>
          *
-         * This wrapper method makes sure we pass a {@code RowFilter.Builder}
-         * that is always in conjunction mode to the respective {@code addToRowFilter} method. If multiple expressions
-         * are added to the row filter, this method makes sure they are joined with AND in
-         * their own FilterElement.
+         * This wrapper method makes sure we pass a {@code RowFilter.Builder} that is always in conjunction mode to the
+         * respective {@code addToRowFilterDelegate} method. If multiple expressions are added to the row filter, this 
+         * method makes sure they are joined with AND in their own {@link FilterElement}.
          *
          * @param addToRowFilterDelegate a function that adds expressions / child filter elements
          *                               to a provided {@link RowFilter.Builder}, and expects all

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -328,7 +328,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         {
             if (current.isDisjunction)
             {
-                // If we're in discujnction mode, we must not pass the current builder to addToRowFilter.
+                // If we're in disjunction mode, we must not pass the current builder to addToRowFilter.
                 // We create a new conjunction sub-builder instead and add all expressions there.
                 var builder = new Builder();
                 addToRowFilterDelegate.accept(builder);

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectSingleColumnRelationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectSingleColumnRelationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class SelectSingleColumnRelationTest extends CQLTester
 {
     @Test
-    public void testInvalidCollectionEqualityRelation() throws Throwable
+    public void testInvalidCollectionEqualityRelation()
     {
         createTable("CREATE TABLE %s (a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)");
         createIndex("CREATE INDEX ON %s (b)");
@@ -45,7 +45,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInvalidCollectionNonEQRelation() throws Throwable
+    public void testInvalidCollectionNonEQRelation()
     {
         createTable("CREATE TABLE %s (a int PRIMARY KEY, b set<int>, c int)");
         createIndex("CREATE INDEX ON %s (c)");
@@ -160,7 +160,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testPartitionKeyColumnRelations() throws Throwable
+    public void testPartitionKeyColumnRelations()
     {
         createTable("CREATE TABLE %s (a text, b int, c int, d int, primary key((a, b), c))");
         execute("insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 1, 1);
@@ -206,7 +206,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testClusteringColumnRelationsWithClusteringOrder() throws Throwable
+    public void testClusteringColumnRelationsWithClusteringOrder()
     {
         createTable("CREATE TABLE %s (a text, b int, c int, d int, primary key(a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC);");
         execute("insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 5, 1);
@@ -226,7 +226,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testAllowFilteringWithClusteringColumn() throws Throwable
+    public void testAllowFilteringWithClusteringColumn()
     {
         createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
 
@@ -265,7 +265,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testAllowFilteringWithIndexedColumn() throws Throwable
+    public void testAllowFilteringWithIndexedColumn()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, a int, b int)");
         createIndex("CREATE INDEX ON %s(a)");
@@ -286,7 +286,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testAllowFilteringWithIndexedColumnAndStaticColumns() throws Throwable
+    public void testAllowFilteringWithIndexedColumnAndStaticColumns()
     {
         createTable("CREATE TABLE %s (a int, b int, c int, s int static, PRIMARY KEY(a, b))");
         createIndex("CREATE INDEX ON %s(c)");
@@ -305,7 +305,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testIndexQueriesOnComplexPrimaryKey() throws Throwable
+    public void testIndexQueriesOnComplexPrimaryKey()
     {
         createTable("CREATE TABLE %s (pk0 int, pk1 int, ck0 int, ck1 int, ck2 int, value int, PRIMARY KEY ((pk0, pk1), ck0, ck1, ck2))");
 
@@ -328,7 +328,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testIndexOnClusteringColumns() throws Throwable
+    public void testIndexOnClusteringColumns()
     {
         createTable("CREATE TABLE %s (id1 int, id2 int, author text, time bigint, v1 text, v2 text, PRIMARY KEY ((id1, id2), author, time))");
         createIndex("CREATE INDEX ON %s(time)");
@@ -390,7 +390,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testRangeQueryOnIndex() throws Throwable
+    public void testRangeQueryOnIndex()
     {
         createTable("CREATE TABLE %s (id int primary key, row int, setid int);");
         createIndex("CREATE INDEX ON %s (setid)");
@@ -420,7 +420,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testINWithDuplicateValue() throws Throwable
+    public void testINWithDuplicateValue()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, v int, PRIMARY KEY (k1, k2))");
         execute("INSERT INTO %s (k1,  k2, v) VALUES (?, ?, ?)", 1, 1, 1);
@@ -436,7 +436,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testLargeClusteringINValues() throws Throwable
+    public void testLargeClusteringINValues()
     {
         createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
         execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 0)");
@@ -448,7 +448,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testMultiplePartitionKeyWithIndex() throws Throwable
+    public void testMultiplePartitionKeyWithIndex()
     {
         createTable("CREATE TABLE %s (a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))");
         createIndex("CREATE INDEX ON %s (c)");
@@ -486,18 +486,18 @@ public class SelectSingleColumnRelationTest extends CQLTester
                 row(0, 0, 1, 1, 1, 5),
                 row(0, 0, 2, 0, 0, 5));
 
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"),
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'),
                              "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?", 0, 0, 1, 5);
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING", 0, 1, 3, 5),
                    row(0, 0, 1, 1, 1, 5));
 
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"),
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'),
                              "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?", 0, 1, 2, 5);
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING", 0, 1, 2, 5),
                    row(0, 0, 1, 1, 1, 5),
                    row(0, 0, 2, 0, 0, 5));
 
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"),
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'),
                              "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ?", 0, 1, 3, 0, 3);
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ? ALLOW FILTERING", 0, 1, 3, 0, 3),
                    row(0, 0, 1, 0, 0, 3));
@@ -508,7 +508,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
                 row(0, 0, 1, 1, 1, 5),
                 row(0, 0, 2, 0, 0, 5));
 
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"),
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'),
                              "SELECT * FROM %s WHERE a = ? AND c >= ? AND f = ?", 0, 1, 5);
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND b = ? AND c >= ? AND f = ?", 0, 0, 1, 5),
                    row(0, 0, 1, 1, 1, 5),
@@ -529,7 +529,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testFunctionCallWithUnset() throws Throwable
+    public void testFunctionCallWithUnset()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, s text, i int)");
 
@@ -540,7 +540,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testLimitWithUnset() throws Throwable
+    public void testLimitWithUnset()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, i int)");
         execute("INSERT INTO %s (k, i) VALUES (1, 1)");
@@ -552,7 +552,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testWithUnsetValues() throws Throwable
+    public void testWithUnsetValues()
     {
         createTable("CREATE TABLE %s (k int, i int, j int, s text, PRIMARY KEY(k,i,j))");
         createIndex("CREATE INDEX s_index ON %s (s)");
@@ -580,7 +580,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInvalidSliceRestrictionOnPartitionKey() throws Throwable
+    public void testInvalidSliceRestrictionOnPartitionKey()
     {
         createTable("CREATE TABLE %s (a int PRIMARY KEY, b int, c text)");
         assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -590,7 +590,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInvalidMulticolumnSliceRestrictionOnPartitionKey() throws Throwable
+    public void testInvalidMulticolumnSliceRestrictionOnPartitionKey()
     {
         createTable("CREATE TABLE %s (a int, b int, c text, PRIMARY KEY ((a, b)))");
         assertInvalidMessage("Multi-column relations can only be applied to clustering columns but was applied to: a",
@@ -608,7 +608,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInvalidColumnNames() throws Throwable
+    public void testInvalidColumnNames()
     {
         createTable("CREATE TABLE %s (a int, b int, c map<int, int>, PRIMARY KEY (a, b))");
         assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d = 0");
@@ -630,10 +630,10 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInvalidNonFrozenUDTRelation() throws Throwable
+    public void testInvalidNonFrozenUDTRelation()
     {
         String type = createType("CREATE TYPE %s (a int)");
-        createTable("CREATE TABLE %s (a int PRIMARY KEY, b " + type + ")");
+        createTable("CREATE TABLE %s (a int PRIMARY KEY, b " + type + ')');
         Object udt = userType("a", 1);
 
         // All operators
@@ -656,7 +656,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInRestrictionWithClusteringColumn() throws Throwable
+    public void testInRestrictionWithClusteringColumn()
     {
         createTable("CREATE TABLE %s (key int, c1 int, c2 int, s1 text static, PRIMARY KEY ((key, c1), c2))");
 
@@ -690,7 +690,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInRestrictionsWithAllowFiltering() throws Throwable
+    public void testInRestrictionsWithAllowFiltering()
     {
         createTable("CREATE TABLE %s (pk1 int, pk2 int, c text, s int static, v int, primary key((pk1, pk2), c))");
         execute("INSERT INTO %s (pk1, pk2, c, s, v) values (?, ?, ?, ?, ?)", 1, 0, "5", 1, 3);
@@ -743,7 +743,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testInRestrictionsWithAllowFilteringAndOrdering() throws Throwable
+    public void testInRestrictionsWithAllowFilteringAndOrdering()
     {
         createTable("CREATE TABLE %s (pk int, c text, v int, primary key(pk, c)) WITH CLUSTERING ORDER BY (c DESC)");
         execute("INSERT INTO %s (pk, c, v) values (?, ?, ?)", 1, "0", 5);
@@ -790,7 +790,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testClusteringSlicesWithNotIn() throws Throwable
+    public void testClusteringSlicesWithNotIn()
     {
         createTable("CREATE TABLE %s (a text, b int, c int, d int, primary key(a, b, c))");
         execute("insert into %s (a, b, c, d) values (?, ?, ?, ?)", "key", 1, 4, 1);
@@ -948,7 +948,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testClusteringSlicesWithNotInAndReverseOrdering() throws Throwable
+    public void testClusteringSlicesWithNotInAndReverseOrdering()
     {
         createTable("CREATE TABLE %s (a text, b int, c int, d int, primary key(a, b, c)) with clustering order by (b desc, c desc)");
         execute("insert into %s (a, b, c, d) values (?, ?, ?, ?)", "key", 1, 4, 1);
@@ -1095,7 +1095,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testNotInRestrictionsWithAllowFiltering() throws Throwable
+    public void testNotInRestrictionsWithAllowFiltering()
     {
         createTable("CREATE TABLE %s (pk int, c int, v int, primary key(pk, c))");
         execute("insert into %s (pk, c, v) values (?, ?, ?)", 1, 1, 1);
@@ -1189,7 +1189,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
     }
 
     @Test
-    public void testNotInRestrictionsWithOrAndAllowFiltering() throws Throwable
+    public void testNotInRestrictionsWithOrAndAllowFiltering()
     {
         createTable("CREATE TABLE %s (pk int, c int, v int, PRIMARY KEY(pk, c))");
         execute("INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", 1, 1, 1);
@@ -1261,7 +1261,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
 
 
     @Test
-    public void testNonEqualsRelationWithFiltering() throws Throwable
+    public void testNonEqualsRelationWithFiltering()
     {
         createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, 0);

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectTest.java
@@ -3514,4 +3514,5 @@ public class SelectTest extends CQLTester
         createTable(KEYSPACE, "CREATE TABLE %s (a blob, b blob, PRIMARY KEY ((a, b)))");
         execute("INSERT INTO %s (a, b) VALUES (?, ?)", ByteBuffer.allocate(Short.MAX_VALUE + 1), EMPTY_BYTE_BUFFER);
     }
+
 }


### PR DESCRIPTION
This commit fixes a serious correctness bug in the way we build RowFilter for expressions involving OR.

If a query contained multiple complex predicates such as NOT IN joined with the OR operator, the slices produced by NOT IN were incorrectly also joined by OR instead of by AND.

In addition, a NOT IN with an empty list, if ORed with another expression, was incorrectly treated as an expression matching 0 rows, instead of matching all rows.

Example 1:
`SELECT * FROM t WHERE x = 1 OR x NOT IN (2, 3, 4)`
was incorrectly matching all rows, including the ones with x = 2 or x = 3 or x = 4.

Example 2:
`SELECT * FROM t WHERE x = 1 OR x NOT IN ()`
was incorrectly matching only row with x = 1, instead of all rows.

The bug was technically not limited to NOT IN, but any single restriction that wanted to add in exactly zero or more than one filter expression.

Fixes https://github.com/riptano/cndb/issues/10923