### PR TITLE
CNDB-12460: Fix PQVector reencoding when refining in CompactionGraph

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -311,9 +311,10 @@ public class CompactionGraph implements Closeable, Accountable
                     trainingVectors.clear(); // don't need these anymore so let GC reclaim if it wants to
 
                     // re-encode the vectors added so far
+                    int encodedVectorCount = compressedVectors.count();
                     compressedVectors = new MutablePQVectors((ProductQuantization) compressor);
                     compactionFjp.submit(() -> {
-                        IntStream.range(0, builder.getGraph().getIdUpperBound())
+                        IntStream.range(0, encodedVectorCount)
                                  // FIXME parallel is disabled until 4.0.0 beta2 (encodeAndSet is not threadsafe before then)
 //                                 .parallel()
                                  .forEach(i -> {


### PR DESCRIPTION
### What is the issue
When refining PQVectors in CompactionGraph, indexing of vectors may fail because vectors in the graph aren't yet encoded, or vectors may incorrectly be encoded as all zeroes.

### What does this PR fix and why was it fixed
When re-encoding vectors after refinement, use the previous count of compressed vectors rather than the max ordinal in the graph. Because adding to the graph is asynchronous, there may be encoded vectors that aren't in the graph. The old approach would not re-encode any vectors with ordinals above the max ordinal. Depending on timing, this could cause vectors to fail to index (if they try to compare to an ordinal that isn't in the encoded vectors) or be encoded as all zeroes (due to the code that fills holes in compressed vectors).

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits