### PR TITLE
CNDB-10289: Improve local testing

### DIFF
--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -51,6 +51,10 @@
     </target>
 
     <target name="resolver-init" depends="init,_resolver_download" unless="resolver-ant-tasks.initialized" description="Initialize Resolver ANT Tasks">
+        <delete>
+            <fileset dir="${build.dir.lib}" includes="**/*"/>
+            <fileset dir="${test.lib}" includes="**/*"/>
+        </delete>
 
         <typedef uri="antlib:org.apache.maven.resolver.ant" resource="org/apache/maven/resolver/ant/antlib.xml" classpathref="resolver-ant-tasks.classpath" />
         <resolver:remoterepos id="all">

--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
     <property name="test.driver.connection_timeout_ms" value="5000"/>
     <property name="test.driver.read_timeout_ms" value="12000"/>
     <property name="dist.dir" value="${build.dir}/dist"/>
-    <property name="tmp.dir" value="${java.io.tmpdir}"/>
+    <property name="tmp.dir" value="${build.test.dir}/cassandra"/>
     <property name="test.logback.configurationFile" value="${test.conf}/logback-test.xml"/>
     <property name="doc.dir" value="${basedir}/doc"/>
     <property name="repetition" value=""/>
@@ -129,7 +129,7 @@
     <property name="cassandra.test.processorCount" value="4"/>
 
     <!-- skip flushing schema tables during tests -->
-    <property name="cassandra.test.flush_local_schema_changes" value="true" />
+    <property name="cassandra.unsafesystem" value="true" />
 
     <!-- fast shutdown of messaging service -->
     <property name="cassandra.test.messagingService.nonGracefulShutdown" value="false"/>
@@ -441,7 +441,10 @@
     </target>
 
     <target name="clean" description="Remove all locally created artifacts">
-        <delete dir="${build.test.dir}" />
+        <delete includeemptydirs="true" failonerror="false">
+            <fileset dir="${build.test.dir}/cassandra" includes="**/*"/>
+            <fileset dir="${build.test.dir}" includes="**/*" excludes="cassandra"/>
+        </delete>
         <delete dir="${build.classes}" />
         <delete dir="${build.src.gen-java}" />
         <delete dir="${version.properties.dir}" />
@@ -454,7 +457,7 @@
         <delete>
           <fileset dir="${build.lib}" excludes="cassandra-driver-internal-only-*"/>
         </delete>
-        <delete dir="${build.dir}" />
+        <delete includeemptydirs="false" dir="${build.dir}" failonerror="false"/>
         <delete dir="${doc.dir}/build" />
         <delete dir="${doc.dir}/source/tools/nodetool" />
     </target>
@@ -1516,7 +1519,6 @@
         <jvmarg value="-Dcassandra.test.driver.read_timeout_ms=${test.driver.read_timeout_ms}"/>
         <jvmarg value="-Dcassandra.memtable_row_overhead_computation_step=100"/>
         <jvmarg value="-Dcassandra.test.use_prepared=${cassandra.test.use_prepared}"/>
-        <jvmarg value="-Dcassandra.test.flush_local_schema_changes=${cassandra.test.flush_local_schema_changes}"/>
         <jvmarg value="-Dcassandra.test.messagingService.nonGracefulShutdown=${cassandra.test.messagingService.nonGracefulShutdown}"/>
         <jvmarg value="-Dcassandra.cluster_version_provider.min_stable_duration_ms=0"/>
         <jvmarg value="-Dcassandra.test.cluster_version_provider.skip_wait_for_gossip=true"/>
@@ -1528,7 +1530,7 @@
         <jvmarg value="-Dcassandra.testtag=${tag}.jdk${ant.java.version}"/>
         <jvmarg value="-Dcassandra.keepBriefBrief=${cassandra.keepBriefBrief}" />
         <jvmarg value="-Dcassandra.strict.runtime.checks=true" />
-        <jvmarg value="-Dcassandra.test.flush_local_schema_changes=${cassandra.test.flush_local_schema_changes}"/>
+        <jvmarg value="-Dcassandra.unsafesystem=${cassandra.unsafesystem}"/>
         <jvmarg value="-Dcassandra.test.messagingService.nonGracefulShutdown=${cassandra.test.messagingService.nonGracefulShutdown}"/>
         <jvmarg value="-Dcassandra.use_nix_recursive_delete=${cassandra.use_nix_recursive_delete}"/>
         <jvmarg line="${java-jvmargs}"/>
@@ -1538,6 +1540,7 @@
         <jvmarg value="-Dcassandra.use_nix_recursive_delete=true"/>
         <jvmarg value="-Dcassandra.test.fail_on_forbidden_log_entries=${cassandra.test.fail_on_forbidden_log_entries}"/>
         <jvmarg line="${_std-test-jvmargs} " />
+        <jvmarg value="-Djava.io.tmpdir=${build.test.dir}/cassandra"/>
         <optjvmargs/>
         <!-- Uncomment to debug unittest, attach debugger to port 1416 -->
         <!--

--- a/ide/idea/vcs.xml
+++ b/ide/idea/vcs.xml
@@ -10,6 +10,14 @@
           <option name="issueRegexp" value="CASSANDRA-(\d+)" />
           <option name="linkRegexp" value="https://issues.apache.org/jira/browse/CASSANDRA-$1" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="CNDB-(\d+)"/>
+          <option name="linkRegexp" value="https://github.com/riptano/cndb/issues/$1"/>
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(DSP|STAR|HCD|DB)-\d+"/>
+          <option name="linkRegexp" value="https://datastax.jira.com/browse/$0"/>
+        </IssueNavigationLink>
       </list>
     </option>
   </component>

--- a/ide/idea/vcs.xml
+++ b/ide/idea/vcs.xml
@@ -7,15 +7,15 @@
     <option name="links">
       <list>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="CASSANDRA-(\d+)" />
+          <option name="issueRegexp" value="(?i)CASSANDRA-(\d+)" />
           <option name="linkRegexp" value="https://issues.apache.org/jira/browse/CASSANDRA-$1" />
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="CNDB-(\d+)"/>
+          <option name="issueRegexp" value="(?i)CNDB-(\d+)"/>
           <option name="linkRegexp" value="https://github.com/riptano/cndb/issues/$1"/>
         </IssueNavigationLink>
         <IssueNavigationLink>
-          <option name="issueRegexp" value="(DSP|STAR|HCD|DB)-\d+"/>
+          <option name="issueRegexp" value="(?i)(DSP|STAR|HCD|DB)-\d+"/>
           <option name="linkRegexp" value="https://datastax.jira.com/browse/$0"/>
         </IssueNavigationLink>
       </list>

--- a/ide/idea/workspace.xml
+++ b/ide/idea/workspace.xml
@@ -188,7 +188,7 @@
                                           -Dcassandra.ring_delay_ms=1000
                                           -Dcassandra.skip_sync=true
                                           -Dcassandra.strict.runtime.checks=true
-                                          -Dcassandra.test.flush_local_schema_changes=false
+                                          -Dcassandra.unsafesystem=true
                                           -Dcassandra.test.messagingService.nonGracefulShutdown=true
                                           -Dcassandra.tolerate_sstable_size=true
                                           -Dcassandra.use_nix_recursive_delete=true
@@ -200,6 +200,7 @@
                                           -Dlegacy-sstable-root=$PROJECT_DIR$/test/data/legacy-sstables
                                           -Dlogback.configurationFile=file://$PROJECT_DIR$/test/conf/logback-test.xml
                                           -Dmigration-sstable-root=$PROJECT_DIR$/test/data/migration-sstables
+                                          -Djava.io.tmpdir=$PROJECT_DIR$/build/test/cassandra
                                           -XX:ActiveProcessorCount=4
                                           -XX:SoftRefLRUPolicyMSPerMB=0
                                           -ea

--- a/mount-tmpfs
+++ b/mount-tmpfs
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This script simply mounts a tmpfs filesystem at build/test/cassandra
+# If there is already a tmpfs mounted at that location, it will be unmounted first
+# The size of the tmpfs is 1GB
+
+# The script is expected to work on both Linux and MacOS
+
+(grep "apache-cassandra" build.xml || grep "dse-db" build.xml) 1> /dev/null
+
+os="$(uname | tr '[:upper:]' '[:lower:]')"
+
+if [[ "$os" == "darwin" ]]; then
+	existing="$(diskutil list | grep CassandraBuildTmp || true)"
+	if [[ -n "$existing" ]]; then
+		diskname="$(hdiutil | grep CassandraBuildTmp | cut -f 1)"
+		diskutil unmount CassandraBuildTmp
+		hdiutil detach "$diskname"
+	fi
+
+	rm -rf build/test/cassandra
+	mkdir -p build/test/cassandra
+
+	diskutil erasevolume HFS+ CassandraBuildTmp "$(hdiutil attach -nomount ram://2097152)"
+	diskutil mount -mountPoint "$(pwd)/build/test/cassandra" CassandraBuildTmp
+elif [[ "$os" == "linux" ]]; then
+	mount | grep tmpfs | grep /build/test/cassandra | cut -f 3 -d ' ' | while read -r line;
+	do
+		sudo umount "$line"
+	done
+
+	rm -rf build/test/cassandra
+	mkdir -p build/test/cassandra
+
+	sudo mount -t tmpfs -o size=1024M tmpfs "$(pwd)/build/test/cassandra"
+else
+	echo "Unrecognized OS: $os" 1>&2
+	exit 1
+fi

--- a/mount-tmpfs
+++ b/mount-tmpfs
@@ -6,6 +6,10 @@
 
 # The script is expected to work on both Linux and MacOS
 
+# Run the script from the root of your project. In most cases it should improve performance of running unit tests.
+# Do not run it using sudo, it will ask for sudo password if needed.
+# The script does not expect any arguments.
+
 (grep "apache-cassandra" build.xml || grep "dse-db" build.xml) 1> /dev/null
 
 os="$(uname | tr '[:upper:]' '[:lower:]')"

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -287,11 +287,11 @@ public enum CassandraRelevantProperties
      * when the JVM terminates. Therefore, we can use such optimization and not wait unnecessarily. */
     NON_GRACEFUL_SHUTDOWN("cassandra.test.messagingService.nonGracefulShutdown"),
 
-    /** Flush changes of {@link org.apache.cassandra.schema.SchemaKeyspace} after each schema modification. In production,
-     * we always do that. However, tests which do not restart nodes may disable this functionality in order to run
-     * faster. Note that this is disabled for unit tests but if an individual test requires schema to be flushed, it
-     * can be also done manually for that particular case: {@code flush(SchemaConstants.SCHEMA_KEYSPACE_NAME);}. */
-    FLUSH_LOCAL_SCHEMA_CHANGES("cassandra.test.flush_local_schema_changes", "true"),
+    /** Disables flush changes to local and schema keyspaces. Also, disables recycling all segments of commitlog after
+     * dropping a table. Tests which do not restart nodes may enable this option in order to run faster. Note that this
+     * is enabled for unit tests but if an individual test requires schema to be flushed, it can be also done manually
+     * for that particular case: {@code flush(SchemaConstants.SCHEMA_KEYSPACE_NAME);}. */
+    UNSAFE_SYSTEM("cassandra.unsafesystem", "false"),
 
     /**
      * Delay before checking if gossip is settled.

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -158,7 +158,6 @@ public class DatabaseDescriptor
     private static final int searchConcurrencyFactor = Integer.parseInt(System.getProperty(Config.PROPERTY_PREFIX + "search_concurrency_factor", "1"));
 
     private static volatile boolean disableSTCSInL0 = Boolean.getBoolean(Config.PROPERTY_PREFIX + "disable_stcs_in_l0");
-    private static final boolean unsafeSystem = Boolean.getBoolean(Config.PROPERTY_PREFIX + "unsafesystem");
 
     // turns some warnings into exceptions for testing
     private static final boolean strictRuntimeChecks = Boolean.getBoolean("cassandra.strict.runtime.checks");
@@ -3327,11 +3326,6 @@ public class DatabaseDescriptor
     public static int searchConcurrencyFactor()
     {
         return searchConcurrencyFactor;
-    }
-
-    public static boolean isUnsafeSystem()
-    {
-        return unsafeSystem;
     }
 
     public static boolean diagnosticEventsEnabled()

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -175,6 +175,7 @@ import org.json.simple.JSONObject;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_AUTO_COMPACTION_PROPERTY;
+import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
 import static org.apache.cassandra.utils.Throwables.perform;
@@ -3465,7 +3466,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         }
         else
         {
-            if (!DatabaseDescriptor.isUnsafeSystem())
+            if (!UNSAFE_SYSTEM.getBoolean())
             {
                 if (logger.isTraceEnabled())
                     logger.trace("Recycling CL segments for dropping {}", metadata);

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3465,9 +3465,12 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         }
         else
         {
-            if (logger.isTraceEnabled())
-                logger.trace("Recycling CL segments for dropping {}", metadata);
-            CommitLog.instance.forceRecycleAllSegments(Collections.singleton(metadata.id));
+            if (!DatabaseDescriptor.isUnsafeSystem())
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("Recycling CL segments for dropping {}", metadata);
+                CommitLog.instance.forceRecycleAllSegments(Collections.singleton(metadata.id));
+            }
         }
 
         if (logger.isTraceEnabled())

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -97,6 +97,7 @@ import org.apache.cassandra.utils.UUIDGen;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
 
@@ -546,7 +547,7 @@ public final class SystemKeyspace
 
     public static void forceBlockingFlush(String ...cfnames)
     {
-        if (!DatabaseDescriptor.isUnsafeSystem())
+        if (!UNSAFE_SYSTEM.getBoolean())
         {
             List<ListenableFuture<CommitLogPosition>> futures = new ArrayList<>();
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
@@ -37,6 +37,8 @@ import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.security.EncryptionUtils;
 import org.apache.cassandra.security.EncryptionContext;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.SYNC_MARKER_SIZE;
 import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
@@ -46,6 +48,8 @@ import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
  */
 public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.SyncSegment>
 {
+    private final static Logger logger = LoggerFactory.getLogger(CommitLogSegmentReader.class);
+
     private final CommitLogReadHandler handler;
     private final CommitLogDescriptor descriptor;
     private final RandomAccessReader reader;
@@ -105,6 +109,7 @@ public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.S
                 }
                 catch(CommitLogSegmentReader.SegmentReadException e)
                 {
+                    logger.debug("Error reading commit log", e);
                     try
                     {
                         handler.handleUnrecoverableError(new CommitLogReadException(
@@ -119,6 +124,7 @@ public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.S
                 }
                 catch (IOException e)
                 {
+                    logger.debug("Error reading commit log", e);
                     try
                     {
                         boolean tolerateErrorsInSection = tolerateTruncation & segmenter.tolerateSegmentErrors(end, reader.length());

--- a/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/repair/SystemDistributedKeyspace.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
@@ -61,6 +60,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static java.lang.String.format;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
 
 public final class SystemDistributedKeyspace
@@ -378,7 +378,7 @@ public final class SystemDistributedKeyspace
 
     public static void forceBlockingFlush(String table, ColumnFamilyStore.FlushReason reason)
     {
-        if (!DatabaseDescriptor.isUnsafeSystem())
+        if (!UNSAFE_SYSTEM.getBoolean())
             FBUtilities.waitOnFuture(Keyspace.open(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME)
                                              .getColumnFamilyStore(table)
                                              .forceFlush(reason));

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -88,6 +88,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DURATION_IN_MAPS_COMPATIBILITY_MODE;
+import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
 import static org.apache.cassandra.schema.SchemaKeyspaceTables.AGGREGATES;
@@ -377,7 +378,7 @@ public final class SchemaKeyspace
 
     private static void flush()
     {
-        if (!DatabaseDescriptor.isUnsafeSystem())
+        if (!UNSAFE_SYSTEM.getBoolean())
             ALL.forEach(table -> FBUtilities.waitOnFuture(getSchemaCFS(table).forceFlush(ColumnFamilyStore.FlushReason.INTERNALLY_FORCED)));
     }
 

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -117,7 +117,6 @@ public final class SchemaKeyspace
 
     private static final Logger logger = LoggerFactory.getLogger(SchemaKeyspace.class);
 
-    private static final boolean FLUSH_SCHEMA_TABLES = CassandraRelevantProperties.FLUSH_LOCAL_SCHEMA_CHANGES.getBoolean();
     private static final boolean IGNORE_CORRUPTED_SCHEMA_TABLES = Boolean.parseBoolean(System.getProperty("cassandra.ignore_corrupted_schema_tables", "false"));
 
     /**
@@ -1318,8 +1317,7 @@ public final class SchemaKeyspace
     static void applyChanges(Collection<Mutation> mutations)
     {
         mutations.forEach(Mutation::apply);
-        if (SchemaKeyspace.FLUSH_SCHEMA_TABLES)
-            SchemaKeyspace.flush();
+        SchemaKeyspace.flush();
     }
 
     static Keyspaces fetchKeyspaces(Set<String> toFetch)

--- a/test/conf/logback-test.xml
+++ b/test/conf/logback-test.xml
@@ -75,4 +75,6 @@
   <root level="DEBUG">
     <appender-ref ref="ASYNC"/>
   </root>
+
+  <logger name="io.netty.util.internal" level="WARN"/>
 </configuration>

--- a/test/distributed/org/apache/cassandra/distributed/Cluster.java
+++ b/test/distributed/org/apache/cassandra/distributed/Cluster.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.distributed;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import org.apache.cassandra.distributed.api.IInstanceConfig;

--- a/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
@@ -169,7 +169,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
             // Indicate that we are running in the in-jvm dtest environment
             CassandraRelevantProperties.DTEST_IS_IN_JVM_DTEST.setBoolean(true);
             // those properties may be set for unit-test optimizations; those should not be used when running dtests
-            CassandraRelevantProperties.FLUSH_LOCAL_SCHEMA_CHANGES.reset();
+            CassandraRelevantProperties.UNSAFE_SYSTEM.reset();
             CassandraRelevantProperties.NON_GRACEFUL_SHUTDOWN.reset();
         }
 

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.concurrent.ExecutorLocals;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.concurrent.SharedExecutorPool;
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.YamlConfigurationLoader;
@@ -803,7 +804,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
     @Override
     public Future<Void> shutdown(boolean graceful)
     {
-        if (!Boolean.parseBoolean(System.getProperty("cassandra.test.flush_local_schema_changes", "true")))
+        if (!CassandraRelevantProperties.UNSAFE_SYSTEM.getBoolean())
             flush(SchemaKeyspace.metadata().name);
 
         if (!graceful)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -379,14 +379,14 @@ public abstract class CQLTester
     @BeforeClass
     public static void setUpClass()
     {
+        DatabaseDescriptor.setAutoSnapshot(false);
+
         if (ROW_CACHE_SIZE_IN_MB > 0)
             DatabaseDescriptor.setRowCacheSizeInMB(ROW_CACHE_SIZE_IN_MB);
         StorageService.instance.setPartitionerUnsafe(Murmur3Partitioner.instance);
 
         // Once per-JVM is enough
         prepareServer();
-
-        StorageService.instance.setUpDistributedSystemKeyspaces();
     }
 
     @AfterClass
@@ -425,7 +425,7 @@ public abstract class CQLTester
     public void beforeTest() throws Throwable
     {
         Schema.instance.transform(schema -> schema.withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE_PER_TEST, KeyspaceParams.simple(1)))
-                                          .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1))), true);
+                                                  .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1))), true);
     }
 
     @After
@@ -448,8 +448,7 @@ public abstract class CQLTester
 
         try
         {
-            logger.debug("Dropping {} materialized view created in previous test", viewsToDrop.size());
-            Schema.instance.transform(schema -> schema.withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE_PER_TEST, KeyspaceParams.simple(1)))
+            Schema.instance.transform(schema -> schema.without(KEYSPACE_PER_TEST)
                                                       .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1)))
                                                       .without(keyspacesToDrop), true);
 

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -425,7 +425,7 @@ public abstract class CQLTester
     public void beforeTest() throws Throwable
     {
         Schema.instance.transform(schema -> schema.withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE_PER_TEST, KeyspaceParams.simple(1)))
-                                                  .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1))), true);
+                                                  .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1))), false);
     }
 
     @After
@@ -450,18 +450,7 @@ public abstract class CQLTester
         {
             Schema.instance.transform(schema -> schema.without(List.of(KEYSPACE_PER_TEST))
                                                       .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1)))
-                                                      .without(keyspacesToDrop), true);
-
-
-            // Dropping doesn't delete the sstables. It's not a huge deal but it's cleaner to cleanup after us
-            // Thas said, we shouldn't delete blindly before the TransactionLogs.SSTableTidier for the table we drop
-            // have run or they will be unhappy. Since those taks are scheduled on StorageService.tasks and that's
-            // mono-threaded, just push a task on the queue to find when it's empty. No perfect but good enough.
-            final CountDownLatch latch = new CountDownLatch(1);
-            ScheduledExecutors.nonPeriodicTasks.execute(latch::countDown);
-            latch.await(2, TimeUnit.SECONDS);
-            removeAllSSTables(KEYSPACE, tablesToDrop);
-            removeAllSSTables(KEYSPACE_PER_TEST, tablesToDrop);
+                                                      .without(keyspacesToDrop), false);
         }
         catch (Exception e)
         {

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -448,9 +448,10 @@ public abstract class CQLTester
 
         try
         {
-            Schema.instance.transform(schema -> schema.without(KEYSPACE_PER_TEST)
+            Schema.instance.transform(schema -> schema.without(List.of(KEYSPACE_PER_TEST))
                                                       .withAddedOrUpdated(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1)))
                                                       .without(keyspacesToDrop), true);
+
 
             // Dropping doesn't delete the sstables. It's not a huge deal but it's cleaner to cleanup after us
             // Thas said, we shouldn't delete blindly before the TransactionLogs.SSTableTidier for the table we drop

--- a/test/unit/org/apache/cassandra/cql3/KeywordTestBase.java
+++ b/test/unit/org/apache/cassandra/cql3/KeywordTestBase.java
@@ -27,9 +27,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.service.StorageService;
 
 /**
  * This class tests all keywords which took a long time. Hence it was split into multiple
@@ -57,6 +59,12 @@ public abstract class KeywordTestBase extends CQLTester
     {
         this.keyword = keyword;
         this.isReserved = isReserved;
+    }
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        StorageService.instance.setUpDistributedSystemKeyspaces();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
@@ -35,6 +35,7 @@ public class UserTypesTest extends CQLTester
         StorageService.instance.setPartitionerUnsafe(ByteOrderedPartitioner.instance);
 
         prepareServer();
+        StorageService.instance.setUpDistributedSystemKeyspaces();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compaction/ActiveOperationsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ActiveOperationsTest.java
@@ -33,12 +33,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cache.AutoSavingCache;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.view.View;
 import org.apache.cassandra.db.view.ViewBuilderTask;
@@ -50,6 +50,7 @@ import org.apache.cassandra.io.sstable.IndexSummaryRedistribution;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.service.CacheService;
+import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NonThrowingCloseable;
 
@@ -61,6 +62,12 @@ import static org.junit.Assert.assertTrue;
 
 public class ActiveOperationsTest extends CQLTester
 {
+    @BeforeClass
+    public static void beforeClass()
+    {
+        StorageService.instance.setUpDistributedSystemKeyspaces();
+    }
+
     @Test
     public void testActiveCompactionTrackingRaceWithIndexBuilder() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ShardedMultiWriterTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ShardedMultiWriterTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.db.compaction.ShardManager;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.service.StorageService;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -127,14 +128,14 @@ public class ShardedMultiWriterTest extends CQLTester
             // token boundaries, so we don't assert even distribution. We do however konw that the coverage should
             // add up to about 1 without crossing that boundary. The coverage is measured by measuring the distance
             // between the min and the max token in each shard, so we have a large delta in the assertion.
-            assertTrue(tokenSpaceCoverage <= 1.0);
+            assertThat(tokenSpaceCoverage).isLessThanOrEqualTo(1.0);
             assertEquals(1.0, tokenSpaceCoverage, 0.1);
             // If we have more split points than tokens, the sstables must be split along token boundaries
             var numSplitPoints = numShards - 1;
             var expectedSpannedTokens = Math.max(0, tokenMetadata.sortedTokens().size() - numSplitPoints);
             // There is a chance that the sstable bounds don't contain a token boundary due to the random selection
             // of the first token, so we can only assert that we don't have more spanned tokens than expected.
-            assertTrue(expectedSpannedTokens >= spannedTokens);
+            assertThat(spannedTokens).isLessThanOrEqualTo(expectedSpannedTokens);
         }
         else
         {

--- a/test/unit/org/apache/cassandra/db/memtable/FlushingTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/FlushingTest.java
@@ -64,12 +64,12 @@ public class FlushingTest extends CQLTester
     @Before
     public void setup() throws Throwable
     {
-        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value int)");
+        createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int PRIMARY KEY, value int)");
 
         for (int i = 0; i < 10000; i++)
-            execute("INSERT INTO %s (pk, value) VALUES (?, ?)", i, i);
+            execute(String.format("INSERT INTO %s.%s (pk, value) VALUES (?, ?)", KEYSPACE_PER_TEST, currentTable()), i, i);
 
-        cfs = getCurrentColumnFamilyStore();
+        cfs = getCurrentColumnFamilyStore(KEYSPACE_PER_TEST);
         memtable = cfs.getTracker().getView().getCurrentMemtable();
 
         OpOrder.Barrier barrier = cfs.keyspace.writeOrder.newBarrier();

--- a/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
+++ b/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
@@ -91,6 +91,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        DatabaseDescriptor.setAutoSnapshot(true);
         DatabaseDescriptor.daemonInitialization();
 
         localAdr = InetAddress.getByName("127.0.1.1");

--- a/test/unit/org/apache/cassandra/schema/KeyspaceMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/KeyspaceMetadataTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableCollection;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
@@ -37,6 +38,7 @@ import org.apache.cassandra.cql3.functions.UDFunction;
 import org.apache.cassandra.cql3.functions.UserFunction;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UserType;
+import org.apache.cassandra.service.StorageService;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
@@ -47,6 +49,12 @@ import static org.psjava.util.AssertStatus.assertTrue;
 public class KeyspaceMetadataTest extends CQLTester
 {
     private static final String NEW_KEYSPACE = "new_keyspace";
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        StorageService.instance.setUpDistributedSystemKeyspaces();
+    }
 
     @Test
     public void testRenameWithNestedTypes()

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -29,7 +29,9 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.locator.SimpleSnitch;
+import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.utils.FBUtilities;
@@ -119,7 +121,7 @@ public class StatusTest extends CQLTester
         String hostStatus = lines[lines.length-1].trim();
         assertThat(hostStatus, startsWith("UN"));
         assertThat(hostStatus, containsString(hostForm));
-        assertThat(hostStatus, matchesPattern(".*0 bytes.*"));
+        assertThat(hostStatus, matchesPattern(".*\\d+(\\.\\d+)? (bytes|KiB).*"));
         assertThat(hostStatus, matchesPattern(".*\\d+\\.\\d+%.*"));
         assertThat(hostStatus, containsString(localHostId));
         assertThat(hostStatus, containsString(token));

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -19,11 +19,15 @@
 package org.apache.cassandra.tools.nodetool;
 
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.locator.SimpleSnitch;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.StorageService;
@@ -55,6 +59,8 @@ public class StatusTest extends CQLTester
     @Test
     public void testStatusOutput()
     {
+        SchemaConstants.LOCAL_SYSTEM_KEYSPACE_NAMES.forEach(k -> Keyspace.open(k).flush(ColumnFamilyStore.FlushReason.UNIT_TESTS));
+
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false),
                             "status");
@@ -73,6 +79,8 @@ public class StatusTest extends CQLTester
     @Test
     public void testOutputWhileBootstrapping()
     {
+        SchemaConstants.LOCAL_SYSTEM_KEYSPACE_NAMES.forEach(k -> Keyspace.open(k).flush(ColumnFamilyStore.FlushReason.UNIT_TESTS));
+
         // Deleting these tables will simulate we're bootstrapping
         schemaChange("DROP KEYSPACE " + SchemaConstants.TRACE_KEYSPACE_NAME);
         schemaChange("DROP KEYSPACE " + CQLTester.KEYSPACE);


### PR DESCRIPTION
This pull request includes several changes to the build configuration and source code, primarily focused on improving the handling of temporary directories and enhancing the logging and schema management processes. The most important changes include modifications to the build files, the addition of a new script for mounting a tmpfs filesystem, and updates to logging and schema management in the source code.

* Added a `delete` task to clean up library directories before resolving libraries. This is important because when we update, say version of a library, and then build the project, the library at old version would stay along with the library at new version causing unpredictable behaviour unless explicit clean is run.
* The default tmp dir is set ot `${build.test.dir}/cassandra` instead of system default temp dir (obviously that can be overridden). This way will keep stuff inside build directory.
* Replaced the `cassandra.test.flush_local_schema_changes` property with `cassandra.unsafesystem` for better control over schema changes and commit log recycling.

* Added a new script to mount a tmpfs filesystem at `build/test/cassandra`, with support for both Linux and MacOS - it has proven bringing performance improvements when running unit tests locally when the disk is encrypted.

* Updated `onTableDropped` method to respect the `UNSAFE_SYSTEM` property when recycling commit log segments. This is important change for the unit tests - recycling entire commit log when a table is dropped makes no sense in unit tests because they would never restart a node. That is only important when we would create a table with the same name and ID after restart (so for example, some backups testing and edge cases). At the same time, we drop keyspaces and table frequently in the unit tests, especially, we drop the default keyspace after each test case. It does not take long time, however in case of unit tests, which are often very tiny and fast, the stuff we do after/before each test starts being meaningful. 

In case of many tiny tests, the performance improvement can be significant - for example, on a linux machine, SSTablesIteratedTest takes ~50 seconds without improvements, while applying those improvements reduces their time to ~20 seconds, and then with tmpfs mounted - to 8 seconds.

Ticket https://github.com/riptano/cndb/issues/10289
