### PR TITLE
CNDB-11655: Limit the number of clauses before optimizing the Plan

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -361,6 +361,7 @@ abstract public class Plan
 
     /**
      * Modifies all intersections to not intersect more clauses than the given limit.
+     * Retains the most selective clauses.
      */
     public final Plan limitIntersectedClauses(int clauseLimit)
     {
@@ -1700,7 +1701,8 @@ abstract public class Plan
         }
 
         /**
-         * Constructs a plan node representing an intersection of two key sets.
+         * Constructs a plan node representing an intersection of key sets.
+         * The subplans will be sorted by selectivity from the most selective to the least selective ones.
          * @param subplans a list of subplans for intersected key sets
          */
         public KeysIteration intersection(List<KeysIteration> subplans)

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -98,8 +98,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     /**
      * Controls whether we optimize query plans.
      * 0 disables the optimizer. As a side effect, hybrid ANN queries will default to FilterSortOrder.SCAN_THEN_FILTER.
-     * 1 enables the optimizer and tells the optimizer to respect the intersection clause limit.
-     * Higher values enable the optimizer and disable the hard intersection clause limit.
+     * 1 enables the optimizer.
      * Note: the config is not final to simplify testing.
      */
     @VisibleForTesting
@@ -346,34 +345,42 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         rowsIteration = planFactory.recheckFilter(command.rowFilter(), rowsIteration);
         rowsIteration = planFactory.limit(rowsIteration, command.limits().rows());
 
-        Plan optimizedPlan;
-        optimizedPlan = QUERY_OPT_LEVEL > 0
-                        ? rowsIteration.optimize()
-                        : rowsIteration;
-        optimizedPlan = KeyRangeIntersectionIterator.INTERSECTION_CLAUSE_LIMIT > 0 && QUERY_OPT_LEVEL <= 1
-                        ? optimizedPlan.limitIntersectedClauses(KeyRangeIntersectionIterator.INTERSECTION_CLAUSE_LIMIT)
-                        : optimizedPlan;
+        // Limit the number of intersected clauses before optimizing so we reduce the size of the
+        // plan given to the optimizer and hence reduce the plan search space and speed up optimization.
+        // It is possible that some index operators like ':' expand to a huge number of MATCH predicates
+        // (see CNDB-10085) and could overload the optimizer.
+        // The intersected subplans are ordered by selectivity in the way the best ones are at the beginning
+        // of the list, therefore this limit is unlikely to remove good branches of the tree.
+        // The limit here is higher than the final limit, so that the optimizer has a bit more freedom
+        // in which predicates it leaves in the plan and the probability of accidentally removing a good branch
+        // here is even lower.
+        Plan plan = rowsIteration.limitIntersectedClauses(KeyRangeIntersectionIterator.INTERSECTION_CLAUSE_LIMIT * 3);
 
-        if (optimizedPlan.contains(node -> node instanceof Plan.AnnIndexScan))
+        if (QUERY_OPT_LEVEL > 0)
+            plan = plan.optimize();
+
+        plan = plan.limitIntersectedClauses(KeyRangeIntersectionIterator.INTERSECTION_CLAUSE_LIMIT);
+
+        if (plan.contains(node -> node instanceof Plan.AnnIndexScan))
             queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SCAN_THEN_FILTER);
-        if (optimizedPlan.contains(node -> node instanceof Plan.KeysSort))
+        if (plan.contains(node -> node instanceof Plan.KeysSort))
             queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SEARCH_THEN_ORDER);
 
         if (logger.isTraceEnabled())
-            logger.trace("Query execution plan:\n" + optimizedPlan.toStringRecursive());
+            logger.trace("Query execution plan:\n" + plan.toStringRecursive());
 
         if (Tracing.isTracing())
         {
-            Tracing.trace("Query execution plan:\n" + optimizedPlan.toStringRecursive());
+            Tracing.trace("Query execution plan:\n" + plan.toStringRecursive());
             List<Plan.IndexScan> origIndexScans = keysIterationPlan.nodesOfType(Plan.IndexScan.class);
-            List<Plan.IndexScan> selectedIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
+            List<Plan.IndexScan> selectedIndexScans = plan.nodesOfType(Plan.IndexScan.class);
             Tracing.trace("Selecting {} {} of {} out of {} indexes",
                           selectedIndexScans.size(),
                           selectedIndexScans.size() > 1 ? "indexes with cardinalities" : "index with cardinality",
                           selectedIndexScans.stream().map(s -> "" + ((long) s.expectedKeys())).collect(Collectors.joining(", ")),
                           origIndexScans.size());
         }
-        return optimizedPlan;
+        return plan;
     }
 
     private Plan.KeysIteration buildKeysIterationPlan()


### PR DESCRIPTION
### What is the issue
Plan#optimize can take a very long time when given plans with thousands of intersected clauses, which can result from using ngram analyzers. Related issue: https://github.com/riptano/cndb/issues/10085.

### What does this PR fix and why was it fixed
Fixes https://github.com/riptano/cndb/issues/11655

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits