### PR TITLE
CNDB-9046: cross-node messaging metrics fixes

### DIFF
--- a/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
@@ -62,7 +62,8 @@ public class MessagingMetrics implements InboundMessageHandlers.GlobalMetricCall
             this.allLatency = allLatency;
         }
 
-        public void accept(long timeTaken, TimeUnit units)
+        @Override
+        public void accept(Verb verb, long timeTaken, TimeUnit units)
         {
             if (timeTaken > 0)
             {

--- a/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
@@ -31,9 +31,6 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.metrics.InternodeInboundMetrics;
 import org.apache.cassandra.net.Message.Header;
 
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.cassandra.utils.MonotonicClock.approxTime;
-
 /**
  * An aggregation of {@link InboundMessageHandler}s for all connections from a peer.
  *
@@ -201,9 +198,9 @@ public final class InboundMessageHandlers
             @Override
             public void onHeaderArrived(int messageSize, Header header, long timeElapsed, TimeUnit unit)
             {
-                // do not log latency if we are within error bars of zero
-                if (timeElapsed > unit.convert(approxTime.error(), NANOSECONDS))
-                    internodeLatency.accept(timeElapsed, unit);
+                // log latency even if we are within error bars of zero
+                // log negative numbers too; we are interested in the distribution, not precise values
+                internodeLatency.accept(header.verb, timeElapsed, unit);
             }
 
             @Override

--- a/src/java/org/apache/cassandra/net/LatencyConsumer.java
+++ b/src/java/org/apache/cassandra/net/LatencyConsumer.java
@@ -21,5 +21,5 @@ import java.util.concurrent.TimeUnit;
 
 public interface LatencyConsumer
 {
-    void accept(long timeElapsed, TimeUnit unit);
+    void accept(Verb verb, long timeElapsed, TimeUnit unit);
 }

--- a/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
+++ b/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
@@ -84,9 +84,10 @@ public class ConnectionBurnTest
         static final NoGlobalInboundMetrics instance = new NoGlobalInboundMetrics();
         public LatencyConsumer internodeLatencyRecorder(InetAddressAndPort to)
         {
-            return (timeElapsed, timeUnit) -> {};
+            return (verb, timeElapsed, timeUnit) -> {};
         }
         public void recordInternalLatency(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit timeUnit) {}
+
         public void recordInternodeDroppedMessage(Verb verb, long timeElapsed, TimeUnit timeUnit) {}
     }
 

--- a/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
@@ -178,7 +178,7 @@ public class MessagingServiceTest
         long sentAt = now - latency;
 
         long count = updater.dcLatency.getCount();
-        updater.accept(now - sentAt, MILLISECONDS);
+        updater.accept(Verb.READ_REQ, now - sentAt, MILLISECONDS);
         // negative value shoudln't be recorded
         assertEquals(count, updater.dcLatency.getCount());
     }
@@ -212,7 +212,7 @@ public class MessagingServiceTest
 
     private static void addDCLatency(long sentAt, long nowTime)
     {
-        MessagingService.instance().metrics.internodeLatencyRecorder(InetAddressAndPort.getLocalHost()).accept(nowTime - sentAt, MILLISECONDS);
+        MessagingService.instance().metrics.internodeLatencyRecorder(InetAddressAndPort.getLocalHost()).accept(Verb.READ_REQ, nowTime - sentAt, MILLISECONDS);
     }
 
     /**


### PR DESCRIPTION
Cross-node messaging metrics are now collected per Verb. Cross-node measurements are reported
regardless of their absolute values, including negative values.

### What is the issue
For an uknown reason InboundMessageHandlers was able to silently make a decision whether
a particular time measurement of a cross-node action is valid or not. Apart from it being
a perculiar design choice, the direct consequence was that we were loosing some measurements.
Additionally, the measurements are coarse-grained, per InboundMessageHandlers, whereas
the underlying messaging implementation may use more fine tuned approach (e.g. small vs
large messages using different connections). Another problem is that we don't have
visibility into load balancing wrt message types.

### What does this PR fix and why was it fixed
This PR makes the consumer of the cross-node latency measurements responsible for
processing the measurements, including seemingly invalid ones, so that we can compute
the proper averages, distributions etc. as we see fit.
The measurements are now tagged with message type for more visibility in what the
node processes.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
