### PR TITLE
Revert "Use query view's locked indexes for Plan#estimateAnnNodesVisited (#1238)"

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -900,11 +900,12 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     {
         Preconditions.checkArgument(limit > 0, "limit must be > 0");
 
-        var queryView = queryContext.view;
-        assert queryView != null;
+        IndexContext context = ordering.context;
+        Collection<MemtableIndex> memtables = context.getLiveMemtables().values();
+        View queryView = context.getView();
 
         double cost = 0;
-        for (MemtableIndex index : queryView.memtableIndexes)
+        for (MemtableIndex index : memtables)
         {
             // FIXME convert nodes visited to search cost
             int memtableCandidates = (int) Math.min(Integer.MAX_VALUE, candidates);
@@ -912,10 +913,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         }
 
         long totalRows = 0;
-        for (SSTableIndex index : queryView.referencedIndexes)
+        for (SSTableIndex index : queryView.getIndexes())
             totalRows += index.getSSTable().getTotalRows();
 
-        for (SSTableIndex index : queryView.referencedIndexes)
+        for (SSTableIndex index : queryView.getIndexes())
         {
             for (Segment segment : index.getSegments())
             {


### PR DESCRIPTION
This commit does not work because the queryView is not set until
after we get the plan. Since the view is only used to estimate
the cost of work and not to skip work, it is safe to use a
different view.

This reverts commit 9333708db652ec47a69d10326ae38ded998a174d.
