### PR TITLE
CNDB-11459 and 11413: More logging for SAI vector index events

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -919,7 +919,8 @@ public class IndexContext
                 }
 
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
-                logger.debug(logMessage("Successfully created index for SSTable {}."), context.descriptor());
+                long count = context.primaryKeyMapFactory().count();
+                logger.debug(logMessage("Successfully created index for SSTable {} with {} rows."), context.descriptor(), count);
 
                 // Try to add new index to the set, if set already has such index, we'll simply release and move on.
                 // This covers situation when SSTable collection has the same SSTable multiple

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -47,6 +47,23 @@ public interface PrimaryKeyMap extends Closeable
          */
         PrimaryKeyMap newPerSSTablePrimaryKeyMap();
 
+        /**
+         * Returns the number of primary keys in the map. This is part of the factory because
+         * it can be retrieved without opening the map.
+         * @return
+         */
+        default long count()
+        {
+            try (PrimaryKeyMap map = newPerSSTablePrimaryKeyMap())
+            {
+                return map.count();
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
         @Override
         default void close() throws IOException
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -50,7 +50,7 @@ public interface PrimaryKeyMap extends Closeable
         /**
          * Returns the number of primary keys in the map. This is part of the factory because
          * it can be retrieved without opening the map.
-         * @return
+         * @return the number of primary keys in the map
          */
         default long count()
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -68,6 +68,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         private final IPartitioner partitioner;
         private final PrimaryKey.Factory primaryKeyFactory;
         private final SSTableId<?> sstableId;
+        private final long count;
 
         private FileHandle token = null;
         private FileHandle offset = null;
@@ -85,6 +86,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
                 NumericValuesMeta offsetsMeta = new NumericValuesMeta(this.metadata.get(offsetsComponent));
                 NumericValuesMeta tokensMeta = new NumericValuesMeta(this.metadata.get(tokensComponent));
 
+                count = tokensMeta.valueCount;
                 token = tokensComponent.createFileHandle();
                 offset = offsetsComponent.createFileHandle();
 
@@ -108,6 +110,12 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
             final LongArray rowIdToOffset = new LongArray.DeferredLongArray(() -> offsetReaderFactory.open());
 
             return new PartitionAwarePrimaryKeyMap(rowIdToToken, rowIdToOffset, partitioner, keyFetcher, primaryKeyFactory, sstableId);
+        }
+
+        @Override
+        public long count()
+        {
+            return count;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -80,10 +80,13 @@ public class Segment implements Closeable
 
         var version = indexFiles.usedPerIndexComponents().version();
         IndexSearcher searcher = version.onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
-        logger.info("Opened searcher {} for segment {}:{} for index [{}] on column [{}] at version {}",
+        logger.info("Opened searcher {} for segment {} with row id meta ({},{},{},{}) for index [{}] on column [{}] at version {}",
                     searcher.getClass().getSimpleName(),
                     sstableContext.descriptor(),
                     metadata.segmentRowIdOffset,
+                    metadata.numRows,
+                    metadata.minSSTableRowId,
+                    metadata.maxSSTableRowId,
                     indexContext.getIndexName(),
                     indexContext.getColumnName(),
                     version);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -74,6 +74,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         private final IndexComponents.ForRead perSSTableComponents;
         private final LongArray.Factory tokenReaderFactory;
         private final SortedTermsReader sortedTermsReader;
+        private final long count;
         private FileHandle token = null;
         private FileHandle termsDataBlockOffsets = null;
         private FileHandle termsData = null;
@@ -90,6 +91,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
                 this.perSSTableComponents = perSSTableComponents;
                 MetadataSource metadataSource = MetadataSource.loadMetadata(perSSTableComponents);
                 NumericValuesMeta tokensMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.TOKEN_VALUES)));
+                count = tokensMeta.valueCount;
                 SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS)));
                 NumericValuesMeta blockOffsetsMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS)));
 
@@ -128,6 +130,12 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
             {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        @Override
+        public long count()
+        {
+            return count;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -510,6 +510,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     private IntIntPairArray flatmapPrimaryKeysToBitsAndRows(List<PrimaryKey> keysInRange) throws IOException
     {
         var segmentOrdinalPairs = new IntIntPairArray(keysInRange.size());
+        int lastSegementRowId = -1;
         try (var primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
              var ordinalsView = graph.getOrdinalsView())
         {
@@ -593,6 +594,13 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
 
                 // convert the global row id to segment row id and from segment row id to graph ordinal
                 int segmentRowId = metadata.toSegmentRowId(sstableRowId);
+                // This requirement is required by the ordinals view. There are cases where we have broken this
+                // requirement, and in order to make future debugging easier, we check here and throw an exception
+                // with additional detail.
+                if (segmentRowId <= lastSegementRowId)
+                    throw new IllegalStateException("Row ids must ascend monotonically. Got " + segmentRowId + " after " + lastSegementRowId
+                                                    + " for " + primaryKey + " on sstable " + primaryKeyMap.getSSTableId());
+                lastSegementRowId = segmentRowId;
                 int ordinal = ordinalsView.getOrdinalForRowId(segmentRowId);
                 if (ordinal >= 0)
                     segmentOrdinalPairs.add(segmentRowId, ordinal);

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -510,7 +510,7 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
     private IntIntPairArray flatmapPrimaryKeysToBitsAndRows(List<PrimaryKey> keysInRange) throws IOException
     {
         var segmentOrdinalPairs = new IntIntPairArray(keysInRange.size());
-        int lastSegementRowId = -1;
+        int lastSegmentRowId = -1;
         try (var primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
              var ordinalsView = graph.getOrdinalsView())
         {
@@ -597,10 +597,10 @@ public class V2VectorIndexSearcher extends IndexSearcher implements SegmentOrder
                 // This requirement is required by the ordinals view. There are cases where we have broken this
                 // requirement, and in order to make future debugging easier, we check here and throw an exception
                 // with additional detail.
-                if (segmentRowId <= lastSegementRowId)
-                    throw new IllegalStateException("Row ids must ascend monotonically. Got " + segmentRowId + " after " + lastSegementRowId
+                if (segmentRowId <= lastSegmentRowId)
+                    throw new IllegalStateException("Row ids must ascend monotonically. Got " + segmentRowId + " after " + lastSegmentRowId
                                                     + " for " + primaryKey + " on sstable " + primaryKeyMap.getSSTableId());
-                lastSegementRowId = segmentRowId;
+                lastSegmentRowId = segmentRowId;
                 int ordinal = ordinalsView.getOrdinalForRowId(segmentRowId);
                 if (ordinal >= 0)
                     segmentOrdinalPairs.add(segmentRowId, ordinal);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -163,14 +163,14 @@ public class VectorMemtableIndex implements MemtableIndex
                 overwriteCount.increment();
             }
             if (oldRemaining > 0)
-            {
                 graph.remove(oldValue, primaryKey);
-                removedCount.increment();
-            }
 
             // remove primary key if it's no longer indexed
             if (newRemaining <= 0 && oldRemaining > 0)
+            {
                 primaryKeys.remove(primaryKey);
+                removedCount.increment();
+            }
         }
     }
 
@@ -445,7 +445,7 @@ public class VectorMemtableIndex implements MemtableIndex
     {
         // Note that range deletions won't show up in the removed count, which is why it's just named removedCount and
         // not deleted count.
-        logger.debug("Writing {} nodes to disk after {} inserts, {} overwrites, and {} revomals for {}", graph.size(),
+        logger.debug("Writing {} nodes to disk after {} inserts, {} overwrites, and {} removals for {}", graph.size(),
                      writeCount.longValue(), overwriteCount.longValue(), removedCount.longValue(), perIndexComponents.descriptor());
         return graph.flush(perIndexComponents);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -85,6 +85,8 @@ public class VectorMemtableIndex implements MemtableIndex
     private final IndexContext indexContext;
     private final CassandraOnHeapGraph<PrimaryKey> graph;
     private final LongAdder writeCount = new LongAdder();
+    private final LongAdder overwriteCount = new LongAdder();
+    private final LongAdder removedCount = new LongAdder();
 
     private PrimaryKey minimumKey;
     private PrimaryKey maximumKey;
@@ -156,9 +158,15 @@ public class VectorMemtableIndex implements MemtableIndex
 
             // make the changes in this order so we don't have a window where the row is not in the index at all
             if (newRemaining > 0)
+            {
                 graph.add(newValue, primaryKey);
+                overwriteCount.increment();
+            }
             if (oldRemaining > 0)
+            {
                 graph.remove(oldValue, primaryKey);
+                removedCount.increment();
+            }
 
             // remove primary key if it's no longer indexed
             if (newRemaining <= 0 && oldRemaining > 0)
@@ -435,13 +443,17 @@ public class VectorMemtableIndex implements MemtableIndex
 
     public SegmentMetadata.ComponentMetadataMap writeData(IndexComponents.ForWrite perIndexComponents) throws IOException
     {
+        // Note that range deletions won't show up in the removed count, which is why it's just named removedCount and
+        // not deleted count.
+        logger.debug("Writing {} nodes to disk after {} inserts, {} overwrites, and {} revomals for {}", graph.size(),
+                     writeCount.longValue(), overwriteCount.longValue(), removedCount.longValue(), perIndexComponents.descriptor());
         return graph.flush(perIndexComponents);
     }
 
     @Override
     public long writeCount()
     {
-        return writeCount.longValue();
+        return writeCount.longValue() + overwriteCount.longValue();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -85,6 +85,12 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
     }
 
     @Test
+    public void testPrimaryKeyMapFactoryCount()
+    {
+        assertEquals(Long.MAX_VALUE, KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY.count());
+    }
+
+    @Test
     public void testEqQueriesAgainstStringIndex() throws Exception
     {
         doTestEqQueriesAgainstStringIndex(version);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/LegacyOnDiskFormatTest.java
@@ -146,7 +146,12 @@ public class LegacyOnDiskFormatTest
         var perSSTableComponents = indexDescriptor.perSSTableComponents();
         PrimaryKeyMap.Factory primaryKeyMapFactory = perSSTableComponents.version().onDiskFormat().newPrimaryKeyMapFactory(perSSTableComponents, pkFactory, sstable);
 
+        long countFromFactory = primaryKeyMapFactory.count();
+
         PrimaryKeyMap primaryKeyMap = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
+
+        long countFromMap = primaryKeyMap.count();
+        assertEquals(countFromFactory, countFromMap);
 
         PrimaryKey expected = pkFactory.createTokenOnly(Murmur3Partitioner.instance.decorateKey(Int32Type.instance.decompose(23)).getToken());
 


### PR DESCRIPTION
### What is the issue
Two issues: https://github.com/riptano/cndb/issues/11413 and https://github.com/riptano/cndb/issues/11459

### What does this PR fix and why was it fixed

This PR adds more logging to the vector indexing lifecycle events. We had two issues recently that needed more information, and this should help us get closer next time.

None of the logs should be excessive since they are only done on unexpected errors or at start up or flush.

Note that some of the errors are unreachable since we don't have an exact way to reproduce the issue.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits