### PR TITLE
CNDB-10295 Followup - Do not use lambdas in InMemoryTrie

### DIFF
--- a/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
@@ -152,7 +152,7 @@ public class InMemoryTrie<T> extends InMemoryReadTrie<T>
                     @Override
                     public int allocate() throws TrieSpaceExhaustedException
                     {
-                        return allocateCell();
+                        return allocateNewCell();
                     }
                 }, opOrder);
                 objectAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(new MemoryAllocationStrategy.Allocator()

--- a/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
@@ -129,12 +129,40 @@ public class InMemoryTrie<T> extends InMemoryReadTrie<T>
         switch (lifetime)
         {
             case SHORT:
-                cellAllocator = new MemoryAllocationStrategy.NoReuseStrategy(this::allocateNewCell);
-                objectAllocator = new MemoryAllocationStrategy.NoReuseStrategy(this::allocateNewObject);
+                cellAllocator = new MemoryAllocationStrategy.NoReuseStrategy(new MemoryAllocationStrategy.Allocator()
+                {
+                    @Override
+                    public int allocate() throws TrieSpaceExhaustedException
+                    {
+                        return allocateNewCell();
+                    }
+                });
+                objectAllocator = new MemoryAllocationStrategy.NoReuseStrategy(new MemoryAllocationStrategy.Allocator()
+                {
+                    @Override
+                    public int allocate() throws TrieSpaceExhaustedException
+                    {
+                        return allocateNewObject();
+                    }
+                });
                 break;
             case LONG:
-                cellAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(this::allocateNewCell, opOrder);
-                objectAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(this::allocateNewObject, opOrder);
+                cellAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(new MemoryAllocationStrategy.Allocator()
+                {
+                    @Override
+                    public int allocate() throws TrieSpaceExhaustedException
+                    {
+                        return allocateCell();
+                    }
+                }, opOrder);
+                objectAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(new MemoryAllocationStrategy.Allocator()
+                {
+                    @Override
+                    public int allocate() throws TrieSpaceExhaustedException
+                    {
+                        return allocateNewObject();
+                    }
+                }, opOrder);
                 break;
             default:
                 throw new AssertionError();

--- a/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
@@ -140,7 +140,7 @@ public class InMemoryTrie<T> extends InMemoryReadTrie<T>
                 objectAllocator = new MemoryAllocationStrategy.NoReuseStrategy(new MemoryAllocationStrategy.Allocator()
                 {
                     @Override
-                    public int allocate() throws TrieSpaceExhaustedException
+                    public int allocate()
                     {
                         return allocateNewObject();
                     }
@@ -158,7 +158,7 @@ public class InMemoryTrie<T> extends InMemoryReadTrie<T>
                 objectAllocator = new MemoryAllocationStrategy.OpOrderReuseStrategy(new MemoryAllocationStrategy.Allocator()
                 {
                     @Override
-                    public int allocate() throws TrieSpaceExhaustedException
+                    public int allocate()
                     {
                         return allocateNewObject();
                     }


### PR DESCRIPTION
Fixes this error while running on JDK22


```
Caused by: java.lang.ExceptionInInitializerError: null
5864
	at org.apache.cassandra.db.memtable.TrieMemtable$MemtableShard.<init>(TrieMemtable.java:642)
5865
	at org.apache.cassandra.db.memtable.TrieMemtable$MemtableShard.<init>(TrieMemtable.java:635)
5866
	at org.apache.cassandra.db.memtable.TrieMemtable.generatePartitionShards(TrieMemtable.java:180)
5867
	at org.apache.cassandra.db.memtable.TrieMemtable.<init>(TrieMemtable.java:169)
5868
	at org.apache.cassandra.db.memtable.TrieMemtable$Factory.create(TrieMemtable.java:846)
5869
	at org.apache.cassandra.db.memtable.DefaultMemtableFactory.create(DefaultMemtableFactory.java:38)
5870
	at org.apache.cassandra.db.ColumnFamilyStore.createMemtable(ColumnFamilyStore.java:1494)
5871
	at org.apache.cassandra.db.ColumnFamilyStore.<init>(ColumnFamilyStore.java:548)
5872
	at org.apache.cassandra.db.ColumnFamilyStore.createColumnFamilyStore(ColumnFamilyStore.java:868)
5873
	at org.apache.cassandra.db.ColumnFamilyStore.createColumnFamilyStore(ColumnFamilyStore.java:855)
5874
	at org.apache.cassandra.db.ColumnFamilyStore.createColumnFamilyStore(ColumnFamilyStore.java:846)
5875
	at org.apache.cassandra.db.Keyspace.initCf(Keyspace.java:524)
5876
	at org.apache.cassandra.db.Keyspace.<init>(Keyspace.java:379)
5877
	at org.apache.cassandra.db.Keyspace.lambda$open$0(Keyspace.java:168)
5878
	at org.apache.cassandra.utils.concurrent.LoadingMap.lambda$blockingLoadIfAbsent$1(LoadingMap.java:273)
5879
	at org.apache.cassandra.utils.concurrent.LoadingMap.lambda$computeIfAbsent$0(LoadingMap.java:98)
5880
	at org.apache.cassandra.utils.concurrent.LoadingMap.updateOrRemoveEntry(LoadingMap.java:178)
5881
	at org.apache.cassandra.utils.concurrent.LoadingMap.computeIfAbsent(LoadingMap.java:98)
5882
	at org.apache.cassandra.utils.concurrent.LoadingMap.blockingLoadIfAbsent(LoadingMap.java:272)
5883
	at org.apache.cassandra.schema.Schema.maybeAddKeyspaceInstance(Schema.java:246)
5884
	at org.apache.cassandra.db.Keyspace.open(Keyspace.java:166)
5885
	at org.apache.cassandra.db.Keyspace.open(Keyspace.java:155)
5886
	at com.datastax.cndb.metadata.schema.CloudSchemaUpdateHandler.lambda$initLocalSchema$1(CloudSchemaUpdateHandler.java:164)
5887
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
5888
	at com.datastax.cndb.metadata.schema.CloudSchemaUpdateHandler.initLocalSchema(CloudSchemaUpdateHandler.java:164)
5889
	at com.datastax.cndb.metadata.schema.OnlineCloudSchemaUpdateHandler.initLocalSchema(OnlineCloudSchemaUpdateHandler.java:146)
5890
	at com.datastax.cndb.metadata.schema.CloudSchemaUpdateHandler.loadSchema(CloudSchemaUpdateHandler.java:147)
5891
	at com.datastax.cndb.metadata.tenant.TenantManager.loadSchema(TenantManager.java:531)
5892
	... 4 common frames omitted
5893
Caused by: java.lang.UnsupportedOperationException: can't get field offset on a hidden class: private final org.apache.cassandra.db.tries.InMemoryTrie org.apache.cassandra.db.tries.InMemoryTrie$$Lambda/0x00007fabf380c0a0.arg$1
5894
	at jdk.unsupported/sun.misc.Unsafe.objectFieldOffset(Unsafe.java:652)
5895
	at org.github.jamm.MemoryLayoutSpecification.sizeOfInstanceWithUnsafe(MemoryLayoutSpecification.java:108)
5896
	at org.github.jamm.MemoryLayoutSpecification.sizeOfWithUnsafe(MemoryLayoutSpecification.java:89)
5897
	at org.github.jamm.MemoryMeter.measure(MemoryMeter.java:217)
5898
	at org.github.jamm.MemoryMeter.measureDeep(MemoryMeter.java:259)
5899
	at org.apache.cassandra.utils.ObjectSizes.measureDeep(ObjectSizes.java:216)
5900
	at org.apache.cassandra.db.tries.InMemoryTrie.<clinit>(InMemoryTrie.java:111)
```