### PR TITLE
CNDB-11388: ChunkCache rebuffer wait timeouts

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -64,7 +64,7 @@ import org.apache.cassandra.metrics.ChunkCacheMetrics;
 import org.apache.cassandra.utils.memory.BufferPool;
 import org.apache.cassandra.utils.memory.BufferPools;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.CHUNK_CACHE_REBUFFER_JOIN_TIMEOUT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.CHUNK_CACHE_REBUFFER_WAIT_TIMEOUT_MS;
 
 public class ChunkCache
         implements RemovalListener<ChunkCache.Key, ChunkCache.Buffer>, CacheSize
@@ -426,12 +426,12 @@ public class ChunkCache
                         }
                         else
                         {
-                            chunk = existing.orTimeout(CHUNK_CACHE_REBUFFER_JOIN_TIMEOUT.getInt(), TimeUnit.MILLISECONDS).join();
+                            chunk = existing.get(CHUNK_CACHE_REBUFFER_WAIT_TIMEOUT_MS.getInt(), TimeUnit.MILLISECONDS);
                         }
                     }
                     else
                     {
-                        chunk = cachedValue.orTimeout(CHUNK_CACHE_REBUFFER_JOIN_TIMEOUT.getInt(), TimeUnit.MILLISECONDS).join();
+                        chunk = cachedValue.get(CHUNK_CACHE_REBUFFER_WAIT_TIMEOUT_MS.getInt(), TimeUnit.MILLISECONDS);
                     }
 
                     buf = chunk.reference();

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -512,10 +512,10 @@ public enum CassandraRelevantProperties
     DEDICATED_STAGE_EXECUTOR_ENABLED("cassandra.stage.dedicated_executor", "false"),
 
     /**
-     * Hotfix property to allow setting the maximum time that CachingRebufferer.rebuffer will wait when joining
-     * a CompletableFuture fetched from the cache. This is part of a migitation for DBPE-13261
+     * This property allows configuring the maximum time that CachingRebufferer.rebuffer will wait when waiting for a
+     * CompletableFuture fetched from the cache to complete. This is part of a migitation for DBPE-13261.
      */
-    CHUNK_CACHE_REBUFFER_JOIN_TIMEOUT("cassandra.chunk_cache_rebuffer_join_timeout_ms", "30000");
+    CHUNK_CACHE_REBUFFER_WAIT_TIMEOUT_MS("cassandra.chunk_cache_rebuffer_wait_timeout_ms", "30000");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {


### PR DESCRIPTION
Set timeouts when joining CompletableFutures fetched while rebuffering from the ChunkCache. Configurable via cassandra.chunk_cache_rebuffer_join_timeout_ms, defaults to 30000 ms.