### PR TITLE
CNDB-11437: Disable key cache in LazyBloomFilterTest

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/format/LazyBloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/LazyBloomFilterTest.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.metrics.RestorableMeter;
+import org.apache.cassandra.schema.CachingParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.AlwaysPresentFilter;
 import org.apache.cassandra.utils.BloomFilter;
@@ -74,7 +75,8 @@ public class LazyBloomFilterTest
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE1,
                                     KeyspaceParams.simple(1),
-                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD).bloomFilterFpChance(0.1));
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD).bloomFilterFpChance(0.1)
+                                                .caching(new CachingParams(false, 0)));
 
         store = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD);
     }


### PR DESCRIPTION
### What is the issue
When run under the bigtable test profile, LazyBloomFilterTest rate threshold tests fail.

### What does this PR fix and why was it fixed
This PR disables the key cache on the table used for this test. The test generates partition index accesses by reusing the same key, and if the key cache is enabled, the test will fail for bigtable profiles because the key will be in the key cache.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits