### PR TITLE
CNDB-11850 Support ignoring properties from newer versions (allow_auto_snapshot)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
+++ b/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
@@ -46,7 +46,7 @@ public class PropertyDefinitions
             throw new SyntaxException(String.format("Multiple definition for property '%s'", name));
     }
 
-    public void validate(Set<String> keywords, Set<String> obsolete) throws SyntaxException
+    public void validate(Set<String> keywords, Set<String> obsolete, Set<String> keywordsFromNewVersions) throws SyntaxException
     {
         for (String name : properties.keySet())
         {
@@ -55,6 +55,8 @@ public class PropertyDefinitions
 
             if (obsolete.contains(name))
                 logger.warn("Ignoring obsolete property {}", name);
+            else if (keywordsFromNewVersions.contains(name))
+                logger.warn("Ignoring property {} that is not supported in this version", name);
             else
                 throw new SyntaxException(String.format("Unknown property '%s'", name));
         }


### PR DESCRIPTION
### What is the issue
when upgrading to Cassandra 5 some tables are added the attribute allow_auto_snapshot that is no accepted

### What does this PR fix and why was it fixed
- add allow_auto_snapshot as ignored property
- add a way to ignore more new properties to allow smother introduction of new attributes in the future (-Dcassandra.table_attributes_ignore_keys=a,b,c)

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits