### PR TITLE
CNDB-11581: Stage metrics improvements

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/TaskExecutionCallback.java
+++ b/src/java/org/apache/cassandra/concurrent/TaskExecutionCallback.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.concurrent;
+
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_TASK_EXECUTION_CALLBACK_CLASS;
+
+public interface TaskExecutionCallback
+{
+    TaskExecutionCallback instance = CUSTOM_TASK_EXECUTION_CALLBACK_CLASS.isPresent() ?
+                                        FBUtilities.construct(CUSTOM_TASK_EXECUTION_CALLBACK_CLASS.getString(), "Task execution callback") :
+                                        new NoopTaskExecutionCallback();
+
+    void onCompleted(Stage stage, long executionDurationNanos);
+    void onDequeue(Stage stage, long enqueuedDurationNanos);
+
+    class NoopTaskExecutionCallback implements TaskExecutionCallback
+    {
+        @Override
+        public void onCompleted(Stage stage, long executionDurationNanos)
+        {
+        }
+
+        @Override
+        public void onDequeue(Stage stage, long enqueuedDurationNanos)
+        {
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -334,6 +334,11 @@ public enum CassandraRelevantProperties
     CUSTOM_GUARDRAILS_FACTORY_PROPERTY("cassandra.custom_guardrails_factory_class"),
 
     /**
+     * Which class to use when notifying about stage task execution
+     */
+    CUSTOM_TASK_EXECUTION_CALLBACK_CLASS("cassandra.custom_task_execution_callback_class"),
+
+    /**
      * Used to support directory creation for different file system and remote/local conversion
      */
     CUSTOM_STORAGE_PROVIDER("cassandra.custom_storage_provider"),

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Sets;
 import org.apache.cassandra.cache.IRowCacheEntry;
 import org.apache.cassandra.cache.RowCacheKey;
 import org.apache.cassandra.cache.RowCacheSentinel;
+import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.filter.*;
 import org.apache.cassandra.db.lifecycle.*;
@@ -574,7 +575,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     {
         assert executionController != null && executionController.validForReadOn(cfs);
         if (Tracing.traceSinglePartitions())
-            Tracing.trace("Executing single-partition query on {}", cfs.name);
+            Tracing.trace("Executing single-partition query on {}; stage READ pending: {}, active: {}", cfs.name, Stage.READ.getPendingTaskCount(), Stage.READ.getActiveTaskCount());
 
         return queryMemtableAndDiskInternal(cfs, executionController, System.nanoTime());
     }
@@ -586,7 +587,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     {
         assert executionController != null && executionController.validForReadOn(cfs);
         if (Tracing.traceSinglePartitions())
-            Tracing.trace("Executing single-partition query on {}", cfs.name);
+            Tracing.trace("Executing single-partition query on {}; stage READ pending: {}, active: {}", cfs.name, Stage.READ.getPendingTaskCount(), Stage.READ.getActiveTaskCount());
 
         return queryMemtableAndDiskInternal(cfs, view, rowTransformer, executionController, System.nanoTime());
     }

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -281,7 +281,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     private static boolean isInGossipStage()
     {
-        return ((JMXEnabledSingleThreadExecutor) Stage.GOSSIP.executor()).isExecutedBy(Thread.currentThread());
+        return Stage.GOSSIP.runsInSingleThread(Thread.currentThread());
     }
 
     private static void checkProperThreadForStateMutation()
@@ -1048,7 +1048,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         long now = System.currentTimeMillis();
         long nowNano = System.nanoTime();
 
-        long pending = ((JMXEnabledThreadPoolExecutor) Stage.GOSSIP.executor()).metrics.pendingTasks.getValue();
+        long pending = Stage.GOSSIP.getPendingTaskCount();
         if (pending > 0 && lastProcessedMessageAt < now - 1000)
         {
             // if some new messages just arrived, give the executor some time to work on them

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -499,7 +499,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
         isShuttingDown = true;
         logger.info("Waiting for messaging service to quiesce");
         // We may need to schedule hints on the mutation stage, so it's erroneous to shut down the mutation stage first
-        assert !MUTATION.executor().isShutdown();
+        assert !MUTATION.isShutdown();
 
         if (shutdownGracefully)
         {
@@ -567,7 +567,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
         isShuttingDown = true;
         logger.info("Waiting for messaging service to quiesce");
         // We may need to schedule hints on the mutation stage, so it's erroneous to shut down the mutation stage first
-        assert !MUTATION.executor().isShutdown();
+        assert !MUTATION.isShutdown();
 
         callbacks.shutdownNow(false);
         inboundSockets.close();

--- a/src/java/org/apache/cassandra/schema/DefaultSchemaUpdateHandler.java
+++ b/src/java/org/apache/cassandra/schema/DefaultSchemaUpdateHandler.java
@@ -67,7 +67,7 @@ public class DefaultSchemaUpdateHandler implements SchemaUpdateHandler, IEndpoin
     private MigrationCoordinator createMigrationCoordinator(MessagingService messagingService)
     {
         return new MigrationCoordinator(messagingService,
-                                        Stage.MIGRATION.executor(),
+                                        Stage.MIGRATION,
                                         ScheduledExecutors.scheduledTasks,
                                         MAX_OUTSTANDING_VERSION_REQUESTS,
                                         Gossiper.instance,

--- a/src/java/org/apache/cassandra/schema/MigrationCoordinator.java
+++ b/src/java/org/apache/cassandra/schema/MigrationCoordinator.java
@@ -54,6 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.exceptions.RequestFailureReason;
@@ -223,7 +224,7 @@ public class MigrationCoordinator
     private final Supplier<UUID> schemaVersion;
     private final BiConsumer<InetAddressAndPort, Collection<Mutation>> schemaUpdateCallback;
 
-    final ExecutorService executor;
+    final Stage executor;
 
     /**
      * Creates but does not start migration coordinator instance.
@@ -232,7 +233,7 @@ public class MigrationCoordinator
      * @param periodicCheckExecutor executor on which the periodic checks are scheduled
      */
     MigrationCoordinator(MessagingService messagingService,
-                         ExecutorService executor,
+                         Stage executor,
                          ScheduledExecutorService periodicCheckExecutor,
                          int maxOutstandingVersionRequests,
                          Gossiper gossiper,
@@ -619,7 +620,7 @@ public class MigrationCoordinator
         }
         else
         {
-            return CompletableFuture.runAsync(task, executor);
+            return executor.submit(task);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -371,8 +371,7 @@ public class StorageProxy implements StorageProxyMBean
         {
             EndpointsForToken selected = targets.contacts().withoutSelf();
             Replicas.temporaryAssertFull(selected); // TODO CASSANDRA-14548
-            Stage.COUNTER_MUTATION.executor()
-                                  .execute(counterWriteTask(mutation, targets.withContact(selected), responseHandler, localDataCenter));
+            Stage.COUNTER_MUTATION.execute(counterWriteTask(mutation, targets.withContact(selected), responseHandler, localDataCenter));
         };
 
         ReadRepairMetrics.init();

--- a/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
+++ b/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
@@ -104,13 +104,13 @@ public class TraceStateImpl extends TraceState
 
     void executeMutation(final Mutation mutation)
     {
-        CompletableFuture<Void> fut = CompletableFuture.runAsync(new WrappedRunnable()
+        CompletableFuture<Void> fut = Stage.TRACING.submit(new WrappedRunnable()
         {
             protected void runMayThrow()
             {
                 mutateWithCatch(clientState, mutation);
             }
-        }, Stage.TRACING.executor());
+        });
 
         boolean ret = pendingFutures.add(fut);
         if (!ret)

--- a/test/long/org/apache/cassandra/cql3/ViewLongTest.java
+++ b/test/long/org/apache/cassandra/cql3/ViewLongTest.java
@@ -434,8 +434,8 @@ public class ViewLongTest extends CQLTester
     private void updateViewWithFlush(String query, boolean flush, Object... params) throws Throwable
     {
         executeNet(version, query, params);
-        while (!(((SEPExecutor) Stage.VIEW_MUTATION.executor()).getPendingTaskCount() == 0
-                && ((SEPExecutor) Stage.VIEW_MUTATION.executor()).getActiveTaskCount() == 0))
+        while (!(Stage.VIEW_MUTATION.getPendingTaskCount() == 0
+                && Stage.VIEW_MUTATION.getActiveTaskCount() == 0))
         {
             Thread.sleep(1);
         }

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1295,7 +1295,7 @@ public abstract class CQLTester
     {
         try
         {
-            Stage.TRACING.executor().submit(() -> {}).get();
+            Stage.TRACING.submit(() -> {}).get();
         }
         catch (Throwable t)
         {

--- a/test/unit/org/apache/cassandra/cql3/ViewAbstractTest.java
+++ b/test/unit/org/apache/cassandra/cql3/ViewAbstractTest.java
@@ -102,7 +102,7 @@ public abstract class ViewAbstractTest extends CQLTester
     {
         Awaitility.await()
                   .atMost(5, TimeUnit.MINUTES)
-                  .until(() -> Stage.VIEW_MUTATION.executor().getPendingTaskCount() == 0
-                               && Stage.VIEW_MUTATION.executor().getActiveTaskCount() == 0);
+                  .until(() -> Stage.VIEW_MUTATION.getPendingTaskCount() == 0
+                               && Stage.VIEW_MUTATION.getActiveTaskCount() == 0);
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/ViewComplexTester.java
+++ b/test/unit/org/apache/cassandra/cql3/ViewComplexTester.java
@@ -123,8 +123,8 @@ public abstract class ViewComplexTester extends CQLTester
     protected void updateViewWithFlush(String query, boolean flush, Object... params) throws Throwable
     {
         executeNet(version, query, params);
-        while (!(Stage.VIEW_MUTATION.executor().getPendingTaskCount() == 0
-                 && Stage.VIEW_MUTATION.executor().getActiveTaskCount() == 0))
+        while (!(Stage.VIEW_MUTATION.getPendingTaskCount() == 0
+                 && Stage.VIEW_MUTATION.getActiveTaskCount() == 0))
         {
             Thread.sleep(1);
         }

--- a/test/unit/org/apache/cassandra/cql3/ViewFilteringTester.java
+++ b/test/unit/org/apache/cassandra/cql3/ViewFilteringTester.java
@@ -107,8 +107,8 @@ public abstract class ViewFilteringTester extends CQLTester
     protected void updateView(String query, Object... params) throws Throwable
     {
         executeNet(version, query, params);
-        while (!(Stage.VIEW_MUTATION.executor().getPendingTaskCount() == 0
-                 && Stage.VIEW_MUTATION.executor().getActiveTaskCount() == 0))
+        while (!(Stage.VIEW_MUTATION.getPendingTaskCount() == 0
+                 && Stage.VIEW_MUTATION.getActiveTaskCount() == 0))
         {
             Thread.sleep(1);
         }

--- a/test/unit/org/apache/cassandra/cql3/ViewSchemaTest.java
+++ b/test/unit/org/apache/cassandra/cql3/ViewSchemaTest.java
@@ -98,8 +98,8 @@ public class ViewSchemaTest extends CQLTester
     private void updateView(String query, Object... params) throws Throwable
     {
         executeNet(protocolVersion, query, params);
-        while (!(((SEPExecutor) Stage.VIEW_MUTATION.executor()).getPendingTaskCount() == 0
-                 && ((SEPExecutor) Stage.VIEW_MUTATION.executor()).getActiveTaskCount() == 0))
+        while (!(Stage.VIEW_MUTATION.getPendingTaskCount() == 0
+                 && Stage.VIEW_MUTATION.getActiveTaskCount() == 0))
         {
             Thread.sleep(1);
         }

--- a/test/unit/org/apache/cassandra/schema/MigrationCoordinatorTest.java
+++ b/test/unit/org/apache/cassandra/schema/MigrationCoordinatorTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Mutation;
@@ -138,7 +139,7 @@ public class MigrationCoordinatorTest
             when(versions.knows(any())).thenReturn(true);
             when(versions.getRaw(any())).thenReturn(MessagingService.current_version);
             this.coordinator = new MigrationCoordinator(messagingService,
-                                                        MoreExecutors.newDirectExecutorService(),
+                                                        Stage.IMMEDIATE,
                                                         oneTimeExecutor,
                                                         maxOutstandingRequests,
                                                         gossiper,


### PR DESCRIPTION
With this change an external actor can now track task queue and execution times on stages.
The Stage encapsulation was improved. Executor-related particulars can no longer leak out.

### What is the issue
The issue is that we don't have visibility into where do the user requests spend time
in the system

### What does this PR fix and why was it fixed
This PR adds queue wait and execution time for the Stages. Additionally, the encapsulation
of Stages was improved and there is no longer an API to reach out directly to the executor
that powers the stage.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
