### PR TITLE
Moves the deletion of index components on index drop to an overridable method…

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -51,6 +51,7 @@ import org.apache.cassandra.index.sai.utils.RangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.utils.RangeIterator;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.io.sstable.SSTableIdFactory;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -281,7 +282,7 @@ public class SSTableIndex
              * components are not in use.
              */
             if (indexWasDropped.get())
-                perIndexComponents.forWrite().forceDeleteAllComponents();
+                SSTableWatcher.instance.onIndexDropped(perIndexComponents.forWrite());
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.index.sai.plan.StorageAttachedIndexQueryPlan;
 import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.notifications.INotification;
@@ -143,7 +144,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             contextManager.clear();
 
             contexts.forEach(context -> {
-                context.usedPerSSTableComponents().forWrite().forceDeleteAllComponents();
+                SSTableWatcher.instance.onIndexDropped(context.usedPerSSTableComponents().forWrite());
             });
         }
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableWatcher.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableWatcher.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.io.sstable;
 
 import java.util.Set;
 
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -60,5 +61,23 @@ public interface SSTableWatcher
      */
     default void onIndexBuild(SSTableReader sstable)
     {
+    }
+
+    /**
+     * Called when an index is dropped on index components affected by that drop.
+     * <p>
+     * By default, this method simply deletes the components locally, but it can overriden if different/additional
+     * behavior is needed.
+     *
+     * @param components index components that are no longer in used due to an index drop. Note that this can
+     *                   be either per-index components (for the components of the exact index being dropped),
+     *                   or per-sstable components if the index dropped was the only index for the table and the
+     *                   per-sstable components are no longer needed. More precisely, if the last index of a table
+     *                   is dropped, then this method will usually be called twice per sstable, once for the index
+     *                   components, and once for the per-sstable components.
+     */
+    default void onIndexDropped(IndexComponents.ForWrite components)
+    {
+        components.forceDeleteAllComponents();
     }
 }


### PR DESCRIPTION
This commit simply move the code that deletes index components locally when an index is dropped inside a new method of the `SSTableWatcher` interface. As is, this just creates a minor indirection without changing any behaviour, but this allows custom implementations of `SSTableWatcher` to modify this behaviour, typically to handle tiered storage concerns.