### PR TITLE
CNDB-11426 main-5.0: Fix PlanTest.testLazyAccessPropagation

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -1030,7 +1030,7 @@ public class PlanTest
     @Test
     public void testLazyAccessPropagation()
     {
-        Plan.KeysIteration indexScan1 = Mockito.mock(Plan.KeysIteration.class);
+        Plan.KeysIteration indexScan1 = Mockito.mock(Plan.KeysIteration.class, Mockito.CALLS_REAL_METHODS);
         Mockito.when(indexScan1.withAccess(Mockito.any())).thenReturn(indexScan1);
         Mockito.when(indexScan1.estimateCost()).thenReturn(new Plan.KeysIterationCost(20,0.0, 0.5));
         Mockito.when(indexScan1.estimateSelectivity()).thenReturn(0.001);


### PR DESCRIPTION
I think the failure is due to the version of Mockito used in 5.0 having different behaviour than the one in `main`. The test expects that the mock defaults to the real methods if no specific behaviour has been defined for them. That seems to be the default behaviour in `main`, but in 5.0 we need to specify it with Mockito settings.