### PR TITLE
CNDB-11219: Make TokenAllocatorBase take a supplier for first token allocation

### DIFF
--- a/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
+++ b/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -47,6 +48,14 @@ public class NoReplicationTokenAllocator<Unit> extends TokenAllocatorBase<Unit>
                                        IPartitioner partitioner)
     {
         super(sortedTokens, strategy, partitioner);
+    }
+
+    public NoReplicationTokenAllocator(NavigableMap<Token, Unit> sortedTokens,
+                                       ReplicationStrategy<Unit> strategy,
+                                       IPartitioner partitioner,
+                                       Supplier<Token> seedTokenSupplier)
+    {
+        super(sortedTokens, strategy, partitioner, seedTokenSupplier);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorFastTest.java
+++ b/test/unit/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocatorFastTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.dht.tokenallocator;
+
+import java.util.Random;
+import java.util.TreeMap;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NoReplicationTokenAllocatorFastTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
+    @Test
+    public void testOverridenSeedToken()
+    {
+        var random = new Random();
+        var initialToken = Murmur3Partitioner.instance.getToken(UTF8Type.instance.fromString("initial"));
+        // Confirm that up to num_tokens 32, we get the same first token.
+        for (int i = 0; i < 32; i++)
+        {
+            var allocator = new NoReplicationTokenAllocator<>(new TreeMap<>(), new BasicReplicationStrategy(),
+                                                              Murmur3Partitioner.instance, () -> initialToken);
+            var tokens = allocator.addUnit(random.nextInt(), i);
+            var first = tokens.stream().findFirst();
+            assertTrue(first.isPresent());
+            assertEquals(first.get().getToken(), initialToken);
+        }
+    }
+
+    private static class BasicReplicationStrategy implements ReplicationStrategy<Integer>
+    {
+        @Override
+        public int replicas()
+        {
+            return 1;
+        }
+
+        @Override
+        public Object getGroup(Integer unit)
+        {
+            return unit;
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue

https://github.com/riptano/cndb/issues/11219 - this work is part of an ongoing effort to make deterministic token allocation work. @blambov pointed out that it would be simplest to provide the seed token to the `TokenAllocatorBase`, so I do that here. I also revert part of the PR from https://github.com/riptano/cndb/issues/11217 that was not necessary.

### What does this PR fix and why was it fixed

This PR updates the TokenAllocatorBase and the
NoReplicationTokenAllocator by making each take
a Supplier<Token> object. This supplier is used
to allocate the first token in the ring. The
change is backwards compatible.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits