### PR TITLE
CNDB-11189: Fix usages of waitForTableIndexesQueryable

### DIFF
--- a/test/long/index/sai/cql/AnalyzerQueryLongTest.java
+++ b/test/long/index/sai/cql/AnalyzerQueryLongTest.java
@@ -27,13 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AnalyzerQueryLongTest extends CQLTester
 {
     @Test
-    public void manyWritesTest() throws Throwable
+    public void manyWritesTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, not_analyzed int, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable(KEYSPACE,"val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {
@@ -63,13 +62,12 @@ public class AnalyzerQueryLongTest extends CQLTester
     }
 
     @Test
-    public void manyWritesAndUpsertsTest() throws Throwable
+    public void manyWritesAndUpsertsTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable(KEYSPACE,"val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {
@@ -94,13 +92,12 @@ public class AnalyzerQueryLongTest extends CQLTester
         assertThat(result).hasSize(iterations / 2 + 1);
     }
     @Test
-    public void manyWritesUpsertsAndDeletesForSamePKTest() throws Throwable
+    public void manyWritesUpsertsAndDeletesForSamePKTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable(KEYSPACE, "val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/IndexGroupRemovalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/IndexGroupRemovalTest.java
@@ -44,7 +44,7 @@ public class IndexGroupRemovalTest extends SAITester
     @Test
     public void testDropAndRecreate() throws Throwable
     {
-        String tableName = createTable("CREATE TABLE %s (pk text, value text, PRIMARY KEY (pk))");
+        createTable("CREATE TABLE %s (pk text, value text, PRIMARY KEY (pk))");
         populateOneSSTable();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -53,7 +53,6 @@ public class IndexGroupRemovalTest extends SAITester
 
         // create index and drop it: StorageAttachedIndexGroup should be removed
         createIndex("CREATE CUSTOM INDEX sai ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable("sai");
 
         StorageAttachedIndexGroup group = (StorageAttachedIndexGroup) cfs.indexManager.getIndexGroup(StorageAttachedIndexGroup.GROUP_KEY);
         assertTrue(tracker.contains(group));
@@ -70,7 +69,6 @@ public class IndexGroupRemovalTest extends SAITester
 
         // create index again: expect a new StorageAttachedIndexGroup to be registered into tracker
         createIndex("CREATE CUSTOM INDEX sai ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable("sai");
 
         StorageAttachedIndexGroup newGroup = (StorageAttachedIndexGroup) cfs.indexManager.getIndexGroup(StorageAttachedIndexGroup.GROUP_KEY);
         assertNotSame(group, newGroup);

--- a/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
@@ -88,7 +88,6 @@ public class IndexParallelBuildTest extends SAITester
 
         // create indexes
         String index = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable(index);
         assertTrue(getCurrentColumnFamilyStore().getLiveSSTables().isEmpty());
 
         Injections.Counter parallelBuildCounter = Injections.newCounter("IndexParallelBuildCounter")

--- a/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
@@ -71,9 +71,7 @@ public class RandomisedComplexQueryTest extends SAITester
 
         createTable(schema.toTableDefinition());
 
-        List<String> indexes = schema.generateIndexStrings().stream().map(this::createIndex).collect(Collectors.toList());
-
-        indexes.forEach(this::waitForIndexQueryable);
+        schema.generateIndexStrings().forEach(this::createIndex);
 
         List<RandomRow> data = schema.generateDataset();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/TokenRangeReadTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/TokenRangeReadTest.java
@@ -38,8 +38,7 @@ public class TokenRangeReadTest extends SAITester
     public void testTokenRangeRead() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, v1 text, PRIMARY KEY (k1))");
-        String index = createIndex(format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable(index);
+        createIndex(format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
 
         execute("INSERT INTO %S(k1, v1) values(1, '1')");
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
@@ -45,7 +45,7 @@ public class IndexGroupMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void verifyIndexGroupMetrics() throws Throwable
+    public void verifyIndexGroupMetrics()
     {
         // create first index
         createTable(CREATE_TABLE_TEMPLATE);
@@ -75,7 +75,6 @@ public class IndexGroupMetricsTest extends AbstractMetricsTest
         // create second index
         String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
         IndexContext v2IndexContext = createIndexContext(v2IndexName, UTF8Type.instance);
-        waitForIndexQueryable(v2IndexName);
 
         // same number of sstables, but more string index files.
         int stringIndexOpenFileCount = sstables * V1OnDiskFormat.instance.openFilesPerIndex(v2IndexContext);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -88,7 +88,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testMetricRelease() throws Throwable
+    public void testMetricRelease()
     {
         String table = "test_metric_release";
         String index = "test_metric_release_index";
@@ -97,7 +97,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace, table));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForTableIndexesQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES ('0', 0, '0')");
 
@@ -116,7 +115,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testIndexQueryWithPartitionKey() throws Throwable
+    public void testIndexQueryWithPartitionKey()
     {
         String table = "test_range_key_type_with_index";
         String index = "test_range_key_type_with_index_index";
@@ -140,8 +139,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
             flush(keyspace, table);
         }
 
-        waitForIndexQueryable(keyspace, table);
-
         ResultSet rows2 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '36' and v1 < 51");
         assertEquals(1, rows2.all().size());
 
@@ -164,7 +161,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreeQueryMetricsWithSingleIndex() throws Throwable
+    public void testKDTreeQueryMetricsWithSingleIndex()
     {
         String table = "test_metrics_through_write_lifecycle";
         String index = "test_metrics_through_write_lifecycle_index";
@@ -228,7 +225,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreePostingsQueryMetricsWithSingleIndex() throws Throwable
+    public void testKDTreePostingsQueryMetricsWithSingleIndex()
     {
         String table = "test_kdtree_postings_metrics_through_write_lifecycle";
         String v1Index = "test_kdtree_postings_metrics_through_write_lifecycle_v1_index";
@@ -271,7 +268,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testInvertedIndexQueryMetricsWithSingleIndex() throws Throwable
+    public void testInvertedIndexQueryMetricsWithSingleIndex()
     {
         String table = "test_invertedindex_metrics_through_write_lifecycle";
         String index = "test_invertedindex_metrics_through_write_lifecycle_index";
@@ -334,7 +331,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreePartitionsReadAndRowsFiltered() throws Throwable
+    public void testKDTreePartitionsReadAndRowsFiltered()
     {
         String table = "test_rows_filtered_large_partition";
         String index = "test_rows_filtered_large_partition_index";
@@ -345,7 +342,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
                                   "WITH compaction = {'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }", keyspace,  table));
 
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForTableIndexesQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (0, 0, 0)");
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (1, 1, 1)");
@@ -366,7 +362,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreeQueryEarlyExit() throws Throwable
+    public void testKDTreeQueryEarlyExit()
     {
         String table = "test_queries_exited_early";
         String index = "test_queries_exited_early_index";
@@ -377,7 +373,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
                                   "WITH compaction = {'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }", keyspace, table));
 
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForTableIndexesQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (0, 0, 0)");
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (1, 1, 1)");
@@ -402,7 +397,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForEquals(objectName("KDTreeIntersectionEarlyExits", keyspace, table, index, GLOBAL_METRIC_TYPE), 2L);
     }
 
-    private long getPerQueryMetrics(String keyspace, String table, String metricsName) throws Exception
+    private long getPerQueryMetrics(String keyspace, String table, String metricsName)
     {
         return (long) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, PER_QUERY_METRIC_TYPE));
     }


### PR DESCRIPTION
Fixes `QueryMetricsTest.testIndexQueryWithPartitionKey` and `AnalyzerQueryLongTest`.