### PR TITLE
CNDB-11149: Add missing SAI implementation of Index.getUnloadTask

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -536,6 +536,19 @@ public class StorageAttachedIndex implements Index
     }
 
     @Override
+    public Callable<?> getUnloadTask()
+    {
+        return () ->
+        {
+            // mark index as invalid, in-progress SSTableIndexWriters will abort
+            valid = false;
+
+            indexContext.invalidate(false);
+            return null;
+        };
+    }
+
+    @Override
     public Callable<?> getPreJoinTask(boolean hadBootstrap)
     {
         /*

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -35,21 +35,22 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class GroupComponentsTest extends SAITester
 {
     @Test
-    public void testInvalidateWithoutObsolete() throws Throwable
+    public void testInvalidateWithoutObsolete()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
-        String idx = createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable(idx);
+        createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
         execute("INSERT INTO %s (pk) VALUES (1)");
         flush();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
-        StorageAttachedIndex index = (StorageAttachedIndex) group.getIndexes().iterator().next();
+        assertNotNull(group);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
         Set<Component> components = group.activeComponents(sstable);
@@ -63,16 +64,16 @@ public class GroupComponentsTest extends SAITester
     }
 
     @Test
-    public void getLiveComponentsForEmptyIndex() throws Throwable
+    public void getLiveComponentsForEmptyIndex()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
         execute("INSERT INTO %s (pk) VALUES (1)");
         flush();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        assertNotNull(group);
         Set<SSTableReader> sstables = cfs.getLiveSSTables();
 
         assertEquals(1, sstables.size());
@@ -83,16 +84,16 @@ public class GroupComponentsTest extends SAITester
     }
 
     @Test
-    public void getLiveComponentsForPopulatedIndex() throws Throwable
+    public void getLiveComponentsForPopulatedIndex()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
         IndexContext indexContext = createIndexContext(createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'"), Int32Type.instance);
-        waitForTableIndexesQueryable();
         execute("INSERT INTO %s (pk, value) VALUES (1, 1)");
         flush();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        assertNotNull(group);
         Set<SSTableReader> sstables = cfs.getLiveSSTables();
 
         assertEquals(1, sstables.size());


### PR DESCRIPTION
This fixes `GroupComponentsTest.testInvalidateWithoutObsolete`. I wouldn't be surprised if it fixed some other issues.

Since we are here, I have also done some minor cleaning in `GroupComponentsTest`.