### PR TITLE
CNDB-11105: Fix AbstractTypeTest#ordering()

### DIFF
--- a/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
@@ -671,12 +671,12 @@ public class AbstractTypeTest
         return version -> type.asComparableBytes(bb, version);
     }
 
-    @Test // TODO fix this test - it seems like something is broken with DateRange and geometric types comparisons
+    @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void ordering()
     {
         TypeGenBuilder baseline = genBuilder()
-                                  .withoutPrimitive(DurationType.instance) // this uses byte ordering and vint, which makes the ordering effectivlly random from a user's point of view
+                                  .withoutPrimitive(DurationType.instance) // this uses byte ordering and vint, which makes the ordering effectively random from a user's point of view
                                   .withoutTypeKinds(COUNTER); // counters don't allow ordering
         // composite requires all elements fit into Short.MAX_VALUE bytes
         // so try to limit the possible expansion of types

--- a/test/unit/org/apache/cassandra/utils/AbstractTypeGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/AbstractTypeGenerators.java
@@ -174,10 +174,10 @@ public final class AbstractTypeGenerators
                                                                                               .thenComparingLong(Duration::getNanoseconds)),
               TypeSupport.of(IntegerType.instance, Generators.bigInt()),
               TypeSupport.of(DecimalType.instance, Generators.bigDecimal()),
-              TypeSupport.of(DateRangeType.instance, Generators.DATE_RANGE_GEN, Comparator.comparing(DateRangeType.instance::decompose)),
-              TypeSupport.of(LineStringType.instance, Generators.LINE_STRING_GEN, Comparator.comparing(LineStringType.instance::decompose)),
-              TypeSupport.of(PolygonType.instance, Generators.POLYGON_GEN, Comparator.comparing(PolygonType.instance::decompose)),
-              TypeSupport.of(PointType.instance, Generators.POINT_GEN, Comparator.comparing(PointType.instance::decompose))
+              TypeSupport.ofNotComparableValues(DateRangeType.instance, Generators.DATE_RANGE_GEN), // DateRangeType is not comparable
+              TypeSupport.ofNotComparableValues(LineStringType.instance, Generators.LINE_STRING_GEN), // LineStringType is not comparable
+              TypeSupport.ofNotComparableValues(PolygonType.instance, Generators.POLYGON_GEN), // PolygonType is not comparable
+              TypeSupport.ofNotComparableValues(PointType.instance, Generators.POINT_GEN) // PointType is not comparable
     ).collect(Collectors.toMap(t -> t.type, t -> t));
     // NOTE not supporting reversed as CQL doesn't allow nested reversed types
     // when generating part of the clustering key, it would be good to allow reversed types as the top level
@@ -1307,6 +1307,11 @@ public final class AbstractTypeGenerators
         public static <A, B> TypeSupport<A> of(AbstractType<A> type, Serde<A, B> serde, Gen<B> valueGen, Comparator<B> valueComparator)
         {
             return of(type, valueGen.map(serde::from), (a, b) -> valueComparator.compare(serde.to(a), serde.to(b)));
+        }
+
+        public static <T> TypeSupport<T> ofNotComparableValues(AbstractType<T> type, Gen<T> valueGen)
+        {
+            return new TypeSupport<>(type, valueGen, (x, y) -> type.compare(type.decompose(x), type.decompose(y)));
         }
 
         /**


### PR DESCRIPTION
The failing test compares the ordering of decomposed values to the ordering of composed values defined in `AbstractTypeGenerators`. The latter is usually a call to the `compareTo` method of the base type of the `AbstractType`.

The problem here is that all the geometry types and `DateRange` don't implement `Comparable`. It seems correct that those types don't implement `Comparable`, since it doesn't seem there is a natural way of comparing that kind of data.

However, the `AbstractTypeGenerators` machinery seems to drag us into defining a comparator of composed types. Thus, CNDB-9145 provided comparators for the composed values of those types that were based on their decomposed values. 

However, those decomposed values are compared with the natural order of `ByteBuffer`, which is different to the comparison done by the `AbstractType`, which uses `ByteBufferUtil.compareUnsigned` instead.

Thus, the proposed fix povides a decomposed value comparator based on `AbstractType#compare`. We might as wll consider simply excluding those types from `AbstractTypeTest#ordering`.