### PR TITLE
CNDB-10945: Change calculation of sstable span for small sstables

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionRealm.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionRealm.java
@@ -96,7 +96,7 @@ public interface CompactionRealm
     Directories getDirectories();
 
     /**
-     * @return the {@DiskBoundaries} that are currently applied to the directories backing table.
+     * @return the {@link DiskBoundaries} that are currently applied to the directories backing table.
      */
     DiskBoundaries getDiskBoundaries();
 
@@ -105,6 +105,21 @@ public interface CompactionRealm
      * but should be set when the strategy is asked to select or run compactions.
      */
     TableMetrics metrics();
+
+    /**
+     * Return the estimated partition count, used when the number of partitions in an sstable is not sufficient to give
+     * a sensible range estimation.
+     */
+    default long estimatedPartitionCount()
+    {
+        final long INITIAL_ESTIMATED_PARTITION_COUNT = 1 << 16; // If we don't yet have a count, use a sensible default.
+        if (metrics() == null)
+            return INITIAL_ESTIMATED_PARTITION_COUNT;
+        final Long estimation = metrics().estimatedPartitionCount.getValue();
+        if (estimation == null || estimation == 0)
+            return INITIAL_ESTIMATED_PARTITION_COUNT;
+        return estimation;
+    }
 
     /**
      * @return the secondary index manager, which is responsible for all secondary indexes.

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -70,7 +70,7 @@ public interface ShardManager
             return new ShardManagerDiskAware(localRanges, diskPositions);
         else if (partitioner.splitter().isPresent())
             if (isReplicaAware)
-                return new ShardManagerReplicaAware(rs);
+                return new ShardManagerReplicaAware(rs, localRanges.getRealm().estimatedPartitionCount());
             else
                 return new ShardManagerNoDisks(localRanges);
         else
@@ -139,9 +139,9 @@ public interface ShardManager
         if (partitionCount >= PER_PARTITION_SPAN_THRESHOLD && span >= MINIMUM_TOKEN_COVERAGE)
             return span;
 
-        // Too small ranges are expected to be the result of either a single-partition sstable or falling outside
-        // the local token ranges. In these cases we substitute use a per-partition minimum calculated from the number
-        // of partitions in the table.
+        // Too small ranges are expected to be the result of either an sstable with a very small number of partitions,
+        // or falling outside the local token ranges. In these cases we apply a per-partition minimum calculated from
+        // the number of partitions in the table.
         double perPartitionMinimum = Math.min(partitionCount * minimumPerPartitionSpan(), 1.0);
         return span > perPartitionMinimum ? span : perPartitionMinimum; // The latter will be chosen if span is NaN too.
     }

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -34,9 +34,16 @@ public interface ShardManager
     /**
      * Single-partition, and generally sstables with very few partitions, can cover very small sections of the token
      * space, resulting in very high densities.
-     * Additionally, sstables that have completely fallen outside of the local token ranges will end up with a zero
+     * When the number of partitions in an sstable is smaller than this threshold, we will use a per-partition minimum
+     * span, calculated from the total number of partitions in this table.
+     */
+    static final long PER_PARTITION_SPAN_THRESHOLD = 100;
+
+    /**
+     * Additionally, sstables that have completely fallen outside the local token ranges will end up with a zero
      * coverage.
-     * To avoid problems with both we check if coverage is below the minimum, and replace it with 1.
+     * To avoid problems with this we check if coverage is below the minimum, and replace it using the per-partition
+     * calculation.
      */
     static final double MINIMUM_TOKEN_COVERAGE = Math.scalb(1.0, -48);
 
@@ -88,6 +95,12 @@ public interface ShardManager
     double shardSetCoverage();
 
     /**
+     * The minimum token space share per partition that should be assigned to sstables with small numbers of partitions
+     * or which have fallen outside the local token ranges.
+     */
+    double minimumPerPartitionSpan();
+
+    /**
      * Construct a boundary/shard iterator for the given number of shards.
      *
      * Note: This does not offer a method of listing the shard boundaries it generates, just to advance to the
@@ -115,19 +128,22 @@ public interface ShardManager
     default double rangeSpanned(CompactionSSTable rdr)
     {
         double reported = rdr.tokenSpaceCoverage();
+
         double span;
         if (reported > 0)   // also false for NaN
             span = reported;
         else
             span = rangeSpanned(rdr.getFirst(), rdr.getLast());
 
-        if (span >= MINIMUM_TOKEN_COVERAGE)
+        long partitionCount = rdr.estimatedKeys();
+        if (partitionCount >= PER_PARTITION_SPAN_THRESHOLD && span >= MINIMUM_TOKEN_COVERAGE)
             return span;
 
         // Too small ranges are expected to be the result of either a single-partition sstable or falling outside
-        // of the local token ranges. In these cases we substitute it with 1 because for them sharding and density
-        // tiering does not make sense.
-        return 1.0;  // This will be chosen if span is NaN too.
+        // the local token ranges. In these cases we substitute use a per-partition minimum calculated from the number
+        // of partitions in the table.
+        double perPartitionMinimum = Math.min(partitionCount * minimumPerPartitionSpan(), 1.0);
+        return span > perPartitionMinimum ? span : perPartitionMinimum; // The latter will be chosen if span is NaN too.
     }
 
     default double rangeSpanned(PartitionPosition first, PartitionPosition last)

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
@@ -39,6 +39,8 @@ public class ShardManagerNoDisks implements ShardManager
      */
     final double[] localRangePositions;
 
+    private final double minimumPerPartitionSpan;
+
     public ShardManagerNoDisks(SortedLocalRanges localRanges)
     {
         this.localRanges = localRanges;
@@ -51,6 +53,7 @@ public class ShardManagerNoDisks implements ShardManager
             position += span;
             localRangePositions[i] = position;
         }
+        minimumPerPartitionSpan = localSpaceCoverage() / Math.max(1, localRanges.getRealm().estimatedPartitionCount());
     }
 
     @Override
@@ -83,6 +86,11 @@ public class ShardManagerNoDisks implements ShardManager
     public double shardSetCoverage()
     {
         return localSpaceCoverage();
+    }
+
+    public double minimumPerPartitionSpan()
+    {
+        return minimumPerPartitionSpan;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
@@ -58,8 +58,9 @@ public class ShardManagerReplicaAware implements ShardManager
     private final TokenMetadata tokenMetadata;
     private final IPartitioner partitioner;
     private final ConcurrentHashMap<Integer, Token[]> splitPointCache;
+    private final double minimumPerPartitionSpan;
 
-    public ShardManagerReplicaAware(AbstractReplicationStrategy rs)
+    public ShardManagerReplicaAware(AbstractReplicationStrategy rs, long estimatedPartitionCount)
     {
         this.rs = rs;
         // Clone the map to ensure it has a consistent view of the tokenMetadata. UCS creates a new instance of the
@@ -67,6 +68,7 @@ public class ShardManagerReplicaAware implements ShardManager
         this.tokenMetadata = rs.getTokenMetadata().cloneOnlyTokenMap();
         this.splitPointCache = new ConcurrentHashMap<>();
         this.partitioner = tokenMetadata.partitioner;
+        this.minimumPerPartitionSpan = 1.0 / Math.max(1, estimatedPartitionCount);
     }
 
     @Override
@@ -87,6 +89,12 @@ public class ShardManagerReplicaAware implements ShardManager
     {
         // For now there are no disks defined, so this is the same as localSpaceCoverage
         return 1;
+    }
+
+    @Override
+    public double minimumPerPartitionSpan()
+    {
+        return minimumPerPartitionSpan;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
@@ -68,6 +68,11 @@ public class ShardManagerTrivial implements ShardManager
         return 1;
     }
 
+    public double minimumPerPartitionSpan()
+    {
+        throw new AssertionError(); // rangeSpanned is overridden and does not call this method
+    }
+
     ShardTracker iterator = new ShardTracker()
     {
         @Override

--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -259,6 +259,8 @@ public class BaseCompactionStrategyTest
         when(ret.getMinTTL()).thenReturn(ttl);
         when(ret.getMaxTTL()).thenReturn(ttl);
 
+        when(ret.estimatedKeys()).thenReturn(ShardManager.PER_PARTITION_SPAN_THRESHOLD * 2);
+
         diskIndexMap.put(ret, diskIndex);
         if (diskIndex >= diskIndexes)
             diskIndexes = diskIndex + 1;

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
@@ -50,7 +50,7 @@ public class ShardManagerReplicaAwareTest
         {
             var rs = buildStrategy(numTokens, 1, 1, 1);
             var expectedTokens = rs.getTokenMetadata().sortedTokens();
-            var shardManager = new ShardManagerReplicaAware(rs);
+            var shardManager = new ShardManagerReplicaAware(rs, 1L<<16);
 
             var shardCount = numTokens + 1;
             var iterator = shardManager.boundaries(shardCount);
@@ -82,7 +82,7 @@ public class ShardManagerReplicaAwareTest
                     // Confirm test set up is correct.
                     assertEquals(numTokensPerNode * nodeCount, initialSplitPoints.size());
                     // Use a shared instance to
-                    var shardManager = new ShardManagerReplicaAware(rs);
+                    var shardManager = new ShardManagerReplicaAware(rs, 1L<<16);
 
                     // The tokens for one level lower.
                     var lowerTokens = new ArrayList<Token>();

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
@@ -58,8 +58,11 @@ public class ShardManagerTest
     public void setUp()
     {
         weightedRanges = new ArrayList<>();
+        var realm = Mockito.mock(CompactionRealm.class);
         localRanges = Mockito.mock(SortedLocalRanges.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
         Mockito.when(localRanges.getRanges()).thenAnswer(invocation -> weightedRanges);
+        Mockito.when(localRanges.getRealm()).thenReturn(realm);
+        Mockito.when(realm.estimatedPartitionCount()).thenReturn(10000L);
     }
 
     @Test
@@ -75,8 +78,12 @@ public class ShardManagerTest
         assertEquals(0.2, shardManager.rangeSpanned(range(0.3, 0.5)), delta);
 
         assertEquals(0.2, shardManager.rangeSpanned(mockedTable(0.5, 0.7, Double.NaN)), delta);
-        // single-partition correction
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN)), delta);
+        // single-token-span correction
+        assertEquals(0.02, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN, 200)), delta);
+        // small partition count correction
+        assertEquals(0.0001, shardManager.rangeSpanned(mockedTable(0.3, 0.30001, Double.NaN, 1)), delta);
+        assertEquals(0.001, shardManager.rangeSpanned(mockedTable(0.3, 0.30001, Double.NaN, 10)), delta);
+        assertEquals(0.01, shardManager.rangeSpanned(mockedTable(0.3, 0.31, Double.NaN, 10)), delta);
 
         // reported coverage
         assertEquals(0.1, shardManager.rangeSpanned(mockedTable(0.5, 0.7, 0.1)), delta);
@@ -85,7 +92,7 @@ public class ShardManagerTest
         assertEquals(0.2, shardManager.rangeSpanned(mockedTable(0.5, 0.7, -1)), delta);
 
         // correction over coverage
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.3, 0.5, 1e-50)), delta);
+        assertEquals(0.02, shardManager.rangeSpanned(mockedTable(0.3, 0.5, 1e-50, 200)), delta);
     }
 
     @Test
@@ -115,10 +122,11 @@ public class ShardManagerTest
         assertEquals(0.1, shardManager.rangeSpanned(mockedTable(0.5, 0.8, Double.NaN)), delta);
 
         // single-partition correction
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN)), delta);
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN, 200)), delta);
         // out-of-local-range correction
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.6, 0.7, Double.NaN)), delta);
-        assertEquals(0.001, shardManager.rangeSpanned(mockedTable(0.6, 0.701, Double.NaN)), delta);
+        assertEquals(0.03, shardManager.rangeSpanned(mockedTable(0.6, 0.73, Double.NaN, 200)), delta);
+        // completely outside should use partition-based count
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.6, 0.7, Double.NaN, 200)), delta);
 
         // reported coverage
         assertEquals(0.1, shardManager.rangeSpanned(mockedTable(0.5, 0.7, 0.1)), delta);
@@ -127,7 +135,7 @@ public class ShardManagerTest
         assertEquals(0.1, shardManager.rangeSpanned(mockedTable(0.5, 0.8, -1)), delta);
 
         // correction over coverage, no recalculation
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.5, 0.8, 1e-50)), delta);
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.5, 0.8, 1e-50, 200)), delta);
     }
 
     @Test
@@ -157,10 +165,10 @@ public class ShardManagerTest
         assertEquals(0.06, shardManager.rangeSpanned(mockedTable(0.5, 0.8, Double.NaN)), delta);
 
         // single-partition correction
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN)), delta);
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.3, 0.3, Double.NaN, 200)), delta);
         // out-of-local-range correction
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.6, 0.7, Double.NaN)), delta);
-        assertEquals(0.001, shardManager.rangeSpanned(mockedTable(0.6, 0.701, Double.NaN)), delta);
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.6, 0.7, Double.NaN, 200)), delta);
+        assertEquals(0.03, shardManager.rangeSpanned(mockedTable(0.6, 0.73, Double.NaN)), delta);
 
         // reported coverage
         assertEquals(0.1, shardManager.rangeSpanned(mockedTable(0.5, 0.7, 0.1)), delta);
@@ -169,7 +177,7 @@ public class ShardManagerTest
         assertEquals(0.06, shardManager.rangeSpanned(mockedTable(0.5, 0.8, -1)), delta);
 
         // correction over coverage, no recalculation
-        assertEquals(1.0, shardManager.rangeSpanned(mockedTable(0.5, 0.8, 1e-50)), delta);
+        assertEquals(0.02 * total, shardManager.rangeSpanned(mockedTable(0.5, 0.8, 1e-50, 200)), delta);
     }
 
     Token tokenAt(double pos)
@@ -184,10 +192,16 @@ public class ShardManagerTest
 
     CompactionSSTable mockedTable(double start, double end, double reportedCoverage)
     {
+        return mockedTable(start, end, reportedCoverage, 200L);
+    }
+
+    CompactionSSTable mockedTable(double start, double end, double reportedCoverage, long estimatedKeys)
+    {
         CompactionSSTable mock = Mockito.mock(CompactionSSTable.class);
         Mockito.when(mock.getFirst()).thenReturn(tokenAt(start).minKeyBound());
         Mockito.when(mock.getLast()).thenReturn(tokenAt(end).minKeyBound());
         Mockito.when(mock.tokenSpaceCoverage()).thenReturn(reportedCoverage);
+        Mockito.when(mock.estimatedKeys()).thenReturn(estimatedKeys);
         return mock;
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
@@ -192,7 +192,7 @@ public class ShardManagerTest
 
     CompactionSSTable mockedTable(double start, double end, double reportedCoverage)
     {
-        return mockedTable(start, end, reportedCoverage, 200L);
+        return mockedTable(start, end, reportedCoverage, ShardManager.PER_PARTITION_SPAN_THRESHOLD * 2);
     }
 
     CompactionSSTable mockedTable(double start, double end, double reportedCoverage, long estimatedKeys)


### PR DESCRIPTION
In addition to correcting for very small spans, this also corrects sstable spans for ones having a small number of partitions where keys can easily fall in a small range. For these cases we use a value derived from the number of partitions in the table, which should work well for all scenarios, including wide-partition tables with a very limited number of partitions.