### PR TITLE
CNDB-10991: skip aggregate that includes any sstables that are already selected by other aggregates

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -1084,6 +1084,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 logger.trace("Creating compaction aggregate with sstable set {}", sstables);
 
 
+            // Note that adjacent overlap sets may include deduplicated sstable
             List<Set<CompactionSSTable>> overlaps = Overlaps.constructOverlapSets(sstables,
                                                                                   UnifiedCompactionStrategy::startsAfter,
                                                                                   CompactionSSTable.firstKeyComparator,

--- a/test/unit/org/apache/cassandra/utils/OverlapsTest.java
+++ b/test/unit/org/apache/cassandra/utils/OverlapsTest.java
@@ -254,11 +254,10 @@ public class OverlapsTest
         };
         String[] none3 = new String[]{
         "ABCD",
-        "ADE",
         "NPQ",
         "RST",
         };
-        int[] noneUnselected = new int[]{2, 3, 4, 5};
+        int[] noneUnselected = new int[]{1, 5, 4, 2, 3};
         String[] single3 = new String[]{
         "ABCDE",
         "LNOPQ",
@@ -286,6 +285,8 @@ public class OverlapsTest
         List<String> actual;
         IntArrayList unselected = new IntArrayList();
         actual = Overlaps.assignOverlapsIntoBuckets(3, method, input, this::makeBucket, s -> unselected.add(input.indexOf(s)));
+        actual.sort(String::compareTo);
+
         assertEquals(Arrays.asList(expected), actual);
         assertArrayEquals(expectedUnselected, unselected.toIntArray());
     }


### PR DESCRIPTION
- prioritize overlap set with more sstables in `Overlaps.constructOverlapSets`