### PR TITLE
CNDB-12393: Refactor TransportTest to account for JEP-416

### DIFF
--- a/test/unit/org/apache/cassandra/transport/TransportTest.java
+++ b/test/unit/org/apache/cassandra/transport/TransportTest.java
@@ -118,7 +118,7 @@ public class TransportTest extends CQLTester
             ExecuteMessage executeMessage = new ExecuteMessage(prepareResponse.statementId, prepareResponse.resultMetadataId, QueryOptions.DEFAULT);
             Message.Response executeResponse = client.execute(executeMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-prepared", executeResponse.getWarnings().getFirst());
+            Assert.assertEquals("async-prepared", executeResponse.getWarnings().get(0));
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
@@ -128,7 +128,7 @@ public class TransportTest extends CQLTester
             QueryMessage readMessage = new QueryMessage("SELECT * FROM " + KEYSPACE + ".atable", QueryOptions.DEFAULT);
             Message.Response readResponse = client.execute(readMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-process", readResponse.getWarnings().getFirst());
+            Assert.assertEquals("async-process", readResponse.getWarnings().get(0));
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
@@ -138,7 +138,7 @@ public class TransportTest extends CQLTester
                                                          QueryOptions.DEFAULT);
             Message.Response batchResponse = client.execute(batchMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-batch", batchResponse.getWarnings().getFirst());
+            Assert.assertEquals("async-batch", batchResponse.getWarnings().get(0));
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
@@ -148,7 +148,7 @@ public class TransportTest extends CQLTester
             QueryMessage insertMessage = new QueryMessage("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')", QueryOptions.DEFAULT);
             Message.Response insertResponse = client.execute(insertMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-process", insertResponse.getWarnings().getFirst());
+            Assert.assertEquals("async-process", insertResponse.getWarnings().get(0));
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
         }

--- a/test/unit/org/apache/cassandra/transport/TransportTest.java
+++ b/test/unit/org/apache/cassandra/transport/TransportTest.java
@@ -134,7 +134,7 @@ public class TransportTest extends CQLTester
 
             BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
                                                          Collections.singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
-                                                         Collections.singletonList(Collections.emptyList()),
+                                                         Collections.singletonList(Collections.<ByteBuffer>emptyList()),
                                                          QueryOptions.DEFAULT);
             Message.Response batchResponse = client.execute(batchMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());

--- a/test/unit/org/apache/cassandra/transport/TransportTest.java
+++ b/test/unit/org/apache/cassandra/transport/TransportTest.java
@@ -17,8 +17,6 @@
  */
 package org.apache.cassandra.transport;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -57,47 +54,12 @@ import org.awaitility.core.TimeoutEvent;
 
 public class TransportTest extends CQLTester
 {
-    private static Field cqlQueryHandlerField;
-    private static boolean modifiersAccessible;
-
     @BeforeClass
-    public static void makeCqlQueryHandlerAccessible()
+    public static void setUpClass()
     {
-        try
-        {
-            cqlQueryHandlerField = ClientState.class.getDeclaredField("cqlQueryHandler");
-            cqlQueryHandlerField.setAccessible(true);
-
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersAccessible = modifiersField.isAccessible();
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(cqlQueryHandlerField, cqlQueryHandlerField.getModifiers() & ~Modifier.FINAL);
-        }
-        catch (IllegalAccessException | NoSuchFieldException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @AfterClass
-    public static void resetCqlQueryHandlerField()
-    {
-        if (cqlQueryHandlerField == null)
-            return;
-        try
-        {
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(cqlQueryHandlerField, cqlQueryHandlerField.getModifiers() | Modifier.FINAL);
-
-            cqlQueryHandlerField.setAccessible(false);
-
-            modifiersField.setAccessible(modifiersAccessible);
-        }
-        catch (IllegalAccessException | NoSuchFieldException e)
-        {
-            throw new RuntimeException(e);
-        }
+        System.setProperty("cassandra.custom_query_handler_class", "org.apache.cassandra.transport.TransportTest$TestQueryHandler");
+        CQLTester.setUpClass();
+        CQLTester.requireNetwork();
     }
 
     @After
@@ -116,6 +78,8 @@ public class TransportTest extends CQLTester
     @Test
     public void testAsyncTransport() throws Throwable
     {
+        Assert.assertSame(TransportTest.TestQueryHandler.class, ClientState.getCQLQueryHandler().getClass());
+
         CassandraRelevantProperties.NATIVE_TRANSPORT_ASYNC_READ_WRITE_ENABLED.setBoolean(true);
         try
         {
@@ -129,13 +93,8 @@ public class TransportTest extends CQLTester
 
     private void doTestTransport() throws Throwable
     {
-        SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort);
-        QueryHandler queryHandler = (QueryHandler) cqlQueryHandlerField.get(null);
-        cqlQueryHandlerField.set(null, new TransportTest.TestQueryHandler());
-        try
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort))
         {
-            requireNetwork();
-
             client.connect(false);
 
             // Async native transport causes native transport requests to be executed asynchronously on the coordinator read and coordinator write
@@ -153,13 +112,13 @@ public class TransportTest extends CQLTester
             QueryMessage createMessage = new QueryMessage("CREATE TABLE " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", QueryOptions.DEFAULT);
             PrepareMessage prepareMessage = new PrepareMessage("SELECT * FROM " + KEYSPACE + ".atable", null);
 
-            Message.Response createResponse = client.execute(createMessage);
+            client.execute(createMessage);
             ResultMessage.Prepared prepareResponse = (ResultMessage.Prepared) client.execute(prepareMessage);
 
             ExecuteMessage executeMessage = new ExecuteMessage(prepareResponse.statementId, prepareResponse.resultMetadataId, QueryOptions.DEFAULT);
             Message.Response executeResponse = client.execute(executeMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-prepared", executeResponse.getWarnings().get(0));
+            Assert.assertEquals("async-prepared", executeResponse.getWarnings().getFirst());
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
@@ -169,17 +128,17 @@ public class TransportTest extends CQLTester
             QueryMessage readMessage = new QueryMessage("SELECT * FROM " + KEYSPACE + ".atable", QueryOptions.DEFAULT);
             Message.Response readResponse = client.execute(readMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-process", readResponse.getWarnings().get(0));
+            Assert.assertEquals("async-process", readResponse.getWarnings().getFirst());
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
             BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
                                                          Collections.singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
-                                                         Collections.singletonList(Collections.<ByteBuffer>emptyList()),
+                                                         Collections.singletonList(Collections.emptyList()),
                                                          QueryOptions.DEFAULT);
             Message.Response batchResponse = client.execute(batchMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-batch", batchResponse.getWarnings().get(0));
+            Assert.assertEquals("async-batch", batchResponse.getWarnings().getFirst());
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
 
@@ -189,14 +148,9 @@ public class TransportTest extends CQLTester
             QueryMessage insertMessage = new QueryMessage("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')", QueryOptions.DEFAULT);
             Message.Response insertResponse = client.execute(insertMessage);
             Assert.assertEquals(1, executeResponse.getWarnings().size());
-            Assert.assertEquals("async-process", insertResponse.getWarnings().get(0));
+            Assert.assertEquals("async-process", insertResponse.getWarnings().getFirst());
             awaitUntil(() -> Stage.COORDINATE_READ.getCompletedTaskCount() == ref.expectedCoordinateReadTasks);
             awaitUntil(() -> Stage.READ.getCompletedTaskCount() == ref.expectedExecuteReadTasks);
-        }
-        finally
-        {
-            client.close();
-            cqlQueryHandlerField.set(null, queryHandler);
         }
     }
 
@@ -209,16 +163,19 @@ public class TransportTest extends CQLTester
 
     public static class TestQueryHandler implements QueryHandler
     {
+        @Override
         public QueryProcessor.Prepared getPrepared(MD5Digest id)
         {
             return QueryProcessor.instance.getPrepared(id);
         }
 
+        @Override
         public CQLStatement parse(String query, QueryState state, QueryOptions options)
         {
             return QueryProcessor.instance.parse(query, state, options);
         }
 
+        @Override
         public ResultMessage.Prepared prepare(String query,
                                               ClientState clientState,
                                               Map<String, ByteBuffer> customPayload)
@@ -227,6 +184,7 @@ public class TransportTest extends CQLTester
             return QueryProcessor.instance.prepare(query, clientState, customPayload);
         }
 
+        @Override
         public ResultMessage process(CQLStatement statement,
                                      QueryState state,
                                      QueryOptions options,
@@ -238,6 +196,7 @@ public class TransportTest extends CQLTester
             return QueryProcessor.instance.process(statement, state, options, customPayload, queryStartNanoTime);
         }
 
+        @Override
         public ResultMessage processBatch(BatchStatement statement,
                                           QueryState state,
                                           BatchQueryOptions options,
@@ -249,6 +208,7 @@ public class TransportTest extends CQLTester
             return QueryProcessor.instance.processBatch(statement, state, options, customPayload, queryStartNanoTime);
         }
 
+        @Override
         public ResultMessage processPrepared(CQLStatement statement,
                                              QueryState state,
                                              QueryOptions options,


### PR DESCRIPTION
### What is the issue
...
TransportTest was not accounting for JEP-416 and failing on JDK22 as observed in #11508.
### What does this PR fix and why was it fixed
...

The PR contains:
-  the commits from #11508 that enable JDK22 and which should be merged until tomorrow as part of #11508.
- last commit fixes the issue we tackle here and we target to commit only that commit as part of this ticket. The #11508 commits are added just for test purposes. 


### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits