### PR TITLE
CNDB-11480 main-5.0: Split tests extending AbstractQueryTester

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/AbstractQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/AbstractQueryTester.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.distributed.test.sai;
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -32,15 +32,15 @@ import org.junit.runners.Parameterized;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.shared.Byteman;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
-import org.apache.cassandra.index.sai.cql.DataModel;
-import org.apache.cassandra.index.sai.cql.IndexQuerySupport;
+import org.apache.cassandra.index.sai.cql.datamodels.DataModel;
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 import org.apache.cassandra.utils.Shared;
 
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 
 @RunWith(Parameterized.class)
-public class AbstractQueryTester extends TestBaseImpl
+abstract class AbstractQueryTester extends TestBaseImpl
 {
     protected static final String INJECTION_SCRIPT = "RULE count searches\n" +
                                                      "CLASS org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher\n" +
@@ -48,7 +48,7 @@ public class AbstractQueryTester extends TestBaseImpl
                                                      "AT ENTRY\n" +
                                                      "IF TRUE\n" +
                                                      "DO\n" +
-                                                     "   org.apache.cassandra.distributed.test.sai.AbstractQueryTester$Counter.increment()\n" +
+                                                     "   org.apache.cassandra.distributed.test.sai.datamodels.AbstractQueryTester$Counter.increment()\n" +
                                                      "ENDRULE\n";
 
     @Parameterized.Parameter(0)

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeExecutor.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeExecutor.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.distributed.test.sai;
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -25,8 +25,9 @@ import java.util.List;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.test.sai.SAIUtil;
 import org.apache.cassandra.distributed.util.ColumnTypeUtil;
-import org.apache.cassandra.index.sai.cql.DataModel;
+import org.apache.cassandra.index.sai.cql.datamodels.DataModel;
 
 public class MultiNodeExecutor implements DataModel.Executor
 {

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeExecutor.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeExecutor.java
@@ -90,12 +90,12 @@ public class MultiNodeExecutor implements DataModel.Executor
     @Override
     public void counterReset()
     {
-        AbstractQueryTester.Counter.reset();
+        MultiNodeQueryTester.Counter.reset();
     }
 
     @Override
     public long getCounter()
     {
-        return AbstractQueryTester.Counter.get();
+        return MultiNodeQueryTester.Counter.get();
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
@@ -40,7 +40,7 @@ import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 
 @RunWith(Parameterized.class)
-abstract class AbstractQueryTester extends TestBaseImpl
+abstract class MultiNodeQueryTester extends TestBaseImpl
 {
     protected static final String INJECTION_SCRIPT = "RULE count searches\n" +
                                                      "CLASS org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher\n" +

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
@@ -48,7 +48,7 @@ abstract class MultiNodeQueryTester extends TestBaseImpl
                                                      "AT ENTRY\n" +
                                                      "IF TRUE\n" +
                                                      "DO\n" +
-                                                     "   org.apache.cassandra.distributed.test.sai.datamodels.AbstractQueryTester$Counter.increment()\n" +
+                                                     "   org.apache.cassandra.distributed.test.sai.datamodels.MultiNodeQueryTester$Counter.increment()\n" +
                                                      "ENDRULE\n";
 
     @Parameterized.Parameter(0)

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 
-public class QueryCellDeletionsTest extends AbstractQueryTester
+public class QueryCellDeletionsTest extends MultiNodeQueryTester
 {
     @Test
     public void testCellDeletions() throws Throwable

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsTest.java
@@ -16,17 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.distributed.test.sai;
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.cql.IndexQuerySupport;
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 
-public class QueryRowDeletionsTest extends AbstractQueryTester
+public class QueryCellDeletionsTest extends AbstractQueryTester
 {
     @Test
-    public void testRowDeletions() throws Throwable
+    public void testCellDeletions() throws Throwable
     {
-        IndexQuerySupport.rowDeletions(executor, dataModel.get(), sets);
+        IndexQuerySupport.cellDeletions(executor, dataModel.get(), sets);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsTest.java
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import org.junit.Test;
 
-public class QueryCellDeletionsTest extends AbstractQueryTester
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class QueryRowDeletionsTest extends AbstractQueryTester
 {
     @Test
-    public void testCellDeletions() throws Throwable
+    public void testRowDeletions() throws Throwable
     {
-        IndexQuerySupport.cellDeletions(executor, dataModel, sets);
+        IndexQuerySupport.rowDeletions(executor, dataModel.get(), sets);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 
-public class QueryRowDeletionsTest extends AbstractQueryTester
+public class QueryRowDeletionsTest extends MultiNodeQueryTester
 {
     @Test
     public void testRowDeletions() throws Throwable

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveTest.java
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import org.junit.Test;
 
-public class QueryWriteLifecycleTest extends AbstractQueryTester
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class QueryTimeToLiveTest extends AbstractQueryTester
 {
     @Test
-    public void testWriteLifecycle() throws Throwable
+    public void testTimeToLive() throws Throwable
     {
-        IndexQuerySupport.writeLifecycle(executor, dataModel, sets);
+        IndexQuerySupport.timeToLive(executor, dataModel.get(), sets);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 
-public class QueryTimeToLiveTest extends AbstractQueryTester
+public class QueryTimeToLiveTest extends MultiNodeQueryTester
 {
     @Test
     public void testTimeToLive() throws Throwable

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleTest.java
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
 
 import org.junit.Test;
 
-public class QueryRowDeletionsTest extends AbstractQueryTester
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class QueryWriteLifecycleTest extends AbstractQueryTester
 {
     @Test
-    public void testRowDeletions() throws Throwable
+    public void testWriteLifecycle() throws Throwable
     {
-        IndexQuerySupport.rowDeletions(executor, dataModel, sets);
+        IndexQuerySupport.writeLifecycle(executor, dataModel.get(), sets);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 
-public class QueryWriteLifecycleTest extends AbstractQueryTester
+public class QueryWriteLifecycleTest extends MultiNodeQueryTester
 {
     @Test
     public void testWriteLifecycle() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/AbstractQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/AbstractQueryTester.java
@@ -16,14 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -35,8 +37,9 @@ import org.apache.cassandra.inject.Injections;
 
 import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
 
+@Ignore
 @RunWith(Parameterized.class)
-public class AbstractQueryTester extends SAITester
+abstract class AbstractQueryTester extends SAITester
 {
     protected static final Injections.Counter INDEX_QUERY_COUNTER = Injections.newCounter("IndexQueryCounter")
                                                                               .add(newInvokePoint().onClass(StorageAttachedIndexSearcher.class).onMethod("search"))
@@ -73,10 +76,20 @@ public class AbstractQueryTester extends SAITester
         SAIUtil.setLatestVersion(latest);
     }
 
-
-    @SuppressWarnings("unused")
     @Parameterized.Parameters(name = "{0}_{1}")
-    public static List<Object[]> params() throws Throwable
+    public static List<Object[]> allParams()
+    {
+        List<Object[]> scenarios = new LinkedList<>();
+
+        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::baseDataModelParams));
+        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compoundKeyParams));
+        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams));
+        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams));
+
+        return scenarios;
+    }
+
+    protected static List<Object[]> allIndexVersionsParams(Function<Version, Object[]> params)
     {
         List<Object[]> scenarios = new LinkedList<>();
 
@@ -86,14 +99,40 @@ public class AbstractQueryTester extends SAITester
             if (version.equals(Version.BA))
                 continue;
 
-            scenarios.add(new Object[]{ version, new DataModel.BaseDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA), IndexQuerySupport.BASE_QUERY_SETS });
-            scenarios.add(new Object[]{ version, new DataModel.CompoundKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA), IndexQuerySupport.BASE_QUERY_SETS });
-            scenarios.add(new Object[]{ version, new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA), IndexQuerySupport.STATIC_QUERY_SETS });
-            scenarios.add(new Object[]{ version, new DataModel.CompositePartitionKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA),
-                                        ImmutableList.builder().addAll(IndexQuerySupport.BASE_QUERY_SETS).addAll(IndexQuerySupport.COMPOSITE_PARTITION_QUERY_SETS).build()});
-
+            scenarios.add(params.apply(version));
         }
 
         return scenarios;
+    }
+
+    protected static Object[] baseDataModelParams(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.BaseDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA),
+                             IndexQuerySupport.BASE_QUERY_SETS};
+    }
+
+    protected static Object[] compoundKeyParams(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompoundKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA),
+                             IndexQuerySupport.BASE_QUERY_SETS};
+    }
+
+    protected static Object[] compoundKeyWithStaticsParams(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA),
+                             IndexQuerySupport.STATIC_QUERY_SETS};
+    }
+
+    protected static Object[] compositePartitionKeyParams(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompositePartitionKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA),
+                             ImmutableList.<IndexQuerySupport.BaseQuerySet>builder()
+                                          .addAll(IndexQuerySupport.BASE_QUERY_SETS)
+                                          .addAll(IndexQuerySupport.COMPOSITE_PARTITION_QUERY_SETS)
+                                     .build() };
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/DataModel.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,9 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
 import java.util.Collections;
 import java.util.List;

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/IndexQuerySupport.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/IndexQuerySupport.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,17 +7,15 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +37,7 @@ import org.apache.cassandra.utils.Pair;
 import org.hamcrest.Matchers;
 
 import static org.apache.cassandra.distributed.test.TestBaseImpl.list;
-import static org.apache.cassandra.index.sai.cql.DataModel.INET_COLUMN;
+import static org.apache.cassandra.index.sai.cql.datamodels.DataModel.INET_COLUMN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsTester.java
@@ -15,27 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-/**
- * Force generates segments due to a small RAM size on compaction, to test segment splitting
- */
-public class TinySegmentQueryWriteLifecycleTest extends AbstractQueryTester
+@Ignore
+abstract class QueryCellDeletionsTester extends AbstractQueryTester
 {
-    @Before
-    public void setSegmentWriteBufferSpace() throws Throwable
-    {
-        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
-    }
-
     @Test
-    public void testWriteLifecycle() throws Throwable
+    public void testCellDeletions() throws Throwable
     {
-        IndexQuerySupport.writeLifecycle(executor, dataModel, sets);
+        IndexQuerySupport.cellDeletions(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsTester.java
@@ -21,7 +21,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
-abstract class QueryCellDeletionsTester extends AbstractQueryTester
+abstract class QueryCellDeletionsTester extends SingleNodeQueryTester
 {
     @Test
     public void testCellDeletions() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelTest.java
@@ -24,6 +24,6 @@ public class QueryCellDeletionsWithBaseDataModelTest extends QueryCellDeletionsT
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryCellDeletionsWithBaseDataModelTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class QueryCellDeletionsWithCompositePartitionKeyTest extends QueryCellDe
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryCellDeletionsWithCompositePartitionKeyTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryCellDeletionsWithCompoundKeyTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class QueryCellDeletionsWithCompoundKeyTest extends QueryCellDeletionsTes
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryCellDeletionsWithCompoundKeyWithStaticsTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class QueryCellDeletionsWithCompoundKeyWithStaticsTest extends QueryCellD
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsTester.java
@@ -21,7 +21,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
-abstract class QueryRowDeletionsTester extends AbstractQueryTester
+abstract class QueryRowDeletionsTester extends SingleNodeQueryTester
 {
     @Test
     public void testRowDeletions() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsTester.java
@@ -15,27 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-/**
- * Force generates segments due to a small RAM size on compaction, to test segment splitting
- */
-public class TinySegmentQueryTimeToLiveTest extends AbstractQueryTester
+@Ignore
+abstract class QueryRowDeletionsTester extends AbstractQueryTester
 {
-    @Before
-    public void setSegmentWriteBufferSpace() throws Throwable
-    {
-        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
-    }
-
     @Test
-    public void testTimeToLive() throws Throwable
+    public void testRowDeletions() throws Throwable
     {
-        IndexQuerySupport.timeToLive(executor, dataModel, sets);
+        IndexQuerySupport.rowDeletions(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class QueryRowDeletionsWithBaseModelTest extends QueryRowDeletionsTester
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryRowDeletionsWithBaseModelTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class QueryRowDeletionsWithCompositePartitionKeyTest extends QueryRowDele
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryRowDeletionsWithCompositePartitionKeyTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class QueryRowDeletionsWithCompoundKeyTest extends QueryRowDeletionsTeste
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryRowDeletionsWithCompoundKeyTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class QueryRowDeletionsWithCompoundKeyWithStaticsTest extends QueryRowDel
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryRowDeletionsWithCompoundKeyWithStaticsTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveTester.java
@@ -21,7 +21,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
-abstract class QueryTimeToLiveTester extends AbstractQueryTester
+abstract class QueryTimeToLiveTester extends SingleNodeQueryTester
 {
     @Test
     public void testTimeToLive() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveTester.java
@@ -15,18 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-package org.apache.cassandra.distributed.test.sai;
-
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.cql.IndexQuerySupport;
-
-public class QueryCellDeletionsTest extends AbstractQueryTester
+@Ignore
+abstract class QueryTimeToLiveTester extends AbstractQueryTester
 {
     @Test
-    public void testCellDeletions() throws Throwable
+    public void testTimeToLive() throws Throwable
     {
-        IndexQuerySupport.cellDeletions(executor, dataModel.get(), sets);
+        IndexQuerySupport.timeToLive(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryTimeToLiveWithBaseModelTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class QueryTimeToLiveWithBaseModelTest extends QueryTimeToLiveTester
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryTimeToLiveWithCompositePartitionKeyTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class QueryTimeToLiveWithCompositePartitionKeyTest extends QueryTimeToLiv
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class QueryTimeToLiveWithCompoundKeyTest extends QueryTimeToLiveTester
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryTimeToLiveWithCompoundKeyTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class QueryTimeToLiveWithCompoundKeyWithStaticsTest extends QueryTimeToLi
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryTimeToLiveWithCompoundKeyWithStaticsTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleTester.java
@@ -15,27 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-/**
- * Force generates segments due to a small RAM size on compaction, to test segment splitting
- */
-public class TinySegmentQueryCellDeletionsTest extends AbstractQueryTester
+@Ignore
+abstract class QueryWriteLifecycleTester extends AbstractQueryTester
 {
-    @Before
-    public void setSegmentWriteBufferSpace() throws Throwable
-    {
-        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
-    }
-
     @Test
-    public void testCellDeletions() throws Throwable
+    public void testWriteLifecycle() throws Throwable
     {
-        IndexQuerySupport.cellDeletions(executor, dataModel, sets);
+        IndexQuerySupport.writeLifecycle(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleTester.java
@@ -21,7 +21,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
-abstract class QueryWriteLifecycleTester extends AbstractQueryTester
+abstract class QueryWriteLifecycleTester extends SingleNodeQueryTester
 {
     @Test
     public void testWriteLifecycle() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class QueryWriteLifecycleWithBaseModelTest extends QueryWriteLifecycleTes
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryWriteLifecycleWithBaseModelTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class QueryWriteLifecycleWithCompositePartitionKeyTest extends QueryWrite
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryWriteLifecycleWithCompositePartitionKeyTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class QueryWriteLifecycleWithCompoundKeyTest extends QueryWriteLifecycleT
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryWriteLifecycleWithCompoundKeyTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class QueryWriteLifecycleWithCompoundKeyWithStaticsTest extends QueryWrit
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class QueryWriteLifecycleWithCompoundKeyWithStaticsTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeExecutor.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeExecutor.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
@@ -39,7 +39,7 @@ import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
 
 @Ignore
 @RunWith(Parameterized.class)
-abstract class AbstractQueryTester extends SAITester
+abstract class SingleNodeQueryTester extends SAITester
 {
     protected static final Injections.Counter INDEX_QUERY_COUNTER = Injections.newCounter("IndexQueryCounter")
                                                                               .add(newInvokePoint().onClass(StorageAttachedIndexSearcher.class).onMethod("search"))
@@ -81,10 +81,10 @@ abstract class AbstractQueryTester extends SAITester
     {
         List<Object[]> scenarios = new LinkedList<>();
 
-        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::baseDataModelParams));
-        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compoundKeyParams));
-        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams));
-        scenarios.addAll(allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams));
+        scenarios.addAll(allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams));
+        scenarios.addAll(allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams));
+        scenarios.addAll(allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams));
+        scenarios.addAll(allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams));
 
         return scenarios;
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsTester.java
@@ -15,15 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-public class QueryTimeToLiveTest extends AbstractQueryTester
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+/**
+ * Force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryCellDeletionsTester extends AbstractQueryTester
 {
-    @Test
-    public void testTimeToLive() throws Throwable
+    @Before
+    public void setSegmentWriteBufferSpace()
     {
-        IndexQuerySupport.timeToLive(executor, dataModel, sets);
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testCellDeletions() throws Throwable
+    {
+        IndexQuerySupport.cellDeletions(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsTester.java
@@ -27,7 +27,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
  * Force generates segments due to a small RAM size on compaction, to test segment splitting
  */
 @Ignore
-abstract class TinySegmentQueryCellDeletionsTester extends AbstractQueryTester
+abstract class TinySegmentQueryCellDeletionsTester extends SingleNodeQueryTester
 {
     @Before
     public void setSegmentWriteBufferSpace()

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryCellDeletionsWithBaseModelTest extends TinySegmentQueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryCellDeletionsWithBaseModelTest extends TinySegmentQ
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest extends TinySegmentQueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryCellDeletionsWithCompositePartitionKeyTest extends 
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryCellDeletionsWithCompoundKeyTest extends TinySegmen
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryCellDeletionsWithCompoundKeyTest extends TinySegmentQueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest extends
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsTest extends TinySegmentQueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsTester.java
@@ -15,18 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-package org.apache.cassandra.distributed.test.sai;
-
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.cql.IndexQuerySupport;
+import org.apache.cassandra.config.DatabaseDescriptor;
 
-public class QueryWriteLifecycleTest extends AbstractQueryTester
+/**
+ * Force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryRowDeletionsTester extends AbstractQueryTester
 {
-    @Test
-    public void testWriteLifecycle() throws Throwable
+    @Before
+    public void setSegmentWriteBufferSpace()
     {
-        IndexQuerySupport.writeLifecycle(executor, dataModel.get(), sets);
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testRowDeletions() throws Throwable
+    {
+        IndexQuerySupport.rowDeletions(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsTester.java
@@ -27,7 +27,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
  * Force generates segments due to a small RAM size on compaction, to test segment splitting
  */
 @Ignore
-abstract class TinySegmentQueryRowDeletionsTester extends AbstractQueryTester
+abstract class TinySegmentQueryRowDeletionsTester extends SingleNodeQueryTester
 {
     @Before
     public void setSegmentWriteBufferSpace()

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryRowDeletionsWithBaseModelTest extends TinySegmentQu
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryRowDeletionsWithBaseModelTest extends TinySegmentQueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest extends TinySegmentQueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryRowDeletionsWithCompositePartitionKeyTest extends T
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryRowDeletionsWithCompoundKeyTest extends TinySegmentQueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryRowDeletionsWithCompoundKeyTest extends TinySegment
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest extends 
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsTest extends TinySegmentQueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveTester.java
@@ -15,18 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.cassandra.index.sai.cql.datamodels;
 
-package org.apache.cassandra.distributed.test.sai;
-
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.cql.IndexQuerySupport;
+import org.apache.cassandra.config.DatabaseDescriptor;
 
-public class QueryTimeToLiveTest extends AbstractQueryTester
+/**
+ * Force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryTimeToLiveTester extends AbstractQueryTester
 {
+    @Before
+    public void setSegmentWriteBufferSpace()
+    {
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
     @Test
     public void testTimeToLive() throws Throwable
     {
-        IndexQuerySupport.timeToLive(executor, dataModel.get(), sets);
+        IndexQuerySupport.timeToLive(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveTester.java
@@ -27,7 +27,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
  * Force generates segments due to a small RAM size on compaction, to test segment splitting
  */
 @Ignore
-abstract class TinySegmentQueryTimeToLiveTester extends AbstractQueryTester
+abstract class TinySegmentQueryTimeToLiveTester extends SingleNodeQueryTester
 {
     @Before
     public void setSegmentWriteBufferSpace()

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryTimeToLiveWithBaseModelTest extends TinySegmentQueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryTimeToLiveWithBaseModelTest extends TinySegmentQuer
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest extends TinySegmentQueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryTimeToLiveWithCompositePartitionKeyTest extends Tin
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryTimeToLiveWithCompoundKeyTest extends TinySegmentQu
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryTimeToLiveWithCompoundKeyTest extends TinySegmentQueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest extends TinySegmentQueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsTest extends Ti
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleTester.java
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.index.sai.cql;
+package org.apache.cassandra.index.sai.cql.datamodels;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -25,17 +26,18 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 /**
  * Force generates segments due to a small RAM size on compaction, to test segment splitting
  */
-public class TinySegmentQueryRowDeletionsTest extends AbstractQueryTester
+@Ignore
+abstract class TinySegmentQueryWriteLifecycleTester extends AbstractQueryTester
 {
     @Before
-    public void setSegmentWriteBufferSpace() throws Throwable
+    public void setSegmentWriteBufferSpace()
     {
         DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
     }
 
     @Test
-    public void testRowDeletions() throws Throwable
+    public void testWriteLifecycle() throws Throwable
     {
-        IndexQuerySupport.rowDeletions(executor, dataModel, sets);
+        IndexQuerySupport.writeLifecycle(executor, dataModel, sets);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleTester.java
@@ -27,7 +27,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
  * Force generates segments due to a small RAM size on compaction, to test segment splitting
  */
 @Ignore
-abstract class TinySegmentQueryWriteLifecycleTester extends AbstractQueryTester
+abstract class TinySegmentQueryWriteLifecycleTester extends SingleNodeQueryTester
 {
     @Before
     public void setSegmentWriteBufferSpace()

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryWriteLifecycleWithBaseModelTest extends TinySegment
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryWriteLifecycleWithBaseModelTest extends TinySegmentQueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest extends
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryWriteLifecycleWithCompositePartitionKeyTest extends TinySegmentQueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryWriteLifecycleWithCompoundKeyTest extends TinySegmentQueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryWriteLifecycleWithCompoundKeyTest extends TinySegme
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest extends TinySegmentQueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
@@ -24,6 +24,6 @@ public class TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsTest extend
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> params()
     {
-        return allIndexVersionsParams(AbstractQueryTester::compoundKeyWithStaticsParams);
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
     }
 }


### PR DESCRIPTION
Split all the tests extending `AbstractQueryTester` so they are less prone to timeouts and better for CI parallelization. Each test class is split into a class per data model, and each class is still parameterized by index version. Also, move these tests and their utilities into their own package.

Relevant Slack discussion: https://datastax.slack.com/archives/C05LHP4HX5J/p1729784421174259