### PR TITLE
CNDB-12272: Fix SimpleClientPerfTest

### DIFF
--- a/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
@@ -113,11 +113,12 @@ public class SimpleClientBurnTest
                 QueryMessage queryMessage = QueryMessage.codec.decode(body, version);
                 return new QueryMessage(queryMessage.query, queryMessage.options)
                 {
-                    public Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
+                    @Override
+                    public CompletableFuture<Response> maybeExecuteAsync(QueryState state, long queryStartNanoTime, boolean traceRequest)
                     {
                         int idx = Integer.parseInt(queryMessage.query);
                         SizeCaps caps = idx % largeMessageFrequency == 0 ? largeMessageCap : smallMessageCap;
-                        return generateRows(idx, caps);
+                        return CompletableFuture.completedFuture(generateRows(idx, caps));
                     }
                 };
             }

--- a/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
@@ -172,10 +172,11 @@ public class SimpleClientPerfTest
                 QueryMessage queryMessage = QueryMessage.codec.decode(body, version);
                 return new QueryMessage(queryMessage.query, queryMessage.options)
                 {
-                    public Message.Response executeSync(QueryState state, long queryStartNanoTime, boolean traceRequest)
+                    @Override
+                    public CompletableFuture<Response> maybeExecuteAsync(QueryState state, long queryStartNanoTime, boolean traceRequest)
                     {
                         int idx = Integer.parseInt(queryMessage.query); // unused
-                        return generateRows(idx, responseCaps);
+                        return CompletableFuture.completedFuture(generateRows(idx, responseCaps));
                     }
                 };
             }


### PR DESCRIPTION
### What is the issue
SimpleClientPerfTest has been failing in CI since changes from CNDB-10759

### What does this PR fix and why was it fixed
This change in `SimpleClientPerfTest`, updates the anonymous class `Message.Codec<QueryMessage>` to override the correct method, `public CompletableFuture<Response> maybeExecuteAsync` from `QueryMessage`, whose signature was changed as part of CNDB-10759.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits