### PR TITLE
CNDB-11518 main-5.0: Split o.a.c.index.sai.cql.VectorTypeTest to prevent timeouts

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -19,43 +19,17 @@
 package org.apache.cassandra.index.sai.cql;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import org.apache.cassandra.index.sai.SAIUtil;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
-public class VectorCompactionTest extends VectorTester
+public class VectorCompactionTest extends VectorTester.Versioned
 {
-    @Parameterized.Parameter
-    public Version version;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data()
-    {
-        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
-    }
-
-    @Before
-    @Override
-    public void setup() throws Throwable
-    {
-        super.setup();
-        SAIUtil.setLatestVersion(version);
-    }
-
     @Test
     public void testCompactionWithEnoughRowsForPQAndDeleteARow()
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.plan.QueryController;
+
+public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
+{
+    @Test
+    public void testHybridSearchWithPrimaryKeyHoles() throws Throwable
+    {
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, val text, vec vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Insert rows into two sstables. The tokens for each PK are in each line's comment.
+        execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'A', [1, 3])"); // -4069959284402364209
+        execute("INSERT INTO %s (pk, val, vec) VALUES (2, 'A', [1, 2])"); // -3248873570005575792
+        // Make the last row in the sstable the correct result. That way we verify the ceiling logic
+        // works correctly.
+        execute("INSERT INTO %s (pk, val, vec) VALUES (3, 'A', [1, 1])"); // 9010454139840013625
+        flush();
+        execute("INSERT INTO %s (pk, val, vec) VALUES (5, 'A', [1, 5])"); // -7509452495886106294
+        execute("INSERT INTO %s (pk, val, vec) VALUES (4, 'A', [1, 4])"); // -2729420104000364805
+        execute("INSERT INTO %s (pk, val, vec) VALUES (6, 'A', [1, 6])"); // 2705480034054113608
+
+        // Get all rows using first predicate, then filter to get top 1
+        // Use a small limit to ensure we do not use brute force
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
+                       row(3));
+        });
+    }
+
+    // Clustering columns hit a different code path, we need both sets of tests, even though queries
+    // that expose the underlying regression are the same.
+    @Test
+    public void testHybridSearchWithPrimaryKeyHolesAndWithClusteringColumns() throws Throwable
+    {
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Insert rows into two sstables. The tokens for each PK are in each line's comment.
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])"); // -4069959284402364209
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (2, 1, 'A', [1, 2])"); // -3248873570005575792
+        // Make the last row in the sstable the correct result. That way we verify the ceiling logic
+        // works correctly.
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (3, 1, 'A', [1, 1])"); // 9010454139840013625
+        flush();
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (5, 1, 'A', [1, 5])"); // -7509452495886106294
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (4, 1, 'A', [1, 4])"); // -2729420104000364805
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (6, 1, 'A', [1, 6])"); // 2705480034054113608
+
+        // Get all rows using first predicate, then filter to get top 1
+        // Use a small limit to ensure we do not use brute force
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"),
+                       row(3));
+        });
+    }
+
+    @Test
+    public void testHybridSearchSequentialClusteringColumns() throws Throwable
+    {
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])");
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 2, 'A', [1, 2])");
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 3, 'A', [1, 1])");
+
+        // Get all rows using first predicate, then filter to get top 1
+        // Use a small limit to ensure we do not use brute force
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,3] LIMIT 1"), row(1));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,2] LIMIT 1"), row(2));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"), row(3));
+        });
+    }
+
+    @Test
+    public void testHybridSearchHoleInClusteringColumnOrdering() throws Throwable
+    {
+        setMaxBruteForceRows(0);
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        // Create two sstables. The first needs a hole forcing us to skip.
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])");
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 3, 'A', [1, 2])");
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 4, 'A', [1, 1])");
+        flush();
+        execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 2, 'A', [1, 4])");
+
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"), row(4));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,2] LIMIT 1"), row(3));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,3] LIMIT 1"), row(1));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,4] LIMIT 1"), row(2));
+        });
+    }
+
+    @Test
+    public void testHybridSearchSeqLogicForMappingPKsBackToRowIds() throws Throwable
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Insert rows into two sstables. The rows are interleaved to ensure binary search is less efficient, which
+        // pushes us to use a sequential scan when we map PKs back to row ids in the sstable.
+        int rowCount = 100;
+        // Insert even rows to first sstable
+        for (int i = 0; i < rowCount; i += 2)
+            execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, ?, 'A', ?)", i, vector(1, i));
+
+        flush();
+        // Insert odd rows to new sstable
+        for (int i = 1; i < rowCount; i += 2)
+            execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, ?, 'A', ?)", i, vector(1, i));
+
+        // Verify result for rows in different memtables/sstables
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,49] LIMIT 1"),
+                       row(49));
+            assertRows(execute("SELECT a FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,50] LIMIT 1"),
+                       row(50));
+        });
+    }
+
+    // This test covers a bug in the RowIdMatchingOrdinalsView logic. Essentially, when the final rows in a segment
+    // do not have an associated vector, we will think we can do fast mapping from row id to ordinal, but in reality
+    // we have to do bounds checking still.
+    @Test
+    public void testHybridIndexWithPartialRowInsertsAtSegmentBoundaries() throws Throwable
+    {
+        // This test requires the non-bruteforce route
+        setMaxBruteForceRows(0);
+        createTable("CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'A', [1, 1])");
+        execute("INSERT INTO %s (pk, val) VALUES (2, 'A')");
+        flush();
+        execute("INSERT INTO %s (pk, vec) VALUES (2, [1,3])");
+
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"), row(1));
+        });
+
+        // Assert the opposite with these writes where the lower bound is not present. (This case actually pushes us to
+        // use disk based ordinal mapping.)
+        execute("INSERT INTO %s (pk, val, vec) VALUES (2, 'A', [1, 2])");
+        execute("INSERT INTO %s (pk, val) VALUES (1, 'A')");
+
+        beforeAndAfterFlush(() -> {
+            assertRows(execute("SELECT pk FROM %s WHERE val = 'A' ORDER BY vec ANN OF [1,1] LIMIT 1"), row(1));
+        });
+    }
+
+    @Test
+    public void testHybridQueryWithMissingVectorValuesForMaxSegmentRow() throws Throwable
+    {
+        // Want to test the search then order path
+        QueryController.QUERY_OPT_LEVEL = 0;
+
+        // We use a clustered primary key to simplify the mental model for this test.
+        // The bug this test exposed happens when the last row(s) in a segment, based on PK order, are present
+        // in a peer index for an sstable's search index but not its vector index.
+        createTable("CREATE TABLE %s (k int, i int, v vector<float, 2>, c int,  PRIMARY KEY(k, i))");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+        // We'll manually control compaction.
+        disableCompaction();
+
+        // Insert a complete row. We need at least one row with a vector and an entry for column c to ensure that
+        // the query doesn't skip the query portion where we map from Primary Key back to sstable row id.
+        execute("INSERT INTO %s (k, i, v, c) VALUES (0, ?, ?, ?)", 1, vector(1, 1), 1);
+
+        // Insert the first and last row in the table and leave of the vector
+        execute("INSERT INTO %s (k, i, c) VALUES (0, 0, 0)");
+        execute("INSERT INTO %s (k, i, c) VALUES (0, 2, 2)");
+
+        // The bug was specifically for sstables after compaction, but it's trivial to cover the before flush and before
+        // compaction cases here, so we do.
+        runThenFlushThenCompact(() -> {
+            // There is only one row that satisfies the WHERE clause and has a vector for each of these queries.
+            assertRows(execute("SELECT i FROM %s WHERE c <= 1 ORDER BY v ANN OF [1,1] LIMIT 1"), row(1));
+            assertRows(execute("SELECT i FROM %s WHERE c >= 1 ORDER BY v ANN OF [1,1] LIMIT 1"), row(1));
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -20,21 +20,16 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -45,36 +40,17 @@ import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.Murmur3Partitioner;
-import org.apache.cassandra.index.sai.SAIUtil;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.utils.Glove;
 import org.assertj.core.data.Percentage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
-public class VectorLocalTest extends VectorTester
+public class VectorLocalTest extends VectorTester.VersionedWithChecksums
 {
-    @Parameterized.Parameter
-    public Version version;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data()
-    {
-        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
-    }
-
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     private static Glove.WordVector word2vec;
-
-    @Before
-    public void setup() throws Throwable
-    {
-        super.setup();
-        SAIUtil.setLatestVersion(version);
-    }
 
     @BeforeClass
     public static void loadModel() throws Throwable
@@ -101,7 +77,6 @@ public class VectorLocalTest extends VectorTester
         createIndex("CREATE CUSTOM INDEX lat_high_precision_index ON %s (lat_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
         createIndex("CREATE CUSTOM INDEX lat_lon_embedding_index ON %s (lat_lon_embedding) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'};");
         createIndex("CREATE CUSTOM INDEX lon_high_precision_index ON %s (lon_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
-        waitForTableIndexesQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
         List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(2)).collect(Collectors.toList());
@@ -137,11 +112,10 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void vectorEqualityTest() throws Throwable
+    public void vectorEqualityTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
 
         String vs = vectorString(new float[]{1.0f, 2.0f, 3.0f});
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, '1', [2.5, 3.5, 4.5])");
@@ -163,22 +137,21 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void randomizedTest() throws Throwable
+    public void randomizedTest()
     {
         randomizedTest(word2vec.dimension());
     }
 
     @Test
-    public void randomizedBqCompressedTest() throws Throwable
+    public void randomizedBqCompressedTest()
     {
         randomizedTest(2048);
     }
 
-    private void randomizedTest(int dimension) throws Throwable
+    private void randomizedTest(int dimension)
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimension));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
         List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(dimension)).collect(Collectors.toList());
@@ -229,11 +202,10 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void multiSSTablesTest() throws Throwable
+    public void multiSSTablesTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
         disableCompaction(keyspace());
 
         int sstableCount = getRandom().nextIntBetween(3, 6);
@@ -270,11 +242,10 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void partitionRestrictedTest() throws Throwable
+    public void partitionRestrictedTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -310,28 +281,27 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void partitionRestrictedWidePartitionTest() throws Throwable
+    public void partitionRestrictedWidePartitionTest()
     {
         partitionRestrictedWidePartitionTest(word2vec.dimension(), 0, 1000);
     }
 
     @Test
-    public void partitionRestrictedWidePartitionBqCompressedTest() throws Throwable
+    public void partitionRestrictedWidePartitionBqCompressedTest()
     {
         partitionRestrictedWidePartitionTest(2048, 0, Integer.MAX_VALUE);
     }
 
     @Test
-    public void partitionRestrictedWidePartitionPqCompressedTest() throws Throwable
+    public void partitionRestrictedWidePartitionPqCompressedTest()
     {
         partitionRestrictedWidePartitionTest(word2vec.dimension(), 2000, Integer.MAX_VALUE);
     }
 
-    public void partitionRestrictedWidePartitionTest(int dimension, int minvectorCount, int maxvectorCount) throws Throwable
+    public void partitionRestrictedWidePartitionTest(int dimension, int minvectorCount, int maxvectorCount)
     {
         createTable(String.format("CREATE TABLE %%s (pk int, ck int, val vector<float, %d>, PRIMARY KEY(pk, ck))", dimension));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
 
         int partitions = getRandom().nextIntBetween(20, 40);
         int vectorCountPerPartition = getRandom().nextIntBetween(50, 100);
@@ -390,11 +360,10 @@ public class VectorLocalTest extends VectorTester
     }
 
     @Test
-    public void rangeRestrictedTest() throws Throwable
+    public void rangeRestrictedTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -501,7 +470,6 @@ public class VectorLocalTest extends VectorTester
         // create index on existing sstable to produce multiple segments
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
         verifyChecksum();
 
         // query multiple on-disk indexes
@@ -534,7 +502,7 @@ public class VectorLocalTest extends VectorTester
 
     // search across multiple segments, combined with a non-ann predicate
     @Test
-    public void multipleNonAnnSegmentsTest() throws Throwable
+    public void multipleNonAnnSegmentsTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
         disableCompaction(KEYSPACE);
@@ -563,7 +531,6 @@ public class VectorLocalTest extends VectorTester
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        waitForTableIndexesQueryable();
         flush();
         verifyChecksum();
 
@@ -583,45 +550,45 @@ public class VectorLocalTest extends VectorTester
         }
     }
 
-    private UntypedResultSet search(String stringValue, float[] queryVector, int limit) throws Throwable
+    private UntypedResultSet search(String stringValue, float[] queryVector, int limit)
     {
         UntypedResultSet result = execute("SELECT * FROM %s WHERE str_val = '" + stringValue + "' ORDER BY val ann of " + Arrays.toString(queryVector) + " LIMIT " + limit);
         assertThat(result).hasSize(limit);
         return result;
     }
 
-    private UntypedResultSet search(float[] queryVector, int limit) throws Throwable
+    private UntypedResultSet search(float[] queryVector, int limit)
     {
         UntypedResultSet result = execute("SELECT * FROM %s ORDER BY val ann of " + Arrays.toString(queryVector) + " LIMIT " + limit);
         assertThat(result.size()).isCloseTo(limit, Percentage.withPercentage(5));
         return result;
     }
 
-    private UntypedResultSet search(Vector<Float> queryVector, int limit) throws Throwable
+    private UntypedResultSet search(Vector<Float> queryVector, int limit)
     {
         UntypedResultSet result = execute("SELECT * FROM %s ORDER BY val ann of ? LIMIT " + limit, queryVector);
         assertThat(result.size()).isCloseTo(limit, Percentage.withPercentage(5));
         return result;
     }
 
-    private List<float[]> searchWithRange(float[] queryVector, long minToken, long maxToken, int expectedSize) throws Throwable
+    private List<float[]> searchWithRange(float[] queryVector, long minToken, long maxToken, int expectedSize)
     {
         UntypedResultSet result = execute("SELECT * FROM %s WHERE token(pk) <= " + maxToken + " AND token(pk) >= " + minToken + " ORDER BY val ann of " + Arrays.toString(queryVector) + " LIMIT 1000");
         assertThat(result.size()).isCloseTo(expectedSize, Percentage.withPercentage(5));
         return getVectorsFromResult(result);
     }
 
-    private void searchWithNonExistingKey(float[] queryVector, int key) throws Throwable
+    private void searchWithNonExistingKey(float[] queryVector, int key)
     {
         searchWithKey(queryVector, key, 0);
     }
 
-    private void searchWithNonExistingKey(Vector<Float> queryVector, int key) throws Throwable
+    private void searchWithNonExistingKey(Vector<Float> queryVector, int key)
     {
         searchWithKey(queryVector, key, 0);
     }
 
-    private void searchWithKey(float[] queryVector, int key, int expectedSize) throws Throwable
+    private void searchWithKey(float[] queryVector, int key, int expectedSize)
     {
         UntypedResultSet result = execute("SELECT * FROM %s WHERE pk = " + key + " ORDER BY val ann of " + Arrays.toString(queryVector) + " LIMIT 1000");
 
@@ -633,12 +600,12 @@ public class VectorLocalTest extends VectorTester
         result.stream().forEach(row -> assertThat(row.getInt("pk")).isEqualTo(key));
     }
 
-    private void searchWithKey(Vector<Float> queryVector, int key, int expectedSize) throws Throwable
+    private void searchWithKey(Vector<Float> queryVector, int key, int expectedSize)
     {
         searchWithKey(queryVector, key, expectedSize, 1000);
     }
 
-    private void searchWithKey(Vector<Float> queryVector, int key, int expectedSize, int limit) throws Throwable
+    private void searchWithKey(Vector<Float> queryVector, int key, int expectedSize, int limit)
     {
         UntypedResultSet result = execute("SELECT * FROM %s WHERE pk = ? ORDER BY val ann of ? LIMIT " + limit, key, queryVector);
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorRangeSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorRangeSearchTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VectorRangeSearchTest extends VectorTester.VersionedWithChecksums
+{
+    private static final IPartitioner partitioner = Murmur3Partitioner.instance;
+
+    @Test
+    public void rangeSearchTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (partition int, val vector<float, 2>, PRIMARY KEY(partition))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        waitForTableIndexesQueryable();
+
+        var nPartitions = 100;
+        Map<Integer, float[]> vectorsByKey = new HashMap<>();
+
+        for (int i = 1; i <= nPartitions; i++)
+        {
+            float[] vector = {(float) i, (float) i};
+            execute("INSERT INTO %s (partition, val) VALUES (?, ?)", i, vector(vector));
+            vectorsByKey.put(i, vector);
+        }
+
+        var queryVector = vector(1.5f, 1.5f);
+        CheckedFunction tester = () -> {
+            for (int i = 1; i <= nPartitions; i++)
+            {
+                UntypedResultSet result = execute("SELECT partition FROM %s WHERE token(partition) > token(?) ORDER BY val ann of ? LIMIT 1000", i, queryVector);
+                assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysWithLowerBound(vectorsByKey.keySet(), i, false));
+
+                result = execute("SELECT partition FROM %s WHERE token(partition) >= token(?) ORDER BY val ann of ? LIMIT 1000", i, queryVector);
+                assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysWithLowerBound(vectorsByKey.keySet(), i, true));
+
+                result = execute("SELECT partition FROM %s WHERE token(partition) < token(?) ORDER BY val ann of ? LIMIT 1000", i, queryVector);
+                assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysWithUpperBound(vectorsByKey.keySet(), i, false));
+
+                result = execute("SELECT partition FROM %s WHERE token(partition) <= token(?) ORDER BY val ann of ? LIMIT 1000", i, queryVector);
+                assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysWithUpperBound(vectorsByKey.keySet(), i, true));
+
+                for (int j = 1; j <= nPartitions; j++)
+                {
+                    result = execute("SELECT partition FROM %s WHERE token(partition) >= token(?) AND token(partition) <= token(?) ORDER BY val ann of ? LIMIT 1000", i, j, queryVector);
+                    assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysInBounds(vectorsByKey.keySet(), i, true, j, true));
+
+                    result = execute("SELECT partition FROM %s WHERE token(partition) > token(?) AND token(partition) <= token(?) ORDER BY val ann of ? LIMIT 1000", i, j, queryVector);
+                    assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysInBounds(vectorsByKey.keySet(), i, false, j, true));
+
+                    result = execute("SELECT partition FROM %s WHERE token(partition) >= token(?) AND token(partition) < token(?) ORDER BY val ann of ? LIMIT 1000", i, j, queryVector);
+                    assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysInBounds(vectorsByKey.keySet(), i, true, j, false));
+
+                    result = execute("SELECT partition FROM %s WHERE token(partition) > token(?) AND token(partition) < token(?) ORDER BY val ann of ? LIMIT 1000", i, j, queryVector);
+                    assertThat(keys(result)).containsExactlyInAnyOrderElementsOf(keysInBounds(vectorsByKey.keySet(), i, false, j, false));
+                }
+            }
+        };
+
+        tester.apply();
+
+        flush();
+
+        tester.apply();
+    }
+
+    private Collection<Integer> keys(UntypedResultSet result)
+    {
+        List<Integer> keys = new ArrayList<>(result.size());
+        for (UntypedResultSet.Row row : result)
+            keys.add(row.getInt("partition"));
+        return keys;
+    }
+
+    private Collection<Integer> keysWithLowerBound(Collection<Integer> keys, int leftKey, boolean leftInclusive)
+    {
+        return keysInTokenRange(keys, partitioner.getToken(Int32Type.instance.decompose(leftKey)), leftInclusive,
+                                partitioner.getMaximumToken().getToken(), true);
+    }
+
+    private Collection<Integer> keysWithUpperBound(Collection<Integer> keys, int rightKey, boolean rightInclusive)
+    {
+        return keysInTokenRange(keys, partitioner.getMinimumToken().getToken(), true,
+                                partitioner.getToken(Int32Type.instance.decompose(rightKey)), rightInclusive);
+    }
+
+    private Collection<Integer> keysInBounds(Collection<Integer> keys, int leftKey, boolean leftInclusive, int rightKey, boolean rightInclusive)
+    {
+        return keysInTokenRange(keys, partitioner.getToken(Int32Type.instance.decompose(leftKey)), leftInclusive,
+                                partitioner.getToken(Int32Type.instance.decompose(rightKey)), rightInclusive);
+    }
+
+    private Collection<Integer> keysInTokenRange(Collection<Integer> keys, Token leftToken, boolean leftInclusive, Token rightToken, boolean rightInclusive)
+    {
+        long left = leftToken.getLongValue();
+        long right = rightToken.getLongValue();
+        return keys.stream()
+                   .filter(k -> {
+                       long t = partitioner.getToken(Int32Type.instance.decompose(k)).getLongValue();
+                       return (left < t || left == t && leftInclusive) && (t < right || t == right && rightInclusive);
+                   }).collect(Collectors.toSet());
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.tracing.TracingTestImpl;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_TRACING_CLASS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VectorTracingTest extends VectorTester.VersionedWithChecksums
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CUSTOM_TRACING_CLASS.setString("org.apache.cassandra.tracing.TracingTestImpl");
+        CQLTester.setUpClass();
+    }
+
+    @Test
+    public void tracingTest()
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])");
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
+
+        flush();
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (4, 'E', [5.0, 2.0, 3.0])");
+
+        Tracing.instance.newSession(ClientState.forInternalCalls(), Tracing.TraceType.QUERY);
+        execute("SELECT * FROM %s ORDER BY val ann of [9.5, 5.5, 6.5] LIMIT 5");
+        for (String trace : ((TracingTestImpl) Tracing.instance).getTraces())
+            assertThat(trace).doesNotContain("Executing single-partition query");
+        // manual inspection to verify that no extra traces were included
+        logger.info(((TracingTestImpl) Tracing.instance).getTraces().toString());
+
+        // because we parameterized the test class we need to clean up after ourselves or the second run will fail
+        Tracing.instance.stopSession();
+    }
+}


### PR DESCRIPTION
### What is the issue
...

### What does this PR fix and why was it fixed
...

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits