### PR TITLE
[Port DSP-24384] Adds Guardrail setting for column

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1495,9 +1495,22 @@ enable_drop_compact_storage: false
   # Default value is 10, may differ if emulate_dbaas_defaults is enabled
   # unlogged_batch_across_partitions_warn_threshold: 10
 
-  # Failure threshold to prevent writing large column value into Cassandra.
+  # Guardrail to warn or fail when writing column values larger than threshold into Cassandra.
+  # This guardrail is only applied to the values of regular columns because both the serialized partitions keys and the
+  # values of the components of the clustering key already have a fixed, relatively small size limit of 65535 bytes, which
+  # is probably lesser than the thresholds defined here.
+  # Deleting individual elements of non-frozen sets and maps involves creating tombstones that contain the value of the
+  # deleted element, independently on whether the element existed or not. That tombstone value is also guarded by this
+  # guardrail, to prevent the insertion of tombstones over the threshold. The downside is that enabling or raising this
+  # threshold can prevent users from deleting set/map elements that were written when the guardrail was disabled or with a
+  # lower value. Deleting the entire column, row or partition is always allowed, since the tombstones created for those
+  # operations don't contain the CQL column values.
+  # This guardrail is different to max_value_size. max_value_size is checked when deserializing any value to detect
+  # sstable corruption, whereas this guardrail is checked on the CQL layer at write time to reject regular user queries
+  # inserting too large columns.
   # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
   # column_value_size_failure_threshold_in_kb: -1
+  # column_value_size_warn_threshold_in_kb: -1
 
   # Failure threshold to prevent creating more columns per table than threshold.
   # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -74,10 +74,12 @@ public abstract class Guardrails
 
     public static final Threshold columnValueSize =
             factory.threshold("column_value_size",
-                              () -> -1L, // not needed so far
+                              () -> config.column_value_size_warn_threshold_in_kb * 1024L,
                               () -> config.column_value_size_failure_threshold_in_kb * 1024L,
-                              (x, what, v, t) -> format("Value of %s of size %s is greater than the maximum allowed (%s)",
-                                                        what, formatSize(v), formatSize(t)));
+                              (isWarning, what, v, t) -> isWarning ?
+                                      format("Value of %s of size %s is greater than the warn threshold (%s)", what, v, t )
+                                    : format("Value of %s of size %s is greater than the maximum allowed (%s)",
+                                            what, v, t));
 
     public static final Threshold columnsPerTable =
             factory.threshold("columns_per_table",

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -172,6 +172,7 @@ public class GuardrailsConfig
         enforceDefault(user_timestamps_enabled, v -> user_timestamps_enabled = v, true, true);
 
         enforceDefault(column_value_size_failure_threshold_in_kb, v -> column_value_size_failure_threshold_in_kb = v, -1L, 5 * 1024L);
+        enforceDefault(column_value_size_warn_threshold_in_kb, v -> column_value_size_warn_threshold_in_kb = v, -1L, -1L);
 
         enforceDefault(read_before_write_list_operations_enabled, v -> read_before_write_list_operations_enabled = v, true, false);
 
@@ -243,8 +244,12 @@ public class GuardrailsConfig
      */
     public void validate()
     {
+        validateStrictlyPositiveInteger(column_value_size_warn_threshold_in_kb,
+                                        "column_value_size_warn_threshold_in_kb");
         validateStrictlyPositiveInteger(column_value_size_failure_threshold_in_kb,
                                         "column_value_size_failure_threshold_in_kb");
+        validateWarnLowerThanFail(column_value_size_failure_threshold_in_kb,
+                                        column_value_size_failure_threshold_in_kb, "column_value");
 
         validateStrictlyPositiveInteger(columns_per_table_failure_threshold,
                                         "columns_per_table_failure_threshold");


### PR DESCRIPTION
Adds warning level for column size in the guardrail configuration.

[DSP-24384](https://github.com/riptano/bdp/pull/21254) from commit afa777b0d173fca5ac028147cd8d69edb80c57a9

[DSP-24384]: https://datastax.jira.com/browse/DSP-24384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ