### PR TITLE
CNDB-11137 v2: Allow SortedLocalRanges to be empty

### DIFF
--- a/src/java/org/apache/cassandra/db/DiskBoundaryManager.java
+++ b/src/java/org/apache/cassandra/db/DiskBoundaryManager.java
@@ -74,7 +74,7 @@ public class DiskBoundaryManager
         }
         while (directoriesVersion != DisallowedDirectories.getDirectoriesVersion()); // if directoriesVersion has changed we need to recalculate
 
-        if (localRanges == null || localRanges.getRanges().size() <= 1)
+        if (localRanges == null || localRanges.getRanges().isEmpty())
             return new DiskBoundaries(cfs, dirs, null, localRanges, directoriesVersion);
 
         List<Token> positions = getDiskBoundaries(localRanges.getRanges(), cfs.getPartitioner(), dirs);

--- a/src/java/org/apache/cassandra/db/SortedLocalRanges.java
+++ b/src/java/org/apache/cassandra/db/SortedLocalRanges.java
@@ -58,13 +58,17 @@ public class SortedLocalRanges
         this.realm = realm;
         this.ringVersion = ringVersion;
 
-        if (ranges == null || ranges.isEmpty())
+        if (ranges == null)
         {
             IPartitioner partitioner = realm.getPartitioner();
             var range = new Splitter.WeightedRange(1.0,
                                                    new Range<>(partitioner.getMinimumToken(),
                                                                partitioner.getMinimumToken()));
             this.ranges = List.of(range);
+        }
+        else if (ranges.isEmpty())
+        {
+            this.ranges = ranges;
         }
         else
         {

--- a/test/unit/org/apache/cassandra/db/SortedLocalRangesTest.java
+++ b/test/unit/org/apache/cassandra/db/SortedLocalRangesTest.java
@@ -113,14 +113,16 @@ public class SortedLocalRangesTest
         assertEquals(sortedRanges, sortedRanges);
         assertEquals(sortedRanges.hashCode(), sortedRanges.hashCode());
 
+        assertEquals(sortedRanges.getRanges(), ranges);
+
         assertFalse(sortedRanges.isOutOfDate());
-        assertEquals(1, sortedRanges.getRanges().size());
+        assertEquals(0, sortedRanges.getRanges().size());
         assertEquals(ringVersion, sortedRanges.getRingVersion());
 
-        // split(x) returns 1 range for all x <= 1
+        // split(x) returns 1 range for all x when empty
         assertEquals(1, sortedRanges.split(0).size());
-        for (int i = 1; i <= 10; i++)
-            assertEquals(i, sortedRanges.split(i).size());
+        for (int i = 0; i <= 10; i++)
+            assertEquals(1, sortedRanges.split(i).size());
     }
 
     @Test


### PR DESCRIPTION
Fixes #11137 Undoes v1 and instead allows SortedLocalRanges to be empty, allowing scrub to work and passing the test that v1 broke: https://jenkins-stargazer.aws.dsinternal.org/job/ds-cassandra-build-fast-ci-5.0/22/#showFailuresLink