### PR TITLE
CNDB-11391 main-5.0: Set cassandra.test.processorCount default to 4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,13 +132,10 @@
     <property name="cassandra.test.use_prepared" value="true" />
 
     <!-- The number of active processors seen by JVM -->
-    <property name="cassandra.test.processorCount" value="2"/>
+    <property name="cassandra.test.processorCount" value="4"/>
 
     <!-- skip flushing schema tables during tests -->
     <property name="cassandra.test.flush_local_schema_changes" value="true" />
-
-    <!-- fast shutdown of messaging service -->
-    <property name="cassandra.test.messagingService.nonGracefulShutdown" value="false"/>
 
     <!-- fast shutdown of messaging service -->
     <property name="cassandra.test.messagingService.nonGracefulShutdown" value="true"/>


### PR DESCRIPTION
Sets `cassandra.test.processorCount` default to 4, same as in `main`. It will also make it consistent with the `-XX:ActiveProcessorCount=4` option used by `ide/idea/workspace.xml`.