### PR TITLE
CNDB-11440: Set QueryMetricsTest to at least Version.EB

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 
@@ -37,6 +38,10 @@ import static org.junit.Assert.assertTrue;
 
 public class QueryMetricsTest extends AbstractMetricsTest
 {
+    static {
+        SAIUtil.setLatestVersion(Version.latest().onOrAfter(Version.EB) ? Version.latest() : Version.EB);
+    }
+
     private static final String CREATE_TABLE_TEMPLATE = "CREATE TABLE %s.%s (id1 TEXT PRIMARY KEY, v1 INT, v2 TEXT) WITH compaction = " +
                                                         "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }";
     private static final String CREATE_INDEX_TEMPLATE = "CREATE CUSTOM INDEX IF NOT EXISTS %s ON %s.%s(%s) USING 'StorageAttachedIndex'";


### PR DESCRIPTION
### What is the issue
QueryMetricsTest.testKDTreePostingsQueryMetricsWithSingleIndex is failing.

### What does this PR fix and why was it fixed
This sets the latest SAI version to a least EB in this test. This test was updated for #1253, which introduced Version.EB and set `latest` accordingly. When #1364 reverted `latest` to DB, updating this test was missed. This PR follows the strategy for other updated tests in the revert, which is to set `latest` appropriately.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits