### PR TITLE
CNDB-7343: Fix RequestFailureReason reason codes according to Apache and avoid future conflicts

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -88,7 +88,7 @@ public enum RequestFailureReason
             throw new IllegalArgumentException("RequestFailureReason code must be non-negative (got " + code + ')');
 
         // be forgiving and return UNKNOWN if we aren't aware of the code - for forward compatibility
-        return code < codeToReasonMap.length ? codeToReasonMap[code] : UNKNOWN;
+        return (code < codeToReasonMap.length && codeToReasonMap[code] != null) ? codeToReasonMap[code] : UNKNOWN;
     }
 
     public static RequestFailureReason forException(Throwable t)

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -63,27 +63,18 @@ public enum RequestFailureReason
         return code;
     }
 
-    private static final RequestFailureReason[] codeToReasonMap;
+    private static final Map<Integer, RequestFailureReason> codeToReasonMap = new HashMap<>();
     private static final Map<Class<? extends Throwable>, RequestFailureReason> exceptionToReasonMap = new HashMap<>();
 
     static
     {
         RequestFailureReason[] reasons = values();
 
-        int max = -1;
-        for (RequestFailureReason r : reasons)
-            max = max(r.code, max);
-
-        RequestFailureReason[] codeMap = new RequestFailureReason[max + 1];
-
         for (RequestFailureReason reason : reasons)
         {
-            if (codeMap[reason.code] != null)
+            if (codeToReasonMap.put(reason.code, reason) != null)
                 throw new RuntimeException("Two RequestFailureReason-s that map to the same code: " + reason.code);
-            codeMap[reason.code] = reason;
         }
-
-        codeToReasonMap = codeMap;
 
         exceptionToReasonMap.put(TombstoneOverwhelmingException.class, READ_TOO_MANY_TOMBSTONES);
         exceptionToReasonMap.put(IncompatibleSchemaException.class, INCOMPATIBLE_SCHEMA);
@@ -102,7 +93,7 @@ public enum RequestFailureReason
             throw new IllegalArgumentException("RequestFailureReason code must be non-negative (got " + code + ')');
 
         // be forgiving and return UNKNOWN if we aren't aware of the code - for forward compatibility
-        return (code < codeToReasonMap.length && codeToReasonMap[code] != null) ? codeToReasonMap[code] : UNKNOWN;
+        return codeToReasonMap.getOrDefault(code, UNKNOWN);
     }
 
     public static RequestFailureReason forException(Throwable t)

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -37,10 +37,12 @@ public enum RequestFailureReason
     READ_TOO_MANY_TOMBSTONES (1),
     TIMEOUT                  (2),
     INCOMPATIBLE_SCHEMA      (3),
-    INDEX_NOT_AVAILABLE      (4),
-    UNKNOWN_COLUMN           (5),
-    UNKNOWN_TABLE            (6),
-    REMOTE_STORAGE_FAILURE   (7);
+    INDEX_NOT_AVAILABLE      (6), // We match it to Apache Cassandra's INDEX_NOT_AVAILABLE code introduced in 5.0
+    // The following codes are not present in Apache Cassandra's RequestFailureReason
+    // We should add new codes in HCD (which do not exist in Apache Cassandra) only with big numbers, to avoid conflicts
+    UNKNOWN_COLUMN           (500),
+    UNKNOWN_TABLE            (501),
+    REMOTE_STORAGE_FAILURE   (502);
 
     public static final Serializer serializer = new Serializer();
 

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -101,6 +102,9 @@ public enum RequestFailureReason
 
         if (t instanceof AbortedOperationException)
             return TIMEOUT;
+
+        if (t instanceof IndexNotAvailableException)
+            return INDEX_NOT_AVAILABLE;
 
         return UNKNOWN;
     }

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+public class RequestFailureReasonTest
+{
+    private static final RequestFailureReason[] REASONS = RequestFailureReason.values();
+    private static final Object[][] EXPECTED_VALUES =
+    {
+    { 0, "UNKNOWN" },
+    { 1, "READ_TOO_MANY_TOMBSTONES" },
+    { 2, "TIMEOUT" },
+    { 3, "INCOMPATIBLE_SCHEMA" },
+    { 6, "INDEX_NOT_AVAILABLE" },
+    { 500, "UNKNOWN_COLUMN" },
+    { 501, "UNKNOWN_TABLE" },
+    { 502, "REMOTE_STORAGE_FAILURE" }
+    };
+    @Test
+    public void testEnumCodesAndNames()
+    {
+        for (int i = 0; i < REASONS.length; i++)
+        {
+            assertEquals("RequestFailureReason code mismatch for " +
+                         REASONS[i].name(), EXPECTED_VALUES[i][0], REASONS[i].code);
+            assertEquals("RequestFailureReason name mismatch for code " +
+                         REASONS[i].code, EXPECTED_VALUES[i][1], REASONS[i].name());
+        }
+        assertEquals("Number of RequestFailureReason enum constants has changed. Update the test.",
+                     EXPECTED_VALUES.length, REASONS.length);
+    }
+}

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -19,6 +19,8 @@
 package org.apache.cassandra.exceptions;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 public class RequestFailureReasonTest
 {
     private static final RequestFailureReason[] REASONS = RequestFailureReason.values();
@@ -45,5 +47,24 @@ public class RequestFailureReasonTest
         }
         assertEquals("Number of RequestFailureReason enum constants has changed. Update the test.",
                      EXPECTED_VALUES.length, REASONS.length);
+    }
+
+    @Test
+    public void testFromCode()
+    {
+        // Test valid codes
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(0));
+        assertEquals(RequestFailureReason.READ_TOO_MANY_TOMBSTONES, RequestFailureReason.fromCode(1));
+        assertEquals(RequestFailureReason.TIMEOUT, RequestFailureReason.fromCode(2));
+        assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, RequestFailureReason.fromCode(3));
+        assertEquals(RequestFailureReason.INDEX_NOT_AVAILABLE, RequestFailureReason.fromCode(6));
+        assertEquals(RequestFailureReason.UNKNOWN_COLUMN, RequestFailureReason.fromCode(500));
+        assertEquals(RequestFailureReason.UNKNOWN_TABLE, RequestFailureReason.fromCode(501));
+        assertEquals(RequestFailureReason.REMOTE_STORAGE_FAILURE, RequestFailureReason.fromCode(502));
+
+        // Test invalid codes
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(200));
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(999));
+        assertThrows(IllegalArgumentException.class, () -> RequestFailureReason.fromCode(-1));
     }
 }


### PR DESCRIPTION
### What is the issue
Inconsistent codes and failing to update the `forException` method in `RequestFailureReason` lead to inconsistent, confusing, and even incorrect error reasons returned to users when executing queries. 

### What does this PR fix and why was it fixed

Fix `RequestFailureReason` reason codes in consistence with Apache and avoid future conflicts by assigning new HCD-specific codes to higher numbers.
Improve testing to prevent regressions.

### Checklist before you submit for review
- [x ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ x] Verify test results on Butler
- [ x] Test coverage for new/modified code is > 80%
- [ x] Proper code formatting
- [ x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ x] Each commit has a meaningful description
- [x ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits