### PR TITLE
CNDB-11663: Handle posting list ordinal assignment race

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -174,7 +174,9 @@ public class CassandraOnHeapGraph<T> implements Accountable
     public int getOrdinal(VectorFloat<?> vector)
     {
         VectorPostings<T> postings = postingsMap.get(vector);
-        return postings == null ? -1 : postings.getOrdinal();
+        // There is a small race from when the postings list is created to when it is assigned an ordinal,
+        // so we do not assert that the ordinal is set here
+        return postings == null ? -1 : postings.getOrdinal(false);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorPostings.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorPostings.java
@@ -151,7 +151,12 @@ public class VectorPostings<T>
 
     public int getOrdinal()
     {
-        assert ordinal >= 0 : "ordinal not set";
+        return getOrdinal(true);
+    }
+
+    public int getOrdinal(boolean assertSet)
+    {
+        assert !assertSet || ordinal >= 0 : "ordinal not set";
         return ordinal;
     }
 


### PR DESCRIPTION
### What is the issue
fixes https://github.com/riptano/cndb/issues/11663

```
Uncaught exception on thread Thread[#436,ReadStage-24,5,main]
     java.lang.RuntimeException: java.lang.AssertionError: ordinal not set
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:113)
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)
     	at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)
     	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
     	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
     	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
     	at java.base/java.lang.Thread.run(Thread.java:1570)
     Caused by: java.lang.AssertionError: ordinal not set
     	at org.apache.cassandra.index.sai.disk.vector.VectorPostings.getOrdinal(VectorPostings.java:154)
     	at org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.getOrdinal(CassandraOnHeapGraph.java:177)
     	at org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex.lambda$orderResultsBy$2(VectorMemtableIndex.java:292)
     	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
     	at java.base/java.util.stream.WhileOps$1$1.accept(WhileOps.java:98)
     	at java.base/java.util.stream.WhileOps$1Op$1OpSink.accept(WhileOps.java:382)
     	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1686)
     	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:144)
     	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:574)
     	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:560)
     	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
     	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
     	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
```

### What does this PR fix and why was it fixed

The solution is to not assert that the value is set. There is a known data race in this part of the code and it is benign. The result is that the vector is excluded from the result set on this iteration but is expected to be include once the race is resolved.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits