### PR TITLE
CNDB-10870: Upgrade JVector dependency to 3.0.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.0" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.1" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">


### PR DESCRIPTION
This PR updates the JVector dependency to 3.0.1.

This includes two noteworthy PRs:

- https://github.com/jbellis/jvector/pull/359 -- this improves the performance of orphaned node reconnection.
- https://github.com/jbellis/jvector/pull/356 -- select entry node randomly if the graph is too disconnected to search for a centroid.

In particular, this PR aims to pull in PR #359, which can help performance when reconnecting large, significantly disconnected graphs during compaction.