### PR TITLE
CNDB-8187 Move SAI writing metrics to micros and use counters

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1357,7 +1357,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 reclaim(memtable);
                 return Collections.emptyList();
             }
-
+            long start = System.nanoTime();
             List<Future<SSTableMultiWriter>> futures = new ArrayList<>();
             long totalBytesOnDisk = 0;
             long maxBytesOnDisk = 0;
@@ -1467,6 +1467,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                         }
                     }
                 }
+                metric.memTableFlushCompleted(System.nanoTime() - start);
 
                 cfs.replaceFlushed(memtable, sstables, Optional.of(txn.opId()));
             }

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -224,8 +224,8 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
                 completeSSTable(txn, indexWriter, sstable, indexes, perSSTableFileLock, replacedComponents);
             }
             long timeTaken = ApproximateTime.nanoTime() - startTimeNanos;
-            group.table().metric.storageAttachedIndexBuildTime.update(timeTaken);
-            logger.debug("Completed indexing sstable {} in {} seconds", sstable.descriptor, TimeUnit.NANOSECONDS.toSeconds(timeTaken));
+            group.table().metric.updateStorageAttachedIndexBuildTime(timeTaken);
+            logger.trace("Completed indexing sstable {} in {} seconds", sstable.descriptor, TimeUnit.NANOSECONDS.toSeconds(timeTaken));
 
             return false;
         }

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -82,17 +82,17 @@ public class KeyspaceMetrics
     /** Tombstones scanned in queries on this Keyspace */
     public final Histogram tombstoneScannedHistogram;
     /** Time spent flushing memtables */
-    public final Histogram flushTime;
-    public final Histogram storageAttachedIndexBuildTime;
+    public final Counter flushTime;
+    public final Counter storageAttachedIndexBuildTime;
 
     /** Time spent writing SAI */
-    public final Histogram storageAttachedIndexWritingTimeForIndexBuild;
-    public final Histogram storageAttachedIndexWritingTimeForCompaction;
-    public final Histogram storageAttachedIndexWritingTimeForFlush;
-    public final Histogram storageAttachedIndexWritingTimeForOther;
+    public final Counter storageAttachedIndexWritingTimeForIndexBuild;
+    public final Counter storageAttachedIndexWritingTimeForCompaction;
+    public final Counter storageAttachedIndexWritingTimeForFlush;
+    public final Counter storageAttachedIndexWritingTimeForOther;
 
     /** Time spent writing  memtables during compaction */
-    public final Histogram compactionTime;
+    public final Counter compactionTime;
 
     /** Shadowed keys scan metrics **/
     public final Histogram shadowedKeysScannedHistogram;
@@ -230,13 +230,13 @@ public class KeyspaceMetrics
         // create histograms for TableMetrics to replicate updates to
         sstablesPerReadHistogram = createKeyspaceHistogram("SSTablesPerReadHistogram", true);
         tombstoneScannedHistogram = createKeyspaceHistogram("TombstoneScannedHistogram", false);
-        flushTime = createKeyspaceHistogram("FlushTime", false);
-        storageAttachedIndexBuildTime = createKeyspaceHistogram("StorageAttachedIndexBuildTime", false);
-        storageAttachedIndexWritingTimeForIndexBuild = createKeyspaceHistogram("StorageAttachedIndexWritingTimeForIndexBuild", false);
-        storageAttachedIndexWritingTimeForCompaction = createKeyspaceHistogram("StorageAttachedIndexWritingTimeForCompaction", false);
-        storageAttachedIndexWritingTimeForFlush = createKeyspaceHistogram("StorageAttachedIndexWritingTimeForFlush", false);
-        storageAttachedIndexWritingTimeForOther = createKeyspaceHistogram("StorageAttachedIndexWritingTimeForOther", false);
-        compactionTime = createKeyspaceHistogram("CompactionTime", false);
+        flushTime = createKeyspaceCounter("FlushTime", v -> v.flushTime.getCount());
+        storageAttachedIndexBuildTime = createKeyspaceCounter("StorageAttachedIndexBuildTime", v -> v.storageAttachedIndexBuildTime.getCount());
+        storageAttachedIndexWritingTimeForIndexBuild = createKeyspaceCounter("StorageAttachedIndexWritingTimeForIndexBuild", v -> v.storageAttachedIndexWritingTimeForIndexBuild.getCount());
+        storageAttachedIndexWritingTimeForCompaction = createKeyspaceCounter("StorageAttachedIndexWritingTimeForCompaction", v -> v.storageAttachedIndexWritingTimeForCompaction.getCount());
+        storageAttachedIndexWritingTimeForFlush = createKeyspaceCounter("StorageAttachedIndexWritingTimeForFlush", v -> v.storageAttachedIndexWritingTimeForFlush.getCount());
+        storageAttachedIndexWritingTimeForOther = createKeyspaceCounter("StorageAttachedIndexWritingTimeForOther", v -> v.storageAttachedIndexWritingTimeForOther.getCount());
+        compactionTime = createKeyspaceCounter("CompactionTime", v -> v.compactionTime.getCount());
         shadowedKeysScannedHistogram = createKeyspaceHistogram("ShadowedKeysScannedHistogram", false);
         shadowedKeysLoopsHistogram = createKeyspaceHistogram("ShadowedKeysLoopsHistogram", false);
         liveScannedHistogram = createKeyspaceHistogram("LiveScannedHistogram", false);


### PR DESCRIPTION
While building the Grafana dashboards I found that:
- the time spent for memtable flush was taken in the wrong places (and in fact the time to write SAI was bigger then the time reported as total flush time)
- the histograms don't show well how much time we spend in compaction/flush vs Index build, because with the histograms you track only the distribution of many smaller events, and with BucketedGauge we cannot have the total sum
- nanosecond precision is useless


Modifications:
This patch reworks #1329 with these changes:
- metrics become counters
- we track microseconds instead of nanoseconds
- the time to flush is measoured in a better place