### PR TITLE
CNDB-12466: Wait for OutboundConnection to notice disconnect when simulating disconnect in ConnectionTest.testMessageDeliveryOnReconnect

### DIFF
--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -67,6 +67,7 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.FBUtilities;
+import org.awaitility.Awaitility;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -759,6 +760,7 @@ public class ConnectionTest
 
                 // Simulate disconnect
                 inbound.close().get(10, SECONDS);
+                Awaitility.await().timeout(10, SECONDS).until(() -> !outbound.isConnected());
                 MessagingService.instance().removeInbound(endpoint);
                 inbound = new InboundSockets(settings.inbound.apply(new InboundConnectionSettings()));
                 inbound.open().sync();


### PR DESCRIPTION
### What is the issue
ConnectionTest.testMessageDeliveryOnReconnect is flaky, where sometimes an outbound message is not delivered to the handler.

### What does this PR fix and why was it fixed
If the OutboundConnection does not see that its channel is closed until flushing the message in `Delivery#doRun`, the message will be handled via `onFailedSerialize` and dropped. This PR changes the test to ensure the OutboundConnection is disconnected before enqueuing a message, triggering a reconnect. This fix has been tested 200 times in CI and did not fail.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits