### PR TITLE
[DRAFT] CNDB-12408 Track memory usage via sensors

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -575,6 +575,7 @@ public enum CassandraRelevantProperties
      * If true, the coordinator will propagate sensors via the native protocol custom payload bytes map.
      */
     SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false"),
+    MUTATION_REQUESTS_DELAY_ENABLED("cassandra.mutation_requests_delay_enabled", "false"),
 
     MUTATION_REQUESTS_DELAY_PROBABILITY("cassandra.mutation_requests_delay_probability", "1.0"),
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -574,7 +574,13 @@ public enum CassandraRelevantProperties
     /**
      * If true, the coordinator will propagate sensors via the native protocol custom payload bytes map.
      */
-    SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false");
+    SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false"),
+
+    MUTATION_REQUESTS_DELAY_PROBABILITY("cassandra.mutation_requests_delay_probability", "1.0"),
+
+    MUTATION_REQUESTS_MIN_DELAY_MILLIS("cassandra.mutation_requests_min_delay_millis", "500"),
+    MUTATION_REQUESTS_MAX_DELAY_MILLIS("cassandra.mutation_requests_max_delay_millis", "1000");
+
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
+++ b/src/java/org/apache/cassandra/sensors/ActiveRequestSensors.java
@@ -99,6 +99,13 @@ public class ActiveRequestSensors implements RequestSensors
             sensor.increment(value);
     }
 
+    public synchronized void updateSensor(Context context, Type type, double value)
+    {
+        Sensor sensor = getSensorFast(context, type);
+        if (sensor != null)
+            sensor.update(value);
+    }
+
     public synchronized void syncAllSensors()
     {
         sensors.values().forEach(types -> {

--- a/src/java/org/apache/cassandra/sensors/Context.java
+++ b/src/java/org/apache/cassandra/sensors/Context.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.schema.TableMetadata;
  */
 public class Context
 {
+    private static final Context ALL = new Context("all", "all", "all");
     private final String keyspace;
     private final String table;
     private final String tableId;
@@ -101,5 +102,14 @@ public class Context
     public static Context from(IndexContext indexContext)
     {
         return new Context(indexContext.getKeyspace(), indexContext.getTable(), indexContext.getTableId().toString());
+    }
+
+    /**
+     * A context that it is not related to any specific keyspace or table. It is basically a workaround to leverage
+     * existing sensors mechanics (including metrics publishing on CNDB sides)
+     */
+    public static Context all()
+    {
+        return ALL;
     }
 }

--- a/src/java/org/apache/cassandra/sensors/Sensor.java
+++ b/src/java/org/apache/cassandra/sensors/Sensor.java
@@ -66,6 +66,12 @@ public class Sensor
         this.increment(value, (ignored) -> false, 0L);
     }
 
+    @VisibleForTesting
+    public void update(double value)
+    {
+        this.value.set(value);
+    }
+
     protected void increment(double value, Predicate<Sensor> snapshotSensorValue, long now)
     {
         double oldValue = this.value.getAndAdd(value);

--- a/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
+++ b/src/java/org/apache/cassandra/sensors/SensorsRegistry.java
@@ -290,6 +290,29 @@ public class SensorsRegistry implements SchemaChangeListener
                : sensor.getValue() - sensor.getLastSnapshotValue();
     }
 
+    /**
+     * @return get the total rate for a sensor of a given types across all contexts
+     */
+    @VisibleForTesting
+    public double getSensorRate(Type... type)
+    {
+        double totalRate = 0;
+        boolean hasRate = false;
+        // O(context*types), consider optimizing if needed
+        for (Context context : identity.keySet())
+        {
+            for (Type t : type)
+            {
+                double rate = getSensorRate(context, t);
+                if (rate == -1)
+                    continue;
+                hasRate = true;
+                totalRate += rate;
+            }
+        }
+        return hasRate ? totalRate : -1;
+    }
+
     @VisibleForTesting
     public void setClock(MonotonicClock clock)
     {

--- a/src/java/org/apache/cassandra/sensors/Type.java
+++ b/src/java/org/apache/cassandra/sensors/Type.java
@@ -38,4 +38,5 @@ public enum Type
     OFF_HEAP_BYTES, // for bytes capped at -XX:MaxDirectMemorySize
     UNSAFE_BYTES, // not configured, only capped by the amount of physical memory
     OOM_PREDICTION_SECONDS, // time in seconds until OOM is predicted
+    CPU_UTILIZATION, // CPU utilization percentage, reflective of load
 }

--- a/src/java/org/apache/cassandra/sensors/Type.java
+++ b/src/java/org/apache/cassandra/sensors/Type.java
@@ -36,5 +36,6 @@ public enum Type
      */
     ON_HEAP_BYTES, // for bytes capped at -Xmx
     OFF_HEAP_BYTES, // for bytes capped at -XX:MaxDirectMemorySize
-    UNSAFE_BYTES // not configured, only capped by the amount of physical memory
+    UNSAFE_BYTES, // not configured, only capped by the amount of physical memory
+    OOM_PREDICTION_SECONDS, // time in seconds until OOM is predicted
 }

--- a/src/java/org/apache/cassandra/sensors/Type.java
+++ b/src/java/org/apache/cassandra/sensors/Type.java
@@ -28,5 +28,13 @@ public enum Type
     READ_BYTES,
 
     WRITE_BYTES,
-    INDEX_WRITE_BYTES
+    INDEX_WRITE_BYTES,
+
+    /**
+     * Memory types, alternatively, we could use MEMORY_BYTES only type, and have a specialized {@link Context} for
+     * memory with MemoryType (ON_HEAP_BYTES, OFF_HEAP_BYTES, UNSAFE_BYTES) and ExpectedLifetime (SHORT, LONG) etc.
+     */
+    ON_HEAP_BYTES, // for bytes capped at -Xmx
+    OFF_HEAP_BYTES, // for bytes capped at -XX:MaxDirectMemorySize
+    UNSAFE_BYTES // not configured, only capped by the amount of physical memory
 }

--- a/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
+++ b/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
@@ -86,6 +86,9 @@ public final class MemorySensors
 
     private static OperatingSystemMXBean OS;
 
+    private static volatile long prevProcessCpuTimeNanos = 0;
+    private static volatile long prevInvocationNanos = 0;
+
     /**
      * Perhaps add a start/stop methods to control fom CNDB and tests
      */
@@ -172,7 +175,7 @@ public final class MemorySensors
                                                               MEMORY_SNAPSHOT_INTERVAL_SECONDS,
                                                               TimeUnit.SECONDS);
 
-        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(this::getCpuUsage,
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> CPU_UTILIZATION.set(getCpuUsage()),
                                                               MEMORY_SNAPSHOT_INTERVAL_SECONDS,
                                                               MEMORY_SNAPSHOT_INTERVAL_SECONDS,
                                                               TimeUnit.SECONDS);
@@ -257,9 +260,6 @@ public final class MemorySensors
         activeRequestSensors.updateSensor(Context.all(), Type.CPU_UTILIZATION, CPU_UTILIZATION.get());
         noSpamLogger.info("CPU utilization: {}%", CPU_UTILIZATION.get());
     }
-
-    private static volatile long prevProcessCpuTimeNanos = 0;
-    private static volatile long prevInvocationNanos = 0;
 
     private static final MovingAverage processCpuPercentage = ExpMovingAverage.decayBy100();
 

--- a/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
+++ b/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
@@ -22,6 +22,7 @@ import java.lang.management.ManagementFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +45,14 @@ public final class MemorySensors
     private static final Logger logger = LoggerFactory.getLogger(MemorySensors.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
+    public static final MemorySensors instance = new MemorySensors();
+
     /**
      * If we settle on the Context.all() approach, we might as we add a special rule in CNDB to handle this case so
      * we can selectively enable and do the "sensors idiomatic" way of invoking SensorsFactory.instance.createRequestSensors(Context.all().getKeyspace);
      *
      */
-    private static final ActiveRequestSensors activeRequestSensors = new ActiveRequestSensors();
+    private ActiveRequestSensors activeRequestSensors;
     private static final int SENSORS_REGISTRY_SYNC_INTERVAL_SECONDS = 10;
 
     private static final int MEMORY_SNAPSHOT_INTERVAL_SECONDS = 30;
@@ -57,9 +60,11 @@ public final class MemorySensors
     /**
      * Expose all snapshots in gauge like metrics (or the final OOM prediction) for auto-scaler to consume.
      */
-    private static final AtomicLong ON_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
-    private static final AtomicLong OFF_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
-    private static final AtomicLong UNSAFE_ALLOCATED_SNAPSHOT = new AtomicLong();
+    private final AtomicLong ON_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
+    private final AtomicLong OFF_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
+    private final AtomicLong UNSAFE_ALLOCATED_SNAPSHOT = new AtomicLong();
+
+    private final AtomicDouble CPU_USAGE = new AtomicDouble();
 
     /**
      * Presumably, those don't change without a restart, so we can keep them as final statics.
@@ -74,6 +79,7 @@ public final class MemorySensors
     private static final long OFF_HEAP_MAX_MEMORY;
     private static final long UNSAFE_MAX_MEMORY = ((com.sun.management.OperatingSystemMXBean)
                                                      java.lang.management.ManagementFactory.getOperatingSystemMXBean()).getTotalPhysicalMemorySize();
+    private volatile boolean started;
 
     /**
      * Perhaps add a start/stop methods to control fom CNDB and tests
@@ -105,8 +111,20 @@ public final class MemorySensors
             offHeapMaxMemory = ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getMax();
         }
         OFF_HEAP_MAX_MEMORY = offHeapMaxMemory;
+    }
 
+    private MemorySensors()
+    {
 
+    }
+
+    /**
+     * TODO: add a stop method to clean up resources
+     * TODO: fina a better way to init MemorySensors only when SensorsRegistry is ready
+     */
+    public synchronized void start()
+    {
+        activeRequestSensors = new ActiveRequestSensors();
         activeRequestSensors.registerSensor(Context.all(), Type.ON_HEAP_BYTES);
         activeRequestSensors.registerSensor(Context.all(), Type.OFF_HEAP_BYTES);
         activeRequestSensors.registerSensor(Context.all(), Type.UNSAFE_BYTES);
@@ -135,29 +153,36 @@ public final class MemorySensors
                                                               MEMORY_SNAPSHOT_INTERVAL_SECONDS,
                                                               TimeUnit.SECONDS);
 
-        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(MemorySensors::LoggingOOMPredictor,
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> CPU_USAGE.set(ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage() / Runtime.getRuntime().availableProcessors()),
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              TimeUnit.SECONDS);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(this::LoggingOOMPredictor,
                                                               1,
                                                               1,
                                                               TimeUnit.MINUTES);
+        started = true;
     }
 
-    private MemorySensors()
+    public void incrementOnHeapBytes(long bytes)
     {
-
-    }
-
-    public static void incrementOnHeapBytes(long bytes)
-    {
+        if (!started)
+            return;
         activeRequestSensors.incrementSensor(Context.all(), Type.ON_HEAP_BYTES, bytes);
     }
 
-    public static void incrementOffHeapBytes(long bytes)
+    public void incrementOffHeapBytes(long bytes)
     {
+        if (!started)
+            return;
         activeRequestSensors.incrementSensor(Context.all(), Type.OFF_HEAP_BYTES, bytes);
     }
 
-    public static void incrementUnsafeBytes(long bytes)
+    public void incrementUnsafeBytes(long bytes)
     {
+        if (!started)
+            return;
         activeRequestSensors.incrementSensor(Context.all(), Type.UNSAFE_BYTES, bytes);
     }
 
@@ -165,8 +190,10 @@ public final class MemorySensors
      * Perhaps we need an OOM Predictor class/interface with different implementations and output (some would push
      * to logs (and metrics, or autoscaler can do the math on metrics) other can be polled for traffic shaping purposes)
      */
-    private static void LoggingOOMPredictor()
+    private void LoggingOOMPredictor()
     {
+        if (!started)
+            return;
         int W = 60; // look ahead window in seconds, fix its readability/visibility/configurability
         double MPercentage = 0.95d; // percentage of memory allocated, to calculate a threshold for OOM predictions
 

--- a/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
+++ b/src/java/org/apache/cassandra/sensors/memory/MemorySensors.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sensors.memory;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.sensors.ActiveRequestSensors;
+import org.apache.cassandra.sensors.Context;
+import org.apache.cassandra.sensors.Sensor;
+import org.apache.cassandra.sensors.SensorsRegistry;
+import org.apache.cassandra.sensors.Type;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+
+/**
+ * A convenience class to manage memory sensors.
+ */
+public final class MemorySensors
+{
+    private static final Logger logger = LoggerFactory.getLogger(MemorySensors.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
+
+    /**
+     * If we settle on the Context.all() approach, we might as we add a special rule in CNDB to handle this case so
+     * we can selectively enable and do the "sensors idiomatic" way of invoking SensorsFactory.instance.createRequestSensors(Context.all().getKeyspace);
+     *
+     */
+    private static final ActiveRequestSensors activeRequestSensors = new ActiveRequestSensors();
+    private static final int SENSORS_REGISTRY_SYNC_INTERVAL_SECONDS = 10;
+
+    private static final int MEMORY_SNAPSHOT_INTERVAL_SECONDS = 30;
+
+    /**
+     * Expose all snapshots in gauge like metrics (or the final OOM prediction) for auto-scaler to consume.
+     */
+    private static final AtomicLong ON_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
+    private static final AtomicLong OFF_HEAP_ALLOCATED_SNAPSHOT = new AtomicLong();
+    private static final AtomicLong UNSAFE_ALLOCATED_SNAPSHOT = new AtomicLong();
+
+    /**
+     * Presumably, those don't change without a restart, so we can keep them as final statics.
+     * Each one of those need analysis to know what is the most accurate and efficient way to measure. Here I'm just
+     * adding the most naive way for each one to iterate on.
+     */
+    private static final long ON_HEAP_MAX_MEMORY = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+
+    /**
+     * return -1 on Mac unit test although -XX:MaxDirectMemorySize is set in the test
+     */
+    private static final long OFF_HEAP_MAX_MEMORY = ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getMax();
+    private static final long UNSAFE_MAX_MEMORY = ((com.sun.management.OperatingSystemMXBean)
+                                                     java.lang.management.ManagementFactory.getOperatingSystemMXBean()).getTotalPhysicalMemorySize();
+
+    /**
+     * Perhaps add a start/stop methods to control fom CNDB and tests
+     */
+    static
+    {
+        activeRequestSensors.registerSensor(Context.all(), Type.ON_HEAP_BYTES);
+        activeRequestSensors.registerSensor(Context.all(), Type.OFF_HEAP_BYTES);
+        activeRequestSensors.registerSensor(Context.all(), Type.UNSAFE_BYTES);
+
+        // although memory sensors are effectively monotonic (sense they outlive any request), here we sync them
+        // to the registry SensorsMetrics in CNDB register to Sensors Register events
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(activeRequestSensors::syncAllSensors,
+                                                              SENSORS_REGISTRY_SYNC_INTERVAL_SECONDS,
+                                                              SENSORS_REGISTRY_SYNC_INTERVAL_SECONDS,
+                                                              TimeUnit.SECONDS);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> ON_HEAP_ALLOCATED_SNAPSHOT.set(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed()),
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              TimeUnit.SECONDS);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> OFF_HEAP_ALLOCATED_SNAPSHOT.set(ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed()),
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              TimeUnit.SECONDS);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(() -> UNSAFE_ALLOCATED_SNAPSHOT.set(MemoryUtil.allocated()),
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              MEMORY_SNAPSHOT_INTERVAL_SECONDS,
+                                                              TimeUnit.SECONDS);
+
+        ScheduledExecutors.scheduledTasks.scheduleAtFixedRate(MemorySensors::LoggingOOMPredictor,
+                                                              1,
+                                                              1,
+                                                              TimeUnit.MINUTES);
+    }
+
+    private MemorySensors()
+    {
+
+    }
+
+    public static void incrementOnHeapBytes(long bytes)
+    {
+        activeRequestSensors.incrementSensor(Context.all(), Type.ON_HEAP_BYTES, bytes);
+    }
+
+    public static void incrementOffHeapBytes(long bytes)
+    {
+        activeRequestSensors.incrementSensor(Context.all(), Type.OFF_HEAP_BYTES, bytes);
+    }
+
+    public static void incrementUnsafeBytes(long bytes)
+    {
+        activeRequestSensors.incrementSensor(Context.all(), Type.UNSAFE_BYTES, bytes);
+    }
+
+    /**
+     * Perhaps we need an OOM Predictor class/interface with different implementations and output (some would push
+     * to logs (and metrics, or autoscaler can do the math on metrics) other can be polled for traffic shaping purposes)
+     */
+    private static void LoggingOOMPredictor()
+    {
+        int W = 60; // look ahead window in seconds, fix its readability/visibility/configurability
+        double MPercentage = 0.95d; // percentage of memory allocated, to calculate a threshold for OOM predictions
+
+        long onHeapMThreshold = (long) (ON_HEAP_MAX_MEMORY * MPercentage);
+        long offHeapMThreshold = (long) (OFF_HEAP_MAX_MEMORY * MPercentage);
+        // for unsafe, for now subtract what's allocated on heap and off heap from the total physical memory
+        long unsafeEffectiveMaxMemory = UNSAFE_MAX_MEMORY - ON_HEAP_ALLOCATED_SNAPSHOT.get() - OFF_HEAP_MAX_MEMORY;
+        long unsafeHeapMThreshold = (long) (unsafeEffectiveMaxMemory * MPercentage);
+
+        double onHeapAllocationRate = SensorsRegistry.instance.getSensorRate(Context.all(), Type.ON_HEAP_BYTES);
+        double offHeapAllocationRate = SensorsRegistry.instance.getSensorRate(Context.all(), Type.OFF_HEAP_BYTES);
+        double unsafeAllocationRate = SensorsRegistry.instance.getSensorRate(Context.all(), Type.UNSAFE_BYTES);
+
+        long onHeapUsed = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        long offHeapUsed = ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed();
+        long unsafeUsed = MemoryUtil.allocated();
+
+        boolean onHeapOOM = onHeapUsed + onHeapAllocationRate * W > onHeapMThreshold;
+        boolean offHeapOOM = offHeapUsed + offHeapAllocationRate * W > offHeapMThreshold;
+        boolean unsafeOOM = unsafeUsed + unsafeAllocationRate * W > unsafeHeapMThreshold;
+
+        noSpamLogger.info("OOM prediction report with W={}s and M=0.95% of max available memory\n" +
+                          "    prediction: onHeapOOM={}, offHeapOOM={}, unsafeOOM={}\n" +
+                          "    variables: onHeapMaxMemory={}, offHeapMaxMemory={}, unsafeMaxMemory={}, unsafeEffectiveMaxMemory={}\n" +
+                          "               onHeapUsed={}, offHeapUsed={}, unsafeUsed={}\n" +
+                          "               onHeapBytesSensorValue={}, offHeapBytesSensorValue={}, unsafeBytesSensorValue={}\n" +
+                          "               onHeapAllocationRate={}, offHeapAllocationRate={}, unsafeAllocationRate={}\n",
+                          W,
+                          onHeapOOM, offHeapOOM, unsafeOOM,
+                          FBUtilities.prettyPrintMemory(ON_HEAP_MAX_MEMORY), FBUtilities.prettyPrintMemory(OFF_HEAP_MAX_MEMORY), FBUtilities.prettyPrintMemory(UNSAFE_MAX_MEMORY), FBUtilities.prettyPrintMemory(unsafeEffectiveMaxMemory),
+                          FBUtilities.prettyPrintMemory(onHeapUsed), FBUtilities.prettyPrintMemory(offHeapUsed), FBUtilities.prettyPrintMemory(unsafeUsed),
+                          FBUtilities.prettyPrintMemory(activeRequestSensors.getSensor(Context.all(), Type.ON_HEAP_BYTES).map(Sensor::getValue).orElse(-1d).longValue()),
+                          FBUtilities.prettyPrintMemory(activeRequestSensors.getSensor(Context.all(), Type.OFF_HEAP_BYTES).map(Sensor::getValue).orElse(-1d).longValue()),
+                          FBUtilities.prettyPrintMemory((activeRequestSensors.getSensor(Context.all(), Type.UNSAFE_BYTES).map(Sensor::getValue).orElse(-1d)).longValue()),
+                          FBUtilities.prettyPrintMemoryPerSecond((long) onHeapAllocationRate), FBUtilities.prettyPrintMemoryPerSecond((long) offHeapAllocationRate), FBUtilities.prettyPrintMemoryPerSecond((long) unsafeAllocationRate));
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -232,12 +232,12 @@ public class BufferPool
         ByteBuffer newBuffer;
         if (bufferType == BufferType.ON_HEAP)
         {
-            MemorySensors.incrementOnHeapBytes(size);
+            MemorySensors.instance.incrementOnHeapBytes(size);
             newBuffer = ByteBuffer.allocate(size);
         }
         else
         {
-            MemorySensors.incrementOffHeapBytes(size);
+            MemorySensors.instance.incrementOffHeapBytes(size);
             newBuffer = ByteBuffer.allocateDirect(size);
         }
         return newBuffer;
@@ -1093,7 +1093,7 @@ public class BufferPool
         if (Integer.bitCount(align) != 1)
             throw new IllegalArgumentException("Alignment must be a power of 2");
 
-        MemorySensors.incrementOffHeapBytes(capacity + align);
+        MemorySensors.instance.incrementOffHeapBytes(capacity + align);
         ByteBuffer buffer = ByteBuffer.allocateDirect(capacity + align);
         long address = MemoryUtil.getAddress(buffer);
         long offset = address & (align -1); // (address % align)

--- a/src/java/org/apache/cassandra/utils/memory/HeapCloner.java
+++ b/src/java/org/apache/cassandra/utils/memory/HeapCloner.java
@@ -34,7 +34,7 @@ public final class HeapCloner extends ByteBufferCloner
 
     public ByteBuffer allocate(int size)
     {
-        MemorySensors.incrementOnHeapBytes(size);
+        MemorySensors.instance.incrementOnHeapBytes(size);
         return ByteBuffer.allocate(size);
     }
 }

--- a/src/java/org/apache/cassandra/utils/memory/HeapCloner.java
+++ b/src/java/org/apache/cassandra/utils/memory/HeapCloner.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.utils.memory;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.sensors.memory.MemorySensors;
+
 /**
  * Cloner class that can be use to clone partition elements on heap.
  *
@@ -32,6 +34,7 @@ public final class HeapCloner extends ByteBufferCloner
 
     public ByteBuffer allocate(int size)
     {
+        MemorySensors.incrementOnHeapBytes(size);
         return ByteBuffer.allocate(size);
     }
 }

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -101,7 +101,7 @@ public abstract class MemoryUtil
     public static long allocate(long size)
     {
         memoryAllocated.addAndGet(size);
-        MemorySensors.incrementUnsafeBytes(size);
+        MemorySensors.instance.incrementUnsafeBytes(size);
         return Native.malloc(size);
     }
 

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.sun.jna.Native;
 
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.sensors.memory.MemorySensors;
 import org.apache.cassandra.utils.Architecture;
 
 import sun.misc.Unsafe;
@@ -100,6 +101,7 @@ public abstract class MemoryUtil
     public static long allocate(long size)
     {
         memoryAllocated.addAndGet(size);
+        MemorySensors.incrementUnsafeBytes(size);
         return Native.malloc(size);
     }
 

--- a/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
@@ -108,10 +108,10 @@ public class SlabAllocator extends MemtableBufferAllocator
             unslabbedSize.addAndGet(size);
             if (allocateOnHeapOnly)
             {
-                MemorySensors.incrementOnHeapBytes(size);
+                MemorySensors.instance.incrementOnHeapBytes(size);
                 return ByteBuffer.allocate(size);
             }
-            MemorySensors.incrementOffHeapBytes(size);
+            MemorySensors.instance.incrementOffHeapBytes(size);
             Region region = new Region(ByteBuffer.allocateDirect(size));
             offHeapRegions.add(region);
             return region.allocate(size);
@@ -157,12 +157,12 @@ public class SlabAllocator extends MemtableBufferAllocator
             {
                 if (allocateOnHeapOnly)
                 {
-                    MemorySensors.incrementOnHeapBytes(REGION_SIZE);
+                    MemorySensors.instance.incrementOnHeapBytes(REGION_SIZE);
                     region = new Region(ByteBuffer.allocate(REGION_SIZE));
                 }
                 else
                 {
-                    MemorySensors.incrementOffHeapBytes(REGION_SIZE);
+                    MemorySensors.instance.incrementOffHeapBytes(REGION_SIZE);
                     region = new Region(ByteBuffer.allocateDirect(REGION_SIZE));
                 }
             }

--- a/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/SlabAllocator.java
@@ -107,7 +107,10 @@ public class SlabAllocator extends MemtableBufferAllocator
         {
             unslabbedSize.addAndGet(size);
             if (allocateOnHeapOnly)
+            {
+                MemorySensors.incrementOnHeapBytes(size);
                 return ByteBuffer.allocate(size);
+            }
             MemorySensors.incrementOffHeapBytes(size);
             Region region = new Region(ByteBuffer.allocateDirect(size));
             offHeapRegions.add(region);


### PR DESCRIPTION
### What is the issue
Tracking memory (allocations and snapshots) in order to prevent crashing: https://github.com/riptano/cndb/issues/12408

### What does this PR fix and why was it fixed
VERY draft pr to get a sense of all work areas required, and to deploy in CNDB with metrics enabled so we can iterate. In the meantime, I'm asking for high level feedback (don't chase low level details for now) like:
* The whole idea of taking allocation rate + snapshot for prediction. 
* Should we create specialized sensor APIs for node level metrics? Today the context, that is unique on keyspace/table/table_id is a central design decision. 
* Should publish max memory snapshots as gauges? Or only emit a final boolean OOM prediction to autoscaler? Otherwise, programmatically all info is available. Also, arguably, on-heap and off-heap have well defined maxes by java settings. For unsafe, we need to think how to cap it (should it compete again onheap/offheap maxes or allocated?)
* Better API to use for snapshotting on-heap/off-heap/physical memory? 
* Sensor rate calculation
* ... 

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits