### PR TITLE
CNDB-11678: Use DenseIntMap for CassandraOnHeapGraph

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/BitsUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/BitsUtil.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.cliffc.high_scale_lib.NonBlockingHashMapLong;
 
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.util.DenseIntMap;
 
 public class BitsUtil
 {
@@ -33,7 +34,7 @@ public class BitsUtil
                : toAccept == Bits.ALL ? new NoDeletedBits(deletedOrdinals) : new NoDeletedIntersectingBits(toAccept, deletedOrdinals);
     }
 
-    public static <T> Bits bitsIgnoringDeleted(Bits toAccept, NonBlockingHashMapLong<VectorPostings<T>> postings)
+    public static <T> Bits bitsIgnoringDeleted(Bits toAccept, DenseIntMap<VectorPostings<T>> postings)
     {
         return toAccept == Bits.ALL ? new NoDeletedPostings(postings) : new NoDeletedIntersectingPostings(toAccept, postings);
     }
@@ -84,9 +85,9 @@ public class BitsUtil
 
     private static class NoDeletedPostings<T> extends BitsWithoutLength
     {
-        private final NonBlockingHashMapLong<VectorPostings<T>> postings;
+        private final DenseIntMap<VectorPostings<T>> postings;
 
-        public NoDeletedPostings(NonBlockingHashMapLong<VectorPostings<T>> postings)
+        public NoDeletedPostings(DenseIntMap<VectorPostings<T>> postings)
         {
             this.postings = postings;
         }
@@ -103,9 +104,9 @@ public class BitsUtil
     private static class NoDeletedIntersectingPostings<T> extends BitsWithoutLength
     {
         private final Bits toAccept;
-        private final NonBlockingHashMapLong<VectorPostings<T>> postings;
+        private final DenseIntMap<VectorPostings<T>> postings;
 
-        public NoDeletedIntersectingPostings(Bits toAccept, NonBlockingHashMapLong<VectorPostings<T>> postings)
+        public NoDeletedIntersectingPostings(Bits toAccept, DenseIntMap<VectorPostings<T>> postings)
         {
             this.toAccept = toAccept;
             this.postings = postings;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/ConcurrentVectorValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/ConcurrentVectorValues.java
@@ -25,6 +25,7 @@ import java.util.function.IntUnaryOperator;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import io.github.jbellis.jvector.util.DenseIntMap;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.ArrayVectorFloat;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
@@ -36,7 +37,7 @@ import org.jctools.maps.NonBlockingHashMapLong;
 public class ConcurrentVectorValues implements RamAwareVectorValues
 {
     private final int dimensions;
-    private final NonBlockingHashMapLong<VectorFloat<?>> values = new NonBlockingHashMapLong<>();
+    private final DenseIntMap<VectorFloat<?>> values = new DenseIntMap<>(1024);
 
     public ConcurrentVectorValues(int dimensions)
     {
@@ -64,8 +65,9 @@ public class ConcurrentVectorValues implements RamAwareVectorValues
     /** return approximate bytes used by the new vector */
     public long add(int ordinal, VectorFloat<?> vector)
     {
-        values.put(ordinal, vector);
-        return RamEstimation.concurrentHashMapRamUsed(1) + oneVectorBytesUsed();
+        if (!values.compareAndPut(ordinal, null, vector))
+            throw new IllegalStateException("Vector already exists for ordinal " + ordinal);
+        return RamUsageEstimator.NUM_BYTES_OBJECT_REF;
     }
 
     @Override
@@ -85,7 +87,7 @@ public class ConcurrentVectorValues implements RamAwareVectorValues
     {
         long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         return 2 * REF_BYTES
-               + RamEstimation.concurrentHashMapRamUsed(values.size())
+               + RamEstimation.denseIntMapRamUsed(values.size())
                + values.size() * oneVectorBytesUsed();
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/RamEstimation.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/RamEstimation.java
@@ -50,4 +50,28 @@ public class RamEstimation
         + chmCounters
         + REF_BYTES; // the Map reference itself
     }
+
+    /**
+     * @param elementCount the size() of the DenseIntMap
+     * @return an estimate of the number of bytes used by a DenseIntMap
+     */
+    public static long denseIntMapRamUsed(int elementCount) {
+        long REF_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        long AH_BYTES = RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+        long RWLOCK_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 3 * REF_BYTES; // Approx. size for ReadWriteLock
+        long ATOMIC_INT_BYTES = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES + REF_BYTES; // AtomicInteger overhead
+
+        // Find power of 2 greater than or equal to elementCount
+        int capacity = 1;
+        while (capacity < elementCount) {
+            capacity <<= 1;
+        }
+
+        // Calculate size for AtomicReferenceArray with for capacity elements
+        long atomicRefArrayBytes = AH_BYTES + capacity * REF_BYTES;
+
+        return RWLOCK_BYTES // Size of the ReadWriteLock object
+               + ATOMIC_INT_BYTES // Size of the AtomicInteger
+               + atomicRefArrayBytes; // Size of the AtomicReferenceArray structure
+    }
 }


### PR DESCRIPTION
### What is the issue

Fixes https://github.com/riptano/cndb/issues/11678

### What does this PR fix and why was it fixed

The `NonBlockingHashMapLong` class was popping up on several profiles because of the `get` method. We can instead use the `DenseIntMap` from jvector because we know that the map keys are ordinals in the vector index. We technically don't need all of the features that the `DenseIntMap` gives us (e.g. we don't update map values after they are set), but given that I haven't seen the `DenseIntMap` on any of the flame graphs and the class is used internally in jvector in similar ways, I am guessing this should be a solid improvement.

Note: I also considered a more custom class that might have had fewer volatile references, but ultimately, I think this code is well tested and we should use it until we find that it is a large enough bottleneck to justify the higher cognitive load associated with a custom class.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits