### PR TITLE
CNDB-11021: Improve performance of ORDER BY using KD-tree index

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/KDTreeIndexSearcher.java
@@ -111,7 +111,8 @@ public class KDTreeIndexSearcher extends IndexSearcher
         var query = slice != null && slice.getOp().isEqualityOrRange()
                     ? bkdQueryFrom(slice, bkdReader.getNumDimensions(), bkdReader.getBytesPerDimension())
                     : null;
-        var iter = new RowIdIterator(bkdReader.iteratorState(orderer.isAscending(), query));
+        var direction = orderer.isAscending() ? BKDReader.Direction.FORWARD : BKDReader.Direction.BACKWARD;
+        var iter = new RowIdIterator(bkdReader.iteratorState(direction, query));
         return toMetaSortedIterator(iter, queryContext);
     }
 


### PR DESCRIPTION
The eagerly populated leafNodeToLeafFP TreeMap has been replaced with a LeafCursor which allows to traverse the index tree directly, in a lazy way.

The change significantly reduces the amount of up-front work we did to initialize the BKDReader.IteratorState.
It also reduces GC pressure and memory usage.

The user-facing effect is that `ORDER BY ... LIMIT ...` queries using a numeric index (KD-tree) are significantly faster.

Fixes https://github.com/riptano/cndb/issues/11021