### PR TITLE
CNDB-11078: Prevent InaccessibleObjectException when the Leak Detector is traversing objects (port CASSANDRA-18708)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Future version (tbd)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
 Merged from 5.0:
+ * Prevent InaccessibleObjectException when the Leak Detector is traversing objects (CASSANDRA-18708)
  * Remove Scripted UDFs internals; hooks to be added later in CASSANDRA-17281 (CASSANDRA-18252)
  * Add guardrail for vector dimensions (CASSANDRA-18730)
  * Add support for CQL functions on collections, tuples and UDTs (CASSANDRA-17811)

--- a/src/java/org/apache/cassandra/exceptions/UnaccessibleFieldException.java
+++ b/src/java/org/apache/cassandra/exceptions/UnaccessibleFieldException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+public class UnaccessibleFieldException extends RuntimeException
+{
+    private static final long serialVersionUID = 7340063332562337064L;
+
+    public UnaccessibleFieldException(String message)
+    {
+        super(message);
+    }
+
+    public UnaccessibleFieldException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/concurrent/Ref.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/Ref.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.apache.cassandra.concurrent.InfiniteLoopExecutor;
+import org.apache.cassandra.exceptions.UnaccessibleFieldException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,8 @@ import org.apache.cassandra.io.util.SafeMemory;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.Pair;
+import sun.misc.Unsafe;
+
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 
 import static java.util.Collections.emptyList;
@@ -68,10 +72,10 @@ import static org.apache.cassandra.utils.Throwables.merge;
  *   - encapsulates a Ref, we'll call selfRef, to which it proxies all calls to RefCounted behaviours
  *   - users must ensure no references to the selfRef leak, or are retained outside of a method scope.
  *     (to ensure the selfRef is collected with the object, so that leaks may be detected and corrected)
- *
+ * <p>
  * This class' functionality is achieved by what may look at first glance like a complex web of references,
  * but boils down to:
- *
+ * <p>
  * {@code
  * Target --> selfRef --> [Ref.State] <--> Ref.GlobalState --> Tidy
  *                                             ^
@@ -81,10 +85,10 @@ import static org.apache.cassandra.utils.Throwables.merge;
  * Global -------------------------------------
  * }
  * So that, if Target is collected, Impl is collected and, hence, so is selfRef.
- *
+ * <p>
  * Once ref or selfRef are collected, the paired Ref.State's release method is called, which if it had
  * not already been called will update Ref.GlobalState and log an error.
- *
+ * <p>
  * Once the Ref.GlobalState has been completely released, the Tidy method is called and it removes the global reference
  * to itself so it may also be collected.
  */
@@ -392,7 +396,7 @@ public final class Ref<T> implements RefCounted<T>
         }
     }
 
-    static final Deque<InProgressVisit> inProgressVisitPool = new ArrayDeque<InProgressVisit>();
+    static final Deque<InProgressVisit> inProgressVisitPool = new ArrayDeque<>();
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     static InProgressVisit newInProgressVisit(Object o, List<Field> fields, Field field, String name)
@@ -517,16 +521,16 @@ public final class Ref<T> implements RefCounted<T>
                 if (o instanceof WeakReference & nextField.getDeclaringClass() == Reference.class)
                     continue;
 
-                Object nextObject = nextField.get(o);
+                Object nextObject = getFieldValue(o, nextField);
                 if (nextObject != null)
-                    return Pair.create(nextField.get(o), nextField);
+                    return Pair.create(getFieldValue(o, nextField), nextField);
             }
         }
 
         @Override
         public String toString()
         {
-            return field == null ? name : field.toString() + "-" + o.getClass().getName();
+            return field == null ? name : field + "-" + o.getClass().getName();
         }
     }
 
@@ -603,7 +607,6 @@ public final class Ref<T> implements RefCounted<T>
                     {
                         path.offer(inProgress);
                         inProgress = newInProgressVisit(child, getFields(child.getClass()), field, null);
-                        continue;
                     }
                     else if (visiting == child)
                     {
@@ -621,7 +624,6 @@ public final class Ref<T> implements RefCounted<T>
                     {
                         returnInProgressVisit(inProgress);
                         inProgress = null;
-                        continue;
                     }
                 }
                 catch (IllegalAccessException e)
@@ -645,11 +647,66 @@ public final class Ref<T> implements RefCounted<T>
         {
             if (field.getType().isPrimitive() || Modifier.isStatic(field.getModifiers()))
                 continue;
-            field.setAccessible(true);
             fields.add(field);
         }
         fields.addAll(getFields(clazz.getSuperclass()));
         return fields;
+    }
+
+    /**
+     * The unsafe instance used to access object protected by the Module System
+     */
+    private static final Unsafe unsafe = loadUnsafe();
+
+    private static Unsafe loadUnsafe()
+    {
+        try
+        {
+            return Unsafe.getUnsafe();
+        }
+        catch (final Exception ex)
+        {
+            try
+            {
+                Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                return (Unsafe) field.get(null);
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+        }
+    }
+
+    public static Object getFieldValue(Object object, Field field)
+    {
+        try
+        {
+            // This call will unfortunately emit a warning for some scenario (which was a weird decision from the JVM designer)
+            if (field.trySetAccessible())
+            {
+                // The field is accessible lets use reflection.
+                return field.get(object);
+            }
+
+            // The access to the field is being restricted by the module system. Let's try to go around it through Unsafe.
+            if (unsafe == null)
+                throw new UnaccessibleFieldException("The value of the '" + field.getName() + "' field from " + object.getClass().getName()
+                                                     + " cannot be retrieved as the field cannot be made accessible and Unsafe is unavailable");
+
+            long offset = unsafe.objectFieldOffset(field);
+
+            boolean isFinal = Modifier.isFinal(field.getModifiers());
+            boolean isVolatile = Modifier.isVolatile(field.getModifiers());
+
+            return isFinal || isVolatile ? unsafe.getObjectVolatile(object, offset) : unsafe.getObject(object, offset);
+
+        }
+        catch (Throwable e)
+        {
+            throw new UnaccessibleFieldException("The value of the '" + field.getName() + "' field from " + object.getClass().getName() + " cannot be retrieved", e);
+        }
     }
 
     public static class IdentityCollection


### PR DESCRIPTION
The issue can be seen in the logs when running (even if the test completes successfully):
`ant testsome -Dtest.name=org.apache.cassandra.index.sai.disk.vector.VectorCompressionTest -Dcassandra.test.random.seed=792966663435 -Duse.jdk11=true`

After the patch, it is not reproducible anymore