### PR TITLE
CNDB-11782: additional messaging metrics

### DIFF
--- a/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MessagingMetrics.java
@@ -145,6 +145,18 @@ public class MessagingMetrics implements InboundMessageHandlers.GlobalMetricCall
         recordDroppedMessage(verb, timeElapsed, timeUnit, true);
     }
 
+    @Override
+    public void recordMessageStageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit)
+    {
+        // NOOP
+    }
+
+    @Override
+    public void recordTotalMessageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit)
+    {
+        // NOOP
+    }
+
     public void recordDroppedMessage(Message<?> message, long timeElapsed, TimeUnit timeUnit)
     {
         recordDroppedMessage(message.verb(), timeElapsed, timeUnit, message.isCrossNode());

--- a/src/java/org/apache/cassandra/net/InboundMessageCallbacks.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageCallbacks.java
@@ -94,6 +94,13 @@ interface InboundMessageCallbacks
 
     /**
      * Invoked at the very end of execution of the message-processing task, no matter the outcome of processing.
+     * timeElapsed is the duration on message processing in the relevant stage
      */
     void onExecuted(int messageSize, Header header, long timeElapsed, TimeUnit unit);
+
+    /**
+     * Invoked at the very end of execution of the message-processing task, no matter the outcome of processing.
+     * timeElapsed is the duration of the whole messaging processing, including deserialization, stage queue wait time
+     */
+    void onMessageHandlingCompleted(Header header, long timeElapsed, TimeUnit unit);
 }

--- a/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
@@ -87,6 +87,8 @@ public final class InboundMessageHandlers
         LatencyConsumer internodeLatencyRecorder(InetAddressAndPort to);
         void recordInternalLatency(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit timeUnit);
         void recordInternodeDroppedMessage(Verb verb, long timeElapsed, TimeUnit timeUnit);
+        void recordMessageStageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit);
+        void recordTotalMessageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit);
     }
 
     public InboundMessageHandlers(InetAddressAndPort self,
@@ -268,6 +270,13 @@ public final class InboundMessageHandlers
             public void onExecuted(int messageSize, Header header, long timeElapsed, TimeUnit unit)
             {
                 counters.removePending(messageSize);
+                globalMetrics.recordMessageStageProcessingTime(header.verb, header.from, timeElapsed, unit);
+            }
+
+            @Override
+            public void onMessageHandlingCompleted(Header header, long timeElapsed, TimeUnit unit)
+            {
+                globalMetrics.recordTotalMessageProcessingTime(header.verb, header.from, timeElapsed, unit);
             }
 
             @Override

--- a/test/burn/org/apache/cassandra/net/Connection.java
+++ b/test/burn/org/apache/cassandra/net/Connection.java
@@ -333,6 +333,11 @@ public class Connection implements InboundMessageCallbacks, OutboundMessageCallb
     {
     }
 
+    @Override
+    public void onMessageHandlingCompleted(Message.Header header, long timeElapsed, TimeUnit unit)
+    {
+    }
+
     InboundCounters inboundCounters()
     {
         return inbound.countersFor(outbound.type());

--- a/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
+++ b/test/burn/org/apache/cassandra/net/ConnectionBurnTest.java
@@ -89,6 +89,16 @@ public class ConnectionBurnTest
         public void recordInternalLatency(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit timeUnit) {}
 
         public void recordInternodeDroppedMessage(Verb verb, long timeElapsed, TimeUnit timeUnit) {}
+
+        @Override
+        public void recordMessageStageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit)
+        {
+        }
+
+        @Override
+        public void recordTotalMessageProcessingTime(Verb verb, InetAddressAndPort from, long timeElapsed, TimeUnit unit)
+        {
+        }
     }
 
     static class Inbound
@@ -562,6 +572,13 @@ public class ConnectionBurnTest
             {
                 forId(header.id).onExecuted(messageSize, header, timeElapsed, unit);
                 wrapped.onExecuted(messageSize, header, timeElapsed, unit);
+            }
+
+            @Override
+            public void onMessageHandlingCompleted(Message.Header header, long timeElapsed, TimeUnit unit)
+            {
+                forId(header.id).onMessageHandlingCompleted(header, timeElapsed, unit);
+                wrapped.onMessageHandlingCompleted(header, timeElapsed, unit);
             }
         }
 


### PR DESCRIPTION
New message-oriented metrics: node message handling time (per message type), and time spent by each message handler on the relevant stage (again per message type)

### What is the issue
The isssue is lack of visibility into how much time nodes actually spend handling messages.
So far, we only had cross-node metrics.

### What does this PR fix and why was it fixed
This PR adds two additional metrics:
- node total (queue+execution) message handling time
- execution time of the message handler in the relevant stage

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
