### PR TITLE
Fix access to JDK internals for jamm post CNDB-9850

### DIFF
--- a/conf/jvm17-server.options
+++ b/conf/jvm17-server.options
@@ -115,7 +115,7 @@
 --add-modules jdk.incubator.vector
 
 ### Compatibility Options
---add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
 -Djava.security.manager=allow
 
 # The newline in the end of file is intentional


### PR DESCRIPTION
Tested locally that Cassandra starts on JDK22