### PR TITLE
CNDB-12342 Fix query view builder inifinite loop

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -83,6 +83,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.index.sai.view.IndexViewManager;
 import org.apache.cassandra.index.sai.view.View;
+import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -152,6 +153,8 @@ public class IndexContext
 
     private final int maxTermSize;
 
+    private volatile boolean dropped = false;
+
     public IndexContext(@Nonnull String keyspace,
                         @Nonnull String table,
                         @Nonnull TableId tableId,
@@ -173,7 +176,6 @@ public class IndexContext
         this.viewManager = new IndexViewManager(this);
         this.validator = TypeUtil.cellValueType(column, indexType);
         this.cfs = cfs;
-
         this.primaryKeyFactory = Version.latest().onDiskFormat().newPrimaryKeyFactory(clusteringComparator);
 
         if (config != null)
@@ -564,9 +566,12 @@ public class IndexContext
     /**
      * @return A set of SSTables which have attached to them invalid index components.
      */
-    public Set<SSTableContext> onSSTableChanged(Collection<SSTableReader> oldSSTables, Collection<SSTableContext> newSSTables, boolean validate)
+    public Set<SSTableContext> onSSTableChanged(Collection<SSTableReader> oldSSTables,
+                                                Collection<SSTableReader> newSSTables,
+                                                Collection<SSTableContext> newContexts,
+                                                boolean validate)
     {
-        return viewManager.update(oldSSTables, newSSTables, validate);
+        return viewManager.update(oldSSTables, newSSTables, newContexts, validate);
     }
 
     public ColumnMetadata getDefinition()
@@ -656,7 +661,12 @@ public class IndexContext
 
     public boolean isIndexed()
     {
-        return config != null;
+        return config != null && !dropped;
+    }
+
+    public boolean isDropped()
+    {
+        return dropped;
     }
 
     /**
@@ -675,6 +685,7 @@ public class IndexContext
      */
     public void invalidate(boolean obsolete)
     {
+        dropped = true;
         liveMemtables.clear();
         viewManager.invalidate(obsolete);
         indexMetrics.release();
@@ -690,6 +701,16 @@ public class IndexContext
     public ConcurrentMap<Memtable, MemtableIndex> getLiveMemtables()
     {
         return liveMemtables;
+    }
+
+    public @Nullable MemtableIndex getMemtableIndex(Memtable memtable)
+    {
+        return liveMemtables.get(memtable);
+    }
+
+    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
+    {
+        return getView().getSSTableIndex(descriptor);
     }
 
     public boolean supports(Operator op)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -801,7 +801,7 @@ public class StorageAttachedIndex implements Index
             //   1. The current view does not contain the SSTable
             //   2. The SSTable is not marked compacted
             //   3. The column index does not have a completion marker
-            if (!view.containsSSTable(sstable)
+            if (!view.containsSSTableIndex(sstable.descriptor)
                 && !sstable.isMarkedCompacted()
                 && !IndexDescriptor.isIndexBuildCompleteOnDisk(sstable, indexContext))
             {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -34,6 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,6 +89,8 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     private final ColumnFamilyStore baseCfs;
 
     private final SSTableContextManager contextManager;
+
+
 
     StorageAttachedIndexGroup(ColumnFamilyStore baseCfs)
     {
@@ -302,7 +305,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             // Avoid validation for index files just written following Memtable flush. ZCS streaming should
             // validate index checksum.
             boolean validate = notice.fromStreaming() || !notice.memtable().isPresent();
-            onSSTableChanged(Collections.emptySet(), notice.added, indices, validate);
+            onSSTableChanged(Collections.emptySet(), Lists.newArrayList(notice.added), indices, validate);
         }
         else if (notification instanceof SSTableListChangedNotification)
         {
@@ -342,7 +345,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
      * @return the set of column indexes that were marked as non-queryable as a result of their per-SSTable index
      * files being corrupt or being unable to successfully update their views
      */
-    public synchronized Set<StorageAttachedIndex> onSSTableChanged(Collection<SSTableReader> removed, Iterable<SSTableReader> added,
+    public synchronized Set<StorageAttachedIndex> onSSTableChanged(Collection<SSTableReader> removed, Collection<SSTableReader> added,
                                                             Set<StorageAttachedIndex> indexes, boolean validate)
     {
         Optional<Set<SSTableContext>> optValid = contextManager.update(removed, added, validate, indices);
@@ -357,7 +360,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
 
         for (StorageAttachedIndex index : indexes)
         {
-            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, optValid.get(), validate);
+            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, added, optValid.get(), validate);
 
             if (!invalid.isEmpty())
             {

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.plan;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -27,12 +28,12 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.googlecode.concurrenttrees.common.Iterables;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -40,10 +41,12 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
+import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
+
 
 public class QueryView implements AutoCloseable
 {
@@ -102,79 +105,160 @@ public class QueryView implements AutoCloseable
         }
 
         /**
+         * Denotes a situation when there exist no index for an active memtable or sstable.
+         * This can happen e.g. when the index gets dropped while running the query.
+         */
+        static class MissingIndexException extends RuntimeException
+        {
+            final IndexContext context;
+
+            public MissingIndexException(IndexContext context, String message)
+            {
+                super(message);
+                this.context = context;
+            }
+        }
+
+        /**
          * Acquire references to all the memtables, memtable indexes, sstables, and sstable indexes required for the
          * given expression.
-         * <p>
-         * Will retry if the active sstables change concurrently.
          */
-        protected QueryView build()
+        protected QueryView build() throws MissingIndexException
         {
             var referencedIndexes = new HashSet<SSTableIndex>();
-            long failingSince = -1L;
+            ColumnFamilyStore.RefViewFragment refViewFragment = null;
+
+            // We must use the canonical view in order for the equality check for source sstable/memtable
+            // to work correctly.
+            var filter = RangeUtil.coversFullRing(range)
+                         ? View.selectFunction(SSTableSet.CANONICAL)
+                         : View.select(SSTableSet.CANONICAL, s -> RangeUtil.intersects(s, range));
+
+
             try
             {
+                // Keeps track of which memtables we've already tried to match the index to.
+                // If we fail to match the index to the memtable for the first time, we have to retry
+                // because the memtable could be flushed and its index removed between the moment we
+                // got the view and the moment we did the lookup.
+                // If we get the same memtable in the view again, and there is no index,
+                // then the missing index is not due to a concurrent modification, but it doesn't contain indexed
+                // data, so we can ignore it.
+                var processedMemtables = new HashSet<Memtable>();
+
+
+                var start = MonotonicClock.approxTime.now();
+                Memtable unmatchedMemtable = null;
+                Descriptor unmatchedSStable = null;
+
+                // This loop will spin only if there is a mismatch between the view managed by IndexViewManager
+                // and the view managed by Cassandra Tracker. Such a mismatch can happen at the moment when
+                // the sstable or memtable sets are updated, e.g. on flushes or compactions. The mismatch
+                // should last only until all Tracker notifications get processed by SAI
+                // (which doesn't involve I/O and should be very fast). We expect the mismatch to resolve in order
+                // of nanoceconds, but the timeout is large enough just in case of unpredictable performance hiccups.
                 outer:
-                while (true)
+                while (!MonotonicClock.approxTime.isAfter(start + TimeUnit.MILLISECONDS.toNanos(2000)))
                 {
-                    // Prevent an infinite loop
+                    // cleanup after the previous iteration if we're retrying
+                    release(referencedIndexes);
+                    release(refViewFragment);
+
+                    // Prevent exceeding the query timeout
                     queryContext.checkpoint();
 
-                    // Acquire live memtable index and memtable references first to avoid missing an sstable due to flush.
-                    // Copy the memtable indexes to avoid concurrent modification.
-                    var memtableIndexes = new HashSet<>(indexContext.getLiveMemtables().values());
+                    // Lock a consistent view of memtables and sstables.
+                    // A consistent view is required for correctness of order by and vector queries.
+                    refViewFragment = cfs.selectAndReference(filter);
+                    var indexView = indexContext.getView();
 
-                    // We must use the canonical view in order for the equality check for source sstable/memtable
-                    // to work correctly.
-                    var filter = RangeUtil.coversFullRing(range)
-                                 ? View.selectFunction(SSTableSet.CANONICAL)
-                                 : View.select(SSTableSet.CANONICAL, s -> RangeUtil.intersects(s, range));
-                    var refViewFragment = cfs.selectAndReference(filter);
-                    var memtables = Iterables.toSet(refViewFragment.memtables);
-                    // Confirm that all the memtables associated with the memtable indexes we already have are still live.
-                    // There might be additional memtables that are not associated with the expression because tombstones
-                    // are not indexed.
-                    for (MemtableIndex memtableIndex : memtableIndexes)
+                    // Lookup the indexes corresponding to memtables:
+                    var memtableIndexes = new HashSet<MemtableIndex>();
+                    for (Memtable memtable : refViewFragment.memtables)
                     {
-                        if (!memtables.contains(memtableIndex.getMemtable()))
+                        // Empty memtables have no index but that's not a problem, we can ignore them.
+                        if (memtable.getLiveDataSize() == 0)
+                            continue;
+
+                        MemtableIndex index = indexContext.getMemtableIndex(memtable);
+                        if (index != null)
                         {
-                            refViewFragment.release();
+                            memtableIndexes.add(index);
+                        }
+                        else if (indexContext.isDropped())
+                        {
+                            // Index was dropped deliberately by the user.
+                            // We cannot recover here.
+                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
+                                                                          " not found for memtable: " + memtable);
+                        }
+                        else if (!processedMemtables.contains(memtable))
+                        {
+                            // We can end up here if a flush happened right after we referenced the refViewFragment
+                            // but before looking up the memtable index.
+                            // In that case, we need to retry with the updated view
+                            // (we expect the updated view to not contain this memtable).
+
+                            // Remember this metable to protect from infinite looping in case we have a permanent
+                            // inconsistency between the index set and the memtable set.
+                            processedMemtables.add(memtable);
+
+                            unmatchedMemtable = memtable;
                             continue outer;
                         }
+                        // If the memtable was non-empty, the index context hasn't been dropped, but the
+                        // index doesn't exist on the second attempt, then his means there is no indexed data
+                        // in that memtable. In this case we just continue without it.
+                        // Memtable indexes are created lazily, on the first insert, therefore a missing index
+                        // is a normal situation.
                     }
 
-                    Set<SSTableIndex> indexes = getIndexesForExpression(indexContext);
-                    // Attempt to reference each of the indexes, and thn confirm that the sstable associated with the index
-                    // is in the refViewFragment. If it isn't in the refViewFragment, we will get incorrect results, so
-                    // we release the indexes and refViewFragment and try again.
-                    for (SSTableIndex index : indexes)
+                    // Lookup and reference the indexes corresponding to the sstables:
+                    for (SSTableReader sstable : refViewFragment.sstables)
                     {
-                        var success = index.reference();
-                        if (success)
-                            referencedIndexes.add(index);
+                        // Empty sstables are ok to not have the index.
+                        if (sstable.getTotalRows() == 0)
+                            continue;
 
-                        if (!success || !refViewFragment.sstables.contains(index.getSSTable()))
+                        // If the IndexViewManager never saw this sstable, then we need to spin.
+                        // Let's hope in the next iteration we get the indexView based on the same sstable set
+                        // as the refViewFragment.
+                        if (!indexView.isAwareOfSSTable(sstable.descriptor))
                         {
-                            referencedIndexes.forEach(SSTableIndex::release);
-                            referencedIndexes.clear();
-                            refViewFragment.release();
+                            if (MonotonicClock.approxTime.isAfter(start + 100))
+                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
+                                                 "Spinning trying to get the index for sstable {} because index view is out of sync", sstable.descriptor);
 
-                            // Log about the failures
-                            if (failingSince <= 0)
-                            {
-                                failingSince = MonotonicClock.approxTime.now();
-                            }
-                            else if (MonotonicClock.approxTime.now() - failingSince > TimeUnit.MILLISECONDS.toNanos(100))
-                            {
-                                failingSince = MonotonicClock.approxTime.now();
-                                if (success)
-                                    NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                     "Spinning trying to capture index reader for {}, but it was released.", index);
-                                else
-                                    NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                     "Spinning trying to capture readers for {}, but : {}, ", refViewFragment.sstables, index.getSSTable());
-                            }
+                            unmatchedSStable = sstable.descriptor;
                             continue outer;
                         }
+
+                        SSTableIndex index = indexView.getSSTableIndex(sstable.descriptor);
+
+                        // The IndexViewManager got the update about this sstable, but there is no index for the sstable
+                        // (e.g. index was dropped or got corrupt, etc.). In this case retrying won't fix it.
+                        if (index == null)
+                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
+                                                                          " not found for sstable: " + sstable.descriptor);
+
+                        if (!indexInRange(index))
+                            continue;
+
+                        // It is unlikely but possible the index got unreferenced just between the moment we grabbed the
+                        // refViewFragment and getting here. In that case we won't be able to reference it and we have
+                        // to retry.
+                        if (!index.reference())
+                        {
+
+                            if (MonotonicClock.approxTime.isAfter(start + 100))
+                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
+                                                 "Spinning trying to get the index for sstable {} because index was released", sstable.descriptor);
+
+                            unmatchedSStable = sstable.descriptor;
+                            continue outer;
+                        }
+
+                        referencedIndexes.add(index);
                     }
 
                     // freeze referencedIndexes and memtableIndexes, so we can safely give access to them
@@ -185,6 +269,24 @@ public class QueryView implements AutoCloseable
                                          Collections.unmodifiableSet(memtableIndexes),
                                          indexContext);
                 }
+
+
+                if (unmatchedMemtable != null)
+                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
+                                                                  " not found for memtable " + unmatchedMemtable);
+                if (unmatchedSStable != null)
+                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
+                                                                  " not found for sstable " + unmatchedSStable);
+
+                // This should be unreachable, because whenever we retry, we always set unmatchedMemtable
+                // or unmatchedSSTable, so we'd log a better message above.
+                throw new MissingIndexException(indexContext, "Failed to build QueryView for index " + indexContext.getIndexName());
+            }
+            catch (MissingIndexException e)
+            {
+                release(referencedIndexes);
+                release(refViewFragment);
+                throw e;
             }
             finally
             {
@@ -200,16 +302,17 @@ public class QueryView implements AutoCloseable
             }
         }
 
-        /**
-         * Get the index
-         */
-        private Set<SSTableIndex> getIndexesForExpression(IndexContext indexContext)
+        private void release(ColumnFamilyStore.RefViewFragment refViewFragment)
         {
-            if (!indexContext.isIndexed())
-                throw new IllegalArgumentException("Expression is not indexed");
+            if (refViewFragment != null)
+                refViewFragment.release();
+        }
 
-            // Get all the indexes in the range.
-            return indexContext.getView().getIndexes().stream().filter(this::indexInRange).collect(Collectors.toSet());
+        private void release(Collection<SSTableIndex> indexes)
+        {
+            for (var index : indexes)
+                index.release();
+            indexes.clear();
         }
 
         // I've removed the concept of "most selective index" since we don't actually have per-sstable
@@ -227,5 +330,4 @@ public class QueryView implements AutoCloseable
             return range.left.compareTo(sstable.last) <= 0 && (range.right.isMinimum() || sstable.first.compareTo(range.right) <= 0);
         }
     }
-
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -67,6 +67,8 @@ import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.FBUtilities;
 
+import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
+
 public class StorageAttachedIndexSearcher implements Index.Searcher
 {
     private static final Logger logger = LoggerFactory.getLogger(StorageAttachedIndexSearcher.class);
@@ -97,32 +99,54 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     @SuppressWarnings("unchecked")
     public UnfilteredPartitionIterator search(ReadExecutionController executionController) throws RequestTimeoutException
     {
-        try
+        int retries = 0;
+        while (true)
         {
-            FilterTree filterTree = analyzeFilter();
-            Plan plan = controller.buildPlan();
-            Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
+            try
+            {
+                FilterTree filterTree = analyzeFilter();
+                Plan plan = controller.buildPlan();
+                Iterator<? extends PrimaryKey> keysIterator = controller.buildIterator(plan);
 
-            // Can't check for `command.isTopK()` because the planner could optimize sorting out
-            Orderer ordering = plan.ordering();
-            if (ordering != null)
-            {
-                assert !(keysIterator instanceof KeyRangeIterator);
-                var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
-                var result = new ScoreOrderedResultRetriever(scoredKeysIterator, filterTree, controller,
-                                                             executionController, queryContext, command.limits().count());
-                return (UnfilteredPartitionIterator) new TopKProcessor(command).filter(result);
+                // Can't check for `command.isTopK()` because the planner could optimize sorting out
+                Orderer ordering = plan.ordering();
+                if (ordering != null)
+                {
+                    assert !(keysIterator instanceof KeyRangeIterator);
+                    var scoredKeysIterator = (CloseableIterator<PrimaryKeyWithSortKey>) keysIterator;
+                    var result = new ScoreOrderedResultRetriever(scoredKeysIterator, filterTree, controller,
+                                                                 executionController, queryContext, command.limits().count());
+                    return (UnfilteredPartitionIterator) new TopKProcessor(command).filter(result);
+                }
+                else
+                {
+                    assert keysIterator instanceof KeyRangeIterator;
+                    return new ResultRetriever((KeyRangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
+                }
             }
-            else
+            catch (QueryView.Builder.MissingIndexException e)
             {
-                assert keysIterator instanceof KeyRangeIterator;
-                return new ResultRetriever((KeyRangeIterator) keysIterator, filterTree, controller, executionController, queryContext);
+                // If an index was dropped while we were preparing the plan or between preparing the plan
+                // and creating the result retriever, we can retry without that index,
+                // because there may be other indexes that could be used to run the query.
+                // And if there are no good indexes left, we'd get a good contextual request error message.
+                if (e.context.isDropped() && retries < 8)
+                {
+                    logger.debug("Index " + e.context.getIndexName() + " dropped while preparing the query plan. Retrying.");
+                    retries++;
+                    continue;
+                }
+
+                // If we end up here, this is either a bug or a problem with an index (corrupted / missing components?).
+                controller.abort();
+                logger.error("Index not found", e);
+                throw invalidRequest("Index missing or corrupt: " + e.context.getIndexName());
             }
-        }
-        catch (Throwable t)
-        {
-            controller.abort();
-            throw t;
+            catch (Throwable t)
+            {
+                controller.abort();
+                throw t;
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/view/View.java
+++ b/src/java/org/apache/cassandra/index/sai/view/View.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -39,15 +41,17 @@ import org.apache.cassandra.utils.IntervalTree;
 
 public class View implements Iterable<SSTableIndex>
 {
+    private final Set<Descriptor> sstables;
     private final Map<Descriptor, SSTableIndex> view;
 
     private final TermTree termTree;
     private final AbstractType<?> keyValidator;
     private final IntervalTree<Key, SSTableIndex, Interval<Key, SSTableIndex>> keyIntervalTree;
 
-    public View(IndexContext context, Collection<SSTableIndex> indexes)
+    public View(IndexContext context, Collection<Descriptor> sstables, Collection<SSTableIndex> indexes)
     {
         this.view = new HashMap<>();
+        this.sstables = new HashSet<>(sstables);
         this.keyValidator = context.keyValidator();
 
         AbstractType<?> validator = context.getValidator();
@@ -94,19 +98,49 @@ public class View implements Iterable<SSTableIndex>
         return view.values().iterator();
     }
 
+    public Collection<Descriptor> getSSTables()
+    {
+        return sstables;
+    }
+
     public Collection<SSTableIndex> getIndexes()
     {
         return view.values();
     }
 
-    public boolean containsSSTable(SSTableReader sstable)
-    {
-        return view.containsKey(sstable.descriptor);
-    }
-
     public int size()
     {
         return view.size();
+    }
+
+    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
+    {
+        return view.get(descriptor);
+    }
+    
+    /**
+     * Tells if an index for the given sstable exists.
+     * It's equivalent to {@code getSSTableIndex(descriptor) != null }.
+     * @param descriptor identifies the sstable
+     */
+    public boolean containsSSTableIndex(Descriptor descriptor)
+    {
+        return view.containsKey(descriptor);
+    }
+
+    /**
+     * Returns true if this view has been based on the Cassandra view containing given sstable.
+     * In other words, it tells if SAI was given a chance to load the index for the given sstable.
+     * It does not determine if the index exists and was actually loaded.
+     * To check the existence of the index, use {@link #containsSSTableIndex(Descriptor)}.
+     * <p>
+     * This method allows to distinguish a situation when the sstable has no index, the index is
+     * invalid, or was not loaded for whatever reason,
+     * from a situation where the view hasn't been updated yet to reflect the newly added sstable.
+     */
+    public boolean isAwareOfSSTable(Descriptor descriptor)
+    {
+        return sstables.contains(descriptor);
     }
 
     /**

--- a/src/java/org/apache/cassandra/notifications/SSTableAddedNotification.java
+++ b/src/java/org/apache/cassandra/notifications/SSTableAddedNotification.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -192,10 +192,10 @@ public class SecondaryIndexManagerTest extends CQLTester
         assertEmpty(execute("SELECT * FROM %s WHERE a=1"));
         assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
-        // track sstable again: expect no rows to be read by index
+        // track sstable again: expect the query that needs the index cannot execute
         cfs.getTracker().addInitialSSTables(sstables);
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
-        assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
+        assertInvalid("SELECT * FROM %s WHERE c=1");
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -43,12 +43,32 @@ public class DropIndexWhileQueryingTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(z) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
-        injectIndexDrop("drop_index", indexName, true);
+        injectIndexDrop("drop_index", indexName, "buildPlan", true);
 
         execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "car", 0, "y0", "z0");
         String query = "SELECT * FROM %s WHERE x IN (0, 1) OR (y IN ('Y0', 'Y1' ) OR z IN ('z1', 'z2'))";
         assertInvalidMessage(QueryController.INDEX_MAY_HAVE_BEEN_DROPPED, query);
         assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);
+    }
+
+    @Test
+    public void testFallbackToAnotherIndex() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, x int, y text, z text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(y) USING 'StorageAttachedIndex'");
+        String indexName1 = createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+        String indexName2 = createIndex("CREATE CUSTOM INDEX ON %s(z) USING 'StorageAttachedIndex'");
+        waitForTableIndexesQueryable();
+
+        injectIndexDrop("drop_index_1", indexName1, "buildIterator", true);
+        injectIndexDrop("drop_index_2", indexName2, "buildIterator", true);
+
+        execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k1", 0, "y0", "z0"); // match
+        execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k2", 0, "y1", "z2"); // no match
+        execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k3", 5, "y2", "z0"); // no match
+        String query = "SELECT * FROM %s WHERE x = 0 AND y = 'y0' AND z = 'z0'";
+        assertRowCount(execute(query), 1);
     }
 
     // See CNDB-10535
@@ -59,7 +79,7 @@ public class DropIndexWhileQueryingTest extends SAITester
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
-        injectIndexDrop("drop_index2", indexName, false);
+        injectIndexDrop("drop_index2", indexName, "buildPlan", false);
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
 
@@ -68,9 +88,9 @@ public class DropIndexWhileQueryingTest extends SAITester
         assertInvalidMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"), query);
     }
 
-    private static void injectIndexDrop(String injectionName, String indexName, boolean atEntry) throws Throwable
+    private static void injectIndexDrop(String injectionName, String indexName, String methodName, boolean atEntry) throws Throwable
     {
-        InvokePointBuilder invokePoint = newInvokePoint().onClass(QueryController.class).onMethod("buildPlan");
+        InvokePointBuilder invokePoint = newInvokePoint().onClass(QueryController.class).onMethod(methodName);
         Injection injection = Injections.newCustom(injectionName)
                                         .add(atEntry ? invokePoint.atEntry() : invokePoint.atExit())
                                         .add(ActionBuilder
@@ -88,7 +108,7 @@ public class DropIndexWhileQueryingTest extends SAITester
     @SuppressWarnings("unused")
     public static void dropIndexForBytemanInjections(String indexName)
     {
-        String fullQuery = String.format("DROP INDEX %s.%s", KEYSPACE, indexName);
+        String fullQuery = String.format("DROP INDEX IF EXISTS %s.%s", KEYSPACE, indexName);
         logger.info(fullQuery);
         schemaChange(fullQuery);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -1036,6 +1036,8 @@ public class NativeIndexDDLTest extends SAITester
             (corruptionType != CorruptionType.REMOVED))
             return;
 
+        logger.info("CORRUPTING: " + component + ", corruption type = " + corruptionType);
+
         int rowCount = 2;
 
         // initial verification


### PR DESCRIPTION
### What is the issue
QueryView.Builder#build falls into an infinite loop sometimes and a query timeout happens

### What does this PR fix and why was it fixed
This PR changes the direction we match indexes with sstables/memtables.
Instead of going from the indexes to sstables/memtables, we start with sstables/memtables and then match indexes to them. 
This allows to limit the looping and also reliably detect the situations when an index is permanently missing (e.g. it was dropped or invalid).

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits