### PR TITLE
CNDB-11950: cache sstable density result to speed up test

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -873,19 +872,20 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         for (Arena arena : arenas)
         {
             List<Level> levels = new ArrayList<>(MAX_LEVELS);
-            // Precompute the densities and cache them for the sstables in this arena
-            Map<CompactionSSTable, Double> sstableDensityCache = new HashMap<>();
-            arena.sstables.forEach(sstable -> sstableDensityCache.put(sstable, currentShardManager.density(sstable)));
 
-            // Sort the list in place using the density cache
-            arena.sstables.sort(Comparator.comparing(sstableDensityCache::get));
+            // Precompute the density, then sort.
+            List<SSTableWithDensity> ssTableWithDensityList = new ArrayList<>(arena.sstables.size());
+            for (CompactionSSTable sstable : arena.sstables)
+                ssTableWithDensityList.add(new SSTableWithDensity(sstable, currentShardManager.density(sstable)));
+            Collections.sort(ssTableWithDensityList);
 
             double maxSize = controller.getMaxLevelDensity(0, controller.getBaseSstableSize(controller.getFanout(0)) / currentShardManager.localSpaceCoverage());
             int index = 0;
             Level level = new Level(controller, index, 0, maxSize);
-            for (CompactionSSTable candidate : arena.sstables)
+            for (SSTableWithDensity candidateWithDensity : ssTableWithDensityList)
             {
-                final double size = sstableDensityCache.get(candidate);
+                final CompactionSSTable candidate = candidateWithDensity.sstable;
+                final double size = candidateWithDensity.density;
                 if (size < level.max)
                 {
                     level.add(candidate);
@@ -1448,6 +1448,27 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             return String.format("Current limits: running=%d, max=%d, maxConcurrent=%d, perLevel=%s, levelCount=%d, spaceAvailable=%s, rateLimitLog=%s, remainingAdaptiveCompactions=%d",
                                  runningCompactions, maxCompactions, maxConcurrentCompactions, Arrays.toString(perLevel), levelCount,
                                  FBUtilities.prettyPrintMemory(spaceAvailable), rateLimitLog, remainingAdaptiveCompactions);
+        }
+    }
+
+    /**
+     * Utility wrapper to efficiently store the density of an SSTable with the SSTable itself.
+     */
+    private static class SSTableWithDensity implements Comparable<SSTableWithDensity>
+    {
+        final CompactionSSTable sstable;
+        final double density;
+
+        SSTableWithDensity(CompactionSSTable sstable, double density)
+        {
+            this.sstable = sstable;
+            this.density = density;
+        }
+
+        @Override
+        public int compareTo(SSTableWithDensity o)
+        {
+            return Double.compare(density, o.density);
         }
     }
 }


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/11950

### What does this PR fix and why was it fixed
We saw many test failures in `UnifiedCompactionStrategyTest` after #1407. After investigating it a bit, it seems that the root cause to the unit test failure is likely the cost associated with the mockito calls to get different values.

However, without changing anything in Mockito, I was able to optimize the `UCS::getLevels` method enough to make the test suite go from timing out to taking 3 minutes 11 seconds when running `ant test -Dtest.name=UnifiedCompactionStrategyTest` on the command line.

Let's see if the test passes in butler.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits