### PR TITLE
CNDB-11535 main-5.0: Fix failure of VectorSiftSmallTest.testMultiSegmentBuild

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1438,7 +1438,20 @@ public abstract class CQLTester
      */
     public void waitForIndexQueryable(String keyspace, String index)
     {
-        waitForAssert(() -> assertTrue(isIndexQueryable(keyspace, index)), 60, TimeUnit.SECONDS);
+        waitForIndexQueryable(keyspace, index, 1, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Index creation is asynchronous. This method waits until the specified index is queryable.
+     *
+     * @param keyspace the index keyspace name
+     * @param index the index name
+     * @param timeout the timeout
+     * @param unit the timeout unit
+     */
+    public void waitForIndexQueryable(String keyspace, String index, long timeout, TimeUnit unit)
+    {
+        waitForAssert(() -> assertTrue(isIndexQueryable(keyspace, index)), timeout, unit);
     }
 
     protected void waitForIndexBuilds(String index)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
@@ -60,9 +61,8 @@ public class VectorSiftSmallTest extends VectorTester
         var groundTruth = readIvecs(String.format("test/data/%s/%s_groundtruth.ivecs", DATASET, DATASET));
 
         // Create table and index
-        createTable(KEYSPACE, "CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForTableIndexesQueryable();
+        createTable();
+        createIndex();
 
         insertVectors(baseVectors, 0);
         double memoryRecall = testRecall(100, queryVectors, groundTruth);
@@ -81,9 +81,8 @@ public class VectorSiftSmallTest extends VectorTester
         var groundTruth = readIvecs(String.format("test/data/%s/%s_groundtruth.ivecs", DATASET, DATASET));
 
         // Create table and index
-        createTable(KEYSPACE, "CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForTableIndexesQueryable();
+        createTable();
+        createIndex();
 
         // we're going to compact manually, so disable background compactions to avoid interference
         disableCompaction();
@@ -119,8 +118,8 @@ public class VectorSiftSmallTest extends VectorTester
         var queryVectors = readFvecs(String.format("test/data/%s/%s_query.fvecs", DATASET, DATASET));
         var groundTruth = readIvecs(String.format("test/data/%s/%s_groundtruth.ivecs", DATASET, DATASET));
 
-        // Create table and index
-        createTable(KEYSPACE, "CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
+        // Create table without index
+        createTable();
 
         // we're going to compact manually, so disable background compactions to avoid interference
         disableCompaction();
@@ -131,8 +130,7 @@ public class VectorSiftSmallTest extends VectorTester
         compact();
 
         SegmentBuilder.updateLastValidSegmentRowId(2000); // 2000 rows per segment, enough for PQ to be created
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-        waitForTableIndexesQueryable();
+        createIndex();
 
         // verify that we got the expected number of segments and that PQ is present in all of them
         var sim = getCurrentColumnFamilyStore().getIndexManager();
@@ -224,6 +222,18 @@ public class VectorSiftSmallTest extends VectorTester
         });
 
         return (double) topKfound.get() / (queryVectors.size() * topK);
+    }
+
+    private void createTable()
+    {
+        createTable("CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
+    }
+
+    private void createIndex()
+    {
+        // we need a long timeout because we are adding many vectors
+        String index = createIndexAsync("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        waitForIndexQueryable(KEYSPACE, index, 5, TimeUnit.MINUTES);
     }
 
     private void insertVectors(List<float[]> vectors, int baseRowId)


### PR DESCRIPTION
Increase the timeout for waiting on the index creation. We are indexing more vectors than usual, so the default one-minute timeout might not be enough.