### PR TITLE
CNDB-11535 main: Fix failure of VectorSiftSmallTest.testMultiSegmentBuild

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1147,7 +1147,20 @@ public abstract class CQLTester
      */
     public void waitForIndexQueryable(String keyspace, String index)
     {
-        waitForAssert(() -> assertTrue(isIndexQueryable(keyspace, index)), 60, TimeUnit.SECONDS);
+        waitForIndexQueryable(keyspace, index, 1, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Index creation is asynchronous. This method waits until the specified index is queryable.
+     *
+     * @param keyspace the index keyspace name
+     * @param index the index name
+     * @param timeout the timeout
+     * @param unit the timeout unit
+     */
+    public void waitForIndexQueryable(String keyspace, String index, long timeout, TimeUnit unit)
+    {
+        waitForAssert(() -> assertTrue(isIndexQueryable(keyspace, index)), timeout, unit);
     }
 
     protected void waitForIndexBuilds(String index)


### PR DESCRIPTION
Increase the timeout for waiting on the index creation. We are indexing more vectors than usual, so the default one-minute timeout might not be enough.