### PR TITLE
Revert "CNDB-12342: Avoid unnecessary looping in QueryView#build (#1491)"

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -83,7 +83,6 @@ import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.index.sai.view.IndexViewManager;
 import org.apache.cassandra.index.sai.view.View;
-import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -153,8 +152,6 @@ public class IndexContext
 
     private final int maxTermSize;
 
-    private volatile boolean dropped = false;
-
     public IndexContext(@Nonnull String keyspace,
                         @Nonnull String table,
                         @Nonnull TableId tableId,
@@ -176,6 +173,7 @@ public class IndexContext
         this.viewManager = new IndexViewManager(this);
         this.validator = TypeUtil.cellValueType(column, indexType);
         this.cfs = cfs;
+
         this.primaryKeyFactory = Version.latest().onDiskFormat().newPrimaryKeyFactory(clusteringComparator);
 
         if (config != null)
@@ -566,12 +564,9 @@ public class IndexContext
     /**
      * @return A set of SSTables which have attached to them invalid index components.
      */
-    public Set<SSTableContext> onSSTableChanged(Collection<SSTableReader> oldSSTables,
-                                                Collection<SSTableReader> newSSTables,
-                                                Collection<SSTableContext> newContexts,
-                                                boolean validate)
+    public Set<SSTableContext> onSSTableChanged(Collection<SSTableReader> oldSSTables, Collection<SSTableContext> newSSTables, boolean validate)
     {
-        return viewManager.update(oldSSTables, newSSTables, newContexts, validate);
+        return viewManager.update(oldSSTables, newSSTables, validate);
     }
 
     public ColumnMetadata getDefinition()
@@ -661,12 +656,7 @@ public class IndexContext
 
     public boolean isIndexed()
     {
-        return config != null && !dropped;
-    }
-
-    public boolean isDropped()
-    {
-        return dropped;
+        return config != null;
     }
 
     /**
@@ -685,7 +675,6 @@ public class IndexContext
      */
     public void invalidate(boolean obsolete)
     {
-        dropped = true;
         liveMemtables.clear();
         viewManager.invalidate(obsolete);
         indexMetrics.release();
@@ -701,16 +690,6 @@ public class IndexContext
     public ConcurrentMap<Memtable, MemtableIndex> getLiveMemtables()
     {
         return liveMemtables;
-    }
-
-    public @Nullable MemtableIndex getMemtableIndex(Memtable memtable)
-    {
-        return liveMemtables.get(memtable);
-    }
-
-    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
-    {
-        return getView().getSSTableIndex(descriptor);
     }
 
     public boolean supports(Operator op)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -801,7 +801,7 @@ public class StorageAttachedIndex implements Index
             //   1. The current view does not contain the SSTable
             //   2. The SSTable is not marked compacted
             //   3. The column index does not have a completion marker
-            if (!view.hasIndexForSSTable(sstable)
+            if (!view.containsSSTable(sstable)
                 && !sstable.isMarkedCompacted()
                 && !IndexDescriptor.isIndexBuildCompleteOnDisk(sstable, indexContext))
             {

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -442,7 +442,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      * Invocations are memorized - multiple calls for the same context return the same view.
      * The views are kept for the lifetime of this {@code QueryController}.
      */
-    QueryView getQueryView(IndexContext context) throws QueryView.Builder.MissingIndexException
+    QueryView getQueryView(IndexContext context)
     {
         return queryViews.computeIfAbsent(context,
                                           c -> new QueryView.Builder(c, mergeRange, queryContext).build());
@@ -586,13 +586,6 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             sstableResults.addAll(memtableResults);
             return MergeIterator.getNonReducingCloseable(sstableResults, orderer.getComparator());
         }
-        catch (QueryView.Builder.MissingIndexException e)
-        {
-            if (orderer.context.isDropped())
-                throw invalidRequest(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED);
-            else
-                throw new IllegalStateException("Index not found but hasn't been dropped", e);
-        }
         catch (Throwable t)
         {
             FileUtils.closeQuietly(memtableResults);
@@ -655,16 +648,15 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(List<PrimaryKey> sourceKeys, int softLimit)
     {
         Tracing.logAndTrace(logger, "SAI predicates produced {} keys", sourceKeys.size());
-        List<CloseableIterator<PrimaryKeyWithSortKey>> memtableResults = null;
+        QueryView view = getQueryView(orderer.context);
+        var memtableResults = view.memtableIndexes.stream()
+                                                               .map(index -> index.orderResultsBy(queryContext,
+                                                                                                  sourceKeys,
+                                                                                                  orderer,
+                                                                                                  softLimit))
+                                                               .collect(Collectors.toList());
         try
         {
-            QueryView view = getQueryView(orderer.context);
-            memtableResults = view.memtableIndexes.stream()
-                                                  .map(index -> index.orderResultsBy(queryContext,
-                                                                                     sourceKeys,
-                                                                                     orderer,
-                                                                                     softLimit))
-                                                  .collect(Collectors.toList());
             var totalRows = view.getTotalSStableRows();
             SSTableSearcher ssTableSearcher = index -> index.orderResultsBy(queryContext,
                                                                             sourceKeys,
@@ -675,17 +667,9 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             sstableScoredPrimaryKeyIterators.addAll(memtableResults);
             return MergeIterator.getNonReducingCloseable(sstableScoredPrimaryKeyIterators, orderer.getComparator());
         }
-        catch (QueryView.Builder.MissingIndexException e)
-        {
-            if (orderer.context.isDropped())
-                throw invalidRequest(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED);
-            else
-                throw new IllegalStateException("Index not found but hasn't been dropped", e);
-        }
         catch (Throwable t)
         {
-            if (memtableResults != null)
-                FileUtils.closeQuietly(memtableResults);
+            FileUtils.closeQuietly(memtableResults);
             throw t;
         }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.index.sai.plan;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,12 +27,12 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.googlecode.concurrenttrees.common.Iterables;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
-import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -41,12 +40,10 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
-import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
-
 
 public class QueryView implements AutoCloseable
 {
@@ -105,157 +102,79 @@ public class QueryView implements AutoCloseable
         }
 
         /**
-         * Denotes a situation when there exist no index for an active memtable or sstable.
-         * This can happen e.g. when the index gets dropped while running the query.
-         */
-        static class MissingIndexException extends RuntimeException
-        {
-            final IndexContext context;
-
-            public MissingIndexException(IndexContext context, String message)
-            {
-                super(message);
-                this.context = context;
-            }
-        }
-
-        /**
          * Acquire references to all the memtables, memtable indexes, sstables, and sstable indexes required for the
          * given expression.
+         * <p>
+         * Will retry if the active sstables change concurrently.
          */
-        protected QueryView build() throws MissingIndexException
+        protected QueryView build()
         {
             var referencedIndexes = new HashSet<SSTableIndex>();
-            ColumnFamilyStore.RefViewFragment refViewFragment = null;
-
-            // We must use the canonical view in order for the equality check for source sstable/memtable
-            // to work correctly.
-            var filter = RangeUtil.coversFullRing(range)
-                         ? View.selectFunction(SSTableSet.CANONICAL)
-                         : View.select(SSTableSet.CANONICAL, s -> RangeUtil.intersects(s, range));
-
-
+            long failingSince = -1L;
             try
             {
-                // Keeps track of which memtables we've already tried to match the index to.
-                // If we fail to match the index to the memtable for the first time, we have to retry
-                // because the memtable could be flushed and its index removed between the moment we
-                // got the view and the moment we did the lookup.
-                // If we get the same memtable in the view again, and there is no index,
-                // then the missing index is not due to a concurrent modification, but it doesn't contain indexed
-                // data, so we can ignore it.
-                var processedMemtables = new HashSet<Memtable>();
-
-
-                var start = MonotonicClock.approxTime.now();
-                Memtable unmatchedMemtable = null;
-                Descriptor unmatchedSStable = null;
-
-                // This loop will spin only if there is a mismatch between the view managed by IndexViewManager
-                // and the view managed by Cassandra Tracker. Such a mismatch can happen at the moment when
-                // the sstable or memtable sets are updated, e.g. on flushes or compactions. The mismatch
-                // should last only until all Tracker notifications get processed by SAI
-                // (which doesn't involve I/O and should be very fast). We expect the mismatch to resolve in order
-                // of nanoceconds, but the timeout is large enough just in case of unpredictable performance hiccups.
                 outer:
-                while (!MonotonicClock.approxTime.isAfter(start + TimeUnit.MILLISECONDS.toNanos(2000)))
+                while (true)
                 {
-                    // cleanup after the previous iteration if we're retrying
-                    release(referencedIndexes);
-                    release(refViewFragment);
-
-                    // Prevent exceeding the query timeout
+                    // Prevent an infinite loop
                     queryContext.checkpoint();
 
-                    // Lock a consistent view of memtables and sstables.
-                    // A consistent view is required for correctness of order by and vector queries.
-                    refViewFragment = cfs.selectAndReference(filter);
-                    var indexView = indexContext.getView();
+                    // Acquire live memtable index and memtable references first to avoid missing an sstable due to flush.
+                    // Copy the memtable indexes to avoid concurrent modification.
+                    var memtableIndexes = new HashSet<>(indexContext.getLiveMemtables().values());
 
-                    // Lookup the indexes corresponding to memtables:
-                    var memtableIndexes = new HashSet<MemtableIndex>();
-                    for (Memtable memtable : refViewFragment.memtables)
+                    // We must use the canonical view in order for the equality check for source sstable/memtable
+                    // to work correctly.
+                    var filter = RangeUtil.coversFullRing(range)
+                                 ? View.selectFunction(SSTableSet.CANONICAL)
+                                 : View.select(SSTableSet.CANONICAL, s -> RangeUtil.intersects(s, range));
+                    var refViewFragment = cfs.selectAndReference(filter);
+                    var memtables = Iterables.toSet(refViewFragment.memtables);
+                    // Confirm that all the memtables associated with the memtable indexes we already have are still live.
+                    // There might be additional memtables that are not associated with the expression because tombstones
+                    // are not indexed.
+                    for (MemtableIndex memtableIndex : memtableIndexes)
                     {
-                        // Empty memtables have no index but that's not a problem, we can ignore them.
-                        if (memtable.getLiveDataSize() == 0)
-                            continue;
-
-                        MemtableIndex index = indexContext.getMemtableIndex(memtable);
-                        if (index != null)
+                        if (!memtables.contains(memtableIndex.getMemtable()))
                         {
-                            memtableIndexes.add(index);
-                        }
-                        else if (indexContext.isDropped())
-                        {
-                            // Index was dropped deliberately by the user.
-                            // We cannot recover here.
                             refViewFragment.release();
-                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                          " not found for memtable: " + memtable);
-                        }
-                        else if (!processedMemtables.contains(memtable))
-                        {
-                            // We can end up here if a flush happened right after we referenced the refViewFragment
-                            // but before looking up the memtable index.
-                            // In that case, we need to retry with the updated view
-                            // (we expect the updated view to not contain this memtable).
-
-                            // Remember this metable to protect from infinite looping in case we have a permanent
-                            // inconsistency between the index set and the memtable set.
-                            processedMemtables.add(memtable);
-
-                            unmatchedMemtable = memtable;
                             continue outer;
                         }
-                        // If the memtable was non-empty, the index context hasn't been dropped, but the
-                        // index doesn't exist on the second attempt, then his means there is no indexed data
-                        // in that memtable. In this case we just continue without it.
-                        // Memtable indexes are created lazily, on the first insert, therefore a missing index
-                        // is a normal situation.
                     }
 
-                    // Lookup and reference the indexes corresponding to the sstables:
-                    for (SSTableReader sstable : refViewFragment.sstables)
+                    Set<SSTableIndex> indexes = getIndexesForExpression(indexContext);
+                    // Attempt to reference each of the indexes, and thn confirm that the sstable associated with the index
+                    // is in the refViewFragment. If it isn't in the refViewFragment, we will get incorrect results, so
+                    // we release the indexes and refViewFragment and try again.
+                    for (SSTableIndex index : indexes)
                     {
-                        // If the IndexViewManager never saw this sstable, then we need to spin.
-                        // Let's hope in the next iteration we get the indexView based on the same sstable set
-                        // as the refViewFragment.
-                        if (!indexView.containsSSTable(sstable))
-                        {
-                            if (MonotonicClock.approxTime.isAfter(start + 100))
-                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                 "Spinning trying to get the index for sstable {} because index view is out of sync", sstable.descriptor);
+                        var success = index.reference();
+                        if (success)
+                            referencedIndexes.add(index);
 
-                            unmatchedSStable = sstable.descriptor;
+                        if (!success || !refViewFragment.sstables.contains(index.getSSTable()))
+                        {
+                            referencedIndexes.forEach(SSTableIndex::release);
+                            referencedIndexes.clear();
+                            refViewFragment.release();
+
+                            // Log about the failures
+                            if (failingSince <= 0)
+                            {
+                                failingSince = MonotonicClock.approxTime.now();
+                            }
+                            else if (MonotonicClock.approxTime.now() - failingSince > TimeUnit.MILLISECONDS.toNanos(100))
+                            {
+                                failingSince = MonotonicClock.approxTime.now();
+                                if (success)
+                                    NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
+                                                     "Spinning trying to capture index reader for {}, but it was released.", index);
+                                else
+                                    NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
+                                                     "Spinning trying to capture readers for {}, but : {}, ", refViewFragment.sstables, index.getSSTable());
+                            }
                             continue outer;
                         }
-
-                        SSTableIndex index = indexView.getSSTableIndex(sstable.descriptor);
-
-                        // The IndexViewManager got the update about this sstable, but there is no index for the sstable
-                        // (e.g. index was dropped or got corrupt, etc.). In this case retrying won't fix it.
-                        if (index == null)
-                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                          " not found for sstable: " + sstable.descriptor);
-
-                        if (!indexInRange(index))
-                            continue;
-
-                        // It is unlikely but possible the index got unreferenced just between the moment we grabbed the
-                        // refViewFragment and getting here. In that case we won't be able to reference it and we have
-                        // to retry.
-                        if (!index.reference())
-                        {
-
-                            if (MonotonicClock.approxTime.isAfter(start + 100))
-                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                 "Spinning trying to get the index for sstable {} because index was released", sstable.descriptor);
-
-                            unmatchedSStable = sstable.descriptor;
-                            continue outer;
-                        }
-
-                        referencedIndexes.add(index);
                     }
 
                     // freeze referencedIndexes and memtableIndexes, so we can safely give access to them
@@ -266,24 +185,6 @@ public class QueryView implements AutoCloseable
                                          Collections.unmodifiableSet(memtableIndexes),
                                          indexContext);
                 }
-
-
-                if (unmatchedMemtable != null)
-                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                  " not found for memtable " + unmatchedMemtable);
-                if (unmatchedSStable != null)
-                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                  " not found for sstable " + unmatchedSStable);
-
-                // This should be unreachable, because whenever we retry, we always set unmatchedMemtable
-                // or unmatchedSSTable, so we'd log a better message above.
-                throw new MissingIndexException(indexContext, "Failed to build QueryView for index " + indexContext.getIndexName());
-            }
-            catch (MissingIndexException e)
-            {
-                release(referencedIndexes);
-                release(refViewFragment);
-                throw e;
             }
             finally
             {
@@ -299,17 +200,16 @@ public class QueryView implements AutoCloseable
             }
         }
 
-        private void release(ColumnFamilyStore.RefViewFragment refViewFragment)
+        /**
+         * Get the index
+         */
+        private Set<SSTableIndex> getIndexesForExpression(IndexContext indexContext)
         {
-            if (refViewFragment != null)
-                refViewFragment.release();
-        }
+            if (!indexContext.isIndexed())
+                throw new IllegalArgumentException("Expression is not indexed");
 
-        private void release(Collection<SSTableIndex> indexes)
-        {
-            for (var index : indexes)
-                index.release();
-            indexes.clear();
+            // Get all the indexes in the range.
+            return indexContext.getView().getIndexes().stream().filter(this::indexInRange).collect(Collectors.toSet());
         }
 
         // I've removed the concept of "most selective index" since we don't actually have per-sstable
@@ -327,4 +227,5 @@ public class QueryView implements AutoCloseable
             return range.left.compareTo(sstable.last) <= 0 && (range.right.isMinimum() || sstable.first.compareTo(range.right) <= 0);
         }
     }
+
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -67,8 +67,6 @@ import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.FBUtilities;
 
-import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
-
 public class StorageAttachedIndexSearcher implements Index.Searcher
 {
     private static final Logger logger = LoggerFactory.getLogger(StorageAttachedIndexSearcher.class);
@@ -99,54 +97,32 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     @SuppressWarnings("unchecked")
     public UnfilteredPartitionIterator search(ReadExecutionController executionController) throws RequestTimeoutException
     {
-        int retries = 0;
-        while (true)
+        try
         {
-            try
-            {
-                FilterTree filterTree = analyzeFilter();
-                Plan plan = controller.buildPlan();
-                Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
+            FilterTree filterTree = analyzeFilter();
+            Plan plan = controller.buildPlan();
+            Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
 
-                // Can't check for `command.isTopK()` because the planner could optimize sorting out
-                Orderer ordering = plan.ordering();
-                if (ordering != null)
-                {
-                    assert !(keysIterator instanceof KeyRangeIterator);
-                    var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
-                    var result = new ScoreOrderedResultRetriever(scoredKeysIterator, filterTree, controller,
-                                                                 executionController, queryContext, command.limits().count());
-                    return (UnfilteredPartitionIterator) new TopKProcessor(command).filter(result);
-                }
-                else
-                {
-                    assert keysIterator instanceof KeyRangeIterator;
-                    return new ResultRetriever((KeyRangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
-                }
-            }
-            catch (QueryView.Builder.MissingIndexException e)
+            // Can't check for `command.isTopK()` because the planner could optimize sorting out
+            Orderer ordering = plan.ordering();
+            if (ordering != null)
             {
-                // If an index was dropped while we were preparing the plan or between preparing the plan
-                // and creating the result retriever, we can retry without that index,
-                // because there may be other indexes that could be used to run the query.
-                // And if there are no good indexes left, we'd get a good contextual request error message.
-                if (e.context.isDropped() && retries < 8)
-                {
-                    logger.debug("Index " + e.context.getIndexName() + " dropped while preparing the query plan. Retrying.");
-                    retries++;
-                    continue;
-                }
-
-                // If we end up here, this is either a bug or a problem with an index (corrupted / missing components?).
-                controller.abort();
-                logger.error("Index not found", e);
-                throw invalidRequest("Index missing or corrupt: " + e.context.getIndexName());
+                assert !(keysIterator instanceof KeyRangeIterator);
+                var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
+                var result = new ScoreOrderedResultRetriever(scoredKeysIterator, filterTree, controller,
+                                                             executionController, queryContext, command.limits().count());
+                return (UnfilteredPartitionIterator) new TopKProcessor(command).filter(result);
             }
-            catch (Throwable t)
+            else
             {
-                controller.abort();
-                throw t;
+                assert keysIterator instanceof KeyRangeIterator;
+                return new ResultRetriever((KeyRangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
             }
+        }
+        catch (Throwable t)
+        {
+            controller.abort();
+            throw t;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
+++ b/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -53,17 +52,16 @@ public class IndexViewManager
     private final IndexContext context;
     private final AtomicReference<View> view = new AtomicReference<>();
 
-
     public IndexViewManager(IndexContext context)
     {
-        this(context, Collections.emptySet(), Collections.emptySet());
+        this(context, Collections.emptySet());
     }
 
     @VisibleForTesting
-    IndexViewManager(IndexContext context, Collection<Descriptor> sstables, Collection<SSTableIndex> indices)
+    IndexViewManager(IndexContext context, Collection<SSTableIndex> indices)
     {
         this.context = context;
-        this.view.set(new View(context, sstables, indices));
+        this.view.set(new View(context, indices));
     }
 
     public View getView()
@@ -75,16 +73,12 @@ public class IndexViewManager
      * Replaces old SSTables with new by creating new immutable view.
      *
      * @param oldSSTables A set of SSTables to remove.
-     * @param newSSTables A set of SSTables added in Cassandra.
      * @param newSSTableContexts A set of SSTableContexts to add to tracker.
      * @param validate if true, per-column index files' header and footer will be validated.
      *
      * @return A set of SSTables which have attached to them invalid index components.
      */
-    public Set<SSTableContext> update(Collection<SSTableReader> oldSSTables,
-                                      Collection<SSTableReader> newSSTables,
-                                      Collection<SSTableContext> newSSTableContexts,
-                                      boolean validate)
+    public Set<SSTableContext> update(Collection<SSTableReader> oldSSTables, Collection<SSTableContext> newSSTableContexts, boolean validate)
     {
         // Valid indexes on the left and invalid SSTable contexts on the right...
         Pair<Set<SSTableIndex>, Set<SSTableContext>> indexes = context.getBuiltIndexes(newSSTableContexts, validate);
@@ -93,18 +87,12 @@ public class IndexViewManager
         Map<Descriptor, SSTableIndex> newViewIndexes = new HashMap<>();
         Collection<SSTableIndex> releasableIndexes = new ArrayList<>();
         Collection<SSTableReader> toRemove = new HashSet<>(oldSSTables);
-
+        
         do
         {
             currentView = view.get();
             newViewIndexes.clear();
             releasableIndexes.clear();
-
-            Set<Descriptor> sstables = new HashSet<>(currentView.getSSTables());
-            for (SSTableReader sstable : oldSSTables)
-                sstables.remove(sstable.descriptor);
-            for (SSTableReader sstable : newSSTables)
-                sstables.add(sstable.descriptor);
 
             for (SSTableIndex sstableIndex : currentView)
             {
@@ -123,7 +111,7 @@ public class IndexViewManager
                 addOrUpdateSSTableIndex(sstableIndex, newViewIndexes, releasableIndexes);
             }
 
-            newView = new View(context, sstables, newViewIndexes.values());
+            newView = new View(context, newViewIndexes.values());
         }
         while (!view.compareAndSet(currentView, newView));
 
@@ -157,24 +145,19 @@ public class IndexViewManager
 
     public void prepareSSTablesForRebuild(Collection<SSTableReader> sstablesToRebuild)
     {
-        Set<SSTableReader> toRemove = new HashSet<>(sstablesToRebuild);
-        View oldView, newView;
-        Set<SSTableIndex> indexesToRemove;
-        do
-        {
-            oldView = view.get();
-            indexesToRemove = oldView.getIndexes()
-                                     .stream()
-                                     .filter(index -> toRemove.contains(index.getSSTable()))
-                                     .collect(Collectors.toSet());
-            var newIndexes = new HashSet<>(oldView.getIndexes());
-            newIndexes.removeAll(indexesToRemove);
-            newView = new View(context, oldView.getSSTables(), newIndexes);
-        }
-        while (!view.compareAndSet(oldView, newView));
+        View currentView = view.get();
 
-        for (SSTableIndex index : indexesToRemove)
+        Set<SSTableReader> toRemove = new HashSet<>(sstablesToRebuild);
+        for (SSTableIndex index : currentView)
+        {
+            SSTableReader sstable = index.getSSTable();
+            if (!toRemove.contains(sstable))
+                continue;
+
             index.release();
+        }
+
+        update(toRemove, Collections.emptyList(), false);
     }
 
     /**
@@ -186,15 +169,9 @@ public class IndexViewManager
      */
     public void invalidate(boolean indexWasDropped)
     {
-        View oldView, newView;
-        do
-        {
-            oldView = view.get();
-            newView = new View(context, oldView.getSSTables(), Collections.emptySet());
+        View previousView = view.getAndSet(new View(context, Collections.emptyList()));
 
-        } while (!view.compareAndSet(oldView, newView));
-
-        for (SSTableIndex index : oldView)
+        for (SSTableIndex index : previousView)
         {
             if (indexWasDropped)
                 index.markIndexDropped();

--- a/src/java/org/apache/cassandra/index/sai/view/View.java
+++ b/src/java/org/apache/cassandra/index/sai/view/View.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -41,17 +39,15 @@ import org.apache.cassandra.utils.IntervalTree;
 
 public class View implements Iterable<SSTableIndex>
 {
-    private final Set<Descriptor> sstables;
     private final Map<Descriptor, SSTableIndex> view;
 
     private final TermTree termTree;
     private final AbstractType<?> keyValidator;
     private final IntervalTree<Key, SSTableIndex, Interval<Key, SSTableIndex>> keyIntervalTree;
 
-    public View(IndexContext context, Collection<Descriptor> sstables, Collection<SSTableIndex> indexes)
+    public View(IndexContext context, Collection<SSTableIndex> indexes)
     {
         this.view = new HashMap<>();
-        this.sstables = new HashSet<>(sstables);
         this.keyValidator = context.keyValidator();
 
         AbstractType<?> validator = context.getValidator();
@@ -98,11 +94,6 @@ public class View implements Iterable<SSTableIndex>
         return view.values().iterator();
     }
 
-    public Collection<Descriptor> getSSTables()
-    {
-        return sstables;
-    }
-
     public Collection<SSTableIndex> getIndexes()
     {
         return view.values();
@@ -110,22 +101,12 @@ public class View implements Iterable<SSTableIndex>
 
     public boolean containsSSTable(SSTableReader sstable)
     {
-        return sstables.contains(sstable.descriptor);
+        return view.containsKey(sstable.descriptor);
     }
 
     public int size()
     {
         return view.size();
-    }
-
-    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
-    {
-        return view.get(descriptor);
-    }
-
-    public boolean hasIndexForSSTable(SSTableReader sstable)
-    {
-        return view.containsKey(sstable.descriptor);
     }
 
     /**

--- a/src/java/org/apache/cassandra/notifications/SSTableAddedNotification.java
+++ b/src/java/org/apache/cassandra/notifications/SSTableAddedNotification.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.compaction.OperationType;
-import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -192,10 +192,10 @@ public class SecondaryIndexManagerTest extends CQLTester
         assertEmpty(execute("SELECT * FROM %s WHERE a=1"));
         assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
-        // track sstable again: expect the query that needs the index cannot execute
+        // track sstable again: expect no rows to be read by index
         cfs.getTracker().addInitialSSTables(sstables);
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
-        assertInvalid("SELECT * FROM %s WHERE c=1");
+        assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -1036,8 +1036,6 @@ public class NativeIndexDDLTest extends SAITester
             (corruptionType != CorruptionType.REMOVED))
             return;
 
-        logger.info("CORRUPTING: " + component + ", corruption type = " + corruptionType);
-
         int rowCount = 2;
 
         // initial verification

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -160,7 +160,6 @@ public class IndexViewManagerTest extends SAITester
                                                 .map(desc -> new Descriptor(new File(tmpDir), KEYSPACE, tableName, desc.id))
                                                 .map(desc -> desc.getFormat().getReaderFactory().open(desc))
                                                 .collect(Collectors.toList());
-
         assertThat(sstables).hasSize(4);
 
         List<SSTableReader> none = Collections.emptyList();
@@ -179,19 +178,16 @@ public class IndexViewManagerTest extends SAITester
                 initialIndexes.add(mockSSTableIndex);
             }
 
-            IndexViewManager tracker = new IndexViewManager(columnContext, descriptors, initialIndexes);
+            IndexViewManager tracker = new IndexViewManager(columnContext, initialIndexes);
             View initialView = tracker.getView();
             assertEquals(2, initialView.size());
 
-            List<SSTableReader> compacted = List.of(sstables.get(2));
-            List<SSTableReader> flushed = List.of(sstables.get(3));
-
-            List<SSTableContext> compactedContexts = compacted.stream().map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
-            List<SSTableContext> flushedContexts = flushed.stream().map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
+            List<SSTableContext> compacted = sstables.stream().skip(2).limit(1).map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
+            List<SSTableContext> flushed = sstables.stream().skip(3).limit(1).map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
 
             // concurrently update from both flush and compaction
-            Future<?> compaction = executor.submit(() -> tracker.update(initial, compacted, compactedContexts, true));
-            Future<?> flush = executor.submit(() -> tracker.update(none, flushed, flushedContexts, true));
+            Future<?> compaction = executor.submit(() -> tracker.update(initial, compacted, true));
+            Future<?> flush = executor.submit(() -> tracker.update(none, flushed, true));
 
             FBUtilities.waitOnFutures(Arrays.asList(compaction, flush));
 
@@ -210,11 +206,11 @@ public class IndexViewManagerTest extends SAITester
             initialContexts.forEach(group -> assertTrue(group.isCleanedUp()));
 
             // release compacted and flushed SSTableContext original and shared copies
-            compactedContexts.forEach(SSTableContext::close);
-            flushedContexts.forEach(SSTableContext::close);
+            compacted.forEach(SSTableContext::close);
+            flushed.forEach(SSTableContext::close);
             tracker.getView().getIndexes().forEach(SSTableIndex::release);
-            compactedContexts.forEach(group -> assertTrue(group.isCleanedUp()));
-            flushedContexts.forEach(group -> assertTrue(group.isCleanedUp()));
+            compacted.forEach(group -> assertTrue(group.isCleanedUp()));
+            flushed.forEach(group -> assertTrue(group.isCleanedUp()));
         }
         sstables.forEach(sstable -> sstable.selfRef().release());
         executor.shutdown();


### PR DESCRIPTION

This commit failed several CNDB tests.

This reverts commit 6a1e98148bc6ce02003d2569d66e7d31c216a0f1.