### PR TITLE
Improve performance of SingleRestrictionEstimatedRowCountTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -64,7 +64,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         return null;
     }
 
-    static Map.Entry<Version, CQL3Type.Native> tablesEntrykey(Version version, CQL3Type.Native type)
+    static Map.Entry<Version, CQL3Type.Native> tablesEntryKey(Version version, CQL3Type.Native type)
     {
         return new AbstractMap.SimpleEntry<>(version, type);
     }
@@ -74,7 +74,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
     {
         createTables();
 
-        var test = new RowCountTest(Operator.NEQ, 25);
+        RowCountTest test = new RowCountTest(Operator.NEQ, 25);
         test.doTest(Version.DB, INT, 97.0);
         test.doTest(Version.EB, INT, 97.0);
         // Truncated numeric types planned differently
@@ -111,7 +111,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
             {
                 createTable("CREATE TABLE %s (pk text PRIMARY KEY, age " + type + ')');
                 createIndex("CREATE CUSTOM INDEX ON %s(age) USING 'StorageAttachedIndex'");
-                tables.put(tablesEntrykey(version, type), getCurrentColumnFamilyStore());
+                tables.put(tablesEntryKey(version, type), getCurrentColumnFamilyStore());
             }
         }
         flush();
@@ -125,7 +125,8 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         cfs.unsafeRunWithoutFlushing(() -> {
             for (int i = 0; i < 100; i++)
             {
-                String query = String.format("INSERT INTO %s (pk, age) VALUES (?, " + i + ')', cfs.keyspace.getName() + '.' + cfs.name);
+                String query = String.format("INSERT INTO %s (pk, age) VALUES (?, " + i + ')',
+                        cfs.keyspace.getName() + '.' + cfs.name);
                 executeFormattedQuery(query, "key" + i);
             }
         });

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -21,8 +21,6 @@ package org.apache.cassandra.index.sai.plan;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.Util;
@@ -44,8 +42,6 @@ import static org.junit.Assert.fail;
 
 public class SingleRestrictionEstimatedRowCountTest extends SAITester
 {
-    private int queryOptLevel;
-
     static protected Object getFilterValue(CQL3Type.Native type, int value)
     {
         switch (type)
@@ -59,19 +55,6 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         }
         fail("Must be known type");
         return null;
-    }
-
-    @Before
-    public void setup()
-    {
-        queryOptLevel = QueryController.QUERY_OPT_LEVEL;
-        QueryController.QUERY_OPT_LEVEL = 0;
-    }
-
-    @After
-    public void teardown()
-    {
-        QueryController.QUERY_OPT_LEVEL = queryOptLevel;
     }
 
     @Test


### PR DESCRIPTION
Reduces amount of created tables by creating all needed tables in advance. As the result the test can be placed into single test function.
This improves local test execution time from 5.5 seconds down to 1.4 seconds. Reduction in CI from 13 to 5 seconds.

Also removes disabling optimizer, which wasn't necessary.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits