### PR TITLE
CNDB-11495: add REMOTE_STORAGE_HANDLER_FACTORY

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -214,9 +214,9 @@ public enum CassandraRelevantProperties
     UCS_COMPACTION_INCLUDE_NON_DATA_FILES_SIZE("unified_compaction.include_non_data_files_size", "true"),
 
     /**
-     * The handler of the storage of sstables, and possibly other files such as txn logs.
+     * The factory for handler of the storage of sstables
      */
-    REMOTE_STORAGE_HANDLER("cassandra.remote_storage_handler"),
+    REMOTE_STORAGE_HANDLER_FACTORY("cassandra.remote_storage_handler_factory"),
 
     /**
      * To provide a provider to a different implementation of the truncate statement.

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -434,7 +434,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     private void reloadCompactionStrategy(CompactionParams compactionParams, CompactionStrategyContainer.ReloadReason reason)
     {
         CompactionStrategyContainer previous = strategyContainer;
-        strategyContainer = strategyFactory.reload(strategyContainer, compactionParams, reason, !storageHandler.isRemote());
+        strategyContainer = strategyFactory.reload(strategyContainer, compactionParams, reason, storageHandler.enableAutoCompaction());
         if (strategyContainer != previous)
         {
             getTracker().subscribe(strategyContainer);
@@ -567,6 +567,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             this.directories = new Directories(metadata.get());
 
         storageHandler = StorageHandler.create(metadata, directories, data);
+        logger.debug("Initialized storage handler with {} for {}.{}", storageHandler.getClass().getSimpleName(), keyspace.getName(), name);
 
         Collection<SSTableReader> sstables = null;
         // scan for sstables corresponding to this cf and load them
@@ -578,7 +579,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         this.strategyContainer = strategyFactory.reload(null,
                                                         metadata.get().params.compaction,
                                                         CompactionStrategyContainer.ReloadReason.FULL,
-                                                        !storageHandler.isRemote());
+                                                        storageHandler.enableAutoCompaction());
         getTracker().subscribe(strategyContainer);
 
         if (!strategyContainer.isEnabled() || DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean())

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -213,7 +213,7 @@ public class Directories
     public Directories(@Nullable KeyspaceMetadata ksMetadata, final TableMetadata metadata, DataDirectory[] dirs)
     {
         this.metadata = metadata;
-        this.paths = StorageProvider.instance.createDataDirectories(ksMetadata, metadata.keyspace, dirs);
+        this.paths = StorageProvider.instance.createDataDirectories(ksMetadata, metadata, dirs);
 
         ImmutableMap.Builder<Path, DataDirectory> canonicalPathsBuilder = ImmutableMap.builder();
         String tableId = metadata.id.toHexString();

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -53,6 +53,7 @@ import static org.apache.cassandra.db.lifecycle.Helpers.*;
 import static org.apache.cassandra.db.lifecycle.View.updateCompacting;
 import static org.apache.cassandra.db.lifecycle.View.updateLiveSet;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
+import static org.apache.cassandra.utils.Throwables.merge;
 import static org.apache.cassandra.utils.concurrent.Refs.release;
 import static org.apache.cassandra.utils.concurrent.Refs.selfRefs;
 
@@ -366,6 +367,10 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
 
         // check the current versions of the readers we're replacing haven't somehow been replaced by someone else
         checkNotReplaced(filterIn(toUpdate, staged.update));
+
+        // notify the tracker of the new readers are about to be added and visible
+        if (!fresh.isEmpty())
+            accumulate = merge(accumulate, tracker.notifyAdding(fresh, null, null, opType(), Optional.of(opId())));
 
         // ensure any new readers are in the compacting set, since we aren't done with them yet
         // and don't want anyone else messing with them

--- a/src/java/org/apache/cassandra/io/sstable/DefaultStorageHandler.java
+++ b/src/java/org/apache/cassandra/io/sstable/DefaultStorageHandler.java
@@ -66,9 +66,9 @@ public class DefaultStorageHandler extends StorageHandler
     }
 
     @Override
-    public boolean isRemote()
+    public boolean enableAutoCompaction()
     {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/StorageHandlerFactory.java
+++ b/src/java/org/apache/cassandra/io/sstable/StorageHandlerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable;
+
+import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.lifecycle.Tracker;
+import org.apache.cassandra.schema.TableMetadataRef;
+
+public interface StorageHandlerFactory
+{
+    StorageHandlerFactory DEFAULT = new StorageHandlerFactory() {};
+
+    default StorageHandler create(TableMetadataRef metadata, Directories directories, Tracker dataTracker)
+    {
+        return new DefaultStorageHandler(metadata, directories, dataTracker);
+    }
+}

--- a/src/java/org/apache/cassandra/io/storage/StorageProvider.java
+++ b/src/java/org/apache/cassandra/io/storage/StorageProvider.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.INativeLibrary;
 
@@ -108,11 +109,11 @@ public interface StorageProvider
      *
      * @param ksMetadata   The keyspace metadata, can be null. This is used when schema metadata is
      *                     not available in {@link Schema}, eg. CNDB backup & restore
-     * @param keyspaceName the name of the keyspace
+     * @param tableMetadata the metadata of the table
      * @param dirs         current local data directories
      * @return data directories that are created
      */
-    Directories.DataDirectory[] createDataDirectories(@Nullable KeyspaceMetadata ksMetadata, String keyspaceName, Directories.DataDirectory[] dirs);
+    Directories.DataDirectory[] createDataDirectories(@Nullable KeyspaceMetadata ksMetadata, TableMetadata tableMetadata, Directories.DataDirectory[] dirs);
 
     /**
      * Create directory for the given path and type, either locally or remotely if any remote storage parameters are passed in.
@@ -237,7 +238,7 @@ public interface StorageProvider
         }
 
         @Override
-        public Directories.DataDirectory[] createDataDirectories(@Nullable KeyspaceMetadata ksMetadata, String keyspaceName, Directories.DataDirectory[] dirs)
+        public Directories.DataDirectory[] createDataDirectories(@Nullable KeyspaceMetadata ksMetadata, TableMetadata tableMetadata, Directories.DataDirectory[] dirs)
         {
             // data directories are already created in DatabadeDescriptor#createAllDirectories
             return dirs;

--- a/test/unit/org/apache/cassandra/db/CustomStorageProviderTest.java
+++ b/test/unit/org/apache/cassandra/db/CustomStorageProviderTest.java
@@ -127,11 +127,11 @@ public class CustomStorageProviderTest
          */
         @Override
         public Directories.DataDirectory[] createDataDirectories(@Nullable KeyspaceMetadata ksMetadata,
-                                                                 String keyspaceName,
+                                                                 TableMetadata tableMetadata,
                                                                  Directories.DataDirectory[] dirs)
         {
             if (!useCustomBehavior)
-                return super.createDataDirectories(ksMetadata, keyspaceName, dirs);
+                return super.createDataDirectories(ksMetadata, tableMetadata, dirs);
 
             for (Directories.DataDirectory d : dirs)
             {


### PR DESCRIPTION
- use `cassandra.remote_storage_handler_factory` to replace `cassandra.remote_storage_handler`

- add `TableMetadata` to `StorageProvider#createDataDirectories` signature

- use `enableAutoCompaction` to replace `StorageHandler#isRemote`

- emit SSTaleAddingNotification in LifecycleTransaction#checkpoint before new sstables are made visible. Note that early open is not supported because it opens sstables before `trackNewWritten`