### PR TITLE
CNDB-11076: bump SLF4J version to 2.0.9; bump logback version to 1.4.14 to get rid of security holes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -596,6 +596,8 @@
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>
           </dependency>
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="2.0.9"/>
+          <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="2.0.9"/>
+          <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.9" />
           <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.4.14"/>
           <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.4.14"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.13.2"/>
@@ -864,6 +866,8 @@
         <dependency groupId="org.antlr" artifactId="ST4"/>
         <dependency groupId="org.antlr" artifactId="antlr-runtime"/>
         <dependency groupId="org.slf4j" artifactId="slf4j-api"/>
+        <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j"/>
+        <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations"/>

--- a/build.xml
+++ b/build.xml
@@ -595,11 +595,9 @@
           <dependency groupId="org.antlr" artifactId="antlr-runtime" version="3.5.2">
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>
           </dependency>
-          <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.25"/>
-          <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.25"/>
-          <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.25" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.9"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.9"/>
+          <dependency groupId="org.slf4j" artifactId="slf4j-api" version="2.0.9"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.4.14"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.4.14"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.13.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.13.2.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.13.2"/>
@@ -866,8 +864,6 @@
         <dependency groupId="org.antlr" artifactId="ST4"/>
         <dependency groupId="org.antlr" artifactId="antlr-runtime"/>
         <dependency groupId="org.slf4j" artifactId="slf4j-api"/>
-        <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j"/>
-        <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind"/>
         <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations"/>

--- a/src/java/org/apache/cassandra/utils/logging/LogbackLoggingSupport.java
+++ b/src/java/org/apache/cassandra/utils/logging/LogbackLoggingSupport.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.utils.logging;
 
-import java.lang.management.ManagementFactory;
 import java.security.AccessControlException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -26,8 +25,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.management.JMX;
-import javax.management.ObjectName;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
@@ -37,14 +34,14 @@ import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.jmx.JMXConfiguratorMBean;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.TurboFilterList;
 import ch.qos.logback.classic.turbo.ReconfigureOnChangeFilter;
 import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.filter.Filter;
-import ch.qos.logback.core.hook.DelayingShutdownHook;
+import ch.qos.logback.core.hook.DefaultShutdownHook;
 import ch.qos.logback.core.spi.AppenderAttachable;
 import org.apache.cassandra.security.ThreadAwareSecurityManager;
 
@@ -92,7 +89,7 @@ public class LogbackLoggingSupport implements LoggingSupport
     @Override
     public void onShutdown()
     {
-        DelayingShutdownHook logbackHook = new DelayingShutdownHook();
+        DefaultShutdownHook logbackHook = new DefaultShutdownHook();
         logbackHook.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
         logbackHook.run();
     }
@@ -105,10 +102,11 @@ public class LogbackLoggingSupport implements LoggingSupport
         // if both classQualifier and rawLevel are empty, reload from configuration
         if (StringUtils.isBlank(classQualifier) && StringUtils.isBlank(rawLevel))
         {
-            JMXConfiguratorMBean jmxConfiguratorMBean = JMX.newMBeanProxy(ManagementFactory.getPlatformMBeanServer(),
-                                                                          new ObjectName("ch.qos.logback.classic:Name=default,Type=ch.qos.logback.classic.jmx.JMXConfigurator"),
-                                                                          JMXConfiguratorMBean.class);
-            jmxConfiguratorMBean.reloadDefaultConfiguration();
+            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+            lc.reset();
+
+            ContextInitializer ci = new ContextInitializer(lc);
+            ci.autoConfig();
             return;
         }
         // classQualifier is set, but blank level given

--- a/test/conf/logback-burntest.xml
+++ b/test/conf/logback-burntest.xml
@@ -20,7 +20,7 @@
   <define name="instance_id" class="org.apache.cassandra.distributed.impl.InstanceIDDefiner" />
 
   <!-- Shutdown hook ensures that async appender flushes -->
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 

--- a/test/conf/logback-dtest.xml
+++ b/test/conf/logback-dtest.xml
@@ -34,7 +34,7 @@
 
   <appender name="INSTANCESTDERR" target="System.err" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+      <pattern>%-5level %date{"HH:mm:ss,SSS"} %msg%n</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>

--- a/test/conf/logback-dtest.xml
+++ b/test/conf/logback-dtest.xml
@@ -22,7 +22,7 @@
   <define name="instance_id" class="org.apache.cassandra.distributed.impl.InstanceIDDefiner" />
 
   <!-- Shutdown hook ensures that async appender flushes -->
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 
   <appender name="INSTANCEFILE" class="ch.qos.logback.core.FileAppender">
     <file>./build/test/logs/${cassandra.testtag}/${suitename}/${cluster_id}/${instance_id}/system.log</file>

--- a/test/conf/logback-test-jenkins.xml
+++ b/test/conf/logback-test-jenkins.xml
@@ -19,7 +19,7 @@
 
 <configuration debug="false" scan="true" scanPeriod="60 seconds">
   <!-- Shutdown hook ensures that async appender flushes -->
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 
   <!-- Status listener is used to wrap stdout/stderr and tee to log file -->
   <statusListener class="org.apache.cassandra.LogbackStatusListener"/>

--- a/test/conf/logback-test.xml
+++ b/test/conf/logback-test.xml
@@ -19,7 +19,7 @@
 
 <configuration debug="false" scan="true" scanPeriod="60 seconds">
   <!-- Shutdown hook ensures that async appender flushes -->
-  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 
   <!-- Status listener is used to wrap stdout/stderr and tee to log file -->
   <statusListener class="org.apache.cassandra.LogbackStatusListener"/>

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -28,7 +28,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.time.DateUtils;
 
@@ -43,7 +46,6 @@ import ch.qos.logback.classic.joran.ReconfigureOnChangeTask;
 import ch.qos.logback.classic.spi.TurboFilterList;
 import ch.qos.logback.classic.turbo.ReconfigureOnChangeFilter;
 import ch.qos.logback.classic.turbo.TurboFilter;
-import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
@@ -59,7 +61,6 @@ import org.apache.cassandra.transport.Event.SchemaChange.Target;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
-import static ch.qos.logback.core.CoreConstants.RECONFIGURE_ON_CHANGE_TASK;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1814,9 +1815,16 @@ public class AggregationTest extends CQLTester
     public void testLogbackReload() throws Throwable
     {
         // see https://issues.apache.org/jira/browse/CASSANDRA-11033
+        Logger l = LoggerFactory.getLogger(AggregationTest.class);
+        ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) l;
+        LoggerContext ctx = logbackLogger.getLoggerContext();
 
-        // make logback's scan interval 1ms - boilerplate, but necessary for this test
-        configureLogbackScanPeriod(1L);
+        ReconfigureOnChangeTask rocTask = new ReconfigureOnChangeTask();
+        rocTask.setContext(ctx);
+
+        ScheduledExecutorService scheduledExecutorService = ctx.getScheduledExecutorService();
+        ScheduledFuture<?> scheduledFuture = scheduledExecutorService.scheduleAtFixedRate(rocTask, 1, 1,
+                                                                                          TimeUnit.MILLISECONDS);
         try
         {
 
@@ -1865,41 +1873,8 @@ public class AggregationTest extends CQLTester
         }
         finally
         {
-            configureLogbackScanPeriod(60000L);
+            scheduledFuture.cancel(true);
         }
-    }
-
-    private static void configureLogbackScanPeriod(long millis)
-    {
-        Logger l = LoggerFactory.getLogger(AggregationTest.class);
-        ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) l;
-        LoggerContext ctx = logbackLogger.getLoggerContext();
-        TurboFilterList turboFilterList = ctx.getTurboFilterList();
-        boolean done = false;
-        for (TurboFilter turboFilter : turboFilterList)
-        {
-            if (turboFilter instanceof ReconfigureOnChangeFilter)
-            {
-                ReconfigureOnChangeFilter reconfigureFilter = (ReconfigureOnChangeFilter) turboFilter;
-                reconfigureFilter.setContext(ctx);
-                reconfigureFilter.setRefreshPeriod(millis);
-                reconfigureFilter.stop();
-                reconfigureFilter.start(); // start() sets the next check timestammp
-                done = true;
-                break;
-            }
-        }
-
-        ReconfigureOnChangeTask roct = (ReconfigureOnChangeTask) ctx.getObject(RECONFIGURE_ON_CHANGE_TASK);
-        if (roct != null)
-        {
-            // New functionality in logback - they replaced ReconfigureOnChangeFilter (which runs in the logging code)
-            // with an async ReconfigureOnChangeTask - i.e. in a thread that does not become sandboxed.
-            // Let the test run anyway, just we cannot reconfigure it (and it is pointless to reconfigure).
-            return;
-        }
-
-        assertTrue("ReconfigureOnChangeFilter not in logback's turbo-filter list - do that by adding scan=\"true\" to logback-test.xml's configuration element", done);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -34,19 +34,13 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.time.DateUtils;
-
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.ReconfigureOnChangeTask;
-import ch.qos.logback.classic.spi.TurboFilterList;
-import ch.qos.logback.classic.turbo.ReconfigureOnChangeFilter;
-import ch.qos.logback.classic.turbo.TurboFilter;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -55,6 +49,7 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.TypeParser;
 import org.apache.cassandra.exceptions.FunctionExecutionException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.Event.SchemaChange.Change;
 import org.apache.cassandra.transport.Event.SchemaChange.Target;

--- a/test/unit/org/apache/cassandra/utils/OrderCheckingIterator.java
+++ b/test/unit/org/apache/cassandra/utils/OrderCheckingIterator.java
@@ -18,7 +18,7 @@
  */
 package org.apache.cassandra.utils;
 
-import org.apache.log4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.DecoratedKey;
@@ -133,7 +133,7 @@ public final class OrderCheckingIterator extends AbstractIterator<Unfiltered> im
         //   -- tombstones with DeletionTime.LIVE
         if (next.isRangeTombstoneMarker())
         {
-            Logger.getLogger(getClass()).info("tombstone: " + next.toString(metadata()));
+            LoggerFactory.getLogger(getClass()).info("tombstone: {}", next.toString(metadata()));
             RangeTombstoneMarker marker = (RangeTombstoneMarker) next;
 
             if (marker.isOpen(reversed) && marker.openDeletionTime(reversed).isLive() ||

--- a/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
+++ b/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.logging;
+
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+import static org.junit.Assert.assertSame;
+
+public class LogbackLoggingSupportTest
+{
+    @Test
+    public void setLogLevelWithoutOptionsReloadsConfiguration() throws Exception
+    {
+        // given
+        Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        assertSame("the default test log level is DEBUG", Level.DEBUG, rootLogger.getLevel());
+
+        rootLogger.setLevel(Level.TRACE);
+        assertSame("the log level should have been switched to TRACE", Level.TRACE, rootLogger.getLevel());
+
+        LogbackLoggingSupport loggingSupport = new LogbackLoggingSupport();
+        loggingSupport.onStartup();
+
+        // when
+        // empty class and level reset to the default configuration
+        loggingSupport.setLoggingLevel("", "");
+
+        // then
+        assertSame("reset test log level should be DEBUG", Level.DEBUG, rootLogger.getLevel());
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
+++ b/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
@@ -36,16 +36,16 @@ public class LogbackLoggingSupportTest
         loggingSupport.onStartup();
 
         Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-        assertSame("the default test log level is DEBUG", Level.DEBUG, rootLogger.getLevel());
+        Level defaultLevel = rootLogger.getLevel();
 
-        rootLogger.setLevel(Level.TRACE);
-        assertSame("the log level should have been switched to TRACE", Level.TRACE, rootLogger.getLevel());
+        rootLogger.setLevel(Level.OFF);
+        assertSame("the log level should have been switched to OFF", Level.OFF, rootLogger.getLevel());
 
         // when
         // empty class and level reset to the default configuration
         loggingSupport.setLoggingLevel("", "");
 
         // then
-        assertSame("reset test log level should be DEBUG", Level.DEBUG, rootLogger.getLevel());
+        assertSame("reset test log level should be reset", defaultLevel, rootLogger.getLevel());
     }
 }

--- a/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
+++ b/test/unit/org/apache/cassandra/utils/logging/LogbackLoggingSupportTest.java
@@ -32,14 +32,14 @@ public class LogbackLoggingSupportTest
     public void setLogLevelWithoutOptionsReloadsConfiguration() throws Exception
     {
         // given
+        LogbackLoggingSupport loggingSupport = new LogbackLoggingSupport();
+        loggingSupport.onStartup();
+
         Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         assertSame("the default test log level is DEBUG", Level.DEBUG, rootLogger.getLevel());
 
         rootLogger.setLevel(Level.TRACE);
         assertSame("the log level should have been switched to TRACE", Level.TRACE, rootLogger.getLevel());
-
-        LogbackLoggingSupport loggingSupport = new LogbackLoggingSupport();
-        loggingSupport.onStartup();
 
         // when
         // empty class and level reset to the default configuration


### PR DESCRIPTION
### What is the issue
Old slf4j and logback are suffering from known security vulnerabilities.

### What does this PR fix and why was it fixed
This change upgrades the dependencies to versions with fixed vulnerabilities.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits
