### PR TITLE
CNDB-10886: Bump JVector to 3.0.2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -706,7 +706,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.1" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.2" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">


### PR DESCRIPTION
This brings in 2 changes:

- no longer cap the max version of JDK for enabling Panama/native vectorization (https://github.com/jbellis/jvector/pull/362)
- use fma rather than mul/add in vectorized cosineSimilarity (https://github.com/jbellis/jvector/pull/363)