### PR TITLE
CNDB-10907: Implement overlap diagnostics

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.compaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,6 +29,7 @@ import java.util.UUID;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import org.slf4j.Logger;
@@ -48,6 +50,7 @@ import org.apache.cassandra.io.sstable.SSTableMultiWriter;
 import org.apache.cassandra.io.sstable.ScannerList;
 import org.apache.cassandra.io.sstable.SimpleSSTableMultiWriter;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.Overlaps;
 
 abstract class AbstractCompactionStrategy implements CompactionStrategy
 {
@@ -396,5 +399,15 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
             logCount = 0;
             logger.statistics(this, "periodic", backgroundCompactions.getStatistics(this));
         }
+    }
+
+    @Override
+    public Map<String, String> getMaxOverlapsMap()
+    {
+        final Set<? extends CompactionSSTable> liveSSTables = getSSTables();
+        return ImmutableMap.of("all", Integer.toString(Overlaps.maxOverlap(liveSSTables,
+                                                                           CompactionSSTable.startsAfter,
+                                                                           CompactionSSTable.firstKeyComparator,
+                                                                           CompactionSSTable.lastKeyComparator)));
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionSSTable.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionSSTable.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.UUID;
+import java.util.function.BiPredicate;
 
 import javax.annotation.Nullable;
 
@@ -57,6 +58,7 @@ public interface CompactionSSTable
     Comparator<CompactionSSTable> sizeComparator = (o1, o2) -> Long.compare(o1.onDiskLength(), o2.onDiskLength());
     Comparator<CompactionSSTable> idComparator = (o1, o2) -> SSTableIdFactory.COMPARATOR.compare(o1.getId(), o2.getId());
     Comparator<CompactionSSTable> idReverseComparator = idComparator.reversed();
+    BiPredicate<CompactionSSTable, CompactionSSTable> startsAfter = (a, b) -> a.getFirst().compareTo(b.getLast()) > 0;
 
     /**
      * @return the position of the first partition in the sstable

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
@@ -18,6 +18,7 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -200,4 +201,10 @@ public interface CompactionStrategy extends CompactionObserver
     }
 
     void periodicReport();
+
+    /**
+     * Returns a map of sstable regions (e.g. repaired, unrepaired, possibly combined with level information) to the
+     * maximum overlap between the sstables in the region.
+     */
+    Map<String, String> getMaxOverlapsMap();
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -24,7 +24,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -1153,5 +1155,17 @@ public class CompactionStrategyManager implements CompactionStrategyContainer
     public void onCompleted(UUID id, boolean isSuccess)
     {
 
+    }
+
+    @Override
+    public Map<String, String> getMaxOverlapsMap()
+    {
+        Map<String, String> result = new LinkedHashMap<>();
+
+        for (AbstractStrategyHolder holder : holders)
+            for (LegacyAbstractCompactionStrategy strategy : holder.allStrategies())
+                result.putAll(strategy.getMaxOverlapsMap());
+
+        return result;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -18,8 +18,14 @@
 
 package org.apache.cassandra.db.compaction;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import org.apache.cassandra.db.DiskBoundaries;
 import org.apache.cassandra.db.PartitionPosition;
@@ -28,6 +34,8 @@ import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.SortingIterator;
 
 public interface ShardManager
 {
@@ -37,7 +45,7 @@ public interface ShardManager
      * When the number of partitions in an sstable is smaller than this threshold, we will use a per-partition minimum
      * span, calculated from the total number of partitions in this table.
      */
-    static final long PER_PARTITION_SPAN_THRESHOLD = 100;
+    long PER_PARTITION_SPAN_THRESHOLD = 100;
 
     /**
      * Additionally, sstables that have completely fallen outside the local token ranges will end up with a zero
@@ -45,7 +53,7 @@ public interface ShardManager
      * To avoid problems with this we check if coverage is below the minimum, and replace it using the per-partition
      * calculation.
      */
-    static final double MINIMUM_TOKEN_COVERAGE = Math.scalb(1.0, -48);
+    double MINIMUM_TOKEN_COVERAGE = Math.scalb(1.0, -48);
 
     static ShardManager create(DiskBoundaries diskBoundaries, AbstractReplicationStrategy rs, boolean isReplicaAware)
     {
@@ -58,9 +66,9 @@ public interface ShardManager
         if (localRanges.getRanges().isEmpty() || !localRanges.getRanges()
                                                              .get(0)
                                                              .range()
-                                                             .left
-                                                             .getPartitioner()
-                                                             .equals(localRanges.getRealm().getPartitioner()))
+                                                  .left
+                                                  .getPartitioner()
+                                                  .equals(localRanges.getRealm().getPartitioner()))
             localRanges = new SortedLocalRanges(localRanges.getRealm(),
                                                 localRanges.getRingVersion(),
                                                 null);
@@ -102,7 +110,7 @@ public interface ShardManager
 
     /**
      * Construct a boundary/shard iterator for the given number of shards.
-     *
+     * <p>
      * Note: This does not offer a method of listing the shard boundaries it generates, just to advance to the
      * corresponding one for a given token.  The only usage for listing is currently in tests. Should a need for this
      * arise, see {@link CompactionSimulationTest} for a possible implementation.
@@ -136,6 +144,11 @@ public interface ShardManager
             span = rangeSpanned(rdr.getFirst(), rdr.getLast());
 
         long partitionCount = rdr.estimatedKeys();
+        return adjustSmallSpans(span, partitionCount);
+    }
+
+    private double adjustSmallSpans(double span, long partitionCount)
+    {
         if (partitionCount >= PER_PARTITION_SPAN_THRESHOLD && span >= MINIMUM_TOKEN_COVERAGE)
             return span;
 
@@ -143,7 +156,7 @@ public interface ShardManager
         // or falling outside the local token ranges. In these cases we apply a per-partition minimum calculated from
         // the number of partitions in the table.
         double perPartitionMinimum = Math.min(partitionCount * minimumPerPartitionSpan(), 1.0);
-        return span > perPartitionMinimum ? span : perPartitionMinimum; // The latter will be chosen if span is NaN too.
+        return span > perPartitionMinimum ? span : perPartitionMinimum;
     }
 
     default double rangeSpanned(PartitionPosition first, PartitionPosition last)
@@ -168,9 +181,13 @@ public interface ShardManager
         return Double.compare(density(a), density(b));
     }
 
-    /**
-     * Estimate the density of the sstable that will be the result of compacting the given sources.
-     */
+    default double density(long onDiskLength, PartitionPosition min, PartitionPosition max, long approximatePartitionCount)
+    {
+        double span = rangeSpanned(min, max);
+        return onDiskLength / adjustSmallSpans(span, approximatePartitionCount);
+    }
+
+    /// Estimate the density of the sstable that will be the result of compacting the given sources.
     default double calculateCombinedDensity(Set<? extends CompactionSSTable> sstables)
     {
         if (sstables.isEmpty())
@@ -189,5 +206,214 @@ public interface ShardManager
             return onDiskLength / span;
         else
             return onDiskLength;
+    }
+
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    ///
+    /// This version restricts the operation to the given token range, and assumes all sstables cover at least some
+    /// portion of that range.
+    private <R extends CompactionSSTable> void assignSSTablesInShards(Collection<R> sstables,
+                                                                      Range<Token> operationRange,
+                                                                      int numShardsForDensity,
+                                                                      BiConsumer<Collection<R>, ShardTracker> consumer)
+    {
+        var boundaries = boundaries(numShardsForDensity);
+        SortingIterator<R> items = SortingIterator.create(CompactionSSTable.firstKeyComparator, sstables);
+        PriorityQueue<R> active = new PriorityQueue<>(CompactionSSTable.lastKeyComparator);
+        // Advance inside the range. This will add all sstables that start before the end of the covering shard.
+        if (operationRange != null)
+            boundaries.advanceTo(operationRange.left.nextValidToken());
+        while (items.hasNext() || !active.isEmpty())
+        {
+            if (active.isEmpty())
+            {
+                boundaries.advanceTo(items.peek().getFirst().getToken());
+                active.add(items.next());
+            }
+            Token shardEnd = boundaries.shardEnd();
+            if (operationRange != null && (!operationRange.right.isMinimum() && shardEnd.compareTo(operationRange.right) >= 0))
+                shardEnd = null;    // Take all remaining sstables.
+
+            while (items.hasNext() && (shardEnd == null || items.peek().getFirst().getToken().compareTo(shardEnd) <= 0))
+                active.add(items.next());
+
+            consumer.accept(active, boundaries);
+
+            while (!active.isEmpty() && (shardEnd == null || active.peek().getLast().getToken().compareTo(shardEnd) <= 0))
+                active.poll();
+
+            if (!active.isEmpty()) // shardEnd must be non-null (otherwise the line above exhausts all)
+                boundaries.advanceTo(shardEnd.nextValidToken());
+        }
+    }
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    default <T, R extends CompactionSSTable> List<T> splitSSTablesInShards(Collection<R> sstables,
+                                                                           int numShardsForDensity,
+                                                                           BiFunction<Collection<R>, Range<Token>, T> maker)
+    {
+        return splitSSTablesInShards(sstables, null, numShardsForDensity, maker);
+    }
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    ///
+    /// This version restricts the operation to the given token range, and assumes all sstables cover at least some
+    /// portion of that range.
+    default <T, R extends CompactionSSTable> List<T> splitSSTablesInShards(Collection<R> sstables,
+                                                                           Range<Token> operationRange,
+                                                                           int numShardsForDensity,
+                                                                           BiFunction<Collection<R>, Range<Token>, T> maker)
+    {
+        List<T> tasks = new ArrayList<>();
+        assignSSTablesInShards(sstables, operationRange, numShardsForDensity, (rangeSSTables, boundaries) -> {
+            final T result = maker.apply(rangeSSTables, boundaries.shardSpan());
+            if (result != null)
+                tasks.add(result);
+        });
+        return tasks;
+    }
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    ///
+    /// This version restricts the operation to the given token range, and assumes all sstables cover at least some
+    /// portion of that range.
+    default <R extends CompactionSSTable> void assignSSTablesToShardIndexes(Collection<R> sstables,
+                                                                            Range<Token> operationRange,
+                                                                            int numShardsForDensity,
+                                                                            BiConsumer<Collection<R>, Integer> consumer)
+    {
+        assignSSTablesInShards(sstables, operationRange, numShardsForDensity,
+                               (rangeSSTables, boundaries) -> consumer.accept(rangeSSTables, boundaries.shardIndex()));
+    }
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    ///
+    /// This version accepts a parallelism limit and will group shards together to fit within that limit.
+    default <T, R extends CompactionSSTable> List<T> splitSSTablesInShardsLimited(Collection<R> sstables,
+                                                                                  int numShardsForDensity,
+                                                                                  int coveredShards,
+                                                                                  int maxParallelism,
+                                                                                  BiFunction<Collection<R>, Range<Token>, T> maker)
+    {
+        if (coveredShards <= maxParallelism)
+            return splitSSTablesInShards(sstables, numShardsForDensity, maker);
+        // We may be in a simple case where we can reduce the number of shards by some power of 2.
+        int multiple = Integer.highestOneBit(coveredShards / maxParallelism);
+        if (maxParallelism * multiple == coveredShards)
+            return splitSSTablesInShards(sstables, numShardsForDensity / multiple, maker);
+
+        var shards = splitSSTablesInShards(sstables,
+                                           numShardsForDensity,
+                                           (rangeSSTables, range) -> Pair.create(Set.copyOf(rangeSSTables), range));
+        return applyMaxParallelism(maxParallelism, maker, shards);
+    }
+
+    /// Seggregate the given sstables into the shard ranges that intersect sstables from the collection, and call
+    /// the given function on the combination of each shard range and the intersecting sstable set.
+    ///
+    /// This version accepts a parallelism limit and will group shards together to fit within that limit and a
+    /// restricted operation range.
+    default <T, R extends CompactionSSTable> List<T> splitSSTablesInShardsLimited(Collection<R> sstables,
+                                                                                  Range<Token> operationRange,
+                                                                                  int numShardsForDensity,
+                                                                                  int coveredShards,
+                                                                                  int maxParallelism,
+                                                                                  BiFunction<Collection<R>, Range<Token>, T> maker)
+    {
+        if (coveredShards <= maxParallelism)
+            return splitSSTablesInShards(sstables, operationRange, numShardsForDensity, maker);
+        // We may be in a simple case where we can reduce the number of shards by some power of 2.
+        int multiple = Integer.highestOneBit(coveredShards / maxParallelism);
+        if (maxParallelism * multiple == coveredShards)
+            return splitSSTablesInShards(sstables, operationRange, numShardsForDensity / multiple, maker);
+
+        var shards = splitSSTablesInShards(sstables,
+                                           operationRange,
+                                           numShardsForDensity,
+                                           (rangeSSTables, range) -> Pair.create(Set.copyOf(rangeSSTables), range));
+        return applyMaxParallelism(maxParallelism, maker, shards);
+    }
+
+    private static <T, R extends CompactionSSTable> List<T> applyMaxParallelism(int maxParallelism, BiFunction<Collection<R>, Range<Token>, T> maker, List<Pair<Set<R>, Range<Token>>> shards)
+    {
+        int actualParallelism = shards.size();
+        if (maxParallelism >= actualParallelism)
+        {
+            // We can fit within the parallelism limit without grouping, because some ranges are empty.
+            // This is not expected to happen often, but if it does, take advantage.
+            List<T> tasks = new ArrayList<>();
+            for (Pair<Set<R>, Range<Token>> pair : shards)
+                tasks.add(maker.apply(pair.left, pair.right));
+            return tasks;
+        }
+
+        // Otherwise we have to group shards together. Define a target token span per task and greedily group
+        // to be as close to it as possible.
+        double spanPerTask = shards.stream().map(Pair::right).mapToDouble(t -> t.left.size(t.right)).sum() / maxParallelism;
+        double currentSpan = 0;
+        Set<R> currentSSTables = new HashSet<>();
+        Token rangeStart = null;
+        Token prevEnd = null;
+        List<T> tasks = new ArrayList<>(maxParallelism);
+        for (var pair : shards)
+        {
+            final Token currentEnd = pair.right.right;
+            final Token currentStart = pair.right.left;
+            double span = currentStart.size(currentEnd);
+            if (rangeStart == null)
+                rangeStart = currentStart;
+            if (currentSpan + span >= spanPerTask - 0.001) // rounding error safety
+            {
+                boolean includeCurrent = currentSpan + span - spanPerTask <= spanPerTask - currentSpan;
+                if (includeCurrent)
+                    currentSSTables.addAll(pair.left);
+                tasks.add(maker.apply(currentSSTables, new Range<>(rangeStart, includeCurrent ? currentEnd : prevEnd)));
+                currentSpan -= spanPerTask;
+                rangeStart = null;
+                currentSSTables.clear();
+                if (!includeCurrent)
+                {
+                    currentSSTables.addAll(pair.left);
+                    rangeStart = currentStart;
+                }
+            }
+            else
+                currentSSTables.addAll(pair.left);
+
+            currentSpan += span;
+            prevEnd = currentEnd;
+        }
+        assert currentSSTables.isEmpty();
+        return tasks;
+    }
+
+    default int coveredShardCount(PartitionPosition first, PartitionPosition last, int numShardsForDensity)
+    {
+        var boundaries = boundaries(numShardsForDensity);
+        boundaries.advanceTo(first.getToken());
+        int firstShard = boundaries.shardIndex();
+        boundaries.advanceTo(last.getToken());
+        int lastShard = boundaries.shardIndex();
+        return lastShard - firstShard + 1;
+    }
+
+    default List<Range<Token>> getShardRanges(int shardCount)
+    {
+        var boundaries = boundaries(shardCount);
+        var result = new ArrayList<Range<Token>>(shardCount);
+        while (true)
+        {
+            result.add(boundaries.shardSpan());
+            if (boundaries.shardEnd() == null)
+                break;
+            boundaries.advanceTo(boundaries.shardEnd().nextValidToken());
+        }
+        return result;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionContainer.java
@@ -18,6 +18,7 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -356,6 +357,12 @@ public class UnifiedCompactionContainer implements CompactionStrategyContainer
     public void periodicReport()
     {
         strategy.periodicReport();
+    }
+
+    @Override
+    public Map<String, String> getMaxOverlapsMap()
+    {
+        return strategy.getMaxOverlapsMap();
     }
 
     BackgroundCompactions getBackgroundCompactions()

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiPredicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -230,7 +229,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     public static List<Set<CompactionSSTable>> splitInNonOverlappingSets(List<CompactionSSTable> sstables)
     {
         List<Set<CompactionSSTable>> overlapSets = Overlaps.constructOverlapSets(sstables,
-                                                                                 UnifiedCompactionStrategy::startsAfter,
+                                                                                 CompactionSSTable.startsAfter,
                                                                                  CompactionSSTable.firstKeyComparator,
                                                                                  CompactionSSTable.lastKeyComparator);
         Set<CompactionSSTable> group = overlapSets.get(0);
@@ -281,8 +280,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         // TODO - we should perhaps consider executing this code less frequently than legacy strategies
         // since it's more expensive, and we should therefore prevent a second concurrent thread from executing at all
 
-        // Repairs can leave behind sstables in pending repair state if they race with a compaction on those sstables. 
-        // Both the repair and the compact process can't modify the same sstables set at the same time. So compaction 
+        // Repairs can leave behind sstables in pending repair state if they race with a compaction on those sstables.
+        // Both the repair and the compact process can't modify the same sstables set at the same time. So compaction
         // is left to eventually move those sstables from FINALIZED repair sessions away from repair states.
         Collection<AbstractCompactionTask> repairFinalizationTasks = ActiveRepairService
                                                                      .instance
@@ -925,6 +924,61 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         return ret;
     }
 
+    /**
+     * Creates a map of maximum overlap, organized as a map from arena:level to the maximum number of sstables that
+     * overlap in that level, as well as a list showing the per-shard maximum overlap.
+     *
+     * The number of shards to list is calculated based on the maximum density of the sstables in the realm.
+     */
+    @Override
+    public Map<String, String> getMaxOverlapsMap()
+    {
+        final Set<? extends CompactionSSTable> liveSSTables = realm.getLiveSSTables();
+        Map<UnifiedCompactionStrategy.Arena, List<UnifiedCompactionStrategy.Level>> arenas =
+                getLevels(liveSSTables, (i1, i2) -> true); // take all sstables
+
+        // find the sstable with the biggest density to define the global shard count
+        ShardManager shardManager = getShardManager();
+        double maxDensity = 0;
+        for (CompactionSSTable liveSSTable : liveSSTables)
+            maxDensity = Math.max(maxDensity, shardManager.density(liveSSTable));
+        int shardCount = controller.getNumShards(maxDensity);
+
+        Map<String, String> map = new LinkedHashMap<>();
+        // max general overlap (max # of sstables per query)
+        map.put("all", getMaxOverlapsPerShardString(liveSSTables, shardManager, shardCount));
+
+        for (var arena : arenas.entrySet())
+        {
+            final String arenaName = arena.getKey().name();
+            for (var level : arena.getValue())
+                map.put(arenaName + ":" + level.getIndex(), getMaxOverlapsPerShardString(level.getSSTables(), shardManager, controller.getNumShards(level.max)));
+        }
+        return map;
+    }
+
+    private static String getMaxOverlapsPerShardString(Collection<? extends CompactionSSTable> sstables, ShardManager shardManager, int shardCount)
+    {
+        int[] overlapsMap = getMaxOverlapsPerShard(sstables, shardManager, shardCount);
+        int max = 0;
+        for (int i : overlapsMap)
+            max = Math.max(max, i);
+        return max + ", per shard: " + Arrays.toString(overlapsMap);
+    }
+
+    public static int[] getMaxOverlapsPerShard(Collection<? extends CompactionSSTable> sstables, ShardManager shardManager, int shardCount)
+    {
+        int[] overlapsMap = new int[shardCount];
+        shardManager.assignSSTablesToShardIndexes(sstables, null, shardCount,
+                                                  (shardSSTables, shard) ->
+                                                  overlapsMap[shard] = Overlaps.maxOverlap(shardSSTables,
+                                                                                           CompactionSSTable.startsAfter,
+                                                                                           CompactionSSTable.firstKeyComparator,
+                                                                                           CompactionSSTable.lastKeyComparator));
+        // Indexes that do not have sstables are left with 0 overlaps.
+        return overlapsMap;
+    }
+    
     private static int levelOf(CompactionPick pick)
     {
         return (int) pick.parent();
@@ -933,12 +987,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     public TableMetadata getMetadata()
     {
         return realm.metadata();
-    }
-
-    private static boolean startsAfter(CompactionSSTable a, CompactionSSTable b)
-    {
-        // Strict comparison because the span is end-inclusive.
-        return a.getFirst().compareTo(b.getLast()) > 0;
     }
 
     /**
@@ -1089,7 +1137,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
             // Note that adjacent overlap sets may include deduplicated sstable
             List<Set<CompactionSSTable>> overlaps = Overlaps.constructOverlapSets(sstables,
-                                                                                  UnifiedCompactionStrategy::startsAfter,
+                                                                                  CompactionSSTable.startsAfter,
                                                                                   CompactionSSTable.firstKeyComparator,
                                                                                   CompactionSSTable.lastKeyComparator);
             for (Set<CompactionSSTable> overlap : overlaps)

--- a/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
@@ -101,6 +101,8 @@ public class CompactionMetrics
     /** Total number compactions that consisted of only expired SSTables */
     public final Meter deleteOnlyCompactions;
 
+    public final Gauge<Map<String, Map<String, Map<String, String>>>> overlapsMap;
+
     public CompactionMetrics(final ThreadPoolExecutor... collectors)
     {
         pendingTasks = Metrics.register(factory.createMetricName("PendingTasks"), () -> {
@@ -219,6 +221,26 @@ public class CompactionMetrics
                                                         return ret;
                                                     }
                                                 });
+
+        overlapsMap = Metrics.register(factory.createMetricName("MaxOverlapsMap"),
+                                    new CachedGauge<Map<String, Map<String, Map<String, String>>>>(50, TimeUnit.MILLISECONDS)
+                                    {
+                                        public Map<String, Map<String, Map<String, String>>> loadValue()
+                                        {
+                                            Map<String, Map<String, Map<String, String>>> ret = new HashMap<>();
+                                            for (String keyspaceName : Schema.instance.getKeyspaces())
+                                            {
+                                                Map<String, Map<String, String>> ksMap = new HashMap<>();
+                                                ret.put(keyspaceName, ksMap);
+                                                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                                                {
+                                                    Map<String, String> overlaps = cfs.getCompactionStrategy().getMaxOverlapsMap();
+                                                    ksMap.put(cfs.getTableName(), overlaps);
+                                                }
+                                            }
+                                            return ret;
+                                        }
+                                    });
 
         runningCompactions = Metrics.register(factory.createMetricName("RunningCompactions"),
                                               new DerivativeGauge<List<CompactionStrategyStatistics>, Integer>(aggregateCompactions)

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionStats.java
@@ -49,6 +49,11 @@ public class CompactionStats extends NodeToolCmd
     description = "Show the compaction aggregates for the compactions in progress, e.g. the levels for LCS or the buckets for STCS and TWCS.")
     private boolean aggregate = false;
 
+    @Option(title = "overlap",
+    name = {"-O", "--overlap"},
+    description = "Show a map of the maximum sstable overlap per compaction region.")
+    private boolean overlap = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
@@ -94,6 +99,9 @@ public class CompactionStats extends NodeToolCmd
         {
             reportAggregateCompactions(probe);
         }
+
+        if (overlap)
+            reportOverlap((Map<String, Map<String, Map<String, String>>>) probe.getCompactionMetric("MaxOverlapMap"));
     }
 
     public static void reportCompactionTable(List<Map<String,String>> compactions, int compactionThroughput, boolean humanReadable, PrintStream out)
@@ -141,5 +149,25 @@ public class CompactionStats extends NodeToolCmd
         System.out.println("Aggregated view:");
         for (CompactionStrategyStatistics stat : statistics)
             System.out.println(stat.toString());
+    }
+
+    private static void reportOverlap(Map<String, Map<String, Map<String, String>>> maxOverlap)
+    {
+        if (maxOverlap == null)
+            System.out.println("Overlap map is not available.");
+
+        for (Map.Entry<String, Map<String, Map<String, String>>> ksEntry : maxOverlap.entrySet())
+        {
+            String ksName = ksEntry.getKey();
+            for (Map.Entry<String, Map<String, String>> tableEntry : ksEntry.getValue().entrySet())
+            {
+                String tableName = tableEntry.getKey();
+                System.out.println("Max overlap map for " + ksName + "." + tableName + ":");
+                for (Map.Entry<String, String> compactionEntry : tableEntry.getValue().entrySet())
+                {
+                    System.out.println("  " + compactionEntry.getKey() + ": " + compactionEntry.getValue());
+                }
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/utils/Overlaps.java
+++ b/src/java/org/apache/cassandra/utils/Overlaps.java
@@ -21,61 +21,124 @@ package org.apache.cassandra.utils;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 public class Overlaps
 {
-    /**
-     * Construct a minimal list of overlap sets, i.e. the sections of the range span when we have overlapping items,
-     * where we ensure:
-     * - non-overlapping items are never put in the same set
-     * - no item is present in non-consecutive sets
-     * - for any point where items overlap, the result includes a set listing all overlapping items
-     * <p>
-     * For example, for inputs A[0, 4), B[2, 8), C[6, 10), D[1, 9) the result would be the sets ABD and BCD. We are not
-     * interested in the spans where A, B, or C are present on their own or in combination with D, only that there
-     * exists a set in the list that is a superset of any such combination, and that the non-overlapping A and C are
-     * never together in a set.
-     * <p>
-     * Note that the full list of overlap sets A, AD, ABD, BD, BCD, CD, C is also an answer that satisfies the three
-     * conditions above, but it contains redundant sets (e.g. AD is already contained in ABD).
-     *
-     * @param items            A list of items to distribute in overlap sets. This is assumed to be a transient list and the method
-     *                         may modify or consume it. It is assumed that the start and end positions of an item are ordered,
-     *                         and the items are non-empty.
-     * @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
-     *                         This will only be used with arguments where left's start is known to be after right's start.
-     *                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
-     *                         and non-strict (>=) for end-exclusive.
-     * @param startsComparator Comparator of items' starting positions.
-     * @param endsComparator   Comparator of items' ending positions.
-     * @return List of overlap sets.
-     */
-    public static <E> List<Set<E>> constructOverlapSets(List<E> items,
-                                                        BiPredicate<E, E> startsAfter,
-                                                        Comparator<E> startsComparator,
-                                                        Comparator<E> endsComparator)
+    /// Construct a minimal list of overlap sets, i.e. the sections of the range span when we have overlapping items,
+    /// where we ensure:
+    /// - non-overlapping items are never put in the same set
+    /// - no item is present in non-consecutive sets
+    /// - for any point where items overlap, the result includes a set listing all overlapping items
+    ///
+    /// For example, for inputs A[0, 4), B[2, 8), C[6, 10), D[1, 9) the result would be the sets ABD and BCD. We are not
+    /// interested in the spans where A, B, or C are present on their own or in combination with D, only that there
+    /// exists a set in the list that is a superset of any such combination, and that the non-overlapping A and C are
+    /// never together in a set.
+    ///
+    /// Note that the full list of overlap sets A, AD, ABD, BD, BCD, CD, C is also an answer that satisfies the three
+    /// conditions above, but it contains redundant sets (e.g. AD is already contained in ABD).
+    ///
+    /// @param items            A list of items to distribute in overlap sets. This is assumed to be a transient list and the method
+    ///                         may modify or consume it. It is assumed that the start and end positions of an item are ordered,
+    ///                         and the items are non-empty.
+    /// @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
+    ///                         This will only be used with arguments where left's start is known to be after right's start.
+    ///                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
+    ///                         and non-strict (>=) for end-exclusive.
+    /// @param startsComparator Comparator of items' starting positions.
+    /// @param endsComparator   Comparator of items' ending positions.
+    /// @return List of overlap sets.
+    public static <E> List<Set<E>> constructOverlapSets(Collection<E> items,
+                                                        BiPredicate<? super E, ? super E> startsAfter,
+                                                        Comparator<? super E> startsComparator,
+                                                        Comparator<? super E> endsComparator)
     {
-        List<Set<E>> overlaps = new ArrayList<>();
+        return constructOverlapSets(items, startsAfter, startsComparator, endsComparator,
+                                    (sets, active) -> {
+                                        sets.add(new HashSet<>(active));
+                                        return sets;
+                                    },
+                                    new ArrayList<>());
+    }
+
+    /// This is the same as the method above, but only returns the size of the biggest overlap set
+    ///
+    /// @param items            A list of items to distribute in overlap sets. This is assumed to be a transient list and the method
+    ///                         may modify or consume it. It is assumed that the start and end positions of an item are ordered,
+    ///                         and the items are non-empty.
+    /// @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
+    ///                         This will only be used with arguments where left's start is known to be after right's start.
+    ///                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
+    ///                         and non-strict (>=) for end-exclusive.
+    /// @param startsComparator Comparator of items' starting positions.
+    /// @param endsComparator   Comparator of items' ending positions.
+    /// @return The maximum overlap in the given set of items.
+    public static <E> int maxOverlap(Collection<E> items,
+                                     BiPredicate<? super E, ? super E> startsAfter,
+                                     Comparator<? super E> startsComparator,
+                                     Comparator<? super E> endsComparator)
+    {
+        return constructOverlapSets(items, startsAfter, startsComparator, endsComparator,
+                                    (max, active) -> Math.max(max, active.size()), 0);
+    }
+
+    /// Construct a minimal list of overlap sets, i.e. the sections of the range span when we have overlapping items,
+    /// where we ensure:
+    /// - non-overlapping items are never put in the same set
+    /// - no item is present in non-consecutive sets
+    /// - for any point where items overlap, the result includes a set listing all overlapping items
+    /// and process it with the given reducer function. Implements the methods above.
+    ///
+    /// For example, for inputs A[0, 4), B[2, 8), C[6, 10), D[1, 9) the result would be the sets ABD and BCD. We are not
+    /// interested in the spans where A, B, or C are present on their own or in combination with D, only that there
+    /// exists a set in the list that is a superset of any such combination, and that the non-overlapping A and C are
+    /// never together in a set.
+    ///
+    /// Note that the full list of overlap sets A, AD, ABD, BD, BCD, CD, C is also an answer that satisfies the three
+    /// conditions above, but it contains redundant sets (e.g. AD is already contained in ABD).
+    ///
+    /// @param items            A list of items to distribute in overlap sets. It is assumed that the start and end
+    ///                         positions of an item are ordered, and the items are non-empty.
+    /// @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
+    ///                         This will only be used with arguments where left's start is known to be after right's start.
+    ///                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
+    ///                         and non-strict (>=) for end-exclusive.
+    /// @param startsComparator Comparator of items' starting positions.
+    /// @param endsComparator   Comparator of items' ending positions.
+    /// @param reducer          Function to apply to each overlap set.
+    /// @param initialValue     Initial value for the reducer.
+    /// @return The result of processing the overlap sets.
+    public static <E, R> R constructOverlapSets(Collection<E> items,
+                                                BiPredicate<? super E, ? super E> startsAfter,
+                                                Comparator<? super E> startsComparator,
+                                                Comparator<? super E> endsComparator,
+                                                BiFunction<R, Collection<E>, R> reducer,
+                                                R initialValue)
+    {
+        R overlaps = initialValue;
         if (items.isEmpty())
             return overlaps;
 
         PriorityQueue<E> active = new PriorityQueue<>(endsComparator);
-        items.sort(startsComparator);
-        for (E item : items)
+        SortingIterator<E> itemsSorted = SortingIterator.create(startsComparator, items);
+        while (itemsSorted.hasNext())
         {
+            E item = itemsSorted.next();
             if (!active.isEmpty() && startsAfter.test(item, active.peek()))
             {
                 // New item starts after some active ends. It does not overlap with it, so:
                 // -- output the previous active set
-                overlaps.add(new HashSet<>(active));
+                overlaps = reducer.apply(overlaps, active);
                 // -- remove all items that also end before the current start
                 do
                 {
@@ -90,14 +153,60 @@ public class Overlaps
         }
 
         assert !active.isEmpty();
-        overlaps.add(new HashSet<>(active));
+        overlaps = reducer.apply(overlaps, active);
 
         return overlaps;
     }
 
+    /// Transform a list to transitively combine adjacent sets that have a common element, resulting in disjoint sets.
+    public static <T> List<Set<T>> combineSetsWithCommonElement(List<? extends Set<T>> overlapSets)
+    {
+        Set<T> group = overlapSets.get(0);
+        List<Set<T>> groups = new ArrayList<>();
+        for (int i = 1; i < overlapSets.size(); ++i)
+        {
+            Set<T> current = overlapSets.get(i);
+            if (Collections.disjoint(current, group))
+            {
+                groups.add(group);
+                group = current;
+            }
+            else
+            {
+                group.addAll(current);
+            }
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    /// Split a list of items into disjoint non-overlapping sets.
+    ///
+    /// @param items            A list of items to distribute in overlap sets. It is assumed that the start and end
+    ///                         positions of an item are ordered, and the items are non-empty.
+    /// @param startsAfter      Predicate determining if its left argument's start if fully after the right argument's end.
+    ///                         This will only be used with arguments where left's start is known to be after right's start.
+    ///                         It is up to the caller if this is a strict comparison -- strict (>) for end-inclusive spans
+    ///                         and non-strict (>=) for end-exclusive.
+    /// @param startsComparator Comparator of items' starting positions.
+    /// @param endsComparator   Comparator of items' ending positions.
+    /// @return list of non-overlapping sets of items
+    public static <T> List<Set<T>> splitInNonOverlappingSets(List<T> items,
+                                                             BiPredicate<T, T> startsAfter,
+                                                             Comparator<T> startsComparator,
+                                                             Comparator<T> endsComparator)
+    {
+        if (items.isEmpty())
+            return List.of();
+
+        List<Set<T>> overlapSets = Overlaps.constructOverlapSets(items, startsAfter, startsComparator, endsComparator);
+        return combineSetsWithCommonElement(overlapSets);
+    }
+
+
     public enum InclusionMethod
     {
-        NONE, SINGLE, TRANSITIVE;
+        NONE, SINGLE, TRANSITIVE
     }
 
     public interface BucketMaker<E, B>
@@ -105,26 +214,23 @@ public class Overlaps
         B makeBucket(List<Set<E>> sets, int startIndexInclusive, int endIndexExclusive);
     }
 
-    /**
-     * Assign overlap sections into buckets Identify sections that have at least threshold-many overlapping
-     * items and apply the overlap inclusion method to combine with any neighbouring sections that contain
-     * selected sstables to make sure we make full use of any sstables selected for compaction (i.e. avoid
-     * recompacting, see {@link org.apache.cassandra.db.compaction.unified.Controller#overlapInclusionMethod()}).
-     *
-     * For non-transitive inclusionMethod the order in which we select the buckets matters because an sstables that
-     * spans overlap sets could be chosen for only one of the candidate buckets
-     *      * containing it. To make the most efficient selection we thus perform it by descending size, starting with the
-     *      * sets with most overlap.
-     *
-     * @param threshold       Threshold for selecting a bucket. Sets below this size will be ignored, unless they need
-     *                        to be grouped with a neighboring set due to overlap.
-     * @param inclusionMethod NONE to only form buckets of the overlapping sets, SINGLE to include all
-     *                        sets that share an sstable with a selected bucket, or TRANSITIVE to include
-     *                        all sets that have an overlap chain to a selected bucket.
-     * @param overlaps        An ordered list of overlap sets as returned by {@link #constructOverlapSets}.
-     * @param bucketer        Method used to create a bucket out of the supplied set indexes.
-     * @param unselectedHandler Action to take on sets that are below the threshold and not included in any bucket.
-     */
+    /// Assign overlap sections into buckets Identify sections that have at least threshold-many overlapping
+    /// items and apply the overlap inclusion method to combine with any neighbouring sections that contain
+    /// selected sstables to make sure we make full use of any sstables selected for compaction (i.e. avoid
+    /// recompacting, see [#overlapInclusionMethod()]).
+    /// For non-transitive inclusionMethod the order in which we select the buckets matters because an sstables that
+    /// spans overlap sets could be chosen for only one of the candidate buckets
+    ///      * containing it. To make the most efficient selection we thus perform it by descending size, starting with the
+    ///      * sets with most overlap.
+    ///
+    /// @param threshold       Threshold for selecting a bucket. Sets below this size will be ignored, unless they need
+    ///                        to be grouped with a neighboring set due to overlap.
+    /// @param inclusionMethod NONE to only form buckets of the overlapping sets, SINGLE to include all
+    ///                        sets that share an sstable with a selected bucket, or TRANSITIVE to include
+    ///                        all sets that have an overlap chain to a selected bucket.
+    /// @param overlaps        An ordered list of overlap sets as returned by [#constructOverlapSets].
+    /// @param bucketer        Method used to create a bucket out of the supplied set indexes.
+    /// @param unselectedHandler Action to take on sets that are below the threshold and not included in any bucket.
     public static <E, B> List<B> assignOverlapsIntoBuckets(int threshold,
                                                            InclusionMethod inclusionMethod,
                                                            List<Set<E>> overlaps,
@@ -281,9 +387,7 @@ public class Overlaps
         return false;
     }
 
-    /**
-     * Pull the last elements from the given list, up to the given limit.
-     */
+    /// Pull the last elements from the given list, up to the given limit.
     public static <T> List<T> pullLast(List<T> source, int limit)
     {
         List<T> result = new ArrayList<>(limit);
@@ -292,11 +396,9 @@ public class Overlaps
         return result;
     }
 
-    /**
-     * Select up to `limit` sstables from each overlapping set (more than `limit` in total) by taking the last entries
-     * from `allObjectsSorted`. To achieve this, keep selecting the last sstable until the next one we would add would
-     * bring the number selected in some overlap section over `limit`.
-     */
+    /// Select up to `limit` sstables from each overlapping set (more than `limit` in total) by taking the last entries
+    /// from `allObjectsSorted`. To achieve this, keep selecting the last sstable until the next one we would add would
+    /// bring the number selected in some overlap section over `limit`.
     public static <T> Collection<T> pullLastWithOverlapLimit(List<T> allObjectsSorted, List<Set<T>> overlapSets, int limit)
     {
         int setsCount = overlapSets.size();

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.cassandra.db.compaction;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -29,14 +31,18 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.agrona.collections.IntArrayList;
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DiskBoundaries;
 import org.apache.cassandra.db.SortedLocalRanges;
+import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Splitter;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.utils.Pair;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
@@ -382,5 +388,150 @@ public class ShardManagerTest
                 assertEquals(numDisks * numShards, count);
             }
         }
+    }
+
+
+    @Test
+    public void testSplitSSTablesInRanges()
+    {
+        testSplitSSTablesInRanges(8, ints(1, 2, 4));
+        testSplitSSTablesInRanges(4, ints(1, 2, 4));
+        testSplitSSTablesInRanges(2, ints(1, 2, 4));
+        testSplitSSTablesInRanges(5, ints(1, 2, 4));
+        testSplitSSTablesInRanges(5, ints(2, 4, 8));
+        testSplitSSTablesInRanges(3, ints(1, 3, 5));
+        testSplitSSTablesInRanges(3, ints(3, 3, 3));
+
+        testSplitSSTablesInRanges(1, ints(1, 2, 3));
+
+        testSplitSSTablesInRanges(3, ints());
+    }
+
+    @Test
+    public void testSplitSSTablesInRangesMissingParts()
+    {
+        // Drop some sstables without losing ranges
+        testSplitSSTablesInRanges(8, ints(2, 4, 8),
+                                ints(1));
+
+        testSplitSSTablesInRanges(8, ints(2, 4, 8),
+                                ints(1), ints(0), ints(2, 7));
+
+        testSplitSSTablesInRanges(5, ints(2, 4, 8),
+                                ints(1), ints(0), ints(2, 7));
+    }
+
+    @Test
+    public void testSplitSSTablesInRangesOneRange()
+    {
+        // Drop second half
+        testSplitSSTablesInRanges(2, ints(2, 4, 8),
+                                ints(1), ints(2, 3), ints(4, 5, 6, 7));
+        // Drop all except center, within shard
+        testSplitSSTablesInRanges(3, ints(5, 7, 9),
+                                ints(0, 1, 3, 4), ints(0, 1, 2, 4, 5, 6), ints(0, 1, 2, 6, 7, 8));
+    }
+
+    @Test
+    public void testSplitSSTablesInRangesSkippedRange()
+    {
+        // Drop all sstables containing the 4/8-5/8 range.
+        testSplitSSTablesInRanges(8, ints(2, 4, 8),
+                                ints(1), ints(2), ints(4));
+        // Drop all sstables containing the 4/8-6/8 range.
+        testSplitSSTablesInRanges(8, ints(2, 4, 8),
+                                ints(1), ints(2), ints(4, 5));
+        // Drop all sstables containing the 4/8-8/8 range.
+        testSplitSSTablesInRanges(8, ints(2, 4, 8),
+                                ints(1), ints(2, 3), ints(4, 5, 6, 7));
+
+        // Drop all sstables containing the 0/8-2/8 range.
+        testSplitSSTablesInRanges(5, ints(2, 4, 8),
+                                ints(0), ints(0), ints(0, 1));
+        // Drop all sstables containing the 6/8-8/8 range.
+        testSplitSSTablesInRanges(5, ints(2, 4, 8),
+                                ints(1), ints(3), ints(6, 7));
+        // Drop sstables on both ends.
+        testSplitSSTablesInRanges(5, ints(3, 4, 8),
+                                ints(0, 2), ints(0, 3), ints(0, 1, 6, 7));
+    }
+
+    public void testSplitSSTablesInRanges(int numShards, int[] perLevelCounts, int[]... dropsPerLevel)
+    {
+        weightedRanges.clear();
+        weightedRanges.add(new Splitter.WeightedRange(1.0, new Range<>(minimumToken, minimumToken)));
+        ShardManager manager = new ShardManagerNoDisks(localRanges);
+
+        Set<CompactionSSTable> allSSTables = new HashSet<>();
+        int levelNum = 0;
+        for (int perLevelCount : perLevelCounts)
+        {
+            List<CompactionSSTable> ssTables = mockNonOverlappingSSTables(perLevelCount);
+            if (levelNum < dropsPerLevel.length)
+            {
+                for (int i = dropsPerLevel[levelNum].length - 1; i >= 0; i--)
+                    ssTables.remove(dropsPerLevel[levelNum][i]);
+            }
+            allSSTables.addAll(ssTables);
+            ++levelNum;
+        }
+
+        var results = new ArrayList<Pair<Range<Token>, Set<CompactionSSTable>>>();
+        manager.splitSSTablesInShards(allSSTables, numShards, (sstables, range) -> results.add(Pair.create(range, Set.copyOf(sstables))));
+        int i = 0;
+        int[] expectedSSTablesInTasks = new int[results.size()];
+        int[] collectedSSTablesPerTask = new int[results.size()];
+        for (var t : results)
+        {
+            collectedSSTablesPerTask[i] = t.right().size();
+            expectedSSTablesInTasks[i] = (int) allSSTables.stream().filter(x -> intersects(x, t.left())).count();
+            ++i;
+        }
+        Assert.assertEquals(Arrays.toString(expectedSSTablesInTasks), Arrays.toString(collectedSSTablesPerTask));
+        System.out.println(Arrays.toString(expectedSSTablesInTasks));
+    }
+
+    private boolean intersects(CompactionSSTable r, Range<Token> range)
+    {
+        if (range == null)
+            return true;
+        return range.intersects(range(r));
+    }
+
+
+    private Bounds<Token> range(CompactionSSTable x)
+    {
+        return new Bounds<>(x.getFirst().getToken(), x.getLast().getToken());
+    }
+
+    List<CompactionSSTable> mockNonOverlappingSSTables(int numSSTables)
+    {
+        if (!partitioner.splitter().isPresent())
+            throw new IllegalStateException(String.format("Cannot split ranges with current partitioner %s", partitioner));
+
+        ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+
+        List<CompactionSSTable> sstables = new ArrayList<>(numSSTables);
+        for (int i = 0; i < numSSTables; i++)
+        {
+            DecoratedKey first = new BufferDecoratedKey(boundary(numSSTables, i).nextValidToken(), emptyBuffer);
+            DecoratedKey last =  new BufferDecoratedKey(boundary(numSSTables, i+1), emptyBuffer);
+            sstables.add(mockSSTable(first, last));
+        }
+
+        return sstables;
+    }
+
+    private Token boundary(int numSSTables, int i)
+    {
+        return partitioner.split(partitioner.getMinimumToken(), partitioner.getMaximumToken(), i * 1.0 / numSSTables);
+    }
+
+    private CompactionSSTable mockSSTable(DecoratedKey first, DecoratedKey last)
+    {
+        CompactionSSTable sstable = Mockito.mock(CompactionSSTable.class);
+        when(sstable.getFirst()).thenReturn(first);
+        when(sstable.getLast()).thenReturn(last);
+        return sstable;
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -1726,6 +1726,10 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 }
             }
         }
+
+        Mockito.when(controller.getNumShards(anyDouble())).thenReturn(16);  // co-prime with counts to ensure multiple sstables fall in each shard
+        System.out.println(strategy.getMaxOverlapsMap());
+
         dataTracker.removeUnsafe(allSSTables);
     }
 


### PR DESCRIPTION
### What is the issue
Extra diagnostics methods to better understand UCS compaction hierarchy structure.

For Cassandra itself this provides a new `--overlaps` (`-O`) option to `nodetool compactionstats` that generates an overlap map showing the maximum overlaps for every shard of every level in the strategy, as well as a total for all sstables in the system (not necessarily the sum of the per-level overlaps).

Also implements methods to be used by CNDB-side diagnostics.

### What does this PR fix and why was it fixed
...

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits