### PR TITLE
CNDB-10716: do not use lambdas as they don't work with Jamm 3 on JDK22

### DIFF
--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -56,8 +56,15 @@ public class ClusteringComparator implements Comparator<Clusterable>
     private final Comparator<IndexInfo> indexReverseComparator;
     private final Comparator<Clusterable> reverseComparator;
 
-    private final Comparator<Row> rowComparator = (r1, r2) -> compare((ClusteringPrefix<?>) r1.clustering(),
-                                                                      (ClusteringPrefix<?>) r2.clustering());
+    private final Comparator<Row> rowComparator = new Comparator<>()
+    {
+        @Override
+        public int compare(Row r1, Row r2)
+        {
+            return ClusteringComparator.this.compare((ClusteringPrefix<?>) r1.clustering(),
+                           (ClusteringPrefix<?>) r2.clustering());
+        }
+    };
 
     public ClusteringComparator(AbstractType<?>... clusteringTypes)
     {
@@ -69,11 +76,34 @@ public class ClusteringComparator implements Comparator<Clusterable>
         // copy the list to ensure despatch is monomorphic
         this.clusteringTypes = ImmutableList.copyOf(clusteringTypes);
 
-        this.indexComparator = (o1, o2) -> ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.lastName,
-                                                                             (ClusteringPrefix<?>) o2.lastName);
-        this.indexReverseComparator = (o1, o2) -> ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.firstName,
-                                                                                    (ClusteringPrefix<?>) o2.firstName);
-        this.reverseComparator = (c1, c2) -> ClusteringComparator.this.compare(c2, c1);
+        this.indexComparator = new Comparator<>()
+        {
+            @Override
+            public int compare(IndexInfo o1, IndexInfo o2)
+            {
+                return ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.lastName,
+                               (ClusteringPrefix<?>) o2.lastName);
+            }
+        };
+
+        this.indexReverseComparator = new Comparator<>()
+        {
+            @Override
+            public int compare(IndexInfo o1, IndexInfo o2)
+            {
+                return ClusteringComparator.this.compare((ClusteringPrefix<?>) o1.firstName,
+                               (ClusteringPrefix<?>) o2.firstName);
+            }
+        };
+
+        this.reverseComparator = new Comparator<>()
+        {
+            @Override
+            public int compare(Clusterable o1, Clusterable o2)
+            {
+                return ClusteringComparator.this.compare(o2, o1);
+            }
+        };
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -118,8 +118,21 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
             throw new IllegalStateException();
         }
 
-        comparatorSet = new ValueComparators((l, r) -> compare(l, ByteArrayAccessor.instance, r, ByteArrayAccessor.instance),
-                                             (l, r) -> compare(l, ByteBufferAccessor.instance, r, ByteBufferAccessor.instance));
+        comparatorSet = new ValueComparators(new Comparator<>()
+        {
+            @Override
+            public int compare(byte[] l, byte[] r)
+            {
+                return AbstractType.this.compare(l, ByteArrayAccessor.instance, r, ByteArrayAccessor.instance);
+            }
+        }, new Comparator<>()
+        {
+            @Override
+            public int compare(ByteBuffer l, ByteBuffer r)
+            {
+                return AbstractType.this.compare(l, ByteBufferAccessor.instance, r, ByteBufferAccessor.instance);
+            }
+        });
 
         this.isMultiCell = isMultiCell;
 


### PR DESCRIPTION
Jamm doesn't work on JDK22 with hidden classes, generated from Lamdas

```
java.lang.UnsupportedOperationException: can't get field offset on a hidden class: private final org.apache.cassandra.db.ClusteringComparator org.apache.cassandra.db.ClusteringComparator$$Lambda/0x00007f6b17593298.arg$1
	at jdk.unsupported/sun.misc.Unsafe.objectFieldOffset(Unsafe.java:652)
	at org.github.jamm.MemoryLayoutSpecification.sizeOfInstanceWithUnsafe(MemoryLayoutSpecification.java:108)
	at org.github.jamm.MemoryLayoutSpecification.sizeOfWithUnsafe(MemoryLayoutSpecification.java:89)
	at org.github.jamm.MemoryMeter.measure(MemoryMeter.java:217)
	at org.github.jamm.MemoryMeter.measureDeep(MemoryMeter.java:259)
	at org.apache.cassandra.utils.ObjectSizes.measureDeep(ObjectSizes.java:216)
	at org.apache.cassandra.cql3.QueryProcessor.measurePStatementCacheEntrySize(QueryProcessor.java:890)
	at org.apache.cassandra.cql3.QueryProcessor.storePreparedStatement(QueryProcessor.java:755)
	at io.stargate.db.dse.impl.TenantAwareQueryHandler.prepare(TenantAwareQueryHandler.java:238)
	at org.apache.cassandra.transport.messages.PrepareMessage.execute(PrepareMessage.java:125)
	at org.apache.cassandra.transport.Message$Request.execute(Message.java:243)
```


This patch converts lambdas to inner classes