### PR TITLE
Add warning when rewriting TOC that does not exist

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -367,6 +367,18 @@ public abstract class SSTable
     private static void rewriteTOC(Descriptor descriptor, Collection<Component> components)
     {
         File tocFile = descriptor.fileFor(Component.TOC);
+        // As this method *re*-write the TOC (and is currently only called by "unregisterComponents"), it should only
+        // be called in contexts where the TOC is expected to exist. If it doesn't, there is probably something
+        // unexpected happening, so we log relevant information to help diagnose a potential earlier problem.
+        // But in principle, this isn't a big deal for this method, and we still end up with the TOC in the state we
+        // expect.
+        if (!tocFile.exists())
+        {
+            // Note: we pass a dummy runtime exception as a simple way to get a stack-trace. Knowing from where this
+            // is called in this case is likely useful information.
+            logger.warn("Was asked to 'rewrite' TOC file {} for sstable {}, but it does not exists. The file will be created but this is unexpected. The components to 'overwrite' are: {}", tocFile, descriptor, components, new RuntimeException());
+        }
+
         writeTOC(tocFile, components, OVERWRITE);
     }
 


### PR DESCRIPTION
When we call the method to rewrite the TOC file of an sstable, we expect that TOC to exists previously. It's not important to the rewrite itself, we can still get the end state we want regardless, but not having a TOC is unexpected and could be a delayed sign of an earlier issue. Before commit bc62d52652241866e00dea371d133ed0118946b6, we used to log a warning in that situation (technically, we used to log if we couldn't delete the prior version of the TOC, and having that file not existing was the main reason this would fail). This patch adds back a log warning for that situation, so we can keep an eye on that unexpected situation.