### PR TITLE
CNDB-12484: Fix flaky VectorUpdateDeleteTest failures

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1905,15 +1905,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return data.getLiveSSTables();
     }
 
-    /**
-     * Convenience method for getting the canonical sstables associated with this ColumnFamilyStore.
-     * @return the tracker's current view's {@link SSTableSet#CANONICAL} sstables
-     */
-    public Iterable<SSTableReader> getCanonicalSSTables()
-    {
-        return getSSTables(SSTableSet.CANONICAL);
-    }
-
     public Iterable<SSTableReader> getSSTables(SSTableSet sstableSet)
     {
         return data.getView().select(sstableSet);

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -63,6 +63,8 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.lifecycle.SSTableSet;
+import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestFailureReason;
@@ -332,15 +334,19 @@ public class SAITester extends CQLTester
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
 
-        for (SSTableReader sstable : cfs.getCanonicalSSTables())
+        try (ColumnFamilyStore.RefViewFragment rvf = cfs.selectAndReference(View.selectFunction(SSTableSet.CANONICAL)))
         {
-            IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
-            if (indexDescriptor.isIndexEmpty(context))
-                continue;
-            if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true)
-                || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true))
-                return false;
+            for (SSTableReader sstable : rvf.sstables)
+            {
+                IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
+                if (indexDescriptor.isIndexEmpty(context))
+                    continue;
+                if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true)
+                    || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true))
+                    return false;
+            }
         }
+
         return true;
     }
 


### PR DESCRIPTION
### What is the issue
VectorUpdateDeleteTest sees flaky failures where it fails to verify the checksums of all sstables.

### What does this PR fix and why was it fixed
SAITester.verifyChecksum is swapped to consider canonical sstables rather than live sstables. If the SAITester.verifier overlaps with a compaction, it could previously see a preemptively opened SSTable. Validating the SAI components for this preemptively opened sstable fails, as they haven't yet been written. The verifier should only consider canonical sstables, which are expected to have valid SAI components.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits