### PR TITLE
CNDB-11594 fix test_counter_leader_with_partial_view by restoring CASSANDRA-13043

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1952,6 +1952,7 @@ public class StorageProxy implements StorageProxyMBean
         // CASSANDRA-13043: filter out those endpoints not accepting clients yet, maybe because still bootstrapping
         // We have a keyspace, so filter by affinity too
         replicas = replicas.filter(IFailureDetector.isReplicaAlive)
+                           .filter(r -> StorageService.instance.isRpcReady(r.endpoint()))
                            .filter(snitch.filterByAffinity(keyspace.getName()));
 
         // CASSANDRA-17411: filter out endpoints that are not alive


### PR DESCRIPTION
Restores the filter from CASSANDRA-13043 for nodes that are rpc_ready