### PR TITLE
CC5 fix for CNDB-11311 to correct use of SSTableWatcher.discoverCompo…

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -430,7 +430,6 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
                                      boolean validate,
                                      boolean isOffline)
     {
-        components = SSTableWatcher.instance.discoverComponents(descriptor, components);
         SSTableReaderLoadingBuilder<?, ?> builder = descriptor.getFormat().getReaderFactory().loadingBuilder(descriptor, metadata, components);
 
         return builder.build(owner, validate, !isOffline);

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderLoadingBuilder.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.IOOptions;
 import org.apache.cassandra.io.sstable.KeyReader;
 import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
 import org.apache.cassandra.metrics.TableMetrics;
@@ -71,15 +72,17 @@ public abstract class SSTableReaderLoadingBuilder<R extends SSTableReader, B ext
 
     public R build(SSTable.Owner owner, boolean validate, boolean online)
     {
-        checkArgument(components.contains(Components.DATA), "Data component is missing for sstable %s", descriptor);
+        Set<Component> discoveredComponents = SSTableWatcher.instance.discoverComponents(descriptor, components);
+
+        checkArgument(discoveredComponents.contains(Components.DATA), "Data component is missing for sstable %s", descriptor);
         if (validate)
-            checkArgument(this.components.containsAll(descriptor.getFormat().primaryComponents()), "Some required components (%s) are missing for sstable %s", Sets.difference(descriptor.getFormat().primaryComponents(), this.components), descriptor);
+            checkArgument(discoveredComponents.containsAll(descriptor.getFormat().primaryComponents()), "Some required components (%s) are missing for sstable %s", Sets.difference(descriptor.getFormat().primaryComponents(), this.components), descriptor);
 
         B builder = (B) descriptor.getFormat().getReaderFactory().builder(descriptor);
         builder.setOpenReason(NORMAL);
         builder.setMaxDataAge(Clock.Global.currentTimeMillis());
         builder.setTableMetadataRef(tableMetadataRef);
-        builder.setComponents(components);
+        builder.setComponents(discoveredComponents);
 
         R reader = null;
 

--- a/src/java/org/apache/cassandra/io/sstable/format/TOCComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/TOCComponent.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
@@ -113,6 +114,7 @@ public class TOCComponent
         {
             try
             {
+                SSTableWatcher.instance.discoverComponents(descriptor);
                 return TOCComponent.loadTOC(descriptor);
             }
             catch (FileNotFoundException | NoSuchFileException e)


### PR DESCRIPTION
…nents from CNDB-1707: Port remote file system abstractions to Stargazer

Summary of the change:
* Add call to `SSTableWatcher.instance.discoverComponents(descriptor)` - this is used in CNDB to download/unpack the archive from remote storage, if needed - to `TOCComponent.loadOrCreate(descriptor)`.  This is the equivalent location to `SSTable.componentsFor` in `main`.
* Move call to `SSTableWatcher.instance.discoverComponents(descriptor, components)` from `SSTableReader.open` to `SSTableReadingLoaderBuilder.build`. This is equivalent to `SSTableReader.open`, `SSTableReader.openForBatch` and `TrieIndexSSTableReader.open` in CC `main`.