### PR TITLE
CNDB-10718: Make RowFilter non-iterable

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1227,9 +1227,9 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                     orderingComparator = orderingComparator.reverse();
             }
 
-            checkDisjunctionIsSupported(table, restrictions);
-
             checkNeedsFiltering(table, restrictions);
+
+            checkDisjunctionIsSupported(table, restrictions);
 
             return new SelectStatement(rawCQLStatement,
                                        table,
@@ -1529,9 +1529,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
          */
         private void checkDisjunctionIsSupported(TableMetadata table, StatementRestrictions restrictions) throws InvalidRequestException
         {
-            if (restrictions.usesSecondaryIndexing())
-                if (restrictions.needsDisjunctionSupport(table))
-                    restrictions.throwsRequiresIndexSupportingDisjunctionError();
+            if (!parameters.allowFiltering &&
+                restrictions.usesSecondaryIndexing() &&
+                restrictions.needsDisjunctionSupport(table))
+            {
+                restrictions.throwsRequiresIndexSupportingDisjunctionError();
+            }
         }
 
         /** If ALLOW FILTERING was not specified, this verifies that it is not needed */

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -61,7 +60,6 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.lucene.util.SloppyMath;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkBindValueSet;
@@ -76,10 +74,9 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNu
  * be handled by a 2ndary index, and the rest is simply filtered out from the
  * result set (the later can only happen if the query was using ALLOW FILTERING).
  */
-public class RowFilter implements Iterable<RowFilter.Expression>
+public class RowFilter
 {
     private static final Logger logger = LoggerFactory.getLogger(RowFilter.class);
-    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
     public static final Serializer serializer = new Serializer();
     public static final RowFilter NONE = new RowFilter(FilterElement.NONE);
@@ -96,10 +93,12 @@ public class RowFilter implements Iterable<RowFilter.Expression>
         return root;
     }
 
-    public List<Expression> getExpressions()
+    /**
+     * @return all the expressions in this filter expression tree by traversing it in pre-order
+     */
+    public List<Expression> traversedExpressions()
     {
-        warnIfFilterIsATree();
-        return root.expressions;
+        return root.traversedExpressions();
     }
 
     /**
@@ -108,8 +107,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      */
     public boolean hasExpressionOnClusteringOrRegularColumns()
     {
-        warnIfFilterIsATree();
-        for (Expression expression : root)
+        for (Expression expression : traversedExpressions())
         {
             ColumnMetadata column = expression.column();
             if (column.isClusteringColumn() || column.isRegular())
@@ -220,8 +218,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      */
     public boolean partitionKeyRestrictionsAreSatisfiedBy(DecoratedKey key, AbstractType<?> keyValidator)
     {
-        warnIfFilterIsATree();
-        for (Expression e : root)
+        for (Expression e : traversedExpressions())
         {
             if (!e.column.isPartitionKey())
                 continue;
@@ -241,8 +238,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      */
     public boolean clusteringKeyRestrictionsAreSatisfiedBy(Clustering<?> clustering)
     {
-        warnIfFilterIsATree();
-        for (Expression e : root)
+        for (Expression e : traversedExpressions())
         {
             if (!e.column.isClusteringColumn())
                 continue;
@@ -259,7 +255,6 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      */
     public RowFilter without(Expression expression)
     {
-        warnIfFilterIsATree();
         assert root.contains(expression);
         if (root.size() == 1)
             return RowFilter.NONE;
@@ -270,6 +265,14 @@ public class RowFilter implements Iterable<RowFilter.Expression>
     public RowFilter withoutExpressions()
     {
         return NONE;
+    }
+
+    /**
+     * @return this filter but pruning all the branches of its expression tree that have a disjunction on top.
+     */
+    public RowFilter withoutDisjunctions()
+    {
+        return new RowFilter(root.withoutDisjunctions());
     }
 
     public RowFilter restrict(Predicate<Expression> filter)
@@ -283,25 +286,9 @@ public class RowFilter implements Iterable<RowFilter.Expression>
     }
 
     @Override
-    public Iterator<Expression> iterator()
-    {
-        warnIfFilterIsATree();
-        return root.iterator();
-    }
-
-    @Override
     public String toString()
     {
         return root.toString();
-    }
-
-    private void warnIfFilterIsATree()
-    {
-        if (!root.children.isEmpty())
-        {
-            noSpamLogger.warn("RowFilter is a tree, but we're using it as a list of top-levels expressions",
-                              new Exception("stacktrace of a potential misuse"));
-        }
     }
 
     public static Builder builder()
@@ -337,7 +324,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
             if (Guardrails.queryFilters.enabled(queryState))
                 Guardrails.queryFilters.guard(root.numFilteredValues(), "Select query", false, queryState);
 
-            return new RowFilter(doBuild(restrictions, table, options));
+            return new RowFilter(root);
         }
 
         private FilterElement doBuild(StatementRestrictions restrictions, TableMetadata table, QueryOptions options)
@@ -496,7 +483,7 @@ public class RowFilter implements Iterable<RowFilter.Expression>
         }
     }
 
-    public static class FilterElement implements Iterable<Expression>
+    public static class FilterElement
     {
         public static final Serializer serializer = new Serializer();
 
@@ -525,13 +512,29 @@ public class RowFilter implements Iterable<RowFilter.Expression>
             return expressions;
         }
 
-        @Override
-        public Iterator<Expression> iterator()
+        private List<Expression> traversedExpressions()
         {
             List<Expression> allExpressions = new ArrayList<>(expressions);
             for (FilterElement child : children)
-                allExpressions.addAll(child.expressions);
-            return allExpressions.iterator();
+                allExpressions.addAll(child.traversedExpressions());
+            return allExpressions;
+        }
+
+        private FilterElement withoutDisjunctions()
+        {
+            if (isDisjunction)
+                return NONE;
+
+            FilterElement.Builder builder = new Builder(false);
+            builder.expressions.addAll(expressions);
+
+            for (FilterElement child : children)
+            {
+                if (!child.isDisjunction)
+                    builder.children.add(child);
+            }
+
+            return builder.build();
         }
 
         public FilterElement filter(Predicate<Expression> filter)

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -102,6 +102,14 @@ public class RowFilter
     }
 
     /**
+     * @return {@code true} if this filter contains any disjunction, {@code false} otherwise.
+     */
+    public boolean containsDisjunctions()
+    {
+        return root.containsDisjunctions();
+    }
+
+    /**
      * Checks if some of the expressions apply to clustering or regular columns.
      * @return {@code true} if some of the expressions apply to clustering or regular columns, {@code false} otherwise.
      */
@@ -268,7 +276,7 @@ public class RowFilter
     }
 
     /**
-     * @return this filter but pruning all the branches of its expression tree that have a disjunction on top.
+     * @return this filter pruning all its disjunction branches
      */
     public RowFilter withoutDisjunctions()
     {
@@ -505,6 +513,18 @@ public class RowFilter
         public boolean isDisjunction()
         {
             return isDisjunction;
+        }
+
+        private boolean containsDisjunctions()
+        {
+            if (isDisjunction)
+                return true;
+
+            for (FilterElement child : children)
+                if (child.containsDisjunctions())
+                    return true;
+
+            return false;
         }
 
         public List<Expression> expressions()

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -96,7 +96,7 @@ public class RowFilter
     /**
      * @return all the expressions in this filter expression tree by traversing it in pre-order
      */
-    public List<Expression> traversedExpressions()
+    public List<Expression> expressions()
     {
         return root.traversedExpressions();
     }
@@ -115,7 +115,7 @@ public class RowFilter
      */
     public boolean hasExpressionOnClusteringOrRegularColumns()
     {
-        for (Expression expression : traversedExpressions())
+        for (Expression expression : expressions())
         {
             ColumnMetadata column = expression.column();
             if (column.isClusteringColumn() || column.isRegular())
@@ -226,7 +226,7 @@ public class RowFilter
      */
     public boolean partitionKeyRestrictionsAreSatisfiedBy(DecoratedKey key, AbstractType<?> keyValidator)
     {
-        for (Expression e : traversedExpressions())
+        for (Expression e : expressions())
         {
             if (!e.column.isPartitionKey())
                 continue;
@@ -246,7 +246,7 @@ public class RowFilter
      */
     public boolean clusteringKeyRestrictionsAreSatisfiedBy(Clustering<?> clustering)
     {
-        for (Expression e : traversedExpressions())
+        for (Expression e : expressions())
         {
             if (!e.column.isClusteringColumn())
                 continue;

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1195,7 +1195,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
         if (indexes.isEmpty() || rowFilter.isEmpty())
             return null;
 
-        for (RowFilter.Expression expression : rowFilter.traversedExpressions())
+        for (RowFilter.Expression expression : rowFilter.expressions())
         {
             if (expression.isCustom())
             {

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1195,7 +1195,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
         if (indexes.isEmpty() || rowFilter.isEmpty())
             return null;
 
-        for (RowFilter.Expression expression : rowFilter)
+        for (RowFilter.Expression expression : rowFilter.traversedExpressions())
         {
             if (expression.isCustom())
             {

--- a/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.transactions.IndexTransaction;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
-import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
@@ -109,7 +108,16 @@ public class SingletonIndexGroup implements Index.Group
     public Index.QueryPlan queryPlanFor(RowFilter rowFilter)
     {
         Preconditions.checkNotNull(delegate);
-        return SingletonIndexQueryPlan.create(delegate, rowFilter);
+
+        // Indexes using a singleton group don't support disjunctions,
+        // so we only consider the top-level AND expressions for index selection.
+        for (RowFilter.Expression e : rowFilter.withoutDisjunctions().traversedExpressions())
+        {
+            if (delegate.supportsExpression(e.column(), e.operator()))
+                return new SingletonIndexQueryPlan(delegate, delegate.getPostIndexQueryFilter(rowFilter));
+        }
+
+        return null;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
@@ -111,7 +111,7 @@ public class SingletonIndexGroup implements Index.Group
 
         // Indexes using a singleton group don't support disjunctions,
         // so we only consider the top-level AND expressions for index selection.
-        for (RowFilter.Expression e : rowFilter.withoutDisjunctions().traversedExpressions())
+        for (RowFilter.Expression e : rowFilter.withoutDisjunctions().expressions())
         {
             if (delegate.supportsExpression(e.column(), e.operator()))
                 return new SingletonIndexQueryPlan(delegate, delegate.getPostIndexQueryFilter(rowFilter));

--- a/src/java/org/apache/cassandra/index/SingletonIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexQueryPlan.java
@@ -42,18 +42,6 @@ public class SingletonIndexQueryPlan implements Index.QueryPlan
         this.postIndexFilter = postIndexFilter;
     }
 
-    @Nullable
-    protected static SingletonIndexQueryPlan create(Index index, RowFilter rowFilter)
-    {
-        for (RowFilter.Expression e : rowFilter.traversedExpressions())
-        {
-            if (index.supportsExpression(e.column(), e.operator()))
-                return new SingletonIndexQueryPlan(index, index.getPostIndexQueryFilter(rowFilter));
-        }
-
-        return null;
-    }
-
     @Override
     public Set<Index> getIndexes()
     {

--- a/src/java/org/apache/cassandra/index/SingletonIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexQueryPlan.java
@@ -45,7 +45,7 @@ public class SingletonIndexQueryPlan implements Index.QueryPlan
     @Nullable
     protected static SingletonIndexQueryPlan create(Index index, RowFilter rowFilter)
     {
-        for (RowFilter.Expression e : rowFilter.getExpressions())
+        for (RowFilter.Expression e : rowFilter.traversedExpressions())
         {
             if (index.supportsExpression(e.column(), e.operator()))
                 return new SingletonIndexQueryPlan(index, index.getPostIndexQueryFilter(rowFilter));

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
@@ -288,7 +288,7 @@ public abstract class CassandraIndex implements Index
     private Optional<RowFilter.Expression> getTargetExpression(RowFilter rowFilter)
     {
         // This index doesn't support disjunctions, so we only consider the top-level AND expressions.
-        for (RowFilter.Expression expression : rowFilter.withoutDisjunctions().traversedExpressions())
+        for (RowFilter.Expression expression : rowFilter.withoutDisjunctions().expressions())
         {
             if (supportsExpression(expression))
                 return Optional.of(expression);

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
@@ -281,11 +281,13 @@ public abstract class CassandraIndex implements Index
 
     public RowFilter getPostIndexQueryFilter(RowFilter filter)
     {
-        return getTargetExpression(filter).map(filter::without).orElse(filter);
+        // This index doesn't support disjunctions, so if the query has any, we simply apply the entire filter.
+        return filter.containsDisjunctions() ? filter : getTargetExpression(filter).map(filter::without).orElse(filter);
     }
 
     private Optional<RowFilter.Expression> getTargetExpression(RowFilter rowFilter)
     {
+        // This index doesn't support disjunctions, so we only consider the top-level AND expressions.
         for (RowFilter.Expression expression : rowFilter.withoutDisjunctions().traversedExpressions())
         {
             if (supportsExpression(expression))

--- a/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
@@ -368,7 +368,7 @@ public class TopKProcessor
     {
         ColumnFamilyStore cfs = Keyspace.openAndGetStore(command.metadata());
 
-        for (RowFilter.Expression expression : command.rowFilter().traversedExpressions())
+        for (RowFilter.Expression expression : command.rowFilter().expressions())
         {
             StorageAttachedIndex sai = findVectorIndexFor(cfs.indexManager, expression);
             if (sai != null)

--- a/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
@@ -368,7 +368,7 @@ public class TopKProcessor
     {
         ColumnFamilyStore cfs = Keyspace.openAndGetStore(command.metadata());
 
-        for (RowFilter.Expression expression : command.rowFilter().getExpressions())
+        for (RowFilter.Expression expression : command.rowFilter().traversedExpressions())
         {
             StorageAttachedIndex sai = findVectorIndexFor(cfs.indexManager, expression);
             if (sai != null)

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndex.java
@@ -253,7 +253,9 @@ public class SASIIndex implements Index, INotificationConsumer
 
     public RowFilter getPostIndexQueryFilter(RowFilter filter)
     {
-        return filter.withoutExpressions();
+        // This index doesn't support disjunctions, so if the query has any, we simply apply the entire filter.
+        // Otherwise, the index searcher should be able to handle the entire filter without postfiltering.
+        return filter.containsDisjunctions() ? filter : filter.withoutExpressions();
     }
 
     public long getEstimatedResultRows()

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
@@ -75,7 +75,7 @@ public class QueryController
 
     public Collection<RowFilter.Expression> getExpressions()
     {
-        return command.rowFilter().getExpressions();
+        return command.rowFilter().withoutDisjunctions().traversedExpressions();
     }
 
     public DataRange dataRange()

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
@@ -76,7 +76,7 @@ public class QueryController
     public Collection<RowFilter.Expression> getExpressions()
     {
         // This index doesn't support disjunctions, so we only consider the top-level AND expressions.
-        return command.rowFilter().withoutDisjunctions().traversedExpressions();
+        return command.rowFilter().withoutDisjunctions().expressions();
     }
 
     public DataRange dataRange()

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
@@ -75,6 +75,7 @@ public class QueryController
 
     public Collection<RowFilter.Expression> getExpressions()
     {
+        // This index doesn't support disjunctions, so we only consider the top-level AND expressions.
         return command.rowFilter().withoutDisjunctions().traversedExpressions();
     }
 

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -105,9 +105,11 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.cql3.functions.FunctionName;
 import org.apache.cassandra.cql3.functions.types.ParseUtils;
+import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.BooleanType;
 import org.apache.cassandra.db.marshal.ByteType;
@@ -1536,6 +1538,18 @@ public abstract class CQLTester
     {
         String currentTable = currentTable();
         return currentTable == null ? query : String.format(query, keyspace + "." + currentTable);
+    }
+
+    protected CQLStatement parseStatement(String query)
+    {
+        String formattedQuery = formatQuery(query);
+        return QueryProcessor.parseStatement(formattedQuery, ClientState.forInternalCalls());
+    }
+
+    protected ReadCommand parseReadCommand(String query)
+    {
+        SelectStatement select = (SelectStatement) parseStatement(query);
+        return  (ReadCommand) select.getQuery(QueryState.forInternalCalls(), QueryOptions.DEFAULT, FBUtilities.nowInSeconds());
     }
 
     protected ResultMessage.Prepared prepare(String query) throws Throwable

--- a/test/unit/org/apache/cassandra/index/AllIndexImplementationsTest.java
+++ b/test/unit/org/apache/cassandra/index/AllIndexImplementationsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.internal.CassandraIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sasi.SASIIndex;
+
+import static org.apache.cassandra.cql3.restrictions.StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION;
+import static org.apache.cassandra.cql3.restrictions.StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE;
+
+/**
+ * Tests common functionality across all included index implementations.
+ */
+@RunWith(Parameterized.class)
+public class AllIndexImplementationsTest extends CQLTester
+{
+    @Parameterized.Parameter
+    public String alias;
+
+    @Parameterized.Parameter(1)
+    public Class<Index> indexClass;
+
+    @Parameterized.Parameter(2)
+    public String createIndexQuery;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> parameters()
+    {
+        List<Object[]> parameters = new LinkedList<>();
+        parameters.add(new Object[]{ "none", null, null });
+        parameters.add(new Object[]{ "legacy", CassandraIndex.class, "CREATE INDEX ON %%s(%s)" });
+        parameters.add(new Object[]{ "SASI", SASIIndex.class, "CREATE CUSTOM INDEX ON %%s(%s) USING 'org.apache.cassandra.index.sasi.SASIIndex'" });
+        parameters.add(new Object[]{ "SAI", StorageAttachedIndex.class, "CREATE CUSTOM INDEX ON %%s(%s) USING 'StorageAttachedIndex'" });
+        return parameters;
+    }
+
+    @Test
+    public void testDisjunction()
+    {
+        createTable("CREATE TABLE %s (pk int, a int, b int, PRIMARY KEY(pk))");
+
+        boolean indexSupportsDisjuntion = StorageAttachedIndex.class.equals(indexClass);
+        boolean hasIndex = createIndexQuery != null;
+        if (hasIndex)
+            createIndex(String.format(createIndexQuery, 'a'));
+
+        execute("INSERT INTO %s (pk, a, b) VALUES (?, ?, ?)", 1, 1, 1);
+        execute("INSERT INTO %s (pk, a, b) VALUES (?, ?, ?)", 2, 2, 2);
+
+        // query with disjunctions on both columns when only one of them is indexed
+        assertDisjunction("a = 1 OR a = 2",
+                          !indexSupportsDisjuntion,
+                          hasIndex && indexSupportsDisjuntion,
+                          hasIndex ? INDEX_DOES_NOT_SUPPORT_DISJUNCTION : REQUIRES_ALLOW_FILTERING_MESSAGE,
+                          row(1), row(2));
+        assertDisjunction("a = 1 OR b = 2", true, false, row(1), row(2));
+        assertDisjunction("a = 1 AND (a = 1 OR b = 1)", true, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 1 OR b = 2)", true, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 2 OR b = 1)", true, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 2 OR b = 2)", true, hasIndex);
+        assertDisjunction("a = 2 AND (a = 1 OR b = 1)", true, hasIndex);
+        assertDisjunction("a = 2 AND (a = 1 OR b = 2)", true, hasIndex, row(2));
+        assertDisjunction("a = 2 AND (a = 2 OR b = 1)", true, hasIndex, row(2));
+        assertDisjunction("a = 2 AND (a = 2 OR b = 2)", true, hasIndex, row(2));
+        assertDisjunction("a = 1 OR (a = 1 AND b = 1)", true, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 1 AND b = 2)", true, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 2 AND b = 1)", true, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 2 AND b = 2)", true, indexSupportsDisjuntion, row(1), row(2));
+        assertDisjunction("a = 2 OR (a = 1 AND b = 1)", true, indexSupportsDisjuntion, row(1), row(2));
+        assertDisjunction("a = 2 OR (a = 1 AND b = 2)", true, indexSupportsDisjuntion, row(2));
+        assertDisjunction("a = 2 OR (a = 2 AND b = 1)", true, indexSupportsDisjuntion, row(2));
+        assertDisjunction("a = 2 OR (a = 2 AND b = 2)", true, indexSupportsDisjuntion, row(2));
+
+        // create a second index in the remaining column, so all columns are indexed
+        if (hasIndex)
+            createIndex(String.format(createIndexQuery, 'b'));
+
+        // test with all columns indexed
+        assertDisjunction("a = 1 OR a = 2",
+                          !indexSupportsDisjuntion,
+                          hasIndex && indexSupportsDisjuntion,
+                          hasIndex ? INDEX_DOES_NOT_SUPPORT_DISJUNCTION : REQUIRES_ALLOW_FILTERING_MESSAGE,
+                          row(1), row(2));
+        assertDisjunction("a = 1 OR b = 2", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1), row(2));
+        assertDisjunction("a = 1 AND (a = 1 OR b = 1)", !indexSupportsDisjuntion, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 1 OR b = 2)", !indexSupportsDisjuntion, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 2 OR b = 1)", !indexSupportsDisjuntion, hasIndex, row(1));
+        assertDisjunction("a = 1 AND (a = 2 OR b = 2)", !indexSupportsDisjuntion, hasIndex);
+        assertDisjunction("a = 2 AND (a = 1 OR b = 1)", !indexSupportsDisjuntion, hasIndex);
+        assertDisjunction("a = 2 AND (a = 1 OR b = 2)", !indexSupportsDisjuntion, hasIndex, row(2));
+        assertDisjunction("a = 2 AND (a = 2 OR b = 1)", !indexSupportsDisjuntion, hasIndex, row(2));
+        assertDisjunction("a = 2 AND (a = 2 OR b = 2)", !indexSupportsDisjuntion, hasIndex, row(2));
+        assertDisjunction("a = 1 OR (a = 1 AND b = 1)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 1 AND b = 2)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 2 AND b = 1)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1));
+        assertDisjunction("a = 1 OR (a = 2 AND b = 2)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1), row(2));
+        assertDisjunction("a = 2 OR (a = 1 AND b = 1)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(1), row(2));
+        assertDisjunction("a = 2 OR (a = 1 AND b = 2)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(2));
+        assertDisjunction("a = 2 OR (a = 2 AND b = 1)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(2));
+        assertDisjunction("a = 2 OR (a = 2 AND b = 2)", !indexSupportsDisjuntion, indexSupportsDisjuntion, row(2));
+    }
+
+    private void assertDisjunction(String restrictions,
+                                   boolean requiresFiltering,
+                                   boolean shouldUseIndexes,
+                                   Object[]... rows)
+    {
+        assertDisjunction(restrictions, requiresFiltering, shouldUseIndexes, REQUIRES_ALLOW_FILTERING_MESSAGE, rows);
+    }
+
+    private void assertDisjunction(String restrictions,
+                                   boolean requiresFiltering,
+                                   boolean shouldUseIndexes,
+                                   String error,
+                                   Object[]... rows)
+    {
+        // without ALLOW FILTERING
+        String query = "SELECT pk FROM %s WHERE " + restrictions;
+        if (requiresFiltering)
+            assertInvalidThrowMessage(error, InvalidRequestException.class, query);
+        else
+            assertRowsIgnoringOrder(execute(query), rows);
+
+        // with ALLOW FILTERING
+        query += " ALLOW FILTERING";
+        assertRowsIgnoringOrder(execute(query), rows);
+
+        // verify whether the indexes are used
+        Index.QueryPlan plan = parseReadCommand(query).indexQueryPlan();
+        Assert.assertEquals(shouldUseIndexes, plan != null);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/internal/CustomCassandraIndex.java
+++ b/test/unit/org/apache/cassandra/index/internal/CustomCassandraIndex.java
@@ -216,7 +216,7 @@ public class CustomCassandraIndex implements Index
 
     private Optional<RowFilter.Expression> getTargetExpression(RowFilter rowFilter)
     {
-        for (RowFilter.Expression expression : rowFilter.traversedExpressions())
+        for (RowFilter.Expression expression : rowFilter.expressions())
         {
             if (supportsExpression(expression))
                 return Optional.of(expression);

--- a/test/unit/org/apache/cassandra/index/internal/CustomCassandraIndex.java
+++ b/test/unit/org/apache/cassandra/index/internal/CustomCassandraIndex.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -47,7 +46,6 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -55,7 +53,6 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.index.SecondaryIndexBuilder;
 import org.apache.cassandra.index.transactions.IndexTransaction;
-import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.io.sstable.ReducingKeyIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.IndexMetadata;
@@ -214,13 +211,17 @@ public class CustomCassandraIndex implements Index
 
     public RowFilter getPostIndexQueryFilter(RowFilter filter)
     {
-        return getTargetExpression(filter.getExpressions()).map(filter::without)
-                                                           .orElse(filter);
+        return getTargetExpression(filter).map(filter::without).orElse(filter);
     }
 
-    private Optional<RowFilter.Expression> getTargetExpression(List<RowFilter.Expression> expressions)
+    private Optional<RowFilter.Expression> getTargetExpression(RowFilter rowFilter)
     {
-        return expressions.stream().filter(this::supportsExpression).findFirst();
+        for (RowFilter.Expression expression : rowFilter.traversedExpressions())
+        {
+            if (supportsExpression(expression))
+                return Optional.of(expression);
+        }
+        return Optional.empty();
     }
 
     public Index.Searcher searcherFor(ReadCommand command)

--- a/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ComplexQueryTest.java
@@ -257,8 +257,7 @@ public class ComplexQueryTest extends SAITester
         assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE a = 1 or a = 2")).isInstanceOf(InvalidRequestException.class)
                                                                                    .hasMessage(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION);
 
-        assertThatThrownBy(() -> execute("SELECT pk FROM %s WHERE a = 1 or a = 2 ALLOW FILTERING")).isInstanceOf(InvalidRequestException.class)
-                                                                                                   .hasMessage(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_DISJUNCTION);
+        assertRows(execute("SELECT pk FROM %s WHERE a = 1 or a = 2 ALLOW FILTERING"), row(1), row(2));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/filtering/FilteredQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/filtering/FilteredQueryTester.java
@@ -111,10 +111,7 @@ public abstract class FilteredQueryTester extends SAITester
         assertRowsIgnoringOrder(execute(query), expectedRows);
 
         // verify whether indexes are used or skipped
-        String formattedQuery = formatQuery(query);
-        SelectStatement select = (SelectStatement) QueryProcessor.parseStatement(formattedQuery, ClientState.forInternalCalls());
-        ReadCommand cmd = (ReadCommand) select.getQuery(QueryState.forInternalCalls(), QueryOptions.DEFAULT, FBUtilities.nowInSeconds());
-        org.apache.cassandra.index.Index.QueryPlan plan = cmd.indexQueryPlan();
+        org.apache.cassandra.index.Index.QueryPlan plan = parseReadCommand(query).indexQueryPlan();
         assertEquals(shouldUseIndexes, plan != null);
 
         // if we are using indexes, verify that we are using the expected ones


### PR DESCRIPTION
Make `RowFilter` non-iterable because that’s confusing in a tree of expressions.

Instead, add an explicit `#traversedExpressions()` to traverse the expressions. Also, add a `#withoutDisjunctions()` utility method for legacy indexes. That should allow us to remove the `warnIfFilterIsATree` warning since it should be clear what each method does.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits