### PR TITLE
CNDB-11435 Fix CQLSH TestConstants.test_cql_reserved_keywords

### DIFF
--- a/pylib/cqlshlib/cqlhandling.py
+++ b/pylib/cqlshlib/cqlhandling.py
@@ -26,7 +26,7 @@ Hint = pylexotron.Hint
 
 cql_keywords_reserved = set((
     'add', 'allow', 'alter', 'and', 'apply', 'asc', 'authorize', 'batch', 'begin', 'by', 'columnfamily', 'create',
-    'delete', 'desc', 'describe', 'drop', 'entries', 'execute', 'from', 'full', 'grant', 'if', 'in', 'index',
+    'delete', 'desc', 'describe', 'drop', 'entries', 'execute', 'from', 'full', 'grant', 'geo_distance', 'if', 'in', 'index',
     'infinity', 'insert', 'into', 'is', 'keyspace', 'limit', 'materialized', 'modify', 'nan', 'norecursive', 'not',
     'null', 'of', 'on', 'or', 'order', 'primary', 'rename', 'revoke', 'schema', 'select', 'set', 'table', 'to', 'token',
     'truncate', 'unlogged', 'update', 'use', 'using', 'view', 'where', 'with'


### PR DESCRIPTION
### What is the issue
The CQLSH TestConstants.test_cql_reserved_keywords has been failing since #837 

### What does this PR fix and why was it fixed
Adds missing `geo_distance` keyword to the list of cqlsh reserved words.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits