### PR TITLE
CNDB-12434: Fix flaky CQLCompressionTest failures

### DIFF
--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -260,16 +260,11 @@ public class CQLCompressionTest extends CQLTester
     {
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
 
-        // Insert multiple entries to force overlap
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k10", "v10");
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k11", "v11");
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k12", "v12");
+        execute("INSERT INTO %s (k, v) values (?, ?)", "k1" , "v1");
         flush();
         assertEquals(1, cfs.getLiveSSTables().size());
 
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k20", "v20");
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k21", "v21");
-        execute("INSERT INTO %s (k, v) values (?, ?)", "k22", "v22");
+        execute("INSERT INTO %s (k, v) values (?, ?)", "k2", "v2");
         flush();
         assertEquals(2, cfs.getLiveSSTables().size());
 


### PR DESCRIPTION
### What is the issue
CQLCompressionTest experiences flaky test failures when 3 sstables are detected rather than the expected 2.

### What does this PR fix and why was it fixed
This PR switches back to inserting single rows before triggering flushes in the test. Multiple rows were needed due to UCS's previous maximal compaction behavior, but if an asynchronous CQLTester schema change dropped a table while rows were being inserted, an additional flush could be trigger in the middle of inserting multiple rows. This would generate more sstables than expected. Since multiple rows are no longer needed after #1342 due to changes in UCS behavior, we can revert to the previous behavior and avoid the flakiness without waiting for schema changes to complete between tests.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits