### PR TITLE
CNDB-11760: Prevent full deserialization in CQL's CONTAINS operator

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -132,23 +130,8 @@ public enum Operator
         @Override
         public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
-            switch(((CollectionType<?>) type).kind)
-            {
-                case LIST :
-                    ListType<?> listType = (ListType<?>) type;
-                    List<?> list = listType.getSerializer().deserialize(leftOperand);
-                    return list.contains(listType.getElementsType().getSerializer().deserialize(rightOperand));
-                case SET:
-                    SetType<?> setType = (SetType<?>) type;
-                    Set<?> set = setType.getSerializer().deserialize(leftOperand);
-                    return set.contains(setType.getElementsType().getSerializer().deserialize(rightOperand));
-                case MAP:
-                    MapType<?, ?> mapType = (MapType<?, ?>) type;
-                    Map<?, ?> map = mapType.getSerializer().deserialize(leftOperand);
-                    return map.containsValue(mapType.getValuesType().getSerializer().deserialize(rightOperand));
-                default:
-                    throw new AssertionError();
-            }
+            CollectionType<?> collectionType = (CollectionType<?>) type;
+            return collectionType.contains(leftOperand, rightOperand);
         }
     },
     CONTAINS_KEY(6)
@@ -163,8 +146,7 @@ public enum Operator
         public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand, @Nullable Index.Analyzer analyzer)
         {
             MapType<?, ?> mapType = (MapType<?, ?>) type;
-            Map<?, ?> map = mapType.getSerializer().deserialize(leftOperand);
-            return map.containsKey(mapType.getKeysType().getSerializer().deserialize(rightOperand));
+            return mapType.containsKey(leftOperand, rightOperand);
         }
     },
 

--- a/src/java/org/apache/cassandra/db/marshal/CollectionType.java
+++ b/src/java/org/apache/cassandra/db/marshal/CollectionType.java
@@ -191,6 +191,14 @@ public abstract class CollectionType<T> extends MultiCellCapableType<T>
         return kind == ((CollectionType<?>)that).kind;
     }
 
+    /**
+     * Checks if the specified serialized collection contains the specified serialized collection element.
+     *
+     * @param element a serialized collection element
+     * @return {@code true} if the collection contains the value, {@code false} otherwise
+     */
+    public abstract boolean contains(ByteBuffer collection, ByteBuffer element);
+
     private static class CollectionPathSerializer implements CellPath.Serializer
     {
         public void serialize(CellPath path, DataOutputPlus out) throws IOException

--- a/src/java/org/apache/cassandra/db/marshal/ListType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ListType.java
@@ -288,4 +288,10 @@ public class ListType<T> extends CollectionType<List<T>>
     {
         return true;
     }
+
+    @Override
+    public boolean contains(ByteBuffer list, ByteBuffer element)
+    {
+        return CollectionSerializer.contains(getElementsType(), list, element, false, false, ProtocolVersion.V3);
+    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.Json;
 import org.apache.cassandra.cql3.Maps;
 import org.apache.cassandra.cql3.Term;
@@ -345,5 +344,30 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
             sb.append(values.toJSONString(vv, protocolVersion));
         }
         return sb.append('}').toString();
+    }
+
+    /**
+     * Checks if the specified serialized map contains the specified serialized map value.
+     *
+     * @param map a serialized map
+     * @param value a serialized map value
+     * @return {@code true} if the map contains the value, {@code false} otherwise
+     */
+    @Override
+    public boolean contains(ByteBuffer map, ByteBuffer value)
+    {
+        return CollectionSerializer.contains(getValuesType(), map, value, true, false, ProtocolVersion.V3);
+    }
+
+    /**
+     * Checks if the specified serialized map contains the specified serialized map key.
+     *
+     * @param map a serialized map
+     * @param key a serialized map key
+     * @return {@code true} if the map contains the key, {@code false} otherwise
+     */
+    public boolean containsKey(ByteBuffer map, ByteBuffer key)
+    {
+        return CollectionSerializer.contains(getKeysType(), map, key, true, true, ProtocolVersion.V3);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/SetType.java
+++ b/src/java/org/apache/cassandra/db/marshal/SetType.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.serializers.CollectionSerializer;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.serializers.SetSerializer;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -189,5 +190,11 @@ public class SetType<T> extends CollectionType<Set<T>>
     public String toJSONString(ByteBuffer buffer, ProtocolVersion protocolVersion)
     {
         return ListType.setOrListToJsonString(buffer, getElementsType(), protocolVersion);
+    }
+
+    @Override
+    public boolean contains(ByteBuffer set, ByteBuffer element)
+    {
+        return CollectionSerializer.contains(getElementsType(), set, element, false, false, ProtocolVersion.V3);
     }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/CollectionContainsTest.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CollectionContainsTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.SetType;
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static org.apache.cassandra.utils.AbstractTypeGenerators.getTypeSupport;
+import static org.quicktheories.QuickTheory.qt;
+
+/**
+ * Benchmarks {@link org.apache.cassandra.cql3.Operator#CONTAINS} and {@link org.apache.cassandra.cql3.Operator#CONTAINS_KEY}
+ * comparing calls to {@link CollectionType#contains(ByteBuffer, ByteBuffer)} to the full collection deserialization
+ * followed by a call to {@link java.util.Collection#contains(Object)} that was done before CNDB-11760.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1) // seconds
+@Measurement(iterations = 3, time = 1) // seconds
+@Fork(value = 4)
+@Threads(4)
+@State(Scope.Benchmark)
+public class CollectionContainsTest
+{
+    @Param({ "INT", "TEXT" })
+    public String type;
+
+    @Param({ "1", "10", "100", "1000" })
+    public int collectionSize;
+
+    private ListType<?> listType;
+    private SetType<?> setType;
+    private MapType<?, ?> mapType;
+
+    private ByteBuffer list;
+    private ByteBuffer set;
+    private ByteBuffer map;
+
+    private final List<ByteBuffer> values = new ArrayList<>();
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable
+    {
+        AbstractType<?> elementsType = CQL3Type.Native.valueOf(type).getType();
+        setup(elementsType);
+    }
+
+    private <T> void setup(AbstractType<T> elementsType)
+    {
+        ListType<T> listType = ListType.getInstance(elementsType, false);
+        SetType<T> setType = SetType.getInstance(elementsType, false);
+        MapType<T, T> mapType = MapType.getInstance(elementsType, elementsType, false);
+
+        List<T> listValues = new ArrayList<>();
+        Set<T> setValues = new HashSet<>();
+        Map<T, T> mapValues = new HashMap<>();
+
+        AbstractTypeGenerators.TypeSupport<T> support = getTypeSupport(elementsType);
+        qt().withExamples(collectionSize).forAll(support.valueGen).checkAssert(value -> {
+            listValues.add(value);
+            setValues.add(value);
+            mapValues.put(value, value);
+        });
+
+        list = listType.decompose(listValues);
+        set = setType.decompose(setValues);
+        map = mapType.decompose(mapValues);
+
+        this.listType = listType;
+        this.setType = setType;
+        this.mapType = mapType;
+
+        qt().withExamples(100).forAll(support.bytesGen()).checkAssert(values::add);
+    }
+
+    @Benchmark
+    public Object listContainsNonDeserializing()
+    {
+        return test(v -> listType.contains(list, v));
+    }
+
+    @Benchmark
+    public Object listContainsDeserializing()
+    {
+        return test(v -> listType.compose(list).contains(listType.getElementsType().compose(v)));
+    }
+
+    @Benchmark
+    public Object setContainsNonDeserializing()
+    {
+        return test(v -> setType.contains(set, v));
+    }
+
+    @Benchmark
+    public Object setContainsDeserializing()
+    {
+        return test(v -> setType.compose(set).contains(setType.getElementsType().compose(v)));
+    }
+
+    @Benchmark
+    public Object mapContainsNonDeserializing()
+    {
+        return test(v -> mapType.contains(map, v));
+    }
+
+    @Benchmark
+    public Object mapContainsDeserializing()
+    {
+        return test(v -> mapType.compose(map).containsValue(mapType.getValuesType().compose(v)));
+    }
+
+    @Benchmark
+    public Object mapContainsKeyNonDeserializing()
+    {
+        return test(v -> mapType.containsKey(map, v));
+    }
+
+    @Benchmark
+    public Object mapContainsKeyDeserializing()
+    {
+        return test(v -> mapType.compose(map).containsKey(mapType.getKeysType().compose(v)));
+    }
+
+    private int test(Function<ByteBuffer, Boolean> containsFunction)
+    {
+        int contained = 0;
+        for (ByteBuffer v : values)
+        {
+            if (containsFunction.apply(v))
+                contained++;
+        }
+        return contained;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/ListTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ListTypeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.core.Gen;
+
+import static org.apache.cassandra.utils.AbstractTypeGenerators.getTypeSupport;
+import static org.quicktheories.QuickTheory.qt;
+
+public class ListTypeTest
+{
+    @Test
+    public void testContains()
+    {
+        qt().forAll(AbstractTypeGenerators.primitiveTypeGen())
+            .checkAssert(ListTypeTest::testContains);
+    }
+
+    private static <V> void testContains(AbstractType<V> type)
+    {
+        ListType<V> listType = ListType.getInstance(type, false);
+
+        // generate a list of random values
+        List<V> values = new ArrayList<>();
+        List<ByteBuffer> bytes = new ArrayList<>();
+        Gen<ByteBuffer> gen = getTypeSupport(type).bytesGen();
+        qt().withExamples(100).forAll(gen).checkAssert(v -> {
+            values.add(type.compose(v));
+            bytes.add(v);
+        });
+        ByteBuffer list = listType.decompose(values);
+
+        // verify that the list contains its own elements
+        bytes.forEach(v -> assertContains(listType, list, v, true));
+
+        // verify some random values, contained or not
+        qt().withExamples(100)
+            .forAll(gen)
+            .checkAssert(v -> assertContains(listType, list, v, contains(type, bytes, v)));
+    }
+
+    private static void assertContains(ListType<?> type, ByteBuffer list, ByteBuffer value, boolean expected)
+    {
+        Assertions.assertThat(type.contains(list, value))
+                  .isEqualTo(expected);
+    }
+
+    private static boolean contains(AbstractType<?> type, Iterable<ByteBuffer> values, ByteBuffer value)
+    {
+        for (ByteBuffer v : values)
+        {
+            if (type.compare(v, value) == 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/MapTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/MapTypeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.core.Gen;
+
+import static org.apache.cassandra.utils.AbstractTypeGenerators.getTypeSupport;
+import static org.quicktheories.QuickTheory.qt;
+
+public class MapTypeTest
+{
+    @Test
+    public void testContains()
+    {
+        Gen<AbstractType<?>> primitiveTypeGen = AbstractTypeGenerators.primitiveTypeGen();
+
+        qt().forAll(primitiveTypeGen, primitiveTypeGen)
+            .checkAssert(MapTypeTest::testContains);
+    }
+
+    private static <K, V> void testContains(AbstractType<K> keyType, AbstractType<V> valType)
+    {
+        MapType<K, V> mapType = MapType.getInstance(keyType, valType, false);
+
+        // generate a map of random key-value pairs
+        Map<K, V> entries = new HashMap<>();
+        Map<ByteBuffer, ByteBuffer> bytes = new HashMap<>();
+        Gen<ByteBuffer> keyGen = getTypeSupport(keyType).bytesGen();
+        Gen<ByteBuffer> valGen = getTypeSupport(valType).bytesGen();
+        qt().withExamples(100).forAll(keyGen, valGen).checkAssert((k, v) -> {
+            entries.put(keyType.compose(k), valType.compose(v));
+            bytes.put(k, v);
+        });
+        ByteBuffer map = mapType.decompose(entries);
+
+        // verify that the map contains its own keys and values
+        bytes.values().forEach(v -> assertContains(mapType, map, v, true));
+        bytes.keySet().forEach(k -> assertContainsKey(mapType, map, k, true));
+
+        // verify some random keys and values, contained or not
+        qt().withExamples(100)
+            .forAll(keyGen, valGen)
+            .checkAssert((k, v) -> {
+                assertContains(mapType, map, v, contains(valType, bytes.values(), v));
+                assertContainsKey(mapType, map, k, contains(keyType, bytes.keySet(), k));
+            });
+    }
+
+    private static void assertContains(MapType<?, ?> type, ByteBuffer map, ByteBuffer value, boolean expected)
+    {
+        Assertions.assertThat(type.contains(map, value))
+                  .isEqualTo(expected);
+    }
+
+    private static void assertContainsKey(MapType<?, ?> type, ByteBuffer map, ByteBuffer key, boolean expected)
+    {
+        Assertions.assertThat(type.containsKey(map, key))
+                  .isEqualTo(expected);
+    }
+
+    private static boolean contains(AbstractType<?> type, Iterable<ByteBuffer> values, ByteBuffer value)
+    {
+        for (ByteBuffer v : values)
+        {
+            if (type.compare(v, value) == 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/SetTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/SetTypeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.core.Gen;
+
+import static org.apache.cassandra.utils.AbstractTypeGenerators.getTypeSupport;
+import static org.quicktheories.QuickTheory.qt;
+
+public class SetTypeTest
+{
+    @Test
+    public void testContains()
+    {
+        qt().forAll(AbstractTypeGenerators.primitiveTypeGen())
+            .checkAssert(SetTypeTest::testContains);
+    }
+
+    private static <V> void testContains(AbstractType<V> type)
+    {
+        SetType<V> setType = SetType.getInstance(type, false);
+
+        // generate a set of random values
+        Set<V> values = new HashSet<>();
+        Set<ByteBuffer> bytes = new HashSet<>();
+        Gen<ByteBuffer> gen = getTypeSupport(type).bytesGen();
+        qt().withExamples(100).forAll(gen).checkAssert(x -> {
+            values.add(type.compose(x));
+            bytes.add(x);
+        });
+        ByteBuffer set = setType.decompose(values);
+
+        // verify that the set contains its own elements
+        bytes.forEach(v -> assertContains(setType, set, v, true));
+
+        // verify some random values, contained or not
+        qt().withExamples(100)
+            .forAll(gen)
+            .checkAssert(v -> assertContains(setType, set, v, contains(type, bytes, v)));
+    }
+
+    private static void assertContains(SetType<?> type, ByteBuffer set, ByteBuffer value, boolean expected)
+    {
+        Assertions.assertThat(type.contains(set, value))
+                  .isEqualTo(expected);
+    }
+
+    private static boolean contains(AbstractType<?> type, Iterable<ByteBuffer> values, ByteBuffer value)
+    {
+        for (ByteBuffer v : values)
+        {
+            if (type.compare(v, value) == 0)
+                return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Prevent full deserialization in CQL's `CONTAINS`/`CONTAINS KEY` operators. This is done by reading the serialized elements of the collection one by one and comparing them in their serialized form to the serialized candidate value. This would save us the unnecessary deserialization of the collection elements. Also, we can stop reading the collection as soon as we find a matching collection element, without having to read the rest of the rest of the elements.

This is not only a performance improvement, but it also solves a minor correctness issue. The full-deserializing approach used the `Object#equals` method of the composed column value to test the identity of the values. This differs from what we do for other operators, conditions, non-frozen collections, etc., where identity is based on the column type comparator. Thus, we could have this surprising behaviour for certain corner cases:
```
CREATE TABLE t (
   k int PRIMARY KEY, 
   v decimal, 
   s set<decimal>, 
   fs frozen<set<decimal>>);
INSERT INTO t(k, v, s, fs) VALUES (0, 0.0, {0.0}, {0.0});
SELECT * FROM t WHERE v = 0.00 ALLOW FILTERING; // one row
SELECT * FROM t WHERE s CONTAINS 0.00 ALLOW FILTERING; // one row
SELECT * FROM t WHERE fs CONTAINS 0.00 ALLOW FILTERING; // no rows!!!
```
The proposed patch ensures that `CONTAINS`/`CONTAINS KEY` is based on the column type comparator.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits