### PR TITLE
DSP-24606: Replace nulls with negative defaults in system_schema

### DIFF
--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -841,7 +841,11 @@ public final class SchemaKeyspace
                .add("language", function.language())
                .add("return_type", function.returnType().asCQL3Type().toString())
                .add("called_on_null_input", function.isCalledOnNullInput())
-               .add("argument_names", function.argNames().stream().map((c) -> bbToString(c.bytes)).collect(toList()));
+               .add("argument_names", function.argNames().stream().map((c) -> bbToString(c.bytes)).collect(toList()))
+               // below values (deterministic, monotonic, monotonic_on) are needed to keep the backward compatibility with some drivers (C# driver for instance)
+               .add("deterministic", false)
+               .add("monotonic", false)
+               .add("monotonic_on", Collections.emptyList());
     }
 
     private static String bbToString(ByteBuffer bb)
@@ -869,6 +873,8 @@ public final class SchemaKeyspace
                .add("state_func", aggregate.stateFunction().name().name)
                .add("state_type", aggregate.stateType().asCQL3Type().toString())
                .add("final_func", aggregate.finalFunction() != null ? aggregate.finalFunction().name().name : null)
+                // below value (deterministic) is needed to keep the backward compatibility with some drivers (C# driver for instance)
+               .add("deterministic", false)
                .add("initcond", aggregate.initialCondition() != null
                                 // must use the frozen state type here, as 'null' for unfrozen collections may mean 'empty'
                                 ? aggregate.stateType().freeze().asCQL3Type().toCQLLiteral(aggregate.initialCondition(), ProtocolVersion.CURRENT)

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.commons.lang3.time.DateUtils;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ import ch.qos.logback.classic.joran.ReconfigureOnChangeTask;
 import ch.qos.logback.classic.spi.TurboFilterList;
 import ch.qos.logback.classic.turbo.ReconfigureOnChangeFilter;
 import ch.qos.logback.classic.turbo.TurboFilter;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
@@ -2173,5 +2175,22 @@ public class AggregationTest extends CQLTester
             }).isInstanceOf(InvalidRequestException.class)
               .hasMessageContaining("Aggregate name '%s' is invalid", funcName);
         }
+    }
+
+    @Test
+    public void testAggregatesAreNonDeterministicByDefault() throws Throwable
+    {
+        String fName = createFunction(KEYSPACE, "int", "CREATE FUNCTION %s(i int, j int) RETURNS NULL ON NULL INPUT " +
+                                                       "RETURNS int " +
+                                                       "LANGUAGE java " +
+                                                       "AS 'return i + j;'");
+        String aName = createAggregate(KEYSPACE, "int", String.format("CREATE AGGREGATE %%s (int) SFUNC %s STYPE int INITCOND 1;", shortFunctionName(fName)));
+
+        UntypedResultSet aggregates = execute("SELECT * FROM system_schema.aggregates " +
+                                             "WHERE keyspace_name=? AND aggregate_name=?;",
+                                             KEYSPACE, shortFunctionName(aName));
+
+        Assert.assertEquals(1, aggregates.size());
+        Assert.assertFalse(aggregates.one().getBoolean("deterministic"));
     }
 }


### PR DESCRIPTION
This patch replaces null values of `deterministic`, `monotonic` and `monotonic_on` columns in `system_schema.functions` and `system_schema.aggregates` with negative defaults. These defaults will be addressed if/once DB-672 gets ported to CC.