### PR TITLE
CNDB-11492: Bump up Version.LATEST to DC

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -68,7 +68,7 @@ public class Version
     // The latest version can be configured to be an earlier version to support partial upgrades that don't
     // write newer versions of the on-disk formats. This is volatile rather than final so that tests may
     // use reflection to change it and safely publish across threads.
-    private static volatile Version LATEST = parse(System.getProperty("cassandra.sai.latest.version", DB.version));
+    private static volatile Version LATEST = parse(System.getProperty("cassandra.sai.latest.version", DC.version));
 
     private static final Pattern GENERATION_PATTERN = Pattern.compile("\\d+");
 

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -564,10 +564,10 @@ public class PlanTest
 
         String prettyStr = limit.toStringRecursive();
 
-        assertEquals("Limit 3 (rows: 3.0, cost/row: 3895.8, cost: 56001.1..67688.5)\n" +
-                     " └─ Filter pred1 < X AND pred2 < X AND pred4 < X (sel: 1.000000000) (rows: 3.0, cost/row: 3895.8, cost: 56001.1..67688.5)\n" +
-                     "     └─ Fetch (rows: 3.0, cost/row: 3895.8, cost: 56001.1..67688.5)\n" +
-                     "         └─ KeysSort (keys: 3.0, cost/key: 3792.4, cost: 56001.1..67378.2)\n" +
+        assertEquals("Limit 3 (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
+                     " └─ Filter pred1 < X AND pred2 < X AND pred4 < X (sel: 1.000000000) (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
+                     "     └─ Fetch (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
+                     "         └─ KeysSort (keys: 3.0, cost/key: 3792.4, cost: 44171.3..55548.4)\n" +
                      "             └─ Union (keys: 1999.0, cost/key: 14.8, cost: 13500.0..43001.3)\n" +
                      "                 ├─ Intersection (keys: 1000.0, cost/key: 29.4, cost: 9000.0..38401.3)\n" +
                      "                 │   ├─ NumericIndexScan of pred2_idx (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 0.1, cost: 4500.0..4700.0)\n" +
@@ -691,8 +691,8 @@ public class PlanTest
     public void replaceIntersectionAndAnnSortWithAnnScan()
     {
         // Similar like the previous test, but now with an intersection:
-        Plan.KeysIteration indexScan1 = factory.indexScan(saiPred1, (long) (0.1 * factory.tableMetrics.rows));
-        Plan.KeysIteration indexScan2 = factory.indexScan(saiPred2, (long) (0.2 * factory.tableMetrics.rows));
+        Plan.KeysIteration indexScan1 = factory.indexScan(saiPred1, (long) (0.5 * factory.tableMetrics.rows));
+        Plan.KeysIteration indexScan2 = factory.indexScan(saiPred2, (long) (0.1 * factory.tableMetrics.rows));
         Plan.KeysIteration intersection = factory.intersection(Lists.newArrayList(indexScan1, indexScan2));
         Plan.KeysIteration sort = factory.sort(intersection, ordering);
         Plan.RowsIteration fetch = factory.fetch(sort);
@@ -905,8 +905,8 @@ public class PlanTest
         testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.00001, 0.00001), List.of(2));
 
         testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 1.0, 1.0), List.of(0));
-        testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 1.0), List.of(0));
-        testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 1.0), List.of(0));
+        testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 1.0), List.of(0, 1));
+        testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 1.0), List.of(0, 1));
         testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 0.5), List.of(1));
         testIntersectionsUnderAnnSort(table1M, Expression.Op.RANGE, List.of(0.1, 0.1, 0.2), List.of(1));
 


### PR DESCRIPTION
Additionally, this required a few minor query optimizer test adjustments because the ANN cost model coefficients changed in version DC.


### What does this PR fix and why was it fixed
Enable performance improvements introduced by version DC od SAI format.
We can do it now because the version already deployed in production (in September) understands DC format.


### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits