### PR TITLE
C11613 sai compression

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 Future version (tbd)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
+Merged from 5.1:
+ * Expose current compaction throughput in nodetool (CASSANDRA-13890)
 Merged from 5.0:
  * Disable chronicle analytics (CASSANDRA-19656)
  * Remove mocking in InternalNodeProbe spying on StorageServiceMBean (CASSANDRA-18152)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -479,6 +479,8 @@ commitlog_segment_size_in_mb: 32
 # none : Flush without compressing blocks but while still doing checksums.
 # fast : Flush with a fast compressor. If the table is already using a
 #        fast compressor that compressor is used.
+# adaptive : Flush with a fast adaptive compressor. If the table is already using a
+#        fast compressor that compressor is used.
 # table: Always flush with the same compressor that the table uses. This
 #        was the pre 4.0 behavior.
 #

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.config;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,7 @@ import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.guardrails.GuardrailsConfig;
+import org.apache.cassandra.io.compress.AdaptiveCompressor;
 import org.apache.cassandra.utils.FBUtilities;
 
 /**
@@ -292,8 +294,9 @@ public class Config
     public double commitlog_sync_group_window_in_ms = Double.NaN;
     public int commitlog_sync_period_in_ms;
     public int commitlog_segment_size_in_mb = 32;
+
     public ParameterizedClass commitlog_compression;
-    public FlushCompression flush_compression = FlushCompression.fast;
+    public FlushCompression flush_compression;
     public int commitlog_max_compression_buffers_in_pool = 3;
     public Integer periodic_commitlog_sync_lag_block_in_ms;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();
@@ -664,6 +667,7 @@ public class Config
     {
         none,
         fast,
+        adaptive,
         table
     }
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2119,7 +2119,9 @@ public class DatabaseDescriptor
 
     public static Config.FlushCompression getFlushCompression()
     {
-        return conf.flush_compression;
+        return Objects.requireNonNullElseGet(conf.flush_compression, () -> shouldUseAdaptiveCompressionByDefault()
+                                                                           ? Config.FlushCompression.adaptive
+                                                                           : Config.FlushCompression.fast);
     }
 
     public static void setFlushCompression(Config.FlushCompression compression)
@@ -2127,7 +2129,12 @@ public class DatabaseDescriptor
         conf.flush_compression = compression;
     }
 
-   /**
+    public static boolean shouldUseAdaptiveCompressionByDefault()
+    {
+        return System.getProperty("cassandra.default_sstable_compression", "fast").equals("adaptive");
+    }
+
+    /**
     * Maximum number of buffers in the compression pool. The default value is 3, it should not be set lower than that
     * (one segment in compression, one written to, one in reserve); delays in compression may cause the log to use
     * more, depending on how soon the sync policy stops all writing threads.

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.statements.RawKeyspaceAwareStatement;
@@ -161,7 +162,12 @@ public final class CreateIndexStatement extends AlterSchemaStatement
 
         Map<String, String> options = attrs.isCustom ? attrs.getOptions() : Collections.emptyMap();
 
-        IndexMetadata index = IndexMetadata.fromIndexTargets(indexTargets, name, kind, options);
+        Map<String, String> compressionOptions = attrs.getMap("compression");
+        CompressionParams compression = compressionOptions != null
+                                        ? CompressionParams.fromMap(compressionOptions)
+                                        : CompressionParams.noCompression();
+
+        IndexMetadata index = IndexMetadata.fromIndexTargets(indexTargets, name, kind, options, compression);
 
         String className = index.getIndexClassName();
         IndexGuardrails guardRails = IndexGuardrails.forClassName(className);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/IndexAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/IndexAttributes.java
@@ -29,6 +29,7 @@ public class IndexAttributes extends PropertyDefinitions
     private static final String DEFAULT_INDEX_CLASS_PROPERTY = "cassandra.default_index_implementation_class";
 
     private static final String KW_OPTIONS = "options";
+    private static final String KW_COMPRESSION = "compression";
 
     private static final Set<String> keywords = new HashSet<>();
     private static final Set<String> obsoleteKeywords = new HashSet<>();
@@ -39,6 +40,7 @@ public class IndexAttributes extends PropertyDefinitions
     static
     {
         keywords.add(KW_OPTIONS);
+        keywords.add(KW_COMPRESSION);
     }
 
     public void maybeApplyDefaultIndex()

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -172,6 +172,9 @@ public final class TableAttributes extends PropertyDefinitions
             builder.compression(CompressionParams.fromMap(getMap(Option.COMPRESSION)));
         }
 
+        if (hasOption(Option.INDEX_COMPRESSION))
+            builder.indexCompression(CompressionParams.fromMap(getMap(Option.INDEX_COMPRESSION)));
+
         if (hasOption(Option.MEMTABLE))
             builder.memtable(MemtableParams.fromMap(getMap(Option.MEMTABLE)));
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -65,7 +65,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.codahale.metrics.Meter;
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.cache.AutoSavingCache;
 import org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor;
@@ -290,6 +290,11 @@ public class CompactionManager implements CompactionManagerMBean
             compactionRateLimiter.setRate(throughput);
     }
 
+    public Meter getCompactionThroughput()
+    {
+        return metrics.bytesCompactedThroughput;
+    }
+
     /**
      * Call this whenever a compaction might be needed on the given column family store.
      * It's okay to over-call (within reason) if a call is unnecessary, it will
@@ -314,7 +319,7 @@ public class CompactionManager implements CompactionManagerMBean
     {
         return backgroundCompactionRunner.startCompactionTasks(cfs, tasks);
     }
-    
+
     public int getOngoingBackgroundUpgradesCount()
     {
         return backgroundCompactionRunner.getOngoingUpgradesCount();
@@ -1373,7 +1378,7 @@ public class CompactionManager implements CompactionManagerMBean
 
     }
 
-    static boolean compactionRateLimiterAcquire(RateLimiter limiter, long bytesScanned, long lastBytesScanned, double compressionRatio)
+    protected boolean compactionRateLimiterAcquire(RateLimiter limiter, long bytesScanned, long lastBytesScanned, double compressionRatio)
     {
         if (DatabaseDescriptor.getCompactionThroughputMbPerSec() == 0)
             return false;
@@ -1386,8 +1391,9 @@ public class CompactionManager implements CompactionManagerMBean
         return actuallyAcquire(limiter, lengthRead);
     }
 
-    private static boolean actuallyAcquire(RateLimiter limiter, long lengthRead)
+    private boolean actuallyAcquire(RateLimiter limiter, long lengthRead)
     {
+        metrics.bytesCompactedThroughput.mark(lengthRead);
         while (lengthRead >= Integer.MAX_VALUE)
         {
             limiter.acquire(Integer.MAX_VALUE);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -63,7 +63,6 @@ import org.apache.cassandra.utils.concurrent.Refs;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.COMPACTION_HISTORY_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CURSORS_ENABLED;
-import static org.apache.cassandra.db.compaction.CompactionManager.compactionRateLimiterAcquire;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemoryPerSecond;
 
@@ -658,7 +657,7 @@ public class CompactionTask extends AbstractCompactionTask
                 long bytesScanned = compactionIterator.getTotalBytesScanned();
 
                 // Rate limit the scanners, and account for compression
-                if (compactionRateLimiterAcquire(limiter, bytesScanned, lastBytesScanned, compressionRatio))
+                if (CompactionManager.instance.compactionRateLimiterAcquire(limiter, bytesScanned, lastBytesScanned, compressionRatio))
                     lastBytesScanned = bytesScanned;
 
                 maybeStopOrUpdateState();

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -86,6 +86,7 @@ import org.apache.cassandra.index.sai.view.View;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -595,6 +596,11 @@ public class IndexContext
     public String getIndexName()
     {
         return this.config == null ? null : config.name;
+    }
+
+    public CompressionParams getCompression()
+    {
+        return this.config.compression;
     }
 
     public int getIntOption(String name, int defaultValue)

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
@@ -38,7 +38,10 @@ public interface IndexComponent
 
     String fileNamePart();
     Component asCustomComponent();
+
     File file();
+
+    File compressionMetaFile();
 
     default boolean isCompletionMarker()
     {

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentType.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentType.java
@@ -32,21 +32,21 @@ public enum IndexComponentType
      *
      * V1
      */
-    META("Meta"),
+    META("Meta", false),
     /**
      * KDTree written by {@code BKDWriter} indexes mappings of term to one ore more segment row IDs
      * (segment row ID = SSTable row ID - segment row ID offset).
      *
      * V1
      */
-    KD_TREE("KDTree"),
-    KD_TREE_POSTING_LISTS("KDTreePostingLists"),
+    KD_TREE("KDTree", true),
+    KD_TREE_POSTING_LISTS("KDTreePostingLists", true),
 
     /**
      * Vector index components
      */
-    VECTOR("Vector"),
-    PQ("PQ"),
+    VECTOR("Vector", false),
+    PQ("PQ", false),
 
     /**
      * Term dictionary written by {@code TrieTermsDictionaryWriter} stores mappings of term and
@@ -54,19 +54,19 @@ public enum IndexComponentType
      *
      * V1
      */
-    TERMS_DATA("TermsData"),
+    TERMS_DATA("TermsData", true),
     /**
      * Stores postings written by {@code PostingsWriter}
      *
      * V1
      */
-    POSTING_LISTS("PostingLists"),
+    POSTING_LISTS("PostingLists", false),
     /**
      * If present indicates that the column index build completed successfully
      *
      * V1
      */
-    COLUMN_COMPLETION_MARKER("ColumnComplete"),
+    COLUMN_COMPLETION_MARKER("ColumnComplete", false),
 
     // per-sstable components
     /**
@@ -74,50 +74,52 @@ public enum IndexComponentType
      *
      * V1 V2
      */
-    TOKEN_VALUES("TokenValues"),
+    TOKEN_VALUES("TokenValues", false),
     /**
      * Partition key offset in sstable data file for rows including row tombstone and static row. (access key is
      * rowId)
      *
      * V1
      */
-    OFFSETS_VALUES("OffsetsValues"),
+    OFFSETS_VALUES("OffsetsValues", false),
     /**
      * An on-disk trie containing the primary keys used for looking up the rowId from a partition key
      *
      * V2
      */
-    PRIMARY_KEY_TRIE("PrimaryKeyTrie"),
+    PRIMARY_KEY_TRIE("PrimaryKeyTrie", true),
     /**
      * Prefix-compressed blocks of primary keys used for rowId to partition key lookups
      *
      * V2
      */
-    PRIMARY_KEY_BLOCKS("PrimaryKeyBlocks"),
+    PRIMARY_KEY_BLOCKS("PrimaryKeyBlocks", true),
     /**
      * Encoded sequence of offsets to primary key blocks
      *
      * V2
      */
-    PRIMARY_KEY_BLOCK_OFFSETS("PrimaryKeyBlockOffsets"),
+    PRIMARY_KEY_BLOCK_OFFSETS("PrimaryKeyBlockOffsets", false),
     /**
      * Stores per-sstable metadata.
      *
      * V1
      */
-    GROUP_META("GroupMeta"),
+    GROUP_META("GroupMeta", false),
     /**
      * If present indicates that the per-sstable index build completed successfully
      *
      * V1 V2
      */
-    GROUP_COMPLETION_MARKER("GroupComplete");
+    GROUP_COMPLETION_MARKER("GroupComplete", false);
 
     public final String representation;
+    public final boolean compressed;
 
-    IndexComponentType(String representation)
+    IndexComponentType(String representation, boolean compressed)
     {
         this.representation = representation;
+        this.compressed = compressed;
     }
 
     static final Map<String, IndexComponentType> byRepresentation = new HashMap<>();

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -720,10 +720,8 @@ public class IndexDescriptor
                 if (context != null)
                     return context.getCompression();
 
-                // The compression used for sstable has likly far too big chunk size.
-                // Index components are random access, so the chunk must be small.
                 var cfs = ColumnFamilyStore.getIfExists(descriptor.ksname, descriptor.cfname);
-                return cfs.metadata().params.compression.withChunkLength(4096);
+                return cfs.metadata().params.indexCompression;
             }
 
             @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.lifecycle.Tracker;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
@@ -45,6 +46,7 @@ import org.apache.cassandra.index.sai.disk.io.IndexInput;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.disk.oldlucene.EndiannessReverserChecksumIndexInput;
 import org.apache.cassandra.index.sai.utils.IndexFileUtils;
+import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -52,6 +54,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.lucene.store.BufferedChecksumIndexInput;
@@ -628,12 +631,27 @@ public class IndexDescriptor
             }
 
             @Override
+            public File compressionMetaFile()
+            {
+                return IndexFileUtils.addSuffix(file(), "CompressionInfo");
+            }
+
+            public CompressionMetadata compressionMetadata()
+            {
+                var compressionMetaFile = compressionMetaFile();
+                return (compressionMetaFile.exists())
+                       ? new CompressionMetadata(compressionMetaFile, file().length(), true)
+                       : null;
+            }
+
+            @Override
             public FileHandle createFileHandle()
             {
                 try (var builder = StorageProvider.instance.fileHandleBuilderFor(this))
                 {
-                    var b = builder.order(byteOrder());
-                    return b.complete();
+                    return builder.order(byteOrder())
+                                  .withCompressionMetadata(compressionMetadata())
+                                  .complete();
                 }
             }
 
@@ -642,7 +660,9 @@ public class IndexDescriptor
             {
                 try (final FileHandle.Builder builder = StorageProvider.instance.indexBuildTimeFileHandleBuilderFor(this))
                 {
-                    return builder.order(byteOrder()).complete();
+                    return builder.order(byteOrder())
+                                  .withCompressionMetadata(compressionMetadata())
+                                  .complete();
                 }
             }
 
@@ -687,7 +707,23 @@ public class IndexDescriptor
                                  component,
                                  file);
 
-                return IndexFileUtils.instance.openOutput(file, byteOrder(), append);
+                return IndexFileUtils.instance.openOutput(file, byteOrder(), append, compressionMetaFile(), getCompression());
+            }
+
+            private CompressionParams getCompression()
+            {
+                if (!component.compressed)
+                    return CompressionParams.noCompression();
+
+                // Compress per-sstable components with the settings from the sstable metadata.
+                // Compress per-index components with the settings from the index metadata.
+                if (context != null)
+                    return context.getCompression();
+
+                // The compression used for sstable has likly far too big chunk size.
+                // Index components are random access, so the chunk must be small.
+                var cfs = ColumnFamilyStore.getIfExists(descriptor.ksname, descriptor.cfname);
+                return cfs.metadata().params.compression.withChunkLength(4096);
             }
 
             @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/io/IndexOutputWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/io/IndexOutputWriter.java
@@ -55,7 +55,9 @@ public class IndexOutputWriter extends IndexOutput
     @Override
     public long getChecksum()
     {
-        return ((IndexFileUtils.ChecksumWriter)out).getChecksum();
+        return (out instanceof IndexFileUtils.ChecksumWriter)
+            ? ((IndexFileUtils.ChecksumWriter)out).getChecksum()
+            : -1;
     }
 
     @Override
@@ -137,6 +139,7 @@ public class IndexOutputWriter extends IndexOutput
             {
                 logger.trace("Closing index output: {}", this);
             }
+
 
             // The writer should sync its contents to disk before closing...
             out.close();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -169,7 +169,6 @@ public abstract class SegmentBuilder
                                                                     rowCount,
                                                                     indexWriterConfig))
             {
-
                 MutableOneDimPointValues values = kdTreeRamBuffer.asPointValues();
                 var metadataMap = writer.writeAll(metadataBuilder.intercept(values));
                 metadataBuilder.setComponentsMetadata(metadataMap);

--- a/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexFileUtils.java
@@ -26,24 +26,27 @@ import java.nio.channels.FileChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.CRC32;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import net.nicoulaj.compilecommand.annotations.DontInline;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sai.disk.io.IndexInputReader;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.io.compress.BufferType;
+import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 import org.apache.cassandra.io.storage.StorageProvider;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.lucene.codecs.CodecUtil;
 
 public class IndexFileUtils
@@ -77,22 +80,40 @@ public class IndexFileUtils
         this.writerOption = writerOption;
     }
 
-    public IndexOutputWriter openOutput(File file, ByteOrder order, boolean append) throws IOException
+    public IndexOutputWriter openOutput(File file, ByteOrder order, boolean append, @Nullable File compressionMetaFile, @Nullable CompressionParams compression) throws IOException
     {
         assert writerOption.finishOnClose() : "IndexOutputWriter relies on close() to sync with disk.";
+        return (compression != null && compression.isEnabled())
+            ? openCompressedOutput(file, order, compressionMetaFile, compression)
+            : openChecksummedOutput(file, order, append);
+    }
+
+    private IndexOutputWriter openChecksummedOutput(File file, ByteOrder order, boolean append) throws IOException
+    {
         var checksumWriter = new IncrementalChecksumSequentialWriter(file, writerOption, append);
         return new IndexOutputWriter(checksumWriter, order);
     }
 
-    public BufferedRandomAccessWriter openRandomAccessOutput(File file, boolean append) throws IOException
+    private IndexOutputWriter openCompressedOutput(File file, ByteOrder order, File compressionMetaFile, CompressionParams compression)
     {
-        assert writerOption.finishOnClose() : "IndexOutputWriter relies on close() to sync with disk.";
+        var options = SequentialWriterOption.newBuilder()
+                                            .bufferSize(compression.chunkLength())
+                                            .finishOnClose(true)
+                                            .build();
+        var writer = new CompressedSequentialWriter(file, compressionMetaFile, null, options, compression, null);
+        return new IndexOutputWriter(writer, order);
+    }
 
-        var out = new BufferedRandomAccessWriter(file.toPath());
-        if (append)
-            out.seek(file.length());
-
-        return out;
+    public static File addSuffix(File file, String suffix) {
+        if (file == null || suffix == null) {
+            throw new IllegalArgumentException("File and suffix cannot be null.");
+        }
+        String fileName = file.name();
+        int lastDotIndex = fileName.lastIndexOf('.');
+        String baseName = (lastDotIndex == -1) ? fileName : fileName.substring(0, lastDotIndex);
+        String extension = (lastDotIndex == -1) ? "" : fileName.substring(lastDotIndex);
+        String newFileName = baseName + suffix + extension;
+        return new File(file.parent(), newFileName);
     }
 
     public IndexInputReader openInput(FileHandle handle)

--- a/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
@@ -121,7 +121,7 @@ public class SAICodecUtils
         validateFooter(in, false);
         long actualChecksum = in.getChecksum();
         long expectedChecksum = readCRC(in);
-        if (expectedChecksum != actualChecksum)
+        if (expectedChecksum != -1 && expectedChecksum != actualChecksum)
         {
             throw new CorruptIndexException("checksum failed (hardware problem?) : expected=" + Long.toHexString(expectedChecksum) +
                                             " actual=" + Long.toHexString(actualChecksum), in);
@@ -172,6 +172,11 @@ public class SAICodecUtils
     {
         long position = input.getFilePointer();
         long expected = CodecUtil.retrieveChecksum(input);
+
+        // -1 checksum means the original file hasn't been checksummed
+        // this is possible if the file has been e.g. compressed and has its own internal checksum validation
+        if (expected == -1)
+            return;
 
         input.seek(position);
         long actual = CodecUtil.checksumEntireFile(input);
@@ -233,7 +238,7 @@ public class SAICodecUtils
     static long readCRC(IndexInput input) throws IOException
     {
         long value = readBELong(input);
-        if ((value & 0xFFFFFFFF00000000L) != 0)
+        if (value != -1 && (value & 0xFFFFFFFF00000000L) != 0)
         {
             throw new CorruptIndexException("Illegal CRC-32 checksum: " + value, input);
         }
@@ -249,7 +254,7 @@ public class SAICodecUtils
     static void writeCRC(IndexOutput output) throws IOException
     {
         long value = output.getChecksum();
-        if ((value & 0xFFFFFFFF00000000L) != 0)
+        if (value != -1 && (value & 0xFFFFFFFF00000000L) != 0)
         {
             throw new IllegalStateException(
             "Illegal CRC-32 checksum: " + value + " (resource=" + output + ")");

--- a/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
@@ -32,7 +32,10 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDecompressCtx;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
@@ -78,6 +81,7 @@ public class AdaptiveCompressor implements ICompressor
     protected static final String MIN_COMPRESSION_LEVEL_OPTION_NAME = "min_compression_level";
     protected static final String MAX_COMPRESSION_LEVEL_OPTION_NAME = "max_compression_level";
     protected static final String MAX_COMPACTION_QUEUE_LENGTH_OPTION_NAME = "max_compaction_queue_length";
+
 
     /**
      * Maps AdaptiveCompressor compression level to underlying ZStandard compression levels.
@@ -156,7 +160,6 @@ public class AdaptiveCompressor implements ICompressor
     private final ThreadLocal<State> state;
     private final Supplier<Double> writePressureSupplier;
 
-
     static class Params
     {
         final Uses use;
@@ -205,6 +208,9 @@ public class AdaptiveCompressor implements ICompressor
      */
     class State
     {
+        final ZstdCompressCtx compressCtx = new ZstdCompressCtx().setChecksum(true);
+        final ZstdDecompressCtx decompressCtx = new ZstdDecompressCtx();
+
         /**
          * ZStandard compression level that was used when compressing the previous chunk.
          * Can be adjusted up or down by at most 1 with every next block.
@@ -229,7 +235,7 @@ public class AdaptiveCompressor implements ICompressor
         /**
          * Computes the new compression level to use for the next chunk, based on the load.
          */
-        public int adjustAndGetCompressionLevel(long currentTime)
+        public void adjustCompressionLevel(long currentTime)
         {
             // The more write "pressure", the faster we want to go, so the lower the desired compression level.
             double pressure = getWritePressure();
@@ -256,7 +262,7 @@ public class AdaptiveCompressor implements ICompressor
                 currentCompressionLevel++;
 
             currentCompressionLevel = clampCompressionLevel(currentCompressionLevel);
-            return currentCompressionLevel;
+            compressCtx.setLevel(zstdCompressionLevels[currentCompressionLevel]);
         }
 
         /**
@@ -306,11 +312,15 @@ public class AdaptiveCompressor implements ICompressor
         {
             State state = getThreadLocalState();
             long startTime = System.nanoTime();
-            int compressionLevel = zstdCompressionLevels[state.adjustAndGetCompressionLevel(startTime)];
-            Zstd.compress(output, input, compressionLevel, true);
+            state.adjustCompressionLevel(startTime);
+            long inputSize = input.remaining();
+            state.compressCtx.compress(output, input);
             long endTime = System.nanoTime();
             state.recordCompressionDuration(startTime, endTime);
-            metrics.get(params.use).updateFrom(state);
+
+            Metrics m = metrics.get(params.use);
+            m.updateFrom(state);
+            m.compressionRate.mark(inputSize);
         }
         catch (Exception e)
         {
@@ -322,12 +332,14 @@ public class AdaptiveCompressor implements ICompressor
     @Override
     public int uncompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset) throws IOException
     {
-        long dsz = Zstd.decompressByteArray(output, outputOffset, output.length - outputOffset,
-                                            input, inputOffset, inputLength);
+        State state = getThreadLocalState();
+        long dsz = state.decompressCtx.decompressByteArray(output, outputOffset, output.length - outputOffset,
+                                                           input, inputOffset, inputLength);
 
         if (Zstd.isError(dsz))
             throw new IOException(String.format("Decompression failed due to %s", Zstd.getErrorName(dsz)));
 
+        metrics.get(params.use).decompressionRate.mark(dsz);
         return (int) dsz;
     }
 
@@ -336,7 +348,9 @@ public class AdaptiveCompressor implements ICompressor
     {
         try
         {
-            Zstd.decompress(output, input);
+            State state = getThreadLocalState();
+            long dsz = state.decompressCtx.decompress(output, input);
+            metrics.get(params.use).decompressionRate.mark(dsz);
         } catch (Exception e)
         {
             throw new IOException("Decompression failed", e);
@@ -473,6 +487,9 @@ public class AdaptiveCompressor implements ICompressor
     {
         private final Counter[] compressionLevelHistogram;  // separate counters for each compression level
         private final Histogram relativeTimeSpentCompressing; // in % (i.e. multiplied by 100 becaue Histogram can only keep integers)
+        private final Meter compressionRate;
+        private final Meter decompressionRate;
+
 
         Metrics(Uses use)
         {
@@ -489,6 +506,9 @@ public class AdaptiveCompressor implements ICompressor
             }
 
             relativeTimeSpentCompressing = CassandraMetricsRegistry.Metrics.histogram(factory.createMetricName("RelativeTimeSpentCompressing_" + use.name()), true);
+
+            compressionRate = CassandraMetricsRegistry.Metrics.meter(factory.createMetricName("CompressionRate_" + use.name()));
+            decompressionRate = CassandraMetricsRegistry.Metrics.meter(factory.createMetricName("DecompressionRate_" + use.name()));
         }
 
         void updateFrom(State state)

--- a/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.github.luben.zstd.Zstd;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.metrics.DefaultNameFactory;
+import org.apache.cassandra.metrics.MetricNameFactory;
+import org.apache.cassandra.utils.ExpMovingAverage;
+
+/**
+ * A compressor that dynamically adapts the compression level to the load.
+ * If the system is not heavily loaded by writes, data are compressed using high compression level.
+ * If the number of compactions or flushes queue up, it decreases the compression level to speed up
+ * flushing / compacting.
+ * <p>
+ * Underneath, the ZStandard compressor is used. The compression level can be changed between the frames,
+ * even when compressing the same sstable file. ZStandard was chosen because at the fast end it
+ * can reach compression speed of LZ4, but at moderate compression levels it usually offers much better
+ * compression ratio (typically files are smaller by 20-40%) than LZ4 without compromising compression speed by too much.
+ * <p>
+ * This compressor can be used for either of Uses: FAST_COMPRESSION and GENERAL.
+ * Each use can have different minimum and maximum compression level limits.
+ * For FAST_COMPRESSION, the number of pending flushes is used as the indicator of write load.
+ * For GENERAL compression, the number of pending compactions is used as the indicator of write load.
+ * <p>
+ * Valid compression levels are in range 0..15 (inclusive), where 0 means fastest compression and 15 means slowest/best.
+ * Usually levels around 7-11 strike the best balance between performance and compresion ratio.
+ * Going above level 12 usually only results in slower compression but not much compression ratio improvement.
+ * <p>
+ * Caution: This compressor decompresses about 2x-4x slower than LZ4Compressor, regardless of the compression level.
+ * Therefore, it may negatively affect read speed from very read-heavy tables, especially when the chunk-cache
+ * hit ratio is low. In synthetic tests with chunk cache disabled, read throughput turned out to be up to 10%
+ * lower than when using LZ4 on some workloads.
+ */
+public class AdaptiveCompressor implements ICompressor
+{
+    @VisibleForTesting
+    static final Map<Uses, AdaptiveCompressor.Metrics> metrics = new EnumMap<>(Map.of(
+        Uses.FAST_COMPRESSION, new Metrics(Uses.FAST_COMPRESSION),
+        Uses.GENERAL, new Metrics(Uses.GENERAL)
+    ));
+
+    protected static final String MIN_COMPRESSION_LEVEL_OPTION_NAME = "min_compression_level";
+    protected static final String MAX_COMPRESSION_LEVEL_OPTION_NAME = "max_compression_level";
+    protected static final String MAX_COMPACTION_QUEUE_LENGTH_OPTION_NAME = "max_compaction_queue_length";
+
+    /**
+     * Maps AdaptiveCompressor compression level to underlying ZStandard compression levels.
+     * This mapping is needed because ZStandard levels are not continuous, zstd level 0 is special and means level 3.
+     * Hence, we just use our own continuous scale starting at 0.
+     */
+    private static final int[] zstdCompressionLevels = {
+        -7, // 0  (very fast but compresses poorly)
+        -6, // 1
+        -5, // 2  (LZ4 level is somewhere here)
+        -4, // 3
+        -3, // 4
+        -2, // 5
+        -1, // 6
+        1,  // 7  (sweet spot area usually here)
+        2,  // 8  (sweet spot area usually here)
+        3,  // 9  (sweet spot area usually here, ~50% slower than LZ4)
+        4,  // 10 (sweet spot area usually here)
+        5,  // 11 (sweet spot area usually here)
+        6,  // 12
+        7,  // 13
+        8,  // 14
+        9,  // 15 (very slow, usually over 10x slower than LZ4)
+    };
+
+    public static final int MIN_COMPRESSION_LEVEL = 0;
+    public static final int MAX_COMPRESSION_LEVEL = 15;
+
+    public static final int DEFAULT_MIN_FAST_COMPRESSION_LEVEL = 2;     // zstd level -5
+    public static final int DEFAULT_MAX_FAST_COMPRESSION_LEVEL = 9;     // zstd level 5
+    public static final int DEFAULT_MIN_GENERAL_COMPRESSION_LEVEL = 7;  // zstd level 1
+    public static final int DEFAULT_MAX_GENERAL_COMPRESSION_LEVEL = 12; // zstd level 6
+    public static final int DEFAULT_MAX_COMPACTION_QUEUE_LENGTH = 16;
+
+    private static final ConcurrentHashMap<Params, AdaptiveCompressor> instances = new ConcurrentHashMap<>();
+
+    public static AdaptiveCompressor create(Map<String, String> options)
+    {
+        int minCompressionLevel = getMinCompressionLevel(Uses.GENERAL, options);
+        int maxCompressionLevel = getMaxCompressionLevel(Uses.GENERAL, options);
+        int maxCompactionQueueLength = getMaxCompactionQueueLength(options);
+        return createForCompaction(minCompressionLevel, maxCompressionLevel, maxCompactionQueueLength);
+    }
+
+    private static AdaptiveCompressor createForCompaction(int minCompressionLevel, int maxCompressionLevel, int maxCompactionQueueLength)
+    {
+        Params params = new Params(Uses.GENERAL, minCompressionLevel, maxCompressionLevel, maxCompactionQueueLength);
+        Supplier<Double> compactionPressureSupplier = () -> getCompactionPressure(maxCompactionQueueLength);
+        return instances.computeIfAbsent(params, p -> new AdaptiveCompressor(p, compactionPressureSupplier));
+    }
+
+    /**
+     * Creates a compressor that doesn't refer to any other C* components like compaction manager or memory pools.
+     */
+    @VisibleForTesting
+    public static ICompressor createForUnitTesting()
+    {
+        Params params = new Params(Uses.GENERAL, 9, 9, 0);
+        return new AdaptiveCompressor(params, () -> 0.0);
+    }
+
+    public static AdaptiveCompressor createForFlush(Map<String, String> options)
+    {
+        int minCompressionLevel = getMinCompressionLevel(Uses.FAST_COMPRESSION, options);
+        int maxCompressionLevel = getMaxCompressionLevel(Uses.FAST_COMPRESSION, options);
+        return createForFlush(minCompressionLevel, maxCompressionLevel);
+    }
+
+    private static AdaptiveCompressor createForFlush(int minCompressionLevel, int maxCompressionLevel)
+    {
+        Params params = new Params(Uses.FAST_COMPRESSION, minCompressionLevel, maxCompressionLevel, 0);
+        return instances.computeIfAbsent(params, p -> new AdaptiveCompressor(p, AdaptiveCompressor::getFlushPressure));
+    }
+
+    private final Params params;
+    private final ThreadLocal<State> state;
+    private final Supplier<Double> writePressureSupplier;
+
+
+    static class Params
+    {
+        final Uses use;
+        final int minCompressionLevel;
+        final int maxCompressionLevel;
+        final int maxCompactionQueueLength;
+
+        Params(Uses use, int minCompressionLevel, int maxCompressionLevel, int maxCompactionQueueLength)
+        {
+            if (minCompressionLevel < MIN_COMPRESSION_LEVEL || minCompressionLevel > MAX_COMPRESSION_LEVEL)
+                throw new IllegalArgumentException("Min compression level " + minCompressionLevel + "out of range" +
+                                                   " [" + MIN_COMPRESSION_LEVEL + ", " + MAX_COMPRESSION_LEVEL + ']');
+            if (maxCompressionLevel < MIN_COMPRESSION_LEVEL || maxCompressionLevel > MAX_COMPRESSION_LEVEL)
+                throw new IllegalArgumentException("Max compression level " + maxCompressionLevel + "out of range" +
+                                                   " [" + MIN_COMPRESSION_LEVEL + ", " + MAX_COMPRESSION_LEVEL + ']');
+            if (maxCompactionQueueLength < 0)
+                throw new IllegalArgumentException("Negative max compaction queue length: " + maxCompactionQueueLength);
+
+            this.use = use;
+            this.minCompressionLevel = minCompressionLevel;
+            this.maxCompressionLevel = maxCompressionLevel;
+            this.maxCompactionQueueLength = maxCompactionQueueLength;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o == null || getClass() != o.getClass()) return false;
+            Params params = (Params) o;
+            return minCompressionLevel == params.minCompressionLevel && maxCompressionLevel == params.maxCompressionLevel && use == params.use;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(use, minCompressionLevel, maxCompressionLevel);
+        }
+    }
+
+    /**
+     * Keeps thread local state.
+     * We need this because we want to not only monitor pending flushes/compactions but also how much
+     * time we spend in compression relative to time spent by the thread in non-compression tasks like preparation
+     * of data or writing. Because ICompressor can be shared by multiple threads, we need to keep
+     * track of each thread separately.
+     */
+    class State
+    {
+        /**
+         * ZStandard compression level that was used when compressing the previous chunk.
+         * Can be adjusted up or down by at most 1 with every next block.
+         */
+        int currentCompressionLevel;
+
+        /**
+         * How much time is spent by the thread in compression relative to the time spent in non-compression code.
+         * Valid range is [0.0, 1.0].
+         * 1.0 means we're doing only compression and nothing else.
+         * 0.0 means we're not spending any time doing compression.
+         * This indicator allows us to detect whether we're bottlenecked by something else than compression,
+         * e.g. by disk I/O or by preparation of data to compress (e.g. iterating the memtable trie).
+         * If this value is low, then there is not much gain in decreasing the compression
+         * level.
+         */
+        ExpMovingAverage relativeTimeSpentCompressing = ExpMovingAverage.decayBy10();
+
+        long lastCompressionStartTime;
+        long lastCompressionDuration;
+
+        /**
+         * Computes the new compression level to use for the next chunk, based on the load.
+         */
+        public int adjustAndGetCompressionLevel(long currentTime)
+        {
+            // The more write "pressure", the faster we want to go, so the lower the desired compression level.
+            double pressure = getWritePressure();
+            assert pressure >= 0.0 && pressure <= 1.0 : "pressure (" + pressure + ") out of valid range [0.0, 1.0]";
+
+            // Use minCompressionLevel when pressure = 1.0, maxCompressionLevel when pressure = 0.0
+            int pressurePoints = (int) (pressure * (params.maxCompressionLevel - params.minCompressionLevel));
+            int compressionLevelTarget = params.maxCompressionLevel - pressurePoints;
+
+            // We use wall clock time and not CPU time, because we also want to include time spent by I/O.
+            // If we're bottlenecked by writing the data to disk, this indicator should be low.
+            double relativeTimeSpentCompressing = (double) (1 + lastCompressionDuration) / (1 + currentTime - lastCompressionStartTime);
+
+            // Some smoothing is needed to avoid changing level too fast due to performance hiccups
+            this.relativeTimeSpentCompressing.update(relativeTimeSpentCompressing);
+
+            // If we're under pressure to write data fast, we need to decrease compression level.
+            // But we do that only if we're really spending significant amount of time doing compression.
+            if (compressionLevelTarget < currentCompressionLevel && this.relativeTimeSpentCompressing.get() > 0.1)
+                currentCompressionLevel--;
+            // If we're not under heavy write pressure, or we're spending very little time compressing data,
+            // we can increase the compression level and get some space savings at a low performance overhead:
+            else if (compressionLevelTarget > currentCompressionLevel || this.relativeTimeSpentCompressing.get() < 0.02)
+                currentCompressionLevel++;
+
+            currentCompressionLevel = clampCompressionLevel(currentCompressionLevel);
+            return currentCompressionLevel;
+        }
+
+        /**
+         * Must be called after compressing a chunk,
+         * so we can measure how much time we spend in compressing vs time spent not-compressing.
+         */
+        public void recordCompressionDuration(long startTime, long endTime)
+        {
+            this.lastCompressionDuration = endTime - startTime;
+            this.lastCompressionStartTime = startTime;
+        }
+
+        @VisibleForTesting
+        double getRelativeTimeSpentCompressing()
+        {
+            return this.relativeTimeSpentCompressing.get();
+        }
+    }
+
+    /**
+     * @param params user-provided configuration such as min/max compression level range
+     * @param writePressureSupplier returns a non-negative score determining the write load on the system which
+     *                               is used to control the desired compression level. Influences the compression
+     *                               level linearly: an inceease of pressure by 1 point causes the target
+     *                               compression level to be decreased by 1 point. Zero will select the
+     *                               maximum allowed compression level.
+     */
+    @VisibleForTesting
+    AdaptiveCompressor(Params params, Supplier<Double> writePressureSupplier)
+    {
+        this.params = params;
+        this.state = new ThreadLocal<>();
+        this.writePressureSupplier = writePressureSupplier;
+    }
+    
+    @Override
+    public int initialCompressedBufferLength(int chunkLength)
+    {
+        return (int) Zstd.compressBound(chunkLength);
+    }
+
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output) throws IOException
+    {
+        try
+        {
+            State state = getThreadLocalState();
+            long startTime = System.nanoTime();
+            int compressionLevel = zstdCompressionLevels[state.adjustAndGetCompressionLevel(startTime)];
+            Zstd.compress(output, input, compressionLevel, true);
+            long endTime = System.nanoTime();
+            state.recordCompressionDuration(startTime, endTime);
+            metrics.get(params.use).updateFrom(state);
+        }
+        catch (Exception e)
+        {
+            throw new IOException("Compression failed", e);
+        }
+
+    }
+
+    @Override
+    public int uncompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset) throws IOException
+    {
+        long dsz = Zstd.decompressByteArray(output, outputOffset, output.length - outputOffset,
+                                            input, inputOffset, inputLength);
+
+        if (Zstd.isError(dsz))
+            throw new IOException(String.format("Decompression failed due to %s", Zstd.getErrorName(dsz)));
+
+        return (int) dsz;
+    }
+
+    @Override
+    public void uncompress(ByteBuffer input, ByteBuffer output) throws IOException
+    {
+        try
+        {
+            Zstd.decompress(output, input);
+        } catch (Exception e)
+        {
+            throw new IOException("Decompression failed", e);
+        }
+    }
+
+    @Override
+    public BufferType preferredBufferType()
+    {
+        return BufferType.OFF_HEAP;
+    }
+
+    @Override
+    public Set<Uses> recommendedUses()
+    {
+        return params.minCompressionLevel <= DEFAULT_MIN_FAST_COMPRESSION_LEVEL
+               ? EnumSet.of(Uses.GENERAL, Uses.FAST_COMPRESSION)
+               : EnumSet.of(params.use);
+    }
+
+    @Override
+    public ICompressor forUse(Uses use)
+    {
+        if (use == params.use)
+            return this;
+
+        switch (use)
+        {
+            case GENERAL:
+                return createForCompaction(params.minCompressionLevel, params.maxCompressionLevel, params.maxCompactionQueueLength);
+            case FAST_COMPRESSION:
+                return createForFlush(params.minCompressionLevel, params.maxCompressionLevel);
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean supports(BufferType bufferType)
+    {
+        return bufferType == BufferType.OFF_HEAP;
+    }
+
+    @Override
+    public Set<String> supportedOptions()
+    {
+        return Set.of("max_compression_level", "min_compression_level");
+    }
+
+    private static int getMinCompressionLevel(Uses mode, Map<String, String> options)
+    {
+        int defaultValue = mode == Uses.FAST_COMPRESSION ? DEFAULT_MIN_FAST_COMPRESSION_LEVEL : DEFAULT_MIN_GENERAL_COMPRESSION_LEVEL;
+        return getIntOption(options, MIN_COMPRESSION_LEVEL_OPTION_NAME, defaultValue);
+    }
+
+    private static int getMaxCompressionLevel(Uses mode, Map<String, String> options)
+    {
+        var defaultValue = mode == Uses.FAST_COMPRESSION ? DEFAULT_MAX_FAST_COMPRESSION_LEVEL : DEFAULT_MAX_GENERAL_COMPRESSION_LEVEL;
+        return getIntOption(options, MAX_COMPRESSION_LEVEL_OPTION_NAME, defaultValue);
+    }
+
+    private static int getMaxCompactionQueueLength(Map<String, String> options)
+    {
+        return getIntOption(options, MAX_COMPACTION_QUEUE_LENGTH_OPTION_NAME, DEFAULT_MAX_COMPACTION_QUEUE_LENGTH);
+    }
+
+    private static int getIntOption(Map<String, String> options, String key, int defaultValue)
+    {
+        if (options == null)
+            return defaultValue;
+
+        String val = options.get(key);
+        if (val == null)
+            return defaultValue;
+
+        return Integer.parseInt(val);
+    }
+
+    private double getWritePressure()
+    {
+        return writePressureSupplier.get();
+    }
+
+    private static double getFlushPressure()
+    {
+        var memoryPool = AbstractAllocatorMemtable.MEMORY_POOL;
+        var usedRatio = Math.max(memoryPool.onHeap.usedRatio(), memoryPool.offHeap.usedRatio());
+        var cleanupThreshold = DatabaseDescriptor.getMemtableCleanupThreshold();
+        // we max out the pressure when we're halfway between the cleanupThreshold and max memory
+        // so we still have some memory left while compression already working at max speed;
+        // setting the compressor to maximum speed when we exhausted all memory would be too late
+        return Math.min(1.0, Math.max(0.0, 2 * (usedRatio - cleanupThreshold)) / (1.0 - cleanupThreshold));
+    }
+
+    private static double getCompactionPressure(int maxCompactionQueueLength)
+    {
+        CompactionManager compactionManager = CompactionManager.instance;
+        long rateLimit = DatabaseDescriptor.getCompactionThroughputMbPerSec() * FileUtils.ONE_MB;
+        if (rateLimit == 0)
+            rateLimit = Long.MAX_VALUE;
+        double actualRate = compactionManager.getMetrics().bytesCompactedThroughput.getOneMinuteRate();
+        // We don't want to speed up compression if we can keep up with the configured compression rate limit
+        // 0.0 if actualRate >= rateLimit
+        // 1.0 if actualRate <= 0.8 * rateLimit;
+        double rateLimitFactor = Math.min(1.0, Math.max(0.0, (rateLimit - actualRate) / (0.2 * rateLimit)));
+
+        long pendingCompactions = compactionManager.getPendingTasks();
+        long activeCompactions = compactionManager.getActiveCompactions();
+        long queuedCompactions = pendingCompactions - activeCompactions;
+        double compactionQueuePressure = Math.min(1.0, (double) queuedCompactions / (maxCompactionQueueLength * DatabaseDescriptor.getConcurrentCompactors()));
+        return compactionQueuePressure * rateLimitFactor;
+    }
+
+    private int clampCompressionLevel(long compressionLevel)
+    {
+        return (int) Math.min(params.maxCompressionLevel, Math.max(params.minCompressionLevel, compressionLevel));
+    }
+
+    @VisibleForTesting
+    State getThreadLocalState()
+    {
+        State state = this.state.get();
+        if (state == null)
+        {
+            state = new State();
+            state.currentCompressionLevel = params.maxCompressionLevel;
+            state.lastCompressionDuration = 0;
+            this.state.set(state);
+        }
+        return state;
+    }
+
+    static class Metrics
+    {
+        private final Counter[] compressionLevelHistogram;  // separate counters for each compression level
+        private final Histogram relativeTimeSpentCompressing; // in % (i.e. multiplied by 100 becaue Histogram can only keep integers)
+
+        Metrics(Uses use)
+        {
+            MetricNameFactory factory = new DefaultNameFactory("AdaptiveCompression");
+
+            // cannot use Metrics.histogram for compression levels, because histograms do not handle negative numbers;
+            // also this histogram is small enough that storing all buckets is not a problem, but it gives
+            // much more information
+            compressionLevelHistogram = new Counter[MAX_COMPRESSION_LEVEL + 1];
+            for (int i = 0; i < compressionLevelHistogram.length; i++)
+            {
+                CassandraMetricsRegistry.MetricName metricName = factory.createMetricName(String.format("CompressionLevel_%s_%02d", use.name(), i));
+                compressionLevelHistogram[i] = CassandraMetricsRegistry.Metrics.counter(metricName);
+            }
+
+            relativeTimeSpentCompressing = CassandraMetricsRegistry.Metrics.histogram(factory.createMetricName("RelativeTimeSpentCompressing_" + use.name()), true);
+        }
+
+        void updateFrom(State state)
+        {
+            compressionLevelHistogram[state.currentCompressionLevel].inc();
+            relativeTimeSpentCompressing.update((int)(state.getRelativeTimeSpentCompressing() * 100.0));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +65,7 @@ public class CompressedSequentialWriter extends SequentialWriter
     // holds a number of already written chunks
     private int chunkCount = 0;
 
-    private final MetadataCollector sstableMetadataCollector;
+    private final @Nullable MetadataCollector sstableMetadataCollector;
 
     private final ByteBuffer crcCheckBuffer = ByteBuffer.allocate(4);
     private final Optional<File> digestFile;
@@ -91,7 +93,7 @@ public class CompressedSequentialWriter extends SequentialWriter
                                       File digestFile,
                                       SequentialWriterOption option,
                                       CompressionParams parameters,
-                                      MetadataCollector sstableMetadataCollector)
+                                      @Nullable MetadataCollector sstableMetadataCollector)
     {
         super(file, SequentialWriterOption.newBuilder()
                                           .bufferSize(option.bufferSize())
@@ -429,7 +431,8 @@ public class CompressedSequentialWriter extends SequentialWriter
             syncInternal();
             maybeWriteChecksum();
 
-            sstableMetadataCollector.addCompressionRatio(chunkOffset, lastFlushOffset);
+            if (sstableMetadataCollector != null)
+                sstableMetadataCollector.addCompressionRatio(chunkOffset, lastFlushOffset);
             metadataWriter.finalizeLength(current(), chunkCount).prepareToCommit();
         }
 

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -121,7 +121,6 @@ public class CompressionMetadata implements AutoCloseable
                                        sliceDescription);
     }
 
-    @VisibleForTesting
     public CompressionMetadata(File indexFilePath, long compressedLength, boolean hasMaxCompressedSize)
     {
         this(indexFilePath, compressedLength, hasMaxCompressedSize, SliceDescriptor.NONE);

--- a/src/java/org/apache/cassandra/io/compress/ICompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/ICompressor.java
@@ -83,4 +83,18 @@ public interface ICompressor
     {
         return ImmutableSet.copyOf(EnumSet.allOf(Uses.class));
     }
+
+    /**
+     * Returns the compressor configured for a particular use.
+     * Allows creating a compressor implementation that can handle multiple uses but requires different configurations
+     * adapted to a particular use.
+     * <p>
+     * May return this object.
+     * May not modify this object.
+     * Should return null if the request cannot be satisfied.
+     */
+    default ICompressor forUse(Uses use)
+    {
+        return recommendedUses().contains(use) ? this : null;
+    }
 }

--- a/src/java/org/apache/cassandra/io/storage/StorageProvider.java
+++ b/src/java/org/apache/cassandra/io/storage/StorageProvider.java
@@ -331,7 +331,10 @@ public interface StorageProvider
             {
                 builder = builder.adviseRandom();
             }
-            return builder.mmapped(true);
+
+            return builder.mmapped(true)
+                          .withChunkCache(ChunkCache.instance);
+
         }
 
         @Override

--- a/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
@@ -66,6 +66,8 @@ public class CompactionMetrics
     public final Counter totalCompactionsFailed;
     /** Total number of bytes processed by operations since server [re]start */
     public final Counter bytesCompacted;
+    /** Recent/current throughput of compactions take */
+    public final Meter bytesCompactedThroughput;
 
     /**
      * The compaction strategy information for each table. Cached, because its computation might be fairly expensive.
@@ -190,6 +192,7 @@ public class CompactionMetrics
         totalCompactionsCompleted = Metrics.meter(factory.createMetricName("TotalCompactionsCompleted"));
         totalCompactionsFailed = Metrics.counter(factory.createMetricName("FailedCompactions"));
         bytesCompacted = Metrics.counter(factory.createMetricName("BytesCompacted"));
+        bytesCompactedThroughput = Metrics.meter(factory.createMetricName("BytesCompactedThroughput"));
 
         // compaction failure metrics
         compactionsReduced = Metrics.counter(factory.createMetricName("CompactionsReduced"));

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.schema;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -252,6 +251,14 @@ public final class CompressionParams
     }
 
     public CompressionParams copy()
+    {
+        return new CompressionParams(sstableCompressor, chunkLength, maxCompressedLength, minCompressRatio, otherOptions);
+    }
+
+    /**
+     * Returns a copy of CompressionParams with a modified chunk length
+     */
+    public CompressionParams withChunkLength(int chunkLength)
     {
         return new CompressionParams(sstableCompressor, chunkLength, maxCompressedLength, minCompressRatio, otherOptions);
     }

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -35,6 +36,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -66,11 +68,25 @@ public final class CompressionParams
     public static final String ENABLED = "enabled";
     public static final String MIN_COMPRESS_RATIO = "min_compress_ratio";
 
-    public static final CompressionParams DEFAULT = new CompressionParams(LZ4Compressor.create(Collections.<String, String>emptyMap()),
+    public static final CompressionParams FAST = new CompressionParams(LZ4Compressor.create(Collections.emptyMap()),
                                                                           DEFAULT_CHUNK_LENGTH,
                                                                           calcMaxCompressedLength(DEFAULT_CHUNK_LENGTH, DEFAULT_MIN_COMPRESS_RATIO),
                                                                           DEFAULT_MIN_COMPRESS_RATIO,
                                                                           Collections.emptyMap());
+
+    public static final CompressionParams ADAPTIVE = new CompressionParams(AdaptiveCompressor.create(Collections.emptyMap()),
+                                                                           DEFAULT_CHUNK_LENGTH,
+                                                                           calcMaxCompressedLength(DEFAULT_CHUNK_LENGTH, DEFAULT_MIN_COMPRESS_RATIO),
+                                                                           DEFAULT_MIN_COMPRESS_RATIO,
+                                                                           Collections.emptyMap());
+
+    public static final CompressionParams FAST_ADAPTIVE = new CompressionParams(AdaptiveCompressor.createForFlush(Collections.emptyMap()),
+                                                                       DEFAULT_CHUNK_LENGTH,
+                                                                       calcMaxCompressedLength(DEFAULT_CHUNK_LENGTH, DEFAULT_MIN_COMPRESS_RATIO),
+                                                                       DEFAULT_MIN_COMPRESS_RATIO,
+                                                                       Collections.emptyMap());
+
+    public static final CompressionParams DEFAULT = DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault() ? ADAPTIVE : FAST;
 
     public static final CompressionParams NOOP = new CompressionParams(NoopCompressor.create(Collections.emptyMap()),
                                                                        // 4 KiB is often the underlying disk block size
@@ -247,6 +263,24 @@ public final class CompressionParams
     public boolean isEnabled()
     {
         return sstableCompressor != null;
+    }
+
+    /**
+     * Specializes the compressor for given use.
+     * May cause reconfiguration of parameters on some compressors.
+     * Returns null if params are not compatible with the given use.
+     */
+    public CompressionParams forUse(ICompressor.Uses use)
+    {
+        ICompressor specializedCompressor = this.sstableCompressor.forUse(use);
+        if (specializedCompressor == null)
+            return null;
+
+        assert specializedCompressor.recommendedUses().contains(use);
+        if (specializedCompressor == sstableCompressor)
+            return this;
+
+        return new CompressionParams(specializedCompressor, chunkLength, maxCompressedLength, minCompressRatio, otherOptions);
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -57,6 +56,7 @@ public final class CompressionParams
     private static volatile boolean hasLoggedCrcCheckChanceWarning;
 
     public static final int DEFAULT_CHUNK_LENGTH = 1024 * 16;
+    public static final int DEFAULT_INDEX_CHUNK_LENGTH = 1024 * 4;
     public static final double DEFAULT_MIN_COMPRESS_RATIO = 0.0;        // Since pre-4.0 versions do not understand the
                                                                         // new compression parameter we can't use a
                                                                         // different default value.
@@ -86,6 +86,8 @@ public final class CompressionParams
                                                                        Collections.emptyMap());
 
     public static final CompressionParams DEFAULT = DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault() ? ADAPTIVE : FAST;
+
+    public static final CompressionParams INDEX_DEFAULT = DEFAULT.withChunkLength(DEFAULT_INDEX_CHUNK_LENGTH);
 
     public static final CompressionParams NOOP = new CompressionParams(NoopCompressor.create(Collections.emptyMap()),
                                                                        // 4 KiB is often the underlying disk block size

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.exceptions.UnknownIndexException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.internal.CassandraIndex;
@@ -79,21 +80,30 @@ public final class IndexMetadata
     public final UUID id;
     public final String name;
     public final Kind kind;
+
+    public final CompressionParams compression;
     public final Map<String, String> options;
 
     private IndexMetadata(String name,
                           Map<String, String> options,
-                          Kind kind)
+                          Kind kind,
+                          CompressionParams compression)
     {
         this.id = UUID.nameUUIDFromBytes(name.getBytes());
         this.name = name;
         this.options = options == null ? ImmutableMap.of() : ImmutableMap.copyOf(options);
         this.kind = kind;
+        this.compression = compression;
     }
 
     public static IndexMetadata fromSchemaMetadata(String name, Kind kind, Map<String, String> options)
     {
-        return new IndexMetadata(name, options, kind);
+        return new IndexMetadata(name, options, kind, CompressionParams.NOOP);
+    }
+
+    public static IndexMetadata fromSchemaMetadata(String name, Kind kind, Map<String, String> options, CompressionParams compression)
+    {
+        return new IndexMetadata(name, options, kind, compression);
     }
 
     public static IndexMetadata fromIndexTargets(List<IndexTarget> targets,
@@ -101,11 +111,20 @@ public final class IndexMetadata
                                                  Kind kind,
                                                  Map<String, String> options)
     {
+        return fromIndexTargets(targets, name, kind, options, CompressionParams.noCompression());
+    }
+
+    public static IndexMetadata fromIndexTargets(List<IndexTarget> targets,
+                                                 String name,
+                                                 Kind kind,
+                                                 Map<String, String> options,
+                                                 CompressionParams compression)
+    {
         Map<String, String> newOptions = new HashMap<>(options);
         newOptions.put(IndexTarget.TARGET_OPTION_NAME, targets.stream()
                                                               .map(target -> target.asCqlString())
                                                               .collect(Collectors.joining(", ")));
-        return new IndexMetadata(name, newOptions, kind);
+        return new IndexMetadata(name, newOptions, kind, compression);
     }
 
     public static boolean isNameValid(String name)
@@ -289,9 +308,10 @@ public final class IndexMetadata
                    .append(") USING ")
                    .appendWithSingleQuotes(copyOptions.remove(IndexTarget.CUSTOM_INDEX_OPTION_NAME));
 
-            if (!copyOptions.isEmpty())
-                builder.append(" WITH OPTIONS = ")
-                       .append(copyOptions);
+            builder.append(" WITH compression = ")
+                   .append(compression.asMap())
+                   .append(" AND options = ")
+                   .append(copyOptions);
         }
         else
         {

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -1118,7 +1118,11 @@ public final class SchemaKeyspace
         String name = row.getString("index_name");
         IndexMetadata.Kind type = IndexMetadata.Kind.valueOf(row.getString("kind"));
         Map<String, String> options = row.getFrozenTextMap("options");
-        return IndexMetadata.fromSchemaMetadata(name, type, options);
+        Map<String, String> compressionOptions = row.getFrozenTextMap("compression");
+        CompressionParams compression = compressionOptions != null
+                                        ? CompressionParams.fromMap(compressionOptions)
+                                        : CompressionParams.noCompression();
+        return IndexMetadata.fromSchemaMetadata(name, type, options, compression);
     }
 
     private static Triggers fetchTriggers(String keyspace, String table)

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -46,6 +46,7 @@ public final class TableParams
         COMMENT,
         COMPACTION,
         COMPRESSION,
+        INDEX_COMPRESSION,
         MEMTABLE,
         DEFAULT_TIME_TO_LIVE,
         EXTENSIONS,
@@ -79,6 +80,7 @@ public final class TableParams
     public final CachingParams caching;
     public final CompactionParams compaction;
     public final CompressionParams compression;
+    public final CompressionParams indexCompression;
     public final MemtableParams memtable;
     public final ImmutableMap<String, ByteBuffer> extensions;
     public final boolean cdc;
@@ -101,6 +103,7 @@ public final class TableParams
         caching = builder.caching;
         compaction = builder.compaction;
         compression = builder.compression;
+        indexCompression = builder.indexCompression;
         memtable = builder.memtable;
         extensions = builder.extensions;
         cdc = builder.cdc;
@@ -119,6 +122,7 @@ public final class TableParams
                             .comment(params.comment)
                             .compaction(params.compaction)
                             .compression(params.compression)
+                            .indexCompression(params.indexCompression)
                             .memtable(params.memtable)
                             .crcCheckChance(params.crcCheckChance)
                             .defaultTimeToLive(params.defaultTimeToLive)
@@ -215,6 +219,7 @@ public final class TableParams
             && caching.equals(p.caching)
             && compaction.equals(p.compaction)
             && compression.equals(p.compression)
+            && indexCompression.equals(p.indexCompression)
             && memtable.equals(p.memtable)
             && extensions.equals(p.extensions)
             && cdc == p.cdc
@@ -236,6 +241,7 @@ public final class TableParams
                                 caching,
                                 compaction,
                                 compression,
+                                indexCompression,
                                 memtable,
                                 extensions,
                                 cdc,
@@ -258,6 +264,7 @@ public final class TableParams
                           .add(Option.CACHING.toString(), caching)
                           .add(Option.COMPACTION.toString(), compaction)
                           .add(Option.COMPRESSION.toString(), compression)
+                          .add(Option.INDEX_COMPRESSION.toString(), indexCompression)
                           .add(Option.MEMTABLE.toString(), memtable)
                           .add(Option.EXTENSIONS.toString(), extensions)
                           .add(Option.CDC.toString(), cdc)
@@ -281,6 +288,8 @@ public final class TableParams
                .append("AND compaction = ").append(compaction.asMap())
                .newLine()
                .append("AND compression = ").append(compression.asMap())
+               .newLine()
+               .append("AND index_compression = ").append(indexCompression.asMap())
                .newLine()
                .append("AND memtable = ").append(memtable.asMap())
                .newLine()
@@ -327,6 +336,7 @@ public final class TableParams
         private CachingParams caching = CachingParams.DEFAULT;
         private CompactionParams compaction = CompactionParams.DEFAULT;
         private CompressionParams compression = CompressionParams.DEFAULT;
+        private CompressionParams indexCompression = CompressionParams.INDEX_DEFAULT;
         private MemtableParams memtable = MemtableParams.DEFAULT;
         private ImmutableMap<String, ByteBuffer> extensions = ImmutableMap.of();
         private boolean cdc;
@@ -422,6 +432,12 @@ public final class TableParams
         public Builder compression(CompressionParams val)
         {
             compression = val;
+            return this;
+        }
+
+        public Builder indexCompression(CompressionParams val)
+        {
+            indexCompression = val;
             return this;
         }
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -631,6 +631,7 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     public int getCompactionThroughputMbPerSec();
     public void setCompactionThroughputMbPerSec(int value);
+    Map<String, String> getCurrentCompactionThroughputMebibytesPerSec();
 
     public int getBatchlogReplayThrottleInKB();
     public void setBatchlogReplayThrottleInKB(int value);

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1138,6 +1138,11 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.getCompactionThroughputMbPerSec();
     }
 
+    public Map<String, String> getCurrentCompactionThroughputMiBPerSec()
+    {
+        return ssProxy.getCurrentCompactionThroughputMebibytesPerSec();
+    }
+
     public void setBatchlogReplayThrottle(int value)
     {
         ssProxy.setBatchlogReplayThrottleInKB(value);

--- a/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetCompactionThroughput.java
@@ -17,17 +17,24 @@
  */
 package org.apache.cassandra.tools.nodetool;
 
+import java.util.Map;
+
 import io.airlift.airline.Command;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
-@Command(name = "getcompactionthroughput", description = "Print the MB/s throughput cap for compaction in the system")
+@Command(name = "getcompactionthroughput", description = "Print the MiB/s throughput cap for compaction in the system")
 public class GetCompactionThroughput extends NodeToolCmd
 {
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.output().out.println("Current compaction throughput: " + probe.getCompactionThroughput() + " MB/s");
+        probe.output().out.println("Current compaction throughput: " + probe.getCompactionThroughput() + " MiB/s");
+
+        Map<String, String> currentCompactionThroughputMetricsMap = probe.getCurrentCompactionThroughputMiBPerSec();
+        probe.output().out.println("Current compaction throughput (1 minute): " + currentCompactionThroughputMetricsMap.get("1minute") + " MiB/s");
+        probe.output().out.println("Current compaction throughput (5 minute): " + currentCompactionThroughputMetricsMap.get("5minute") + " MiB/s");
+        probe.output().out.println("Current compaction throughput (15 minute): " + currentCompactionThroughputMetricsMap.get("15minute") + " MiB/s");
     }
 }

--- a/test/unit/org/apache/cassandra/io/compress/AdaptiveCompressorTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/AdaptiveCompressorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import org.apache.cassandra.io.util.RandomAccessReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class AdaptiveCompressorTest
+{
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badCompressionLevelParamThrowsExceptionMin()
+    {
+        AdaptiveCompressor.create(ImmutableMap.of(AdaptiveCompressor.MIN_COMPRESSION_LEVEL_OPTION_NAME, Integer.toString(AdaptiveCompressor.MIN_COMPRESSION_LEVEL - 1)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badCompressionLevelParamThrowsExceptionMax()
+    {
+        AdaptiveCompressor.create(ImmutableMap.of(AdaptiveCompressor.MAX_COMPRESSION_LEVEL_OPTION_NAME, Integer.toString(AdaptiveCompressor.MAX_COMPRESSION_LEVEL + 1)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void badMaxCompactionQueueLengthParamThrowsExceptionMin()
+    {
+        AdaptiveCompressor.create(ImmutableMap.of(AdaptiveCompressor.MAX_COMPACTION_QUEUE_LENGTH_OPTION_NAME, "-1"));
+    }
+
+    @Test
+    public void averageRelativeTimeCompressingIsMeasuredProperly() throws IOException, InterruptedException
+    {
+        var params = new AdaptiveCompressor.Params(ICompressor.Uses.GENERAL, 15, 15, 0);
+        AdaptiveCompressor c1 = new AdaptiveCompressor(params, () -> 0.0);
+        ByteBuffer src = getSrcByteBuffer();
+        ByteBuffer dest = getDstByteBuffer(c1);
+        for (int i = 0; i < 20000; i++)
+        {
+            compress(c1, src, dest);
+        }
+        assertTrue(c1.getThreadLocalState().getRelativeTimeSpentCompressing() > 0.8);
+        assertTrue(c1.getThreadLocalState().getRelativeTimeSpentCompressing() < 1.0);
+
+
+        var params2 = new AdaptiveCompressor.Params(ICompressor.Uses.GENERAL, 0, 0, 0);
+        AdaptiveCompressor c2 = new AdaptiveCompressor(params2, () -> 0.0);
+        for (int i = 0; i < 100; i++)
+        {
+            Thread.sleep(1);
+            compress(c2, src, dest);
+        }
+        assertTrue(c2.getThreadLocalState().getRelativeTimeSpentCompressing() < 0.02);
+        assertTrue(c2.getThreadLocalState().getRelativeTimeSpentCompressing() > 0.0);
+    }
+
+    @Test
+    public void compressionLevelAdaptsToWritePressure() throws IOException
+    {
+        var params = new AdaptiveCompressor.Params(ICompressor.Uses.GENERAL, 2, 8, 0);
+        double[] load = { 1.0 };
+
+        AdaptiveCompressor c = new AdaptiveCompressor(params, () -> load[0]);
+        ByteBuffer src = getSrcByteBuffer();
+        ByteBuffer dest = getDstByteBuffer(c);
+
+        for (int i = 0; i < 10; i++)
+            compress(c, src, dest);
+
+        assertEquals(2, c.getThreadLocalState().currentCompressionLevel);
+
+        // Low load; compression level must be increased back to max:
+        load[0] = 0L;
+
+        for (int i = 0; i < 10; i++)
+            compress(c, src, dest);
+
+        assertEquals(8, c.getThreadLocalState().currentCompressionLevel);
+    }
+
+    @Test
+    public void compressionLevelDoesNotDecreaseWhenCompressionIsNotABottleneck() throws IOException, InterruptedException
+    {
+        var params = new AdaptiveCompressor.Params(ICompressor.Uses.GENERAL, 2, 8, 0);
+        // Simulate high write load
+        AdaptiveCompressor c = new AdaptiveCompressor(params, () -> 1.0);
+        ByteBuffer src = getSrcByteBuffer();
+        ByteBuffer dest = getDstByteBuffer(c);
+
+        for (int i = 0; i < 200; i++)
+        {
+            Thread.sleep(1); // creates artificial bottleneck that is much slower than compression
+            compress(c, src, dest);
+        }
+
+        assertEquals(8, c.getThreadLocalState().currentCompressionLevel);
+    }
+
+    private static ByteBuffer getDstByteBuffer(ICompressor compressor)
+    {
+        return ByteBuffer.allocateDirect(compressor.initialCompressedBufferLength(RandomAccessReader.DEFAULT_BUFFER_SIZE));
+    }
+
+    private static ByteBuffer getSrcByteBuffer()
+    {
+        int n = RandomAccessReader.DEFAULT_BUFFER_SIZE;
+        byte[] srcData = new byte[n];
+        new Random().nextBytes(srcData);
+
+        ByteBuffer src = ByteBuffer.allocateDirect(n);
+        src.put(srcData, 0, n);
+        src.flip().position(0);
+        return src;
+    }
+
+    private static void compress(AdaptiveCompressor c, ByteBuffer src, ByteBuffer dest) throws IOException
+    {
+        c.compress(src, dest);
+        src.rewind();
+        dest.rewind();
+    }
+
+}

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -175,6 +175,39 @@ public class CQLCompressionTest extends CQLTester
     }
 
     @Test
+    public void adaptiveFlushTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'AdaptiveCompressor'};");
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.fast);
+        ColumnFamilyStore store = flushTwice();
+
+        // Should flush as LZ4
+        Set<SSTableReader> sstables = store.getLiveSSTables();
+        sstables.forEach(sstable -> {
+            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof LZ4Compressor);
+        });
+        store.truncateBlocking();
+
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.adaptive);
+        store = flushTwice();
+
+        // Should flush as Adaptive
+        sstables = store.getLiveSSTables();
+        sstables.forEach(sstable -> {
+            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof AdaptiveCompressor);
+        });
+
+        // Should compact to Adaptive
+        compact();
+
+        sstables = store.getLiveSSTables();
+        assertEquals(1, sstables.size());
+        store.getLiveSSTables().forEach(sstable -> {
+            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof AdaptiveCompressor);
+        });
+    }
+
+    @Test
     public void deflateFlushTest() throws Throwable
     {
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'DeflateCompressor'};");

--- a/test/unit/org/apache/cassandra/io/compress/CompressorTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressorTest.java
@@ -29,8 +29,10 @@ import java.util.Random;
 
 import com.google.common.io.Files;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
@@ -41,6 +43,12 @@ import static org.junit.Assert.assertEquals;
 
 public class CompressorTest
 {
+    @BeforeClass
+    public static void initialize()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
     ICompressor compressor;
 
     ICompressor[] compressors = new ICompressor[] {
@@ -48,6 +56,7 @@ public class CompressorTest
             DeflateCompressor.create(Collections.<String, String>emptyMap()),
             SnappyCompressor.create(Collections.<String, String>emptyMap()),
             ZstdCompressor.create(Collections.emptyMap()),
+            AdaptiveCompressor.createForUnitTesting(),
             NoopCompressor.create(Collections.emptyMap())
     };
 
@@ -187,6 +196,13 @@ public class CompressorTest
     public void testZstdByteBuffers() throws IOException
     {
         compressor = ZstdCompressor.create(Collections.<String, String>emptyMap());
+        testByteBuffers();
+    }
+
+    @Test
+    public void testAdaptiveByteBuffers() throws IOException
+    {
+        compressor = AdaptiveCompressor.createForUnitTesting();
         testByteBuffers();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.apache.cassandra.tools.ToolRunner.ToolResult;
+import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@code nodetool setcompactionthroughput} and {@code nodetool getcompactionthroughput}.
+ */
+public class SetGetCompactionThroughputTest extends CQLTester
+{
+    private static final int MAX_INT_CONFIG_VALUE_IN_MBIT = Integer.MAX_VALUE - 1;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        requireNetwork();
+        startJMXServer();
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertSetInvalidThroughput(null, "Required parameters are missing: compaction_throughput");
+    }
+
+    @Test
+    public void testPositive()
+    {
+        assertSetGetValidThroughput(7);
+    }
+
+    @Test
+    public void testMaxValue()
+    {
+        assertSetGetValidThroughput(MAX_INT_CONFIG_VALUE_IN_MBIT);
+    }
+
+    @Test
+    public void testZero()
+    {
+        assertSetGetValidThroughput(0);
+    }
+
+    @Test
+    public void testUnparseable()
+    {
+        assertSetInvalidThroughput("1.2", "compaction_throughput: can not convert \"1.2\" to a Integer");
+        assertSetInvalidThroughput("value", "compaction_throughput: can not convert \"value\" to a Integer");
+    }
+
+    @Test
+    public void testCurrentCompactionThroughput()
+    {
+        ToolResult tool = invokeNodetool("getcompactionthroughput");
+        tool.assertOnCleanExit();
+
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(1 minute\\): \\d+\\.\\d+ MiB/s");
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(5 minute\\): \\d+\\.\\d+ MiB/s");
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(15 minute\\): \\d+\\.\\d+ MiB/s");
+    }
+
+    private static void assertSetGetValidThroughput(int throughput)
+    {
+        ToolResult tool = invokeNodetool("setcompactionthroughput", String.valueOf(throughput));
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout()).isEmpty();
+
+        assertGetThroughput(throughput);
+    }
+
+    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    {
+        ToolResult tool = throughput == null ? invokeNodetool("setcompactionthroughput")
+                                             : invokeNodetool("setcompactionthroughput", throughput);
+        assertThat(tool.getExitCode()).isEqualTo(1);
+        assertThat(tool.getStdout()).contains(expectedErrorMessage);
+    }
+
+    private static void assertSetInvalidThroughputMib(String throughput)
+    {
+        ToolResult tool = invokeNodetool("setcompactionthroughput", throughput);
+        assertThat(tool.getExitCode()).isEqualTo(1);
+        assertThat(tool.getStdout()).contains("compaction_throughput: 2147483647 is too large; it should be less than" +
+                                              " 2147483647 in MiB/s");
+    }
+
+    private static void assertGetThroughput(int expected)
+    {
+        ToolResult tool = invokeNodetool("getcompactionthroughput");
+        tool.assertOnCleanExit();
+
+        if (expected > 0)
+            assertThat(tool.getStdout()).contains("Current compaction throughput: " + expected + " MiB/s");
+        else
+            assertThat(tool.getStdout()).contains("Current compaction throughput: 0 MiB/s");
+    }
+}


### PR DESCRIPTION
### What is the issue
SAI Indexes consume too much storage space, sometimes.

### What does this PR fix and why was it fixed
This PR allows to compress both the per-sstable and per-index components of SAI. 
Use `index_compression` table param to control the per-sstable components compression.
Use `compression` property on the index to control the per-index components compression.


### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits