### PR TITLE
CNDB-11436: Fix cqlsh test_complete_in_select_limit_clause

### DIFF
--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -840,8 +840,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
     def test_complete_in_select_limit_clause(self):
         self.trycompletions('SELECT * FROM system.peers LI', immediate='MIT ')
-        self.trycompletions('SELECT * FROM system.peers LIMIT', choices=['<wholenumber>'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT ', choices=['<wholenumber>'])
         self.trycompletions('SELECT * FROM system.peers LIMIT 1 ', choices=[';', 'ALLOW', 'OFFSET'])
         self.trycompletions('SELECT * FROM system.peers LIMIT 1 OF', immediate='FSET ')
-        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET', choices=['<wholenumber>'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET ', choices=['<wholenumber>'])
         self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET 1 ', choices=[';', 'ALLOW'])


### PR DESCRIPTION
Port of https://github.com/datastax/cassandra/commit/5652cd799452e14449fec05019847995801d42b5 from `main-5.0`.