### PR TITLE
CNDB-11322 main-5.0: Fix TrieMemtableIndexTest.indexIteratorTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/memory/OffHeapTrieMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/OffHeapTrieMemtableIndexTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.memtable.AbstractShardedMemtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OffHeapTrieMemtableIndexTest extends AbstractTrieMemtableIndexTest
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.getRawConfig().memtable_allocation_type = Config.MemtableAllocationType.offheap_buffers;
+        AbstractTrieMemtableIndexTest.setUpClass();
+    }
+
+    @Test
+    public void offHeapAllocation()
+    {
+        memtableIndex = new TrieMemtableIndex(indexContext, memtable);
+        assertEquals(AbstractShardedMemtable.getDefaultShardCount(), memtableIndex.shardCount());
+
+        assertEquals(0, memtable.getAllocator().onHeap().owns());
+        assertEquals(0, memtable.getAllocator().offHeap().owns());
+
+        for (int row = 0; row < 100; row++)
+        {
+            addRow(row, row);
+        }
+
+        assertTrue(memtable.getAllocator().onHeap().owns() > 0);
+        assertTrue(memtable.getAllocator().offHeap().owns() > 0);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/memory/OnHeapTrieMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/OnHeapTrieMemtableIndexTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.memory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.memtable.AbstractShardedMemtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OnHeapTrieMemtableIndexTest extends AbstractTrieMemtableIndexTest
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.getRawConfig().memtable_allocation_type = Config.MemtableAllocationType.heap_buffers;
+        AbstractTrieMemtableIndexTest.setUpClass();
+    }
+
+    @Test
+    public void onHeapAllocation()
+    {
+        memtableIndex = new TrieMemtableIndex(indexContext, memtable);
+        assertEquals(AbstractShardedMemtable.getDefaultShardCount(), memtableIndex.shardCount());
+
+        assertEquals(0, memtable.getAllocator().onHeap().owns());
+        assertEquals(0, memtable.getAllocator().offHeap().owns());
+
+        for (int row = 0; row < 100; row++)
+        {
+            addRow(row, row);
+        }
+
+        assertTrue(memtable.getAllocator().onHeap().owns() > 0);
+        assertEquals(0, memtable.getAllocator().offHeap().owns());
+    }
+}


### PR DESCRIPTION
I think the problem is that the test sets `TrieMemtable.BUFFER_TYPE` through reflection multiple times, but there are other parts of the code reading and retaining that before the change. Also, separate accesses to the unmodified `DatabaseDescriptor.getMemtableAllocationType()` might conflict with the modified `TrieMemtable.BUFFER_TYPE`.

The proposed approach splits the test into separate classes for off-heap and on-heap scenarios, and sets `config.memtable_allocation_type` at the beginning of the tests, before initialization. That way we can ensure that we have the proper config everywhere.

Note also that [CASSANDRA-19326](https://issues.apache.org/jira/browse/CASSANDRA-19326) has switched memtable_allocation_type from offheap_objects to heap_buffers in `test/conf/cassandra.yaml`, while the test seems to assume that the default is still off-heap. The modified test should be independent of those changes.