### PR TITLE
CNDB-1141: Update SyncUtil for JDK11 and JDK17

### DIFF
--- a/conf/jvm17-server.options
+++ b/conf/jvm17-server.options
@@ -84,7 +84,6 @@
 --add-opens=java.base/java.io=ALL-UNNAMED
 --add-opens=java.base/java.util=ALL-UNNAMED
 
-
 ### GC logging options -- uncomment to enable
 
 # Java 11 (and newer) GC logging options:
@@ -115,7 +114,7 @@
 --add-modules jdk.incubator.vector
 
 ### Compatibility Options
---add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
 -Djava.security.manager=allow
 
 # The newline in the end of file is intentional


### PR DESCRIPTION
### What is the issue
Clean SyncUtil for newer JDK versions

### What does this PR fix and why was it fixed
Remove --add-opens java.base/java.nio=ALL-UNNAMED which is not needed anymore and clean SyncUtil

patch by Ekaterina Dimitrova; reviewed by Jacek Lewandowki for CASSANDRA-17909
### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits