### PR TITLE
CNDB-9594: collect query count in index metrics

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/metrics/IndexMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/IndexMetrics.java
@@ -40,6 +40,7 @@ public class IndexMetrics extends AbstractMetrics
     public final Counter compactionCount;
     public final Counter memtableIndexFlushErrors;
     public final Counter segmentFlushErrors;
+    public final Counter queriesCount;
     
     public final Histogram memtableFlushCellsPerSecond;
     public final Histogram segmentsPerCompaction;
@@ -60,6 +61,7 @@ public class IndexMetrics extends AbstractMetrics
         compactionCount = Metrics.counter(createMetricName("CompactionCount"));
         memtableIndexFlushErrors = Metrics.counter(createMetricName("MemtableIndexFlushErrors"));
         segmentFlushErrors = Metrics.counter(createMetricName("CompactionSegmentFlushErrors"));
+        queriesCount = Metrics.counter(createMetricName("QueriesCount"));
         liveMemtableIndexWriteCount = Metrics.register(createMetricName("LiveMemtableIndexWriteCount"), context::liveMemtableWriteCount);
         memtableOnHeapIndexBytes = Metrics.register(createMetricName("MemtableOnHeapIndexBytes"), context::estimatedOnHeapMemIndexMemoryUsed);
         memtableOffHeapIndexBytes = Metrics.register(createMetricName("MemtableOffHeapIndexBytes"), context::estimatedOffHeapMemIndexMemoryUsed);

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -324,14 +324,14 @@ abstract public class Plan
     }
 
     /**
-     * Adds an index used by the plan node to the given set of indexes.
-     * Needs to be overwritten by nodes that use indexes.
-     * @param indexes the set of indexes to update with the index used by this node
+     * Returns the index context if the plan node uses one.
+     * Need to be overridden by nodes that use an index.
+     * None-recursive. Use {@link #forEach(Function)} to get the index context of all nodes.
      */
-    protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
+    protected @Nullable IndexContext getIndexIfPresent()
     {
-        // By default, a node does not contain any indexes.
-        // Thus, no-op.
+        // By default, a node does not contain an index.
+        return null;
     }
 
     /**
@@ -896,10 +896,10 @@ abstract public class Plan
         }
 
         @Override
-        final protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
+        final protected IndexContext getIndexIfPresent()
         {
             assert predicate != null || ordering != null;
-            indexes.add(predicate != null ? predicate.context : ordering.context);
+            return predicate != null ? predicate.context : ordering.context;
         }
     }
     /**
@@ -1364,9 +1364,9 @@ abstract public class Plan
         }
 
         @Override
-        protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
+        protected IndexContext getIndexIfPresent()
         {
-            indexes.add(ordering.context);
+            return ordering.context;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -324,12 +324,14 @@ abstract public class Plan
     }
 
     /**
-     * Adds an index to the set of indexes used by the plan node.
+     * Adds an index used by the plan node to the given set of indexes.
      * Needs to be overwritten by nodes that use indexes.
+     * @param indexes the set of indexes to update with the index used by this node
      */
     protected void countIndex(HashSet<IndexContext> indexes)
     {
-        // No index to count by default
+        // By default, a node does not contain any indexes.
+        // Thus, no-op.
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -328,7 +328,7 @@ abstract public class Plan
      * Needs to be overwritten by nodes that use indexes.
      * @param indexes the set of indexes to update with the index used by this node
      */
-    protected void countIndex(HashSet<IndexContext> indexes)
+    protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
     {
         // By default, a node does not contain any indexes.
         // Thus, no-op.
@@ -896,7 +896,7 @@ abstract public class Plan
         }
 
         @Override
-        final protected void countIndex(HashSet<IndexContext> indexes)
+        final protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
         {
             assert predicate != null || ordering != null;
             indexes.add(predicate != null ? predicate.context : ordering.context);
@@ -1364,7 +1364,7 @@ abstract public class Plan
         }
 
         @Override
-        protected void countIndex(HashSet<IndexContext> indexes)
+        protected void addIndexToSetIfPresent(HashSet<IndexContext> indexes)
         {
             indexes.add(ordering.context);
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -326,9 +326,9 @@ abstract public class Plan
     /**
      * Returns the index context if the plan node uses one.
      * Need to be overridden by nodes that use an index.
-     * None-recursive. Use {@link #forEach(Function)} to get the index context of all nodes.
+     * Non-recursive.
      */
-    protected @Nullable IndexContext getIndexIfPresent()
+    protected @Nullable IndexContext getIndex()
     {
         // By default, a node does not contain an index.
         return null;
@@ -896,7 +896,7 @@ abstract public class Plan
         }
 
         @Override
-        final protected IndexContext getIndexIfPresent()
+        final protected IndexContext getIndex()
         {
             assert predicate != null || ordering != null;
             return predicate != null ? predicate.context : ordering.context;
@@ -1364,7 +1364,7 @@ abstract public class Plan
         }
 
         @Override
-        protected IndexContext getIndexIfPresent()
+        protected IndexContext getIndex()
         {
             return ordering.context;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1227,7 +1227,7 @@ abstract public class Plan
         private final KeysIteration source;
         final Orderer ordering;
 
-        protected KeysSort(Factory factory, int id, KeysIteration source, Access access, Orderer ordering)
+        KeysSort(Factory factory, int id, KeysIteration source, Access access, Orderer ordering)
         {
             super(factory, id, access);
             this.source = source;
@@ -1315,7 +1315,7 @@ abstract public class Plan
     {
         final Orderer ordering;
 
-        protected AnnIndexScan(Factory factory, int id, Access access, Orderer ordering)
+        AnnIndexScan(Factory factory, int id, Access access, Orderer ordering)
         {
             super(factory, id, access);
             this.ordering = ordering;

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -328,7 +328,7 @@ abstract public class Plan
      * Need to be overridden by nodes that use an index.
      * Non-recursive.
      */
-    protected @Nullable IndexContext getIndex()
+    protected @Nullable IndexContext getIndexContext()
     {
         // By default, a node does not contain an index.
         return null;
@@ -896,7 +896,7 @@ abstract public class Plan
         }
 
         @Override
-        final protected IndexContext getIndex()
+        final protected IndexContext getIndexContext()
         {
             assert predicate != null || ordering != null;
             return predicate != null ? predicate.context : ordering.context;
@@ -1364,7 +1364,7 @@ abstract public class Plan
         }
 
         @Override
-        protected IndexContext getIndex()
+        protected IndexContext getIndexContext()
         {
             return ordering.context;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -18,12 +18,7 @@
 
 package org.apache.cassandra.index.sai.plan;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -326,6 +321,15 @@ abstract public class Plan
     protected String description()
     {
         return "";
+    }
+
+    /**
+     * Adds an index to the set of indexes used by the plan node.
+     * Needs to be overwritten by nodes that use indexes.
+     */
+    protected void countIndex(HashSet<IndexContext> indexes)
+    {
+        // No index to count by default
     }
 
     /**
@@ -888,6 +892,13 @@ abstract public class Plan
             assert predicate != null || ordering != null;
             return predicate != null ? predicate.getIndexName() : ordering.getIndexName();
         }
+
+        @Override
+        final protected void countIndex(HashSet<IndexContext> indexes)
+        {
+            assert predicate != null || ordering != null;
+            indexes.add(predicate != null ? predicate.context : ordering.context);
+        }
     }
     /**
      * Represents a scan over a numeric storage attached index.
@@ -1348,6 +1359,12 @@ abstract public class Plan
         protected double estimateSelectivity()
         {
             return 1.0;
+        }
+
+        @Override
+        protected void countIndex(HashSet<IndexContext> indexes)
+        {
+            indexes.add(ordering.context);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -347,8 +347,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                 queriedIndexesContexts.add(indexContext);
             return Plan.ControlFlow.Continue;
         });
-        queriedIndexesContexts.stream()
-                              .forEach(indexContext ->
+        queriedIndexesContexts.forEach(indexContext ->
                                        indexContext.getIndexMetrics().queriesCount.inc());
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -341,7 +341,9 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private void updateIndexMetricsQueriesCount(Plan plan) {
         HashSet<IndexContext> queriedIndexes = new HashSet<>();
         plan.forEach(node -> {
-            node.addIndexToSetIfPresent(queriedIndexes);
+            IndexContext index = node.getIndexIfPresent();
+            if (index != null)
+                queriedIndexes.add(index);
             return Plan.ControlFlow.Continue;
         });
         queriedIndexes.stream().forEach(indexContext -> indexContext.getIndexMetrics().queriesCount.inc());

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -341,7 +341,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private void updateIndexMetricsQueriesCount(Plan plan) {
         HashSet<IndexContext> queriedIndexes = new HashSet<>();
         plan.forEach(node -> {
-            node.countIndex(queriedIndexes);
+            node.addIndexToSetIfPresent(queriedIndexes);
             return Plan.ControlFlow.Continue;
         });
         queriedIndexes.stream().forEach(indexContext -> indexContext.getIndexMetrics().queriesCount.inc());

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -338,7 +338,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                                                  makeFilter(key));
     }
 
-    private void updateIndexMetricsQueriesCount(Plan plan) {
+    private void updateIndexMetricsQueriesCount(Plan plan)
+    {
         HashSet<IndexContext> queriedIndexes = new HashSet<>();
         plan.forEach(node -> {
             IndexContext index = node.getIndex();
@@ -346,7 +347,9 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                 queriedIndexes.add(index);
             return Plan.ControlFlow.Continue;
         });
-        queriedIndexes.stream().forEach(indexContext -> indexContext.getIndexMetrics().queriesCount.inc());
+        queriedIndexes.stream()
+                      .forEach(indexContext ->
+                               indexContext.getIndexMetrics().queriesCount.inc());
     }
 
     Plan buildPlan()

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -340,16 +340,16 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
     private void updateIndexMetricsQueriesCount(Plan plan)
     {
-        HashSet<IndexContext> queriedIndexes = new HashSet<>();
+        HashSet<IndexContext> queriedIndexesContexts = new HashSet<>();
         plan.forEach(node -> {
-            IndexContext index = node.getIndex();
-            if (index != null)
-                queriedIndexes.add(index);
+            IndexContext indexContext = node.getIndexContext();
+            if (indexContext != null)
+                queriedIndexesContexts.add(indexContext);
             return Plan.ControlFlow.Continue;
         });
-        queriedIndexes.stream()
-                      .forEach(indexContext ->
-                               indexContext.getIndexMetrics().queriesCount.inc());
+        queriedIndexesContexts.stream()
+                              .forEach(indexContext ->
+                                       indexContext.getIndexMetrics().queriesCount.inc());
     }
 
     Plan buildPlan()

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -341,7 +341,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private void updateIndexMetricsQueriesCount(Plan plan) {
         HashSet<IndexContext> queriedIndexes = new HashSet<>();
         plan.forEach(node -> {
-            IndexContext index = node.getIndexIfPresent();
+            IndexContext index = node.getIndex();
             if (index != null)
                 queriedIndexes.add(index);
             return Plan.ControlFlow.Continue;

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -49,13 +49,13 @@ public class IndexMetricsTest extends AbstractMetricsTest
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace2));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, keyspace2, "v1"));
 
-        execute("INSERT INTO " + keyspace1 + "." + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + keyspace1 + '.' + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
 
         assertEquals(1L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace1, TABLE, INDEX, "IndexMetrics")));
         assertEquals(0L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace2, TABLE, INDEX, "IndexMetrics")));
 
-        execute("INSERT INTO " + keyspace2 + "." + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
-        execute("INSERT INTO " + keyspace2 + "." + TABLE + " (id1, v1, v2) VALUES ('1', 1, '1')");
+        execute("INSERT INTO " + keyspace2 + '.' + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + keyspace2 + '.' + TABLE + " (id1, v1, v2) VALUES ('1', 1, '1')");
 
         assertEquals(1L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace1, TABLE, INDEX, "IndexMetrics")));
         assertEquals(2L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace2, TABLE, INDEX, "IndexMetrics")));
@@ -69,7 +69,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
         createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace));
         createIndex(String.format(CREATE_INDEX_TEMPLATE, keyspace, "v1"));
 
-        execute("INSERT INTO " + keyspace + "." + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + keyspace + '.' + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
         assertEquals(1L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
 
         dropIndex(String.format("DROP INDEX %s." + INDEX, keyspace));
@@ -89,7 +89,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
 
         int rowCount = 10;
         for (int i = 0; i < rowCount; i++)
-            execute("INSERT INTO " + keyspace + "." + TABLE + "(id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
+            execute("INSERT INTO " + keyspace + '.' + TABLE + "(id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
 
         assertEquals(10L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
         assertTrue((Long)getMetricValue(objectName("MemtableOnHeapIndexBytes", keyspace, TABLE, INDEX, "IndexMetrics")) > 0);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -64,42 +64,40 @@ public class IndexMetricsTest extends AbstractMetricsTest
     @Test
     public void testMetricRelease()
     {
-        String keyspace = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
+        String table = createTable("CREATE TABLE %s (ID1 TEXT PRIMARY KEY, v1 INT, v2 TEXT) WITH compaction = " +
+                                   "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+        String index = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v1) USING 'StorageAttachedIndex'");
 
-        createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace));
-        createIndex(String.format(CREATE_INDEX_TEMPLATE, keyspace, "v1"));
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('0', 0, '0')");
+        assertEquals(1L, getMetricValue(objectName("LiveMemtableIndexWriteCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        execute("INSERT INTO " + keyspace + '.' + TABLE + " (id1, v1, v2) VALUES ('0', 0, '0')");
-        assertEquals(1L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-
-        dropIndex(String.format("DROP INDEX %s." + INDEX, keyspace));
+        dropIndex("DROP INDEX %s." + index);
 
         // once the index is dropped, make sure MBeans are no longer accessible
-        assertThatThrownBy(() -> getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")))
+        assertThatThrownBy(() -> getMetricValue(objectName("LiveMemtableIndexWriteCount", KEYSPACE, table, index, "IndexMetrics")))
                 .hasCauseInstanceOf(javax.management.InstanceNotFoundException.class);
     }
 
     @Test
     public void testMetricsThroughWriteLifecycle()
     {
-        String keyspace = createKeyspace(CREATE_KEYSPACE_TEMPLATE);
-
-        createTable(String.format(CREATE_TABLE_TEMPLATE, keyspace));
-        createIndex(String.format(CREATE_INDEX_TEMPLATE, keyspace, "v1"));
+        String table = createTable("CREATE TABLE %s (ID1 TEXT PRIMARY KEY, v1 INT, v2 TEXT) WITH compaction = " +
+                                   "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+        String index = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v1) USING 'StorageAttachedIndex'");
 
         int rowCount = 10;
         for (int i = 0; i < rowCount; i++)
-            execute("INSERT INTO " + keyspace + '.' + TABLE + "(id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
+            execute("INSERT INTO %s (id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
 
-        assertEquals(10L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertTrue((Long)getMetricValue(objectName("MemtableOnHeapIndexBytes", keyspace, TABLE, INDEX, "IndexMetrics")) > 0);
-        assertTrue((Long)getMetricValue(objectName("MemtableOffHeapIndexBytes", keyspace, TABLE, INDEX, "IndexMetrics")) > 0);
-        assertEquals(0L, getMetricValue(objectName("MemtableIndexFlushCount", keyspace, TABLE, INDEX, "IndexMetrics")));
+        assertEquals(10L, getMetricValue(objectName("LiveMemtableIndexWriteCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertTrue((Long)getMetricValue(objectName("MemtableOnHeapIndexBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
+        assertTrue((Long)getMetricValue(objectName("MemtableOffHeapIndexBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
+        assertEquals(0L, getMetricValue(objectName("MemtableIndexFlushCount", KEYSPACE, table, index, "IndexMetrics")));
 
         waitForAssert(() -> {
             try
             {
-                assertEquals(10L, getMBeanAttribute(objectName("MemtableIndexWriteLatency", keyspace, TABLE, INDEX, "IndexMetrics"), "Count"));
+                assertEquals(10L, getMBeanAttribute(objectName("MemtableIndexWriteLatency", KEYSPACE, table, index, "IndexMetrics"), "Count"));
             }
             catch (Throwable ex)
             {
@@ -107,40 +105,40 @@ public class IndexMetricsTest extends AbstractMetricsTest
             }
         }, 60, TimeUnit.SECONDS);
 
-        assertEquals(0L, getMetricValue(objectName("SSTableCellCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(0L, getMetricValue(objectName("DiskUsedBytes", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(0L, getMetricValue(objectName("CompactionCount", keyspace, TABLE, INDEX, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("SSTableCellCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", keyspace, TABLE, INDEX, "IndexMetrics"), 0);
+        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 0);
 
-        flush(keyspace, TABLE);
+        flush(KEYSPACE, table);
 
-        assertEquals(0L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(0L, getMetricValue(objectName("MemtableOnHeapIndexBytes", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(0L, getMetricValue(objectName("MemtableOffHeapIndexBytes", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(1L, getMetricValue(objectName("MemtableIndexFlushCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(10L, getMetricValue(objectName("SSTableCellCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", keyspace, TABLE, INDEX, "IndexMetrics")) > 0);
-        assertEquals(0L, getMetricValue(objectName("CompactionCount", keyspace, TABLE, INDEX, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("LiveMemtableIndexWriteCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("MemtableOnHeapIndexBytes", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("MemtableOffHeapIndexBytes", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(1L, getMetricValue(objectName("MemtableIndexFlushCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(10L, getMetricValue(objectName("SSTableCellCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
+        assertEquals(0L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", keyspace, TABLE, INDEX, "IndexMetrics"), 1);
+        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
 
-        compact(keyspace, TABLE);
+        compact(KEYSPACE, table);
 
-        waitForIndexCompaction(keyspace, TABLE, INDEX);
+        waitForIndexCompaction(KEYSPACE, table, index);
 
-        waitForTableIndexesQueryable(keyspace, TABLE);
+        waitForTableIndexesQueryable(KEYSPACE, table);
 
-        ResultSet rows = executeNet(String.format("SELECT id1 FROM %s.%s WHERE v1 >= 0", keyspace, TABLE));
+        ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1 >= 0");
         assertEquals(rowCount, rows.all().size());
 
-        assertEquals(0L, getMetricValue(objectName("LiveMemtableIndexWriteCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(1L, getMetricValue(objectName("MemtableIndexFlushCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertEquals(10L, getMetricValue(objectName("SSTableCellCount", keyspace, TABLE, INDEX, "IndexMetrics")));
-        assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", keyspace, TABLE, INDEX, "IndexMetrics")) > 0);
-        assertEquals(1L, getMetricValue(objectName("CompactionCount", keyspace, TABLE, INDEX, "IndexMetrics")));
+        assertEquals(0L, getMetricValue(objectName("LiveMemtableIndexWriteCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(1L, getMetricValue(objectName("MemtableIndexFlushCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertEquals(10L, getMetricValue(objectName("SSTableCellCount", KEYSPACE, table, index, "IndexMetrics")));
+        assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
+        assertEquals(1L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("CompactionSegmentCellsPerSecond", keyspace, TABLE, INDEX, "IndexMetrics"), 1);
+        waitForVerifyHistogram(objectName("CompactionSegmentCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
     }
 
     private void assertIndexQueryCount(String index, long expectedCount)

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -151,7 +151,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
     public void testQueriesCount()
     {
         createTable("CREATE TABLE %s (id1 TEXT PRIMARY KEY, v1 INT, v2 TEXT, v3 VECTOR<FLOAT, 2>)");
-        String indexV1 = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v1) USING 'StorageAttachedIndex'");
+        String indexV1 = createIndex("CREATE CUSTOM INDEX ON %s (v1) USING 'StorageAttachedIndex'");
 
         int rowCount = 10;
         for (int i = 0; i < rowCount; i++)
@@ -166,7 +166,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
         executeNet("SELECT id1 FROM %s WHERE (v1 >= 0 OR v1 = 4) AND v2 = '2' ALLOW FILTERING");
         assertIndexQueryCount(indexV1, 2L);
 
-        String indexV2 = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v2) USING 'StorageAttachedIndex'");
+        String indexV2 = createIndex("CREATE CUSTOM INDEX ON %s (v2) USING 'StorageAttachedIndex'");
         executeNet("SELECT id1 FROM %s WHERE (v1 >= 0 OR v1 = 4)");
         assertIndexQueryCount(indexV1, 3L);
         assertIndexQueryCount(indexV2, 0L);
@@ -180,7 +180,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
         assertIndexQueryCount(indexV1, 4L);
         assertIndexQueryCount(indexV2, 2L);
 
-        String indexV3 = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v3) USING 'StorageAttachedIndex'");
+        String indexV3 = createIndex("CREATE CUSTOM INDEX ON %s (v3) USING 'StorageAttachedIndex'");
         assertIndexQueryCount(indexV3, 0L);
         executeNet("SELECT id1 FROM %s WHERE v2 = '2' ORDER BY v3 ANN OF [5,0] LIMIT 10");
         assertIndexQueryCount(indexV1, 4L);


### PR DESCRIPTION
Reviewing comments:
- This PR contains few commits with improvements unrelated to the issue but in the same files
- Tests in `IndexMetricsTest` can be improved similarly to the added test, `testQueriesCount`, if the approach with the help function `assertIndexQueryCount` seems reasonable for reviewer. This is except `testSameIndexNameAcrossKeyspaces`, which is complicated due to several keyspaces.

### What is the issue
Part of https://github.com/riptano/cndb/issues/9594
Some warnings and possibilities for minor improvements  in affected files.

### What does this PR fix and why was it fixed
Implements counting queries for each index in metrics. Adds unit tests for some cases.

Also minor improvements in separate commits:
- Fix warnings on unnecessary protected modifier for final classes' constructors by removing them on touched file Plan.java.
- Fix warnings to use a character instead of a string with a single character.
- Simplify existing tests in IndexMetricsTest to use default keyspace and table created in CQLTester.

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits