### PR TITLE
CNDB-12130: read source file sequentially when sending file through ZCS

### DIFF
--- a/src/java/org/apache/cassandra/net/AsyncStreamingOutputPlus.java
+++ b/src/java/org/apache/cassandra/net/AsyncStreamingOutputPlus.java
@@ -192,17 +192,17 @@ public class AsyncStreamingOutputPlus extends AsyncChannelOutputPlus
     {
         final long length = fc.size();
         long bytesTransferred = 0;
+        assert fc.position() == 0;
 
         try
         {
             while (bytesTransferred < length)
             {
                 int toWrite = (int) min(batchSize, length - bytesTransferred);
-                final long position = bytesTransferred;
 
                 writeToChannel(bufferSupplier -> {
                     ByteBuffer outBuffer = bufferSupplier.get(toWrite);
-                    long read = fc.read(outBuffer, position);
+                    long read = fc.read(outBuffer);
                     if (read != toWrite)
                         throw new IOException(String.format("could not read required number of bytes from " +
                                                             "file to be streamed: read %d bytes, wanted %d bytes",


### PR DESCRIPTION
- add configuration to skip mutating STATS after receiving ZCS sstable