### PR TITLE
Add log for bloom filter loading

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
@@ -136,6 +136,8 @@ public class FilterComponent
             filter = load(descriptor);
             if (filter == null || !filter.isInformative())
                 logger.info("Bloom filter for {} is missing or invalid", descriptor);
+            else
+                logger.debug("Loading bloom filter from {}", descriptor);
         }
         catch (IOException ex)
         {


### PR DESCRIPTION
### What is the issue

CNDB tests need to know when bloom filters are loaded

### What does this PR fix and why was it fixed
...

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits