### PR TITLE
CNDB-11134: Fix data race in adjustForCrossDatacenterClashes to prevent NPE

### DIFF
--- a/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java
@@ -223,9 +223,9 @@ public class TokenAllocation
 
             for (Token t : tokens)
             {
-                while (tokenMetadata.getEndpoint(t) != null)
+                InetAddressAndPort other;
+                while ((other = tokenMetadata.getEndpoint(t)) != null)
                 {
-                    InetAddressAndPort other = tokenMetadata.getEndpoint(t);
                     if (inAllocationRing(other))
                         throw new ConfigurationException(String.format("Allocated token %s already assigned to node %s. Is another node also allocating tokens?", t, other));
                     t = t.nextValidToken();


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/11134

It's possible that there are external reasons why we won't hit an NPE here, but based on reading the code, it seems possible. Instead of two get calls with two different locks, I propose that we store the result of the call to `getEndpoint` and then use that result in the subsequent logic to check `inAllocationRing`