### PR TITLE
CNDB-12445: parameterize ByteComparable.Version for clusteringFromByteComparable

### DIFF
--- a/src/java/org/apache/cassandra/db/ClusteringComparator.java
+++ b/src/java/org/apache/cassandra/db/ClusteringComparator.java
@@ -381,7 +381,7 @@ public class ClusteringComparator implements Comparator<Clusterable>
     /**
      * Produces a clustering from the given byte-comparable value. The method will throw an exception if the value
      * does not correctly encode a clustering of this type, including if it encodes a position before or after a
-     * clustering (i.e. a bound/boundary).
+     * clustering (i.e. a bound/boundary). Uses the OSS50 version of the byte-comparable encoding.
      *
      * @param accessor Accessor to use to construct components. Because this will be used to construct individual
      *                 arrays/buffers for each component, it may be sensible to use an accessor that allocates larger
@@ -391,7 +391,24 @@ public class ClusteringComparator implements Comparator<Clusterable>
     public <V> Clustering<?> clusteringFromByteComparable(ValueAccessor<V> accessor,
                                                           ByteComparable comparable)
     {
-        ByteComparable.Version version = ByteComparable.Version.OSS50;
+        return clusteringFromByteComparable(accessor, comparable, ByteComparable.Version.OSS50);
+    }
+
+    /**
+     * Produces a clustering from the given byte-comparable value. The method will throw an exception if the value
+     * does not correctly encode a clustering of this type, including if it encodes a position before or after a
+     * clustering (i.e. a bound/boundary). Uses the OSS50 version of the byte-comparable encoding.
+     *
+     * @param accessor Accessor to use to construct components. Because this will be used to construct individual
+     *                 arrays/buffers for each component, it may be sensible to use an accessor that allocates larger
+     *                 buffers in advance.
+     * @param comparable The clustering encoded as a byte-comparable sequence.
+     * @param version The version of the byte-comparable encoding.
+     */
+    public <V> Clustering<?> clusteringFromByteComparable(ValueAccessor<V> accessor,
+                                                          ByteComparable comparable,
+                                                          ByteComparable.Version version)
+    {
         ByteSource.Peekable orderedBytes = ByteSource.peekable(comparable.asComparableBytes(version));
         if (orderedBytes == null)
             return null;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -275,7 +275,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
             Clustering clustering = clusteringComparator.size() == 0
                                     ? Clustering.EMPTY
                                     : clusteringComparator.clusteringFromByteComparable(ByteBufferAccessor.instance,
-                                                                                        v -> ByteSourceInverse.nextComponentSource(peekable));
+                                                                                        v -> ByteSourceInverse.nextComponentSource(peekable),
+                                                                                        TypeUtil.BYTE_COMPARABLE_VERSION);
 
             return primaryKeyFactory.create(partitionKey, clustering);
         }

--- a/test/unit/org/apache/cassandra/index/sai/cql/ClusteringKeyIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ClusteringKeyIndexTest.java
@@ -29,24 +29,25 @@ public class ClusteringKeyIndexTest extends SAITester
     @Before
     public void createTableAndIndex()
     {
-        createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, PRIMARY KEY((pk1), pk2)) WITH CLUSTERING ORDER BY (pk2 DESC)");
+        createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, val2 int, PRIMARY KEY((pk1), pk2)) WITH CLUSTERING ORDER BY (pk2 DESC)");
         createIndex("CREATE CUSTOM INDEX pk2_idx ON %s(pk2) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX val2_idx ON %s(val2) USING 'StorageAttachedIndex'");
 
         disableCompaction();
     }
 
     private void insertData1() throws Throwable
     {
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (1, '1', 1)");
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (2, '2', 2)");
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (3, '3', 3)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (1, '1', 1, 1)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (2, '2', 2, 2)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (3, '3', 3, 3)");
     }
 
     private void insertData2() throws Throwable
     {
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (4, '4', 4)");
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (5, '5', 5)");
-        execute("INSERT INTO %s (pk1, pk2, val) VALUES (6, '6', 6)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (4, '4', 4, 4)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (5, '5', 5, 5)");
+        execute("INSERT INTO %s (pk1, pk2, val, val2) VALUES (6, '6', 6, 6)");
     }
 
     @Test
@@ -98,7 +99,7 @@ public class ClusteringKeyIndexTest extends SAITester
 
     private Object[] expectedRow(int index)
     {
-        return row(index, Integer.toString(index), index);
+        return row(index, Integer.toString(index), index, index);
     }
 
     private void runQueries() throws Throwable
@@ -111,5 +112,7 @@ public class ClusteringKeyIndexTest extends SAITester
 
         assertThatThrownBy(()->execute("SELECT * FROM %s WHERE pk1 = -1 AND val = 2")).hasMessageContaining("use ALLOW FILTERING");
 
+        // Add an assertion that covers searching a non-primary key column
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE val2 = 1"), expectedRow(1));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/12445

### What does this PR fix and why was it fixed
Appears to be a regression introduced by https://github.com/datastax/cassandra/commit/338902ce0849e2e6f9b11a689a9c478e0b20ad6c or https://github.com/datastax/cassandra/pull/1177

The general issue is that SAI uses `OSS41` to encode its primary keys in the trie index, but this code path attempted to interpret the clustering columns using `OSS50`.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits