### PR TITLE
CNDB-11646: Reclaculate ShardManager#minimumPerPartitionSpan on each call

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/DelegatingShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/DelegatingShardManager.java
@@ -29,12 +29,12 @@ import org.apache.cassandra.dht.Token;
 public class DelegatingShardManager implements ShardManager
 {
     private final IntFunction<Token[]> tokenGenerator;
-    private final double minimumPerPartitionSpan;
+    private CompactionRealm realm;
 
-    public DelegatingShardManager(IntFunction<Token[]> tokenGenerator, long minimumPerPartitionSpan)
+    public DelegatingShardManager(IntFunction<Token[]> tokenGenerator, CompactionRealm realm)
     {
         this.tokenGenerator = tokenGenerator;
-        this.minimumPerPartitionSpan = minimumPerPartitionSpan;
+        this.realm = realm;
     }
 
     @Override
@@ -60,7 +60,7 @@ public class DelegatingShardManager implements ShardManager
     @Override
     public double minimumPerPartitionSpan()
     {
-        return minimumPerPartitionSpan;
+        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCount());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -70,7 +70,7 @@ public interface ShardManager
             return new ShardManagerDiskAware(localRanges, diskPositions);
         else if (partitioner.splitter().isPresent())
             if (isReplicaAware)
-                return new ShardManagerReplicaAware(rs, localRanges.getRealm().estimatedPartitionCount());
+                return new ShardManagerReplicaAware(rs, localRanges.getRealm());
             else
                 return new ShardManagerNoDisks(localRanges);
         else

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
@@ -39,8 +39,6 @@ public class ShardManagerNoDisks implements ShardManager
      */
     final double[] localRangePositions;
 
-    private final double minimumPerPartitionSpan;
-
     public ShardManagerNoDisks(SortedLocalRanges localRanges)
     {
         this.localRanges = localRanges;
@@ -53,7 +51,6 @@ public class ShardManagerNoDisks implements ShardManager
             position += span;
             localRangePositions[i] = position;
         }
-        minimumPerPartitionSpan = localSpaceCoverage() / Math.max(1, localRanges.getRealm().estimatedPartitionCount());
     }
 
     @Override
@@ -90,7 +87,7 @@ public class ShardManagerNoDisks implements ShardManager
 
     public double minimumPerPartitionSpan()
     {
-        return minimumPerPartitionSpan;
+        return localSpaceCoverage() / Math.max(1, localRanges.getRealm().estimatedPartitionCount());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
@@ -58,9 +58,9 @@ public class ShardManagerReplicaAware implements ShardManager
     private final TokenMetadata tokenMetadata;
     private final IPartitioner partitioner;
     private final ConcurrentHashMap<Integer, Token[]> splitPointCache;
-    private final double minimumPerPartitionSpan;
+    private final CompactionRealm realm;
 
-    public ShardManagerReplicaAware(AbstractReplicationStrategy rs, long estimatedPartitionCount)
+    public ShardManagerReplicaAware(AbstractReplicationStrategy rs, CompactionRealm realm)
     {
         this.rs = rs;
         // Clone the map to ensure it has a consistent view of the tokenMetadata. UCS creates a new instance of the
@@ -68,7 +68,7 @@ public class ShardManagerReplicaAware implements ShardManager
         this.tokenMetadata = rs.getTokenMetadata().cloneOnlyTokenMap();
         this.splitPointCache = new ConcurrentHashMap<>();
         this.partitioner = tokenMetadata.partitioner;
-        this.minimumPerPartitionSpan = 1.0 / Math.max(1, estimatedPartitionCount);
+        this.realm = realm;
     }
 
     @Override
@@ -94,7 +94,7 @@ public class ShardManagerReplicaAware implements ShardManager
     @Override
     public double minimumPerPartitionSpan()
     {
-        return minimumPerPartitionSpan;
+        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCount());
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
@@ -42,10 +42,11 @@ public class DelegatingShardManagerTest
     {
         CompactionRealm realm = Mockito.mock(CompactionRealm.class);
         when(realm.getPartitioner()).thenReturn(partitioner);
+        when(realm.estimatedPartitionCount()).thenReturn(1L << 16);
         SortedLocalRanges localRanges = SortedLocalRanges.forTestingFull(realm);
         ShardManager delegate = new ShardManagerNoDisks(localRanges);
 
-        DelegatingShardManager wrapper = new DelegatingShardManager((x) -> consumeTokens(delegate.boundaries(x)), 1);
+        DelegatingShardManager wrapper = new DelegatingShardManager((x) -> consumeTokens(delegate.boundaries(x)), realm);
 
         var range = new Range<>(partitioner.getMinimumToken(), partitioner.getMinimumToken());
         assertEquals(1, wrapper.rangeSpanned(range), 0);

--- a/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
@@ -52,7 +52,7 @@ public class DelegatingShardManagerTest
         assertEquals(1, wrapper.rangeSpanned(range), 0);
         assertEquals(1, wrapper.localSpaceCoverage(), 0);
         assertEquals(1, wrapper.shardSetCoverage(), 0);
-        assertEquals(1, wrapper.minimumPerPartitionSpan(), 0);
+        assertEquals(1D / (1L << 16), wrapper.minimumPerPartitionSpan(), 0);
 
         // We expect the same shards because the wrapper delegates.
         for (int i = 1; i < 512; i++)

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
@@ -39,6 +39,8 @@ import org.apache.cassandra.locator.TokenMetadata;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ShardManagerReplicaAwareTest
 {
@@ -46,11 +48,14 @@ public class ShardManagerReplicaAwareTest
     @Test
     public void testRangeEndsForShardCountEqualtToNumTokensPlusOne() throws UnknownHostException
     {
+        var mockCompationRealm = mock(CompactionRealm.class);
+        when(mockCompationRealm.estimatedPartitionCount()).thenReturn(1L<<16);
+
         for (int numTokens = 1; numTokens < 32; numTokens++)
         {
             var rs = buildStrategy(numTokens, 1, 1, 1);
             var expectedTokens = rs.getTokenMetadata().sortedTokens();
-            var shardManager = new ShardManagerReplicaAware(rs, 1L<<16);
+            var shardManager = new ShardManagerReplicaAware(rs, mockCompationRealm);
 
             var shardCount = numTokens + 1;
             var iterator = shardManager.boundaries(shardCount);
@@ -69,6 +74,9 @@ public class ShardManagerReplicaAwareTest
     @Test
     public void testRangeEndsAreFromTokenListAndContainLowerRangeEnds() throws UnknownHostException
     {
+        var mockCompationRealm = mock(CompactionRealm.class);
+        when(mockCompationRealm.estimatedPartitionCount()).thenReturn(1L<<16);
+
         for (int nodeCount = 1; nodeCount <= 6; nodeCount++)
         {
             for (int numTokensPerNode = 1; numTokensPerNode < 16; numTokensPerNode++)
@@ -82,7 +90,7 @@ public class ShardManagerReplicaAwareTest
                     // Confirm test set up is correct.
                     assertEquals(numTokensPerNode * nodeCount, initialSplitPoints.size());
                     // Use a shared instance to
-                    var shardManager = new ShardManagerReplicaAware(rs, 1L<<16);
+                    var shardManager = new ShardManagerReplicaAware(rs, mockCompationRealm);
 
                     // The tokens for one level lower.
                     var lowerTokens = new ArrayList<Token>();


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/11646

### What does this PR fix and why was it fixed
Instead of computing the value once and using that for the lifecycle of the `ShardManager`, we compute it each time to ensure better accuracy. The original concern was that the call was expensive, but that does not appear to be the case.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits