### PR TITLE
CNDB-11118 return null serializer if response verb is null

### DIFF
--- a/src/java/org/apache/cassandra/net/RequestCallbacks.java
+++ b/src/java/org/apache/cassandra/net/RequestCallbacks.java
@@ -130,10 +130,11 @@ public class RequestCallbacks implements OutboundMessageCallbacks
         assert previous == null : format("Callback already exists for id %d/%s! (%s)", message.id(), to.endpoint(), previous);
     }
 
+    @Nullable
     <In,Out> IVersionedAsymmetricSerializer<In, Out> responseSerializer(long id, InetAddressAndPort peer)
     {
         CallbackInfo info = get(id, peer);
-        return info == null ? null : info.responseVerb.serializer();
+        return info == null || info.responseVerb == null ? null : info.responseVerb.serializer();
     }
 
     @VisibleForTesting

--- a/test/unit/org/apache/cassandra/net/RequestCallbacksTest.java
+++ b/test/unit/org/apache/cassandra/net/RequestCallbacksTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.IVersionedAsymmetricSerializer;
+import org.apache.cassandra.locator.InetAddressAndPort;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+public class RequestCallbacksTest
+{
+    @BeforeClass
+    public static void init()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test
+    public void testInternalResponseNullSerializer() throws Exception
+    {
+        depractedResponsesShouldReturnNullSerializer(Verb.INTERNAL_RSP);
+    }
+
+    @Test
+    public void testRequestResponseNullSerializer() throws Exception
+    {
+        depractedResponsesShouldReturnNullSerializer(Verb.REQUEST_RSP);
+    }
+
+    public void depractedResponsesShouldReturnNullSerializer(Verb verb) throws Exception
+    {
+        MessagingService messagingService = mock(MessagingService.class);
+        RequestCallbacks requestCallbacks = new RequestCallbacks(messagingService);
+        Message<?> msg = Message.remoteResponse(InetAddressAndPort.getByName("127.0.0.1"), verb, null);
+        requestCallbacks.addWithExpiration(mock(RequestCallback.class), msg, msg.from());
+
+        IVersionedAsymmetricSerializer<Object, Object> serializer = requestCallbacks.responseSerializer(msg.id(), msg.from());
+
+        assertNull(serializer);
+    }
+}


### PR DESCRIPTION
response verb is null for deprecated REQUEST_RSP and INTERNAL_RSP. info.responseVerb.serializer() caused NullPointerExceptions.
The null serializer is later gracefully handled in deserializePayloadPre40.