### PR TITLE
CNDB-10732: Reproduction tests and fixes for CNDB-10732 and CNDB-10535

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -81,7 +81,7 @@ public class StatementRestrictions
     "Restriction on partition key column %s must not be nested under OR operator";
 
     public static final String GEO_DISTANCE_REQUIRES_INDEX_MESSAGE = "GEO_DISTANCE requires the vector column to be indexed";
-    public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE = "Ordering on non-clustering column %s requires the column to be indexed";
+    public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE = "Ordering on non-clustering column %s requires the column to be indexed.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE =
     "Ordering on non-clustering column requires each restricted column to be indexed except for fully-specified partition keys";
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
@@ -90,9 +91,11 @@ import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Throwables;
 
 import static java.lang.Math.max;
+import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
 public class QueryController implements Plan.Executor, Plan.CostEstimator
 {
+    private static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped.";
     private static final Logger logger = LoggerFactory.getLogger(QueryController.class);
 
     /**
@@ -395,7 +398,11 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         if (orderer != null)
             keysIterationPlan = planFactory.sort(keysIterationPlan, orderer);
 
-        assert keysIterationPlan != planFactory.everything; // This would mean we have no WHERE nor ANN clauses at all
+        // This would mean we have no WHERE nor ANN clauses at all; this can happen in case an index was dropped after the
+        // query was initiated
+        if (keysIterationPlan == planFactory.everything)
+            throw invalidRequest(INDEX_MAY_HAVE_BEEN_DROPPED + StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+
         return keysIterationPlan;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -95,7 +95,8 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.invalidReq
 
 public class QueryController implements Plan.Executor, Plan.CostEstimator
 {
-    private static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped.";
+    public static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped. " +
+                                                             StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE;
     private static final Logger logger = LoggerFactory.getLogger(QueryController.class);
 
     /**
@@ -401,7 +402,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         // This would mean we have no WHERE nor ANN clauses at all; this can happen in case an index was dropped after the
         // query was initiated
         if (keysIterationPlan == planFactory.everything)
-            throw invalidRequest(INDEX_MAY_HAVE_BEEN_DROPPED + StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+            throw invalidRequest(INDEX_MAY_HAVE_BEEN_DROPPED);
 
         return keysIterationPlan;
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +43,6 @@ import org.apache.cassandra.concurrent.LocalAwareExecutorService;
 import org.apache.cassandra.concurrent.SharedExecutorPool;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.Operator;
-import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
@@ -91,8 +89,8 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.invalidReq
  */
 public class TopKProcessor
 {
-    private static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped. Ordering on non-clustering " +
-                                                              "column requires the column to be indexed";
+    public static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped. Ordering on non-clustering " +
+                                                             "column requires the column to be indexed";
     protected static final Logger logger = LoggerFactory.getLogger(TopKProcessor.class);
     private static final LocalAwareExecutorService PARALLEL_EXECUTOR = getExecutor();
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
@@ -109,7 +107,7 @@ public class TopKProcessor
         this.command = command;
 
         Pair<IndexContext, RowFilter.Expression> annIndexAndExpression = findTopKIndexContext();
-        //this can happen in case an index was dropped after the query was initiated
+        // this can happen in case an index was dropped after the query was initiated
         if (annIndexAndExpression == null)
             throw invalidRequest(INDEX_MAY_HAVE_BEEN_DROPPED);
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -79,8 +79,7 @@ public class DropIndexWhileQueryingTest extends SAITester
                                              .newActionBuilder()
                                              .actions()
                                              .doAction("org.apache.cassandra.index.sai.cql.DropIndexWhileQueryingTest" +
-                                                       ".dropIndexForBytemanInjections" +
-                                                       "(\"DROP INDEX cql_test_keyspace." + indexName + "\")"))
+                                                       ".dropIndexForBytemanInjections(\"" + indexName + "\")"))
                                         .build();
         Injections.inject(injection);
         injection.enable();
@@ -89,9 +88,9 @@ public class DropIndexWhileQueryingTest extends SAITester
 
     // the method is used by the byteman rule to drop the index
     @SuppressWarnings("unused")
-    public static void dropIndexForBytemanInjections(String query)
+    public static void dropIndexForBytemanInjections(String indexName)
     {
-        String fullQuery = String.format(query, KEYSPACE);
+        String fullQuery = String.format("DROP INDEX %s.%s", KEYSPACE, indexName);
         logger.info(fullQuery);
         schemaChange(fullQuery);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,11 +16,14 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.plan.QueryController;
+import org.apache.cassandra.index.sai.plan.TopKProcessor;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
 
 import org.junit.Test;
 
@@ -31,8 +32,10 @@ import static org.junit.Assert.assertTrue;
 
 public class DropIndexWhileQueryingTest extends SAITester
 {
+    // See CNDB-10732
     @Test
-    public void testReproductionForCNDB10732() throws Throwable
+    public void testDropIndexWhileQuerying() throws Throwable
+
     {
         createTable("CREATE TABLE %s (electronicVehicle TEXT PRIMARY KEY, modelYear INT, make TEXT, vehType TEXT) WITH compaction = " +
                 "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
@@ -42,41 +45,36 @@ public class DropIndexWhileQueryingTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(vehType) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
-        Injection injection = Injections.newCustom("drop_index")
-                                        .add(newInvokePoint()
-                                             .onClass(QueryController.class)
-                                             .onMethod("buildPlan")
-                                             .atEntry())
-                                        .add(ActionBuilder
-                                             .newActionBuilder()
-                                             .actions()
-                                             .doAction("org.apache.cassandra.index.sai.cql.DropIndexWhileQueryingTest" +
-                                                       ".dropIndexForBytemanInjections" +
-                                                       "(\"DROP INDEX cql_test_keyspace." + indexName + "\")"))
-                                        .build();
+        injectIndexDrop("drop_index", indexName, true);
 
-        Injections.inject(injection);
-        injection.enable();
-        assertTrue("Injection should be enabled", injection.isEnabled());
         execute("INSERT INTO %s (electronicVehicle, modelYear, make, vehType) VALUES (?, ?, ?, ?)", "car", 1998, "Ford", "SUV");
-        assertInvalidMessage("An index may have been dropped.Cannot execute this query as it might involve " +
-                             "data filtering and thus may have unpredictable performance. If you want to execute this query" +
-                             " despite the performance unpredictability, use ALLOW FILTERING",
-                             "SELECT * FROM %s WHERE modelYear IN (1998, 2000) OR (make IN ('FORD', 'OPEL' ) OR vehType IN ('car', 'truck'));");
+        String query = "SELECT * FROM %s WHERE modelYear IN (1998, 2000) OR (make IN ('FORD', 'OPEL' ) OR vehType IN ('car', 'truck'))";
+        assertInvalidMessage(QueryController.INDEX_MAY_HAVE_BEEN_DROPPED, query);
+        assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);
     }
 
+    // See CNDB-10535
     @Test
-    public void testReproductionForCNDB10535() throws Throwable
+    public void testDropVectorIndexWhileQuerying() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
-        Injection injection = Injections.newCustom("drop_index2")
-                                        .add(newInvokePoint()
-                                             .onClass(QueryController.class)
-                                             .onMethod("buildPlan")
-                                             .atExit())
+        injectIndexDrop("drop_index2", indexName, false);
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
+
+        String query = "SELECT pk FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 2";
+        assertInvalidMessage(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED, query);
+        assertInvalidMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"), query);
+    }
+
+    private static void injectIndexDrop(String injectionName, String indexName, boolean atEntry) throws Throwable
+    {
+        InvokePointBuilder invokePoint = newInvokePoint().onClass(QueryController.class).onMethod("buildPlan");
+        Injection injection = Injections.newCustom(injectionName)
+                                        .add(atEntry ? invokePoint.atEntry() : invokePoint.atExit())
                                         .add(ActionBuilder
                                              .newActionBuilder()
                                              .actions()
@@ -84,17 +82,13 @@ public class DropIndexWhileQueryingTest extends SAITester
                                                        ".dropIndexForBytemanInjections" +
                                                        "(\"DROP INDEX cql_test_keyspace." + indexName + "\")"))
                                         .build();
-
         Injections.inject(injection);
         injection.enable();
         assertTrue("Injection should be enabled", injection.isEnabled());
-
-        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
-        assertInvalidMessage("An index may have been dropped. Ordering on non-clustering column requires the " +
-                             "column to be indexed", "SELECT pk FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 2");
     }
 
     // the method is used by the byteman rule to drop the index
+    @SuppressWarnings("unused")
     public static void dropIndexForBytemanInjections(String query)
     {
         String fullQuery = String.format(query, KEYSPACE);

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.plan.QueryController;
+import org.apache.cassandra.inject.ActionBuilder;
+import org.apache.cassandra.inject.Injection;
+import org.apache.cassandra.inject.Injections;
+
+import org.junit.Test;
+
+import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
+import static org.junit.Assert.assertTrue;
+
+public class DropIndexWhileQueryingTest extends SAITester
+{
+    @Test
+    public void testReproductionForCNDB10732() throws Throwable
+    {
+        createTable("CREATE TABLE %s (electronicVehicle TEXT PRIMARY KEY, modelYear INT, make TEXT, vehType TEXT) WITH compaction = " +
+                "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(make) USING 'StorageAttachedIndex'");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(modelYear) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(vehType) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        Injection injection = Injections.newCustom("drop_index")
+                                        .add(newInvokePoint()
+                                             .onClass(QueryController.class)
+                                             .onMethod("buildPlan")
+                                             .atEntry())
+                                        .add(ActionBuilder
+                                             .newActionBuilder()
+                                             .actions()
+                                             .doAction("org.apache.cassandra.index.sai.cql.DropIndexWhileQueryingTest" +
+                                                       ".dropIndexForBytemanInjections" +
+                                                       "(\"DROP INDEX cql_test_keyspace." + indexName + "\")"))
+                                        .build();
+
+        Injections.inject(injection);
+        injection.enable();
+        assertTrue("Injection should be enabled", injection.isEnabled());
+        execute("INSERT INTO %s (electronicVehicle, modelYear, make, vehType) VALUES (?, ?, ?, ?)", "car", 1998, "Ford", "SUV");
+        assertInvalidMessage("An index may have been dropped.Cannot execute this query as it might involve " +
+                             "data filtering and thus may have unpredictable performance. If you want to execute this query" +
+                             " despite the performance unpredictability, use ALLOW FILTERING",
+                             "SELECT * FROM %s WHERE modelYear IN (1998, 2000) OR (make IN ('FORD', 'OPEL' ) OR vehType IN ('car', 'truck'));");
+    }
+
+    @Test
+    public void testReproductionForCNDB10535() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        Injection injection = Injections.newCustom("drop_index2")
+                                        .add(newInvokePoint()
+                                             .onClass(QueryController.class)
+                                             .onMethod("buildPlan")
+                                             .atExit())
+                                        .add(ActionBuilder
+                                             .newActionBuilder()
+                                             .actions()
+                                             .doAction("org.apache.cassandra.index.sai.cql.DropIndexWhileQueryingTest" +
+                                                       ".dropIndexForBytemanInjections" +
+                                                       "(\"DROP INDEX cql_test_keyspace." + indexName + "\")"))
+                                        .build();
+
+        Injections.inject(injection);
+        injection.enable();
+        assertTrue("Injection should be enabled", injection.isEnabled());
+
+        execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
+        assertInvalidMessage("An index may have been dropped. Ordering on non-clustering column requires the " +
+                             "column to be indexed", "SELECT pk FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 2");
+    }
+
+    // the method is used by the byteman rule to drop the index
+    public static void dropIndexForBytemanInjections(String query)
+    {
+        String fullQuery = String.format(query, KEYSPACE);
+        logger.info(fullQuery);
+        schemaChange(fullQuery);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -35,20 +35,18 @@ public class DropIndexWhileQueryingTest extends SAITester
     // See CNDB-10732
     @Test
     public void testDropIndexWhileQuerying() throws Throwable
-
     {
-        createTable("CREATE TABLE %s (electronicVehicle TEXT PRIMARY KEY, modelYear INT, make TEXT, vehType TEXT) WITH compaction = " +
-                "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, x int, y text, z text)");
 
-        createIndex("CREATE CUSTOM INDEX ON %s(make) USING 'StorageAttachedIndex'");
-        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(modelYear) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(vehType) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(y) USING 'StorageAttachedIndex'");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(z) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
         injectIndexDrop("drop_index", indexName, true);
 
-        execute("INSERT INTO %s (electronicVehicle, modelYear, make, vehType) VALUES (?, ?, ?, ?)", "car", 1998, "Ford", "SUV");
-        String query = "SELECT * FROM %s WHERE modelYear IN (1998, 2000) OR (make IN ('FORD', 'OPEL' ) OR vehType IN ('car', 'truck'))";
+        execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "car", 0, "y0", "z0");
+        String query = "SELECT * FROM %s WHERE x IN (0, 1) OR (y IN ('Y0', 'Y1' ) OR z IN ('z1', 'z2'))";
         assertInvalidMessage(QueryController.INDEX_MAY_HAVE_BEEN_DROPPED, query);
         assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);
     }

--- a/test/unit/org/apache/cassandra/inject/Injections.java
+++ b/test/unit/org/apache/cassandra/inject/Injections.java
@@ -86,6 +86,9 @@ public class Injections
         long pid = HeapUtils.getProcessId();
         List<String> properties = new ArrayList<>();
         properties.add("org.jboss.byteman.transform.all=true");
+        // uncomment below two lines to add debug or/and more verbose info, if you need to debug an injection
+        // properties.add("org.jboss.byteman.verbose=true");
+        // properties.add("org.jboss.byteman.debug=true");
         Install.install(Long.toString(pid), true, true, FBUtilities.getBroadcastAddressAndPort().address.getHostAddress(), port, properties.toArray(new String[0]));
         return port;
     }


### PR DESCRIPTION
### What is the issue
The issue is that we assert the presence of the indexes at the boundary of the query being handled, and then the `QueryController` assumes these won't change. Two cases were identified:
- one where we use assertions that might not even be enabled in prod environments.
- another one where the precondition actually is doing what it is expected but it does not give enough information.

### What does this PR fix and why was it fixed
Added reproduction tests for both cases identified. Fix by adding `UnsupportedExceptions`, though I am not sure whether we won't prefer preconditions with improved messages for both places. Open to suggestions and to hear other people opinion.

Current CI looks good to me but there is issue with building artifacts today, thus I do not have CNDB PR to upgrade the CC version. Though I think in the meantime the PR can be reviewed already. 

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ x] Verify test results on Butler
- [ x] Test coverage for new/modified code is > 80%
- [ x] Proper code formatting
- [ x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ x] Each commit has a meaningful description
- [ x] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits