### PR TITLE
CNBD-12239: Replace System.nanoTime with approxTime in SAI where appropriate

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
+import org.apache.cassandra.utils.MonotonicClock;
 
 import static java.lang.Math.max;
 
@@ -77,12 +78,12 @@ public class QueryContext
     public QueryContext(long executionQuotaMs)
     {
         this.executionQuotaNano = TimeUnit.MILLISECONDS.toNanos(executionQuotaMs);
-        this.queryStartTimeNanos = System.nanoTime();
+        this.queryStartTimeNanos = MonotonicClock.approxTime.now();
     }
 
     public long totalQueryTimeNs()
     {
-        return System.nanoTime() - queryStartTimeNanos;
+        return MonotonicClock.approxTime.now() - queryStartTimeNanos;
     }
 
     // setters

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 public class QueryView implements AutoCloseable
@@ -160,11 +161,11 @@ public class QueryView implements AutoCloseable
                             // Log about the failures
                             if (failingSince <= 0)
                             {
-                                failingSince = System.nanoTime();
+                                failingSince = MonotonicClock.approxTime.now();
                             }
-                            else if (System.nanoTime() - failingSince > TimeUnit.MILLISECONDS.toNanos(100))
+                            else if (MonotonicClock.approxTime.now() - failingSince > TimeUnit.MILLISECONDS.toNanos(100))
                             {
-                                failingSince = System.nanoTime();
+                                failingSince = MonotonicClock.approxTime.now();
                                 if (success)
                                     NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
                                                      "Spinning trying to capture index reader for {}, but it was released.", index);


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/12239

### What does this PR fix and why was it fixed
We found the System.nanoTime was using significant cpu cost, but because the timeout is high enough, we can accept the inaccuracy.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits