### PR TITLE
CNDB-12308: Remove index-based sorting at CQL level

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -134,15 +134,6 @@ public abstract class MultiColumnRestriction implements SingleRestriction
     }
 
     @Override
-    public final Index findSupportingIndex(IndexRegistry indexRegistry)
-    {
-        for (Index index : indexRegistry.listIndexes())
-            if (isSupportingIndex(index))
-                return index;
-        return null;
-    }
-
-    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (ColumnMetadata column : columnDefs)

--- a/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
@@ -74,14 +74,6 @@ public interface Restriction
     public boolean hasSupportingIndex(IndexRegistry indexRegistry);
 
     /**
-     * Find first supporting index for current restriction
-     *
-     * @param indexRegistry the index registry
-     * @return <code>index</code> if the restriction is on indexed columns, <code>null</code>
-     */
-    public Index findSupportingIndex(IndexRegistry indexRegistry);
-
-    /**
      * Returns whether this restriction would need filtering if the specified index group were used.
      *
      * @param indexGroup an index group

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -101,12 +101,6 @@ public abstract class RestrictionSet implements Restrictions
         }
 
         @Override
-        public Index findSupportingIndex(IndexRegistry indexRegistry)
-        {
-            return null;
-        }
-
-        @Override
         public boolean needsFiltering(Index.Group indexGroup)
         {
             return false;
@@ -281,18 +275,6 @@ public abstract class RestrictionSet implements Restrictions
                 if (restriction.hasSupportingIndex(indexRegistry))
                     return true;
             return false;
-        }
-
-        @Override
-        public Index findSupportingIndex(IndexRegistry indexRegistry)
-        {
-            for (SingleRestriction restriction : restrictionsMap.values())
-            {
-                Index index = restriction.findSupportingIndex(indexRegistry);
-                if (index != null)
-                    return index;
-            }
-            return null;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
@@ -85,12 +85,6 @@ class RestrictionSetWrapper implements Restrictions
     }
 
     @Override
-    public Index findSupportingIndex(IndexRegistry indexRegistry)
-    {
-        return restrictions.findSupportingIndex(indexRegistry);
-    }
-
-    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -84,16 +84,6 @@ public abstract class SingleColumnRestriction implements SingleRestriction
     }
 
     @Override
-    public Index findSupportingIndex(IndexRegistry indexRegistry)
-    {
-        for (Index index : indexRegistry.listIndexes())
-            if (isSupportedBy(index))
-                return index;
-
-        return null;
-    }
-
-    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         for (Index index : indexGroup.getIndexes())

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -331,12 +331,6 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
-    public Index findSupportingIndex(IndexRegistry indexRegistry)
-    {
-        return restrictions.findSupportingIndex(indexRegistry);
-    }
-
-    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return restrictions.needsFiltering(indexGroup);

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -124,11 +124,6 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
-    public Index findSupportingIndex(IndexRegistry indexRegistry)
-    {
-        return null;
-    }
-    @Override
     public boolean needsFiltering(Index.Group indexGroup)
     {
         return false;

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -23,7 +23,6 @@ package org.apache.cassandra.index;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,8 +35,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
-import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.restrictions.Restriction;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -60,8 +57,6 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.TableMetadata;
-
-import org.apache.commons.lang3.NotImplementedException;
 
 
 /**
@@ -469,55 +464,7 @@ public interface Index
      * @return the (hopefully) reduced filter that would still need to be applied after
      *         the index was used to narrow the initial result set
      */
-    public RowFilter getPostIndexQueryFilter(RowFilter filter);
-
-    /**
-     * Returns a {@link Comparator} of CQL result rows, so they can be ordered by the
-     * coordinator before sending them to client.
-     *
-     * @param restriction restriction that requires current index
-     * @param columnIndex idx of the indexed column in returned row
-     * @param options     query options
-     * @return a comparator of rows
-     */
-    default Comparator<List<ByteBuffer>> postQueryComparator(Restriction restriction, int columnIndex, QueryOptions options)
-    {
-        throw new NotImplementedException();
-    }
-
-    /**
-     * Returns a {@link Scorer} to give a similarity/proximity score to CQL result rows, so they can be ordered by the
-     * coordinator before sending them to client.
-     *
-     * @param restriction restriction that requires current index
-     * @param columnIndex idx of the indexed column in returned row
-     * @param options     query options
-     * @return a scorer to score the rows
-     */
-    default Scorer postQueryScorer(Restriction restriction, int columnIndex, QueryOptions options)
-    {
-        throw new NotImplementedException();
-    }
-
-    /**
-     * Gives a similarity/proximity score to CQL result rows.
-     */
-    interface Scorer
-    {
-        /**
-         * @param row a CQL result row
-         * @return the similarity/proximity score for the row
-         */
-        float score(List<ByteBuffer> row);
-
-        /**
-         * @return {@code true} if higher scores are considered better, {@code false} otherwise
-         */
-        default boolean reversed()
-        {
-            return false;
-        }
-    }
+    RowFilter getPostIndexQueryFilter(RowFilter filter);
 
     /**
      * Return an estimate of the number of results this index is expected to return for any given
@@ -527,7 +474,7 @@ public interface Index
      *
      * @return the estimated average number of results a Searcher may return for any given query
      */
-    public long getEstimatedResultRows();
+    long getEstimatedResultRows();
 
     /**
      * Check if current index is queryable based on the index status.

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -41,7 +41,6 @@ import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
@@ -50,15 +49,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import io.github.jbellis.jvector.vector.VectorizationProvider;
-import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Operator;
-import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.restrictions.Restriction;
-import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.CassandraWriteContext;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -124,7 +118,6 @@ public class StorageAttachedIndex implements Index
     "In most cases it's better to use a simpler query_analyzer such as the standard one.";
 
     private static final Logger logger = LoggerFactory.getLogger(StorageAttachedIndex.class);
-    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
 
     private static final boolean VALIDATE_TERMS_AT_COORDINATOR = SAI_VALIDATE_TERMS_AT_COORDINATOR.getBoolean();
 
@@ -693,49 +686,6 @@ public class StorageAttachedIndex implements Index
     {
         // it should be executed from the SAI query plan, this is only used by the singleton index query plan
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Comparator<List<ByteBuffer>> postQueryComparator(Restriction restriction, int columnIndex, QueryOptions options)
-    {
-        assert restriction instanceof SingleColumnRestriction.OrderRestriction;
-
-        SingleColumnRestriction.OrderRestriction orderRestriction = (SingleColumnRestriction.OrderRestriction) restriction;
-        var typeComparator = orderRestriction.getDirection() == Operator.ORDER_BY_DESC
-                             ? indexContext.getValidator().reversed()
-                             : indexContext.getValidator();
-        return (a, b) -> typeComparator.compare(a.get(columnIndex), b.get(columnIndex));
-    }
-
-    @Override
-    public Scorer postQueryScorer(Restriction restriction, int columnIndex, QueryOptions options)
-    {
-        // For now, only support ANN
-        assert restriction instanceof SingleColumnRestriction.AnnRestriction;
-
-        Preconditions.checkState(indexContext.isVector());
-
-        SingleColumnRestriction.AnnRestriction annRestriction = (SingleColumnRestriction.AnnRestriction) restriction;
-        VectorSimilarityFunction similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
-
-        var targetVector = vts.createFloatVector(TypeUtil.decomposeVector(indexContext, annRestriction.value(options).duplicate()));
-
-        return new Scorer()
-        {
-            @Override
-            public float score(List<ByteBuffer> row)
-            {
-                ByteBuffer vectorBuffer = row.get(columnIndex);
-                var vector = vts.createFloatVector(TypeUtil.decomposeVector(indexContext, vectorBuffer.duplicate()));
-                return similarityFunction.compare(vector, targetVector);
-            }
-
-            @Override
-            public boolean reversed()
-            {
-                return true;
-            }
-        };
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -216,7 +216,7 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
             return partitions -> partitions;
 
         // in case of top-k query, filter out rows that are not actually global top-K
-        return partitions -> (PartitionIterator) new TopKProcessor(command).filter(partitions);
+        return partitions -> new TopKProcessor(command).filter(partitions);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -116,7 +116,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                     var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
                     var result = new ScoreOrderedResultRetriever(scoredKeysIterator, filterTree, controller,
                                                                  executionController, queryContext, command.limits().count());
-                    return (UnfilteredPartitionIterator) new TopKProcessor(command).filter(result);
+                    return new TopKProcessor(command).filter(result);
                 }
                 else
                 {

--- a/src/java/org/apache/cassandra/utils/TopKSelector.java
+++ b/src/java/org/apache/cassandra/utils/TopKSelector.java
@@ -86,7 +86,7 @@ public class TopKSelector<T> extends BinaryHeap
     }
 
     @Override
-    protected int size()
+    public int size()
     {
         return size;
     }
@@ -113,6 +113,15 @@ public class TopKSelector<T> extends BinaryHeap
     public <R> List<R> getTransformed(Function<T, R> transformer)
     {
         return getTransformedSliced(transformer, 0);
+    }
+
+    /**
+     * Get a copy of the lowest size-startIndex elements.
+     * The top startIndex elements will remain in the selector.
+     */
+    public List<T> getSliced(int startIndex)
+    {
+        return getTransformedSliced(Function.identity(), startIndex);
     }
 
     /**

--- a/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/QueryInfoTrackerDistributedTest.java
@@ -25,14 +25,13 @@ import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
-import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.distributed.api.IIsolatedExecutor;
 import org.apache.cassandra.distributed.test.sai.SAIUtil;
-import org.apache.cassandra.service.QueryInfoTrackerTest;
+import org.apache.cassandra.service.QueryInfoTrackerTest.TestQueryInfoTracker;
 import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.reads.repair.ReadRepairStrategy;
 
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
-import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
@@ -58,6 +57,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void testTrackingInDataResolverResolve()
     {
         ReadRepairTester tester = new ReadRepairTester(cluster, ReadRepairStrategy.BLOCKING, 1, false, false, false)
@@ -77,18 +77,13 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
 
         tester.mutate(2, "INSERT INTO %s (pk, ck, v) VALUES (1, 1, 2)");
 
-        cluster.get(tester.coordinator).runOnInstance(() -> {
-            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(keyspace));
-        });
+        setQueryTracker(tester.coordinator, keyspace);
 
         tester.assertRowsDistributed("SELECT * FROM %s WHERE pk=1 AND ck=1",
                                      2,
                                      row(1, 1, 2));
 
-        cluster.get(tester.coordinator).runOnInstance(() -> {
-            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
-            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
-
+        assertQueryTracker(tester.coordinator, tracker -> {
             Assert.assertEquals(1, tracker.reads.get());
             Assert.assertEquals(1, tracker.readPartitions.get());
             Assert.assertEquals(1, tracker.readRows.get());
@@ -100,22 +95,16 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
     public void testTrackingInDigestResolverGetData()
     {
         cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
-
-        cluster.get(1).runOnInstance(() -> {
-            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(KEYSPACE));
-        });
-
         cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1)",
                                        ConsistencyLevel.QUORUM);
+
+        setQueryTracker(1, KEYSPACE);
+
         assertRows(cluster.coordinator(1).execute("SELECT * FROM " + KEYSPACE + ".tbl WHERE pk = 1",
                                                   ConsistencyLevel.QUORUM),
                    row(1, 1, 1));
 
-
-        cluster.get(1).runOnInstance(() -> {
-            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
-            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
-
+        assertQueryTracker(1, tracker -> {
             Assert.assertEquals(1, tracker.reads.get());
             Assert.assertEquals(1, tracker.readPartitions.get());
             Assert.assertEquals(1, tracker.readRows.get());
@@ -124,7 +113,7 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
     }
 
     @Test
-    public void testTrackingReadsWithEndpointGrouping() throws Throwable
+    public void testTrackingReadsWithEndpointGrouping()
     {
         String table = rfOneKs + ".saiTbl";
         cluster.schemaChange("CREATE TABLE " + table + " (id1 TEXT PRIMARY KEY, v1 INT, v2 TEXT)");
@@ -142,22 +131,55 @@ public class QueryInfoTrackerDistributedTest extends TestBaseImpl
                                            String.valueOf(i));
         }
 
-
-        cluster.get(1).runOnInstance(() -> {
-            StorageProxy.instance.registerQueryTracker(new QueryInfoTrackerTest.TestQueryInfoTracker(rfOneKs));
-        });
+        setQueryTracker(1, rfOneKs);
 
         cluster.coordinator(1).execute(String.format("SELECT id1 FROM %s WHERE v1>=0", table),
                                        ConsistencyLevel.QUORUM);
 
-        cluster.get(1).runOnInstance(() -> {
-            QueryInfoTrackerTest.TestQueryInfoTracker tracker =
-            (QueryInfoTrackerTest.TestQueryInfoTracker) StorageProxy.instance.queryTracker();
-
+        assertQueryTracker(1, tracker -> {
             Assert.assertEquals(1, tracker.rangeReads.get());
             Assert.assertEquals(rowsCount, tracker.readPartitions.get());
             Assert.assertEquals(rowsCount, tracker.readRows.get());
             Assert.assertEquals(4, tracker.replicaPlans.get());
+        });
+    }
+
+    @Test
+    public void testANNQueryWithIndexRestrictionAndLIMIT()
+    {
+        String table = rfOneKs + ".ann_table";
+        cluster.schemaChange("CREATE TABLE " + table + " (p int PRIMARY KEY, v int, ni int, vec VECTOR<FLOAT, 2>)");
+        cluster.schemaChange("CREATE CUSTOM INDEX ON " + table + "(vec) USING 'StorageAttachedIndex'");
+        cluster.schemaChange("CREATE CUSTOM INDEX ON " + table + "(v) USING 'StorageAttachedIndex'");
+        SAIUtil.waitForIndexQueryable(cluster, rfOneKs);
+
+        for (int rowIdx = 0; rowIdx < 100; rowIdx++)
+        {
+            cluster.coordinator(1).execute("INSERT INTO " + table + "(p, v, ni, vec) VALUES (?, ?, ?, [0.5, 0.3])",
+                                           ConsistencyLevel.ALL, rowIdx, rowIdx, rowIdx);
+        }
+
+        setQueryTracker(1, rfOneKs);
+
+        cluster.coordinator(1).execute("SELECT * FROM " + table + " WHERE v > 50 ORDER BY vec ANN OF [0.1, 0.9] LIMIT 3",
+                                       ConsistencyLevel.ONE);
+
+        assertQueryTracker(1, tracker -> {
+            Assert.assertEquals(1, tracker.rangeReads.get());
+            Assert.assertEquals(3, tracker.readFilteredRows.get());
+        });
+    }
+
+    private void setQueryTracker(int node, String keyspace)
+    {
+        cluster.get(node).runOnInstance(() -> StorageProxy.instance.registerQueryTracker(new TestQueryInfoTracker(keyspace)));
+    }
+
+    private void assertQueryTracker(int node, IIsolatedExecutor.SerializableConsumer<TestQueryInfoTracker> tester)
+    {
+        cluster.get(node).runOnInstance(() -> {
+            TestQueryInfoTracker tracker = (TestQueryInfoTracker) StorageProxy.queryTracker();
+            tester.accept(tracker);
         });
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/GenericOrderByTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/GenericOrderByTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+/**
+ * Test for generic ORDER BY queries with SAI.
+ */
+public class GenericOrderByTest extends TestBaseImpl
+{
+    private static final int NUM_REPLICAS = 3;
+    private static final int RF = 2;
+
+    @Test
+    public void testOrderBy() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(NUM_REPLICAS)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), RF))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t(k int, c int, v int, PRIMARY KEY(k, c))"));
+            cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t(v) USING 'StorageAttachedIndex'"));
+            SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+
+            ICoordinator coordinator = cluster.coordinator(1);
+
+            String insertQuery = withKeyspace("INSERT INTO %s.t(k, c, v) VALUES (?, ?, ?)");
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 1, 1, 1);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 1, 2, 8);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 1, 3, 3);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 2, 1, 6);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 2, 2, 5);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 2, 3, 4);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 3, 1, 7);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 3, 2, 2);
+            coordinator.execute(insertQuery, ConsistencyLevel.ALL, 3, 3, 9);
+
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t ORDER BY v ASC",
+                                row(1, 1, 1),
+                                row(3, 2, 2),
+                                row(1, 3, 3),
+                                row(2, 3, 4),
+                                row(2, 2, 5),
+                                row(2, 1, 6),
+                                row(3, 1, 7),
+                                row(1, 2, 8),
+                                row(3, 3, 9));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t ORDER BY v DESC",
+                                row(3, 3, 9),
+                                row(1, 2, 8),
+                                row(3, 1, 7),
+                                row(2, 1, 6),
+                                row(2, 2, 5),
+                                row(2, 3, 4),
+                                row(1, 3, 3),
+                                row(3, 2, 2),
+                                row(1, 1, 1));
+
+            // with partition key restriction
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=1 ORDER BY v ASC",
+                                row(1, 1, 1),
+                                row(1, 3, 3),
+                                row(1, 2, 8));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=1 ORDER BY v DESC",
+                                row(1, 2, 8),
+                                row(1, 3, 3),
+                                row(1, 1, 1));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=2 ORDER BY v ASC",
+                                row(2, 3, 4),
+                                row(2, 2, 5),
+                                row(2, 1, 6));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=2 ORDER BY v DESC",
+                                row(2, 1, 6),
+                                row(2, 2, 5),
+                                row(2, 3, 4));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=3 ORDER BY v ASC",
+                                row(3, 2, 2),
+                                row(3, 1, 7),
+                                row(3, 3, 9));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE k=3 ORDER BY v DESC",
+                                row(3, 3, 9),
+                                row(3, 1, 7),
+                                row(3, 2, 2));
+
+            // with indexed column filter
+            cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t(c) USING 'StorageAttachedIndex'"));
+            SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=1 ORDER BY v ASC",
+                                row(1, 1, 1),
+                                row(2, 1, 6),
+                                row(3, 1, 7));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=1 ORDER BY v DESC",
+                                row(3, 1, 7),
+                                row(2, 1, 6),
+                                row(1, 1, 1));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=2 ORDER BY v ASC",
+                                row(3, 2, 2),
+                                row(2, 2, 5),
+                                row(1, 2, 8));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=2 ORDER BY v DESC",
+                                row(1, 2, 8),
+                                row(2, 2, 5),
+                                row(3, 2, 2));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=3 ORDER BY v ASC",
+                                row(1, 3, 3),
+                                row(2, 3, 4),
+                                row(3, 3, 9));
+            assertRowsWithLimit(cluster, "SELECT * FROM %s.t WHERE c=3 ORDER BY v DESC",
+                                row(3, 3, 9),
+                                row(2, 3, 4),
+                                row(1, 3, 3));
+        }
+    }
+
+    private void assertRowsWithLimit(Cluster cluster, String query, Object[]... expected)
+    {
+        for (int node = 1; node <= cluster.size(); node++)
+        {
+            assertRowsWithLimit(cluster.coordinator(node), query, expected);
+        }
+    }
+
+    private void assertRowsWithLimit(ICoordinator coordinator, String query, Object[]... expected)
+    {
+        for (int limit = 1; limit <= expected.length; limit++)
+        {
+            String queryWithLimit = withKeyspace(query) + " LIMIT " + limit;
+            Object[][] expectedWithLimit = Arrays.copyOfRange(expected, 0, limit);
+            assertRows(coordinator.execute(queryWithLimit, ConsistencyLevel.ONE), expectedWithLimit);
+        }
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/SortedRowsBuilderBench.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.selection.SortedRowsBuilder;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.index.Index;
 import org.openjdk.jmh.annotations.*;
 
 /**
@@ -44,7 +43,6 @@ public class SortedRowsBuilderBench extends CQLTester
 {
     private static final int NUM_COLUMNS = 10;
     private static final int SORTED_COLUMN_CARDINALITY = 1000;
-    private static final Index.Scorer SCORER = row -> Int32Type.instance.compose(row.get(0));
 
     private static final Comparator<List<ByteBuffer>> COMPARATOR = (o1, o2) -> Int32Type.instance.compare(o1.get(0), o2.get(0));
     private static final Random RANDOM = new Random();
@@ -97,24 +95,6 @@ public class SortedRowsBuilderBench extends CQLTester
     public Object comparatorWithHybrid()
     {
         return test(SortedRowsBuilder.WithHybridSort.create(limit, offset, COMPARATOR));
-    }
-
-    @Benchmark
-    public Object scorerWithList()
-    {
-        return test(SortedRowsBuilder.WithListSort.create(limit, offset, SCORER));
-    }
-
-    @Benchmark
-    public Object scorerWithHeap()
-    {
-        return test(SortedRowsBuilder.WithHeapSort.create(limit, offset, SCORER));
-    }
-
-    @Benchmark
-    public Object scorerWithHybrid()
-    {
-        return test(SortedRowsBuilder.WithHybridSort.create(limit, offset, SCORER));
     }
 
     private List<List<ByteBuffer>> test(SortedRowsBuilder builder)

--- a/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
+++ b/test/unit/org/apache/cassandra/cql3/selection/SortedRowsBuilderTest.java
@@ -29,7 +29,6 @@ import com.google.common.math.IntMath;
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.index.Index;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -88,19 +87,6 @@ public class SortedRowsBuilderTest
                 }
                 test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, comparator), comparator);
                 test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, reverseComparator), reverseComparator);
-
-                // with index scorer
-                test(rows, SortedRowsBuilder.create(limit, offset, scorer(false)), comparator);
-                test(rows, SortedRowsBuilder.create(limit, offset, scorer(true)), reverseComparator);
-                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, scorer(false)), comparator);
-                test(rows, SortedRowsBuilder.WithListSort.create(limit, offset, scorer(true)), reverseComparator);
-                if (totalLimit < 1 << 20)
-                {
-                    test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, scorer(false)), comparator);
-                    test(rows, SortedRowsBuilder.WithHeapSort.create(limit, offset, scorer(true)), reverseComparator);
-                }
-                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, scorer(false)), comparator);
-                test(rows, SortedRowsBuilder.WithHybridSort.create(limit, offset, scorer(true)), reverseComparator);
             }
         }
     }
@@ -142,23 +128,5 @@ public class SortedRowsBuilderTest
         for (List<ByteBuffer> row : rows)
             values.add(Int32Type.instance.compose(row.get(0)));
         return values;
-    }
-
-    private static Index.Scorer scorer(boolean reversed)
-    {
-        return new Index.Scorer()
-        {
-            @Override
-            public float score(List<ByteBuffer> row)
-            {
-                return Int32Type.instance.compose(row.get(0));
-            }
-
-            @Override
-            public boolean reversed()
-            {
-                return reversed;
-            }
-        };
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexTest.java
@@ -35,22 +35,18 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.Lists;
-import org.apache.cassandra.cql3.PageSize;
-import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.Term;
 import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction;
 import org.apache.cassandra.cql3.selection.SortedRowsBuilder;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.transport.ProtocolVersion;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
@@ -134,21 +130,14 @@ public class StorageAttachedIndexTest
     }
 
     @Test
-    public void testOrderResults() {
-        QueryOptions queryOptions = QueryOptions.create(ConsistencyLevel.ONE,
-                                                        byteBufferList,
-                                                        false,
-                                                        PageSize.inRows(1),
-                                                        null,
-                                                        null,
-                                                        ProtocolVersion.CURRENT,
-                                                        KEYSPACE);
+    public void testOrderResults()
+    {
         List<List<ByteBuffer>> rows = new ArrayList<>();
         rows.add(byteBufferList);
 
         SelectStatement selectStatementInstance = (SelectStatement) QueryProcessor.prepareInternal("SELECT key, value FROM " + KEYSPACE + '.' + TABLE).statement;
 
-        SortedRowsBuilder builder = selectStatementInstance.sortedRowsBuilder(Integer.MAX_VALUE, 0, queryOptions);
+        SortedRowsBuilder builder = selectStatementInstance.sortedRowsBuilder(Integer.MAX_VALUE, 0);
         rows.forEach(builder::add);
         List<List<ByteBuffer>> sortedRows = builder.build();
 
@@ -160,7 +149,8 @@ public class StorageAttachedIndexTest
 
         rows.sort(descendingComparator);
 
-        for (int i = 0; i < sortedRows.size(); i++) {
+        for (int i = 0; i < sortedRows.size(); i++)
+        {
             List<ByteBuffer> expectedRow = rows.get(i);
             List<ByteBuffer> actualRow = sortedRows.get(i);
             assertEquals(expectedRow, actualRow);


### PR DESCRIPTION
It was recently found that index-based sorting is done twice in the coordinator. The first sorting is done by `StorageAttachedIndexQueryPlan#postProcessor`, at the service level, which sorts a `PartitionIterator`. Then a second sorting is done by `SortedRowsBuilder`, at the CQL level, which sorts a simpler `List<ByteBuffer>`.

[CNDB-11762](https://github.com/riptano/cndb/issues/11762) removed the entire `StorageAttachedIndexQueryPlan#postProcessor` method so sorting was not duplicated anymore. However, this was problematic for implementations of `QueryInfoTracker.ReadTracker`, which is applied after sorting with the postprocessor, but before sorting at the CQL level, [here](https://github.com/datastax/cassandra/blob/main/src/java/org/apache/cassandra/service/StorageProxy.java#L2304-L2310). Thus, that change was reverted to avoid breaking external trackers relying on the previous behaviour.

I think what we should do instead is to get rid of index-based sorting at the CQL level, so all sorting is done by the postprocessor. The postprocessor works at a lower level so, with some adjustments, it should be able to do all the sorting on its own without needing CQL intervention. That should remove the duplicated sorting and simplify CQL a bit.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits