### PR TITLE
CNDB-11742: Add a client warning when using an n-gram analyzer without a query analyzer

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/IndexFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/IndexFcts.java
@@ -64,7 +64,7 @@ public abstract class IndexFcts
 
             LuceneAnalyzer luceneAnalyzer = null;
             List<String> tokens = new ArrayList<>();
-            try (Analyzer analyzer = JSONAnalyzerParser.parse(json))
+            try (Analyzer analyzer = JSONAnalyzerParser.parse(json).left)
             {
                 luceneAnalyzer = new LuceneAnalyzer(UTF8Type.instance, analyzer, new HashMap<>());
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -106,6 +106,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
@@ -115,6 +116,13 @@ import static org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig.MAX_TOP_K
 
 public class StorageAttachedIndex implements Index
 {
+    public static final String NGRAM_WITHOUT_QUERY_ANALYZER_WARNING =
+    "Using an ngram analyzer without defining a query_analyzer. " +
+    "This means that the same ngram analyzer will be applied to both indexed and queried column values. " +
+    "Applying ngram analysis to the queried values usually produces too many search tokens to be useful. " +
+    "The large number of tokens can also have a negative impact in performance. " +
+    "In most cases it's better to use a simpler query_analyzer such as the standard one.";
+
     private static final Logger logger = LoggerFactory.getLogger(StorageAttachedIndex.class);
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
 
@@ -320,9 +328,16 @@ public class StorageAttachedIndex implements Index
         }
 
         AbstractType<?> type = TypeUtil.cellValueType(target.left, target.right);
-        AbstractAnalyzer.fromOptions(type, options); // will throw if invalid
-        if (AbstractAnalyzer.hasQueryAnalyzer(options))
-            AbstractAnalyzer.fromOptionsQueryAnalyzer(type, options); // will throw if invalid
+
+        // Validate analyzers by building them
+        try (AbstractAnalyzer.AnalyzerFactory analyzerFactory = AbstractAnalyzer.fromOptions(type, options))
+        {
+            if (AbstractAnalyzer.hasQueryAnalyzer(options))
+                AbstractAnalyzer.fromOptionsQueryAnalyzer(type, options).close();
+            else if (analyzerFactory.isNGram())
+                ClientWarn.instance.warn(NGRAM_WITHOUT_QUERY_ANALYZER_WARNING);
+        }
+
         var config = IndexWriterConfig.fromOptions(null, type, options);
 
         // If we are indexing map entries we need to validate the sub-types

--- a/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/JSONAnalyzerParser.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.analyzer.filter.BuiltInAnalyzers;
+import org.apache.cassandra.utils.Pair;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharFilterFactory;
 import org.apache.lucene.analysis.TokenFilterFactory;
@@ -36,12 +37,12 @@ public class JSONAnalyzerParser
 {
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
-    public static Analyzer parse(String json) throws IOException
+    public static Pair<Analyzer, LuceneCustomAnalyzerConfig> parse(String json) throws IOException
     {
         Analyzer analyzer = matchBuiltInAnalzyer(json.toUpperCase());
         if (analyzer != null)
         {
-            return analyzer;
+            return Pair.create(analyzer, null);
         }
 
         LuceneCustomAnalyzerConfig analyzerModel;
@@ -147,12 +148,15 @@ public class JSONAnalyzerParser
                 throw new InvalidRequestException("Error configuring analyzer's charFilter '" + charFilter.getName() + "': " + e.getMessage());
             }
         }
-        return builder.build();
+        return Pair.create(builder.build(), analyzerModel);
     }
 
-    private static Analyzer matchBuiltInAnalzyer(String maybeAnalyzer) {
-        for (BuiltInAnalyzers analyzer : BuiltInAnalyzers.values()) {
-            if (analyzer.name().equals(maybeAnalyzer)) {
+    private static Analyzer matchBuiltInAnalzyer(String maybeAnalyzer)
+    {
+        for (BuiltInAnalyzers analyzer : BuiltInAnalyzers.values())
+        {
+            if (analyzer.name().equals(maybeAnalyzer))
+            {
                 return analyzer.getNewAnalyzer();
             }
         }

--- a/src/java/org/apache/cassandra/index/sai/analyzer/LuceneCustomAnalyzerConfig.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/LuceneCustomAnalyzerConfig.java
@@ -51,4 +51,21 @@ public class LuceneCustomAnalyzerConfig
     {
         return charFilters;
     }
+
+    /**
+     * @return {@link true} if this analyzer configuration has a n-gram tokenizer or any of its filters is n-gram.
+     */
+    public boolean isNGram()
+    {
+        if (getTokenizer().getName().equals("ngram"))
+            return true;
+
+        for (LuceneClassNameAndArgs filter : getFilters())
+        {
+            if (filter.getName().equals("ngram"))
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/analyzer/LuceneAnalyzerTest.java
@@ -189,14 +189,14 @@ public class LuceneAnalyzerTest
 
     public static List<String> tokenize(String testString, String json) throws Exception
     {
-        Analyzer luceneAnalyzer = JSONAnalyzerParser.parse(json);
-        LuceneAnalyzer analyzer = new LuceneAnalyzer(UTF8Type.instance, luceneAnalyzer, new HashMap<String, String>());
+        Analyzer luceneAnalyzer = JSONAnalyzerParser.parse(json).left;
+        LuceneAnalyzer analyzer = new LuceneAnalyzer(UTF8Type.instance, luceneAnalyzer, new HashMap<>());
 
         ByteBuffer toAnalyze = ByteBuffer.wrap(testString.getBytes(Charsets.UTF_8));
         analyzer.reset(toAnalyze);
         ByteBuffer analyzed = null;
 
-        List<String> list = new ArrayList();
+        List<String> list = new ArrayList<>();
 
         while (analyzer.hasNext())
         {


### PR DESCRIPTION
As mentioned in [CNDB-10085](https://github.com/riptano/cndb/issues/10085), it might be useful to throw a client warning when creating an index using an n-gram analyzer for queries. 

In most cases, users will want to use n-gram when indexing, but query with something simpler like a whitespace analyzer, or even a no-op analyzer. Besides functionality, n-gram can produce too many index predicates, for which [CNDB-10085](https://github.com/riptano/cndb/issues/10085) will add a guardrail.

I think we could emit the warning when there is no specific `query_analyzer` and the common analyzer for both reading and writing is n-gram. I think we don't need to warn if there is a specific n-gram `query_analyzer`, since that probably indicates intentionality, rather than a mistake.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits