### PR TITLE
CNDB-11356: Remove mocking in InternalNodeProbe spying on StorageServiceMBean

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Future version (tbd)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
 Merged from 5.0:
+ * Remove mocking in InternalNodeProbe spying on StorageServiceMBean (CASSANDRA-18152)
  * Fix ClassCastException  from jdk GaloisCounterMode when using JDK17 provider (CASSANDRA-18180)
  * Prevent InaccessibleObjectException when the Leak Detector is traversing objects (CASSANDRA-18708)
  * Remove Scripted UDFs internals; hooks to be added later in CASSANDRA-17281 (CASSANDRA-18252)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -64,7 +64,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+import javax.management.ListenerNotFoundException;
 import javax.management.NotificationBroadcasterSupport;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;
@@ -310,6 +313,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 Keyspace.open(keyspace).snapshot(snapshotName, null, false, null);
         }
     }
+
+    @VisibleForTesting // this is used for dtests only, see CASSANDRA-18152
+    public volatile boolean skipNotificationListeners = false;
 
     @Deprecated
     public boolean isInShutdownHook()
@@ -6333,4 +6339,26 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("RepairRpcTimeout set to {}ms via JMX", timeoutInMillis);
     }
 
+    @Override
+    public void removeNotificationListener(NotificationListener listener) throws ListenerNotFoundException
+    {
+        if (!skipNotificationListeners)
+            super.removeNotificationListener(listener);
+    }
+
+    @Override
+    public void removeNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback) throws ListenerNotFoundException
+    {
+        if (!skipNotificationListeners)
+            super.removeNotificationListener(listener, filter, handback);
+    }
+
+    @Override
+    public void addNotificationListener(NotificationListener listener,
+                                        NotificationFilter filter,
+                                        Object handback) throws java.lang.IllegalArgumentException
+    {
+        if (!skipNotificationListeners)
+            super.addNotificationListener(listener, filter, handback);
+    }
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -314,6 +314,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    // Newer versions of mockito contain mockito-inline which creates an issue in our test environment. Without this
+    // change, mocking of static methods is a problem with our DTest framework
     @VisibleForTesting // this is used for dtests only, see CASSANDRA-18152
     public volatile boolean skipNotificationListeners = false;
 

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -907,9 +907,9 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
     public NodeToolResult nodetoolResult(boolean withNotifications, String... commandAndArgs)
     {
         return sync(() -> {
-            try (CapturingOutput output = new CapturingOutput())
+            try (CapturingOutput output = new CapturingOutput();
+                 DTestNodeTool nodetool = new DTestNodeTool(withNotifications, output.delegate))
             {
-                DTestNodeTool nodetool = new DTestNodeTool(withNotifications, output.delegate);
                 // install security manager to get informed about the exit-code
                 System.setSecurityManager(new SecurityManager()
                 {
@@ -993,15 +993,18 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
         }
     }
 
-    public static class DTestNodeTool extends NodeTool {
+    public static class DTestNodeTool extends NodeTool implements AutoCloseable
+    {
         private final StorageServiceMBean storageProxy;
         private final CollectingNotificationListener notifications = new CollectingNotificationListener();
-
+        private final InternalNodeProbe internalNodeProbe;
         private Throwable latestError;
 
-        public DTestNodeTool(boolean withNotifications, Output output) {
+        public DTestNodeTool(boolean withNotifications, Output output)
+        {
             super(new InternalNodeProbeFactory(withNotifications), output);
-            storageProxy = new InternalNodeProbe(withNotifications).getStorageService();
+            internalNodeProbe = new InternalNodeProbe(withNotifications);
+            storageProxy = internalNodeProbe.getStorageService();
             storageProxy.addNotificationListener(notifications, null, null);
         }
 
@@ -1046,6 +1049,12 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                 return;
             super.err(e);
             latestError = e;
+        }
+
+        @Override
+        public void close()
+        {
+            internalNodeProbe.close();
         }
     }
 


### PR DESCRIPTION
patch by Stefan Miklosovic; reviewed by Andrés de la Peña for CASSANDRA-18152

Fix for org.apache.cassandra.distributed.test.FullRepairCoordinatorFastTest

Port [CASSANDRA-18152](https://issues.apache.org/jira/browse/CASSANDRA-18152)