### PR TITLE
CNDB-11146 main-5.0: Fix FailureTest.shouldMakeIndexNonQueryableOnSSTableContextFailureDur…

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
@@ -116,7 +116,7 @@ public class FailureTest extends SAITester
         Injection ssTableContextCreationFailure = newFailureOnEntry("context_failure_on_creation", SSTableContext.class, "<init>", RuntimeException.class);
         Injections.inject(ssTableContextCreationFailure);
 
-        String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+        String v2IndexName = createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v2"));
 
         // Verify that the initial index build fails...
         verifyInitialIndexFailed(v2IndexName);


### PR DESCRIPTION
After the 5.0 rebase `CQLTester#createIndex` waits until the index is queryable. The failing test is creating a index that intentionally fails during build, so we should use `CQLTester#createIndexAsync` so it doesn't wait for the index being queryable.