### PR TITLE
CNDB-12456: Add ANN_OPTIONS to CQL SELECT queries

### DIFF
--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -1073,6 +1073,7 @@ bc(syntax)..
                   ( PER PARTITION LIMIT <integer> )?
                   ( LIMIT <integer> ( OFFSET <integer> )? )?
                   ( ALLOW FILTERING )?
+                  ( WITH ann_options = <map-literal> )?
 
 <select-clause> ::= DISTINCT? <selection-list>
 

--- a/doc/modules/cassandra/examples/BNF/select_statement.bnf
+++ b/doc/modules/cassandra/examples/BNF/select_statement.bnf
@@ -6,6 +6,7 @@ select_statement::= SELECT [ JSON | DISTINCT ] ( select_clause | '*' )
 	[ PER PARTITION LIMIT (`integer` | `bind_marker`) ]  
 	[ LIMIT (`integer` | `bind_marker`) [ OFFSET (`integer` | `bind_marker`) ] ]
 	[ ALLOW FILTERING ]
+	[ WITH ann_options = map-literal ]
 select_clause::= `selector` [ AS `identifier` ] ( ',' `selector` [ AS `identifier` ] ) 
 selector::== `column_name` 
 	| `term`  

--- a/doc/modules/cassandra/examples/CQL/query_with_ann_options.cql
+++ b/doc/modules/cassandra/examples/CQL/query_with_ann_options.cql
@@ -1,0 +1,1 @@
+SELECT * FROM embeddings ORDER BY vector ANN OF [1.2, 3.4] LIMIT 100 WITH ann_options = { 'rerank_k': 1000 }

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -1625,6 +1625,7 @@ FROM  +
 ( PER PARTITION LIMIT )? +
 ( LIMIT ( OFFSET )? )? +
 ( ALLOW FILTERING )?
+( WITH ann_options = )?
 
 ::= DISTINCT?
 

--- a/doc/modules/cassandra/pages/cql/dml.adoc
+++ b/doc/modules/cassandra/pages/cql/dml.adoc
@@ -262,6 +262,16 @@ execute:
 include::example$CQL/query_nofail_allow_filtering.cql[]
 ----
 
+[[ann-options]]
+=== ANN options
+
+`SELECT` queries using `ANN` ordering can provide a set of options to control the behavior of the ANN search:
+
+[source,cql]
+----
+include::example$CQL/query_with_ann_options.cql[]
+----
+
 [[insert-statement]]
 == INSERT
 

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -201,6 +201,7 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
          | <boolean>
          | <blobLiteral>
          | <collectionLiteral>
+         | <vectorLiteral>
          | <functionLiteral> <functionArguments>
          | "NULL"
          ;
@@ -231,6 +232,9 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
                ;
 <mapLiteral> ::= "{" <term> ":" <term> ( "," <term> ":" <term> )* "}"
                ;
+               
+<vectorLiteral> ::= "[" ( <float> ( "," <float> )* )? "]"
+                ;
 
 <anyFunctionName> ::= ( ksname=<cfOrKsName> dot="." )? udfname=<cfOrKsName> ;
 
@@ -716,6 +720,7 @@ syntax_rules += r'''
                           ( "PER" "PARTITION" "LIMIT" perPartitionLimit=<wholenumber> )?
                           ( "LIMIT" limit=<wholenumber> ( "OFFSET" offset=<wholenumber> )? )?
                           ( "ALLOW" "FILTERING" )?
+                          ( "WITH" "ann_options" "=" <mapLiteral> )?
                     ;
 <whereClause> ::= <relation> ( "AND" <relation> )*
                 ;
@@ -741,7 +746,7 @@ syntax_rules += r'''
              ;
 <selectionFunctionArguments> ::= "(" ( <selector> ( "," <selector> )* )? ")"
                           ;
-<orderByClause> ::= [ordercol]=<cident> ( "ASC" | "DESC" )?
+<orderByClause> ::= [ordercol]=<cident> ( "ANN" "OF" <vectorLiteral> )? ( "ASC" | "DESC" )?
                   ;
 <groupByClause> ::= [groupcol]=<cident>
                   ;

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -841,7 +841,14 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_select_limit_clause(self):
         self.trycompletions('SELECT * FROM system.peers LI', immediate='MIT ')
         self.trycompletions('SELECT * FROM system.peers LIMIT ', choices=['<wholenumber>'])
-        self.trycompletions('SELECT * FROM system.peers LIMIT 1 ', choices=[';', 'ALLOW', 'OFFSET'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 ', choices=[';', 'ALLOW', 'OFFSET', 'WITH'])
         self.trycompletions('SELECT * FROM system.peers LIMIT 1 OF', immediate='FSET ')
         self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET ', choices=['<wholenumber>'])
-        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET 1 ', choices=[';', 'ALLOW'])
+        self.trycompletions('SELECT * FROM system.peers LIMIT 1 OFFSET 1 ', choices=[';', 'ALLOW', 'WITH'])
+
+    def test_complete_in_select_order_by_ann_of(self):
+        self.trycompletions('SELECT * FROM system.peers ORDER BY vectorcol ', choices=[',', ';', 'ALLOW', 'ANN', 'ASC', 'DESC', 'LIMIT', 'PER', 'WITH'])
+        self.trycompletions('SELECT * FROM system.peers ORDER BY vectorcol ANN ', immediate='OF [ ')
+        self.trycompletions('SELECT * FROM system.peers ORDER BY vectorcol ANN OF [ 1.2, ', choices=['<float>'])
+        self.trycompletions('SELECT * FROM system.peers ORDER BY vectorcol ANN OF [ 1.0, 2.0] LIMIT 100 ', choices=[';', 'ALLOW', 'OFFSET', 'WITH'])
+        self.trycompletions('SELECT * FROM system.peers ORDER BY vectorcol ANN OF [ 1.0, 2.0] LIMIT 100 WITH ', immediate='ann_options = { ')

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -260,6 +260,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
         List<ColumnIdentifier> groups = new ArrayList<>();
         boolean allowFiltering = false;
         boolean isJson = false;
+        SelectOptions options = new SelectOptions();
     }
     : K_SELECT
         // json is a valid column name. By consequence, we need to resolve the ambiguity for "json - json"
@@ -271,6 +272,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
       ( K_PER K_PARTITION K_LIMIT rows=intValue { perPartitionLimit = rows; } )?
       ( K_LIMIT rows=intValue { limit = rows; } ( K_OFFSET rows=intValue { offset = rows; } )? )?
       ( K_ALLOW K_FILTERING  { allowFiltering = true; } )?
+      ( K_WITH properties[options] )?
       {
           SelectStatement.Parameters params = new SelectStatement.Parameters(orderings,
                                                                              groups,
@@ -278,7 +280,7 @@ selectStatement returns [SelectStatement.RawStatement expr]
                                                                              allowFiltering,
                                                                              isJson);
           WhereClause where = wclause == null ? WhereClause.empty() : wclause.build();
-          $expr = new SelectStatement.RawStatement(cf, params, $sclause.selectors, where, limit, perPartitionLimit, offset);
+          $expr = new SelectStatement.RawStatement(cf, params, $sclause.selectors, where, limit, perPartitionLimit, offset, options);
       }
     ;
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.metrics.TableMetrics;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.sensors.SensorsFactory;
 import org.apache.cassandra.service.reads.range.EndpointGroupingRangeCommandIterator;
 
@@ -574,7 +575,13 @@ public enum CassandraRelevantProperties
     /**
      * If true, the coordinator will propagate sensors via the native protocol custom payload bytes map.
      */
-    SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false");
+    SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false"),
+
+    /**
+     * The current messaging version. This is used when we add new messaging versions without adopting them immediately,
+     * or to force the node to use a specific version for testing purposes.
+     */
+    DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_10));
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.restrictions;
 import java.util.*;
 
 import org.apache.cassandra.guardrails.Guardrails;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.QueryOptions;
@@ -124,7 +125,8 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
     @Override
     public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
-                               QueryOptions options) throws InvalidRequestException
+                               QueryOptions options,
+                               ANNOptions annOptions) throws InvalidRequestException
     {
         int position = 0;
 
@@ -135,7 +137,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             // We ignore all the clustering columns that can be handled by slices.
             if (handleInFilter(restriction, position) || restriction.hasSupportingIndex(indexRegistry))
             {
-                restriction.addToRowFilter(filter, indexRegistry, options);
+                restriction.addToRowFilter(filter, indexRegistry, options, annOptions);
                 continue;
             }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.CollectionSerializer;
 
@@ -238,7 +239,10 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+        public final void addToRowFilter(RowFilter.Builder filter,
+                                         IndexRegistry indexRegistry,
+                                         QueryOptions options,
+                                         ANNOptions annOptions)
         {
             Tuples.Value t = ((Tuples.Value) term.bind(options));
             List<ByteBuffer> values = t.getElements();
@@ -303,7 +307,8 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public final void addToRowFilter(RowFilter.Builder filter,
                                          IndexRegistry indexRegistry,
-                                         QueryOptions options)
+                                         QueryOptions options,
+                                         ANNOptions annOptions)
         {
             // If the relation is of the type (c) IN ((x),(y),(z)) then it is equivalent to
             // c IN (x, y, z) and we can perform filtering
@@ -571,7 +576,8 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public final void addToRowFilter(RowFilter.Builder filter,
                                          IndexRegistry indexRegistry,
-                                         QueryOptions options)
+                                         QueryOptions options,
+                                         ANNOptions annOptions)
         {
             throw invalidRequest("Multi-column slice restrictions cannot be used for filtering.");
         }
@@ -663,7 +669,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public final void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+        public final void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
         {
             throw new UnsupportedOperationException("Secondary indexes do not support IS NOT NULL restrictions");
         }

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 import org.apache.cassandra.guardrails.Guardrails;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.Bound;
@@ -124,13 +125,14 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     @Override
     public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
-                               QueryOptions options)
+                               QueryOptions options,
+                               ANNOptions annOptions)
     {
         List<SingleRestriction> restrictions = restrictions();
         for (int i = 0; i < restrictions.size(); i++)
         {
             SingleRestriction r = restrictions.get(i);
-            r.addToRowFilter(filter, indexRegistry, options);
+            r.addToRowFilter(filter, indexRegistry, options, annOptions);
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/Restriction.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.cql3.restrictions;
 
 import java.util.List;
 
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.QueryOptions;
@@ -87,8 +88,10 @@ public interface Restriction
      * @param filter the row filter to add expressions to
      * @param indexRegistry the index registry
      * @param options the query options
+     * @param annOptions the query ANN options
      */
     public void addToRowFilter(RowFilter.Builder filter,
                                IndexRegistry indexRegistry,
-                               QueryOptions options);
+                               QueryOptions options,
+                               ANNOptions annOptions);
 }

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -30,6 +30,7 @@ import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction.ContainsRestriction;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -55,8 +56,9 @@ public abstract class RestrictionSet implements Restrictions
         }
 
         @Override
-        public void addToRowFilter(RowFilter.Builder rowFilter, IndexRegistry indexRegistry, QueryOptions options) throws InvalidRequestException
+        public void addToRowFilter(RowFilter.Builder rowFilter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
         {
+            // nothing to do here, since there are no restrictions
         }
 
         @Override
@@ -225,10 +227,11 @@ public abstract class RestrictionSet implements Restrictions
         @Override
         public void addToRowFilter(RowFilter.Builder rowFilter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options) throws InvalidRequestException
+                                   QueryOptions options,
+                                   ANNOptions annOptions) throws InvalidRequestException
         {
             for (SingleRestriction restriction : restrictionsMap.values())
-                rowFilter.addAllAsConjunction(b -> restriction.addToRowFilter(b, indexRegistry, options));
+                rowFilter.addAllAsConjunction(b -> restriction.addToRowFilter(b, indexRegistry, options, annOptions));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSetWrapper.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.restrictions;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.QueryOptions;
@@ -46,9 +47,10 @@ class RestrictionSetWrapper implements Restrictions
     @Override
     public void addToRowFilter(RowFilter.Builder rowFilter,
                                IndexRegistry indexRegistry,
-                               QueryOptions options)
+                               QueryOptions options,
+                               ANNOptions annOptions)
     {
-        restrictions.addToRowFilter(rowFilter, indexRegistry, options);
+        restrictions.addToRowFilter(rowFilter, indexRegistry, options, annOptions);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.functions.Function;
@@ -167,7 +168,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             filter.add(columnDef, Operator.EQ, term.bindAndGet(options));
         }
@@ -263,7 +265,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             List<ByteBuffer> values = this.terms.bindAndGet(options, columnDef.name);
             for (ByteBuffer v : values)
@@ -405,7 +408,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
         {
             for (Bound b : Bound.values())
                 if (hasBound(b))
@@ -510,7 +513,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
         {
             var map = new HashMap<ByteBuffer, TermSlice>();
             // First, we iterate through to verify that none of the slices create invalid ranges.
@@ -657,7 +660,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
-        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+        public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
         {
             for (ByteBuffer value : bindAndGet(values, options))
                 filter.add(columnDef, Operator.CONTAINS, value);
@@ -840,7 +843,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             throw new UnsupportedOperationException("Secondary indexes do not support IS NOT NULL restrictions");
         }
@@ -910,7 +914,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             Pair<Operator, ByteBuffer> operation = makeSpecific(value.bindAndGet(options));
 
@@ -1039,11 +1044,12 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             filter.add(columnDef, direction, ByteBufferUtil.EMPTY_BYTE_BUFFER);
             if (otherRestriction != null)
-                otherRestriction.addToRowFilter(filter, indexRegistry, options);
+                otherRestriction.addToRowFilter(filter, indexRegistry, options, annOptions);
         }
 
         @Override
@@ -1127,11 +1133,12 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
-            filter.add(columnDef, Operator.ANN, value.bindAndGet(options));
+            filter.addANNExpression(columnDef, value.bindAndGet(options), annOptions);
             if (boundedAnnRestriction != null)
-                boundedAnnRestriction.addToRowFilter(filter, indexRegistry, options);
+                boundedAnnRestriction.addToRowFilter(filter, indexRegistry, options, annOptions);
         }
 
         @Override
@@ -1216,7 +1223,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             filter.addGeoDistanceExpression(columnDef, value.bindAndGet(options), isInclusive ? Operator.LTE : Operator.LT, distance.bindAndGet(options));
         }
@@ -1300,7 +1308,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public void addToRowFilter(RowFilter.Builder filter,
                                    IndexRegistry indexRegistry,
-                                   QueryOptions options)
+                                   QueryOptions options,
+                                   ANNOptions annOptions)
         {
             for (Term value : values)
             {

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -29,8 +29,10 @@ import com.google.common.collect.Iterables;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.Bound;
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.cql3.statements.StatementType;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.DecimalType;
@@ -88,6 +90,7 @@ public class StatementRestrictions
     public static final String VECTOR_INDEX_PRESENT_NOT_SUPPORT_GEO_DISTANCE_MESSAGE =
     "Vector index present, but configuration does not support GEO_DISTANCE queries. GEO_DISTANCE requires similarity_function 'euclidean'";
     public static final String VECTOR_INDEXES_UNSUPPORTED_OP_MESSAGE = "Vector indexes only support ANN and GEO_DISTANCE queries";
+    public static final String ANN_OPTIONS_WITHOUT_ORDER_BY_ANN = "ANN options specified without ORDER BY ... ANN OF ...";
 
     /**
      * The Column Family meta data
@@ -985,12 +988,26 @@ public class StatementRestrictions
         return table.clusteringColumns().size() != clusteringColumnsRestrictions.size();
     }
 
-    public RowFilter getRowFilter(IndexRegistry indexManager, QueryOptions options, QueryState queryState)
+    public RowFilter getRowFilter(IndexRegistry indexManager, QueryOptions options, QueryState queryState, SelectOptions selectOptions)
     {
-        if (filterRestrictions.isEmpty() && children.isEmpty())
-            return RowFilter.NONE;
+        boolean hasAnnOptions = selectOptions.hasANNOptions();
 
-        return RowFilter.builder(indexManager).buildFromRestrictions(this, table, options, queryState);
+        if (filterRestrictions.isEmpty() && children.isEmpty())
+        {
+            if (hasAnnOptions)
+                throw new InvalidRequestException(ANN_OPTIONS_WITHOUT_ORDER_BY_ANN);
+
+            return RowFilter.NONE;
+        }
+
+        ANNOptions annOptions = selectOptions.parseANNOptions();
+        RowFilter rowFilter = RowFilter.builder(indexManager)
+                                       .buildFromRestrictions(this, table, options, queryState, annOptions);
+
+        if (hasAnnOptions && !rowFilter.hasANN())
+            throw new InvalidRequestException(ANN_OPTIONS_WITHOUT_ORDER_BY_ANN);
+
+        return rowFilter;
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenFilter.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -337,9 +338,9 @@ abstract class TokenFilter implements PartitionKeyRestrictions
     }
 
     @Override
-    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
     {
-        restrictions.addToRowFilter(filter, indexRegistry, options);
+        restrictions.addToRowFilter(filter, indexRegistry, options, annOptions);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TokenRestriction.java
@@ -22,6 +22,7 @@ import java.util.*;
 
 import com.google.common.base.Joiner;
 
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
@@ -130,7 +131,7 @@ public abstract class TokenRestriction implements PartitionKeyRestrictions
     }
 
     @Override
-    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options)
+    public void addToRowFilter(RowFilter.Builder filter, IndexRegistry indexRegistry, QueryOptions options, ANNOptions annOptions)
     {
         throw new UnsupportedOperationException("Index expression cannot be created for token restriction");
     }

--- a/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
+++ b/src/java/org/apache/cassandra/cql3/statements/PropertyDefinitions.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.cql3.statements;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +34,7 @@ public class PropertyDefinitions
     
     protected static final Logger logger = LoggerFactory.getLogger(PropertyDefinitions.class);
 
-    protected final Map<String, Object> properties = new HashMap<String, Object>();
+    protected final Map<String, Object> properties = new HashMap<>();
 
     public void addProperty(String name, String value) throws SyntaxException
     {
@@ -60,6 +62,7 @@ public class PropertyDefinitions
         }
     }
 
+    @Nullable
     protected String getSimple(String name) throws SyntaxException
     {
         Object val = properties.get(name);
@@ -70,6 +73,7 @@ public class PropertyDefinitions
         return (String)val;
     }
 
+    @Nullable
     public Map<String, String> getMap(String name) throws SyntaxException
     {
         Object val = properties.get(name);

--- a/src/java/org/apache/cassandra/cql3/statements/SelectOptions.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectOptions.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.cassandra.db.filter.ANNOptions;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+
+/**
+ * {@code WITH option1=... AND option2=...} options for SELECT statements.
+ */
+public class SelectOptions extends PropertyDefinitions
+{
+    public static final SelectOptions EMPTY = new SelectOptions();
+    public static final String ANN_OPTIONS = "ann_options";
+
+    private static final Set<String> keywords = Collections.singleton(ANN_OPTIONS);
+
+    /**
+     * Validates all the {@code SELECT} options.
+     *
+     * @param limit the {@code SELECT} query user-provided limit
+     * @throws InvalidRequestException if any of the options are invalid
+     */
+    public void validate(int limit) throws RequestValidationException
+    {
+        validate(keywords, Collections.emptySet());
+        parseANNOptions().validate(limit);
+    }
+
+    /**
+     * @return the ANN options within these options, or {@link ANNOptions#NONE} if no options are present
+     * @throws InvalidRequestException if the ANN options are invalid
+     */
+    public ANNOptions parseANNOptions() throws RequestValidationException
+    {
+        Map<String, String> options = getMap(ANN_OPTIONS);
+
+        return options == null
+               ? ANNOptions.NONE
+               : ANNOptions.fromMap(options);
+    }
+
+    /**
+     * @return {@code true} if these options contain ANN options, {@code false} otherwise
+     */
+    public boolean hasANNOptions()
+    {
+        return properties.containsKey(ANN_OPTIONS);
+    }
+}

--- a/src/java/org/apache/cassandra/db/CounterMutation.java
+++ b/src/java/org/apache/cassandra/db/CounterMutation.java
@@ -64,7 +64,8 @@ import static java.util.concurrent.TimeUnit.*;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_FAIR_LOCK;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_NUM_STRIPES_PER_THREAD;
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
-import static org.apache.cassandra.net.MessagingService.VERSION_SG_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_11;
 import static org.apache.cassandra.net.MessagingService.VERSION_30;
 import static org.apache.cassandra.net.MessagingService.VERSION_3014;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
@@ -495,7 +496,8 @@ public class CounterMutation implements IMutation
     private int serializedSize30;
     private int serializedSize3014;
     private int serializedSize40;
-    private int serializedSizeSG10;
+    private int serializedSizeDS10;
+    private int serializedSizeDS11;
 
     public int serializedSize(int version)
     {
@@ -513,10 +515,14 @@ public class CounterMutation implements IMutation
                 if (serializedSize40 == 0)
                     serializedSize40 = (int) serializer.serializedSize(this, VERSION_40);
                 return serializedSize40;
-            case VERSION_SG_10:
-                if (serializedSizeSG10 == 0)
-                    serializedSizeSG10 = (int) serializer.serializedSize(this, VERSION_SG_10);
-                return serializedSizeSG10;
+            case VERSION_DS_10:
+                if (serializedSizeDS10 == 0)
+                    serializedSizeDS10 = (int) serializer.serializedSize(this, VERSION_DS_10);
+                return serializedSizeDS10;
+            case VERSION_DS_11:
+                if (serializedSizeDS11 == 0)
+                    serializedSizeDS11 = (int) serializer.serializedSize(this, VERSION_DS_11);
+                return serializedSizeDS11;
             default:
                 throw new IllegalStateException("Unknown serialization version: " + version);
         }

--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -59,7 +59,8 @@ import static org.apache.cassandra.net.MessagingService.VERSION_30;
 import static org.apache.cassandra.net.MessagingService.VERSION_3014;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.MessagingService.VERSION_41;
-import static org.apache.cassandra.net.MessagingService.VERSION_SG_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_11;
 import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 
 public class Mutation implements IMutation
@@ -321,7 +322,8 @@ public class Mutation implements IMutation
     private int serializedSize3014;
     private int serializedSize40;
     private int serializedSize41;
-    private int serializedSizeSG10;
+    private int serializedSizeDS10;
+    private int serializedSizeDS11;
 
     public int serializedSize(int version)
     {
@@ -343,10 +345,14 @@ public class Mutation implements IMutation
                 if (serializedSize41 == 0)
                     serializedSize41 = (int) serializer.serializedSize(this, VERSION_41);
                 return serializedSize41;
-            case VERSION_SG_10:
-                if (serializedSizeSG10 == 0)
-                    serializedSizeSG10 = (int) serializer.serializedSize(this, VERSION_SG_10);
-                return serializedSizeSG10;
+            case VERSION_DS_10:
+                if (serializedSizeDS10 == 0)
+                    serializedSizeDS10 = (int) serializer.serializedSize(this, VERSION_DS_10);
+                return serializedSizeDS10;
+            case VERSION_DS_11:
+                if (serializedSizeDS11 == 0)
+                    serializedSizeDS11 = (int) serializer.serializedSize(this, VERSION_DS_11);
+                return serializedSizeDS11;
             default:
                 throw new IllegalStateException("Unknown serialization version: " + version);
         }

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -37,6 +37,8 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.cql3.statements.SelectOptions;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
@@ -779,6 +781,11 @@ public abstract class ReadCommand extends AbstractReadQuery
 
         if (limits() != DataLimits.NONE)
             sb.append(' ').append(limits());
+
+        ANNOptions annOptions = rowFilter().annOptions();
+        if (annOptions != ANNOptions.NONE)
+            sb.append(" WITH ").append(SelectOptions.ANN_OPTIONS).append(" = ").append(annOptions.toCQLString());
+
         return sb.toString();
     }
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
@@ -238,7 +238,7 @@ public class CommitLogArchiver
                     descriptor = fromHeader;
                 else descriptor = fromName;
 
-                if (descriptor.version > CommitLogDescriptor.current_version)
+                if (descriptor.version > CommitLogDescriptor.CURRENT_VERSION)
                     throw new IllegalStateException("Unsupported commit log version: " + descriptor.version);
 
                 if (descriptor.compression != null)

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
@@ -67,14 +67,15 @@ public class CommitLogDescriptor
     // For compatibility with CNDB
     private static final int VERSION_DSE_68 = 680;
     // Stargazer 1.0 messaging
-    private static final int VERSION_SG_10 = 100;
+    static final int VERSION_DS_10 = MessagingService.VERSION_DS_10;
+    static final int VERSION_DS_11 = MessagingService.VERSION_DS_11;
 
     /**
      * Increment this number if there is a changes in the commit log disc layout or MessagingVersion changes.
      * Note: make sure to handle {@link #getMessagingVersion()}
      */
     @VisibleForTesting
-    public static final int current_version = VERSION_SG_10;
+    public static final int CURRENT_VERSION = MessagingService.current_version;
 
     final int version;
     public final long id;
@@ -91,7 +92,7 @@ public class CommitLogDescriptor
 
     public CommitLogDescriptor(long id, ParameterizedClass compression, EncryptionContext encryptionContext)
     {
-        this(current_version, id, compression, encryptionContext);
+        this(CURRENT_VERSION, id, compression, encryptionContext);
     }
 
     public static void writeHeader(ByteBuffer out, CommitLogDescriptor descriptor)
@@ -218,8 +219,10 @@ public class CommitLogDescriptor
                 return MessagingService.VERSION_40;
             case VERSION_DSE_68:
                 return MessagingService.VERSION_DSE_68;
-            case VERSION_SG_10:
-                return MessagingService.VERSION_SG_10;
+            case VERSION_DS_10:
+                return MessagingService.VERSION_DS_10;
+            case VERSION_DS_11:
+                return MessagingService.VERSION_DS_11;
             default:
                 throw new IllegalStateException("Unknown commitlog version " + version);
         }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogDescriptor.java
@@ -74,7 +74,6 @@ public class CommitLogDescriptor
      * Increment this number if there is a changes in the commit log disc layout or MessagingVersion changes.
      * Note: make sure to handle {@link #getMessagingVersion()}
      */
-    @VisibleForTesting
     public static final int CURRENT_VERSION = MessagingService.current_version;
 
     final int version;

--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.filter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
+
+/**
+ * {@code SELECT} query options for ANN search.
+ */
+public class ANNOptions
+{
+    public static final String RERANK_K_OPTION_NAME = "rerank_k";
+
+    public static final ANNOptions NONE = new ANNOptions(null);
+
+    public static final Serializer serializer = new Serializer();
+
+    /**
+     * The amplified limit for the ANN query to get more accurate results.
+     * A value lesser or equals to zero means no reranking.
+     * A {@code null} value means the option is not present.
+     */
+    @Nullable
+    public final Integer rerankK;
+
+    private ANNOptions(@Nullable Integer rerankK)
+    {
+        this.rerankK = rerankK;
+    }
+
+    public static ANNOptions create(@Nullable Integer rerankK)
+    {
+        // if all the options are null, return the NONE instance
+        return rerankK == null ? NONE : new ANNOptions(rerankK);
+    }
+
+    public void validate(int limit)
+    {
+        if (rerankK != null && rerankK > 0 && rerankK < limit)
+            throw new InvalidRequestException(String.format("Invalid rerank_k value %d lesser than limit %d", rerankK, limit));
+    }
+
+    /**
+     * Returns the ANN options stored the given map of options.
+     *
+     * @param map the map of options in the {@code WITH ANN_OPTION} of a {@code SELECT} query
+     * @return the ANN options in the specified {@code SELECT} options, or {@link #NONE} if no options are present
+     */
+    public static ANNOptions fromMap(Map<String, String> map)
+    {
+        // ensure that all nodes in the cluster are in a version that supports ANN options, including this one
+        Set<InetAddressAndPort> badNodes = MessagingService.instance().endpointsWithVersionBelow(MessagingService.VERSION_DS_11);
+        if (MessagingService.current_version < MessagingService.VERSION_DS_11)
+            badNodes.add(FBUtilities.getBroadcastAddressAndPort());
+        if (!badNodes.isEmpty())
+            throw new InvalidRequestException("ANN options are not supported in clusters below DS 11.");
+
+        Integer rerankK = null;
+
+        for (Map.Entry<String, String> entry : map.entrySet())
+        {
+            String name = entry.getKey();
+            String value = entry.getValue();
+
+            if (name.equals(RERANK_K_OPTION_NAME))
+            {
+                rerankK = parseRerankK(value);
+            }
+            else
+            {
+                throw new InvalidRequestException("Unknown ANN option: " + name);
+            }
+        }
+
+        return ANNOptions.create(rerankK);
+    }
+
+    private static int parseRerankK(String value)
+    {
+        int rerankK;
+
+        try
+        {
+            rerankK = Integer.parseInt(value);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new InvalidRequestException(String.format("Invalid '%s' ANN option. Expected a positive int but found: %s",
+                                                            RERANK_K_OPTION_NAME, value));
+        }
+
+        return rerankK;
+    }
+
+    public String toCQLString()
+    {
+        return String.format("{'%s': %d}", RERANK_K_OPTION_NAME, rerankK);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ANNOptions that = (ANNOptions) o;
+        return Objects.equals(rerankK, that.rerankK);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(rerankK);
+    }
+
+    /**
+     * Serializer for {@link ANNOptions}.
+     * </p>
+     * This serializer writes an int containing bit flags that indicate which options are present, allowing the future
+     * addition of new options without increasing the messaging version. We should be able to create compatible messages
+     * in the future if we add new options and those are not explicitly set in the user query. If we receive a message
+     * with unknown newer options from a newer node, we will reject it.
+     * </p>
+     * This approach should be more space-efficient than simply using a map, as we do with the index creation options.
+     * Space is more important in this case because the {@link ANNOptions} are sent with every {@code SELECT} query. The
+     * downside is that we only allow for up to 32 options, which seems reasonable. If we ever need more options, we can
+     * use the last bit flag to indicate that we need to read more flags from the input.
+     */
+    public static class Serializer
+    {
+        /** Bit flags mask to check if the rerank K option is present. */
+        private static final int RERANK_K_MASK = 1;
+
+        /** Bit flags mask to check if there are any unknown options. It's the negation of all the known flags. */
+        private static final int UNKNOWN_OPTIONS_MASK = ~RERANK_K_MASK;
+
+        /*
+         * If you add a new option, then update ANNOptionsTest.FutureANNOptions and possibly add a new test verifying
+         * that the serialization of the updated and original versions of the options are compatible.
+         */
+
+        public void serialize(ANNOptions options, DataOutputPlus out, int version) throws IOException
+        {
+            // ANN options are only supported in DS 11 and above, so don't serialize anything if the messaging version is lower
+            if (version < MessagingService.VERSION_DS_11)
+                return;
+
+            int flags = flags(options);
+            out.writeInt(flags);
+
+            if (options.rerankK != null)
+                out.writeUnsignedVInt(options.rerankK);
+        }
+
+        public ANNOptions deserialize(DataInputPlus in, int version) throws IOException
+        {
+            // ANN options are only supported in DS 11 and above, so don't read anything if the messaging version is lower
+            if (version < MessagingService.VERSION_DS_11)
+                return ANNOptions.NONE;
+
+            int flags = in.readInt();
+
+            // Reject any flags for unknown options that may have been written by a node running newer code.
+            if ((flags & UNKNOWN_OPTIONS_MASK) != 0)
+                throw new IOException("Found unsupported ANN options, likely due to the ANN options containing " +
+                                      "new options that are not supported by this node.");
+
+            Integer rerankK = hasRerankK(flags) ? (int) in.readUnsignedVInt() : null;
+
+            return ANNOptions.create(rerankK);
+        }
+
+        public long serializedSize(ANNOptions options, int version)
+        {
+            // ANN options are only supported in DS 11 and above, so no size if the messaging version is lower
+            if (version < MessagingService.VERSION_DS_11)
+                return 0;
+
+            int flags = flags(options);
+            long size = TypeSizes.sizeof(flags);
+
+            if (options.rerankK != null)
+                size += TypeSizes.sizeofUnsignedVInt(options.rerankK);
+
+            return size;
+        }
+
+        private static int flags(ANNOptions options)
+        {
+            int flags = 0;
+
+            if (options == NONE)
+                return flags;
+
+            if (options.rerankK != null)
+                flags |= RERANK_K_MASK;
+
+            return flags;
+        }
+
+        private static boolean hasRerankK(int flags)
+        {
+            return (flags & RERANK_K_MASK) == RERANK_K_MASK;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -699,14 +699,14 @@ public class RowFilter
         {
             public void serialize(FilterElement operation, DataOutputPlus out, int version) throws IOException
             {
-                assert (!operation.isDisjunction && operation.children().isEmpty()) || version == MessagingService.VERSION_SG_10 :
+                assert (!operation.isDisjunction && operation.children().isEmpty()) || version >= MessagingService.VERSION_DS_10 :
                 "Attempting to serialize a disjunct row filter to a node that doesn't support disjunction";
 
                 out.writeUnsignedVInt(operation.expressions.size());
                 for (Expression expr : operation.expressions)
                     Expression.serializer.serialize(expr, out, version);
 
-                if (version < MessagingService.VERSION_SG_10)
+                if (version < MessagingService.VERSION_DS_10)
                     return;
 
                 out.writeBoolean(operation.isDisjunction);
@@ -722,7 +722,7 @@ public class RowFilter
                 for (int i = 0; i < size; i++)
                     expressions.add(Expression.serializer.deserialize(in, version, metadata));
 
-                if (version < MessagingService.VERSION_SG_10)
+                if (version < MessagingService.VERSION_DS_10)
                     return new FilterElement(false, expressions, Collections.emptyList());
 
                 boolean isDisjunction = in.readBoolean();
@@ -739,7 +739,7 @@ public class RowFilter
                 for (Expression expr : operation.expressions)
                     size += Expression.serializer.serializedSize(expr, version);
 
-                if (version < MessagingService.VERSION_SG_10)
+                if (version < MessagingService.VERSION_DS_10)
                     return size;
 
                 size++; // isDisjunction boolean

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -81,7 +81,7 @@ public class RowFilter
     public static final Serializer serializer = new Serializer();
     public static final RowFilter NONE = new RowFilter(FilterElement.NONE);
 
-    protected final FilterElement root;
+    private final FilterElement root;
 
     protected RowFilter(FilterElement root)
     {
@@ -99,6 +99,33 @@ public class RowFilter
     public List<Expression> expressions()
     {
         return root.traversedExpressions();
+    }
+
+    /**
+     * @return {@code true} if this filter contains any expression with an ANN operator, {@code false} otherwise.
+     */
+    public boolean hasANN()
+    {
+        for (Expression expression : root.expressions()) // ANN expressions are always on the first tree level
+        {
+            if (expression.operator == Operator.ANN)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return the {@link ANNOptions} of the ANN expression in this filter, or {@link ANNOptions#NONE} if there is
+     * no ANN expression.
+     */
+    public ANNOptions annOptions()
+    {
+        for (Expression expression : root.expressions()) // ANN expressions are always on the first tree level
+        {
+            if (expression.operator == Operator.ANN)
+                return expression.annOptions();
+        }
+        return ANNOptions.NONE;
     }
 
     /**
@@ -325,9 +352,13 @@ public class RowFilter
             return new RowFilter(current.build());
         }
 
-        public RowFilter buildFromRestrictions(StatementRestrictions restrictions, TableMetadata table, QueryOptions options, QueryState queryState)
+        public RowFilter buildFromRestrictions(StatementRestrictions restrictions,
+                                               TableMetadata table,
+                                               QueryOptions options,
+                                               QueryState queryState,
+                                               ANNOptions annOptions)
         {
-            FilterElement root = doBuild(restrictions, table, options);
+            FilterElement root = doBuild(restrictions, table, options, annOptions);
 
             if (Guardrails.queryFilters.enabled(queryState))
                 Guardrails.queryFilters.guard(root.numFilteredValues(), "Select query", false, queryState);
@@ -335,19 +366,22 @@ public class RowFilter
             return new RowFilter(root);
         }
 
-        private FilterElement doBuild(StatementRestrictions restrictions, TableMetadata table, QueryOptions options)
+        private FilterElement doBuild(StatementRestrictions restrictions,
+                                      TableMetadata table,
+                                      QueryOptions options,
+                                      ANNOptions annOptions)
         {
             FilterElement.Builder element = new FilterElement.Builder(restrictions.isDisjunction());
             this.current = element;
 
             for (Restrictions restrictionSet : restrictions.filterRestrictions().getRestrictions())
-                restrictionSet.addToRowFilter(this, indexRegistry, options);
+                restrictionSet.addToRowFilter(this, indexRegistry, options, annOptions);
 
             for (ExternalRestriction expression : restrictions.filterRestrictions().getExternalExpressions())
                 addAllAsConjunction(b -> expression.addToRowFilter(b, table, options));
 
             for (StatementRestrictions child : restrictions.children())
-                element.children.add(doBuild(child, table, options));
+                element.children.add(doBuild(child, table, options, annOptions));
 
             // Optimize out any conjunctions / disjunctions with TRUE.
             // This is not needed for correctness.
@@ -420,11 +454,32 @@ public class RowFilter
             }
         }
 
+        /**
+         * Adds the specified simple filter expression to this builder.
+         *
+         * @param def the filtered column
+         * @param op the filtering operator, shouldn't be {@link Operator#ANN}.
+         * @param value the filtered value
+         * @return the added expression
+         */
         public SimpleExpression add(ColumnMetadata def, Operator op, ByteBuffer value)
         {
-            SimpleExpression expression = new SimpleExpression(def, op, value, analyzer(def, op));
+            assert op != Operator.ANN : "ANN expressions should be added with the addANNExpression method";
+            SimpleExpression expression = new SimpleExpression(def, op, value, analyzer(def, op), null);
             add(expression);
             return expression;
+        }
+
+        /**
+         * Adds the specified ANN expression to this builder.
+         *
+         * @param def the column for ANN ordering
+         * @param value the value for ANN ordering
+         * @param annOptions the ANN options
+         */
+        public void addANNExpression(ColumnMetadata def, ByteBuffer value, ANNOptions annOptions)
+        {
+            add(new SimpleExpression(def, Operator.ANN, value, null, annOptions));
         }
 
         public void addMapComparison(ColumnMetadata def, ByteBuffer key, Operator op, ByteBuffer value)
@@ -820,6 +875,12 @@ public class RowFilter
             return null;
         }
 
+        @Nullable
+        public ANNOptions annOptions()
+        {
+            return null;
+        }
+
         /**
          * Checks if the operator of this <code>IndexExpression</code> is a <code>CONTAINS</code> operator.
          *
@@ -950,6 +1011,8 @@ public class RowFilter
                 {
                     case SIMPLE:
                         ByteBufferUtil.writeWithShortLength(expression.value, out);
+                        if (expression.operator == Operator.ANN)
+                            ANNOptions.serializer.serialize(expression.annOptions(), out, version);
                         break;
                     case MAP_COMPARISON:
                         MapComparisonExpression mexpr = (MapComparisonExpression)expression;
@@ -993,11 +1056,13 @@ public class RowFilter
                 switch (kind)
                 {
                     case SIMPLE:
-                        return new SimpleExpression(column, operator, ByteBufferUtil.readWithShortLength(in), analyzer);
+                        ByteBuffer value = ByteBufferUtil.readWithShortLength(in);
+                        ANNOptions annOptions = operator == Operator.ANN ? ANNOptions.serializer.deserialize(in, version) : null;
+                        return new SimpleExpression(column, operator, value, analyzer, annOptions);
                     case MAP_COMPARISON:
                         ByteBuffer key = ByteBufferUtil.readWithShortLength(in);
-                        ByteBuffer value = ByteBufferUtil.readWithShortLength(in);
-                        return new MapComparisonExpression(column, key, operator, value, analyzer);
+                        ByteBuffer val = ByteBufferUtil.readWithShortLength(in);
+                        return new MapComparisonExpression(column, key, operator, val, analyzer);
                     case VECTOR_RADIUS:
                         Operator boundaryOperator = Operator.readFrom(in);
                         ByteBuffer distance = ByteBufferUtil.readWithShortLength(in);
@@ -1021,6 +1086,8 @@ public class RowFilter
                 {
                     case SIMPLE:
                         size += ByteBufferUtil.serializedSizeWithShortLength((expression).value);
+                        if (expression.operator == Operator.ANN)
+                            size += ANNOptions.serializer.serializedSize(expression.annOptions(), version);
                         break;
                     case MAP_COMPARISON:
                         MapComparisonExpression mexpr = (MapComparisonExpression)expression;
@@ -1080,9 +1147,23 @@ public class RowFilter
      */
     public static class SimpleExpression extends AnalyzableExpression
     {
-        public SimpleExpression(ColumnMetadata column, Operator operator, ByteBuffer value, @Nullable Index.Analyzer analyzer)
+        @Nullable
+        private final ANNOptions annOptions;
+
+        public SimpleExpression(ColumnMetadata column,
+                                Operator operator,
+                                ByteBuffer value,
+                                @Nullable Index.Analyzer analyzer,
+                                @Nullable ANNOptions annOptions)
         {
             super(column, operator, value, analyzer);
+            this.annOptions = annOptions;
+        }
+
+        @Nullable
+        public ANNOptions annOptions()
+        {
+            return annOptions;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/view/View.java
+++ b/src/java/org/apache/cassandra/db/view/View.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.selection.RawSelector;
 import org.apache.cassandra.cql3.selection.Selectable;
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.rows.*;
@@ -175,7 +176,8 @@ public class View
                                                  definition.whereClause,
                                                  null,
                                                  null,
-                                                 null);
+                                                 null,
+                                                 SelectOptions.EMPTY);
 
             rawSelect.setBindVariables(Collections.emptyList());
 

--- a/src/java/org/apache/cassandra/hints/HintsDescriptor.java
+++ b/src/java/org/apache/cassandra/hints/HintsDescriptor.java
@@ -71,8 +71,9 @@ final class HintsDescriptor
 
     static final int VERSION_30 = 1;
     static final int VERSION_40 = 2;
-    static final int VERSION_SG_10 = 100;
-    static final int CURRENT_VERSION = VERSION_SG_10;
+    static final int VERSION_DS_10 = MessagingService.VERSION_DS_10;
+    static final int VERSION_DS_11 = MessagingService.VERSION_DS_11;
+    static final int CURRENT_VERSION = MessagingService.current_version;
 
     static final String COMPRESSION = "compression";
     static final String ENCRYPTION = "encryption";
@@ -264,8 +265,10 @@ final class HintsDescriptor
                 return MessagingService.VERSION_30;
             case VERSION_40:
                 return MessagingService.VERSION_40;
-            case VERSION_SG_10:
-                return MessagingService.VERSION_SG_10;
+            case VERSION_DS_10:
+                return MessagingService.VERSION_DS_10;
+            case VERSION_DS_11:
+                return MessagingService.VERSION_DS_11;
             default:
                 throw new AssertionError();
         }

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -78,6 +78,7 @@ import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.dht.OrderPreservingPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexBuildDecider;
 import org.apache.cassandra.index.IndexRegistry;
@@ -699,6 +700,10 @@ public class StorageAttachedIndex implements Index
         if (command.limits().isUnlimited() || command.limits().count() > MAX_TOP_K)
             throw new InvalidRequestException(String.format("SAI based ORDER BY clause requires a LIMIT that is not greater than %s. LIMIT was %s",
                                                             MAX_TOP_K, command.limits().isUnlimited() ? "NO LIMIT" : command.limits().count()));
+
+        ANNOptions annOptions = command.rowFilter().annOptions();
+        if (annOptions != ANNOptions.NONE)
+            throw new InvalidRequestException("SAI doesn't support ANN options yet.");
 
         indexContext.validate(command.rowFilter());
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -311,7 +311,8 @@ public class Operation
                                                                                                         ByteBufferAccessor.instance,
                                                                                                         offset,
                                                                                                         ProtocolVersion.V3),
-                                                                               expression.analyzer())));
+                                                                               expression.analyzer(),
+                                                                               expression.annOptions())));
                     offset += TypeSizes.INT_SIZE + ByteBufferAccessor.instance.getInt(expression.getIndexValue(), offset);
                 }
                 if (node.children().size() == 1)

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormat.java
@@ -347,7 +347,7 @@ public class TrieIndexFormat implements SSTableFormat
             hasAccurateLegacyMinMax = version.compareTo("ac") >= 0;
             hasOriginatingHostId = version.matches("(a[d-z])|(b[b-z])") || version.compareTo("ca") >= 0;
             hasMaxColumnValueLengths = version.matches("b[a-z]"); // DSE only field
-            correspondingMessagingVersion = version.compareTo("ca") >= 0 ? MessagingService.VERSION_SG_10 : MessagingService.VERSION_3014;
+            correspondingMessagingVersion = version.compareTo("ca") >= 0 ? MessagingService.VERSION_DS_10 : MessagingService.VERSION_3014;
             hasExplicitlyFrozenTuples = version.compareTo("cc") < 0 || version.compareTo("da") >= 0; // we don't know if what DA is going to be eventually, but it is almost certain it will not include explicitly frozen tuples
             byteComparableVersion = version.compareTo("ca") >= 0 ? ByteComparable.Version.OSS41 : ByteComparable.Version.LEGACY;
         }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -56,7 +56,8 @@ import static org.apache.cassandra.net.MessagingService.VERSION_3014;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.MessagingService.VERSION_41;
 import static org.apache.cassandra.net.MessagingService.VERSION_DSE_68;
-import static org.apache.cassandra.net.MessagingService.VERSION_SG_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_11;
 import static org.apache.cassandra.net.MessagingService.instance;
 import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 import static org.apache.cassandra.utils.vint.VIntCoding.computeUnsignedVIntSize;
@@ -1435,7 +1436,8 @@ public class Message<T>
     private int serializedSize3014;
     private int serializedSize40;
     private int serializedSize41;
-    private int serializedSizeSG10;
+    private int serializedSizeDS10;
+    private int serializedSizeDS11;
     private int serializedSizeDSE68;
 
     /**
@@ -1461,13 +1463,17 @@ public class Message<T>
                 if (serializedSize41 == 0)
                     serializedSize41 = serializer.serializedSize(this, VERSION_41);
                 return serializedSize41;
-            case VERSION_SG_10:
-                if (serializedSizeSG10 == 0)
-                    serializedSizeSG10 = (int) serializer.serializedSize(this, VERSION_SG_10);
-                return serializedSizeSG10;
+            case VERSION_DS_10:
+                if (serializedSizeDS10 == 0)
+                    serializedSizeDS10 = serializer.serializedSize(this, VERSION_DS_10);
+                return serializedSizeDS10;
+            case VERSION_DS_11:
+                if (serializedSizeDS11 == 0)
+                    serializedSizeDS11 = serializer.serializedSize(this, VERSION_DS_11);
+                return serializedSizeDS11;
             case VERSION_DSE_68:
                 if (serializedSizeDSE68 == 0)
-                    serializedSizeDSE68 = (int) serializer.serializedSize(this, VERSION_DSE_68);
+                    serializedSizeDSE68 = serializer.serializedSize(this, VERSION_DSE_68);
                 return serializedSizeDSE68;
             default:
                 throw new IllegalStateException();
@@ -1478,7 +1484,8 @@ public class Message<T>
     private int payloadSize3014 = -1;
     private int payloadSize40   = -1;
     private int payloadSize41   = -1;
-    private int payloadSizeSG10 = -1;
+    private int payloadSizeDS10 = -1;
+    private int payloadSizeDS11 = -1;
     private int payloadSizeDSE68 = -1;
 
     public int payloadSize(int version)
@@ -1501,10 +1508,14 @@ public class Message<T>
                 if (payloadSize41 < 0)
                     payloadSize41 = serializer.payloadSize(this, VERSION_41);
                 return payloadSize41;
-            case VERSION_SG_10:
-                if (payloadSizeSG10 < 0)
-                    payloadSizeSG10 = serializer.payloadSize(this, VERSION_SG_10);
-                return payloadSizeSG10;
+            case VERSION_DS_10:
+                if (payloadSizeDS10 < 0)
+                    payloadSizeDS10 = serializer.payloadSize(this, VERSION_DS_10);
+                return payloadSizeDS10;
+            case VERSION_DS_11:
+                if (payloadSizeDS11 < 0)
+                    payloadSizeDS11 = serializer.payloadSize(this, VERSION_DS_11);
+                return payloadSizeDS11;
             case VERSION_DSE_68:
                 if (payloadSizeDSE68 < 0)
                     payloadSizeDSE68 = serializer.payloadSize(this, VERSION_DSE_68);
@@ -1526,8 +1537,8 @@ public class Message<T>
                 payloadSize40 = other.payloadSize40;
             if (other.payloadSize41 > 0)
                 payloadSize41 = other.payloadSize41;
-            if (other.payloadSizeSG10 > 0)
-                payloadSizeSG10 = other.payloadSizeSG10;
+            if (other.payloadSizeDS10 > 0)
+                payloadSizeDS10 = other.payloadSizeDS10;
             if (other.payloadSizeDSE68 > 0)
                 payloadSizeDSE68 = other.payloadSizeDSE68;
         }

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -216,7 +216,7 @@ public class MessagingService extends MessagingServiceMBeanImpl
     // Current DataStax version while we have serialization differences.
     // If differences get merged upstream then we can revert to OS versioning.
     public static final int VERSION_DS_10 = 100;
-    public static final int VERSION_DS_11 = 101;
+    public static final int VERSION_DS_11 = 101; // adds ann_options (CNDB-12456)
     public static final int minimum_version = VERSION_30;
     public static final int current_version = currentVersion();
     // DSE 6.8 version for backward compatibility
@@ -642,5 +642,22 @@ public class MessagingService extends MessagingServiceMBeanImpl
     public void waitUntilListening() throws InterruptedException
     {
         inboundSockets.open().await();
+    }
+
+    /**
+     * Returns the endpoints that are known to be alive and are using a messaging version older than the given version.
+     *
+     * @param version a messaging version
+     * @return a set of alive endpoints with messaging version below the given version
+     */
+    public Set<InetAddressAndPort> endpointsWithVersionBelow(int version)
+    {
+        Set<InetAddressAndPort> nodes = new HashSet<>();
+        for (InetAddressAndPort node : StorageService.instance.getTokenMetadata().getAllEndpoints())
+        {
+            if (versions.knows(node) && versions.getRaw(node) < version)
+                nodes.add(node);
+        }
+        return nodes;
     }
 }

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -20,8 +20,10 @@ package org.apache.cassandra.net;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.util.concurrent.Future;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -41,6 +44,7 @@ import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.metrics.MessagingMetrics;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.service.AbstractWriteResponseHandler;
+import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -209,17 +213,29 @@ public class MessagingService extends MessagingServiceMBeanImpl
     public static final int VERSION_3014 = 11;
     public static final int VERSION_40 = 12;
     public static final int VERSION_41 = 13;
-    // Current Stargazer version while we have serialization differences
-    // If differences get merged upstream then we can revert to OS versioning
-    public static final int VERSION_SG_10 = 100;
+    // Current DataStax version while we have serialization differences.
+    // If differences get merged upstream then we can revert to OS versioning.
+    public static final int VERSION_DS_10 = 100;
+    public static final int VERSION_DS_11 = 101;
     public static final int minimum_version = VERSION_30;
-    public static final int current_version = VERSION_SG_10;
+    public static final int current_version = currentVersion();
     // DSE 6.8 version for backward compatibility
     public static final int VERSION_DSE_68 = 168;
 
     static AcceptVersions accept_messaging = new AcceptVersions(minimum_version, current_version, SUPPORTED_DSE_VERSION);
     static AcceptVersions accept_streaming = new AcceptVersions(current_version, current_version);
-    static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, v -> v.ordinal()));
+    static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, Enum::ordinal));
+
+    private static int currentVersion()
+    {
+        int version = CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.getInt();
+        for (Version v : Version.values())
+        {
+            if (v.value == version)
+                return version;
+        }
+        throw new IllegalArgumentException("Unsupported current messaging version: " + version);
+    }
 
     /**
      * This is an optimisation to speed up the translation of the serialization
@@ -247,7 +263,8 @@ public class MessagingService extends MessagingServiceMBeanImpl
         VERSION_3014(MessagingService.VERSION_3014),
         VERSION_40(MessagingService.VERSION_40),
         VERSION_41(MessagingService.VERSION_41),
-        STARGAZER_10(MessagingService.VERSION_SG_10),
+        VERSION_DS_10(MessagingService.VERSION_DS_10),
+        VERSION_DS_11(MessagingService.VERSION_DS_11),
         VERSION_DSE68(MessagingService.VERSION_DSE_68);
 
         public final int value;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/ANNOptionsDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/ANNOptionsDistributedTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai;
+
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.net.MessagingService;
+import org.assertj.core.api.Assertions;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+/**
+ * Distributed tests for ANN options.
+ */
+public class ANNOptionsDistributedTest extends TestBaseImpl
+{
+    private static final int NUM_REPLICAS = 2;
+    private static final int RF = 2;
+
+    /**
+     * Test that ANN options are accepted in clusters with all nodes in DS 11 (although SAI will reject them for now).
+     */
+    @Test
+    public void testANNOptionsWithAllDS11() throws Throwable
+    {
+        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_11);
+
+        try (Cluster cluster = init(Cluster.build(NUM_REPLICAS)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), RF))
+        {
+            test(cluster, "SAI doesn't support ANN options yet.");
+        }
+    }
+
+    /**
+     * Test that ANN options are rejected in clusters with all nodes below DS 11.
+     */
+    @Test
+    public void testANNOptionsWithAllDS10() throws Throwable
+    {
+        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_10);
+
+        try (Cluster cluster = init(Cluster.build(NUM_REPLICAS)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), RF))
+        {
+            test(cluster, "ANN options are not supported in clusters below DS 11.");
+        }
+    }
+
+    /**
+     * Test that ANN options are rejected in clusters with some nodes below DS 11.
+     */
+    @Test
+    public void testANNOptionsWithMixedDS10AndDS11() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(NUM_REPLICAS)
+                                           .withInstanceInitializer(BB::install)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK).with(NATIVE_PROTOCOL))
+                                           .start(), RF))
+        {
+            test(cluster, "ANN options are not supported in clusters below DS 11.");
+        }
+    }
+
+    private static void test(Cluster cluster, String expectedErrorMessage)
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, n int, v vector<float, 2>)"));
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t(v) USING 'StorageAttachedIndex'"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE);
+
+        String select = withKeyspace("SELECT * FROM %s.t ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 10}");
+
+        for (int i = 1; i <= cluster.size(); i++)
+        {
+            ICoordinator coordinator = cluster.coordinator(i);
+            Assertions.assertThatThrownBy(() -> coordinator.execute(select, ConsistencyLevel.ONE))
+                      .hasMessageContaining(expectedErrorMessage);
+        }
+    }
+
+    /**
+     * Injection to set the current version of the first cluster node to DS 11.
+     */
+    public static class BB
+    {
+        public static void install(ClassLoader classLoader, int node)
+        {
+            if (node == 1)
+            {
+                // set the current verson to DS 11, which suppors ANN options
+                new ByteBuddy().rebase(MessagingService.class)
+                               .method(named("currentVersion"))
+                               .intercept(MethodDelegation.to(BB.class))
+                               .make()
+                               .load(classLoader, ClassLoadingStrategy.Default.INJECTION);
+            }
+        }
+
+        @SuppressWarnings("unused")
+        public static int currentVersion()
+        {
+            return MessagingService.VERSION_DS_11;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/WhereClauseMutationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/WhereClauseMutationTest.java
@@ -28,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.datastax.driver.core.Row;
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.messages.ResultMessage;
@@ -92,7 +93,8 @@ public class WhereClauseMutationTest extends CQLTester
                                                                         rawStatement.whereClause.mutateRelations(r -> mutateRelation(r)),
                                                                         rawStatement.limit,
                                                                         rawStatement.perPartitionLimit,
-                                                                        null);
+                                                                        null,
+                                                                        SelectOptions.EMPTY);
 
                         selectStatement = rawStatement.prepare(queryState.getClientState());
                         return selectStatement.execute(queryState, options, queryStartNanoTime);

--- a/test/unit/org/apache/cassandra/db/AbstractReadCommandBuilder.java
+++ b/test/unit/org/apache/cassandra/db/AbstractReadCommandBuilder.java
@@ -24,6 +24,7 @@ import java.util.*;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.cql3.PageSize;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -182,7 +183,13 @@ public abstract class AbstractReadCommandBuilder
         else if (op == Operator.CONTAINS_KEY)
             type = forKeys(type);
 
-        this.filter.add(def, op, bb(value, type));
+        ByteBuffer bb = bb(value, type);
+
+        if (op == Operator.ANN)
+            filter.addANNExpression(def, bb, ANNOptions.NONE);
+        else
+            filter.add(def, op, bb);
+
         return this;
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogDescriptorTest.java
@@ -83,7 +83,7 @@ public class CommitLogDescriptorTest
         Assert.assertEquals(1340512736956320000L, CommitLogDescriptor.fromFileName("CommitLog-2-1340512736956320000.log").id);
 
         Assert.assertEquals(MessagingService.current_version, new CommitLogDescriptor(1340512736956320000L, null, neverEnabledEncryption).getMessagingVersion());
-        String newCLName = "CommitLog-" + CommitLogDescriptor.current_version + "-1340512736956320000.log";
+        String newCLName = "CommitLog-" + CommitLogDescriptor.CURRENT_VERSION + "-1340512736956320000.log";
         Assert.assertEquals(MessagingService.current_version, CommitLogDescriptor.fromFileName(newCLName).getMessagingVersion());
     }
 
@@ -107,10 +107,10 @@ public class CommitLogDescriptorTest
     public void testDescriptorPersistence() throws IOException
     {
         testDescriptorPersistence(new CommitLogDescriptor(11, null, neverEnabledEncryption));
-        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.current_version, 13, null, neverEnabledEncryption));
-        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.current_version, 15, null, neverEnabledEncryption));
-        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.current_version, 17, new ParameterizedClass("LZ4Compressor", null), neverEnabledEncryption));
-        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.current_version, 19,
+        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 13, null, neverEnabledEncryption));
+        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 15, null, neverEnabledEncryption));
+        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 17, new ParameterizedClass("LZ4Compressor", null), neverEnabledEncryption));
+        testDescriptorPersistence(new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 19,
                                                           new ParameterizedClass("StubbyCompressor", ImmutableMap.of("parameter1", "value1", "flag2", "55", "argument3", "null")
                                                           ), neverEnabledEncryption));
     }
@@ -123,7 +123,7 @@ public class CommitLogDescriptorTest
         for (int i=0; i<65535; ++i)
             params.put("key"+i, Integer.toString(i, 16));
         try {
-            CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.current_version,
+            CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION,
                                                                21,
                                                                new ParameterizedClass("LZ4Compressor", params),
                                                                neverEnabledEncryption);
@@ -160,7 +160,7 @@ public class CommitLogDescriptorTest
     @Test
     public void writeAndReadHeader_NoCompressionOrEncryption() throws IOException
     {
-        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, neverEnabledEncryption);
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, neverEnabledEncryption);
         ByteBuffer buffer = ByteBuffer.allocate(16 * 1024);
         CommitLogDescriptor.writeHeader(buffer, descriptor);
         buffer.flip();
@@ -174,7 +174,7 @@ public class CommitLogDescriptorTest
     @Test
     public void writeAndReadHeader_OnlyCompression() throws IOException
     {
-        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, neverEnabledEncryption);
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, neverEnabledEncryption);
         ByteBuffer buffer = ByteBuffer.allocate(16 * 1024);
         CommitLogDescriptor.writeHeader(buffer, descriptor);
         buffer.flip();
@@ -188,7 +188,7 @@ public class CommitLogDescriptorTest
     @Test
     public void writeAndReadHeader_WithEncryptionHeader_EncryptionEnabledInYaml() throws IOException
     {
-        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, enabledEncryption);
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, enabledEncryption);
         ByteBuffer buffer = ByteBuffer.allocate(16 * 1024);
         CommitLogDescriptor.writeHeader(buffer, descriptor);
         buffer.flip();
@@ -206,7 +206,7 @@ public class CommitLogDescriptorTest
     @Test
     public void writeAndReadHeader_WithEncryptionHeader_EncryptionDisabledInYaml() throws IOException
     {
-        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, enabledEncryption);
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, enabledEncryption);
         ByteBuffer buffer = ByteBuffer.allocate(16 * 1024);
         CommitLogDescriptor.writeHeader(buffer, descriptor);
         buffer.flip();
@@ -225,7 +225,7 @@ public class CommitLogDescriptorTest
     @Test
     public void writeAndReadHeader_WithCompressionAndEncryption() throws IOException
     {
-        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, enabledEncryption);
+        CommitLogDescriptor descriptor = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, enabledEncryption);
         ByteBuffer buffer = ByteBuffer.allocate(16 * 1024);
         CommitLogDescriptor.writeHeader(buffer, descriptor);
         buffer.flip();
@@ -241,60 +241,60 @@ public class CommitLogDescriptorTest
     @Test
     public void equals_NoCompressionOrEncryption()
     {
-        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, null);
+        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, null);
         Assert.assertEquals(desc1, desc1);
 
-        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, null);
+        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, null);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, neverEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, neverEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, previouslyEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, previouslyEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
     }
 
     @Test
     public void equals_OnlyCompression()
     {
-        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, null);
+        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, null);
         Assert.assertEquals(desc1, desc1);
 
-        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, null);
+        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, null);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, neverEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, neverEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, previouslyEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, previouslyEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
     }
 
     @Test
     public void equals_OnlyEncryption()
     {
-        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, enabledEncryption);
+        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, enabledEncryption);
         Assert.assertEquals(desc1, desc1);
 
-        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, enabledEncryption);
+        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, enabledEncryption);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, neverEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, neverEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, neverEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
 
-        desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, previouslyEnabledEncryption);
+        desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc1);
-        desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, previouslyEnabledEncryption);
+        desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, previouslyEnabledEncryption);
         Assert.assertEquals(desc1, desc2);
     }
 
@@ -304,10 +304,10 @@ public class CommitLogDescriptorTest
     @Test
     public void equals_BothCompressionAndEncryption()
     {
-        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, enabledEncryption);
+        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, enabledEncryption);
         Assert.assertEquals(desc1, desc1);
 
-        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, compression, enabledEncryption);
+        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, compression, enabledEncryption);
         Assert.assertEquals(desc1, desc2);
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -218,8 +218,8 @@ public abstract class CommitLogTest
     {
         runExpecting(() -> {
             CommitLog.instance.recoverFiles(STARTUP, new File[]{
-            tmpFile(CommitLogDescriptor.current_version),
-            tmpFile(CommitLogDescriptor.current_version)
+            tmpFile(CommitLogDescriptor.CURRENT_VERSION),
+            tmpFile(CommitLogDescriptor.CURRENT_VERSION)
             });
             return null;
         }, CommitLogReplayException.class);
@@ -228,7 +228,7 @@ public abstract class CommitLogTest
     @Test
     public void testRecoveryWithEmptyFinalLog() throws Exception
     {
-        CommitLog.instance.recoverFiles(STARTUP, tmpFile(CommitLogDescriptor.current_version));
+        CommitLog.instance.recoverFiles(STARTUP, tmpFile(CommitLogDescriptor.CURRENT_VERSION));
     }
 
     /**
@@ -243,8 +243,8 @@ public abstract class CommitLogTest
 
         File directory = new File(Files.createTempDir());
 
-        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 1, null, DatabaseDescriptor.getEncryptionContext());
-        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.current_version, 2, null, DatabaseDescriptor.getEncryptionContext());
+        CommitLogDescriptor desc1 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 1, null, DatabaseDescriptor.getEncryptionContext());
+        CommitLogDescriptor desc2 = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION, 2, null, DatabaseDescriptor.getEncryptionContext());
 
         ByteBuffer buffer;
 
@@ -302,7 +302,7 @@ public abstract class CommitLogTest
     public void testRecoveryWithShortSize() throws Exception
     {
         runExpecting(() -> {
-            testRecovery(new byte[2], CommitLogDescriptor.current_version);
+            testRecovery(new byte[2], CommitLogDescriptor.CURRENT_VERSION);
             return null;
         }, CommitLogReplayException.class);
     }
@@ -310,7 +310,7 @@ public abstract class CommitLogTest
     @Test
     public void testRecoveryWithTruncatedFileAndTruncationToleration() throws Exception
     {
-        CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.current_version,
+        CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION,
                                                            CommitLog.instance.getSegmentManager().getNextId(),
                                                            DatabaseDescriptor.getCommitLogCompression(),
                                                            DatabaseDescriptor.getEncryptionContext());
@@ -339,7 +339,7 @@ public abstract class CommitLogTest
     {
         byte[] garbage = new byte[100];
         (new java.util.Random()).nextBytes(garbage);
-        testRecovery(garbage, CommitLogDescriptor.current_version);
+        testRecovery(garbage, CommitLogDescriptor.CURRENT_VERSION);
     }
 
     @Test
@@ -611,7 +611,7 @@ public abstract class CommitLogTest
     protected Pair<File, Integer> tmpFile() throws IOException
     {
         EncryptionContext encryptionContext = DatabaseDescriptor.getEncryptionContext();
-        CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.current_version,
+        CommitLogDescriptor desc = new CommitLogDescriptor(CommitLogDescriptor.CURRENT_VERSION,
                                                            CommitLog.instance.getSegmentManager().getNextId(),
                                                            DatabaseDescriptor.getCommitLogCompression(),
                                                            encryptionContext);
@@ -742,7 +742,7 @@ public abstract class CommitLogTest
     {
         ParameterizedClass commitLogCompression = DatabaseDescriptor.getCommitLogCompression();
         EncryptionContext encryptionContext = DatabaseDescriptor.getEncryptionContext();
-        runExpecting(() -> testRecovery(logData, CommitLogDescriptor.current_version), expected);
+        runExpecting(() -> testRecovery(logData, CommitLogDescriptor.CURRENT_VERSION), expected);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.filter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.cql3.statements.schema.IndexTarget;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.StubIndex;
+import org.apache.cassandra.index.TargetParser;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.utils.Pair;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.QuickTheory;
+
+import static org.quicktheories.generators.SourceDSL.integers;
+
+/**
+ * Tests for {@link ANNOptions}, independent of the specific underlying index implementation.
+ */
+public class ANNOptionsTest extends CQLTester
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        // Set the messaging version that adds support for the new ANN options before starting the server
+        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_11);
+        CQLTester.setUpClass();
+    }
+
+    /**
+     * Test parsing and validation of ANN options in {@code SELECT} queries.
+     */
+    @Test
+    public void testParseAndValidate()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, n int, v vector<float, 2>)");
+
+        // invalid queries with ALLOW FILTERING before creating the ANN index
+        assertInvalidThrowMessage(StatementRestrictions.ANN_OPTIONS_WITHOUT_ORDER_BY_ANN,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WHERE v = [1, 1] ALLOW FILTERING WITH ann_options = {}");
+        assertInvalidThrowMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, 'v'),
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s ORDER BY v ANN OF [1, 1] ALLOW FILTERING WITH ann_options = {}");
+
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v) USING '%s'", ANNIndex.class.getName()));
+
+        // correct queries without specific ANN options
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ann_options = {}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ANN_OPTIONS = {}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] ALLOW FILTERING WITH ann_options = {}");
+        execute("SELECT * FROM %s WHERE k=0 ORDER BY v ANN OF [1, 1] WITH ann_options = {}");
+
+        // correct queries with specific ANN options
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 0}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 1000}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': '0'}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': '1000'}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': '-1'}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': '-1000'}");
+
+        String baseQuery = "SELECT * FROM %s ORDER BY v ANN OF [1, 1]";
+
+        // unknown SELECT options
+        assertInvalidThrowMessage("Unknown property 'unknown_options'",
+                                  SyntaxException.class,
+                                  baseQuery + " WITH unknown_options = {}");
+
+        // mixed known and unknown SELECT options
+        assertInvalidThrowMessage("Unknown property 'unknown_options'",
+                                  SyntaxException.class,
+                                  baseQuery + " WITH ann_options = {'rerank_k': 0} AND unknown_options = {}");
+
+        // duplicated SELECT options
+        assertInvalidThrowMessage("Multiple definition for property 'ann_options'",
+                                  SyntaxException.class,
+                                  baseQuery + " WITH ann_options = {'rerank_k': 0} AND ann_options = {'rerank_k': 0}");
+
+        // unknown ANN options
+        assertInvalidThrowMessage("Unknown ANN option: unknown",
+                                  InvalidRequestException.class,
+                                  baseQuery + " WITH ann_options = {'unknown': 0}");
+
+        // mixed known and unknown ANN options
+        assertInvalidThrowMessage("Unknown ANN option: unknown",
+                                  InvalidRequestException.class,
+                                  baseQuery + " WITH ann_options = {'rerank_k': 0, 'unknown': 0}");
+
+        // invalid ANN options (not a number)
+        assertInvalidThrowMessage("Invalid 'rerank_k' ANN option. Expected a positive int but found: a",
+                                  InvalidRequestException.class,
+                                  baseQuery + " WITH ann_options = {'rerank_k': 'a'}");
+
+        // ANN options with rerank lesser than limit
+        assertInvalidThrowMessage("Invalid rerank_k value 10 lesser than limit 100",
+                                  InvalidRequestException.class,
+                                  baseQuery + "LIMIT 100 WITH ann_options = {'rerank_k': 10}");
+
+        // ANN options without ORDER BY ANN with empty options
+        assertInvalidThrowMessage(StatementRestrictions.ANN_OPTIONS_WITHOUT_ORDER_BY_ANN,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WITH ann_options = {}");
+
+        // ANN options without ORDER BY ANN with non-empty options
+        assertInvalidThrowMessage(StatementRestrictions.ANN_OPTIONS_WITHOUT_ORDER_BY_ANN,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WITH ann_options = {'rerank_k': 10}");
+
+        // ANN options without ORDER BY ANN with other expressions
+        assertInvalidThrowMessage(StatementRestrictions.ANN_OPTIONS_WITHOUT_ORDER_BY_ANN,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WHERE n = 0 ALLOW FILTERING WITH ann_options = {'rerank_k': 10}");
+    }
+
+    /**
+     * Test that ANN options are considered when generating the CQL string representation of a {@link ReadCommand}.
+     */
+    @Test
+    public void testToCQLString()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, n int, v vector<float, 2>)");
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v) USING '%s'", ANNIndex.class.getName()));
+
+        // without ANN options
+        String formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1]");
+        ReadCommand command = parseReadCommand(formattedQuery);
+        Assertions.assertThat(command.toCQLString()).doesNotContain("WITH ann_options");
+
+        // with ANN options
+        formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 1 WITH ann_options = {'rerank_k': 2}");
+        command = parseReadCommand(formattedQuery);
+        Assertions.assertThat(command.toCQLString()).contains("WITH ann_options = {'rerank_k': 2}");
+    }
+
+    /**
+     * Verify that the ANN options in a query get to the {@link ReadCommand} and the {@link Index},
+     * even after serialization.
+     */
+    @Test
+    public void testTransport()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, n int, v vector<float, 2>)");
+        createIndex(String.format("CREATE CUSTOM INDEX ON %%s(v) USING '%s'", ANNIndex.class.getName()));
+
+        // unespecified ANN options, should be mapped to NONE
+        testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1]", ANNOptions.NONE);
+        testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ann_options = {}", ANNOptions.NONE);
+
+        // some random negative values, all should be accepted and not be mapped to NONE
+        String negativeQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': %d}";
+        QuickTheory.qt()
+                   .withExamples(100)
+                   .forAll(integers().allPositive())
+                   .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i)));
+
+        // some random positive values, all should be accepted
+        String positiveQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT %d WITH ann_options = {'rerank_k': %<d}";
+        QuickTheory.qt()
+                   .withExamples(100)
+                   .forAll(integers().allPositive())
+                   .checkAssert(i -> testTransport(String.format(positiveQuery, i), ANNOptions.create(i)));
+    }
+
+    private void testTransport(String query, ANNOptions expectedOptions)
+    {
+        // verify that the options arrive correctly at the index
+        execute(query);
+        Assertions.assertThat(ANNIndex.lastQueryAnnOptions).isEqualTo(expectedOptions);
+
+        // verify that the options are correctly parsed and stored in the ReadCommand
+        String formattedQuery = formatQuery(query);
+        ReadCommand command = parseReadCommand(formattedQuery);
+        ANNOptions actualOptions = command.rowFilter().annOptions();
+        Assertions.assertThat(actualOptions).isEqualTo(expectedOptions);
+
+        // serialize and deserialize the command to check if the options are preserved...
+        try
+        {
+            // ...with a version that supports ANN options
+            DataOutputBuffer out = new DataOutputBuffer();
+            ReadCommand.serializer.serialize(command, out, MessagingService.VERSION_DS_11);
+            Assertions.assertThat(ReadCommand.serializer.serializedSize(command, MessagingService.VERSION_DS_11))
+                      .isEqualTo(out.buffer().remaining());
+            DataInputBuffer in = new DataInputBuffer(out.buffer(), true);
+            command = ReadCommand.serializer.deserialize(in, MessagingService.VERSION_DS_11);
+            actualOptions = command.rowFilter().annOptions();
+            Assertions.assertThat(actualOptions).isEqualTo(expectedOptions);
+
+            // ...with a version that doesn't support ANN options
+            out = new DataOutputBuffer();
+            ReadCommand.serializer.serialize(command, out, MessagingService.VERSION_DS_10);
+            Assertions.assertThat(ReadCommand.serializer.serializedSize(command, MessagingService.VERSION_DS_10))
+                      .isEqualTo(out.buffer().remaining());
+            in = new DataInputBuffer(out.buffer(), true);
+            command = ReadCommand.serializer.deserialize(in, MessagingService.VERSION_DS_10);
+            actualOptions = command.rowFilter().annOptions();
+            Assertions.assertThat(actualOptions).isEqualTo(ANNOptions.NONE);
+        }
+        catch (IOException e)
+        {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Tests that any future versions of {@link ANNOptions} can be able to read the current options.
+     */
+    @Test
+    public void testSerializationForFutureVersions() throws IOException
+    {
+        // the current version of the ANN options...
+        ANNOptions sentOptions = ANNOptions.create(7);
+        DataOutputBuffer out = new DataOutputBuffer();
+        ANNOptions.serializer.serialize(sentOptions, out, MessagingService.current_version);
+        int serializedSize = out.buffer().remaining();
+        Assertions.assertThat(ANNOptions.serializer.serializedSize(sentOptions, MessagingService.current_version))
+                  .isEqualTo(serializedSize);
+
+        // ...should be readable with the future serializer
+        DataInputBuffer in = new DataInputBuffer(out.buffer(), true);
+        FutureANNOptions receivedOptions = FutureANNOptions.serializer.deserialize(in);
+        Assertions.assertThat(receivedOptions).isEqualTo(new FutureANNOptions(sentOptions));
+        Assertions.assertThat(FutureANNOptions.serializer.serializedSize(receivedOptions))
+                  .isEqualTo(serializedSize);
+    }
+
+    /**
+     * Tests that we will be able to deserialize future versions of {@link ANNOptions} with new properties if those new
+     * properties are defaults.
+     */
+    @Test
+    public void testDeserializationOfCompatibleFutureVersions() throws IOException
+    {
+        // a future new version of the ANN options with default new properties...
+        FutureANNOptions sentOptions = new FutureANNOptions(7, FutureANNOptions.NEW_PROPERTY_DEFAULT);
+        DataOutputBuffer out = new DataOutputBuffer();
+        FutureANNOptions.serializer.serialize(sentOptions, out);
+        int serializedSize = out.buffer().remaining();
+        Assertions.assertThat(FutureANNOptions.serializer.serializedSize(sentOptions))
+                  .isEqualTo(serializedSize);
+
+        // ...should be readable with the current serializer
+        DataInputBuffer in = new DataInputBuffer(out.buffer(), true);
+        ANNOptions receivedOptions = ANNOptions.serializer.deserialize(in, MessagingService.current_version);
+        Assertions.assertThat(receivedOptions).isEqualTo(ANNOptions.create(sentOptions.rerankK));
+        Assertions.assertThat(ANNOptions.serializer.serializedSize(receivedOptions, MessagingService.current_version))
+                  .isEqualTo(serializedSize);
+    }
+
+    /**
+     * Tests that we won't be able to desrialize future versions of {@link ANNOptions} with new properties if those new
+     * properties are not defaults.
+     */
+    @Test
+    public void testDeserializationOfNonCompatibleFutureVersions() throws IOException
+    {
+        // a future new version of the ANN options with non-default new properties...
+        FutureANNOptions sentOptions = new FutureANNOptions(7, "newProperty");
+        DataOutputBuffer out = new DataOutputBuffer();
+        FutureANNOptions.serializer.serialize(sentOptions, out);
+        int serializedSize = out.buffer().remaining();
+        Assertions.assertThat(FutureANNOptions.serializer.serializedSize(sentOptions))
+                  .isEqualTo(serializedSize);
+
+        // ...should fail in a controlled manner with the current serializer
+        try (DataInputBuffer in = new DataInputBuffer(out.buffer(), true))
+        {
+            Assertions.assertThatThrownBy(() -> ANNOptions.serializer.deserialize(in, MessagingService.current_version))
+                      .isInstanceOf(IOException.class)
+                      .hasMessageContaining("Found unsupported ANN options");
+        }
+    }
+
+    /**
+     * Class simulating a future version of the ANN options, with an additional property.
+     */
+    private static class FutureANNOptions
+    {
+        public static final String NEW_PROPERTY_DEFAULT = "default";
+
+        public static final Serializer serializer = new Serializer();
+
+        @Nullable
+        public final Integer rerankK;
+        public final String newProperty;
+
+        public FutureANNOptions(@Nullable Integer rerankK, String newProperty)
+        {
+            this.rerankK = rerankK;
+            this.newProperty = newProperty;
+        }
+
+        public FutureANNOptions(ANNOptions options)
+        {
+            this.rerankK = options.rerankK;
+            this.newProperty = NEW_PROPERTY_DEFAULT;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FutureANNOptions that = (FutureANNOptions) o;
+            return Objects.equals(rerankK, that.rerankK) && Objects.equals(newProperty, that.newProperty);
+        }
+
+        public static class Serializer
+        {
+            private static final int RERANK_K_MASK = 1;
+            private static final int NEW_PROPERTY_MASK = 1 << 31;
+            private static final int UNKNOWN_OPTIONS_MASK = ~(RERANK_K_MASK | NEW_PROPERTY_MASK);
+
+            public void serialize(FutureANNOptions options, DataOutputPlus out) throws IOException
+            {
+                int flags = flags(options);
+                out.writeInt(flags);
+
+                if (options.rerankK != null)
+                    out.writeUnsignedVInt(options.rerankK);
+
+                if (hasNewProperty(flags))
+                    out.writeUTF(options.newProperty);
+            }
+
+            public FutureANNOptions deserialize(DataInputPlus in) throws IOException
+            {
+                int flags = in.readInt();
+
+                if ((flags & UNKNOWN_OPTIONS_MASK) != 0)
+                    throw new IOException("Found unsupported ANN options");
+
+                Integer rerankK = hasRerankK(flags) ? (int) in.readUnsignedVInt() : null;
+                String newProperty = hasNewProperty(flags) ? in.readUTF() : NEW_PROPERTY_DEFAULT;
+
+                return new FutureANNOptions(rerankK, newProperty);
+            }
+
+            public long serializedSize(FutureANNOptions options)
+            {
+                int flags = flags(options);
+                long size = TypeSizes.sizeof(flags);
+
+                if (options.rerankK != null)
+                    size += TypeSizes.sizeofUnsignedVInt(options.rerankK);
+
+                if (hasNewProperty(flags))
+                    size += TypeSizes.sizeof(options.newProperty);
+
+                return size;
+            }
+
+            private static int flags(FutureANNOptions options)
+            {
+                int flags = 0;
+
+                if (options.rerankK != null)
+                    flags |= RERANK_K_MASK;
+
+                if (!Objects.equals(options.newProperty, NEW_PROPERTY_DEFAULT))
+                    flags |= NEW_PROPERTY_MASK;
+
+                return flags;
+            }
+
+            private static boolean hasRerankK(long flags)
+            {
+                return (flags & RERANK_K_MASK) == RERANK_K_MASK;
+            }
+
+            public static boolean hasNewProperty(long flags)
+            {
+                return (flags & NEW_PROPERTY_MASK) == NEW_PROPERTY_MASK;
+            }
+        }
+    }
+
+    /**
+     * Mock index with dummy ANN support.
+     */
+    public static final class ANNIndex extends StubIndex
+    {
+        private final ColumnMetadata indexedColumn;
+        public static volatile ANNOptions lastQueryAnnOptions;
+
+        public ANNIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+            Pair<ColumnMetadata, IndexTarget.Type> target = TargetParser.parse(baseCfs.metadata(), metadata);
+            indexedColumn = target.left;
+        }
+
+        @Override
+        public boolean supportsExpression(ColumnMetadata column, Operator operator)
+        {
+            return indexedColumn.name.equals(column.name) && operator == Operator.ANN;
+        }
+
+        @Override
+        public Searcher searcherFor(ReadCommand command)
+        {
+            lastQueryAnnOptions = command.rowFilter().annOptions();
+            return super.searcherFor(command);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/net/FramingTest.java
+++ b/test/unit/org/apache/cassandra/net/FramingTest.java
@@ -40,10 +40,8 @@ import io.netty.buffer.ByteBuf;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.compress.BufferType;
-import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputBuffer;
-import org.apache.cassandra.io.util.DataOutputBufferFixed;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.memory.BufferPools;
@@ -53,9 +51,9 @@ import static java.lang.Math.*;
 import static org.apache.cassandra.net.MessagingService.VERSION_30;
 import static org.apache.cassandra.net.MessagingService.VERSION_3014;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
-import static org.apache.cassandra.net.MessagingService.VERSION_SG_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_10;
+import static org.apache.cassandra.net.MessagingService.VERSION_DS_11;
 import static org.apache.cassandra.net.MessagingService.current_version;
-import static org.apache.cassandra.net.MessagingService.minimum_version;
 import static org.apache.cassandra.net.OutboundConnections.LARGE_MESSAGE_THRESHOLD;
 import static org.apache.cassandra.net.ShareableBytes.wrap;
 
@@ -253,7 +251,7 @@ public class FramingTest
 
     private void burnRandomLegacy(int count)
     {
-        int[] versions = new int[] { VERSION_30, VERSION_3014, VERSION_40, VERSION_SG_10 };
+        int[] versions = new int[] { VERSION_30, VERSION_3014, VERSION_40, VERSION_DS_10, VERSION_DS_11 };
         SecureRandom seed = new SecureRandom();
         Random random = new Random();
         for (int i = 0 ; i < count ; ++i)


### PR DESCRIPTION
Add `ANN_OPTIONS` to CQL `SELECT` queries, as described in this document: https://docs.google.com/document/d/1Q2SkE1aBkcy25DnCWkdUqpCf8rZA6R_AOU6bbORbarI

The proposed syntax is:
```
SELECT * FROM t 
   ORDER BY v ANN OF [1.0] 
   LIMIT 10 
   WITH ann_options = {'rerank_k': 10};
```
The new options and not something specific to SAI, same as the `ORDER BY col ANN OF val` part. 

Internally, the ANN options are an attribute of the `RowFilter` included in every `ReadCommand`. Every index implementation receives them as part of the `ReadCommand` passed in methods such as `Index.validate(ReadCommand)`, `Index.Group.queryPlanFor(RowFilter)` or `Index.QueryPlan.searcherFor(ReadCommand)`.

Currently SAI rejects queries with ANN options. I think consuming those options is something we can do in a separate ticket, keeping this one focused on the CQL and internode messaging part.

This patch increases the internode messaging version because the ANN options have to be included in the serialization of the `ReadCommand` they belong to. Hopefully we won't need to bump the messaging version again if we add new ANN options.

I have chosen to include the options in the `RowFilter` because it seemed the cleaner approach, and so possibly less problematic when rebasing on Apache. The downside is that it adds a 32-bit int to the serialization of every `SELECT` query. An alternative, possibly more convoluted approach to save us those 4 extra bytes could be placing the ANN options inside the relevant ANN `RowFilter.Expression`. @jbellis @ekaterinadimitrova2 should I give a go to this alternative approach?

### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits