### PR TITLE
CNDB-10085: Add guardrail for the number of column filters per query after applying analyzers

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1600,3 +1600,12 @@ enable_drop_compact_storage: false
   # Default offset_rows_failure_threshold is 20000, may differ if emulate_dbaas_defaults is enabled
   # offset_rows_warn_threshold: 10000
   # offset_rows_failure_threshold: 20000
+
+  # Guardrail to warn or fail when a SELECT query has more column value filters than threshold.
+  # Note that restrictions on indexed columns can be expanded to multiple column filters if the indexes have an analyzer.
+  # In that case, there will be a filter for every token produced by the analyzer for the queried column value. This can
+  # prevent that productive analyzers such as n-gram explode the query to a large number of filtering operations.
+  # Default query_filters_warn_threshold is 20, may differ if emulate_dbaas_defaults is enabled
+  # Default query_filters_fail_threshold is 50, may differ if emulate_dbaas_defaults is enabled
+  # query_filters_warn_threshold: 50
+  # query_filters_fail_threshold: 100

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1605,7 +1605,6 @@ enable_drop_compact_storage: false
   # Note that restrictions on indexed columns can be expanded to multiple column filters if the indexes have an analyzer.
   # In that case, there will be a filter for every token produced by the analyzer for the queried column value. This can
   # prevent that productive analyzers such as n-gram explode the query to a large number of filtering operations.
-  # Default query_filters_warn_threshold is 20, may differ if emulate_dbaas_defaults is enabled
-  # Default query_filters_fail_threshold is 50, may differ if emulate_dbaas_defaults is enabled
-  # query_filters_warn_threshold: 50
-  # query_filters_fail_threshold: 100
+  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # query_filters_warn_threshold: -1
+  # query_filters_fail_threshold: -1

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -985,12 +985,12 @@ public class StatementRestrictions
         return table.clusteringColumns().size() != clusteringColumnsRestrictions.size();
     }
 
-    public RowFilter getRowFilter(IndexRegistry indexManager, QueryOptions options)
+    public RowFilter getRowFilter(IndexRegistry indexManager, QueryOptions options, QueryState queryState)
     {
         if (filterRestrictions.isEmpty() && children.isEmpty())
             return RowFilter.NONE;
 
-        return RowFilter.builder(indexManager).buildFromRestrictions(this, table, options);
+        return RowFilter.builder(indexManager).buildFromRestrictions(this, table, options, queryState);
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -94,7 +94,7 @@ import static org.apache.cassandra.utils.ByteBufferUtil.UNSET_BYTE_BUFFER;
 /**
  * Encapsulates a completely parsed SELECT query, including the target
  * column family, expression, result count, and ordering clause.
- *
+ * </p>
  * A number of public methods here are only used internally. However,
  * many of these are made accessible for the benefit of custom
  * QueryHandler implementations, so before reducing their accessibility
@@ -687,7 +687,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         if (filter == null || filter.isEmpty(table.comparator))
             return ReadQuery.empty(table);
 
-        RowFilter rowFilter = getRowFilter(options);
+        RowFilter rowFilter = getRowFilter(options, queryState);
 
         List<DecoratedKey> decoratedKeys = new ArrayList<>(keys.size());
         for (ByteBuffer key : keys)
@@ -732,7 +732,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         QueryOptions options = QueryOptions.forInternalCalls(Collections.emptyList());
         ColumnFilter columnFilter = selection.newSelectors(options).getColumnFilter();
         ClusteringIndexFilter filter = makeClusteringIndexFilter(options, columnFilter, state);
-        RowFilter rowFilter = getRowFilter(options);
+        RowFilter rowFilter = getRowFilter(options, state);
         return SinglePartitionReadCommand.create(table, nowInSec, columnFilter, rowFilter, DataLimits.NONE, key, filter);
     }
 
@@ -741,7 +741,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      */
     public RowFilter rowFilterForInternalCalls()
     {
-        return getRowFilter(QueryOptions.forInternalCalls(Collections.emptyList()));
+        return getRowFilter(QueryOptions.forInternalCalls(Collections.emptyList()), QueryState.forInternalCalls());
     }
 
     private ReadQuery getRangeCommand(QueryOptions options, ColumnFilter columnFilter, DataLimits limit, int nowInSec, QueryState queryState)
@@ -750,7 +750,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         if (clusteringIndexFilter == null)
             return ReadQuery.empty(table);
 
-        RowFilter rowFilter = getRowFilter(options);
+        RowFilter rowFilter = getRowFilter(options, queryState);
 
         // The LIMIT provided by the user is the number of CQL row he wants returned.
         // We want to have getRangeSlice to count the number of columns, not the number of keys.
@@ -980,10 +980,10 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     /**
      * May be used by custom QueryHandler implementations
      */
-    public RowFilter getRowFilter(QueryOptions options) throws InvalidRequestException
+    public RowFilter getRowFilter(QueryOptions options, QueryState state) throws InvalidRequestException
     {
         IndexRegistry indexRegistry = IndexRegistry.obtain(table);
-        return restrictions.getRowFilter(indexRegistry, options);
+        return restrictions.getRowFilter(indexRegistry, options, state);
     }
 
     private ResultSet process(PartitionIterator partitions,

--- a/src/java/org/apache/cassandra/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/guardrails/Guardrails.java
@@ -265,6 +265,17 @@ public abstract class Guardrails
                       format("%s requested to skip %s rows, this exceeds the %s threshold of %s.",
                              what, value, isWarning ? "warning" : "failure", threshold));
 
+    /**
+     * Guardrail on the number of query filtering operations per SELECT query (after analysis).
+     */
+    public static final Threshold queryFilters =
+    factory.threshold("query_filters",
+                      () -> config.query_filters_warn_threshold,
+                      () -> config.query_filters_fail_threshold,
+                      (isWarning, what, value, threshold) ->
+                      format("%s has %s column value filters after analysis, this exceeds the %s threshold of %s.",
+                             what, value, isWarning ? "warning" : "failure", threshold));
+
     private static String formatSize(long size)
     {
         return Units.toString(size, SizeUnit.BYTES);

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -145,7 +145,7 @@ public class GuardrailsConfig
     public volatile Integer offset_rows_warn_threshold;
     public volatile Integer offset_rows_failure_threshold;
 
-    // Limit the number of column value filters per SELECT query (after applying analyzers)
+    // Limit the number of column value filters per SELECT query (after applying analyzers, in case they are used)
     public volatile Integer query_filters_warn_threshold;
     public volatile Integer query_filters_fail_threshold;
 

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -169,7 +169,7 @@ public class GuardrailsConfig
         enforceDefault(logged_batch_enabled, v -> logged_batch_enabled = v, true, true);
         enforceDefault(batch_size_warn_threshold_in_kb, v -> batch_size_warn_threshold_in_kb = v, 64, 64);
         enforceDefault(batch_size_fail_threshold_in_kb, v -> batch_size_fail_threshold_in_kb = v, 640, 640);
-        enforceDefault(unlogged_batch_across_partitions_warn_threshold, v -> unlogged_batch_across_partitions_warn_threshold = v, 10, 10);
+        enforceDefault(unlogged_batch_across_partitions_warn_threshold, v -> unlogged_batch_across_partitions_warn_threshold = v, -1, -1);
 
         enforceDefault(truncate_table_enabled, v -> truncate_table_enabled = v, true, true);
 

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -169,7 +169,7 @@ public class GuardrailsConfig
         enforceDefault(logged_batch_enabled, v -> logged_batch_enabled = v, true, true);
         enforceDefault(batch_size_warn_threshold_in_kb, v -> batch_size_warn_threshold_in_kb = v, 64, 64);
         enforceDefault(batch_size_fail_threshold_in_kb, v -> batch_size_fail_threshold_in_kb = v, 640, 640);
-        enforceDefault(unlogged_batch_across_partitions_warn_threshold, v -> unlogged_batch_across_partitions_warn_threshold = v, -1, -1);
+        enforceDefault(unlogged_batch_across_partitions_warn_threshold, v -> unlogged_batch_across_partitions_warn_threshold = v, 10, 10);
 
         enforceDefault(truncate_table_enabled, v -> truncate_table_enabled = v, true, true);
 
@@ -239,8 +239,8 @@ public class GuardrailsConfig
         enforceDefault(offset_rows_warn_threshold, v -> offset_rows_warn_threshold = v, 10000, 10000);
         enforceDefault(offset_rows_failure_threshold, v -> offset_rows_failure_threshold = v, 20000, 20000);
 
-        enforceDefault(query_filters_warn_threshold, v -> query_filters_warn_threshold = v, 25, 25);
-        enforceDefault(query_filters_fail_threshold, v -> query_filters_fail_threshold = v, 50, 50);
+        enforceDefault(query_filters_warn_threshold, v -> query_filters_warn_threshold = v, -1, -1);
+        enforceDefault(query_filters_fail_threshold, v -> query_filters_fail_threshold = v, -1, -1);
     }
 
     /**

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -145,6 +145,10 @@ public class GuardrailsConfig
     public volatile Integer offset_rows_warn_threshold;
     public volatile Integer offset_rows_failure_threshold;
 
+    // Limit the number of column value filters per SELECT query (after applying analyzers)
+    public volatile Integer query_filters_warn_threshold;
+    public volatile Integer query_filters_fail_threshold;
+
     /**
      * If {@link DatabaseDescriptor#isEmulateDbaasDefaults()} is true, apply cloud defaults to guardrails settings that
      * are not specified in yaml; otherwise, apply on-prem defaults to guardrails settings that are not specified in yaml;
@@ -234,6 +238,9 @@ public class GuardrailsConfig
 
         enforceDefault(offset_rows_warn_threshold, v -> offset_rows_warn_threshold = v, 10000, 10000);
         enforceDefault(offset_rows_failure_threshold, v -> offset_rows_failure_threshold = v, 20000, 20000);
+
+        enforceDefault(query_filters_warn_threshold, v -> query_filters_warn_threshold = v, 25, 25);
+        enforceDefault(query_filters_fail_threshold, v -> query_filters_fail_threshold = v, 50, 50);
     }
 
     /**
@@ -300,6 +307,10 @@ public class GuardrailsConfig
         validateStrictlyPositiveInteger(offset_rows_warn_threshold, "offset_rows_warn_threshold");
         validateStrictlyPositiveInteger(offset_rows_failure_threshold, "offset_rows_failure_threshold");
         validateWarnLowerThanFail(offset_rows_warn_threshold, offset_rows_failure_threshold, "offset_rows_threshold");
+
+        validateStrictlyPositiveInteger(query_filters_warn_threshold, "query_filters_warn_threshold");
+        validateStrictlyPositiveInteger(query_filters_fail_threshold, "query_filters_fail_threshold");
+        validateWarnLowerThanFail(query_filters_warn_threshold, query_filters_fail_threshold, "query_filters_threshold");
     }
 
     /**

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
@@ -219,6 +219,22 @@ public class GuardrailQueryFiltersTest extends GuardrailTester
                           () -> "SELECT * FROM %s WHERE x = '1 2 3' AND y = '4 5 6'");
     }
 
+    @Test
+    public void testDisabledGuardrail() throws Throwable
+    {
+        config().query_filters_warn_threshold = -1;
+        config().query_filters_fail_threshold = -1;
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(v) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        assertValid("SELECT * FROM %s WHERE v = '1'");
+        assertValid("SELECT * FROM %s WHERE v = '1 2 3 4 5 6'");
+    }
+
     private void assertWarns(String query, int operations) throws Throwable
     {
         assertWarns(format("Select query has %s column value filters after analysis, this exceeds the warning threshold of %s.",

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
@@ -59,6 +59,12 @@ public class GuardrailQueryFiltersTest extends GuardrailTester
         config().query_filters_warn_threshold = -1;
         testValidationOfStrictlyPositiveProperty((c, v) -> c.query_filters_fail_threshold = v.intValue(),
                                                  "query_filters_fail_threshold");
+
+        // warn threshold larger than fail threshold
+        config().query_filters_warn_threshold = 2;
+        config().query_filters_fail_threshold = 1;
+        assertConfigFails(config()::validate, "The warn threshold 2 for the query_filters_threshold guardrail " +
+                                              "should be lower than the failure threshold 1");
     }
 
     @Test
@@ -144,7 +150,7 @@ public class GuardrailQueryFiltersTest extends GuardrailTester
         assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3 4 5'", 5);
         assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3 4 5 6'", 6);
 
-        // partial partition key restrictions don't count as filters
+        // partial partition key restrictions do count as filters
         assertValid("SELECT * FROM %s WHERE k1 = 0 AND x = '1' ALLOW FILTERING");
         assertWarns("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2' ALLOW FILTERING", 3);
         assertWarns("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2 3' ALLOW FILTERING", 4);

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.guardrails;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.lang.String.format;
+
+/**
+ * Tests the guardrail for the number of column value filters per SELECT query, {@link Guardrails#queryFilters}.
+ */
+public class GuardrailQueryFiltersTest extends GuardrailTester
+{
+    private static final int WARN_THRESHOLD = 2;
+    private static final int FAIL_THRESHOLD = 4;
+
+    private int defaultWarnThreshold;
+    private int defaultFailThreshold;
+
+    @Before
+    public void before()
+    {
+        defaultWarnThreshold = config().query_filters_warn_threshold;
+        defaultFailThreshold = config().query_filters_fail_threshold;
+        config().query_filters_warn_threshold = WARN_THRESHOLD;
+        config().query_filters_fail_threshold = FAIL_THRESHOLD;
+    }
+
+    @After
+    public void after()
+    {
+        config().query_filters_warn_threshold = defaultWarnThreshold;
+        config().query_filters_fail_threshold = defaultFailThreshold;
+    }
+
+    @Test
+    public void testConfigValidation()
+    {
+        config().query_filters_fail_threshold = -1;
+        testValidationOfStrictlyPositiveProperty((c, v) -> c.query_filters_warn_threshold = v.intValue(),
+                                                 "query_filters_warn_threshold");
+
+        config().query_filters_warn_threshold = -1;
+        testValidationOfStrictlyPositiveProperty((c, v) -> c.query_filters_fail_threshold = v.intValue(),
+                                                 "query_filters_fail_threshold");
+    }
+
+    @Test
+    public void testQueryFilters() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k1 int, k2 int, c1 int, c2 int, x text, y text, z text, PRIMARY KEY((k1, k2), c1, c2))");
+
+        String x = createIndex("CREATE CUSTOM INDEX ON %s(x) " +
+                               "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                               "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        String y = createIndex("CREATE CUSTOM INDEX ON %s(y) " +
+                               "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                               "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(z) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+
+        // single column, single expression (analyzed)
+        assertValid("SELECT * FROM %s WHERE x = '1'");
+        assertValid("SELECT * FROM %s WHERE x = '1 2'");
+        assertWarns("SELECT * FROM %s WHERE x = '1 2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1 2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1 2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1 2 3 4 5 6'", 6);
+
+        // single column, single expression (not analyzed)
+        assertValid("SELECT * FROM %s WHERE z = '1'");
+        assertValid("SELECT * FROM %s WHERE z = '1 2'");
+        assertValid("SELECT * FROM %s WHERE z = '1 2 3'");
+        assertValid("SELECT * FROM %s WHERE z = '1 2 3 4'");
+        assertValid("SELECT * FROM %s WHERE z = '1 2 3 4 5'");
+        assertValid("SELECT * FROM %s WHERE z = '1 2 3 4 5 6'");
+
+        // single column, multiple expressions (analyzed, AND)
+        assertValid("SELECT * FROM %s WHERE x = '1' AND x = '2'");
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND x = '2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND x = '2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND x = '2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND x = '2 3 4 5 6'", 6);
+
+        // single column, multiple expressions (analyzed, OR)
+        assertValid("SELECT * FROM %s WHERE x = '1' OR x = '2'");
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR x = '2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR x = '2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR x = '2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR x = '2 3 4 5 6'", 6);
+
+        // multiple columns (analyzed, AND)
+        assertValid("SELECT * FROM %s WHERE x = '1' AND y = '2'");
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND y = '2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND y = '2 3 4 5 6'", 6);
+
+        // multiple columns (analyzed, OR)
+        assertValid("SELECT * FROM %s WHERE x = '1' OR y = '2'");
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR y = '2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR y = '2 3 4 5 6'", 6);
+
+        // multiple columns (analyzed and not analyzed, AND)
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2' AND z = '3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2' AND z = '3 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2 3' AND z = '4'", 4);
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2 3' AND z = '4 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND y = '2 3 4' AND z = '5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' AND y = '2 3 4' AND z = '5 5'", 5);
+
+        // multiple columns (analyzed and not analyzed, OR)
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2' OR z = '3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2' OR z = '3 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2 3' OR z = '4'", 4);
+        assertWarns("SELECT * FROM %s WHERE x = '1' OR y = '2 3' OR z = '4 4'", 4);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR y = '2 3 4' OR z = '5'", 5);
+        assertFails("SELECT * FROM %s WHERE x = '1' OR y = '2 3 4' OR z = '5 5'", 5);
+
+        // full partition key restrictions don't count as filters
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1'");
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2'");
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND x = '1 2 3 4 5 6'", 6);
+
+        // partial partition key restrictions don't count as filters
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND x = '1' ALLOW FILTERING");
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2 3' ALLOW FILTERING", 4);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2 3 4' ALLOW FILTERING", 5);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND x = '1 2 3 4 5' ALLOW FILTERING", 6);
+        assertValid("SELECT * FROM %s WHERE k2 = 0 AND x = '1' ALLOW FILTERING");
+        assertWarns("SELECT * FROM %s WHERE k2 = 0 AND x = '1 2' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE k2 = 0 AND x = '1 2 3' ALLOW FILTERING", 4);
+        assertFails("SELECT * FROM %s WHERE k2 = 0 AND x = '1 2 3 4' ALLOW FILTERING", 5);
+        assertFails("SELECT * FROM %s WHERE k2 = 0 AND x = '1 2 3 4 5' ALLOW FILTERING", 6);
+
+        // full primary key restrictions don't count as filters
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1'");
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1 2'");
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1 2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1 2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1 2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND x = '1 2 3 4 5 6'", 6);
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1'");
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1 2'");
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1 2 3'", 3);
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1 2 3 4'", 4);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1 2 3 4 5'", 5);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c1 = 0 AND c2 = 0 AND x = '1 2 3 4 5 6'", 6);
+
+        // partial primary key restrictions do count as filters
+        assertValid("SELECT * FROM %s WHERE c2 = 0 AND x = '1' ALLOW FILTERING");
+        assertWarns("SELECT * FROM %s WHERE c2 = 0 AND x = '1 2' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE c2 = 0 AND x = '1 2 3' ALLOW FILTERING", 4);
+        assertFails("SELECT * FROM %s WHERE c2 = 0 AND x = '1 2 3 4 5' ALLOW FILTERING", 6);
+        assertFails("SELECT * FROM %s WHERE c2 = 0 AND x = '1 2 3 4 5 6' ALLOW FILTERING", 7);
+        assertValid("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c2 = 0 AND x = '1' ALLOW FILTERING");
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c2 = 0 AND x = '1 2' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c2 = 0 AND x = '1 2 3' ALLOW FILTERING", 4);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c2 = 0 AND x = '1 2 3 4 5' ALLOW FILTERING", 6);
+        assertFails("SELECT * FROM %s WHERE k1 = 0 AND k2 = 0 AND c2 = 0 AND x = '1 2 3 4 5 6' ALLOW FILTERING", 7);
+
+        // without the analyzed indexes
+        dropIndex("DROP INDEX %s." + x);
+        dropIndex("DROP INDEX %s." + y);
+        assertValid("SELECT * FROM %s WHERE x = '1' ALLOW FILTERING");
+        assertValid("SELECT * FROM %s WHERE x = '1 2' ALLOW FILTERING");
+        assertValid("SELECT * FROM %s WHERE x = '1 2 3' ALLOW FILTERING");
+        assertValid("SELECT * FROM %s WHERE x = '1' AND y = '2' ALLOW FILTERING");
+        assertValid("SELECT * FROM %s WHERE x = '1 2' AND y = '3 4' ALLOW FILTERING");
+        assertValid("SELECT * FROM %s WHERE x = '1 2 3' AND y = '4 5 6' ALLOW FILTERING");
+        assertWarns("SELECT * FROM %s WHERE x = '1' AND y = '2' AND z = '3' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1 2' AND y = '3 4' AND z = '5 6' ALLOW FILTERING", 3);
+        assertWarns("SELECT * FROM %s WHERE x = '1 2 3' AND y = '4 5 6' AND z = '7 8 9' ALLOW FILTERING", 3);
+    }
+
+    @Test
+    public void testExcludedUsers() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, x text, y text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(x) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(y) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        testExcludedUsers(() -> "SELECT * FROM %s WHERE x = '1 2 3'",
+                          () -> "SELECT * FROM %s WHERE x = '1 2 3' AND y = '4 5 6'");
+    }
+
+    private void assertWarns(String query, int operations) throws Throwable
+    {
+        assertWarns(format("Select query has %s column value filters after analysis, this exceeds the warning threshold of %s.",
+                           operations, WARN_THRESHOLD),
+                    query);
+    }
+
+    private void assertFails(String query, int operations) throws Throwable
+    {
+        assertFails(format("Select query has %s column value filters after analysis, this exceeds the failure threshold of %s.",
+                           operations, FAIL_THRESHOLD),
+                    query);
+    }
+}


### PR DESCRIPTION
Adds a new `query_filters` guardrail to limit the number of column value filters per query after applying index analyzers.

The guardrail is applied to the sum of all column filters, analyzed or not, indexed or not. Complete primary key restrictions are not considered column value filters so they don't count towards the configured limit.

This should be useful to limit the number of filtered columns in general, and to prevent the explosion of filtering operations produced by analyzers applied to large values.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits