### PR TITLE
CNDB-11498: Make main branch compile on JDK22

### DIFF
--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
@@ -790,7 +790,7 @@ abstract class AbstractPatriciaTrie<K, V> extends AbstractTrie<K, V>
      * This is implemented by going always to the left until
      * we encounter a valid uplink. That uplink is the first key.
      */
-    TrieEntry<K, V> firstEntry()
+    public TrieEntry<K, V> firstEntry()
     {
         // if Trie is empty, no first node.
         return isEmpty() ? null : followLeft(root);

--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
@@ -790,6 +790,7 @@ abstract class AbstractPatriciaTrie<K, V> extends AbstractTrie<K, V>
      * This is implemented by going always to the left until
      * we encounter a valid uplink. That uplink is the first key.
      */
+    @Override
     public TrieEntry<K, V> firstEntry()
     {
         // if Trie is empty, no first node.

--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/AbstractPatriciaTrie.java
@@ -790,7 +790,7 @@ abstract class AbstractPatriciaTrie<K, V> extends AbstractTrie<K, V>
      * This is implemented by going always to the left until
      * we encounter a valid uplink. That uplink is the first key.
      */
-    @Override
+    // @Override needed in JDK 21+.
     public TrieEntry<K, V> firstEntry()
     {
         // if Trie is empty, no first node.

--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
@@ -414,7 +414,7 @@ public class PatriciaTrie<K, V> extends AbstractPatriciaTrie<K, V> implements Se
      * <p>This is implemented by going always to the right until
      * we encounter a valid uplink. That uplink is the last key.
      */
-    private TrieEntry<K, V> lastEntry()
+    public TrieEntry<K, V> lastEntry()
     {
         return followRight(root.left);
     }

--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
@@ -414,7 +414,7 @@ public class PatriciaTrie<K, V> extends AbstractPatriciaTrie<K, V> implements Se
      * <p>This is implemented by going always to the right until
      * we encounter a valid uplink. That uplink is the last key.
      */
-    @Override
+    // @Override needed in JDK 21+.
     public TrieEntry<K, V> lastEntry()
     {
         return followRight(root.left);

--- a/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/trie/PatriciaTrie.java
@@ -414,6 +414,7 @@ public class PatriciaTrie<K, V> extends AbstractPatriciaTrie<K, V> implements Se
      * <p>This is implemented by going always to the right until
      * we encounter a valid uplink. That uplink is the last key.
      */
+    @Override
     public TrieEntry<K, V> lastEntry()
     {
         return followRight(root.left);

--- a/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
@@ -312,6 +312,35 @@ public class BTreeSet<V> implements NavigableSet<V>, List<V>
         throw new UnsupportedOperationException();
     }
 
+    public BTreeSet<V> reversed()
+    {
+        throw new UnsupportedOperationException();
+    }
+    public V removeLast()
+    {
+        throw new UnsupportedOperationException();
+    }
+    public V removeFirst()
+    {
+        throw new UnsupportedOperationException();
+    }
+    public V getLast()
+    {
+        throw new UnsupportedOperationException();
+    }
+    public V getFirst()
+    {
+        throw new UnsupportedOperationException();
+    }
+    public void addLast(V v)
+    {
+        throw new UnsupportedOperationException();
+    }
+    public void addFirst(V v)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     public static class BTreeRange<V> extends BTreeSet<V>
     {
         // both inclusive

--- a/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
@@ -312,30 +312,43 @@ public class BTreeSet<V> implements NavigableSet<V>, List<V>
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public BTreeSet<V> reversed()
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public V removeLast()
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public V removeFirst()
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public V getLast()
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public V getFirst()
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public void addLast(V v)
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
     public void addFirst(V v)
     {
         throw new UnsupportedOperationException();

--- a/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTreeSet.java
@@ -312,43 +312,43 @@ public class BTreeSet<V> implements NavigableSet<V>, List<V>
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public BTreeSet<V> reversed()
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public V removeLast()
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public V removeFirst()
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public V getLast()
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public V getFirst()
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public void addLast(V v)
     {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // @Override needed in JDK 21+.
     public void addFirst(V v)
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
- `firstEntry()` and `lastEntry()` were trying to assign weaker access privileges (e.g., private or package-private) when they need to be public according to the interface they are implementing (SequencedMap).
- JDK 21+ adds `SequencedCollection`: The `List` and `NavigableSet` interfaces now inherit from a new interface called `SequencedCollection`, which introduces the `reversed()` method. However, `NavigableSet.reversed()` returns a `NavigableSet`, while `List.reversed()` returns a `List`. This results in a conflict, as the types are incompatible.
Open question:
Instead of making the two methods `public`, we can use some kind of wrapper/adapter, but it will probably affect performance. I would appreciate more eyes and opinions on that. 

### What is the issue
...

### What does this PR fix and why was it fixed
...

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits