### PR TITLE
CNDB-12423: Fix flaky test failures in LegacySSTableTest by blocking for tidiers to run

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
@@ -129,7 +129,7 @@ public class LegacySSTableTest
     {
         for (String legacyVersion : legacyVersions)
         {
-            truncateTables(legacyVersion);
+            truncateLegacyTables(legacyVersion);
         }
     }
 
@@ -207,7 +207,7 @@ public class LegacySSTableTest
             // Skip 2.0.1 sstables as it doesn't have repaired information
             if (legacyVersion.equals("jb"))
                 continue;
-            truncateTables(legacyVersion);
+            truncateLegacyTables(legacyVersion);
             loadLegacyTables(legacyVersion);
 
             for (ColumnFamilyStore cfs : Keyspace.open("legacy_tables").getColumnFamilyStores())
@@ -434,6 +434,8 @@ public class LegacySSTableTest
         Keyspace.open("legacy_tables").getColumnFamilyStore(String.format("legacy_%s_simple_counter", legacyVersion)).truncateBlocking();
         Keyspace.open("legacy_tables").getColumnFamilyStore(String.format("legacy_%s_clust", legacyVersion)).truncateBlocking();
         Keyspace.open("legacy_tables").getColumnFamilyStore(String.format("legacy_%s_clust_counter", legacyVersion)).truncateBlocking();
+        CacheService.instance.invalidateCounterCache();
+        CacheService.instance.invalidateKeyCache();
     }
 
     private static void compactLegacyTables(String legacyVersion)
@@ -551,16 +553,6 @@ public class LegacySSTableTest
         QueryProcessor.executeInternal(String.format("CREATE TABLE legacy_tables.legacy_%s_simple_counter (pk text PRIMARY KEY, val counter)", legacyVersion));
         QueryProcessor.executeInternal(String.format("CREATE TABLE legacy_tables.legacy_%s_clust (pk text, ck text, val text, PRIMARY KEY (pk, ck))", legacyVersion));
         QueryProcessor.executeInternal(String.format("CREATE TABLE legacy_tables.legacy_%s_clust_counter (pk text, ck text, val counter, PRIMARY KEY (pk, ck))", legacyVersion));
-    }
-
-    private static void truncateTables(String legacyVersion)
-    {
-        QueryProcessor.executeInternal(String.format("TRUNCATE legacy_tables.legacy_%s_simple", legacyVersion));
-        QueryProcessor.executeInternal(String.format("TRUNCATE legacy_tables.legacy_%s_simple_counter", legacyVersion));
-        QueryProcessor.executeInternal(String.format("TRUNCATE legacy_tables.legacy_%s_clust", legacyVersion));
-        QueryProcessor.executeInternal(String.format("TRUNCATE legacy_tables.legacy_%s_clust_counter", legacyVersion));
-        CacheService.instance.invalidateCounterCache();
-        CacheService.instance.invalidateKeyCache();
     }
 
     private static void assertLegacyClustRows(int count, UntypedResultSet rs)


### PR DESCRIPTION
### What is the issue
Tests in LegacySSTableTest can see flaky test failures on loading new sstables into a ColumnFamilyStore. In general, this test class creates tables, and many of the tests load legacy sstables into these tables. They perform some operation, and then they truncate the table. Tests (particularly testAutomaticUpgrade, which does this twice within the test body) can see failures where the truncate runs, the load starts, the load sees the on-disk remnants of an old sstable, the tidier runs on the non-periodic executor and removes these remnants, and the load fails when the remnant is no longer present.

### What does this PR fix and why was it fixed
The truncate helper now uses a helper method to block on the execution of the tidiers, so that they don't run during the process of loading new sstables. The PR also consolidates two truncate helpers to eliminate potential mistakes from divergent fixes to these methods.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits