### PR TITLE
CNDB-11283 main: Unify CQLTester#waitForIndex and SAITester#waitForIndexQueryable

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/types/ParseUtils.java
+++ b/src/java/org/apache/cassandra/cql3/functions/types/ParseUtils.java
@@ -292,7 +292,7 @@ public abstract class ParseUtils
      * @param value The string to un-double quote.
      * @return The un-double quoted string.
      */
-    static String unDoubleQuote(String value)
+    public static String unDoubleQuote(String value)
     {
         return unquote(value, '"');
     }
@@ -482,7 +482,7 @@ public abstract class ParseUtils
      * @return {@code true} if the given string is surrounded by the quote character, and {@code
      * false} otherwise.
      */
-    private static boolean isQuoted(String value, char quoteChar)
+    public static boolean isQuoted(String value, char quoteChar)
     {
         return value != null
                && value.length() > 1

--- a/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
+++ b/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.index.sai;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,7 +63,6 @@ public class LongVectorTest extends SAITester
     {
         createTable(String.format("CREATE TABLE %%s (key int primary key, value vector<float, %s>)", dimension));
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function': 'dot_product' }");
-        waitForIndexQueryable();
 
         AtomicInteger counter = new AtomicInteger();
         long start = System.currentTimeMillis();

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/MultiNodeExecutor.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/MultiNodeExecutor.java
@@ -62,20 +62,20 @@ public class MultiNodeExecutor implements DataModel.Executor
     }
 
     @Override
-    public void waitForIndexQueryable(String keyspace, String table)
+    public void waitForTableIndexesQueryable(String keyspace, String table)
     {
         SAIUtil.waitForIndexQueryable(cluster, keyspace);
     }
 
     @Override
-    public void executeLocal(String query, Object... values) throws Throwable
+    public void executeLocal(String query, Object... values)
     {
         Object[] buffers = ColumnTypeUtil.transformValues(values);
         cluster.coordinator(1).execute(query, ConsistencyLevel.QUORUM, buffers);
     }
 
     @Override
-    public List<Object> executeRemote(String query, int fetchSize, Object... values) throws Throwable
+    public List<Object> executeRemote(String query, int fetchSize, Object... values)
     {
         Object[] buffers = ColumnTypeUtil.transformValues(values);
         Iterator<Object> iterator = cluster.coordinator(1).executeWithPagingWithResult(query, ConsistencyLevel.QUORUM, fetchSize, buffers).map(row -> row.get(0));

--- a/test/long/index/sai/cql/AnalyzerQueryLongTest.java
+++ b/test/long/index/sai/cql/AnalyzerQueryLongTest.java
@@ -27,13 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AnalyzerQueryLongTest extends CQLTester
 {
     @Test
-    public void manyWritesTest() throws Throwable
+    public void manyWritesTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, not_analyzed int, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndex(KEYSPACE, currentTable(), "val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {
@@ -63,13 +62,12 @@ public class AnalyzerQueryLongTest extends CQLTester
     }
 
     @Test
-    public void manyWritesAndUpsertsTest() throws Throwable
+    public void manyWritesAndUpsertsTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndex(KEYSPACE, currentTable(), "val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {
@@ -94,13 +92,12 @@ public class AnalyzerQueryLongTest extends CQLTester
         assertThat(result).hasSize(iterations / 2 + 1);
     }
     @Test
-    public void manyWritesUpsertsAndDeletesForSamePKTest() throws Throwable
+    public void manyWritesUpsertsAndDeletesForSamePKTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndex(KEYSPACE, currentTable(), "val");
         var iterations = 15000;
         for (int i = 0; i < iterations; i++)
         {

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -102,6 +103,7 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.cql3.functions.FunctionName;
+import org.apache.cassandra.cql3.functions.types.ParseUtils;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.Keyspace;
@@ -135,6 +137,7 @@ import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
@@ -165,6 +168,7 @@ import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.TimeUUID;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 
 import static com.datastax.driver.core.SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS;
@@ -193,6 +197,7 @@ public abstract class CQLTester
     public static final String DATA_CENTER = ServerTestUtils.DATA_CENTER;
     public static final String DATA_CENTER_REMOTE = ServerTestUtils.DATA_CENTER_REMOTE;
     public static final String RACK1 = ServerTestUtils.RACK1;
+    private static final int ASSERTION_TIMEOUT_SECONDS = 15;
     private static final User SUPER_USER = new User("cassandra", "cassandra");
 
     private static org.apache.cassandra.transport.Server server;
@@ -1003,114 +1008,255 @@ public abstract class CQLTester
         schemaChange(formattedQuery);
     }
 
+    /**
+     * Creates a secondary index, waiting for it to become queryable.
+     *
+     * @param query the index creation query
+     * @return the name of the created index
+     */
     public String createIndex(String query)
     {
         return createIndex(KEYSPACE, query);
     }
 
+    /**
+     * Creates a secondary index, waiting for it to become queryable.
+     *
+     * @param keyspace the keyspace the created index should belong to
+     * @param query the index creation query
+     * @return the name of the created index
+     */
     protected String createIndex(String keyspace, String query)
     {
         String formattedQuery = formatQuery(keyspace, query);
-        return createFormattedIndex(formattedQuery);
+        Pair<String, String> qualifiedIndexName = createFormattedIndex(keyspace, formattedQuery);
+        waitForIndexQueryable(qualifiedIndexName.left, qualifiedIndexName.right);
+        return qualifiedIndexName.right;
     }
 
-    protected String createFormattedIndex(String formattedQuery)
+    /**
+     * Creates a secondary index without waiting for it to become queryable.
+     *
+     * @param query the index creation query
+     * @return the name of the created index
+     */
+    protected String createIndexAsync(String query)
+    {
+        return createIndexAsync(KEYSPACE, query);
+    }
+
+    /**
+     * Creates a secondary index without waiting for it to become queryable.
+     *
+     * @param keyspace the keyspace the created index should belong to
+     * @param query the index creation query
+     * @return the name of the created index
+     */
+    protected String createIndexAsync(String keyspace, String query)
+    {
+        String formattedQuery = formatQuery(keyspace, query);
+        return createFormattedIndex(keyspace, formattedQuery).right;
+    }
+
+    private Pair<String, String> createFormattedIndex(String keyspace, String formattedQuery)
     {
         logger.info(formattedQuery);
-        String indexName = getCreateIndexName(formattedQuery);
-        indexes.add(indexName);
+        Pair<String, String> qualifiedIndexName = getCreateIndexName(keyspace, formattedQuery);
+        indexes.add(qualifiedIndexName.right);
         schemaChange(formattedQuery);
-        return indexName;
+        return qualifiedIndexName;
     }
 
-    protected static String getCreateIndexName(String formattedQuery)
+    protected static Pair<String, String> getCreateIndexName(String keyspace, String formattedQuery)
     {
         Matcher matcher = CREATE_INDEX_PATTERN.matcher(formattedQuery);
         if (!matcher.find())
             throw new IllegalArgumentException("Expected valid create index query but found: " + formattedQuery);
 
+        String parsedKeyspace = matcher.group(5);
+        if (!Strings.isNullOrEmpty(parsedKeyspace))
+            keyspace = parsedKeyspace;
+
         String index = matcher.group(2);
-        if (!Strings.isNullOrEmpty(index))
-            return index;
-
-        String keyspace = matcher.group(5);
-        if (Strings.isNullOrEmpty(keyspace))
-            throw new IllegalArgumentException("Keyspace name should be specified: " + formattedQuery);
-
-        String table = matcher.group(7);
-        if (Strings.isNullOrEmpty(table))
-            throw new IllegalArgumentException("Table name should be specified: " + formattedQuery);
-
-        String column = matcher.group(9);
-
-        String baseName = Strings.isNullOrEmpty(column)
-                        ? IndexMetadata.generateDefaultIndexName(table)
-                        : IndexMetadata.generateDefaultIndexName(table, new ColumnIdentifier(column, true));
-
-        KeyspaceMetadata ks = Schema.instance.getKeyspaceMetadata(keyspace);
-        return ks.findAvailableIndexName(baseName);
-    }
-
-    /**
-     * Index creation is asynchronous, this method searches in the system table IndexInfo
-     * for the specified index and returns true if it finds it, which indicates the
-     * index was built. If we haven't found it after 5 seconds we give-up.
-     */
-    protected boolean waitForIndex(String keyspace, String table, String index) throws Throwable
-    {
-        long start = System.currentTimeMillis();
-        boolean indexCreated = false;
-        while (!indexCreated)
+        if (Strings.isNullOrEmpty(index))
         {
-            Object[][] results = getRows(execute("select index_name from system.\"IndexInfo\" where table_name = ?", keyspace));
-            for(int i = 0; i < results.length; i++)
-            {
-                if (index.equals(results[i][0]))
-                {
-                    indexCreated = true;
-                    break;
-                }
-            }
+            String table = matcher.group(7);
+            if (Strings.isNullOrEmpty(table))
+                throw new IllegalArgumentException("Table name should be specified: " + formattedQuery);
 
-            if (System.currentTimeMillis() - start > 5000)
-                break;
+            String column = matcher.group(9);
 
-            Thread.sleep(10);
+            String baseName = Strings.isNullOrEmpty(column)
+                              ? IndexMetadata.generateDefaultIndexName(table)
+                              : IndexMetadata.generateDefaultIndexName(table, new ColumnIdentifier(column, true));
+
+            KeyspaceMetadata ks = Schema.instance.getKeyspaceMetadata(keyspace);
+            assertNotNull(ks);
+            index = ks.findAvailableIndexName(baseName);
         }
 
-        return indexCreated;
+        index = ParseUtils.isQuoted(index, '\"')
+                ? ParseUtils.unDoubleQuote(index)
+                : index.toLowerCase();
+
+        return Pair.create(keyspace, index);
+    }
+
+    public void waitForTableIndexesQueryable()
+    {
+        waitForTableIndexesQueryable(60);
+    }
+
+    public void waitForTableIndexesQueryable(int seconds)
+    {
+        waitForTableIndexesQueryable(currentTable(), seconds);
+    }
+
+    public void waitForTableIndexesQueryable(String table, int seconds)
+    {
+        waitForTableIndexesQueryable(KEYSPACE, table, seconds);
+    }
+
+    public void waitForTableIndexesQueryable(String keyspace, String table)
+    {
+        waitForTableIndexesQueryable(keyspace, table, 60);
     }
 
     /**
-     * Index creation is asynchronous, this method waits until the specified index hasn't any building task running.
-     * <p>
-     * This method differs from {@link #waitForIndex(String, String, String)} in that it doesn't require the index to be
-     * fully nor successfully built, so it can be used to wait for failing index builds.
+     * Index creation is asynchronous. This method waits until all the indexes in the specified table are queryable.
+     *
+     * @param keyspace the table keyspace name
+     * @param table the table name
+     * @param seconds the maximum time to wait for the indexes to be queryable
+     */
+    public void waitForTableIndexesQueryable(String keyspace, String table, int seconds)
+    {
+        waitForAssert(() -> Assertions.assertThat(getNotQueryableIndexes(keyspace, table)).isEmpty(), seconds, TimeUnit.SECONDS);
+    }
+
+    public void waitForIndexQueryable(String index)
+    {
+        waitForIndexQueryable(KEYSPACE, index);
+    }
+
+    /**
+     * Index creation is asynchronous. This method waits until the specified index is queryable.
      *
      * @param keyspace the index keyspace name
-     * @param indexName the index name
-     * @return {@code true} if the index build tasks have finished in 5 seconds, {@code false} otherwise
+     * @param index the index name
      */
-    protected boolean waitForIndexBuilds(String keyspace, String indexName) throws InterruptedException
+    public void waitForIndexQueryable(String keyspace, String index)
     {
-        long start = System.currentTimeMillis();
-        SecondaryIndexManager indexManager = getCurrentColumnFamilyStore(keyspace).indexManager;
+        waitForAssert(() -> assertTrue(isIndexQueryable(keyspace, index)), 60, TimeUnit.SECONDS);
+    }
 
-        while (true)
+    protected void waitForIndexBuilds(String index)
+    {
+        waitForIndexBuilds(KEYSPACE, index);
+    }
+
+    /**
+     * Index creation is asynchronous. This method waits until the specified index hasn't any building task running.
+     * <p>
+     * This method differs from {@link #waitForIndexQueryable(String, String)} in that it doesn't require the
+     * index to be fully nor successfully built, so it can be used to wait for failing index builds.
+     *
+     * @param keyspace the index keyspace name
+     * @param index the index name
+     */
+    protected void waitForIndexBuilds(String keyspace, String index)
+    {
+        waitForAssert(() -> assertFalse(isIndexBuilding(keyspace, index)), 60, TimeUnit.SECONDS);
+    }
+
+    /**
+     * @return the names of the indexes in the current table that are not queryable
+     */
+    protected Set<String> getNotQueryableIndexes()
+    {
+        return getNotQueryableIndexes(KEYSPACE, currentTable());
+    }
+
+    /**
+     * @param keyspace the table keyspace name
+     * @param table the table name
+     * @return the names of the indexes in the specified table that are not queryable
+     */
+    protected Set<String> getNotQueryableIndexes(String keyspace, String table)
+    {
+        SecondaryIndexManager sim = Keyspace.open(keyspace).getColumnFamilyStore(table).indexManager;
+        return sim.listIndexes()
+                  .stream()
+                  .filter(index -> !sim.isIndexQueryable(index))
+                  .map(index -> index.getIndexMetadata().name)
+                  .collect(Collectors.toSet());
+    }
+
+    protected boolean isIndexBuilding(String keyspace, String indexName)
+    {
+        SecondaryIndexManager manager = getIndexManager(keyspace, indexName);
+        assertNotNull(manager);
+
+        return manager.isIndexBuilding(indexName);
+    }
+
+    protected boolean isIndexQueryable(String keyspace, String indexName)
+    {
+        SecondaryIndexManager manager = getIndexManager(keyspace, indexName);
+        assertNotNull(manager);
+
+        Index index = manager.getIndexByName(indexName);
+        return manager.isIndexQueryable(index);
+    }
+
+    protected boolean areAllTableIndexesQueryable()
+    {
+        return areAllTableIndexesQueryable(KEYSPACE, currentTable());
+    }
+
+    protected boolean areAllTableIndexesQueryable(String keyspace, String table)
+    {
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        for (Index index : cfs.indexManager.listIndexes())
         {
-            if (!indexManager.isIndexBuilding(indexName))
-            {
-                return true;
-            }
-            else if (System.currentTimeMillis() - start > 5000)
-            {
+            if (!cfs.indexManager.isIndexQueryable(index))
                 return false;
-            }
-            else
-            {
-                Thread.sleep(10);
-            }
         }
+        return true;
+    }
+
+    protected boolean indexNeedsFullRebuild(String index)
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
+        return cfs.indexManager.needsFullRebuild(index);
+    }
+
+    protected void verifyInitialIndexFailed(String indexName)
+    {
+        // Verify that the initial index build fails...
+        waitForAssert(() -> assertTrue(indexNeedsFullRebuild(indexName)));
+    }
+
+    @Nullable
+    protected SecondaryIndexManager getIndexManager(String keyspace, String indexName)
+    {
+        for (ColumnFamilyStore cfs : Keyspace.open(keyspace).getColumnFamilyStores())
+        {
+            Index index = cfs.indexManager.getIndexByName(indexName);
+            if (index != null)
+                return cfs.indexManager;
+        }
+        return null;
+    }
+
+    protected void waitForAssert(Runnable runnableAssert, long timeout, TimeUnit unit)
+    {
+        Awaitility.await().dontCatchUncaughtExceptions().atMost(timeout, unit).untilAsserted(runnableAssert::run);
+    }
+
+    protected void waitForAssert(Runnable assertion)
+    {
+        waitForAssert(assertion, ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     protected void createIndexMayThrow(String query) throws Throwable

--- a/test/unit/org/apache/cassandra/cql3/KeyCacheCqlTest.java
+++ b/test/unit/org/apache/cassandra/cql3/KeyCacheCqlTest.java
@@ -128,7 +128,7 @@ public class KeyCacheCqlTest extends CQLTester
     @Override
     public String createIndex(String query)
     {
-        return createFormattedIndex(formatQuery(KEYSPACE_PER_TEST, query));
+        return createIndex(KEYSPACE_PER_TEST, query);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/InsertUpdateIfConditionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/InsertUpdateIfConditionTest.java
@@ -448,7 +448,7 @@ public class InsertUpdateIfConditionTest extends CQLTester
      * Migrated from cql_tests.py:TestCQL.conditional_ddl_index_test()
      */
     @Test
-    public void testDropCreateIndexIfNotExists() throws Throwable
+    public void testDropCreateIndexIfNotExists()
     {
         String tableName = createTable("CREATE TABLE %s (id text PRIMARY KEY, value1 blob, value2 blob)with comment = 'foo'");
 
@@ -457,8 +457,6 @@ public class InsertUpdateIfConditionTest extends CQLTester
 
         // create and confirm
         createIndex("CREATE INDEX IF NOT EXISTS myindex ON %s (value1)");
-
-        assertTrue(waitForIndex(KEYSPACE, tableName, "myindex"));
 
         // unsuccessful create since it's already there
         execute("CREATE INDEX IF NOT EXISTS myindex ON %s (value1)");

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -82,24 +82,22 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void creatingIndexMarksTheIndexAsBuilt() throws Throwable
+    public void creatingIndexMarksTheIndexAsBuilt()
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
     }
 
     @Test
-    public void testIndexStatusPropagation() throws Throwable
+    public void testIndexStatusPropagation()
     {
         assertFalse(Gossiper.instance.isEnabled());
 
         // create index with Gossiper not enabled: no index status propagation threads
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String indexName1 = createIndex("CREATE INDEX ON %s(b)");
-        waitForIndex(KEYSPACE, tableName, indexName1);
+        createIndex("CREATE INDEX ON %s(b)");
 
         assertTrue(Thread.getAllStackTraces().keySet()
                          .stream()
@@ -110,8 +108,7 @@ public class SecondaryIndexManagerTest extends CQLTester
         try
         {
             // create index again with Gossiper started to submit index status propagation task
-            String indexName2 = createIndex("CREATE INDEX ON %s(c)");
-            waitForIndex(KEYSPACE, tableName, indexName2);
+            createIndex("CREATE INDEX ON %s(c)");
 
             Thread statusPropagationThread = Thread.getAllStackTraces().keySet()
                                                    .stream()
@@ -128,10 +125,9 @@ public class SecondaryIndexManagerTest extends CQLTester
     @Test
     public void rebuilOrRecoveringIndexMarksTheIndexAsBuilt() throws Throwable
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
         
         assertTrue(tryRebuild(indexName, false));
@@ -139,12 +135,11 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void recreatingIndexMarksTheIndexAsBuilt() throws Throwable
+    public void recreatingIndexMarksTheIndexAsBuilt()
     {
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         // drop the index and verify that it has been removed from the built indexes table
@@ -153,17 +148,15 @@ public class SecondaryIndexManagerTest extends CQLTester
 
         // create the index again and verify that it's added to the built indexes table
         createIndex(String.format("CREATE INDEX %s ON %%s(c)", indexName));
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
     }
 
     @Test
-    public void addingSSTablesMarksTheIndexAsBuilt() throws Throwable
+    public void addingSSTablesMarksTheIndexAsBuilt()
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -178,12 +171,11 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void testIndexRebuildWhenAddingSStableViaRemoteReload() throws Throwable
+    public void testIndexRebuildWhenAddingSStableViaRemoteReload()
     {
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         execute("Insert into %s(a,b,c) VALUES(1,1,1)");
@@ -207,19 +199,17 @@ public class SecondaryIndexManagerTest extends CQLTester
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);
-        waitForIndex(KEYSPACE, tableName, indexName); // this is needed because index build on remote reload is async
+        waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
         assertRows(execute("SELECT * FROM %s WHERE c=1"), row(1, 1, 1));
     }
 
-
     @Test
-    public void remoteReloadOnSSTableAddMarksTheIndexAsBuilt() throws Throwable
+    public void remoteReloadOnSSTableAddMarksTheIndexAsBuilt()
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -229,18 +219,17 @@ public class SecondaryIndexManagerTest extends CQLTester
         try (Refs<SSTableReader> sstables = Refs.ref(cfs.getSSTables(SSTableSet.CANONICAL)))
         {
             cfs.indexManager.handleNotification(new SSTableAddedNotification(sstables, null, OperationType.REMOTE_RELOAD, Optional.empty()), cfs.getTracker());
-            waitForIndex(KEYSPACE, tableName, indexName); // this is needed because index build on remote reload is async
+            waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
             assertMarkedAsBuilt(indexName);
         }
     }
 
     @Test
-    public void flushedSSTableDoesntBuildIndex() throws Throwable
+    public void flushedSSTableDoesntBuildIndex()
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         // Mark index removed to later chack the sstable added notification for a flushed sstable
@@ -252,18 +241,17 @@ public class SecondaryIndexManagerTest extends CQLTester
         try (Refs<SSTableReader> sstables = Refs.ref(cfs.getSSTables(SSTableSet.CANONICAL)))
         {
             cfs.indexManager.handleNotification(new SSTableAddedNotification(sstables, Mockito.mock(Memtable.class), OperationType.FLUSH, Optional.empty()), cfs.getTracker());
-            assertEquals(false, waitForIndex(KEYSPACE, tableName, indexName)); // this is needed because index build on remote reload is async
+            waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
             assertNotMarkedAsBuilt(indexName);
         }
     }
 
     @Test
-    public void remoteReloadOnSSTableListChangeMarksTheIndexAsBuilt() throws Throwable
+    public void remoteReloadOnSSTableListChangeMarksTheIndexAsBuilt()
     {
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex("CREATE INDEX ON %s(c)");
 
-        waitForIndex(KEYSPACE, tableName, indexName);
         assertMarkedAsBuilt(indexName);
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -273,7 +261,7 @@ public class SecondaryIndexManagerTest extends CQLTester
         try (Refs<SSTableReader> sstables = Refs.ref(cfs.getSSTables(SSTableSet.CANONICAL)))
         {
             cfs.indexManager.handleNotification(new SSTableListChangedNotification(sstables, null, OperationType.REMOTE_RELOAD, Optional.empty()), cfs.getTracker());
-            waitForIndex(KEYSPACE, tableName, indexName); // this is needed because index build on remote reload is async
+            waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
             assertMarkedAsBuilt(indexName);
         }
     }
@@ -284,9 +272,9 @@ public class SecondaryIndexManagerTest extends CQLTester
         // create an index which blocks on creation
         TestingIndex.blockCreate();
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
-        String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
+        String defaultIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
+        String readOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
+        String writeOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
 
         // try to rebuild/recover the index before the index creation task has finished
         assertFalse(tryRebuild(defaultIndexName, false));
@@ -298,9 +286,9 @@ public class SecondaryIndexManagerTest extends CQLTester
 
         // check that the index is marked as built when the creation finishes
         TestingIndex.unblockCreate();
-        waitForIndex(KEYSPACE, tableName, defaultIndexName);
-        waitForIndex(KEYSPACE, tableName, readOnlyIndexName);
-        waitForIndex(KEYSPACE, tableName, writeOnlyIndexName);
+        waitForIndexQueryable(defaultIndexName);
+        waitForIndexQueryable(readOnlyIndexName);
+        waitForIndexQueryable(writeOnlyIndexName);
         assertMarkedAsBuilt(defaultIndexName);
         assertMarkedAsBuilt(readOnlyIndexName);
         assertMarkedAsBuilt(writeOnlyIndexName);
@@ -317,16 +305,13 @@ public class SecondaryIndexManagerTest extends CQLTester
     @Test
     public void cannotRebuildOrRecoverWhileAnotherRebuildIsInProgress() throws Throwable
     {
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
         String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
         String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
         final AtomicBoolean error = new AtomicBoolean();
 
-        // wait for index initialization and verify it's built:
-        waitForIndex(KEYSPACE, tableName, defaultIndexName);
-        waitForIndex(KEYSPACE, tableName, readOnlyIndexName);
-        waitForIndex(KEYSPACE, tableName, writeOnlyIndexName);
+        // verify it's built after initialization:
         assertMarkedAsBuilt(defaultIndexName);
         assertMarkedAsBuilt(readOnlyIndexName);
         assertMarkedAsBuilt(writeOnlyIndexName);
@@ -374,12 +359,11 @@ public class SecondaryIndexManagerTest extends CQLTester
     @Test
     public void cannotRebuildWhileAnSSTableBuildIsInProgress() throws Throwable
     {
-        final String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         final String indexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
         final AtomicBoolean error = new AtomicBoolean();
 
-        // wait for index initialization and verify it's built:
-        waitForIndex(KEYSPACE, tableName, indexName);
+        // verify it's built after initialization:
         assertMarkedAsBuilt(indexName);
 
         // add sstables in another thread, but make it block:
@@ -420,12 +404,11 @@ public class SecondaryIndexManagerTest extends CQLTester
     @Test
     public void addingSSTableWhileRebuildIsInProgress() throws Throwable
     {
-        final String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         final String indexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
         final AtomicBoolean error = new AtomicBoolean();
 
-        // wait for index initialization and verify it's built:
-        waitForIndex(KEYSPACE, tableName, indexName);
+        // verify it's built after initialization:
         assertMarkedAsBuilt(indexName);
 
         // rebuild the index in another thread, but make it block:
@@ -468,12 +451,11 @@ public class SecondaryIndexManagerTest extends CQLTester
     @Test
     public void addingSSTableWithBuildFailureWhileRebuildIsInProgress() throws Throwable
     {
-        final String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         final String indexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
         final AtomicBoolean error = new AtomicBoolean();
 
-        // wait for index initialization and verify it's built:
-        waitForIndex(KEYSPACE, tableName, indexName);
+        // verify it's built:
         assertMarkedAsBuilt(indexName);
 
         // rebuild the index in another thread, but make it block:
@@ -522,11 +504,10 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void rebuildWithFailure() throws Throwable
+    public void rebuildWithFailure()
     {
-        final String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         final String indexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        waitForIndex(KEYSPACE, tableName, indexName);
 
         // Rebuild the index with failure and verify it is not marked as built
         TestingIndex.shouldFailBuild = true;
@@ -544,13 +525,13 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void initializingIndexNotQueryableButMaybeWritable() throws Throwable
+    public void initializingIndexNotQueryableButMaybeWritable()
     {
         TestingIndex.blockCreate();
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
-        String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        String defaultIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
+        String readOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
+        String writeOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
 
         // the index shouldn't be queryable while the initialization hasn't finished
         assertFalse(isQueryable(defaultIndexName));
@@ -562,9 +543,9 @@ public class SecondaryIndexManagerTest extends CQLTester
 
         // the index should be queryable once the initialization has finished
         TestingIndex.unblockCreate();
-        waitForIndex(KEYSPACE, tableName, defaultIndexName);
-        waitForIndex(KEYSPACE, tableName, readOnlyIndexName);
-        waitForIndex(KEYSPACE, tableName, writeOnlyIndexName);
+        waitForIndexQueryable(defaultIndexName);
+        waitForIndexQueryable(readOnlyIndexName);
+        waitForIndexQueryable(writeOnlyIndexName);
         assertTrue(isQueryable(defaultIndexName));
         assertTrue(isQueryable(readOnlyIndexName));
         assertTrue(isQueryable(writeOnlyIndexName));
@@ -574,13 +555,13 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void initializingIndexNotQueryableButMaybeNotWritableAfterPartialRebuild() throws Throwable
+    public void initializingIndexNotQueryableButMaybeNotWritableAfterPartialRebuild()
     {
         TestingIndex.blockCreate();
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
-        String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
+        String defaultIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
+        String readOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
+        String writeOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
 
         // the index should never be queryable while the initialization hasn't finished
         assertFalse(isQueryable(defaultIndexName));
@@ -624,7 +605,7 @@ public class SecondaryIndexManagerTest extends CQLTester
 
         // the index should be queryable once the initialization has finished
         TestingIndex.unblockCreate();
-        waitForIndex(KEYSPACE, tableName, defaultIndexName);
+        waitForIndexQueryable(defaultIndexName);
         assertTrue(isQueryable(defaultIndexName));
         assertTrue(isQueryable(readOnlyIndexName));
         assertTrue(isQueryable(writeOnlyIndexName));
@@ -638,12 +619,12 @@ public class SecondaryIndexManagerTest extends CQLTester
     {
         TestingIndex.shouldFailCreate = true;
         createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
-        String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
-        assertTrue(waitForIndexBuilds(KEYSPACE, defaultIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, readOnlyIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, writeOnlyIndexName));
+        String defaultIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
+        String readOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
+        String writeOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
+        waitForIndexBuilds(defaultIndexName);
+        waitForIndexBuilds(readOnlyIndexName);
+        waitForIndexBuilds(writeOnlyIndexName);
 
         tryRebuild(defaultIndexName, true);
         tryRebuild(readOnlyIndexName, true);
@@ -662,16 +643,16 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void indexWithFailedInitializationDoesNotChangeQueryabilityNorWritabilityAfterPartialRebuild() throws Throwable
+    public void indexWithFailedInitializationDoesNotChangeQueryabilityNorWritabilityAfterPartialRebuild()
     {
         TestingIndex.shouldFailCreate = true;
         createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
-        String defaultIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        String readOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
-        String writeOnlyIndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
-        assertTrue(waitForIndexBuilds(KEYSPACE, defaultIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, readOnlyIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, writeOnlyIndexName));
+        String defaultIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
+        String readOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", ReadOnlyOnFailureIndex.class.getName()));
+        String writeOnlyIndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", WriteOnlyOnFailureIndex.class.getName()));
+        waitForIndexBuilds(defaultIndexName);
+        waitForIndexBuilds(readOnlyIndexName);
+        waitForIndexBuilds(writeOnlyIndexName);
         TestingIndex.shouldFailCreate = false;
 
         // the index should never be queryable, but it could be writable after the failed initialization
@@ -685,9 +666,9 @@ public class SecondaryIndexManagerTest extends CQLTester
         // a successful partial build doesn't set the index as queryable nor writable
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         cfs.indexManager.handleNotification(new SSTableAddedNotification(cfs.getLiveSSTables(), null), this);
-        assertTrue(waitForIndexBuilds(KEYSPACE, defaultIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, readOnlyIndexName));
-        assertTrue(waitForIndexBuilds(KEYSPACE, writeOnlyIndexName));
+        waitForIndexBuilds(defaultIndexName);
+        waitForIndexBuilds(readOnlyIndexName);
+        waitForIndexBuilds(writeOnlyIndexName);
         assertFalse(isQueryable(defaultIndexName));
         assertFalse(isQueryable(readOnlyIndexName));
         assertFalse(isQueryable(writeOnlyIndexName));
@@ -734,7 +715,7 @@ public class SecondaryIndexManagerTest extends CQLTester
     }
 
     @Test
-    public void handleJVMStablityOnFailedRebuild() throws Throwable
+    public void handleJVMStablityOnFailedRebuild()
     {
         handleJVMStablityOnFailedRebuild(new SocketException("Should not fail"), false);
         handleJVMStablityOnFailedRebuild(new FileNotFoundException("Should not fail"), false);
@@ -743,11 +724,10 @@ public class SecondaryIndexManagerTest extends CQLTester
         handleJVMStablityOnFailedRebuild(new RuntimeException("Should not fail"), false);
     }
 
-    private void handleJVMStablityOnFailedRebuild(Throwable throwable, boolean shouldKillJVM) throws Throwable
+    private void handleJVMStablityOnFailedRebuild(Throwable throwable, boolean shouldKillJVM)
     {
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         String indexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", TestingIndex.class.getName()));
-        waitForIndex(KEYSPACE, tableName, indexName);
 
         KillerForTests killerForTests = new KillerForTests();
         JVMKiller originalKiller = JVMStabilityInspector.replaceKiller(killerForTests);

--- a/test/unit/org/apache/cassandra/index/internal/CassandraIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/internal/CassandraIndexTest.java
@@ -50,7 +50,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -440,7 +439,6 @@ public class CassandraIndexTest extends CQLTester
 
         dropIndex("DROP INDEX %s.no_regulars_idx");
         createIndex("CREATE INDEX no_regulars_idx ON %s(c)");
-        assertTrue(waitForIndex(keyspace(), tableName, "no_regulars_idx"));
 
         assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE c = ?", "c0"), row1, row3);
         assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE c = ?", "c1"), row2, row4);
@@ -572,16 +570,15 @@ public class CassandraIndexTest extends CQLTester
                   .untilAsserted(() -> assertRows(execute(selectBuiltIndexesQuery)));
 
         String indexName = "build_remove_test_idx";
-        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         createIndex(String.format("CREATE INDEX %s ON %%s(c)", indexName));
-        waitForIndex(KEYSPACE, tableName, indexName);
 
         // check that there are no other rows in the built indexes table
         assertRows(execute(selectBuiltIndexesQuery), row(KEYSPACE, indexName, null));
 
         // rebuild the index and verify the built status table
         getCurrentColumnFamilyStore().rebuildSecondaryIndex(indexName);
-        waitForIndex(KEYSPACE, tableName, indexName);
+        waitForIndexQueryable(indexName);
 
         // check that there are no other rows in the built indexes table
         assertRows(execute(selectBuiltIndexesQuery), row(KEYSPACE, indexName, null));

--- a/test/unit/org/apache/cassandra/index/sai/MultiVersionComposabilityTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/MultiVersionComposabilityTest.java
@@ -44,7 +44,7 @@ public class MultiVersionComposabilityTest extends SAITester
 
         // Don't want compaction changing versions on us
         disableCompaction();
-        waitForIndexQueryable();
+        waitForTableIndexesQueryable();
 
         // Copy and randomize versions to ensure we can cover different orders of versions.
         var versions = new ArrayList<>(Version.ALL);

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/AnalyzerEqOperatorSupportTest.java
@@ -72,7 +72,6 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
         populateTable();
 
         createIndex("CREATE INDEX ON %s(v)");
-        waitForIndexQueryable();
 
         // equals (=)
         assertRowsWithoutWarning("SELECT k FROM %s WHERE v = 'Quick fox'", row(1));
@@ -354,7 +353,6 @@ public class AnalyzerEqOperatorSupportTest extends SAITester
     private void assertIndexQueries(String indexOptions, Runnable queries)
     {
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = " + indexOptions);
-        waitForIndexQueryable();
         populateTable();
 
         queries.run();

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -31,12 +31,11 @@ import static org.junit.Assert.assertNotNull;
 public class AllowFilteringTest extends SAITester
 {
     @Test
-    public void testAllowFilteringOnFirstClusteringKeyColumn() throws Throwable
+    public void testAllowFilteringOnFirstClusteringKeyColumn()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, c3 int, v1 int, " +
                     "PRIMARY KEY ((k1, k2), c1, c2, c3))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c1) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE c1=0", false);
@@ -76,12 +75,11 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnNotFirstClusteringKeyColumn() throws Throwable
+    public void testAllowFilteringOnNotFirstClusteringKeyColumn()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, c3 int, c4 int, v1 int, " +
                     "PRIMARY KEY ((k1, k2), c1, c2, c3, c4))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c3) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE c3=0", false);
@@ -122,13 +120,12 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnMultipleClusteringKeyColumns() throws Throwable
+    public void testAllowFilteringOnMultipleClusteringKeyColumns()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, c3 int, c4 int, v1 int, " +
                     "PRIMARY KEY ((k1, k2), c1, c2, c3, c4))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c2) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c4) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE c2=0 AND c4=0", false);
@@ -171,11 +168,10 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnSingleRegularColumn() throws Throwable
+    public void testAllowFilteringOnSingleRegularColumn()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, v1 int, v2 int, PRIMARY KEY ((k1, k2), c1, c2))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE v1=0", false);
@@ -214,13 +210,12 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnMultipleRegularColumns() throws Throwable
+    public void testAllowFilteringOnMultipleRegularColumns()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, v1 int, v2 int, v3 int, " +
                     "PRIMARY KEY ((k1, k2), c1, c2))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v2) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE v1=0 AND v2=0", false);
@@ -262,7 +257,7 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnClusteringAndRegularColumns() throws Throwable
+    public void testAllowFilteringOnClusteringAndRegularColumns()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, c3 int, c4 int, v1 int, v2 int, v3 int, " +
                     "PRIMARY KEY ((k1, k2), c1, c2, c3, c4))");
@@ -270,7 +265,6 @@ public class AllowFilteringTest extends SAITester
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c4) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v2) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         // with only index restrictions
         test("SELECT * FROM %s WHERE c2=0 AND c4=0 AND v1=0 AND v2=0", false);
@@ -307,7 +301,7 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testAllowFilteringOnCollectionColumn() throws Throwable
+    public void testAllowFilteringOnCollectionColumn()
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, l list<int>, s set<int>, m_k map<int,int>,"
                     + " m_v map<int,int>, m_en map<int, int>, not_indexed list<int>, PRIMARY KEY ((k1, k2), c1, c2))");
@@ -316,7 +310,6 @@ public class AllowFilteringTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(keys(m_k)) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(values(m_v)) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(m_en)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // single contains
         test("SELECT * FROM %s WHERE l contains 1", false);
@@ -350,7 +343,7 @@ public class AllowFilteringTest extends SAITester
         test("SELECT * FROM %s WHERE m_en[1] = 1 and not_indexed contains 2", true);
     }
 
-    private void test(String query, boolean requiresAllowFiltering) throws Throwable
+    private void test(String query, boolean requiresAllowFiltering)
     {
         if (requiresAllowFiltering)
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);
@@ -361,13 +354,12 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testUnsupportedIndexRestrictions() throws Throwable
+    public void testUnsupportedIndexRestrictions()
     {
         createTable("CREATE TABLE %s (a text, b text, c text, d text, PRIMARY KEY (a, b))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(c) USING '%s'", StorageAttachedIndex.class.getName()));
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(d) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (a, b, c, d) VALUES ('Test1', 'Test1', 'Test1', 'Test1')");
         execute("INSERT INTO %s (a, b, c, d) VALUES ('Test2', 'Test2', 'Test2', 'Test2')");
@@ -416,7 +408,7 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testIndexedColumnDoesNotSupportLikeRestriction() throws Throwable
+    public void testIndexedColumnDoesNotSupportLikeRestriction()
     {
         createTable("CREATE TABLE %s (a text, b text, c text, d text, PRIMARY KEY (a, b))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", StorageAttachedIndex.class.getName()));
@@ -430,7 +422,7 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testIndexedColumnDoesNotSupportAnalyzerRestriction() throws Throwable
+    public void testIndexedColumnDoesNotSupportAnalyzerRestriction()
     {
         createTable("CREATE TABLE %s (a text, b text, c text, d text, PRIMARY KEY (a, b))");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(b) USING '%s'", StorageAttachedIndex.class.getName()));
@@ -445,11 +437,10 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testQueryRequiresFilteringButHasANNRestriction() throws Throwable
+    public void testQueryRequiresFilteringButHasANNRestriction()
     {
         createTable("CREATE TABLE %s (pk text, i int, j int, k int, vec vector<float, 3>, PRIMARY KEY((pk, i), j))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Should not fail because allow filtering is set but not required
         assertRows(execute("SELECT * FROM %s ORDER BY vec ANN OF [1,1,1] LIMIT 10 ALLOW FILTERING;"));
@@ -488,12 +479,11 @@ public class AllowFilteringTest extends SAITester
     }
 
     @Test
-    public void testMapRangeQueries() throws Throwable
+    public void testMapRangeQueries()
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(keys(item_cost)) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(values(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Insert data for later
         execute("INSERT INTO %s (partition, item_cost) VALUES (0, {'apple': 2, 'orange': 1})");
@@ -520,7 +510,6 @@ public class AllowFilteringTest extends SAITester
 
 
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Show that we're now able to execute the query.
         assertRows(execute("SELECT partition FROM %s WHERE item_cost['apple'] < 3 AND item_cost['apple'] > 1"), row(0));

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
@@ -18,19 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
 import org.junit.Test;
-
-import org.apache.cassandra.cql3.UntypedResultSet;
-import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.index.sai.plan.QueryController;
-
-import static org.apache.cassandra.index.sai.cql.VectorTypeTest.assertContainsInt;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class AnalyzerTest extends VectorTester
 {
@@ -40,7 +28,6 @@ public class AnalyzerTest extends VectorTester
         createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, val2 int, PRIMARY KEY((pk1, pk2)))");
         createIndex("CREATE CUSTOM INDEX ON %s(pk1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(pk2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (-1, 'b', 1)");
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (0, 'b', 2)");
@@ -53,7 +40,6 @@ public class AnalyzerTest extends VectorTester
         flush();
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard'};");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (-1, 'd', 1)");
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (0, 'd', 2)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/BooleanTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BooleanTypeTest.java
@@ -27,12 +27,11 @@ import static org.junit.Assert.assertEquals;
 public class BooleanTypeTest extends SAITester
 {
     @Test
-    public void test() throws Throwable
+    public void test()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val boolean)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('0', false)");
         execute("INSERT INTO %s (id, val) VALUES ('1', true)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
@@ -31,12 +31,11 @@ import static org.junit.Assert.assertEquals;
 public class ComplexQueryTest extends SAITester
 {
     @Test
-    public void partialUpdateTest() throws Throwable
+    public void partialUpdateTest()
     {
         createTable("CREATE TABLE %s (pk int, c1 text, c2 text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, c1, c2) VALUES (?, ?, ?)", 1, "a", "a");
         flush();
@@ -50,12 +49,11 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void splitRowsWithBooleanLogic() throws Throwable
+    public void splitRowsWithBooleanLogic()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with 2 partial rows
@@ -74,11 +72,10 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void basicOrTest() throws Throwable
+    public void basicOrTest()
     {
         createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
@@ -90,11 +87,10 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void basicInTest() throws Throwable
+    public void basicInTest()
     {
         createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
@@ -115,7 +111,6 @@ public class ComplexQueryTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 1, 1, 1, 1, 1);
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 2, 2, 1, 1, 1);
@@ -125,8 +120,6 @@ public class ComplexQueryTest extends SAITester
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 6, 6, 3, 2, 2);
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 7, 7, 4, 3, 2);
         execute("INSERT INTO %s (pk, a, b, c, d) VALUES (?, ?, ?, ?, ?)", 8, 8, 4, 3, 3);
-
-
 
         beforeAndAfterFlush(() -> {
             assertRows(execute("SELECT pk FROM %s WHERE (a = 1 AND c = 1) OR (b IN (3, 4) AND d = 2)"), row(1), row(7), row(6));
@@ -139,7 +132,7 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void disjunctionWithClusteringKey() throws Throwable
+    public void disjunctionWithClusteringKey()
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, PRIMARY KEY(pk, ck))");
 
@@ -156,12 +149,11 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void disjunctionWithIndexOnClusteringKey() throws Throwable
+    public void disjunctionWithIndexOnClusteringKey()
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(ck) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, a) VALUES (?, ?, ?)", 1, 1, 1);
         execute("INSERT INTO %s (pk, ck, a) VALUES (?, ?, ?)", 2, 2, 2);
@@ -172,7 +164,7 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void complexQueryWithMultipleClusterings() throws Throwable
+    public void complexQueryWithMultipleClusterings()
     {
         createTable("CREATE TABLE %s (pk int, ck0 int, ck1 int, a int, b int, c int, d int, e int, PRIMARY KEY(pk, ck0, ck1))");
         createIndex("CREATE CUSTOM INDEX ON %s(ck0) USING 'StorageAttachedIndex'");
@@ -182,7 +174,6 @@ public class ComplexQueryTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(e) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 1, 1, 1, 1, 1, 1, 1, 1);
         execute("INSERT INTO %s (pk, ck0, ck1, a, b, c, d, e) VALUES (?, ?, ?, ?, ?, ? ,?, ?)", 2, 2, 2, 2, 2, 2, 2, 2);
@@ -204,7 +195,7 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void complexQueryWithPartitionKeyRestriction() throws Throwable
+    public void complexQueryWithPartitionKeyRestriction()
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY(pk, ck))");
 
@@ -234,12 +225,11 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void complexQueryWithPartitionKeyRestrictionAndIndexes() throws Throwable
+    public void complexQueryWithPartitionKeyRestrictionAndIndexes()
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 1, 1, 5);
         execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 2, 2, 6);
@@ -256,11 +246,10 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void indexNotSupportingDisjunctionTest() throws Throwable
+    public void indexNotSupportingDisjunctionTest()
     {
         createTable("CREATE TABLE %s (pk int, a int, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'org.apache.cassandra.index.sasi.SASIIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 1, 1);
         execute("INSERT INTO %s (pk, a) VALUES (?, ?)", 2, 2);
@@ -273,12 +262,11 @@ public class ComplexQueryTest extends SAITester
     }
 
     @Test
-    public void complexQueryWithMultipleNEQ() throws Throwable
+    public void complexQueryWithMultipleNEQ()
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 1, 1, 5);
         execute("INSERT INTO %s (pk, ck, a, b) VALUES (?, ?, ?, ?)", 1, 2, 2, 6);

--- a/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
@@ -32,19 +32,18 @@ public class CompositePartitionKeyIndexTest extends SAITester
         createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, PRIMARY KEY((pk1, pk2)))");
         createIndex("CREATE CUSTOM INDEX ON %s(pk1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(pk2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         disableCompaction();
     }
 
-    private void insertData1() throws Throwable
+    private void insertData1()
     {
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (1, '1', 1)");
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (2, '2', 2)");
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (3, '3', 3)");
     }
 
-    private void insertData2() throws Throwable
+    private void insertData2()
     {
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (4, '4', 4)");
         execute("INSERT INTO %s (pk1, pk2, val) VALUES (5, '5', 5)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DataModel.java
@@ -239,7 +239,7 @@ public interface DataModel
                     executeLocalIndexed(tester, String.format(template, column.left, indexedTable, column.left));
                 }
             }
-            tester.waitForIndexQueryable(KEYSPACE, indexedTable);
+            tester.waitForTableIndexesQueryable(KEYSPACE, indexedTable);
         }
 
         public void flush(Executor tester) throws Throwable
@@ -456,7 +456,7 @@ public interface DataModel
                 if (!skipColumns.contains(column.left))
                 {
                     executeLocalIndexed(tester, String.format(template, column.left, indexedTable, column.left));
-                    tester.waitForIndexQueryable(KEYSPACE, indexedTable);
+                    tester.waitForTableIndexesQueryable(KEYSPACE, indexedTable);
                 }
             }
         }
@@ -610,7 +610,7 @@ public interface DataModel
 
         void disableCompaction(String keyspace, String table);
 
-        void waitForIndexQueryable(String keyspace, String table);
+        void waitForTableIndexesQueryable(String keyspace, String table);
 
         void executeLocal(String query, Object...values) throws Throwable;
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/DecimalLargeValueTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DecimalLargeValueTest.java
@@ -37,14 +37,12 @@ public class DecimalLargeValueTest extends SAITester
 
         createIndex("CREATE CUSTOM INDEX ON %s(dec) USING 'StorageAttachedIndex'");
 
-        waitForIndexQueryable();
-
         disableCompaction();
     }
 
     /**
      * This test tries to induce rounding errors involving decimal values with wide significands.
-     *
+     * </p>
      * Two values are indexed:
      * <ul>
      * <li>1.0</li>
@@ -52,7 +50,7 @@ public class DecimalLargeValueTest extends SAITester
      * </ul>
      */
     @Test
-    public void runQueriesWithDecimalValueCollision() throws Throwable
+    public void runQueriesWithDecimalValueCollision()
     {
         final int significandSizeInDecimalDigits = 512;
         // String.repeat(int) exists in JDK 11 and later, but this line was introduced on JDK 8
@@ -112,7 +110,7 @@ public class DecimalLargeValueTest extends SAITester
      * This is a control method with small (two-significant-digit) values.
      */
     @Test
-    public void runQueriesWithoutCollisions() throws Throwable
+    public void runQueriesWithoutCollisions()
     {
         execute("INSERT INTO %s (pk, ck, dec) VALUES (-2, 1, 2.2)");
         execute("INSERT INTO %s (pk, ck, dec) VALUES (-2, 2, 2.2)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/DuplicateRowIDTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DuplicateRowIDTest.java
@@ -36,11 +36,10 @@ public class DuplicateRowIDTest extends SAITester
     }
 
     @Test
-    public void shouldTolerateDuplicatedRowIDsAfterMemtableUpdates() throws Throwable
+    public void shouldTolerateDuplicatedRowIDsAfterMemtableUpdates()
     {
         createTable("CREATE TABLE %s (id1 TEXT PRIMARY KEY, v1 INT)");
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable();
 
         // fill 2 bkd leaves
         for (int i = 0; i < 2048; ++i)

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyMemtableFlushTest.java
@@ -40,7 +40,6 @@ public class EmptyMemtableFlushTest extends SAITester
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val1 int, val2 int)");
         IndexContext val1IndexContext = createIndexContext(createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'"), Int32Type.instance);
         IndexContext val2IndexContext = createIndexContext(createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'"), Int32Type.instance);
-        waitForIndexQueryable();
         execute("INSERT INTO %s (id, val1, val2) VALUES (0, 0, 0)");
         execute("INSERT INTO %s (id, val2) VALUES (1, 1)");
         execute("DELETE FROM %s WHERE id = 0");

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
@@ -31,7 +31,6 @@ public class EmptyStringLifecycleTest extends SAITester
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
         disableCompaction(KEYSPACE);
         createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (k, v) VALUES (0, '')");
         execute("INSERT INTO %s (k) VALUES (1)");
@@ -53,7 +52,6 @@ public class EmptyStringLifecycleTest extends SAITester
         execute("INSERT INTO %s (k, v) VALUES (0, '')");
         execute("INSERT INTO %s (k) VALUES (1)");
         createIndex(String.format(CREATE_INDEX_TEMPLATE, 'v'));
-        waitForIndexQueryable();
 
         UntypedResultSet rows = execute("SELECT * FROM %s WHERE v = ''");
         assertRows(rows, row(0, ""));

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByInvalidQueryTest.java
@@ -50,7 +50,7 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void cannotOrderVarintColumn() throws Throwable
+    public void cannotOrderVarintColumn()
     {
         createTable("CREATE TABLE %s (pk int primary key, val varint)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
@@ -58,14 +58,14 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void cannotOrderDecimalColumn() throws Throwable
+    public void cannotOrderDecimalColumn()
     {
         createTable("CREATE TABLE %s (pk int primary key, val decimal)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         executeOrderByAndAssertInvalidRequestException("decimal");
     }
 
-    private void executeOrderByAndAssertInvalidRequestException(String cqlType) throws Throwable
+    private void executeOrderByAndAssertInvalidRequestException(String cqlType)
     {
         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ASC LIMIT 1"))
         .isInstanceOf(InvalidRequestException.class)
@@ -73,7 +73,7 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void cannotOrderTextColumnWithoutIndex() throws Throwable
+    public void cannotOrderTextColumnWithoutIndex()
     {
         createTable("CREATE TABLE %s (pk int, val text, PRIMARY KEY(pk))");
 
@@ -84,25 +84,21 @@ public class GenericOrderByInvalidQueryTest extends SAITester
                              "SELECT * FROM %s ORDER BY val LIMIT 5 ALLOW FILTERING");
     }
 
-
-
     @Test
-    public void testTextOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
+    public void testTextOrderingIsNotAllowedWithClusteringOrdering()
     {
         createTable("CREATE TABLE %s (pk int, ck int, val text, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("Cannot combine clustering column ordering with non-clustering column ordering",
                              "SELECT * FROM %s ORDER BY val, ck ASC LIMIT 2");
     }
 
     @Test
-    public void textOrderingMustHaveLimit() throws Throwable
+    public void textOrderingMustHaveLimit()
     {
         createTable("CREATE TABLE %s (pk int primary key, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("SAI based ORDER BY clause requires a LIMIT that is not greater than 1000. LIMIT was NO LIMIT",
                              "SELECT * FROM %s ORDER BY val");
@@ -110,7 +106,7 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void testInvalidColumnName() throws Throwable
+    public void testInvalidColumnName()
     {
         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + "." + table),
@@ -118,11 +114,10 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void disallowClusteringColumnPredicateWithoutSupportingIndex() throws Throwable
+    public void disallowClusteringColumnPredicateWithoutSupportingIndex()
     {
         createTable("CREATE TABLE %s (pk int, num int, v text, PRIMARY KEY(pk, num))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, num, v) VALUES (3, 1, 'a')");
         execute("INSERT INTO %s (pk, num, v) VALUES (3, 4, 'b')");
         flush();
@@ -139,7 +134,6 @@ public class GenericOrderByInvalidQueryTest extends SAITester
 
         // Cover the alternative code path
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         assertRows(execute("SELECT num FROM %s WHERE pk=3 AND num > 3 ORDER BY v LIMIT 1"), row(4));
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
@@ -37,7 +37,6 @@ public class GenericOrderByTest extends SAITester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val int, str_val ascii)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction();
 
         var expectedResults = new TreeMap<String, Integer>();
@@ -83,7 +82,6 @@ public class GenericOrderByTest extends SAITester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val int, str_val ascii)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction();
 
         // 'A' will be first
@@ -113,7 +111,6 @@ public class GenericOrderByTest extends SAITester
         createTable("CREATE TABLE %s (pk int primary key, x int, val int, str_val ascii)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Insert many rows and then ensure we can get each of them when querying with specific bounds.
         for (int i = 0; i < 100; i++)
@@ -137,7 +134,6 @@ public class GenericOrderByTest extends SAITester
         createTable("CREATE TABLE %s (pk int, x int, val int, str_val ascii, PRIMARY KEY (pk, x))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We use a primary key with the same partition column value to ensure it goes to the same shard in the
         // memtable, which reproduces a bug we hit.
@@ -163,7 +159,6 @@ public class GenericOrderByTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int, x int, v int, PRIMARY KEY (pk, x))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, x, v) VALUES (?, ?, ?)", 1, 1, 1);
         execute("INSERT INTO %s (pk, x, v) VALUES (?, ?, ?)", 1, 2, 5);
@@ -195,8 +190,6 @@ public class GenericOrderByTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int, x int, v int, PRIMARY KEY (pk, x))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
-
 
         Object[][] rows = new Object[100][];
         var lowerBound = asc ? 0 : 4900;

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByUpdateDeleteTest.java
@@ -83,7 +83,6 @@ public class GenericOrderByUpdateDeleteTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val) VALUES (0, 'a')");
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 'z')");
@@ -107,7 +106,6 @@ public class GenericOrderByUpdateDeleteTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val int)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val) VALUES (0, -10)");
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 0)");
@@ -142,7 +140,6 @@ public class GenericOrderByUpdateDeleteTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction();
 
         execute("INSERT INTO %s (pk, str_val) VALUES (0, 'a')");
@@ -172,7 +169,6 @@ public class GenericOrderByUpdateDeleteTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val int)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val) VALUES (0, 1)");
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 2)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceAccuracyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceAccuracyTest.java
@@ -49,7 +49,6 @@ public class GeoDistanceAccuracyTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
         int numVectors = 20000;
         var vectors = IntStream.range(0, numVectors).mapToObj(s -> Pair.create(s, createRandomNYCVector())).collect(Collectors.toList());
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceInvalidQueryTest.java
@@ -29,11 +29,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class GeoDistanceInvalidQueryTest extends VectorTester
 {
     @Test
-    public void geoDistanceRequiresSearchVectorSizeTwo() throws Throwable
+    public void geoDistanceRequiresSearchVectorSizeTwo()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE GEO_DISTANCE(v, [5]) < 1000"))
         .isInstanceOf(InvalidRequestException.class)
@@ -44,11 +43,10 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     }
 
     @Test
-    public void geoDistanceRequiresVectorIndexSizeTwo() throws Throwable
+    public void geoDistanceRequiresVectorIndexSizeTwo()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // Even though the search vector size is 2, the index vector size is not 2, so the query is not valid.
         assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE GEO_DISTANCE(v, [1, 1]) < 1000"))
@@ -63,11 +61,10 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     }
 
     @Test
-    public void geoDistanceRequiresPositiveSearchRadius() throws Throwable
+    public void geoDistanceRequiresPositiveSearchRadius()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE GEO_DISTANCE(v, [1, 1]) < 0"))
         .isInstanceOf(InvalidRequestException.class)
@@ -87,11 +84,10 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     }
 
     @Test
-    public void geoDistanceRequiresValidLatLonPositions() throws Throwable
+    public void geoDistanceRequiresValidLatLonPositions()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE GEO_DISTANCE(v, [-90.1, 1]) < 100"))
         .isInstanceOf(InvalidRequestException.class)
@@ -111,7 +107,7 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     }
 
     @Test
-    public void geoDistanceMissingOrIncorrectlyConfiguredIndex() throws Throwable
+    public void geoDistanceMissingOrIncorrectlyConfiguredIndex()
     {
         createTable("CREATE TABLE %s (pk int, x int, v vector<float, 2>, PRIMARY KEY(pk))");
 
@@ -122,7 +118,6 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
 
         // Intentionally create index with incorrect similarity function
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Query with incorrectly configured index
         assertThatThrownBy(() -> execute( "SELECT pk FROM %s WHERE GEO_DISTANCE(v, [1, 1]) < 1000"))
@@ -131,11 +126,10 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     }
 
     @Test
-    public void geoDistanceUsageInIfClause() throws Throwable
+    public void geoDistanceUsageInIfClause()
     {
         createTable("CREATE TABLE %s (pk int, x int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // GEO_DISTANCE is not parsable at this part of the CQL
         assertThatThrownBy(() -> execute("UPDATE %s SET x = 100 WHERE pk = 1 IF GEO_DISTANCE(v, [1, 1]) < 1000"))
@@ -147,7 +141,6 @@ public class GeoDistanceInvalidQueryTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, x int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // All of these queries fail with and without filtering
         assertThatThrownBy(() -> execute("select pk from %s WHERE pk > 4 AND geo_distance(v,[5,5]) <= 1000000 ORDER BY v ANN of [5,5] limit 3"))

--- a/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceRestrictionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GeoDistanceRestrictionTest.java
@@ -27,7 +27,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // Distances computed using GeoDistanceAccuracyTest#strictHaversineDistance
         execute("INSERT INTO %s (pk, v) VALUES (0, [1, 2])"); // distance is 555661 m from [5,5]
@@ -52,7 +51,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // Points chosen to be close to the boundary of the search radius. The assertion failed based on earlier
         // versions of the math used to determine whether the square distance was sufficient to short circuit
@@ -79,7 +77,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, v) VALUES (0, [0.10999, 0])"); // distance is 12230.3 m from [0,0]
         execute("INSERT INTO %s (pk, v) VALUES (1, [0.11000, 0])"); // distance is 12231.4 m from [0,0]
@@ -95,7 +92,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, v) VALUES (0, [0.00009, 0])"); // distance is 10.007 m from [0,0]
         execute("INSERT INTO %s (pk, v) VALUES (1, [0.00010, 0])"); // distance is 11.120 m from [0,0]
@@ -112,7 +108,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, num, v) VALUES (0, 0, [1, 2])"); // distance is 555661 m from [5,5]
         execute("INSERT INTO %s (pk, num, v) VALUES (1, 1, [4, 4])"); // distance is 157010 m from [5,5]
@@ -134,7 +129,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, point vector<float, 2>, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(point) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, point, v) VALUES (0, [1, 2], [1, 2, 1])"); // distance is 555661 m from [5,5]
         execute("INSERT INTO %s (pk, point, v) VALUES (1, [4, 4], [4, 4, 1])"); // distance is 157010 m from [5,5]
@@ -154,7 +148,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, num, v) VALUES (0, 0, [1, 2])"); // distance is 555661 m from [5,5]
         execute("INSERT INTO %s (pk, num, v) VALUES (1, 1, [4, 4])"); // distance is 157010 m from [5,5]
@@ -178,7 +171,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, v) VALUES (0, [1, 2])"); // distance is 555661 m from [5,5]
         execute("INSERT INTO %s (pk, v) VALUES (1, [4, 4])"); // distance is 157010 m from [5,5]
@@ -198,7 +190,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (city text primary key, coordinates vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(coordinates) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
-        waitForIndexQueryable();
 
         // coordinates are [latitude, longitude]
         execute("INSERT INTO %s (city, coordinates) VALUES ('Washington DC', [38.8951, -77.0364])");
@@ -236,7 +227,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (city text primary key, coordinates vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(coordinates) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
-        waitForIndexQueryable();
 
         // coordinates are [latitude, longitude]
         // These are from NYC's Central Park
@@ -266,7 +256,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // Distances computed using https://www.nhc.noaa.gov/gccalc.shtml
         execute("INSERT INTO %s (pk, v) VALUES (0, [1, 2])"); // distance is 555 km from [5,5]
@@ -302,7 +291,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, num, v) VALUES (0, 1, [0, -179])");
         execute("INSERT INTO %s (pk, num, v) VALUES (1, 1, [0, 179])");
@@ -333,7 +321,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (location text PRIMARY KEY, coords vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(coords) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // Here are the distances (these distances a not transitive, but do provide general motivation for the
         // results observed in the test)
@@ -371,7 +358,6 @@ public class GeoDistanceRestrictionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, coords vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(coords) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, coords) VALUES (0, [90,0])");
         execute("INSERT INTO %s (pk, coords) VALUES (1, [89.99999, 0])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/IndexGroupRemovalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/IndexGroupRemovalTest.java
@@ -44,7 +44,7 @@ public class IndexGroupRemovalTest extends SAITester
     @Test
     public void testDropAndRecreate() throws Throwable
     {
-        String tableName = createTable("CREATE TABLE %s (pk text, value text, PRIMARY KEY (pk))");
+        createTable("CREATE TABLE %s (pk text, value text, PRIMARY KEY (pk))");
         populateOneSSTable();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
@@ -53,7 +53,6 @@ public class IndexGroupRemovalTest extends SAITester
 
         // create index and drop it: StorageAttachedIndexGroup should be removed
         createIndex("CREATE CUSTOM INDEX sai ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndex(keyspace(), tableName, "sai");
 
         StorageAttachedIndexGroup group = (StorageAttachedIndexGroup) cfs.indexManager.getIndexGroup(StorageAttachedIndexGroup.GROUP_KEY);
         assertTrue(tracker.contains(group));
@@ -70,7 +69,6 @@ public class IndexGroupRemovalTest extends SAITester
 
         // create index again: expect a new StorageAttachedIndexGroup to be registered into tracker
         createIndex("CREATE CUSTOM INDEX sai ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndex(keyspace(), tableName, "sai");
 
         StorageAttachedIndexGroup newGroup = (StorageAttachedIndexGroup) cfs.indexManager.getIndexGroup(StorageAttachedIndexGroup.GROUP_KEY);
         assertNotSame(group, newGroup);

--- a/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/IndexParallelBuildTest.java
@@ -86,7 +86,6 @@ public class IndexParallelBuildTest extends SAITester
 
         // create indexes
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable();
         assertTrue(getCurrentColumnFamilyStore().getLiveSSTables().isEmpty());
 
         Injections.Counter parallelBuildCounter = Injections.newCounter("IndexParallelBuildCounter")

--- a/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
@@ -27,13 +27,13 @@ import org.apache.cassandra.index.sai.cql.types.InetTest;
 
 /**
  * This is testing that we can query ipv4 addresses using ipv6 equivalent addresses.
- *
+ * </p>
  * The remaining InetAddressType tests are now handled by {@link InetTest}
  */
 public class InetAddressTypeEquivalencyTest extends SAITester
 {
     @Before
-    public void createTableAndIndex() throws Throwable
+    public void createTableAndIndex()
     {
         requireNetwork();
 
@@ -46,7 +46,6 @@ public class InetAddressTypeEquivalencyTest extends SAITester
     public void mixedWorkloadQueryTest() throws Throwable
     {
         createIndex("CREATE CUSTOM INDEX ON %s(ip) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, ip) VALUES (1, 1, '127.0.0.1')");
         execute("INSERT INTO %s (pk, ck, ip) VALUES (1, 2, '127.0.0.1')");

--- a/test/unit/org/apache/cassandra/index/sai/cql/LiteralOrderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LiteralOrderTest.java
@@ -18,11 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import java.util.NavigableMap;
-import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -37,7 +33,6 @@ public class LiteralOrderTest extends SAITester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val text, num int)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Each iteration overwrites the previous data, so this test deals with a lot of overwrites.
         for (int i = 0; i < 5; i++)

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 public class LuceneAnalyzerTest extends SAITester
 {
     @Test
-    public void testQueryAnalyzer() throws Throwable
+    public void testQueryAnalyzer()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -51,8 +51,6 @@ public class LuceneAnalyzerTest extends SAITester
                     "\t\"tokenizer\":{\"name\":\"whitespace\"},\n" +
                     "\t\"filters\":[{\"name\":\"porterstem\"}]\n" +
                     "}'};");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the query')");
 
@@ -70,8 +68,6 @@ public class LuceneAnalyzerTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
                     "'index_analyzer': 'standard'};");
 
-        waitForIndexQueryable();
-
         execute("INSERT INTO %s (id, val) VALUES (1, 'some row')");
         execute("INSERT INTO %s (id, val) VALUES (2, 'a different row')");
         execute("INSERT INTO %s (id, val) VALUES (3, 'a row with some and different but not together')");
@@ -87,14 +83,12 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testQueryAnalyzerBuiltIn() throws Throwable
+    public void testQueryAnalyzerBuiltIn()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
                     "'index_analyzer': 'standard', 'query_analyzer': 'lowercase'};");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES (1, 'the query')");
         execute("INSERT INTO %s (id, val) VALUES (2, 'my test Query')");
@@ -122,7 +116,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testDifferentIndexAndQueryAnalyzersWhenAppliedDuringPostFiltering() throws Throwable
+    public void testDifferentIndexAndQueryAnalyzersWhenAppliedDuringPostFiltering()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, c1 text)");
         // This test verifies a bug fix where the query analyzer was incorrectly used in place of the index analyzer.
@@ -130,7 +124,6 @@ public class LuceneAnalyzerTest extends SAITester
         // the index analyzer includes a lowercase filter but the query analyzer does not.
         createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS =" +
                     "{'index_analyzer': 'standard', 'query_analyzer': 'whitespace'}");
-        waitForIndexQueryable();
 
         // The standard analyzer maps this to just one output 'the', but the query analyzer would map this to 'THE'
         execute("INSERT INTO %s (pk, c1) VALUES (?, ?)", 1, "THE");
@@ -140,18 +133,18 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testCreateIndexWithQueryAnalyzerAndNoIndexAnalyzerFails() throws Throwable
+    public void testCreateIndexWithQueryAnalyzerAndNoIndexAnalyzerFails()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, c1 text)");
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS = " +
                     "{'query_analyzer': 'whitespace'}"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessageContaining("Cannot specify query_analyzer without an index_analyzer option or any combination of " +
-                             "case_sensitive, normalize, or ascii options. options={query_analyzer=whitespace, target=c1}");;
+                             "case_sensitive, normalize, or ascii options. options={query_analyzer=whitespace, target=c1}");
     }
 
     @Test
-    public void testCreateIndexWithNormalizersWorks() throws Throwable
+    public void testCreateIndexWithNormalizersWorks()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, c1 text, c2 text, c3 text)");
         createIndex("CREATE CUSTOM INDEX ON %s(c1) USING 'StorageAttachedIndex' WITH OPTIONS = " +
@@ -191,7 +184,6 @@ public class LuceneAnalyzerTest extends SAITester
 
     private void standardAnalyzerTest()
     {
-        waitForIndexQueryable();
         execute("INSERT INTO %s (id, val) VALUES ('1', 'The quick brown fox jumps over the lazy DOG.')");
 
         assertEquals(1, execute("SELECT * FROM %s WHERE val = 'The quick brown fox jumps over the lazy DOG.' ALLOW FILTERING").size());
@@ -220,7 +212,8 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testEmptyAnalyzerFailsAtCreation() {
+    public void testEmptyAnalyzerFailsAtCreation()
+    {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) " +
@@ -232,7 +225,7 @@ public class LuceneAnalyzerTest extends SAITester
 
 // FIXME re-enable exception detection once incompatible options have been purged from prod DBs
     @Test
-    public void testIndexAnalyzerAndNonTokenizingAnalyzerFailsAtCreation() throws Throwable
+    public void testIndexAnalyzerAndNonTokenizingAnalyzerFailsAtCreation()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -254,19 +247,17 @@ public class LuceneAnalyzerTest extends SAITester
     // Technically, the NoopAnalyzer is applied, but that maps each field without modification, so any operator
     // that matches the SAI field will also match the PK field when compared later in the search (there are two phases).
     @Test
-    public void testNoAnalyzerOnClusteredColumn() throws Throwable
+    public void testNoAnalyzerOnClusteredColumn()
     {
         createTable("CREATE TABLE %s (id int, val text, PRIMARY KEY (id, val))");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
 
-        waitForIndexQueryable();
-
         execute("INSERT INTO %s (id, val) VALUES (1, 'dog')");
 
         assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE val : 'dog'"))
-        .isInstanceOf(InvalidRequestException.class);;
+        .isInstanceOf(InvalidRequestException.class);
 
         // Equality still works because indexed value is not analyzed, and so the search can be performed without
         // filtering.
@@ -274,14 +265,13 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStandardAnalyzerInClusteringColumns() throws Throwable
+    public void testStandardAnalyzerInClusteringColumns()
     {
         createTable("CREATE TABLE %s (id int, val text, PRIMARY KEY (id, val))");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(val) WITH OPTIONS = { 'ascii': true }"
         )).isInstanceOf(InvalidRequestException.class);
@@ -296,7 +286,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testBogusAnalyzer() throws Throwable
+    public void testBogusAnalyzer()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -311,7 +301,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStopFilterNoFormat() throws Throwable
+    public void testStopFilterNoFormat()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -322,7 +312,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStopFilterWordSet() throws Throwable
+    public void testStopFilterWordSet()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -333,7 +323,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testStopFilterSnowball() throws Throwable
+    public void testStopFilterSnowball()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -345,10 +335,8 @@ public class LuceneAnalyzerTest extends SAITester
 
     }
 
-    private void verifyStopWordsLoadedCorrectly() throws Throwable
+    private void verifyStopWordsLoadedCorrectly()
     {
-        waitForIndexQueryable();
-
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the big test')");
 
         flush();
@@ -367,7 +355,6 @@ public class LuceneAnalyzerTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 0, "");
         flush();
         assertRows(execute("SELECT * FROM %s WHERE v = ''"), row(0, ""));
@@ -378,7 +365,6 @@ public class LuceneAnalyzerTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'standard'}");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 0, "");
         execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 1, "some text to analyze");
         flush();
@@ -388,13 +374,12 @@ public class LuceneAnalyzerTest extends SAITester
 
     // The english analyzer has a default set of stop words. This test relies on "the" being one of those stop words.
     @Test
-    public void testStopWordFilteringEdgeCases() throws Throwable
+    public void testStopWordFilteringEdgeCases()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         executeNet("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' " +
                    "WITH OPTIONS = {'index_analyzer':'english'}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the test')");
         // When indexing a document with only stop words, the document should not be indexed.
@@ -414,7 +399,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testCharfilter() throws Throwable
+    public void testCharfilter()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -422,8 +407,6 @@ public class LuceneAnalyzerTest extends SAITester
                     "\t\"tokenizer\":{\"name\":\"keyword\"},\n" +
                     "\t\"charFilters\":[{\"name\":\"htmlstrip\"}]\n" +
                     "}'}");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', '<b>hello</b>')");
 
@@ -433,7 +416,7 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testNGramfilter() throws Throwable
+    public void testNGramfilter()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -441,8 +424,6 @@ public class LuceneAnalyzerTest extends SAITester
                      "\t{\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"3\"}}," +
                      "\t\"filters\":[{\"name\":\"lowercase\"}]}'}";
         createIndex(ddl);
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'DoG')");
 
@@ -454,15 +435,13 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testNGramfilterNoFlush() throws Throwable
+    public void testNGramfilterNoFlush()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
                     "\t{\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"3\"}}," +
                     "\t\"filters\":[{\"name\":\"lowercase\"}]}'}");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'DoG')");
 
@@ -483,8 +462,6 @@ public class LuceneAnalyzerTest extends SAITester
                     "{\"name\":\"edgengram\", \"args\":{\"minGramSize\":\"2\", \"maxGramSize\":\"30\"}}],\n" +
                     "\t\"charFilters\":[]" +
                     "}'};");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
         execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
@@ -532,8 +509,6 @@ public class LuceneAnalyzerTest extends SAITester
                     "\t\"charFilters\":[]" +
                     "}'};");
 
-        waitForIndexQueryable();
-
         execute("INSERT INTO %s (id, val) VALUES ('1', 'MAL0133AU')");
         execute("INSERT INTO %s (id, val) VALUES ('2', 'WFS2684AU')");
         execute("INSERT INTO %s (id, val) VALUES ('3', 'FPWMCR005 Mercer High Growth Managed')");
@@ -571,14 +546,12 @@ public class LuceneAnalyzerTest extends SAITester
         });
     }
     @Test
-    public void testWhitespace() throws Throwable
+    public void testWhitespace()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS =" +
                     "{'index_analyzer':'whitespace'}");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'hello world twice the and')");
 
@@ -591,15 +564,13 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testWhitespaceLowercase() throws Throwable
+    public void testWhitespaceLowercase()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
                     "\t{\"tokenizer\":{\"name\":\"whitespace\"}," +
                     "\t\"filters\":[{\"name\":\"lowercase\"}]}'}");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'hELlo woRlD tWice tHe aNd')");
 
@@ -612,15 +583,13 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testTokenizer() throws Throwable
+    public void testTokenizer()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'\n" +
                     "\t{\"tokenizer\":{\"name\":\"whitespace\"}," +
                     "\t\"filters\":[{\"name\":\"porterstem\"}]}'}");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the queries test')");
 
@@ -644,7 +613,6 @@ public class LuceneAnalyzerTest extends SAITester
                                   "}'," +
                                   "'equals_behaviour_when_analyzed': '%s'}";
         createIndex(String.format(createIndexQuery, AnalyzerEqOperatorSupport.Value.MATCH));
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'the queries test')");
 
@@ -664,7 +632,6 @@ public class LuceneAnalyzerTest extends SAITester
         // recreate the index with 'equals_behaviour_when_analyzed': 'UNSUPPORTED'
         dropIndex("DROP INDEX %s." + currentIndex());
         createIndex(String.format(createIndexQuery, AnalyzerEqOperatorSupport.Value.UNSUPPORTED));
-        waitForIndexQueryable();
 
         // If the index does not support EQ, the mixed queries should fail.
         // The error message will slightly change depending on whether EQ or MATCH are before in the query.
@@ -697,28 +664,25 @@ public class LuceneAnalyzerTest extends SAITester
     }
 
     @Test
-    public void testBuiltInAlyzerIndexCreation() throws Throwable
+    public void testBuiltInAlyzerIndexCreation()
     {
         for (BuiltInAnalyzers builtInAnalyzer : BuiltInAnalyzers.values())
             testBuiltInAlyzerIndexCreationFor(builtInAnalyzer.name());
     }
 
-    private void testBuiltInAlyzerIndexCreationFor(String builtInAnalyzerName) throws Throwable
+    private void testBuiltInAlyzerIndexCreationFor(String builtInAnalyzerName)
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = " +
                     "{'index_analyzer':'" + builtInAnalyzerName + "'}");
-
-        waitForIndexQueryable();
     }
 
     @Test
-    public void testInvalidQueryOnNumericColumn() throws Throwable
+    public void testInvalidQueryOnNumericColumn()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, some_num tinyint)");
         createIndex("CREATE CUSTOM INDEX ON %s(some_num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, some_num) VALUES (1, 1)");
         flush();
@@ -732,7 +696,6 @@ public class LuceneAnalyzerTest extends SAITester
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'ascii': 'true', 'case_sensitive': 'false', 'normalize': 'true'}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES (1, 'Aaą')");
 
@@ -747,8 +710,6 @@ public class LuceneAnalyzerTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer':'{" +
                     "\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"1\", \"maxGramSize\":\"26\"}},\n" +
                     "\"filters\":[{\"name\":\"lowercase\"}]}'}");
-
-        waitForIndexQueryable();
 
         assertThatThrownBy(() -> execute("INSERT INTO %s (id, val) VALUES (0, 'abcdedfghijklmnopqrstuvwxyz abcdedfghijklmnopqrstuvwxyz')"))
         .hasMessage("Term's analyzed size for column val exceeds the cumulative limit for index. Max allowed size 8.000KiB.")

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -32,15 +32,13 @@ import static org.junit.Assert.assertEquals;
 public class LuceneUpdateDeleteTest extends SAITester
 {
     @Test
-    public void updateAndDeleteWithAnalyzerRestrictionQueryShouldFail() throws Throwable
+    public void updateAndDeleteWithAnalyzerRestrictionQueryShouldFail()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES (0, 'a sad doG.')");
 
@@ -65,15 +63,13 @@ public class LuceneUpdateDeleteTest extends SAITester
 
     // No flushes
     @Test
-    public void removeUpdateAndDeleteTextInMemoryTest() throws Throwable
+    public void removeUpdateAndDeleteTextInMemoryTest()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-
-        waitForIndexQueryable();
 
         // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
         // Note that capitalization is covered as well as tokenization.
@@ -113,15 +109,13 @@ public class LuceneUpdateDeleteTest extends SAITester
 
     // Flush after every insert/update/delete
     @Test
-    public void removeUpdateAndDeleteTextOnDiskTest() throws Throwable
+    public void removeUpdateAndDeleteTextOnDiskTest()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-
-        waitForIndexQueryable();
 
         // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
         // Note that capitalization is covered as well as tokenization.
@@ -175,15 +169,13 @@ public class LuceneUpdateDeleteTest extends SAITester
 
     // Insert entries, flush them, then perform updates without flushing.
     @Test
-    public void removeUpdateAndDeleteTextMixInMemoryOnDiskTest() throws Throwable
+    public void removeUpdateAndDeleteTextMixInMemoryOnDiskTest()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-
-        waitForIndexQueryable();
 
         // The analyzed text column will result in overlapping and non-overlapping tokens in the in memory trie map.
         // Note that capitalization is covered as well as tokenization.
@@ -233,13 +225,12 @@ public class LuceneUpdateDeleteTest extends SAITester
 
     // row delete will trigger UpdateTransaction#onUpdated
     @Test
-    public void rowDeleteRowInMemoryAndFlushTest() throws Throwable
+    public void rowDeleteRowInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, str_val text, val text, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (0, 0, 'A', 'dog 0')");
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (1, 1, 'B', 'dog 1')");
@@ -258,13 +249,12 @@ public class LuceneUpdateDeleteTest extends SAITester
 
     // range delete won't trigger UpdateTransaction#onUpdated
     @Test
-    public void rangeDeleteRowInMemoryAndFlushTest() throws Throwable
+    public void rangeDeleteRowInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (0, 0, 0, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (1, 1, 1, 'B', 'second insert')");
@@ -282,13 +272,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void updateRowInMemoryAndFlushTest() throws Throwable
+    public void updateRowInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
@@ -306,13 +295,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void deleteRowPostFlushTest() throws Throwable
+    public void deleteRowPostFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
@@ -336,13 +324,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void deletedInOtherSSTablesTest() throws Throwable
+    public void deletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', 'second insert')");
@@ -361,7 +348,7 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void deletedInOtherSSTablesMultiIndexTest() throws Throwable
+    public void deletedInOtherSSTablesMultiIndexTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) " +
@@ -369,7 +356,6 @@ public class LuceneUpdateDeleteTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', 'second insert')");
@@ -388,13 +374,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void rangeDeletedInOtherSSTablesTest() throws Throwable
+    public void rangeDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck1, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', 'first insert')");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', 'second insert')");
@@ -414,13 +399,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void partitionDeletedInOtherSSTablesTest() throws Throwable
+    public void partitionDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val text, PRIMARY KEY(pk, ck1, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', 'some text')");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', 'updated text')");
@@ -444,13 +428,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void upsertTest() throws Throwable
+    public void upsertTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, not_analyzed text, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
         execute("INSERT INTO %s (pk, not_analyzed, val) VALUES (0, 'A', 'this will be tokenized')");
@@ -483,13 +466,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void updateOtherColumnsTest() throws Throwable
+    public void updateOtherColumnsTest()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text, not_analyzed text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val, not_analyzed) VALUES (0, 'a sad doG.', 'more text')");
         execute("INSERT INTO %s (id, val, not_analyzed) VALUES (1, 'A Happy DOG.', 'different text')");
@@ -500,13 +482,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void updateManySSTablesTest() throws Throwable
+    public void updateManySSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val) VALUES (0, 'this is')");
         flush();
@@ -539,13 +520,12 @@ public class LuceneUpdateDeleteTest extends SAITester
     }
 
     @Test
-    public void shadowedPrimaryKeyInDifferentSSTable() throws Throwable
+    public void shadowedPrimaryKeyInDifferentSSTable()
     {
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, str_val text, val text)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) " +
                     "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                     "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector

--- a/test/unit/org/apache/cassandra/index/sai/cql/MapEntriesIndexInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MapEntriesIndexInvalidQueryTest.java
@@ -26,11 +26,10 @@ public class MapEntriesIndexInvalidQueryTest extends SAITester
 {
 
     @Test
-    public void testConflictingBounds() throws Throwable
+    public void testConflictingBounds()
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Invalid queries
         assertInvalidMessage("More than one restriction was found for the end bound on item_cost",

--- a/test/unit/org/apache/cassandra/index/sai/cql/MapEntriesIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MapEntriesIndexTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.InvalidColumnTypeException;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 
 import static org.junit.Assert.assertEquals;
@@ -35,7 +34,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': -2})");
         flush();
@@ -58,7 +56,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We intentionally use apple, banana, and orange to deal with multiple keys in the trie.
         // We then search against banana to show that we only get results for banana
@@ -128,7 +125,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We intentionally use apple, banana, and orange to deal with multiple keys in the trie.
         // We then search against banana to show that we only get results for banana
@@ -154,7 +150,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, coordinates map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(coordinates)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // No rows in table yet, so definitely no results
         assertRows(execute("SELECT partition FROM %s WHERE coordinates['x'] > 10"));
@@ -173,7 +168,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, coordinates map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(coordinates)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, coordinates) VALUES (1, {'x': -1000000, 'y': 1000000})");
         execute("INSERT INTO %s (partition, coordinates) VALUES (4, {'x': -100, 'y': 2})");
@@ -214,7 +208,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, dates map<text, date>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(dates)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, dates) VALUES (1, {'a': '2000-02-03'})");
         execute("INSERT INTO %s (partition, dates) VALUES (4, {'a': '2001-02-03'})");
@@ -246,7 +239,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, timestamps map<text, timestamp>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(timestamps)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // 2011-02-03 04:05+0000 is 1296705900000
         execute("INSERT INTO %s (partition, timestamps) VALUES (1, {'a': '2011-02-03 04:05+0000'})");
@@ -287,7 +279,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': 2})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (2, {'apple': 2, 'orange': 1})");
@@ -304,7 +295,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': 2})");
 
@@ -348,7 +338,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 101, 'orange': 2})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (2, {'apple': 302, 'orange': 2})");
@@ -370,7 +359,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, text>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': '', 'orange': '2'})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (4, {'apple': 'a', 'orange': '2'})");
@@ -389,7 +377,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': -2})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (2, {'apple': 2, 'orange': 1})");
@@ -427,7 +414,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': -2})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (2, {'apple': 2, 'orange': 1})");
@@ -457,7 +443,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (partition, item_cost) VALUES (1, {'apple': 1, 'orange': -2})");
         execute("INSERT INTO %s (partition, item_cost) VALUES (2, {'apple': 2, 'orange': 1})");
@@ -483,7 +468,6 @@ public class MapEntriesIndexTest extends SAITester
         createTable("CREATE TABLE %s (partition int primary key, store_name text, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(store_name) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We intentionally use apple, banana, and orange to deal with multiple keys in the trie.
         // We then search against banana to show that we only get results for banana
@@ -504,7 +488,6 @@ public class MapEntriesIndexTest extends SAITester
     {
         createTable("CREATE TABLE %s (partition int primary key, item_cost map<text, int>)");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(item_cost)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We intentionally use apple, banana, and orange to deal with multiple keys in the trie.
         // We then search against banana to show that we only get results for banana

--- a/test/unit/org/apache/cassandra/index/sai/cql/MixedIndexImplementationsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MixedIndexImplementationsTest.java
@@ -37,7 +37,7 @@ public class MixedIndexImplementationsTest extends SAITester
      * Tests that storage-attached indexes can be dropped when there are other indexes in the same table, and vice versa.
      */
     @Test
-    public void shouldDropOtherIndex() throws Throwable
+    public void shouldDropOtherIndex()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int)");
 
@@ -57,21 +57,18 @@ public class MixedIndexImplementationsTest extends SAITester
      * Tests that storage-attached index queries can include restrictions over columns indexed by other indexes.
      */
     @Test
-    public void shouldAcceptColumnsWithOtherIndex() throws Throwable
+    public void shouldAcceptColumnsWithOtherIndex()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int)");
 
         createIndex("CREATE INDEX ON %s(v1)");
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v2) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         String insert = "INSERT INTO %s(k, v1, v2) VALUES (?, ?, ?)";
         execute(insert, 0, 0, 0);
         execute(insert, 1, 0, 1);
         execute(insert, 2, 1, 0);
         execute(insert, 3, 1, 1);
-
-        waitForIndexQueryable();
 
         String ossSelect = "SELECT * FROM %s WHERE v1 = ?";
         assertRowsIgnoringOrder(execute(ossSelect, 0), new Object[][]{{0, 0, 0}, {1, 0, 1}});
@@ -88,7 +85,7 @@ public class MixedIndexImplementationsTest extends SAITester
      * Tests that storage-attached indexes are not selected when the query contains a custom expression targeted to another index.
      */
     @Test
-    public void shouldNotBeSelectedForCustomExpressions() throws Throwable
+    public void shouldNotBeSelectedForCustomExpressions()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int)");
 
@@ -104,8 +101,6 @@ public class MixedIndexImplementationsTest extends SAITester
         execute(insert, 1, 0, 1);
         execute(insert, 2, 1, 0);
         execute(insert, 3, 1, 1);
-
-        waitForIndexQueryable();
 
         String ndiSelect = "SELECT * FROM %s WHERE v1 = ?";
         assertRowsIgnoringOrder(execute(ndiSelect, 0), new Object[][]{{0, 0, 0}, {1, 0, 1}});
@@ -128,7 +123,7 @@ public class MixedIndexImplementationsTest extends SAITester
     }
 
     @Test
-    public void shouldRequireAllowFilteringWithOtherIndex() throws Throwable
+    public void shouldRequireAllowFilteringWithOtherIndex()
     {
         createTable("CREATE TABLE %s (" +
                     "k1 int, k2 int, " +
@@ -225,7 +220,7 @@ public class MixedIndexImplementationsTest extends SAITester
         testAllowFiltering("SELECT * FROM %s WHERE s1=0 AND c2=0 AND c3=0 AND r1=0 AND r2=0", true);
     }
 
-    private void testAllowFiltering(String query, boolean requiresAllowFiltering) throws Throwable
+    private void testAllowFiltering(String query, boolean requiresAllowFiltering)
     {
         if (requiresAllowFiltering)
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);

--- a/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
@@ -62,8 +62,6 @@ public class MultipleColumnIndexTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(values(text_map)) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(entries(text_map)) USING 'StorageAttachedIndex'");
 
-        waitForIndexQueryable();
-
         beforeAndAfterFlush(() -> {
             assertEquals(1, execute("SELECT * FROM %s WHERE text_map['k1'] = 'v1' AND text_map['k2'] = 'v2'").size());
             assertEquals(2, execute("SELECT * FROM %s WHERE text_map CONTAINS 'v1'").size());

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -154,7 +154,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailUnsupportedType() throws Throwable
+    public void shouldFailUnsupportedType()
     {
         for (CQL3Type.Native cql3Type : CQL3Type.Native.values())
         {
@@ -250,7 +250,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldNotFailCreateWithTupleType() throws Throwable
+    public void shouldNotFailCreateWithTupleType()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val tuple<text, int, double>)");
 
@@ -277,24 +277,23 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateIndexIfExists() throws Throwable
+    public void shouldCreateIndexIfExists()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s(val) USING 'StorageAttachedIndex' ");
 
-        createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s(val) USING 'StorageAttachedIndex' ");
+        createIndexAsync("CREATE CUSTOM INDEX IF NOT EXISTS ON %s(val) USING 'StorageAttachedIndex' ");
 
         assertEquals(1, NDI_CREATION_COUNTER.get());
     }
 
     @Test
-    public void shouldBeCaseSensitiveByDefault() throws Throwable
+    public void shouldBeCaseSensitiveByDefault()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
@@ -304,14 +303,13 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableCaseSensitiveSearch() throws Throwable
+    public void shouldEnableCaseSensitiveSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         // Case sensitive search is the default, and as such, it does not make the SAI qualify as "analyzed".
         // The queries below use '=' and not ':' because : is limited to analyzed indexes.
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : true }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
@@ -321,12 +319,11 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableCaseInsensitiveSearch() throws Throwable
+    public void shouldEnableCaseInsensitiveSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : false }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Camel')");
 
@@ -335,12 +332,11 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldBeNonNormalizedByDefault() throws Throwable
+    public void shouldBeNonNormalizedByDefault()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
@@ -351,14 +347,13 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableNonNormalizedSearch() throws Throwable
+    public void shouldEnableNonNormalizedSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         // Normalize search is disabled by default, and as such, it does not make the SAI qualify as "analyzed".
         // The queries below use '=' and not ':' because : is limited to analyzed indexes.
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'normalize' : false }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
@@ -369,12 +364,11 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableNormalizedSearch() throws Throwable
+    public void shouldEnableNormalizedSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'normalize' : true }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
@@ -382,12 +376,11 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableNormalizedCaseInsensitiveSearch() throws Throwable
+    public void shouldEnableNormalizedCaseInsensitiveSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'normalize' : true, 'case_sensitive' : false}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Cam\u00E1l')");
 
@@ -395,12 +388,11 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldEnableAsciiSearch() throws Throwable
+    public void shouldEnableAsciiSearch()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = { 'ascii' : true, 'case_sensitive' : false}");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, val) VALUES ('1', 'Éppinger')");
 
@@ -408,7 +400,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateIndexOnReversedType() throws Throwable
+    public void shouldCreateIndexOnReversedType()
     {
         createTable("CREATE TABLE %s (id text, ck1 text, ck2 int, val text, PRIMARY KEY (id,ck1,ck2)) WITH CLUSTERING ORDER BY (ck1 desc, ck2 desc)");
 
@@ -439,7 +431,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateIndexWithAlias() throws Throwable
+    public void shouldCreateIndexWithAlias()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -453,7 +445,7 @@ public class NativeIndexDDLTest extends SAITester
      * Not putting in {@link MixedIndexImplementationsTest} because it uses CQLTester which doesn't load NDI dependency.
      */
     @Test
-    public void shouldCreateSASI() throws Throwable
+    public void shouldCreateSASI()
     {
         createTable(CREATE_TABLE_TEMPLATE);
 
@@ -476,7 +468,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateNumericIndexWithBkdPostingsSkipAndMinLeaves() throws Throwable
+    public void shouldCreateNumericIndexWithBkdPostingsSkipAndMinLeaves()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val int)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'bkd_postings_skip' : 3, 'bkd_postings_min_leaves' : 32}");
@@ -485,7 +477,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateNumericIndexWithBkdPostingsSkipOnly() throws Throwable
+    public void shouldCreateNumericIndexWithBkdPostingsSkipOnly()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val int)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'bkd_postings_skip' : 3}");
@@ -494,7 +486,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldCreateNumericIndexWithBkdPostingsMinLeavesOnly() throws Throwable
+    public void shouldCreateNumericIndexWithBkdPostingsMinLeavesOnly()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val int)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'bkd_postings_min_leaves': 32}");
@@ -503,7 +495,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateNumericIndexWithTooLowBkdPostingsSkip() throws Throwable
+    public void shouldFailToCreateNumericIndexWithTooLowBkdPostingsSkip()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val int)");
 
@@ -512,7 +504,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateNumericIndexWithTooLowBkdPostingsMinLeaves() throws Throwable
+    public void shouldFailToCreateNumericIndexWithTooLowBkdPostingsMinLeaves()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val int)");
 
@@ -521,7 +513,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateStringIndexWithBkdPostingsSkip() throws Throwable
+    public void shouldFailToCreateStringIndexWithBkdPostingsSkip()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -530,7 +522,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateStringIndexWithBkdPostingsMinLeaves() throws Throwable
+    public void shouldFailToCreateStringIndexWithBkdPostingsMinLeaves()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -539,7 +531,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateInvalidBooleanOption() throws Throwable
+    public void shouldFailToCreateInvalidBooleanOption()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -548,7 +540,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailToCreateEmptyBooleanOption() throws Throwable
+    public void shouldFailToCreateEmptyBooleanOption()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val text)");
 
@@ -557,7 +549,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailCreationOnMultipleColumns() throws Throwable
+    public void shouldFailCreationOnMultipleColumns()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, val1 text, val2 text)");
 
@@ -567,14 +559,14 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldFailCreationMultipleIndexesOnSimpleColumn() throws Throwable
+    public void shouldFailCreationMultipleIndexesOnSimpleColumn()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, v1 TEXT)");
         execute("INSERT INTO %s (id, v1) VALUES(1, '1')");
         flush();
 
         executeNet("CREATE CUSTOM INDEX index_1 ON %s(v1) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
+        waitForTableIndexesQueryable();
 
         // same name
         assertThatThrownBy(() -> executeNet("CREATE CUSTOM INDEX index_1 ON %s(v1) USING 'StorageAttachedIndex'"))
@@ -596,7 +588,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldIndexBuildingWithInMemoryData() throws Throwable
+    public void shouldIndexBuildingWithInMemoryData()
     {
         createTable(CREATE_TABLE_TEMPLATE);
 
@@ -605,7 +597,6 @@ public class NativeIndexDDLTest extends SAITester
             execute("INSERT INTO %s (id1, v1, v2) VALUES ('" + i + "', " + i + ", '0')");
 
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable();
 
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
         assertEquals(rowCount, rows.all().size());
@@ -624,7 +615,7 @@ public class NativeIndexDDLTest extends SAITester
 
         // Create the index, but do not allow the initial index build to begin:
         Injections.inject(delayInitializationTask);
-        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        String indexName = createIndexAsync("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Flush the Memtable's contents, which will feed data to the index as the SSTable is written:
         flush();
@@ -632,7 +623,7 @@ public class NativeIndexDDLTest extends SAITester
         // Allow the initialization task, which builds the index, to continue:
         delayInitializationTask.countDown();
 
-        waitForIndexQueryable();
+        waitForIndexQueryable(indexName);
 
         ResultSet rows = executeNet("SELECT id FROM %s WHERE val = 'Camel'");
         assertEquals(1, rows.all().size());
@@ -651,7 +642,7 @@ public class NativeIndexDDLTest extends SAITester
             execute("INSERT INTO %s (id1, v1, v2) VALUES ('" + i + "', " + i + ", '0')");
 
         Injections.inject(forceFlushPause);
-        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
 
         assertThatThrownBy(() -> executeNet("SELECT id1 FROM %s WHERE v1>=0")).isInstanceOf(ReadFailureException.class);
     }
@@ -668,7 +659,7 @@ public class NativeIndexDDLTest extends SAITester
         flush();
 
         Injections.inject(failNDIInitialializaion);
-        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         waitForAssert(() -> assertEquals(1, INDEX_BUILD_COUNTER.get()));
         waitForCompactions();
 
@@ -682,7 +673,6 @@ public class NativeIndexDDLTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(m) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(full(frozen_m)) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         String largeTerm = UTF8Type.instance.compose(ByteBuffer.allocate(FBUtilities.MAX_UNSIGNED_SHORT / 2 + 1));
         assertThatThrownBy(() -> executeNet("INSERT INTO %s (k, v) VALUES (0, ?)", largeTerm))
@@ -768,7 +758,6 @@ public class NativeIndexDDLTest extends SAITester
 
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
         IndexContext literalIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2")), UTF8Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext, literalIndexContext, 2, 2);
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
         assertEquals(2, rows.all().size());
@@ -794,13 +783,11 @@ public class NativeIndexDDLTest extends SAITester
         verifyNoIndexFiles();
 
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext, null, 2, 0);
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
         assertEquals(2, rows.all().size());
 
         IndexContext literalIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2")), UTF8Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext, literalIndexContext, 2, 2);
         rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
         assertEquals(2, rows.all().size());
@@ -882,10 +869,10 @@ public class NativeIndexDDLTest extends SAITester
 
         if (concurrentTruncate)
         {
-            String v1IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-            String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+            createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+            createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v2"));
             truncate(true);
-            waitForIndexQueryable();
+            waitForTableIndexesQueryable();
         }
         else
         {
@@ -1190,7 +1177,7 @@ public class NativeIndexDDLTest extends SAITester
         try
         {
             // Create a new index, which will actuate a build compaction and fail, but leave the node running...
-            IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
+            IndexContext numericIndexContext = createIndexContext(createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
             // two index builders running in different compaction threads because of parallelised index initial build
             waitForAssert(() -> assertEquals(2, INDEX_BUILD_COUNTER.get()));
             waitForCompactionsFinished();
@@ -1225,7 +1212,7 @@ public class NativeIndexDDLTest extends SAITester
         try
         {
             // Create a new index, which will actuate a build compaction and fail, but leave the node running...
-            createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+            createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
             // two index builders running in different compaction threads because of parallelised index initial build
             waitForAssert(() -> assertEquals(2, INDEX_BUILD_COUNTER.get()));
             waitForAssert(() -> assertEquals(0, getCompactionTasks()));
@@ -1331,7 +1318,6 @@ public class NativeIndexDDLTest extends SAITester
 
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
         IndexContext literalIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2")), UTF8Type.instance);
-        waitForIndexQueryable();
 
         populateData.run();
         verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V1_COLUMN_IDENTIFIER), 2, 2);
@@ -1392,7 +1378,6 @@ public class NativeIndexDDLTest extends SAITester
 
         // create index again, it should succeed
         indexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable();
         verifySSTableIndexes(indexName, 1);
 
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
@@ -1420,7 +1405,7 @@ public class NativeIndexDDLTest extends SAITester
 
         Injections.inject(delayIndexBuilderCompletion);
 
-        IndexContext numericIndexContext = getIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")));
+        IndexContext numericIndexContext = getIndexContext(createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1")));
 
         waitForAssert(() -> assertTrue(getCompactionTasks() > 0), 1000, TimeUnit.MILLISECONDS);
 
@@ -1445,7 +1430,7 @@ public class NativeIndexDDLTest extends SAITester
 
         // initial index builder should have stopped abruptly resulting in the index not being queryable
         verifyInitialIndexFailed(numericIndexContext.getIndexName());
-        assertFalse(isIndexQueryable());
+        assertFalse(areAllTableIndexesQueryable());
 
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
         for (Index i : cfs.indexManager.listIndexes())
@@ -1474,7 +1459,7 @@ public class NativeIndexDDLTest extends SAITester
     }
 
     @Test
-    public void shouldRejectQueriesWithCustomExpressions() throws Throwable
+    public void shouldRejectQueriesWithCustomExpressions()
     {
         createTable(CREATE_TABLE_TEMPLATE);
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/RandomIntersectionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RandomIntersectionTest.java
@@ -84,7 +84,6 @@ public class RandomIntersectionTest extends SAITester
         createTable("CREATE TABLE %s (pk int, ck int, v1 int, v2 int, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         numRows = getRandom().nextIntBetween(50000, 200000);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/RandomisedComplexQueryTest.java
@@ -46,10 +46,10 @@ import org.assertj.core.util.Lists;
 /**
  * This test produces a random schema, loads it with random data and then runs a series of
  * random queries against it.
- *
+ * </p>
  * The purpose of the test is to test that the <code>RowFilter</code> and <code>Operation</code>
  * classes correctly support complex queries.
- *
+ * </p>
  * At present the test only supports ascii and int datatypes and only supports EQ expressions.
  * It is intended that this can be extended in the future to support more functionality.
  */
@@ -71,9 +71,7 @@ public class RandomisedComplexQueryTest extends SAITester
 
         createTable(schema.toTableDefinition());
 
-        schema.generateIndexStrings().stream().forEach(index -> createIndex(index));
-
-        waitForIndexQueryable();
+        schema.generateIndexStrings().forEach(this::createIndex);
 
         List<RandomRow> data = schema.generateDataset();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeExecutor.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeExecutor.java
@@ -61,13 +61,13 @@ public class SingleNodeExecutor implements DataModel.Executor
     }
 
     @Override
-    public void waitForIndexQueryable(String keyspace, String table)
+    public void waitForTableIndexesQueryable(String keyspace, String table)
     {
         tester.waitForTableIndexesQueryable(keyspace, table);
     }
 
     @Override
-    public void executeLocal(String query, Object... values) throws Throwable
+    public void executeLocal(String query, Object... values)
     {
         tester.executeFormattedQuery(query, values);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeExecutor.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/SingleNodeExecutor.java
@@ -63,7 +63,7 @@ public class SingleNodeExecutor implements DataModel.Executor
     @Override
     public void waitForIndexQueryable(String keyspace, String table)
     {
-        tester.waitForIndexQueryable(keyspace, table);
+        tester.waitForTableIndexesQueryable(keyspace, table);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/cql/TokenCollisionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/TokenCollisionTest.java
@@ -39,11 +39,10 @@ public class TokenCollisionTest extends SAITester
     }
 
     @Test
-    public void testSkippingWhenTokensCollide() throws Throwable
+    public void testSkippingWhenTokensCollide()
     {
         createTable("CREATE TABLE %s (pk blob, value text, PRIMARY KEY (pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         ByteBuffer prefix = ByteBufferUtil.bytes("key");
         final int numRows = 640; // 5 blocks x 128 postings, so skip table will contain 5 entries

--- a/test/unit/org/apache/cassandra/index/sai/cql/TokenRangeReadTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/TokenRangeReadTest.java
@@ -39,7 +39,6 @@ public class TokenRangeReadTest extends SAITester
     {
         createTable("CREATE TABLE %s (k1 int, v1 text, PRIMARY KEY (k1))");
         createIndex(format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
 
         execute("INSERT INTO %S(k1, v1) values(1, '1')");
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorAndLuceneTest.java
@@ -30,13 +30,12 @@ public class VectorAndLuceneTest extends VectorTester
 {
 
     @Test
-    public void basicVectorLuceneSelectTest() throws Throwable
+    public void basicVectorLuceneSelectTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'" +
                     " WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         // The str_val is set up to make sure that tokens are properly analyzed and lowercased.
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'One Duplicate phrase', [1.0, 2.0, 3.0])");
@@ -71,13 +70,12 @@ public class VectorAndLuceneTest extends VectorTester
 
     // partition delete won't trigger UpdateTransaction#onUpdated
     @Test
-    public void partitionDeleteVectorInMemoryTest() throws Throwable
+    public void partitionDeleteVectorInMemoryTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'" +
                     " WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'this test has tokens', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'not so plural token', [2.0, 3.0, 4.0])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -163,7 +163,6 @@ public class VectorCompactionTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
     }
 
     private void validateQueries()

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorInvalidQueryTest.java
@@ -87,11 +87,10 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void cannotQueryWrongNumberOfDimensions() throws Throwable
+    public void cannotQueryWrongNumberOfDimensions()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -104,42 +103,39 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void testMultiVectorOrderingsNotAllowed() throws Throwable
+    public void testMultiVectorOrderingsNotAllowed()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("Cannot specify more than one ordering column when using SAI indexes",
                              "SELECT * FROM %s ORDER BY val1 ann of [2.5, 3.5, 4.5], val2 ann of [2.1, 3.2, 4.0] LIMIT 2");
     }
 
     @Test
-    public void testDescendingVectorOrderingIsNotAllowed() throws Throwable
+    public void testDescendingVectorOrderingIsNotAllowed()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("Descending ANN ordering is not supported",
                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2");
     }
 
     @Test
-    public void testVectorOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
+    public void testVectorOrderingIsNotAllowedWithClusteringOrdering()
     {
         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("Cannot combine clustering column ordering with non-clustering column ordering",
                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2");
     }
 
     @Test
-    public void testVectorOrderingIsNotAllowedWithoutIndex() throws Throwable
+    public void testVectorOrderingIsNotAllowedWithoutIndex()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
 
@@ -151,11 +147,10 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void testVectorEqualityIsNotAllowed() throws Throwable
+    public void testVectorEqualityIsNotAllowed()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage(StatementRestrictions.VECTOR_INDEXES_UNSUPPORTED_OP_MESSAGE,
                              "SELECT * FROM %s WHERE val = [2.5, 3.5, 4.5] LIMIT 1");
@@ -165,11 +160,10 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void annOrderingMustHaveLimit() throws Throwable
+    public void annOrderingMustHaveLimit()
     {
         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         assertInvalidMessage("SAI based ORDER BY clause requires a LIMIT that is not greater than 1000. LIMIT was NO LIMIT",
                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5]");
@@ -177,7 +171,7 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void testInvalidColumnNameWithAnn() throws Throwable
+    public void testInvalidColumnNameWithAnn()
     {
         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + "." + table),
@@ -185,7 +179,7 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void disallowZeroVectorsWithCosineSimilarity() throws Throwable
+    public void disallowZeroVectorsWithCosineSimilarity()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'cosine'}");
@@ -205,7 +199,7 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void disallowZeroVectorsWithDefaultSimilarity() throws Throwable
+    public void disallowZeroVectorsWithDefaultSimilarity()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
@@ -223,11 +217,10 @@ public class VectorInvalidQueryTest extends SAITester
     }
 
     @Test
-    public void disallowClusteringColumnPredicateWithoutSupportingIndex() throws Throwable
+    public void disallowClusteringColumnPredicateWithoutSupportingIndex()
     {
         createTable("CREATE TABLE %s (pk int, num int, v vector<float, 2>, PRIMARY KEY(pk, num))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, num, v) VALUES (3, 1, [1,1])");
         execute("INSERT INTO %s (pk, num, v) VALUES (3, 4, [1,4])");
         flush();
@@ -244,7 +237,6 @@ public class VectorInvalidQueryTest extends SAITester
 
         // Cover the alternative code path
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         assertRows(execute("SELECT num FROM %s WHERE pk=3 AND num > 3 ORDER BY v ANN OF [1,1] LIMIT 1"), row(4));
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -101,7 +101,6 @@ public class VectorLocalTest extends VectorTester
         createIndex("CREATE CUSTOM INDEX lat_high_precision_index ON %s (lat_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
         createIndex("CREATE CUSTOM INDEX lat_lon_embedding_index ON %s (lat_lon_embedding) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'};");
         createIndex("CREATE CUSTOM INDEX lon_high_precision_index ON %s (lon_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
-        waitForIndexQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
         List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(2)).collect(Collectors.toList());
@@ -152,7 +151,6 @@ public class VectorLocalTest extends VectorTester
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimension));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
         List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(dimension)).collect(Collectors.toList());
@@ -207,7 +205,6 @@ public class VectorLocalTest extends VectorTester
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(keyspace());
 
         int sstableCount = getRandom().nextIntBetween(3, 6);
@@ -248,7 +245,6 @@ public class VectorLocalTest extends VectorTester
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -305,7 +301,6 @@ public class VectorLocalTest extends VectorTester
     {
         createTable(String.format("CREATE TABLE %%s (pk int, ck int, val vector<float, %d>, PRIMARY KEY(pk, ck))", dimension));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         int partitions = getRandom().nextIntBetween(20, 40);
         int vectorCountPerPartition = getRandom().nextIntBetween(50, 100);
@@ -368,7 +363,6 @@ public class VectorLocalTest extends VectorTester
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -475,7 +469,6 @@ public class VectorLocalTest extends VectorTester
         // create index on existing sstable to produce multiple segments
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         verifyChecksum();
 
         // query multiple on-disk indexes
@@ -537,7 +530,6 @@ public class VectorLocalTest extends VectorTester
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         flush();
         verifyChecksum();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
@@ -54,7 +54,6 @@ public class VectorSegmentationTest extends VectorTester
 
         SegmentBuilder.updateLastValidSegmentRowId(17); // 17 rows per segment
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         int limit = 35;
         float[] queryVector = randomVector();
@@ -71,7 +70,6 @@ public class VectorSegmentationTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, " + dimension + ">, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         List<float[]> vectors = new ArrayList<>();
         int rowsPerSSTable = 10;

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -62,7 +62,6 @@ public class VectorSiftSmallTest extends VectorTester
         // Create table and index
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         insertVectors(baseVectors, 0);
         double memoryRecall = testRecall(100, queryVectors, groundTruth);
@@ -83,7 +82,6 @@ public class VectorSiftSmallTest extends VectorTester
         // Create table and index
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // we're going to compact manually, so disable background compactions to avoid interference
         disableCompaction();
@@ -132,7 +130,6 @@ public class VectorSiftSmallTest extends VectorTester
 
         SegmentBuilder.updateLastValidSegmentRowId(2000); // 2000 rows per segment, enough for PQ to be created
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         // verify that we got the expected number of segments and that PQ is present in all of them
         var sim = getCurrentColumnFamilyStore().getIndexManager();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -105,11 +105,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void endToEndTest() throws Throwable
+    public void endToEndTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -148,11 +147,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void tracingTest() throws Throwable
+    public void tracingTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -175,7 +173,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void createIndexAfterInsertTest() throws Throwable
+    public void createIndexAfterInsertTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
 
@@ -186,7 +184,6 @@ public class VectorTypeTest extends VectorTester
 
         flush();
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         UntypedResultSet result = execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 3");
         assertThat(result).hasSize(3);
@@ -209,12 +206,11 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testTwoPredicates() throws Throwable
+    public void testTwoPredicates()
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, b, v) VALUES (0, true, [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, b, v) VALUES (1, true, [2.0, 3.0, 4.0])");
@@ -233,7 +229,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testTwoPredicatesWithBruteForce() throws Throwable
+    public void testTwoPredicatesWithBruteForce()
     {
         // Note: the PKs in this test are chosen intentionally to ensure their tokens overlap so that
         // we can test the brute force path.
@@ -241,7 +237,6 @@ public class VectorTypeTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, b, v) VALUES (1, true, [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, b, v) VALUES (2, true, [2.0, 3.0, 4.0])");
@@ -268,12 +263,11 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testTwoPredicatesWithUnnecessaryAllowFiltering() throws Throwable
+    public void testTwoPredicatesWithUnnecessaryAllowFiltering()
     {
         createTable("CREATE TABLE %s (pk int, b int, v vector<float, 3>, PRIMARY KEY(pk, b))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, b, v) VALUES (0, 0, [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, b, v) VALUES (1, 2, [2.0, 3.0, 4.0])");
@@ -286,12 +280,11 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testTwoPredicatesManyRows() throws Throwable
+    public void testTwoPredicatesManyRows()
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         for (int i = 0; i < 100; i++)
             execute("INSERT INTO %s (pk, b, v) VALUES (?, true, ?)",
@@ -308,13 +301,12 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testThreePredicates() throws Throwable
+    public void testThreePredicates()
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, str text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, b, v, str) VALUES (0, true, [1.0, 2.0, 3.0], 'A')");
         execute("INSERT INTO %s (pk, b, v, str) VALUES (1, true, [2.0, 3.0, 4.0], 'B')");
@@ -333,11 +325,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testSameVectorMultipleRows() throws Throwable
+    public void testSameVectorMultipleRows()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [1.0, 2.0, 3.0])");
@@ -354,22 +345,20 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testQueryEmptyTable() throws Throwable
+    public void testQueryEmptyTable()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         var result = execute("SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 1");
         assertThat(result).hasSize(0);
     }
 
     @Test
-    public void testQueryTableWithNulls() throws Throwable
+    public void testQueryTableWithNulls()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', null)");
         var result = execute("SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 1");
@@ -381,11 +370,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testLimitLessThanInsertedRowCount() throws Throwable
+    public void testLimitLessThanInsertedRowCount()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Insert more rows than the query limit
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -398,11 +386,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testQueryMoreRowsThanInserted() throws Throwable
+    public void testQueryMoreRowsThanInserted()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
 
@@ -411,7 +398,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void changingOptionsTest() throws Throwable
+    public void changingOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         if (CassandraRelevantProperties.SAI_HNSW_ALLOW_CUSTOM_PARAMETERS.getBoolean())
@@ -426,7 +413,6 @@ public class VectorTypeTest extends VectorTester
             .isInstanceOf(InvalidRequestException.class);
             return;
         }
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -469,7 +455,6 @@ public class VectorTypeTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'source_model' : 'ada002' }");
-        waitForIndexQueryable();
 
         var sim = getCurrentColumnFamilyStore().indexManager;
         var index = (StorageAttachedIndex) sim.listIndexes().iterator().next();
@@ -482,16 +467,14 @@ public class VectorTypeTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'optimize_for' : 'recall' }");
-        waitForIndexQueryable();
         // as long as CREATE doesn't error out, we're good
     }
 
     @Test
-    public void bindVariablesTest() throws Throwable
+    public void bindVariablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2 , 3, 4));
@@ -503,14 +486,13 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void intersectedSearcherTest() throws Throwable
+    public void intersectedSearcherTest()
     {
         // check that we correctly get back the two rows with str_val=B even when those are not
         // the closest rows to the query vector
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2 , 3, 4));
@@ -527,12 +509,11 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void nullVectorTest() throws Throwable
+    public void nullVectorTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 'B')"); // no vector
@@ -556,11 +537,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void lwtTest() throws Throwable
+    public void lwtTest()
     {
         createTable("CREATE TABLE %s (p int, c int, v text, vec vector<float, 2>, PRIMARY KEY(p, c))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (p, c, v) VALUES (?, ?, ?)", 0, 0, "test");
         execute("INSERT INTO %s (p, c, v) VALUES (?, ?, ?)", 0, 1, "00112233445566");
@@ -573,20 +553,18 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void twoVectorFieldsTest() throws Throwable
+    public void twoVectorFieldsTest()
     {
         createTable("CREATE TABLE %s (pk int, v2 vector<float, 2>, v3 vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v3) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
     }
 
     @Test
-    public void primaryKeySearchTest() throws Throwable
+    public void primaryKeySearchTest()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, i int, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         var N = 5;
         for (int i = 0; i < N; i++)
@@ -609,11 +587,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void partitionKeySearchTest() throws Throwable
+    public void partitionKeySearchTest()
     {
         createTable("CREATE TABLE %s (partition int, row int, val vector<float, 2>, PRIMARY KEY(partition, row))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         var nPartitions = 5;
         var rowsPerPartition = 10;
@@ -656,7 +633,6 @@ public class VectorTypeTest extends VectorTester
     {
         createTable("CREATE TABLE %s (partition int, val vector<float, 2>, PRIMARY KEY(partition))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForIndexQueryable();
 
         var nPartitions = 100;
         Map<Integer, float[]> vectorsByKey = new HashMap<>();
@@ -746,7 +722,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void selectFloatVectorFunctions() throws Throwable
+    public void selectFloatVectorFunctions()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
 
@@ -771,11 +747,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void selectSimilarityWithAnn() throws Throwable
+    public void selectSimilarityWithAnn()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -792,7 +767,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void castedTerminalFloatVectorFunctions() throws Throwable
+    public void castedTerminalFloatVectorFunctions()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
 
@@ -803,7 +778,7 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void inferredTerminalFloatVectorFunctions() throws Throwable
+    public void inferredTerminalFloatVectorFunctions()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
 
@@ -889,7 +864,6 @@ public class VectorTypeTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // There was an edge case where we failed because there was just a single row in the table.
         execute("INSERT INTO %s (pk, val) VALUES (1, 'match me')");
@@ -905,7 +879,6 @@ public class VectorTypeTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // When we search the memtable, we filter out PKs outside the memtable's bounrdaries.
         // Persist two rows and push to sstable that will be outside of bounds.
@@ -925,7 +898,6 @@ public class VectorTypeTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, name text, body text, vals vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vals) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(name) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, name, body, vals) VALUES (1, 'Ann', 'A lizard said bad things to the snakes', [0.1, 0.1])");
         execute("INSERT INTO %s (pk, name, body, vals) VALUES (2, 'Bea', 'Please wear protective gear before operating the machine', [0.2, -0.3])");
         execute("INSERT INTO %s (pk, name, body, vals) VALUES (3, 'Cal', 'My name is Slim Shady', [0.0, 0.9])");
@@ -941,7 +913,6 @@ public class VectorTypeTest extends VectorTester
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // This row is created so that it matches the query parameters, and so that the PK is before the other PKs.
         // The token for 5 is -7509452495886106294 and the token for 1 is -4069959284402364209.
@@ -1025,7 +996,6 @@ public class VectorTypeTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])");
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 2, 'A', [1, 2])");
@@ -1047,7 +1017,6 @@ public class VectorTypeTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Create two sstables. The first needs a hole forcing us to skip.
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])");
@@ -1094,7 +1063,7 @@ public class VectorTypeTest extends VectorTester
 
     // search across multiple sstables each with multiple segments, verify results with and without non-ann filtering
     @Test
-    public void multipleSSTablesAndMultipleSegmentsTest() throws Throwable
+    public void multipleSSTablesAndMultipleSegmentsTest()
     {
         createTable("CREATE TABLE %s (pk int, constant boolean, val vector<float, 2>, PRIMARY KEY(pk))");
         disableCompaction(KEYSPACE);
@@ -1118,7 +1087,6 @@ public class VectorTypeTest extends VectorTester
         // create indexes on existing sstable to produce multiple segments
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(constant) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // query multiple on-disk indexes
         int limit = getRandom().nextIntBetween(5,25);
@@ -1145,7 +1113,6 @@ public class VectorTypeTest extends VectorTester
         createTable("CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'A', [1, 1])");
         execute("INSERT INTO %s (pk, val) VALUES (2, 'A')");
@@ -1167,13 +1134,12 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void insertstuff() throws Throwable
+    public void insertstuff()
     {
         // This test requires the non-bruteforce route
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, val text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Insert data
         execute("INSERT INTO %s (pk, val) VALUES (1, 'A')");
@@ -1193,7 +1159,6 @@ public class VectorTypeTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         var injection = Injections.newCustom("fail_on_searcher_search")
                                   .add(InvokePointBuilder.newInvokePoint().onClass(GraphSearcher.class).onMethod("search").atEntry())
@@ -1213,11 +1178,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void testCompactionWithEnoughRowsForPQAndDeleteARow() throws Throwable
+    public void testCompactionWithEnoughRowsForPQAndDeleteARow()
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         disableCompaction();
 
@@ -1246,7 +1210,6 @@ public class VectorTypeTest extends VectorTester
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>, c int)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // write into memtable
         execute("INSERT INTO %s (k, v, c) VALUES (1, [1, 1], 1)");
@@ -1298,7 +1261,6 @@ public class VectorTypeTest extends VectorTester
         createTable("CREATE TABLE %s (k int, i int, v vector<float, 2>, c int,  PRIMARY KEY(k, i))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         // We'll manually control compaction.
         disableCompaction();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -65,11 +65,10 @@ public class VectorUpdateDeleteTest extends VectorTester
 
     // partition delete won't trigger UpdateTransaction#onUpdated
     @Test
-    public void partitionDeleteVectorInMemoryTest() throws Throwable
+    public void partitionDeleteVectorInMemoryTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -98,11 +97,10 @@ public class VectorUpdateDeleteTest extends VectorTester
 
     // row delete will trigger UpdateTransaction#onUpdated
     @Test
-    public void rowDeleteVectorInMemoryAndFlushTest() throws Throwable
+    public void rowDeleteVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (0, 0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (1, 1, 'B', [2.0, 3.0, 4.0])");
@@ -120,11 +118,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void testFlushWithDeletedVectors() throws Throwable
+    public void testFlushWithDeletedVectors()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, v) VALUES (0, [1.0, 2.0])");
         execute("INSERT INTO %s (pk, v) VALUES (0, null)");
@@ -137,11 +134,10 @@ public class VectorUpdateDeleteTest extends VectorTester
 
     // range delete won't trigger UpdateTransaction#onUpdated
     @Test
-    public void rangeDeleteVectorInMemoryAndFlushTest() throws Throwable
+    public void rangeDeleteVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (0, 0, 0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (1, 1, 1, 'B', [2.0, 3.0, 4.0])");
@@ -159,11 +155,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void updateVectorInMemoryAndFlushTest() throws Throwable
+    public void updateVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -181,11 +176,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void deleteVectorPostFlushTest() throws Throwable
+    public void deleteVectorPostFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -209,11 +203,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void deletedInOtherSSTablesTest() throws Throwable
+    public void deletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -232,12 +225,11 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void deletedInOtherSSTablesMultiIndexTest() throws Throwable
+    public void deletedInOtherSSTablesMultiIndexTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [2.0, 3.0, 4.0])");
@@ -256,11 +248,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void rangeDeletedInOtherSSTablesTest() throws Throwable
+    public void rangeDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck1, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', [2.0, 3.0, 4.0])");
@@ -284,11 +275,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void partitionDeletedInOtherSSTablesTest() throws Throwable
+    public void partitionDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck1, ck2))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', [2.0, 3.0, 4.0])");
@@ -312,11 +302,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void upsertTest() throws Throwable
+    public void upsertTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // insert row A redundantly, and row B once
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -349,11 +338,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void updateTest() throws Throwable
+    public void updateTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // overwrite row A a bunch of times; also write row B with the same vector as a deleted A value
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -406,13 +394,12 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void updateTestWithPredicate() throws Throwable
+    public void updateTestWithPredicate()
     {
         // contrived example to make sure we exercise VectorIndexSearcher.limitToTopResults
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // overwrite row A a bunch of times
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -440,11 +427,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void updateOtherColumnsTest() throws Throwable
+    public void updateOtherColumnsTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -455,11 +441,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void updateManySSTablesTest() throws Throwable
+    public void updateManySSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         flush();
@@ -494,11 +479,10 @@ public class VectorUpdateDeleteTest extends VectorTester
 
 
     @Test
-    public void shadowedPrimaryKeyInDifferentSSTable() throws Throwable
+    public void shadowedPrimaryKeyInDifferentSSTable()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector
@@ -523,7 +507,6 @@ public class VectorUpdateDeleteTest extends VectorTester
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector that is shared by two rows
@@ -545,13 +528,12 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void shadowedPrimaryKeyWithSharedVectorAndOtherPredicates() throws Throwable
+    public void shadowedPrimaryKeyWithSharedVectorAndOtherPredicates()
     {
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector that is shared by two rows
@@ -579,7 +561,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, num int, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // Same PK, different num, different vectors
@@ -598,12 +579,11 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void rangeRestrictedTestWithDuplicateVectorsAndADelete() throws Throwable
+    public void rangeRestrictedTestWithDuplicateVectorsAndADelete()
     {
         setMaxBruteForceRows(0);
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", 2));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])"); // -3485513579396041028
         execute("INSERT INTO %s (pk, val) VALUES (1, [1.0, 2.0])"); // -4069959284402364209
@@ -630,7 +610,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         setMaxBruteForceRows(0);
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", 2));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])");
@@ -664,7 +643,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Split the row across 1 sstable and the memtable.
         execute("INSERT INTO %s (pk, vec) VALUES (1, [1,1])");
@@ -700,7 +678,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         // Use euclidean distance to more easily verify correctness of caching
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // We will search for [11,11]
         execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'match me', [1,1])");
@@ -724,7 +701,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val1, vec) VALUES (1, 'match me', [1,1])");
         execute("INSERT INTO %s (pk, val2, vec) VALUES (2, 'match me', [1,2])");
@@ -742,11 +718,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     // This test intentionally has extra rows with primary keys that are above and below the
     // deleted primary key so that we do not short circuit certain parts of the shadowed key logic.
     @Test
-    public void shadowedPrimaryKeyInDifferentSSTableEachWithMultipleRows() throws Throwable
+    public void shadowedPrimaryKeyInDifferentSSTableEachWithMultipleRows()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector
@@ -777,7 +752,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // Choose a row count that will essentially force us to re-query the index that still has more rows to search.
@@ -814,7 +788,6 @@ public class VectorUpdateDeleteTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 2>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])");
         execute("INSERT INTO %s (pk, val) VALUES (1, [1.0, 3.0])");
@@ -855,7 +828,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // This test is fairly contrived, but it covers a bug we hit due to prematurely closed iterators.
@@ -897,7 +869,6 @@ public class VectorUpdateDeleteTest extends VectorTester
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, val vector<float, " + vectorDimension + ">, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // Insert 100 vectors
         for (int i = 0; i < 100; i++)
@@ -925,14 +896,13 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void testVectorIndexWithAllOrdinalsDeletedViaRangeDeletion() throws Throwable
+    public void testVectorIndexWithAllOrdinalsDeletedViaRangeDeletion()
     {
         QueryController.QUERY_OPT_LEVEL = 0;
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // Insert a row with a vector
@@ -949,14 +919,13 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void testVectorIndexWithAllOrdinalsDeletedAndSomeViaRangeDeletion() throws Throwable
+    public void testVectorIndexWithAllOrdinalsDeletedAndSomeViaRangeDeletion()
     {
         QueryController.QUERY_OPT_LEVEL = 0;
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         disableCompaction(KEYSPACE);
 
         // Insert two rows with different vectors to get different ordinals
@@ -977,11 +946,10 @@ public class VectorUpdateDeleteTest extends VectorTester
     }
 
     @Test
-    public void ensureCompressedVectorsCanFlush() throws Throwable
+    public void ensureCompressedVectorsCanFlush()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 4>, PRIMARY KEY(pk))");
         var indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         // insert enough vectors for pq plus 1 because we need quantization and we're deleting a row
         for (int i = 0; i < MIN_PQ_ROWS + 1; i++)
@@ -1000,7 +968,6 @@ public class VectorUpdateDeleteTest extends VectorTester
     {
         createTable("CREATE TABLE %s (pk int primary key, val vector<float, 3>)");
         var indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0, 3.0]) USING TTL 1");
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/filtering/FilteredQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/filtering/FilteredQueryTester.java
@@ -66,7 +66,6 @@ public abstract class FilteredQueryTester extends SAITester
         indexNames = indexes.stream().map(i -> i.name).collect(Collectors.toSet());
         createTable();
         indexes.forEach(i -> i.create(this));
-        waitForIndexQueryable();
         populateTable();
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/IndexingTypeSupport.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/IndexingTypeSupport.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.index.sai.cql.types;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -106,7 +105,6 @@ public abstract class IndexingTypeSupport extends SAITester
         {
             for (String index : dataset.decorateIndexColumn("value"))
                 createIndex(String.format("CREATE CUSTOM INDEX ON %%s(%s) USING 'StorageAttachedIndex'", index));
-            waitForIndexQueryable();
         }
 
         insertData(this, allRows, scenario);
@@ -124,7 +122,6 @@ public abstract class IndexingTypeSupport extends SAITester
                 flush();
                 for (String index : dataset.decorateIndexColumn("value"))
                     createIndex(String.format("CREATE CUSTOM INDEX ON %%s(%s) USING 'StorageAttachedIndex'", index));
-                waitForIndexQueryable();
                 break;
         }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -33,7 +33,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
@@ -266,7 +265,7 @@ public class NodeStartupTest extends SAITester
     {
         populator.populate(this);
 
-        assertTrue(isIndexQueryable());
+        assertTrue(areAllTableIndexesQueryable());
         assertTrue(isGroupIndexComplete());
         assertTrue(isColumnIndexComplete());
         Assert.assertEquals(expectedDocuments, execute("SELECT * FROM %s WHERE v1 >= 0").size());
@@ -277,7 +276,7 @@ public class NodeStartupTest extends SAITester
 
         simulateNodeRestart();
 
-        assertTrue(isIndexQueryable());
+        assertTrue(areAllTableIndexesQueryable());
         assertTrue(isGroupIndexComplete());
         assertTrue(isColumnIndexComplete());
         Assert.assertEquals(expectedDocuments, execute("SELECT * FROM %s WHERE v1 >= 0").size());

--- a/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
@@ -35,7 +35,6 @@ import org.apache.cassandra.utils.Throwables;
 import static org.apache.cassandra.inject.ActionBuilder.newActionBuilder;
 import static org.apache.cassandra.inject.Expression.quote;
 import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assume.assumeTrue;
 
@@ -89,8 +88,6 @@ public class SingleNodeQueryFailureTest extends SAITester
 
     private void testFailedMultiIndexesQuery(String name, Class<?> targetClass, String targetMethod) throws Throwable
     {
-        String table = "test_mixed_index_query_" + name;
-
         Injection injection = Injections.newCustom(name)
                                         .add(newInvokePoint().onClass(targetClass).onMethod(targetMethod))
                                         .add(newActionBuilder().actions().doThrow(RuntimeException.class, quote("Injected failure!")))
@@ -99,7 +96,6 @@ public class SingleNodeQueryFailureTest extends SAITester
         createTable(CREATE_TABLE_TEMPLATE);
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-        waitForIndexQueryable();
 
         execute("INSERT INTO %s (id, v1, v2) VALUES ('1', 0, '0')");
         flush();

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorCompressionTest.java
@@ -123,7 +123,6 @@ public class VectorCompressionTest extends VectorTester
 
         // create index after compaction so we don't have to wait for it to (potentially) build twice
         createIndex("CREATE CUSTOM INDEX ON %s(v) " + String.format("USING 'StorageAttachedIndex' WITH OPTIONS = {'source_model': '%s'}", model));
-        waitForIndexQueryable();
 
         // get a View of the sstables that contain indexed data
         var sim = getCurrentColumnFamilyStore().indexManager;

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -124,12 +124,11 @@ public class CompactionTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testConcurrentQueryWithCompaction() throws Throwable
+    public void testConcurrentQueryWithCompaction()
     {
         createTable(CREATE_TABLE_TEMPLATE);
         String v1IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-        waitForIndexQueryable();
 
         int num = 10;
         for (int i = 0; i < num; i++)
@@ -151,7 +150,7 @@ public class CompactionTest extends AbstractMetricsTest
                     throw new RuntimeException(e);
                 }
             }
-        }, () -> upgradeSSTables());
+        }, this::upgradeSSTables);
 
         compactionTest.start();
 
@@ -166,8 +165,8 @@ public class CompactionTest extends AbstractMetricsTest
         try
         {
             createTable(CREATE_TABLE_TEMPLATE);
-            String v1IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-            String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+            String v1IndexName = createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+            String v2IndexName = createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v2"));
 
             int num = 10;
             for (int i = 0; i < num; i++)
@@ -199,7 +198,6 @@ public class CompactionTest extends AbstractMetricsTest
         createTable(CREATE_TABLE_TEMPLATE);
         String v1IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-        waitForIndexQueryable();
 
         int sstables = 2;
         int num = 10;
@@ -302,7 +300,6 @@ public class CompactionTest extends AbstractMetricsTest
                             // build indexes on SSTables that will be compacted soon
                             createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
                             createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-                            waitForIndexQueryable();
 
                             // continue in-progress compaction
                             compactionLatch.countDown();

--- a/test/unit/org/apache/cassandra/index/sai/functional/DiskSpaceTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/DiskSpaceTest.java
@@ -41,7 +41,6 @@ public class DiskSpaceTest extends SAITester
 
         // create index, disk space should include index components
         String indexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
-        waitForIndexQueryable();
 
         long indexSize = indexDiskSpaceUse();
         long sstableSizeWithIndex = totalDiskSpaceUsed();

--- a/test/unit/org/apache/cassandra/index/sai/functional/DropTableTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/DropTableTest.java
@@ -51,7 +51,6 @@ public class DropTableTest extends SAITester
         createTable(CREATE_TABLE_TEMPLATE);
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
-        waitForIndexQueryable();
 
         int rows = 100;
         for (int j = 0; j < rows; j++)

--- a/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
@@ -116,7 +116,7 @@ public class FailureTest extends SAITester
         Injection ssTableContextCreationFailure = newFailureOnEntry("context_failure_on_creation", SSTableContext.class, "<init>", RuntimeException.class);
         Injections.inject(ssTableContextCreationFailure);
 
-        String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+        String v2IndexName = createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v2"));
 
         // Verify that the initial index build fails...
         verifyInitialIndexFailed(v2IndexName);

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -39,17 +39,16 @@ import static org.junit.Assert.assertEquals;
 public class GroupComponentsTest extends SAITester
 {
     @Test
-    public void testInvalidateWithoutObsolete() throws Throwable
+    public void testInvalidateWithoutObsolete()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk) VALUES (1)");
         flush();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
-        StorageAttachedIndex index = (StorageAttachedIndex) group.getIndexes().iterator().next();
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
         Set<Component> components = group.activeComponents(sstable);
@@ -63,11 +62,10 @@ public class GroupComponentsTest extends SAITester
     }
 
     @Test
-    public void getLiveComponentsForEmptyIndex() throws Throwable
+    public void getLiveComponentsForEmptyIndex()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk) VALUES (1)");
         flush();
 
@@ -83,11 +81,10 @@ public class GroupComponentsTest extends SAITester
     }
 
     @Test
-    public void getLiveComponentsForPopulatedIndex() throws Throwable
+    public void getLiveComponentsForPopulatedIndex()
     {
         createTable("CREATE TABLE %s (pk int primary key, value int)");
         IndexContext indexContext = createIndexContext(createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex'"), Int32Type.instance);
-        waitForIndexQueryable();
         execute("INSERT INTO %s (pk, value) VALUES (1, 1)");
         flush();
 

--- a/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
@@ -85,7 +85,7 @@ public class IndexBuildDeciderTest extends SAITester
     }
 
     @Test
-    public void testNoInitialBuildWithSAI() throws Throwable
+    public void testNoInitialBuildWithSAI()
     {
         createTable(CREATE_TABLE_TEMPLATE);
 
@@ -104,10 +104,10 @@ public class IndexBuildDeciderTest extends SAITester
 
         // create index: it's not queryable because IndexBuildDeciderWithoutInitialBuild skipped the initial build and
         // didn't consider the index queryable because there was already one sstable
-        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        createIndexAsync(String.format(CREATE_INDEX_TEMPLATE, "v1"));
         Awaitility.await("Index is not queryable")
                   .pollDelay(5, TimeUnit.SECONDS)
-                  .until(() -> !isIndexQueryable());
+                  .until(() -> !areAllTableIndexesQueryable());
         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE v1>=0")).isInstanceOf(ReadFailureException.class);
 
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore());

--- a/test/unit/org/apache/cassandra/index/sai/functional/NodeRestartTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/NodeRestartTest.java
@@ -66,7 +66,7 @@ public class NodeRestartTest extends SAITester
         // We should have completed no actual SSTable validations:
         assertValidationCount(0, 0);
 
-        assertFalse(isIndexQueryable());
+        assertFalse(areAllTableIndexesQueryable());
     }
 
     // We don't allow the node to actually join the ring before a valid index is ready to accept queries.
@@ -115,7 +115,6 @@ public class NodeRestartTest extends SAITester
 
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
         IndexContext literalIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2")), UTF8Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext,literalIndexContext, 1, 1);
         assertNumRows(1, "SELECT * FROM %%s WHERE v1 >= 0");
         assertNumRows(1, "SELECT * FROM %%s WHERE v2 = '0'");
@@ -127,8 +126,6 @@ public class NodeRestartTest extends SAITester
 
         assertNumRows(1, "SELECT * FROM %%s WHERE v1 >= 0");
         assertNumRows(1, "SELECT * FROM %%s WHERE v2 = '0'");
-
-        waitForIndexQueryable();
 
         // index components are included after restart
         verifyIndexComponentsIncludedInSSTable();
@@ -176,7 +173,6 @@ public class NodeRestartTest extends SAITester
         flush();
 
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext, null, 1, 0);
         assertNumRows(1, "SELECT * FROM %%s WHERE v1 >= 0");
         assertValidationCount(0, 0);

--- a/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SnapshotTest.java
@@ -52,7 +52,6 @@ public class SnapshotTest extends SAITester
         // Insert some initial data and create the index over it
         execute("INSERT INTO %s (id1, v1) VALUES ('0', 0);");
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
-        waitForIndexQueryable();
         flush();
         verifyIndexFiles(numericIndexContext, null, 1, 1, 0, 1, 0);
         // Note: This test will fail here if it is run on its own because the per-index validation
@@ -130,7 +129,6 @@ public class SnapshotTest extends SAITester
 
         // create index
         IndexContext numericIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1")), Int32Type.instance);
-        waitForIndexQueryable();
         verifyIndexFiles(numericIndexContext, null, 2, 0);
         assertValidationCount(0, 0);
 
@@ -150,7 +148,7 @@ public class SnapshotTest extends SAITester
 
         // Truncate the table
         truncate(false);
-        waitForAssert(() -> verifyNoIndexFiles());
+        waitForAssert(this::verifyNoIndexFiles);
         assertNumRows(0, "SELECT * FROM %%s WHERE v1 >= 0");
         assertValidationCount(0, 0);
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
@@ -76,7 +76,6 @@ public class IndexGroupMetricsTest extends AbstractMetricsTest
         // create second index
         String v2IndexName = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
         IndexContext v2IndexContext = createIndexContext(v2IndexName, UTF8Type.instance);
-        waitForIndexQueryable();
 
         // same number of sstables, but more string index files.
         int stringIndexOpenFileCount = sstables * V1OnDiskFormat.instance.openFilesPerIndex(v2IndexContext);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -38,7 +38,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
     private static final String CREATE_INDEX_TEMPLATE = "CREATE CUSTOM INDEX IF NOT EXISTS " + INDEX + " ON %s." + TABLE + "(%s) USING 'StorageAttachedIndex'";
 
     @Test
-    public void testSameIndexNameAcrossKeyspaces() throws Throwable
+    public void testSameIndexNameAcrossKeyspaces()
     {
         String keyspace1 = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
         String keyspace2 = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
@@ -62,7 +62,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testMetricRelease() throws Throwable
+    public void testMetricRelease()
     {
         String keyspace = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
 
@@ -80,7 +80,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testMetricsThroughWriteLifecycle() throws Throwable
+    public void testMetricsThroughWriteLifecycle()
     {
         String keyspace = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
 
@@ -129,7 +129,8 @@ public class IndexMetricsTest extends AbstractMetricsTest
 
         waitForIndexCompaction(keyspace, TABLE, INDEX);
 
-        waitForIndexQueryable(keyspace, TABLE);
+        waitForTableIndexesQueryable(keyspace, TABLE);
+
         ResultSet rows = executeNet(String.format("SELECT id1 FROM %s.%s WHERE v1 >= 0", keyspace, TABLE));
         assertEquals(rowCount, rows.all().size());
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -48,7 +48,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void testSameIndexNameAcrossKeyspaces() throws Throwable
+    public void testSameIndexNameAcrossKeyspaces()
     {
         String table = "test_same_index_name_across_keyspaces";
         String index = "test_same_index_name_across_keyspaces_index";
@@ -84,7 +84,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testMetricRelease() throws Throwable
+    public void testMetricRelease()
     {
         String table = "test_metric_release";
         String index = "test_metric_release_index";
@@ -93,7 +93,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace, table));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForIndexQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES ('0', 0, '0')");
 
@@ -112,7 +111,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testIndexQueryWithPartitionKey() throws Throwable
+    public void testIndexQueryWithPartitionKey()
     {
         String table = "test_range_key_type_with_index";
         String index = "test_range_key_type_with_index_index";
@@ -136,7 +135,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
             flush(keyspace, table);
         }
 
-        waitForIndexQueryable(keyspace, table);
+        waitForTableIndexesQueryable(keyspace, table);
 
         ResultSet rows2 = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE id1 = '36' and v1 < 51");
         assertEquals(1, rows2.all().size());
@@ -160,7 +159,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreeQueryMetricsWithSingleIndex() throws Throwable
+    public void testKDTreeQueryMetricsWithSingleIndex()
     {
         String table = "test_metrics_through_write_lifecycle";
         String index = "test_metrics_through_write_lifecycle_index";
@@ -184,7 +183,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
         compact(keyspace, table);
         waitForIndexCompaction(keyspace, table, index);
 
-        waitForIndexQueryable(keyspace, table);
+        waitForTableIndexesQueryable(keyspace, table);
 
         ResultSet rows = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 >= 0");
 
@@ -224,7 +223,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreePostingsQueryMetricsWithSingleIndex() throws Throwable
+    public void testKDTreePostingsQueryMetricsWithSingleIndex()
     {
         String table = "test_kdtree_postings_metrics_through_write_lifecycle";
         String v1Index = "test_kdtree_postings_metrics_through_write_lifecycle_v1_index";
@@ -239,7 +238,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         int rowsWritten = 50;
 
-
         for (int i = 0; i < rowsWritten; i++)
         {
             execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES (?, ?, ?)", Integer.toString(i), i, Integer.toString(i));
@@ -249,7 +247,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
         compact(keyspace, table);
         waitForIndexCompaction(keyspace, table, v1Index);
 
-        waitForIndexQueryable(keyspace, table);
+        waitForTableIndexesQueryable(keyspace, table);
 
         ResultSet rows = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v1 >= 0");
 
@@ -267,7 +265,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testInvertedIndexQueryMetricsWithSingleIndex() throws Throwable
+    public void testInvertedIndexQueryMetricsWithSingleIndex()
     {
         String table = "test_invertedindex_metrics_through_write_lifecycle";
         String index = "test_invertedindex_metrics_through_write_lifecycle_index";
@@ -290,10 +288,9 @@ public class QueryMetricsTest extends AbstractMetricsTest
         compact(keyspace, table);
         waitForIndexCompaction(keyspace, table, index);
 
-        waitForIndexQueryable(keyspace, table);
+        waitForTableIndexesQueryable(keyspace, table);
 
         ResultSet rows = executeNet("SELECT id1 FROM " + keyspace + "." + table + " WHERE v2 = '0'");
-
 
         int actualRows = rows.all().size();
         assertEquals(1, actualRows);
@@ -330,7 +327,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreePartitionsReadAndRowsFiltered() throws Throwable
+    public void testKDTreePartitionsReadAndRowsFiltered()
     {
         String table = "test_rows_filtered_large_partition";
         String index = "test_rows_filtered_large_partition_index";
@@ -341,7 +338,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
                                   "WITH compaction = {'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }", keyspace,  table));
 
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForIndexQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (0, 0, 0)");
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (1, 1, 1)");
@@ -362,7 +358,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testKDTreeQueryEarlyExit() throws Throwable
+    public void testKDTreeQueryEarlyExit()
     {
         String table = "test_queries_exited_early";
         String index = "test_queries_exited_early_index";
@@ -373,7 +369,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
                                   "WITH compaction = {'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }", keyspace, table));
 
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForIndexQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (0, 0, 0)");
         execute("INSERT INTO " + keyspace + "." + table + "(pk, ck, v1) VALUES (1, 1, 1)");
@@ -398,12 +393,12 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForEquals(objectName("KDTreeIntersectionEarlyExits", keyspace, table, index, GLOBAL_METRIC_TYPE), 2L);
     }
 
-    private long getPerQueryMetrics(String keyspace, String table, String metricsName) throws Exception
+    private long getPerQueryMetrics(String keyspace, String table, String metricsName)
     {
         return (long) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, PER_QUERY_METRIC_TYPE));
     }
 
-    private long getTableQueryMetrics(String keyspace, String table, String metricsName) throws Exception
+    private long getTableQueryMetrics(String keyspace, String table, String metricsName)
     {
         return (long) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, TableQueryMetrics.TABLE_QUERY_METRIC_TYPE));
     }

--- a/test/unit/org/apache/cassandra/index/sai/metrics/StateMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/StateMetricsTest.java
@@ -39,7 +39,7 @@ public class StateMetricsTest extends AbstractMetricsTest
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void testMetricRelease() throws Throwable
+    public void testMetricRelease()
     {
         String table = "test_metric_release";
         String index = "test_metric_release_index";
@@ -48,7 +48,6 @@ public class StateMetricsTest extends AbstractMetricsTest
 
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace, table));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index, keyspace, table, "v1"));
-        waitForIndexQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES ('0', 0, '0')");
 
@@ -66,7 +65,7 @@ public class StateMetricsTest extends AbstractMetricsTest
     }
 
     @Test
-    public void testMetricCreation() throws Throwable
+    public void testMetricCreation()
     {
         String table = "test_table";
         String index = "test_index";
@@ -75,7 +74,6 @@ public class StateMetricsTest extends AbstractMetricsTest
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace, table));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index+"_v1", keyspace, table, "v1"));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, index+"_v2", keyspace, table, "v2"));
-        waitForIndexQueryable(keyspace, table);
 
         execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES ('0', 0, '0')");
         execute("INSERT INTO " + keyspace + "." + table + " (id1, v1, v2) VALUES ('1', 1, '1')");
@@ -96,7 +94,7 @@ public class StateMetricsTest extends AbstractMetricsTest
         waitForEquals(objectNameNoIndex("TotalQueryableIndexCount", keyspace, table, TABLE_STATE_METRIC_TYPE), 2);
     }
 
-    private int getTableStateMetrics(String keyspace, String table, String metricsName) throws Exception
+    private int getTableStateMetrics(String keyspace, String table, String metricsName)
     {
         return (int) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, TABLE_STATE_METRIC_TYPE));
     }

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -66,11 +66,10 @@ public class IndexViewManagerTest extends SAITester
     }
 
     @Test
-    public void testUpdateFromFlush() throws Throwable
+    public void testUpdateFromFlush()
     {
         createTable("CREATE TABLE %S (k INT PRIMARY KEY, v INT)");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         IndexContext columnContext = columnIndex(getCurrentColumnFamilyStore(), indexName);
         View initialView = columnContext.getView();
@@ -85,11 +84,10 @@ public class IndexViewManagerTest extends SAITester
     }
 
     @Test
-    public void testUpdateFromCompaction() throws Throwable
+    public void testUpdateFromCompaction()
     {
         createTable("CREATE TABLE %S (k INT PRIMARY KEY, v INT)");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         ColumnFamilyStore store = getCurrentColumnFamilyStore();
         IndexContext columnContext = columnIndex(store, indexName);
@@ -123,7 +121,6 @@ public class IndexViewManagerTest extends SAITester
     {
         String tableName = createTable("CREATE TABLE %S (k INT PRIMARY KEY, v INT)");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         ColumnFamilyStore store = getCurrentColumnFamilyStore();
         IndexContext columnContext = columnIndex(store, indexName);

--- a/test/unit/org/apache/cassandra/index/sai/virtual/IndexesSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/IndexesSystemViewTest.java
@@ -78,14 +78,14 @@ public class IndexesSystemViewTest extends SAITester
 
         // create the index simulating a long build and verify that there is an empty record in the virtual table
         Injections.inject(blockIndexBuild);
-        String v1IndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
+        String v1IndexName = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(v1) USING '%s'", StorageAttachedIndex.class.getName()));
 
         assertRows(execute(SELECT), row(v1IndexName, "v1", false, true, false, 0, 0L));
 
         // unblock the long build and verify that there is an finished empty record in the virtual table
         blockIndexBuild.countDown();
         blockIndexBuild.disable();
-        waitForIndexQueryable();
+        waitForIndexQueryable(v1IndexName);
         assertRows(execute(SELECT), row(v1IndexName, "v1", true, false, false, 0, 0L));
 
         // insert some data and verify that virtual table record is still empty since we haven't flushed yet
@@ -104,7 +104,7 @@ public class IndexesSystemViewTest extends SAITester
 
         // create a second index, this should create a new additional entry in the table
         String v2IndexName = createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v2) USING '%s'", StorageAttachedIndex.class.getName()));
-        waitForIndexQueryable();
+        waitForIndexQueryable(v2IndexName);
         assertRows(execute(SELECT),
                    row(v1IndexName, "v1", true, false, false, 2, 3L),
                    row(v2IndexName, "v2", true, false, true, 2, 3L));

--- a/test/unit/org/apache/cassandra/index/sai/virtual/SSTablesSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/SSTablesSystemViewTest.java
@@ -74,11 +74,10 @@ public class SSTablesSystemViewTest extends SAITester
     }
 
     @Test
-    public void testVirtualTableThroughIndexLifeCycle() throws Throwable
+    public void testVirtualTableThroughIndexLifeCycle()
     {
         createTable("CREATE TABLE %s (k int, c int, v1 int, v2 int, PRIMARY KEY (k, c))");
         String v1IndexName = createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
 
         String insert = "INSERT INTO %s(k, c, v1, v2) VALUES (?, ?, ?, ?)";
 
@@ -106,7 +105,6 @@ public class SSTablesSystemViewTest extends SAITester
 
         // create a second index, this should create a new additional entry in the table for each sstable
         String v2IndexName = createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
-        waitForIndexQueryable();
         Object[] row3 = readRow(v2IndexName, id1, "v2", 1L, 0L, 0L);
         Object[] row4 = readRow(v2IndexName, id2, "v2", 2L, 0L, 1L);
         assertRows(execute(SELECT), row1, row2, row3, row4);
@@ -160,7 +158,7 @@ public class SSTablesSystemViewTest extends SAITester
                              String columnName,
                              long cellCount,
                              long minSSTableRowId,
-                             long maxSSTableRowId) throws Exception
+                             long maxSSTableRowId)
     {
         for (SSTableId generation : generations)
         {
@@ -176,7 +174,7 @@ public class SSTablesSystemViewTest extends SAITester
                              String columnName,
                              long cellCount,
                              long minSSTableRowId,
-                             long maxSSTableRowId) throws Exception
+                             long maxSSTableRowId)
     {
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         StorageAttachedIndex sai = (StorageAttachedIndex) cfs.indexManager.getIndexByName(indexName);

--- a/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
@@ -91,7 +91,6 @@ public class SegmentsSystemViewTest extends SAITester
         createTable("CREATE TABLE %s (k int, c int, v1 int, v2 text, PRIMARY KEY (k, c))");
         String numericIndex = createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex' WITH OPTIONS = {'enable_segment_compaction':true}");
         String stringIndex = createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex' WITH OPTIONS = {'enable_segment_compaction':true}");
-        waitForIndexQueryable();
 
         int num = 100;
 


### PR DESCRIPTION
Port of CASSANDRA-18521, fixes the flakiness of LiteralOrderTest.testTextPrefixes.