### PR TITLE
CNDB-10759 Make native transport stage async in regards to read and writes, which are asynchronously offloaded to the read and write stages when the NATIVE_TRANSPORT_ASYNC_READ_WRITE_ENABLED property is enabled.

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -538,7 +538,15 @@ public enum CassandraRelevantProperties
      * If provided, this custom factory class will be used to create stage executor for a couple of stages.
      * @see Stage for details
      */
-    CUSTOM_STAGE_EXECUTOR_FACTORY_PROPERTY("cassandra.custom_stage_executor_factory_class");
+    CUSTOM_STAGE_EXECUTOR_FACTORY_PROPERTY("cassandra.custom_stage_executor_factory_class"),
+
+    /**
+     * If true, makes read and write CQL statements async, splitting them from the {@link org.apache.cassandra.concurrent.Stage#NATIVE_TRANSPORT_REQUESTS}
+     * stage and into the {@link org.apache.cassandra.concurrent.Stage#COORDINATE_READ} and {@link org.apache.cassandra.concurrent.Stage#COORDINATE_MUTATION}
+     * stages respectively; in other words, the native transport stage will not block, offloading request processing
+     * (and any related blocking behaviour) to the specific read and write stages.
+     */
+    NATIVE_TRANSPORT_ASYNC_READ_WRITE_ENABLED("cassandra.transport.async.read_write", "false");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -124,6 +124,8 @@ public class Config
 
     public int concurrent_reads = 32;
     public int concurrent_writes = 32;
+    public int concurrent_coordinator_reads = 32;
+    public int concurrent_coordinator_writes = 32;
     public int concurrent_counter_writes = 32;
     public int concurrent_materialized_view_writes = 32;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -532,6 +532,16 @@ public class DatabaseDescriptor
             throw new ConfigurationException("concurrent_writes must be at least 2, but was " + conf.concurrent_writes, false);
         }
 
+        if (conf.concurrent_coordinator_reads < 2)
+        {
+            throw new ConfigurationException("concurrent_coordinator_reads must be at least 2, but was " + conf.concurrent_coordinator_reads, false);
+        }
+
+        if (conf.concurrent_coordinator_writes < 2)
+        {
+            throw new ConfigurationException("concurrent_coordinator_writes must be at least 2, but was " + conf.concurrent_coordinator_writes, false);
+        }
+
         if (conf.concurrent_counter_writes < 2)
             throw new ConfigurationException("concurrent_counter_writes must be at least 2, but was " + conf.concurrent_counter_writes, false);
 
@@ -1815,6 +1825,34 @@ public class DatabaseDescriptor
         conf.phi_convict_threshold = phiConvictThreshold;
     }
 
+    public static int getConcurrentCoordinatorReaders()
+    {
+        return conf.concurrent_coordinator_reads;
+    }
+
+    public static void setConcurrentCoordinatorReaders(int concurrent_reads)
+    {
+        if (concurrent_reads < 0)
+        {
+            throw new IllegalArgumentException("Concurrent coordinator readers must be non-negative");
+        }
+        conf.concurrent_coordinator_reads = concurrent_reads;
+    }
+
+    public static int getConcurrentCoordinatorWriters()
+    {
+        return conf.concurrent_coordinator_writes;
+    }
+
+    public static void setConcurrentCoordinatorWriters(int concurrent_writers)
+    {
+        if (concurrent_writers < 0)
+        {
+            throw new IllegalArgumentException("Concurrent coordinator writers must be non-negative");
+        }
+        conf.concurrent_coordinator_writes = concurrent_writers;
+    }
+
     public static int getConcurrentReaders()
     {
         return conf.concurrent_reads;
@@ -1824,7 +1862,7 @@ public class DatabaseDescriptor
     {
         if (concurrent_reads < 0)
         {
-            throw new IllegalArgumentException("Concurrent reads must be non-negative");
+            throw new IllegalArgumentException("Concurrent readers must be non-negative");
         }
         conf.concurrent_reads = concurrent_reads;
     }
@@ -1838,7 +1876,7 @@ public class DatabaseDescriptor
     {
         if (concurrent_writers < 0)
         {
-            throw new IllegalArgumentException("Concurrent reads must be non-negative");
+            throw new IllegalArgumentException("Concurrent writers must be non-negative");
         }
         conf.concurrent_writes = concurrent_writers;
     }

--- a/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
+++ b/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,10 +147,21 @@ public class InitialConnectionHandler extends ByteToMessageDecoder
                         promise = new VoidChannelPromise(ctx.channel(), false);
                     }
 
-                    final Message.Response response = Dispatcher.processRequest((ServerConnection) connection, startup, Overload.NONE);
-                    outbound = response.encode(inbound.header.version);
-                    ctx.writeAndFlush(outbound, promise);
-                    logger.trace("Configured pipeline: {}", ctx.pipeline());
+                    ProtocolVersion version = inbound.header.version;
+                    Dispatcher.processInit((ServerConnection) connection, startup).whenComplete((response, error) -> {
+                        if (error == null)
+                        {
+                            Envelope encoded = response.encode(version);
+                            ctx.writeAndFlush(encoded, promise);
+                            logger.debug("Configured pipeline: {}", ctx.pipeline());
+                        }
+                        else
+                        {
+                            ErrorMessage message = ErrorMessage.fromException(new ProtocolException(String.format("Unexpected error %s", error.getMessage())));
+                            Envelope encoded = message.encode(version);
+                            ctx.writeAndFlush(encoded);
+                        }
+                    });
                     break;
 
                 default:

--- a/src/java/org/apache/cassandra/transport/messages/AuthResponse.java
+++ b/src/java/org/apache/cassandra/transport/messages/AuthResponse.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.transport.messages;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.cassandra.auth.AuthEvents;
@@ -69,7 +70,12 @@ public class AuthResponse extends Message.Request
     }
 
     @Override
-    protected Response execute(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    {
+        return CompletableFuture.completedFuture(executeSync(queryState, queryStartNanoTime, traceRequest));
+    }
+
+    private Response executeSync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
     {
         try
         {

--- a/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
@@ -20,14 +20,13 @@ package org.apache.cassandra.transport.messages;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.common.collect.ImmutableMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.netty.buffer.ByteBuf;
+import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.cql3.Attributes;
 import org.apache.cassandra.cql3.BatchQueryOptions;
 import org.apache.cassandra.cql3.CQLStatement;
@@ -49,7 +48,6 @@ import org.apache.cassandra.transport.ProtocolException;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MD5Digest;
-import org.apache.cassandra.utils.NoSpamLogger;
 
 public class BatchMessage extends Message.Request
 {
@@ -166,7 +164,7 @@ public class BatchMessage extends Message.Request
     }
 
     @Override
-    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+    public CompletableFuture<Response> maybeExecuteAsync(QueryState state, long queryStartNanoTime, boolean traceRequest)
     {
         List<QueryHandler.Prepared> prepared = null;
         try
@@ -223,18 +221,43 @@ public class BatchMessage extends Message.Request
             BatchStatement batch = new BatchStatement(null, batchType,
                                                       VariableSpecifications.empty(), statements, Attributes.none());
 
-            long queryTime = System.currentTimeMillis();
-            Message.Response response = handler.processBatch(batch, state, batchOptions, getCustomPayload(), queryStartNanoTime);
-            if (queries != null)
-                QueryEvents.instance.notifyBatchSuccess(batchType, statements, queries, values, options, state, queryTime, response);
-            return response;
+            long requestStartMillisTime = System.currentTimeMillis();
+            Optional<Stage> asyncStage = Stage.fromStatement(batch);
+            if (asyncStage.isPresent())
+            {
+                List<QueryHandler.Prepared> finalPrepared = prepared;
+                return asyncStage.get().submit(() -> handleRequest(state, queryStartNanoTime, handler, batch, batchOptions, queries, statements, finalPrepared, requestStartMillisTime));
+            }
+            else
+                return CompletableFuture.completedFuture(handleRequest(state, queryStartNanoTime, handler, batch, batchOptions, queries, statements, prepared, requestStartMillisTime));
         }
         catch (Exception e)
         {
-            QueryEvents.instance.notifyBatchFailure(prepared, batchType, queryOrIdList, values, options, state, e);
-            JVMStabilityInspector.inspectThrowable(e);
-            return ErrorMessage.fromException(e);
+            return CompletableFuture.completedFuture(handleException(state, prepared, e));
         }
+    }
+
+    private Response handleRequest(QueryState queryState, long queryStartNanoTime, QueryHandler queryHandler, BatchStatement batch, BatchQueryOptions batchOptions, List<String> queries, List<ModificationStatement> statements, List<QueryHandler.Prepared> preparedList, long requestStartMillisTime)
+    {
+        try
+        {
+            Response response = queryHandler.processBatch(batch, queryState, batchOptions, getCustomPayload(), queryStartNanoTime);
+            if (queries != null)
+                QueryEvents.instance.notifyBatchSuccess(batchType, statements, queries, values, options, queryState, requestStartMillisTime, response);
+
+            return response;
+        }
+        catch (Exception exception)
+        {
+            return handleException(queryState, preparedList, exception);
+        }
+    }
+
+    private ErrorMessage handleException(QueryState state, List<QueryHandler.Prepared> prepared, Exception e)
+    {
+        QueryEvents.instance.notifyBatchFailure(prepared, batchType, queryOrIdList, values, options, state, e);
+        JVMStabilityInspector.inspectThrowable(e);
+        return ErrorMessage.fromException(e);
     }
 
     private void traceQuery(QueryState state)

--- a/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/OptionsMessage.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
@@ -67,7 +68,12 @@ public class OptionsMessage extends Message.Request
     }
 
     @Override
-    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+    protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    {
+        return CompletableFuture.completedFuture(executeSync(queryState, queryStartNanoTime, traceRequest));
+    }
+
+    private Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
     {
         List<String> cqlVersions = new ArrayList<String>();
         cqlVersions.add(QueryProcessor.CQL_VERSION.toString());

--- a/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.transport.messages;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMap;
@@ -112,7 +113,12 @@ public class PrepareMessage extends Message.Request
     }
 
     @Override
-    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+    protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    {
+        return CompletableFuture.completedFuture(executeSync(queryState, queryStartNanoTime, traceRequest));
+    }
+
+    private Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
     {
         try
         {

--- a/src/java/org/apache/cassandra/transport/messages/RegisterMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/RegisterMessage.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.transport.messages;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 
@@ -63,7 +64,12 @@ public class RegisterMessage extends Message.Request
     }
 
     @Override
-    protected Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+    protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    {
+        return CompletableFuture.completedFuture(executeSync(queryState, queryStartNanoTime, traceRequest));
+    }
+
+    private Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
     {
         assert connection instanceof ServerConnection;
         Connection.Tracker tracker = connection.getTracker();

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.transport.messages;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
 
@@ -72,7 +73,12 @@ public class StartupMessage extends Message.Request
     }
 
     @Override
-    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+    protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+    {
+        return CompletableFuture.completedFuture(executeSync(queryState, queryStartNanoTime, traceRequest));
+    }
+
+    private Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
     {
         String cqlVersion = options.get(CQL_VERSION);
         if (cqlVersion == null)

--- a/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
@@ -113,7 +113,7 @@ public class SimpleClientBurnTest
                 QueryMessage queryMessage = QueryMessage.codec.decode(body, version);
                 return new QueryMessage(queryMessage.query, queryMessage.options)
                 {
-                    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+                    public Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
                     {
                         int idx = Integer.parseInt(queryMessage.query);
                         SizeCaps caps = idx % largeMessageFrequency == 0 ? largeMessageCap : smallMessageCap;

--- a/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
@@ -172,7 +172,7 @@ public class SimpleClientPerfTest
                 QueryMessage queryMessage = QueryMessage.codec.decode(body, version);
                 return new QueryMessage(queryMessage.query, queryMessage.options)
                 {
-                    protected Message.Response execute(QueryState state, long queryStartNanoTime, boolean traceRequest)
+                    public Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
                     {
                         int idx = Integer.parseInt(queryMessage.query); // unused
                         return generateRows(idx, responseCaps);

--- a/test/distributed/org/apache/cassandra/distributed/test/UnableToParseClientMessageTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/UnableToParseClientMessageTest.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import org.junit.AfterClass;
@@ -263,7 +263,7 @@ public class UnableToParseClientMessageTest extends TestBaseImpl
         }
 
         @Override
-        protected Response execute(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
+        protected CompletableFuture<Response> maybeExecuteAsync(QueryState queryState, long queryStartNanoTime, boolean traceRequest)
         {
             throw new AssertionError("execute not supported");
         }

--- a/test/unit/org/apache/cassandra/transport/TransportTest.java
+++ b/test/unit/org/apache/cassandra/transport/TransportTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.transport;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.BatchQueryOptions;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.ClientWarn;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.messages.BatchMessage;
+import org.apache.cassandra.transport.messages.ExecuteMessage;
+import org.apache.cassandra.transport.messages.PrepareMessage;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.MD5Digest;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionEvaluationLogger;
+import org.awaitility.core.TimeoutEvent;
+
+public class TransportTest extends CQLTester
+{
+    private static Field cqlQueryHandlerField;
+    private static boolean modifiersAccessible;
+
+    @BeforeClass
+    public static void makeCqlQueryHandlerAccessible()
+    {
+        try
+        {
+            cqlQueryHandlerField = ClientState.class.getDeclaredField("cqlQueryHandler");
+            cqlQueryHandlerField.setAccessible(true);
+
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersAccessible = modifiersField.isAccessible();
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(cqlQueryHandlerField, cqlQueryHandlerField.getModifiers() & ~Modifier.FINAL);
+        }
+        catch (IllegalAccessException | NoSuchFieldException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void resetCqlQueryHandlerField()
+    {
+        if (cqlQueryHandlerField == null)
+            return;
+        try
+        {
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(cqlQueryHandlerField, cqlQueryHandlerField.getModifiers() | Modifier.FINAL);
+
+            cqlQueryHandlerField.setAccessible(false);
+
+            modifiersField.setAccessible(modifiersAccessible);
+        }
+        catch (IllegalAccessException | NoSuchFieldException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @After
+    public void dropCreatedTable()
+    {
+        try
+        {
+            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".atable");
+        }
+        catch (Throwable t)
+        {
+            // ignore
+        }
+    }
+
+    @Test
+    public void testAsyncTransport() throws Throwable
+    {
+        CassandraRelevantProperties.NATIVE_TRANSPORT_ASYNC_READ_WRITE_ENABLED.setBoolean(true);
+        try
+        {
+            doTestTransport();
+        }
+        finally
+        {
+            CassandraRelevantProperties.NATIVE_TRANSPORT_ASYNC_READ_WRITE_ENABLED.setBoolean(false);
+        }
+    }
+
+    private void doTestTransport() throws Throwable
+    {
+        SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort);
+        QueryHandler queryHandler = (QueryHandler) cqlQueryHandlerField.get(null);
+        cqlQueryHandlerField.set(null, new TransportTest.TestQueryHandler());
+        try
+        {
+            requireNetwork();
+
+            client.connect(false);
+
+            // Async native transport causes native transport requests to be executed asynchronously on the coordinator read and coordinator write
+            // stages: this means the expected number of tasks on those stages starts at 1 for the async request.
+            // The read and write stages are used for the actual execution.
+            // Please don't tell me we're not using var. Making final copies is worse. Hardcoding the values is also worse.
+            var ref = new Object()
+            {
+                long expectedCoordinateReadTasks = 1;
+                long expectedExecuteReadTasks = 1;
+                int expectedCoordinateMutationTasks = 1;
+                int expectedExecuteMutationTasks = 1;
+            };
+
+            QueryMessage createMessage = new QueryMessage("CREATE TABLE " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", QueryOptions.DEFAULT);
+            PrepareMessage prepareMessage = new PrepareMessage("SELECT * FROM " + KEYSPACE + ".atable", null);
+
+            Message.Response createResponse = client.execute(createMessage);
+            ResultMessage.Prepared prepareResponse = (ResultMessage.Prepared) client.execute(prepareMessage);
+
+            ExecuteMessage executeMessage = new ExecuteMessage(prepareResponse.statementId, prepareResponse.resultMetadataId, QueryOptions.DEFAULT);
+            Message.Response executeResponse = client.execute(executeMessage);
+            Assert.assertEquals(1, executeResponse.getWarnings().size());
+            Assert.assertEquals("async-prepared", executeResponse.getWarnings().get(0));
+            awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
+            awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
+
+            // we now expect two more tasks
+            ref.expectedCoordinateReadTasks++;
+            ref.expectedExecuteReadTasks++;
+            QueryMessage readMessage = new QueryMessage("SELECT * FROM " + KEYSPACE + ".atable", QueryOptions.DEFAULT);
+            Message.Response readResponse = client.execute(readMessage);
+            Assert.assertEquals(1, executeResponse.getWarnings().size());
+            Assert.assertEquals("async-process", readResponse.getWarnings().get(0));
+            awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
+            awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
+
+            BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
+                                                         Collections.singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
+                                                         Collections.singletonList(Collections.<ByteBuffer>emptyList()),
+                                                         QueryOptions.DEFAULT);
+            Message.Response batchResponse = client.execute(batchMessage);
+            Assert.assertEquals(1, executeResponse.getWarnings().size());
+            Assert.assertEquals("async-batch", batchResponse.getWarnings().get(0));
+            awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
+            awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
+
+            // we now expect two more tasks
+            ref.expectedCoordinateMutationTasks++;
+            ref.expectedExecuteMutationTasks++;
+            QueryMessage insertMessage = new QueryMessage("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')", QueryOptions.DEFAULT);
+            Message.Response insertResponse = client.execute(insertMessage);
+            Assert.assertEquals(1, executeResponse.getWarnings().size());
+            Assert.assertEquals("async-process", insertResponse.getWarnings().get(0));
+            awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
+            awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
+        }
+        finally
+        {
+            client.close();
+            cqlQueryHandlerField.set(null, queryHandler);
+        }
+    }
+
+    private void awaitUntil(Callable<Boolean> condition)
+    {
+        Awaitility.await("await until stages have completed the required number of tasks; on timeout check the ERROR logs for the actual numbers completed")
+                  .conditionEvaluationListener(new DumpStageInfoOnTimeout())
+                  .until(condition);
+    }
+
+    public static class TestQueryHandler implements QueryHandler
+    {
+        public QueryProcessor.Prepared getPrepared(MD5Digest id)
+        {
+            return QueryProcessor.instance.getPrepared(id);
+        }
+
+        public CQLStatement parse(String query, QueryState state, QueryOptions options)
+        {
+            return QueryProcessor.instance.parse(query, state, options);
+        }
+
+        public ResultMessage.Prepared prepare(String query,
+                                              ClientState clientState,
+                                              Map<String, ByteBuffer> customPayload)
+        throws RequestValidationException
+        {
+            return QueryProcessor.instance.prepare(query, clientState, customPayload);
+        }
+
+        public ResultMessage process(CQLStatement statement,
+                                     QueryState state,
+                                     QueryOptions options,
+                                     Map<String, ByteBuffer> customPayload,
+                                     long queryStartNanoTime)
+        throws RequestExecutionException, RequestValidationException
+        {
+            ClientWarn.instance.warn("async-process");
+            return QueryProcessor.instance.process(statement, state, options, customPayload, queryStartNanoTime);
+        }
+
+        public ResultMessage processBatch(BatchStatement statement,
+                                          QueryState state,
+                                          BatchQueryOptions options,
+                                          Map<String, ByteBuffer> customPayload,
+                                          long queryStartNanoTime)
+        throws RequestExecutionException, RequestValidationException
+        {
+            ClientWarn.instance.warn("async-batch");
+            return QueryProcessor.instance.processBatch(statement, state, options, customPayload, queryStartNanoTime);
+        }
+
+        public ResultMessage processPrepared(CQLStatement statement,
+                                             QueryState state,
+                                             QueryOptions options,
+                                             Map<String, ByteBuffer> customPayload,
+                                             long queryStartNanoTime)
+        throws RequestExecutionException, RequestValidationException
+        {
+            ClientWarn.instance.warn("async-prepared");
+            return QueryProcessor.instance.processPrepared(statement, state, options, customPayload, queryStartNanoTime);
+        }
+    }
+
+    private static class DumpStageInfoOnTimeout extends ConditionEvaluationLogger
+    {
+        public DumpStageInfoOnTimeout()
+        {
+            super(logger::warn);
+        }
+
+        @Override
+        public void onTimeout(TimeoutEvent timeoutEvent)
+        {
+            super.onTimeout(timeoutEvent);
+            logger.error("The number of tasks each stage had completed when timed out:");
+            Arrays.stream(Stage.values())
+                  .forEach(stage -> logger.error("{}: {}", stage, stage.getCompletedTaskCount()));
+        }
+    }
+}


### PR DESCRIPTION
Re-using the read and write stages allows to also reuse the related concurrency settings for which we already have support, and is ideal for Coordinator-only nodes in CNDB.

### What is the issue
Long reads or long writes negatively impact latency of the other kind of requests

### What does this PR fix and why was it fixed
This change allows asynchronous offloading of reads and writes 
from the Native Transport Requests stage to read and write stages respectively.
The change is introduced to reduce tail latencies in situations where heavy requests
of one kind saturate NTR threads and make the other kind sit in the queue.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
