### PR TITLE
CNDB-11438 main: Fix CompactionStrategyStatisticsTest

### DIFF
--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.db.BufferDecoratedKey;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DiskBoundaries;
 import org.apache.cassandra.db.SortedLocalRanges;
+import org.apache.cassandra.db.compaction.unified.RealEnvironment;
 import org.apache.cassandra.db.lifecycle.Tracker;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.dht.IPartitioner;
@@ -135,6 +136,7 @@ public class BaseCompactionStrategyTest
         localRanges = SortedLocalRanges.forTestingFull(realm);
 
         when(realm.metadata()).thenReturn(metadata);
+        when(realm.makeUCSEnvironment()).thenAnswer(invocation -> new RealEnvironment(realm));
         when(realm.getKeyspaceName()).thenReturn(keyspace);
         when(realm.getTableName()).thenReturn(table);
         when(realm.getDiskBoundaries()).thenReturn(diskBoundaries);

--- a/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
@@ -309,7 +309,7 @@ public class CQLUnifiedCompactionTest extends CQLTester
                                         .collect(Collectors.joining(","));
 
         createTable("create table %s (id int primary key, val blob) with compression = { 'enabled' : false } AND " +
-                    "compaction = {'class':'UnifiedCompactionStrategy', 'adaptive' : 'false', " +
+                    "compaction = {'class':'UnifiedCompactionStrategy', 'adaptive' : 'false', 'max_sstables_to_compact': 256, " +
                     String.format("'scaling_parameters' : '%s', 'min_sstable_size' : '0B', 'base_shard_count': '%d', 'log_all' : 'true'}",
                                   scalingParamsStr, numShards));
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
@@ -100,6 +100,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSstableSizeBytes);
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.prioritize(anyList())).thenAnswer(answ -> answ.getArgument(0));
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
@@ -163,6 +164,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSize);
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.prioritize(anyList())).thenAnswer(answ -> answ.getArgument(0));
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Overlaps;
 import org.apache.cassandra.utils.Pair;
 import org.mockito.Mockito;
 
@@ -104,6 +105,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.NONE);
         // Calculate the minimum shard size such that the top bucket compactions won't be considered "oversized" and
         // all will be allowed to run. The calculation below assumes (1) that compactions are considered "oversized"
         // if they are more than 1/2 of the max shard size; (2) that mockSSTables uses 15% less than the max SSTable
@@ -166,6 +168,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.NONE);
 
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
@@ -106,7 +106,6 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
-        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
         // Calculate the minimum shard size such that the top bucket compactions won't be considered "oversized" and
         // all will be allowed to run. The calculation below assumes (1) that compactions are considered "oversized"
         // if they are more than 1/2 of the max shard size; (2) that mockSSTables uses 15% less than the max SSTable
@@ -170,7 +169,6 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
-        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
 
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyStatisticsTest.java
@@ -105,7 +105,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
-        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.NONE);
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
         // Calculate the minimum shard size such that the top bucket compactions won't be considered "oversized" and
         // all will be allowed to run. The calculation below assumes (1) that compactions are considered "oversized"
         // if they are more than 1/2 of the max shard size; (2) that mockSSTables uses 15% less than the max SSTable
@@ -168,7 +168,7 @@ public class CompactionStrategyStatisticsTest extends BaseCompactionStrategyTest
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.random()).thenCallRealMethod();
-        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.NONE);
+        when(controller.overlapInclusionMethod()).thenReturn(Overlaps.InclusionMethod.TRANSITIVE);
 
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -123,6 +123,7 @@ public abstract class ControllerTest
 
         when(metadata.toString()).thenReturn("");
         when(replicationStrategy.getReplicationFactor()).thenReturn(ReplicationFactor.fullOnly(3));
+        when(cfs.makeUCSEnvironment()).thenAnswer(invocation -> new RealEnvironment(cfs));
         when(cfs.getKeyspaceReplicationStrategy()).thenReturn(replicationStrategy);
         when(cfs.getKeyspaceName()).thenAnswer(invocation -> keyspaceName);
         when(cfs.getDiskBoundaries()).thenReturn(boundaries);


### PR DESCRIPTION
### What is the issue
Two tests in `CompactionStrategyStatisticsTest` are failing with NPE because `Controller.overlapInclusionMethod()` returns `null` on a mocked object. 

See: https://github.com/riptano/cndb/issues/11438

### What does this PR fix and why was it fixed
This changes the affected tests to return a value for `overlapInclusionMethod()` on the mocked object.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits