### PR TITLE
CNDB-11563 Rename few iterators to KeyRangeIterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ doc/cql3/CQL.html
 doc/build/
 lib/
 pylib/src/
+pylib/cqlshlib/serverversion.py
 !lib/cassandra-driver-internal-only-*.zip
 
 # C* debs

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -73,7 +73,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeUnionIterator;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
-import org.apache.cassandra.index.sai.memory.MemtableRangeIterator;
+import org.apache.cassandra.index.sai.memory.MemtableKeyRangeIterator;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
@@ -503,7 +503,7 @@ public class IndexContext
         {
             for (Memtable memtable : memtables)
             {
-                KeyRangeIterator memtableIterator = new MemtableRangeIterator(memtable, primaryKeyFactory, keyRange);
+                KeyRangeIterator memtableIterator = new MemtableKeyRangeIterator(memtable, primaryKeyFactory, keyRange);
                 builder.add(memtableIterator);
             }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIterator.java
@@ -52,7 +52,7 @@ import org.apache.cassandra.utils.Throwables;
  */
 
 @NotThreadSafe
-public class PostingListRangeIterator extends KeyRangeIterator
+public class PostingListKeyRangeIterator extends KeyRangeIterator
 {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -71,12 +71,12 @@ public class PostingListRangeIterator extends KeyRangeIterator
     private long lastSegmentRowId = -1;
 
     /**
-     * Create a direct PostingListRangeIterator where the underlying PostingList is materialised
+     * Create a direct PostingListKeyRangeIterator where the underlying PostingList is materialised
      * immediately so the posting list size can be used.
      */
-    public PostingListRangeIterator(IndexContext indexContext,
-                                    PrimaryKeyMap primaryKeyMap,
-                                    IndexSearcherContext searcherContext)
+    public PostingListKeyRangeIterator(IndexContext indexContext,
+                                       PrimaryKeyMap primaryKeyMap,
+                                       IndexSearcherContext searcherContext)
     {
         super(searcherContext.minimumKey, searcherContext.maximumKey, searcherContext.count());
 
@@ -142,8 +142,8 @@ public class PostingListRangeIterator extends KeyRangeIterator
             FileUtils.closeQuietly(postingList, primaryKeyMap);
         }
         else {
-            logger.warn("PostingListRangeIterator is already closed",
-                        new IllegalStateException("PostingListRangeIterator is already closed"));
+            logger.warn("PostingListKeyRangeIterator is already closed",
+                        new IllegalStateException("PostingListKeyRangeIterator is already closed"));
         }
 
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexSearcher.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.IndexSearcherContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
-import org.apache.cassandra.index.sai.disk.PostingListRangeIterator;
+import org.apache.cassandra.index.sai.disk.PostingListKeyRangeIterator;
 import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.RowIdToPrimaryKeyWithSortKeyIterator;
@@ -162,7 +162,7 @@ public abstract class IndexSearcher implements Closeable, SegmentOrdering
                                                                         metadata.segmentRowIdOffset,
                                                                         queryContext,
                                                                         postingList);
-        return new PostingListRangeIterator(indexContext, primaryKeyMapFactory.newPerSSTablePrimaryKeyMap(), searcherContext);
+        return new PostingListKeyRangeIterator(indexContext, primaryKeyMapFactory.newPerSSTablePrimaryKeyMap(), searcherContext);
     }
 
     protected CloseableIterator<PrimaryKeyWithSortKey> toMetaSortedIterator(CloseableIterator<? extends RowIdWithMeta> rowIdIterator, QueryContext queryContext) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/AbstractBlockPackedReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/AbstractBlockPackedReader.java
@@ -91,7 +91,7 @@ public abstract class AbstractBlockPackedReader implements LongArray
     private long findBlockRowId(long targetValue)
     {
         // We keep track previous returned value in lastIndex, so searching backward will not return correct result.
-        // Also it's logically wrong to search backward during token iteration in PostingListRangeIterator.
+        // Also it's logically wrong to search backward during token iteration in PostingListKeyRangeIterator.
         if (targetValue < prevTokenValue)
             throw new IllegalArgumentException(String.format("%d is smaller than prev token value %d", targetValue, prevTokenValue));
         prevTokenValue = targetValue;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -202,7 +202,7 @@ public class VectorMemtableIndex implements MemtableIndex
 
         if (keyQueue.size() == 0)
             return KeyRangeIterator.empty();
-        return new ReorderingRangeIterator(keyQueue.build(Comparator.naturalOrder()), keyQueue.size());
+        return new ReorderingKeyRangeIterator(keyQueue.build(Comparator.naturalOrder()), keyQueue.size());
     }
 
     @Override
@@ -508,11 +508,11 @@ public class VectorMemtableIndex implements MemtableIndex
         }
     }
 
-    private class ReorderingRangeIterator extends KeyRangeIterator
+    private class ReorderingKeyRangeIterator extends KeyRangeIterator
     {
         private final SortingIterator<PrimaryKey> keyQueue;
 
-        ReorderingRangeIterator(SortingIterator<PrimaryKey> keyQueue, int expectedSize)
+        ReorderingKeyRangeIterator(SortingIterator<PrimaryKey> keyQueue, int expectedSize)
         {
             super(minimumKey, maximumKey, expectedSize);
             this.keyQueue = keyQueue;

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
@@ -43,7 +43,7 @@ import org.apache.cassandra.schema.TableMetadata;
 /**
  * Iterates over primary keys in a memtable
  */
-public class MemtableRangeIterator extends KeyRangeIterator
+public class MemtableKeyRangeIterator extends KeyRangeIterator
 {
     private final Memtable memtable;
     private final PrimaryKey.Factory pkFactory;
@@ -52,9 +52,9 @@ public class MemtableRangeIterator extends KeyRangeIterator
     private UnfilteredPartitionIterator partitionIterator;
     private UnfilteredRowIterator rowIterator;
 
-    public MemtableRangeIterator(Memtable memtable,
-                                 PrimaryKey.Factory pkFactory,
-                                 AbstractBounds<PartitionPosition> keyRange)
+    public MemtableKeyRangeIterator(Memtable memtable,
+                                    PrimaryKey.Factory pkFactory,
+                                    AbstractBounds<PartitionPosition> keyRange)
     {
         super(minKey(memtable, pkFactory),
               maxKey(memtable, pkFactory),

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
@@ -21,6 +21,7 @@ import javax.management.ObjectName;
 
 import com.datastax.driver.core.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.sai.disk.PostingListKeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.junit.After;
@@ -31,7 +32,6 @@ import com.datastax.driver.core.exceptions.ReadTimeoutException;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.disk.PostingListRangeIterator;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
@@ -123,7 +123,7 @@ public class QueryTimeoutTest extends SAITester
     public void delayDuringTokenLookupShouldProvokeTimeoutInRangeIterator() throws Throwable
     {
         Injection token_lookup_delay = Injections.newPause("token_lookup_delay", DELAY)
-                                                 .add(newInvokePoint().onClass(PostingListRangeIterator.class)
+                                                 .add(newInvokePoint().onClass(PostingListKeyRangeIterator.class)
                                                                             .onMethod("computeNext")
                                                                             .at("INVOKE QueryContext.checkpoint"))
                                                  .build();

--- a/test/unit/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIteratorTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class PostingListRangeIteratorTest
+public class PostingListKeyRangeIteratorTest
 {
     private static final PrimaryKeyMap pkm = KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP;
 
@@ -52,7 +52,7 @@ public class PostingListRangeIteratorTest
                                                     0,
                                                     new QueryContext(10000),
                                                     postingList);
-        try (var iterator = new PostingListRangeIterator(mockIndexContext, pkm, indexContext))
+        try (var iterator = new PostingListKeyRangeIterator(mockIndexContext, pkm, indexContext))
         {
             assertEquals(pkm.primaryKeyFromRowId(1), iterator.next());
             assertEquals(pkm.primaryKeyFromRowId(2), iterator.next());
@@ -72,8 +72,8 @@ public class PostingListRangeIteratorTest
         var mpl = MergePostingList.merge(Lists.newArrayList(postingList1, postingList2));
         var indexContext1 = buildIndexContext(1, 3, mpl);
         var indexContext2 = buildIndexContext(3, 3, postingList3);
-        var plri1 = new PostingListRangeIterator(mockIndexContext, pkm, indexContext1);
-        var plri2 = new PostingListRangeIterator(mockIndexContext, pkm, indexContext2);
+        var plri1 = new PostingListKeyRangeIterator(mockIndexContext, pkm, indexContext1);
+        var plri2 = new PostingListKeyRangeIterator(mockIndexContext, pkm, indexContext2);
         try (var union = KeyRangeUnionIterator.builder().add(plri1).add(plri2).build();)
         {
             union.skipTo(pkm.primaryKeyFromRowId(2));

--- a/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
@@ -57,7 +57,7 @@ public class SingleNodeQueryFailureTest extends SAITester
     @Test
     public void testFailedRangeIteratorOnMultiIndexesQuery() throws Throwable
     {
-        testFailedMultiIndexesQuery("range_iterator", PostingListRangeIterator.class, "getNextRowId");
+        testFailedMultiIndexesQuery("range_iterator", PostingListKeyRangeIterator.class, "getNextRowId");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIteratorTest.java
@@ -338,7 +338,7 @@ public class KeyRangeConcatIteratorTest extends AbstractKeyRangeIteratorTest
     @Test
     public void testDuplicatedElementsInTheSameFlow()
     {
-        // In real case, we should not have duplicated elements from the same PostingListRangeIterator
+        // In real case, we should not have duplicated elements from the same PostingListKeyRangeIterator
         KeyRangeIterator rangeA = build(1L, 2L, 3L, 3L, 4L, 4L);
         KeyRangeIterator rangeB = build(6L, 6L, 7L, 7L);
         KeyRangeIterator rangeC = build(8L, 8L);


### PR DESCRIPTION
Part of CNDB-11563

Some leftovers found in https://github.com/datastax/cassandra/pull/1412.

Also adds a generated file to .gitignore in a separate commit.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits