### PR TITLE
CNDB-11932 plan union of half-ranges for inequality

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIntersectionIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
@@ -1675,6 +1676,13 @@ abstract public class Plan
             return predicate.isLiteral()
                    ? new LiteralIndexScan(this, id, predicate, matchingKeysCount, defaultAccess, null)
                    : new NumericIndexScan(this, id, predicate, matchingKeysCount, defaultAccess, null);
+        }
+
+        public KeysIteration fullIndexScan(IndexContext context)
+        {
+            Expression everythingExpression = new Expression(context);
+            everythingExpression.operation = Expression.Op.RANGE;
+            return indexScan(everythingExpression, tableMetrics.rows);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -532,8 +532,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         {
             if (expression.context.isIndexed())
             {
-                if ( expression.getOp() == Expression.Op.NOT_EQ
-                     || expression.getOp() == Expression.Op.NOT_CONTAINS_KEY)
+                if ( expression.getOp() == Expression.Op.NOT_EQ)
                     builder.add(buildInequalityPlan(expression));
                 else
                 {

--- a/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
@@ -115,6 +115,15 @@ public class CollectionIndexingTest extends SAITester
         assertEquals(2, execute("SELECT * FROM %s WHERE value CONTAINS KEY 1").size());
         assertEquals(0, execute("SELECT * FROM %s WHERE value NOT CONTAINS KEY 1").size());
         assertEquals(2, execute("SELECT * FROM %s WHERE value NOT CONTAINS KEY 5").size());
+
+        execute("INSERT INTO %s (pk, value) VALUES (?, ?)", 3, new HashMap<Integer, String>() {{
+            put(1, "v1");
+            put(3, "v4");
+        }});
+        assertRowsIgnoringOrder(execute("SELECT pk FROM %s WHERE value NOT CONTAINS KEY 2"), row(3));
+
+        execute("INSERT INTO %s (pk, value) VALUES (?, ?)", 4, new HashMap<Integer, String>());
+        assertRowsIgnoringOrder(execute("SELECT pk FROM %s WHERE value NOT CONTAINS KEY 2"), row(3), row(4));
     }
 
     @Test


### PR DESCRIPTION
Comments for reviewing:
- Full scan (e.g., on truncated types) is hacked by range index scan without bounds, since `Everything` plan cannot be translated to iterator and missing iterator info as it's purpose is intermediate during planning. If there is a better approach, welcome to suggest :)

### What is the issue
Closes https://github.com/riptano/cndb/issues/11932

The anti-join strategy for the inequality operator, `!=`, can be replaced with a union strategy of two semi-ranges, which make the plan explicit and can be more efficient.

### What does this PR fix and why was it fixed

This PR plans the inequality operator with the union of two semi-ranges, thus no anti-join iterator is used for it. In the case of truncatable types as Big Decimal and Big Integer it implements full index scan as the range index scan plan node without bounds.

This PR also adds tests for `not contains key` to discard the usage the union strategy by testing the false negative case of an empty map.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits