### PR TITLE
CNDB-11988: Bump jvector to 3.0.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -717,7 +717,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.2" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="3.0.4" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.Feature;
 import io.github.jbellis.jvector.graph.disk.FeatureId;
@@ -529,7 +530,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
         // Build encoder and compress vectors
         VectorCompressor<?> compressor; // will be null if we can't compress
-        Object encoded = null; // byte[][], or long[][]
+        CompressedVectors cv = null; // byte[][], or long[][]
         boolean containsUnitVectors;
         // limit the PQ computation and encoding to one index at a time -- goal during flush is to
         // evict from memory ASAP so better to do the PQ build (in parallel) one at a time
@@ -550,7 +551,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
             assert !vectorValues.isValueShared();
             // encode (compress) the vectors to save
             if (compressor != null)
-                encoded = compressVectors(remapped, compressor);
+                cv = compressor.encodeAll(new RemappedVectorValues(remapped, remapped.maxNewOrdinal, vectorValues));
 
             containsUnitVectors = IntStream.range(0, vectorValues.size())
                                            .parallel()
@@ -564,11 +565,6 @@ public class CassandraOnHeapGraph<T> implements Accountable
             return writer.position();
 
         // save (outside the synchronized block, this is io-bound not CPU)
-        CompressedVectors cv;
-        if (compressor instanceof BinaryQuantization)
-            cv = new BQVectors((BinaryQuantization) compressor, (long[][]) encoded);
-        else
-            cv = new PQVectors((ProductQuantization) compressor, (ByteSequence<?>[]) encoded);
         cv.write(writer, JVECTOR_2_VERSION);
         return writer.position();
     }
@@ -609,31 +605,6 @@ public class CassandraOnHeapGraph<T> implements Accountable
         return compressor;
     }
 
-    private Object compressVectors(V5VectorPostingsWriter.RemappedPostings remapped, VectorCompressor<?> compressor)
-    {
-        if (compressor instanceof ProductQuantization)
-            return IntStream.range(0, remapped.maxNewOrdinal + 1).parallel()
-                            .mapToObj(i -> {
-                                var oldOrdinal = remapped.ordinalMapper.newToOld(i);
-                                if (oldOrdinal == OrdinalMapper.OMITTED)
-                                    return vts.createByteSequence(compressor.compressedVectorSize());
-                                var v = vectorValues.getVector(oldOrdinal);
-                                return ((ProductQuantization) compressor).encode(v);
-                            })
-                            .toArray(ByteSequence<?>[]::new);
-        else if (compressor instanceof BinaryQuantization)
-            return IntStream.range(0, remapped.maxNewOrdinal + 1).parallel()
-                            .mapToObj(i -> {
-                                var oldOrdinal = remapped.ordinalMapper.newToOld(i);
-                                if (oldOrdinal == OrdinalMapper.OMITTED)
-                                    return new long[compressor.compressedVectorSize() / Long.BYTES];
-                                var v = vectorValues.getVector(remapped.ordinalMapper.newToOld(i));
-                                return ((BinaryQuantization) compressor).encode(v);
-                            })
-                            .toArray(long[][]::new);
-        throw new UnsupportedOperationException("Unrecognized compressor " + compressor.getClass());
-    }
-
     public long ramBytesUsed()
     {
         return postingsBytesUsed() + vectorValues.ramBytesUsed() + builder.getGraph().ramBytesUsed();
@@ -670,5 +641,53 @@ public class CassandraOnHeapGraph<T> implements Accountable
     public void cleanup()
     {
         builder.cleanup();
+    }
+
+    /**
+     * A simple wrapper that remaps the ordinals in the vector values to the new ordinals
+     */
+    private static class RemappedVectorValues implements RandomAccessVectorValues
+    {
+        final V5VectorPostingsWriter.RemappedPostings remapped;
+        final int maxNewOrdinal;
+        final RandomAccessVectorValues vectorValues;
+
+        RemappedVectorValues(V5VectorPostingsWriter.RemappedPostings remapped, int maxNewOrdinal, RandomAccessVectorValues vectorValues)
+        {
+            this.remapped = remapped;
+            this.maxNewOrdinal = maxNewOrdinal;
+            this.vectorValues = vectorValues;
+        }
+
+        @Override
+        public int size()
+        {
+            return maxNewOrdinal + 1;
+        }
+
+        @Override
+        public int dimension()
+        {
+            return vectorValues.dimension();
+        }
+
+        @Override
+        public VectorFloat<?> getVector(int i)
+        {
+            var oldOrdinal = remapped.ordinalMapper.newToOld(i);
+            return oldOrdinal == OrdinalMapper.OMITTED ? null : vectorValues.getVector(oldOrdinal);
+        }
+
+        @Override
+        public boolean isValueShared()
+        {
+            return vectorValues.isValueShared();
+        }
+
+        @Override
+        public RandomAccessVectorValues copy()
+        {
+            return new RemappedVectorValues(remapped, maxNewOrdinal, vectorValues.copy());
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -530,7 +530,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
         // Build encoder and compress vectors
         VectorCompressor<?> compressor; // will be null if we can't compress
-        CompressedVectors cv = null; // byte[][], or long[][]
+        CompressedVectors cv = null;
         boolean containsUnitVectors;
         // limit the PQ computation and encoding to one index at a time -- goal during flush is to
         // evict from memory ASAP so better to do the PQ build (in parallel) one at a time

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -98,7 +98,6 @@ public class CompactionGraph implements Closeable, Accountable
     private final VectorSimilarityFunction similarityFunction;
     private final ChronicleMap<VectorFloat<?>, CompactionVectorPostings> postingsMap;
     private final PQVectors pqVectors;
-    private final ArrayList<ByteSequence<?>> pqVectorsList;
     private final IndexComponents.ForWrite perIndexComponents;
     private final IndexContext context;
     private final boolean unitVectors;
@@ -111,8 +110,6 @@ public class CompactionGraph implements Closeable, Accountable
     private OnDiskGraphIndexWriter writer;
     private final long termsOffset;
     private int lastRowId = -1;
-    // placeholder value that won't confuse code (like serialization) that expects non-null vectors
-    private final ByteSequence<?> encodedOmittedVector;
     // if `useSyntheticOrdinals` is true then we use `nextOrdinal` to avoid holes, otherwise use rowId as source of ordinals
     private final boolean useSyntheticOrdinals;
     private int nextOrdinal = 0;
@@ -143,7 +140,6 @@ public class CompactionGraph implements Closeable, Accountable
         similarityFunction = indexConfig.getSimilarityFunction();
         postingsStructure = Structure.ONE_TO_ONE; // until proven otherwise
         this.compressor = compressor;
-        this.encodedOmittedVector = vts.createByteSequence(compressor.compressedVectorSize());
         // `allRowsHaveVectors` only tells us about data for which we have already built indexes; if we
         // are adding previously unindexed data then we could still encounter rows with null vectors,
         // so this is just a best guess.  If the guess is wrong then the penalty is that we end up
@@ -164,8 +160,7 @@ public class CompactionGraph implements Closeable, Accountable
                                          .createPersistedTo(postingsFile.toJavaIOFile());
 
         // VSTODO add LVQ
-        pqVectorsList = new ArrayList<>(postingsEntriesAllocated);
-        pqVectors = new PQVectors(compressor, pqVectorsList);
+        pqVectors = new PQVectors(compressor, postingsEntriesAllocated);
         builder = new GraphIndexBuilder(BuildScoreProvider.pqBuildScoreProvider(similarityFunction, pqVectors),
                                         dimension,
                                         indexConfig.getAnnMaxDegree(),
@@ -256,12 +251,11 @@ public class CompactionGraph implements Closeable, Accountable
             postings = new CompactionVectorPostings(ordinal, segmentRowId);
             postingsMap.put(vector, postings);
             writer.writeInline(ordinal, Feature.singleState(FeatureId.INLINE_VECTORS, new InlineVectors.State(vector)));
-            var encoded = (ArrayByteSequence) compressor.encode(vector);
-            while (pqVectorsList.size() < ordinal)
-                pqVectorsList.add(encodedOmittedVector);
-            pqVectorsList.add(encoded);
+            // Fill in any holes in the pqVectors (setZero has the side effect of increasing the count)
+            while (pqVectors.count() < ordinal)
+                pqVectors.setZero(pqVectors.count());
+            pqVectors.encodeAndSet(ordinal, vector);
 
-            bytesUsed += encoded.ramBytesUsed();
             bytesUsed += postings.ramBytesUsed();
             return new InsertionResult(bytesUsed, ordinal, vector);
         }


### PR DESCRIPTION
### What is the issue

Fixes: https://github.com/riptano/cndb/issues/11988

### What does this PR fix and why was it fixed

Bumps the jvector release to introduce some optimizations for PQ memory utilization and cosine similarity computations.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits