### PR TITLE
Expose index methods that don't require a full `IndexContext` object.

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -164,7 +164,12 @@ public interface OnDiskFormat
      * @param indexContext The {@link IndexContext} for the index
      * @return The set of {@link IndexComponentType} for the per-index index
      */
-    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext);
+    default public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
+    {
+        return perIndexComponentTypes(indexContext.getValidator());
+    }
+
+    public Set<IndexComponentType> perIndexComponentTypes(AbstractType<?> validator);
 
     /**
      * Return the number of open per-SSTable files that can be open during a query.

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -271,9 +271,9 @@ public class V1OnDiskFormat implements OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponentTypes(AbstractType<?> validator)
     {
-        if (TypeUtil.isLiteral(indexContext.getValidator()))
+        if (TypeUtil.isLiteral(validator))
             return LITERAL_COMPONENTS;
         return NUMERIC_COMPONENTS;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ClusteringComparator;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PerSSTableWriter;
@@ -127,11 +128,11 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponentTypes(AbstractType<?> validator)
     {
-        if (indexContext.isVector())
+        if (validator.isVector())
             return VECTOR_COMPONENTS_V2;
-        return super.perIndexComponentTypes(indexContext);
+        return super.perIndexComponentTypes(validator);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
@@ -102,12 +103,12 @@ public class V3OnDiskFormat extends V2OnDiskFormat
     }
 
     @Override
-    public Set<IndexComponentType> perIndexComponentTypes(IndexContext indexContext)
+    public Set<IndexComponentType> perIndexComponentTypes(AbstractType<?> validator)
     {
         // VSTODO add checksums and actual validation
-        if (indexContext.isVector())
+        if (validator.isVector())
             return VECTOR_COMPONENTS_V3;
-        return super.perIndexComponentTypes(indexContext);
+        return super.perIndexComponentTypes(validator);
     }
 
     @VisibleForTesting

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -558,7 +558,7 @@ public class SAITester extends CQLTester
 
         for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perSSTableComponentTypes())
         {
-            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.latest().fileNameFormatter().format(indexComponentType, null, 0)));
+            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.latest().fileNameFormatter().format(indexComponentType, (String)null, 0)));
             assertEquals(tableFiles.toString(), perSSTableFiles, tableFiles.size());
         }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
@@ -259,7 +259,7 @@ public class IndexDescriptorTest
     static void createFakePerSSTableComponents(Descriptor descriptor, Version version, int generation) throws IOException
     {
         for (IndexComponentType type : version.onDiskFormat().perSSTableComponentTypes())
-            createFileOnDisk(descriptor, version.fileNameFormatter().format(type, null, generation));
+            createFileOnDisk(descriptor, version.fileNameFormatter().format(type, (String)null, generation));
     }
 
     static void createFakePerIndexComponents(Descriptor descriptor, IndexContext context, Version version, int generation) throws IOException


### PR DESCRIPTION
WIP (this is likely useful for https://github.com/riptano/cndb/issues/10023 but currently WIP)


### What is the issue
...

### What does this PR fix and why was it fixed
...

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits