### PR TITLE
CNDB-11137 Set positions to null when local ranges are <= 1

### DIFF
--- a/src/java/org/apache/cassandra/db/DiskBoundaryManager.java
+++ b/src/java/org/apache/cassandra/db/DiskBoundaryManager.java
@@ -74,7 +74,7 @@ public class DiskBoundaryManager
         }
         while (directoriesVersion != DisallowedDirectories.getDirectoriesVersion()); // if directoriesVersion has changed we need to recalculate
 
-        if (localRanges == null || localRanges.getRanges().isEmpty())
+        if (localRanges == null || localRanges.getRanges().size() <= 1)
             return new DiskBoundaries(cfs, dirs, null, localRanges, directoriesVersion);
 
         List<Token> positions = getDiskBoundaries(localRanges.getRanges(), cfs.getPartitioner(), dirs);


### PR DESCRIPTION
If `localRanges` is <=1 then set `positions` to `null` for `DiskBoundaries`