### PR TITLE
CNDB-11168 main-5.0: Fix NodeRestartTest and SnapshotTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -135,13 +135,13 @@ public class SAITester extends CQLTester
     protected static final Injections.Counter perSSTableValidationCounter = addConditions(Injections.newCounter("PerSSTableValidationCounter")
                                                                                       .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
                                                                                                            .onMethod("validateComponents")),
-                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args())
     ).build();
 
     protected static final Injections.Counter perColumnValidationCounter = addConditions(Injections.newCounter("PerColumnValidationCounter")
                                                                                      .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
                                                                                                           .onMethod("validateComponents")),
-                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args())
     ).build();
 
     protected static ColumnIdentifier V1_COLUMN_IDENTIFIER = ColumnIdentifier.getInterned("v1", true);

--- a/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
@@ -84,7 +84,7 @@ public class SnapshotTest extends SAITester
 
         // Truncate the table
         truncate(false);
-        waitForAssert(() -> verifyNoIndexFiles());
+        waitForAssert(this::verifyNoIndexFiles);
         assertNumRows(0, "SELECT * FROM %%s WHERE v1 >= 0");
         assertValidationCount(0, 0);
 
@@ -100,10 +100,13 @@ public class SnapshotTest extends SAITester
 
         // Rebuild the index to verify that the index files are overridden
         rebuildIndexes(numericIndexContext.getIndexName());
-        verifyIndexComponentFiles(numericIndexContext, null);
+        verifyIndexFiles(numericIndexContext, null, 2, 2, 0, 2, 0);
         assertNotEquals(snapshotLastModified, indexFilesLastModified());
         assertNumRows(2, "SELECT * FROM %%s WHERE v1 >= 0");
-        assertValidationCount(2, 2); // compaction should not validate
+        assertValidationCount(2, 2);
+
+        verifyIndexComponentFiles(numericIndexContext, null);
+        assertValidationCount(4, 4);
 
         // index components are included after rebuild
         verifyIndexComponentsIncludedInSSTable();
@@ -146,7 +149,7 @@ public class SnapshotTest extends SAITester
 
         // Truncate the table
         truncate(false);
-        waitForAssert(() -> verifyNoIndexFiles());
+        waitForAssert(this::verifyNoIndexFiles);
         assertNumRows(0, "SELECT * FROM %%s WHERE v1 >= 0");
         assertValidationCount(0, 0);
 


### PR DESCRIPTION
I think the failures of these tests are due to merge conflicts between https://github.com/datastax/cassandra/pull/1099 and [CASSANDRA-18714](https://issues.apache.org/jira/browse/CASSANDRA-18714).

https://github.com/datastax/cassandra/pull/1099 modified `SAITester.perSSTableValidationCounter` and `SAITester.perColumnValidationCounter` injections to only count checksum validations, instead of all kind of validations. However, [CASSANDRA-18714](https://issues.apache.org/jira/browse/CASSANDRA-18714) modified the way validations are done to do more checksum validations. As a result, the counting doesn't match what the tests expect.

I have modified those injections to count all validations again, so the new checksum validations are included. 

Additionally, I have made some changes in `SnapshotTest.shouldTakeAndRestoreSnapshots` so it checks the counters immediately after doing the index rebuild. This was failing because it was testing this after a call to `SAITester.verifyIndexComponentFiles` that added new validations to those done by the rebuild.