### PR TITLE
CNDB-11768: DynamicEndpointSnitch tweaks: quantization and quantile is configurable now

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -428,6 +428,12 @@ public enum CassandraRelevantProperties
     USE_PARALLEL_INDEX_READ("cassandra.index_read.parallel", "true"),
     PARALLEL_INDEX_READ_NUM_THREADS("cassandra.index_read.parallel_thread_num"),
 
+    // The quantile used by the dynamic endpoint snitch to compute the score for a replica.
+    DYNAMIC_ENDPOINT_SNITCH_QUANTILE("cassandra.dynamic_endpoint_snitch_quantile", "0.5"),
+
+    // whether to quantize the dynamic endpoint snitch score to milliseconds; if set to false the nanosecond measurement
+    // is used
+    DYNAMIC_ENDPOINT_SNITCH_QUANTIZE_TO_MILLIS("cassandra.dynamic_endpoint_snitch_quantize_to_millis", "true"),
     // bloom filter lazy loading
     /**
      * true if non-local table's bloom filter should be deserialized on read instead of when opening sstable

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -32,14 +32,10 @@ import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Snapshot;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.gms.ApplicationState;
-import org.apache.cassandra.gms.EndpointState;
-import org.apache.cassandra.gms.Gossiper;
-import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.net.LatencySubscribers;
 import org.apache.cassandra.net.MessagingService;
-import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MBeanWrapper;
 
@@ -52,6 +48,10 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
 
     private static final double ALPHA = 0.75; // set to 0.75 to make EDS more biased to towards the newer values
     private static final int WINDOW_SIZE = 100;
+
+    // these need not be volatile; eventually the snitch will see the update and that's good enough
+    private double replicaLatencyQuantile = CassandraRelevantProperties.DYNAMIC_ENDPOINT_SNITCH_QUANTILE.getDouble();
+    private boolean quantizeToMillis = CassandraRelevantProperties.DYNAMIC_ENDPOINT_SNITCH_QUANTIZE_TO_MILLIS.getBoolean();
 
     private volatile int dynamicUpdateInterval = DatabaseDescriptor.getDynamicUpdateInterval();
     private volatile int dynamicResetInterval = DatabaseDescriptor.getDynamicResetInterval();
@@ -268,7 +268,10 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
             if (sample == null)
                 sample = maybeNewSample;
         }
-        sample.update(unit.toMillis(latency));
+        if (quantizeToMillis)
+            sample.update(unit.toMillis(latency));
+        else
+            sample.update(unit.toNanos(latency));
     }
 
     @VisibleForTesting
@@ -298,14 +301,14 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
         HashMap<InetAddressAndPort, Double> newScores = new HashMap<>();
         for (Map.Entry<InetAddressAndPort, Snapshot> entry : snapshots.entrySet())
         {
-            double mean = entry.getValue().getMedian();
-            if (mean > maxLatency)
-                maxLatency = mean;
+            double replicaLatency = entry.getValue().getValue(replicaLatencyQuantile);
+            if (replicaLatency > maxLatency)
+                maxLatency = replicaLatency;
         }
         // now make another pass to do the weighting based on the maximums we found before
         for (Map.Entry<InetAddressAndPort, Snapshot> entry : snapshots.entrySet())
         {
-            double score = entry.getValue().getMedian() / maxLatency;
+            double score = entry.getValue().getValue(replicaLatencyQuantile) / maxLatency;
             // finally, add the severity without any weighting, since hosts scale this relative to their own load and the size of the task causing the severity.
             // "Severity" is basically a measure of compaction activity (CASSANDRA-3722).
             if (USE_SEVERITY)
@@ -376,6 +379,34 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
     public double getSeverity()
     {
         return getSeverity(FBUtilities.getBroadcastAddressAndPort());
+    }
+
+    @Override
+    public void setQuantile(double quantile)
+    {
+        if (quantile < 0.0 || quantile > 1.0 || Double.isNaN(quantile))
+        {
+            throw new IllegalArgumentException(quantile + " is not in [0..1]");
+        }
+        replicaLatencyQuantile = quantile;
+    }
+
+    @Override
+    public double getQuantile()
+    {
+        return replicaLatencyQuantile;
+    }
+
+    @Override
+    public void setQuantization(boolean enabled)
+    {
+        quantizeToMillis = enabled;
+    }
+
+    @Override
+    public boolean getQuantization()
+    {
+        return quantizeToMillis;
     }
 
     public boolean isWorthMergingForRangeQuery(ReplicaCollection<?> merged, ReplicaCollection<?> l1, ReplicaCollection<?> l2)

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitchMBean.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitchMBean.java
@@ -74,7 +74,7 @@ public interface DynamicEndpointSnitchMBean
     /**
      * set replica latency quantization to 1ms
      */
-    public void setQuantization(boolean enabled);
+    public void setQuantizationToMillis(boolean enabled);
 
-    public boolean getQuantization();
+    public boolean getQuantizationToMillis();
 }

--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitchMBean.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitchMBean.java
@@ -58,4 +58,23 @@ public interface DynamicEndpointSnitchMBean
      * @return the current manually injected Severity.
      */
     public double getSeverity();
+
+    /**
+     * set replica latency quantile used for replica score computation
+     * @param quantile (0.0 - 1.0); for default see
+     *        {@link org.apache.cassandra.config.CassandraRelevantProperties#DYNAMIC_ENDPOINT_SNITCH_QUANTILE}
+     */
+    public void setQuantile(double quantile);
+
+    /**
+     * @return the replica latency quantile currently used for replica score computation
+     */
+    public double getQuantile();
+
+    /**
+     * set replica latency quantization to 1ms
+     */
+    public void setQuantization(boolean enabled);
+
+    public boolean getQuantization();
 }

--- a/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
@@ -140,15 +140,15 @@ public class DynamicEndpointSnitchTest
     }
 
     @Test
-    public void testDynamicSnitchSetQuantization()
+    public void testDynamicSnitchSetQuantizationToMillis()
     {
         // do this because SS needs to be initialized before DES can work properly.
         SimpleSnitch ss = new SimpleSnitch();
 
         DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
-        boolean originalQuantization = dsnitch.getQuantization();
-        dsnitch.setQuantization(!originalQuantization);
-        Assert.assertEquals(!originalQuantization, dsnitch.getQuantization());
+        boolean originalQuantization = dsnitch.getQuantizationToMillis();
+        dsnitch.setQuantizationToMillis(!originalQuantization);
+        Assert.assertEquals(!originalQuantization, dsnitch.getQuantizationToMillis());
     }
 
     @Test
@@ -200,7 +200,7 @@ public class DynamicEndpointSnitchTest
 
         DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
 
-        dsnitch.setQuantization(true);
+        dsnitch.setQuantizationToMillis(true);
         // add a slow replica, that always reports 1999us
         for (int i = 0; i < 100; i++)
         {
@@ -229,7 +229,7 @@ public class DynamicEndpointSnitchTest
 
         DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
 
-        dsnitch.setQuantization(false);
+        dsnitch.setQuantizationToMillis(false);
         dsnitch.setQuantile(0.9);
         // add a slow replica, that always reports 100us
         for (int i = 0; i < 100; i++)

--- a/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/DynamicEndpointSnitchTest.java
@@ -19,7 +19,10 @@
 package org.apache.cassandra.locator;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -31,6 +34,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class DynamicEndpointSnitchTest
@@ -40,6 +44,9 @@ public class DynamicEndpointSnitchTest
     public static void setupDD()
     {
         DatabaseDescriptor.daemonInitialization();
+        DatabaseDescriptor.setDynamicBadnessThreshold(0.1);
+        DatabaseDescriptor.setDynamicUpdateInterval(1000000);
+        StorageService.instance.unsafeInitialize();
     }
 
     private static void setScores(DynamicEndpointSnitch dsnitch, int rounds, List<InetAddressAndPort> hosts, Integer... scores) throws InterruptedException
@@ -49,7 +56,7 @@ public class DynamicEndpointSnitchTest
             for (int i = 0; i < hosts.size(); i++)
                 dsnitch.receiveTiming(hosts.get(i), scores[i], MILLISECONDS);
         }
-        Thread.sleep(150);
+        dsnitch.updateScores();
     }
 
     private static EndpointsForRange full(InetAddressAndPort... endpoints)
@@ -66,8 +73,6 @@ public class DynamicEndpointSnitchTest
     public void testDynamicSnitchSetSeverity()
     {
         // do this because SS needs to be initialized before DES can work properly.
-        DatabaseDescriptor.setDynamicBadnessThreshold(0.1);
-        StorageService.instance.unsafeInitialize();
         SimpleSnitch ss = new SimpleSnitch();
 
         DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
@@ -132,5 +137,155 @@ public class DynamicEndpointSnitchTest
         setScores(dsnitch, 20, hosts, 10, 10, 10);
         order = full(host4, host1, host2, host3);
         Util.assertRCEquals(order, dsnitch.sortedByProximity(self, full(host1, host2, host3, host4)));
+    }
+
+    @Test
+    public void testDynamicSnitchSetQuantization()
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+        boolean originalQuantization = dsnitch.getQuantization();
+        dsnitch.setQuantization(!originalQuantization);
+        Assert.assertEquals(!originalQuantization, dsnitch.getQuantization());
+    }
+
+    @Test
+    public void testDynamicSnitchSetQuantile()
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+        double quantile = ThreadLocalRandom.current().nextDouble();
+        dsnitch.setQuantile(quantile);
+        Assert.assertEquals(quantile, dsnitch.getQuantile(), 0.01);
+    }
+
+    @Test
+    public void testDynamicSnitchQuantilePicking() throws UnknownHostException
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+        dsnitch.setQuantile(0.9);
+
+        // add a slow replica, that always reports 100ms
+        for (int i = 0; i < 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.1"), 100, MILLISECONDS);
+        }
+        // add a replica that has p90 = 90ms
+        for (int i = 1; i <= 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.2"), i, MILLISECONDS);
+        }
+
+        dsnitch.updateScores();
+
+        // the score for the slow replica should be 1, and the score for the fast replica should be 9/10 = 0.9
+        Map<InetAddress, Double> scores = dsnitch.getScores();
+
+        Assert.assertEquals(1.0, scores.get(InetAddress.getByName("127.0.0.1")), 0.01);
+        Assert.assertEquals(0.9, scores.get(InetAddress.getByName("127.0.0.2")), 0.01);
+    }
+
+    @Test
+    public void testQuantizationToMillisEnabled() throws UnknownHostException
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+
+        dsnitch.setQuantization(true);
+        // add a slow replica, that always reports 1999us
+        for (int i = 0; i < 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.1"), 1999, MICROSECONDS);
+        }
+        // add a fast replica, that always reports 1001us
+        for (int i = 0; i < 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.2"), 1001, MICROSECONDS);
+        }
+
+        dsnitch.updateScores();
+
+        // the score for both replicas should be 1 because the quantization should round to 1ms
+        Map<InetAddress, Double> scores = dsnitch.getScores();
+
+        Assert.assertEquals(1.0, scores.get(InetAddress.getByName("127.0.0.1")), 0.01);
+        Assert.assertEquals(1.0, scores.get(InetAddress.getByName("127.0.0.2")), 0.01);
+    }
+
+    @Test
+    public void testQuantizationToMillisDisabled() throws UnknownHostException
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+
+        dsnitch.setQuantization(false);
+        dsnitch.setQuantile(0.9);
+        // add a slow replica, that always reports 100us
+        for (int i = 0; i < 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.1"), 100, MICROSECONDS);
+        }
+        // add a fast replica, that always reports 10us
+        for (int i = 0; i < 100; i++)
+        {
+            dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.2"), 10, MICROSECONDS);
+        }
+
+        dsnitch.updateScores();
+
+        // the score for the slow replica should be 1, and the score for the fast replica should be 10/100 = 0.1
+        // there should be no quantization rounding to 1ms
+        Map<InetAddress, Double> scores = dsnitch.getScores();
+
+        Assert.assertEquals(1.0, scores.get(InetAddress.getByName("127.0.0.1")), 0.01);
+        Assert.assertEquals(0.1, scores.get(InetAddress.getByName("127.0.0.2")), 0.01);
+    }
+
+    @Test
+    public void testScoresAreUpdatedPeriodically() throws UnknownHostException, InterruptedException
+    {
+        // do this because SS needs to be initialized before DES can work properly.
+        SimpleSnitch ss = new SimpleSnitch();
+
+        int updateInterval = DatabaseDescriptor.getDynamicUpdateInterval();
+        try
+        {
+            DynamicEndpointSnitch dsnitch = new DynamicEndpointSnitch(ss, String.valueOf(ss.hashCode()));
+
+            // add a slow replica, that always reports 100ms
+            for (int i = 0; i < 100; i++)
+            {
+                dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.1"), 100, MILLISECONDS);
+            }
+            // add a fast replica, that always reports 1ms
+            for (int i = 0; i < 100; i++)
+            {
+                dsnitch.receiveTiming(InetAddressAndPort.getByName("127.0.0.2"), 1, MILLISECONDS);
+            }
+
+            Assert.assertTrue(dsnitch.getScores().isEmpty());
+
+            DatabaseDescriptor.setDynamicUpdateInterval(100);
+            dsnitch.applyConfigChanges();
+
+            Thread.sleep(150);
+
+            Assert.assertFalse(dsnitch.getScores().isEmpty());
+        }
+        finally
+        {
+            DatabaseDescriptor.setDynamicUpdateInterval(updateInterval);
+        }
     }
 }


### PR DESCRIPTION
This change let us:
* get rid of DES coarsening the replica latency measurements to ms
resolution.
* pick a specific quantile of replica latency for the score computation

### What is the issue
On some clusters with fast reads p50 of replica latency can be so low
that most of the measurements will be 0ms. This can be disruptive to 
replica ordering.

### What does this PR fix and why was it fixed
This fix lets us configure if we want the coarsening of the latency measurements to ms.
Additionally, it lets us configure which quantile is used for computing the scores.
In particular, DSE uses p90, not p50.
This PR does *NOT* disable the use of approximate clock for replica latency
measurements. The clock will be switched via a property set in CNDB.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
