### PR TITLE
CNDB-11627: increase max_sstables_to_compact in CQLUnifiedCompactionTest

### DIFF
--- a/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CQLUnifiedCompactionTest.java
@@ -314,7 +314,7 @@ public class CQLUnifiedCompactionTest extends CQLTester
                                         .collect(Collectors.joining(","));
 
         createTable("create table %s (id int primary key, val blob) with compression = { 'enabled' : false } AND " +
-                    "compaction = {'class':'UnifiedCompactionStrategy', 'adaptive' : 'false', " +
+                    "compaction = {'class':'UnifiedCompactionStrategy', 'adaptive' : 'false', 'max_sstables_to_compact': 256, " +
                     String.format("'scaling_parameters' : '%s', 'min_sstable_size' : '0B', 'base_shard_count': '%d', 'log_all' : 'true'}",
                                   scalingParamsStr, numShards));
 


### PR DESCRIPTION
`CQLUnifiedCompactionTest.testMultipleCompactionsDifferentWs` needs max_sstables_to_compact increased to pass.