### PR TITLE
When deserializing inbound messages, use the SchemaUpdateHandler to v…

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/NotReadyException.java
+++ b/src/java/org/apache/cassandra/exceptions/NotReadyException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.exceptions;
+
+public class NotReadyException extends RequestExecutionException
+{
+    public NotReadyException(ExceptionCode code, String msg)
+    {
+        super(code, msg);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/StorageHandler.java
+++ b/src/java/org/apache/cassandra/io/sstable/StorageHandler.java
@@ -69,7 +69,9 @@ public abstract class StorageHandler
         /** When region status changed */
         REGION_CHANGED(false),
         /** When index is built */
-        INDEX_BUILT(false);
+        INDEX_BUILT(false),
+        /** New node restarted with existing on disk data*/
+        REPLACE(true);
 
         /** When this is true, a reload operation will reload all sstables even those that could
          * have been flushed by other nodes. */

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -31,6 +31,7 @@ import io.netty.channel.ChannelHandlerContext;
 import org.apache.cassandra.concurrent.ExecutorLocals;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.exceptions.IncompatibleSchemaException;
+import org.apache.cassandra.exceptions.NotReadyException;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message.Header;
@@ -178,6 +179,11 @@ public class InboundMessageHandler extends AbstractMessageHandler
         {
             callbacks.onFailedDeserialize(size, header, e);
             noSpamLogger.info("{} incompatible schema encountered while deserializing a message", this, e);
+        }
+        catch (NotReadyException e)
+        {
+            callbacks.onFailedDeserialize(size, header, e);
+            noSpamLogger.info("{}: {}", NotReadyException.class.getSimpleName(), e.getMessage());
         }
         catch (Throwable t)
         {
@@ -375,6 +381,11 @@ public class InboundMessageHandler extends AbstractMessageHandler
             {
                 callbacks.onFailedDeserialize(size, header, e);
                 noSpamLogger.info("{} incompatible schema encountered while deserializing a message", InboundMessageHandler.this, e);
+            }
+            catch (NotReadyException e)
+            {
+                callbacks.onFailedDeserialize(size, header, e);
+                noSpamLogger.info("{}: {}", NotReadyException.class.getSimpleName(), e.getMessage());
             }
             catch (Throwable t)
             {

--- a/src/java/org/apache/cassandra/schema/Schema.java
+++ b/src/java/org/apache/cassandra/schema/Schema.java
@@ -51,7 +51,10 @@ import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.ExceptionCode;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.NotReadyException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.UnknownKeyspaceException;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -327,6 +330,10 @@ public class Schema implements SchemaProvider
     public KeyspaceMetadata getKeyspaceMetadata(String keyspaceName)
     {
         assert keyspaceName != null;
+
+        if (!updateHandler.isReady(keyspaceName))
+            throw new NotReadyException(ExceptionCode.UNAVAILABLE, String.format("Keyspace %s not ready", keyspaceName));
+
         KeyspaceMetadata keyspace = distributedAndLocalKeyspaces().getNullable(keyspaceName);
         return null != keyspace ? keyspace : VirtualKeyspaceRegistry.instance.getKeyspaceMetadataNullable(keyspaceName);
     }

--- a/src/java/org/apache/cassandra/schema/SchemaUpdateHandler.java
+++ b/src/java/org/apache/cassandra/schema/SchemaUpdateHandler.java
@@ -50,6 +50,20 @@ public interface SchemaUpdateHandler
     boolean waitUntilReady(Duration timeout);
 
     /**
+     * Checks if the schema for the given keyspace is ready to be used: should be invoked during request processing
+     * to make sure the schema is readily accessible before further processing the request.
+     *
+     * @param keyspaceName The name of the keyspace to check, as different implementations could manage the schema
+     *                     of different keyspaces separately.
+     *
+     * @return True if the schema is ready, false otherwise.
+     */
+    default boolean isReady(String keyspaceName)
+    {
+        return true;
+    }
+
+    /**
      * Applies schema transformation in the underlying storage and synchronizes with other nodes.
      *
      * @param transformation schema transformation to be performed


### PR DESCRIPTION
…erify if the node is ready to process messages for a given keyspace: this can be used in CNDB to skip processing of messages whose tenant is not fully joined.