### PR TITLE
CNDB-12431: Report correct total size of parallelized compactions

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractTableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractTableOperation.java
@@ -20,8 +20,6 @@ package org.apache.cassandra.db.compaction;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -229,7 +227,7 @@ public abstract class AbstractTableOperation implements TableOperation
 
         public String toString()
         {
-            return defaultToString();
+            return progressToString();
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractTableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractTableOperation.java
@@ -74,12 +74,12 @@ public abstract class AbstractTableOperation implements TableOperation
     @Override
     public boolean shouldStop(Predicate<SSTableReader> predicate)
     {
-        OperationProgress progress = getProgress();
-        if (progress.sstables.isEmpty())
-        {
+        Progress progress = getProgress();
+        final Set<SSTableReader> sstables = progress.sstables();
+        if (sstables.isEmpty())
             return true;
-        }
-        return progress.sstables.stream().anyMatch(predicate);
+
+        return sstables.stream().anyMatch(predicate);
     }
 
     /**
@@ -119,10 +119,6 @@ public abstract class AbstractTableOperation implements TableOperation
          */
         private final Unit unit;
         /**
-         * The total bytes that have been scanned. For single file operation, it's the same as "completed"
-         */
-        private final long totalBytesScanned;
-        /**
          * A unique ID for this operation
          */
         private final UUID operationId;
@@ -143,25 +139,6 @@ public abstract class AbstractTableOperation implements TableOperation
                  bytesComplete,
                  totalBytes,
                  Unit.BYTES,
-                 bytesComplete,
-                 operationId,
-                 sstables);
-        }
-
-        public OperationProgress(TableMetadata metadata,
-                                 OperationType operationType,
-                                 long bytesComplete,
-                                 long totalBytes,
-                                 long totalBytesScanned,
-                                 UUID operationId,
-                                 Collection<SSTableReader> sstables)
-        {
-            this(metadata,
-                 operationType,
-                 bytesComplete,
-                 totalBytes,
-                 Unit.BYTES,
-                 totalBytesScanned,
                  operationId,
                  sstables);
         }
@@ -171,18 +148,6 @@ public abstract class AbstractTableOperation implements TableOperation
                                  long completed,
                                  long total,
                                  Unit unit,
-                                 UUID operationId,
-                                 Collection<? extends SSTableReader> sstables)
-        {
-            this(metadata, operationType, completed, total, unit, completed, operationId, sstables);
-        }
-
-        public OperationProgress(TableMetadata metadata,
-                                 OperationType operationType,
-                                 long completed,
-                                 long total,
-                                 Unit unit,
-                                 long totalBytesScanned,
                                  UUID operationId,
                                  Collection<? extends SSTableReader> sstables)
         {
@@ -191,7 +156,6 @@ public abstract class AbstractTableOperation implements TableOperation
             this.total = total;
             this.metadata = metadata;
             this.unit = unit;
-            this.totalBytesScanned = totalBytesScanned;
             this.operationId = operationId;
             this.sstables = ImmutableSet.copyOf(sstables);
         }
@@ -201,7 +165,7 @@ public abstract class AbstractTableOperation implements TableOperation
          */
         public OperationProgress forProgress(long complete, long total)
         {
-            return new OperationProgress(metadata, operationType, complete, total, unit, complete, operationId, sstables);
+            return new OperationProgress(metadata, operationType, complete, total, unit, operationId, sstables);
         }
 
         public static OperationProgress withoutSSTables(TableMetadata metadata, OperationType tasktype, long completed, long total, AbstractTableOperation.Unit unit, UUID compactionId)
@@ -263,37 +227,9 @@ public abstract class AbstractTableOperation implements TableOperation
             return sstables;
         }
 
-        /**
-         * @return the total number of units that has been scanned by the operation
-         */
-        public long totalByteScanned()
-        {
-            return totalBytesScanned;
-        }
-
         public String toString()
         {
-            StringBuilder buff = new StringBuilder();
-            buff.append(String.format("%s(%s, %s / %s %s)", operationType, operationId, completed, total, unit));
-            if (metadata != null)
-            {
-                buff.append(String.format("@%s(%s, %s)", metadata.id, metadata.keyspace, metadata.name));
-            }
-            return buff.toString();
-        }
-
-        public Map<String, String> asMap()
-        {
-            Map<String, String> ret = new HashMap<>(8);
-            ret.put(ID, metadata != null ? metadata.id.toString() : "");
-            ret.put(KEYSPACE, keyspace().orElse(null));
-            ret.put(COLUMNFAMILY, table().orElse(null));
-            ret.put(COMPLETED, Long.toString(completed));
-            ret.put(TOTAL, Long.toString(total));
-            ret.put(OPERATION_TYPE, operationType.toString());
-            ret.put(UNIT, unit.toString());
-            ret.put(OPERATION_ID, operationId == null ? "" : operationId.toString());
-            return ret;
+            return defaultToString();
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
+++ b/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
@@ -52,12 +52,12 @@ public class ActiveOperations implements TableOperationObserver
         /**
          * Called when compaction started
          */
-        default void onStarted(AbstractTableOperation.OperationProgress progress) {}
+        default void onStarted(TableOperation.Progress progress) {}
 
         /**
          * Called when compaction completed
          */
-        default void onCompleted(AbstractTableOperation.OperationProgress progressOnCompleted) {}
+        default void onCompleted(TableOperation.Progress progressOnCompleted) {}
     }
 
     public void registerListener(CompactionProgressListener listener)
@@ -87,7 +87,7 @@ public class ActiveOperations implements TableOperationObserver
     @Override
     public NonThrowingCloseable onOperationStart(TableOperation op)
     {
-        AbstractTableOperation.OperationProgress progress = op.getProgress();
+        TableOperation.Progress progress = op.getProgress();
         for (CompactionProgressListener listener : listeners)
         {
             try
@@ -104,7 +104,7 @@ public class ActiveOperations implements TableOperationObserver
         operations.add(op);
         return () -> {
             operations.remove(op);
-            AbstractTableOperation.OperationProgress progressOnCompleted = op.getProgress();
+            TableOperation.Progress progressOnCompleted = op.getProgress();
             CompactionManager.instance.getMetrics().bytesCompacted.inc(progressOnCompleted.total());
             CompactionManager.instance.getMetrics().totalCompactionsCompleted.mark();
 
@@ -129,15 +129,15 @@ public class ActiveOperations implements TableOperationObserver
      *
      * Number of entries in operations should be small (< 10) but avoid calling in any time-sensitive context
      */
-    public Collection<AbstractTableOperation.OperationProgress> getOperationsForSSTable(SSTableReader sstable, OperationType operationType)
+    public Collection<TableOperation.Progress> getOperationsForSSTable(SSTableReader sstable, OperationType operationType)
     {
-        List<AbstractTableOperation.OperationProgress> toReturn = null;
+        List<TableOperation.Progress> toReturn = null;
 
         synchronized (operations)
         {
             for (TableOperation op : operations)
             {
-                AbstractTableOperation.OperationProgress progress = op.getProgress();
+                TableOperation.Progress progress = op.getProgress();
                 if (progress.sstables().contains(sstable) && progress.operationType() == operationType)
                 {
                     if (toReturn == null)

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
@@ -275,8 +275,13 @@ public class BackgroundCompactions
 
     private void updateCompactionRate(CompactionProgress progress)
     {
-        if (progress != null && progress.durationInNanos() > 0 && progress.outputDiskSize() > 0)
-            compactionRate.update(progress.outputDiskSize() * 1.e9 / progress.durationInNanos());
+        if (progress != null)
+        {
+            final long durationInMillis = progress.durationInMillis();
+            final long outputDiskSize = progress.outputDiskSize();
+            if (durationInMillis > 0 && outputDiskSize > 0)
+                compactionRate.update(outputDiskSize * 1.e3 / durationInMillis);
+        }
     }
 
     public Collection<CompactionAggregate> getAggregates()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionCursor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionCursor.java
@@ -195,19 +195,14 @@ public class CompactionCursor implements SSTableCursorMerger.MergeListener, Auto
      * metrics in the compaction manager. The caller is responsible for registering the operation and checking
      * {@link TableOperation#isStopRequested()}.
      */
-    public TableOperation createOperation()
+    public TableOperation createOperation(TableOperation.Progress progress)
     {
         return new AbstractTableOperation() {
 
             @Override
-            public OperationProgress getProgress()
+            public Progress getProgress()
             {
-                return new OperationProgress(controller.realm.metadata(),
-                                             type,
-                                             bytesRead(),
-                                             totalBytes(),
-                                             compactionId,
-                                             sstables);
+                return progress;
             }
 
             @Override

--- a/src/java/org/apache/cassandra/db/compaction/CompactionCursor.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionCursor.java
@@ -53,8 +53,6 @@ public class CompactionCursor implements SSTableCursorMerger.MergeListener, Auto
 
     private final OperationType type;
     private final CompactionController controller;
-    private final ImmutableSet<SSTableReader> sstables;
-    private final UUID compactionId;
     private final SSTableCursor cursor;
     private final Row.Builder rowBuilder;
 
@@ -71,15 +69,13 @@ public class CompactionCursor implements SSTableCursorMerger.MergeListener, Auto
     private final long[] mergedPartitionsHistogram;
     private final long[] mergedRowsHistogram;
 
-    public CompactionCursor(OperationType type, Collection<SSTableReader> readers, Range<Token> tokenRange, CompactionController controller, RateLimiter limiter, int nowInSec, UUID compactionId)
+    public CompactionCursor(OperationType type, Collection<SSTableReader> readers, Range<Token> tokenRange, CompactionController controller, RateLimiter limiter, int nowInSec)
     {
         this.controller = controller;
         this.type = type;
-        this.compactionId = compactionId;
         this.mergedPartitionsHistogram = new long[readers.size()];
         this.mergedRowsHistogram = new long[readers.size()];
         this.rowBuilder = BTreeRow.sortedBuilder();
-        this.sstables = ImmutableSet.copyOf(readers);
         this.cursor = makeMergedAndPurgedCursor(readers, tokenRange, controller, limiter, nowInSec);
         this.totalBytes = cursor.bytesTotal();
         this.currentBytes = 0;

--- a/src/java/org/apache/cassandra/db/compaction/CompactionInterruptedException.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionInterruptedException.java
@@ -21,7 +21,7 @@ public class CompactionInterruptedException extends RuntimeException
 {
     private static final long serialVersionUID = -8651427062512310398L;
 
-    public CompactionInterruptedException(AbstractTableOperation.OperationProgress info, TableOperation.StopTrigger trigger)
+    public CompactionInterruptedException(TableOperation.Progress info, TableOperation.StopTrigger trigger)
     {
         super(String.format("Compaction interrupted due to %s: %s",
                             (trigger == null ? TableOperation.StopTrigger.NONE : trigger).toString().toLowerCase(),

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1772,9 +1772,9 @@ public class CompactionManager implements CompactionManagerMBean
     {
         return new CompactionIterator(OperationType.ANTICOMPACTION, scanners, controller, nowInSec, timeUUID) {
             @Override
-            public TableOperation createOperation()
+            public TableOperation createOperation(CompactionProgress progress)
             {
-                return getAntiCompactionOperation(super.createOperation(), isCancelled);
+                return getAntiCompactionOperation(super.createOperation(progress), isCancelled);
             }
         };
     }
@@ -1791,7 +1791,7 @@ public class CompactionManager implements CompactionManagerMBean
             }
 
             @Override
-            public OperationProgress getProgress()
+            public Progress getProgress()
             {
                 return compaction.getProgress();
             }
@@ -2331,7 +2331,7 @@ public class CompactionManager implements CompactionManagerMBean
         Set<TableOperation> interrupted = new HashSet<>();
         for (TableOperation operationSource : active.getTableOperations())
         {
-            AbstractTableOperation.OperationProgress info = operationSource.getProgress();
+            TableOperation.Progress info = operationSource.getProgress();
 
             if (Iterables.contains(tables, info.metadata()) && opPredicate.test(info.operationType()))
             {
@@ -2381,7 +2381,7 @@ public class CompactionManager implements CompactionManagerMBean
         boolean interrupted = false;
         for (TableOperation operationSource : active.getTableOperations())
         {
-            AbstractTableOperation.OperationProgress info = operationSource.getProgress();
+            TableOperation.Progress info = operationSource.getProgress();
             if ((info.operationType() == OperationType.VALIDATION) && !interruptValidation)
                 continue;
 
@@ -2429,7 +2429,7 @@ public class CompactionManager implements CompactionManagerMBean
     }
 
 
-    public List<AbstractTableOperation.OperationProgress> getSSTableTasks()
+    public List<TableOperation.Progress> getSSTableTasks()
     {
         return active.getTableOperations()
                      .stream()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionProgress.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionProgress.java
@@ -92,16 +92,17 @@ public interface CompactionProgress extends TableOperation.Progress
     long uncompressedBytesWritten();
 
     /**
-     * @return the start time of this operation in nanoTime.
+     * @return the start time of this operation in millis since the epoch, i.e. as {@link System#currentTimeMillis}
+     * would report it.
      */
-    long startTimeNanos();
+    long startTimeMillis();
 
     /**
-     * @return the duration so far in nanoseconds.
+     * @return the duration so far in milliseconds.
      */
-    default long durationInNanos()
+    default long durationInMillis()
     {
-        return System.nanoTime() - startTimeNanos();
+        return System.currentTimeMillis() - startTimeMillis();
     }
 
     /**
@@ -144,13 +145,13 @@ public interface CompactionProgress extends TableOperation.Progress
 
     default double readThroughput()
     {
-        long durationNanos = durationInNanos();
-        return durationNanos == 0 ? 0 : ((double) uncompressedBytesRead() / durationNanos) * TimeUnit.SECONDS.toNanos(1);
+        long durationMillis = durationInMillis();
+        return durationMillis == 0 ? 0 : ((double) uncompressedBytesRead() / durationMillis) * TimeUnit.SECONDS.toMillis(1);
     }
 
     default double writeThroughput()
     {
-        long durationNanos = durationInNanos();
-        return durationNanos == 0 ? 0 : ((double) uncompressedBytesWritten() / durationNanos) * TimeUnit.SECONDS.toNanos(1);
+        long durationMillis = durationInMillis();
+        return durationMillis == 0 ? 0 : ((double) uncompressedBytesWritten() / durationMillis) * TimeUnit.SECONDS.toMillis(1);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -804,7 +804,7 @@ public class CompactionTask extends AbstractCompactionTask
         @Override
         TableOperation initializeSource(Range<Token> tokenRange)
         {
-            this.compactionCursor = new CompactionCursor(compactionType, actuallyCompact, tokenRange, controller, limiter, FBUtilities.nowInSeconds(), taskId);
+            this.compactionCursor = new CompactionCursor(compactionType, actuallyCompact, tokenRange, controller, limiter, FBUtilities.nowInSeconds());
             // We use `this` rather than `sharedProgress()` because the `TableOperation` tracks individual compactions.
             return compactionCursor.createOperation(this);
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -595,6 +595,12 @@ public class CompactionTask extends AbstractCompactionTask
             return transaction.originals();
         }
 
+        @Override
+        public String toString()
+        {
+            return defaultToString();
+        }
+
         //
         // CompactionProgress
         //
@@ -687,7 +693,8 @@ public class CompactionTask extends AbstractCompactionTask
             var rangeList = tokenRange != null ? ImmutableList.of(tokenRange) : null;
             this.scanners = strategy != null ? strategy.getScanners(actuallyCompact, rangeList)
                                              : ScannerList.of(actuallyCompact, rangeList);
-            this.compactionIterator = new CompactionIterator(compactionType, scanners.scanners, controller, FBUtilities.nowInSeconds(), taskId);
+            // We use `this` rather than `sharedProgress()` because the `TableOperation` tracks individual compactions.
+            this.compactionIterator = new CompactionIterator(compactionType, scanners.scanners, controller, FBUtilities.nowInSeconds(), taskId, this);
             return compactionIterator.getOperation();
         }
 
@@ -798,7 +805,8 @@ public class CompactionTask extends AbstractCompactionTask
         TableOperation initializeSource(Range<Token> tokenRange)
         {
             this.compactionCursor = new CompactionCursor(compactionType, actuallyCompact, tokenRange, controller, limiter, FBUtilities.nowInSeconds(), taskId);
-            return compactionCursor.createOperation();
+            // We use `this` rather than `sharedProgress()` because the `TableOperation` tracks individual compactions.
+            return compactionCursor.createOperation(this);
         }
 
         void execute0()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -396,7 +396,6 @@ public class CompactionTask extends AbstractCompactionTask
                 this.sstableRefs = Refs.ref(actuallyCompact);
                 this.op = initializeSource(tokenRange());
                 this.writer = getCompactionAwareWriter(realm, dirs, actuallyCompact);
-                this.obsCloseable = opObserver.onOperationStart(op);
                 CompactionProgress progress = this;
                 var sharedProgress = sharedProgress();
                 if (sharedProgress != null)
@@ -405,6 +404,7 @@ public class CompactionTask extends AbstractCompactionTask
                     progress = sharedProgress;
                 }
 
+                this.obsCloseable = opObserver.onOperationStart(op);
                 for (var obs : getCompObservers())
                     obs.onInProgress(progress);
             }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -598,7 +598,7 @@ public class CompactionTask extends AbstractCompactionTask
         @Override
         public String toString()
         {
-            return defaultToString();
+            return progressToString();
         }
 
         //

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -52,7 +52,20 @@ public class CompositeCompactionTask extends AbstractCompactionTask
     protected void runMayThrow() throws Exception
     {
         // Run all tasks in sequence, regardless if any of them fail.
-        Throwables.perform(tasks.stream().map(x -> x::execute));
+        Throwable accumulate = null;
+        for (AbstractCompactionTask task : tasks)
+        {
+            Throwables.perform(accumulate, () -> task.execute(opObserver));
+            // The previous operation may have completed due to a requested stop. We do not stop other tasks in our
+            // list if that is the case, because if the tasks are related, the [SharedTableOperation] will have already
+            // requested a stop from the other components as well. If we stopped the other tasks here, we may
+            // overrespond to a user's request to stop an individual operation.
+            // On the other hand, [CompactionManager] sometimes requests a stop of all ongoing operations e.g. to
+            // initiate a table drop. Such requests, however, do not affect tasks in the executor queue; as this class
+            // is acting similarly to an executor queue, we do not apply such stop requests to the remaining tasks
+            // either.
+        }
+        Throwables.maybeFail(accumulate);
     }
 
     @Override
@@ -77,14 +90,6 @@ public class CompositeCompactionTask extends AbstractCompactionTask
         for (AbstractCompactionTask task : tasks)
             task.setCompactionType(compactionType);
         return super.setCompactionType(compactionType);
-    }
-
-    @Override
-    public AbstractCompactionTask setOpObserver(TableOperationObserver opObserver)
-    {
-        for (AbstractCompactionTask task : tasks)
-            task.setOpObserver(opObserver);
-        return super.setOpObserver(opObserver);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -55,7 +55,7 @@ public class CompositeCompactionTask extends AbstractCompactionTask
         Throwable accumulate = null;
         for (AbstractCompactionTask task : tasks)
         {
-            Throwables.perform(accumulate, () -> task.execute(opObserver));
+            accumulate = Throwables.perform(accumulate, () -> task.execute(opObserver));
             // The previous operation may have completed due to a requested stop. We do not stop other tasks in our
             // list if that is the case, because if the tasks are related, the [SharedTableOperation] will have already
             // requested a stop from the other components as well. If we stopped the other tasks here, we may

--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
@@ -47,6 +47,8 @@ public class SharedCompactionProgress implements CompactionProgress
     private final List<CompactionProgress> sources = new CopyOnWriteArrayList<>();
     private final AtomicInteger toComplete = new AtomicInteger(0);
     private final AtomicLong totalSize = new AtomicLong(0);
+    private final AtomicLong totalCompressedSize = new AtomicLong(0);
+    private final AtomicLong totalUncompressedSize = new AtomicLong(0);
     private final UUID operationId;
     private final OperationType operationType;
     private final TableOperation.Unit unit;
@@ -61,10 +63,12 @@ public class SharedCompactionProgress implements CompactionProgress
     /// Register a subtask to be expected to run. This must be called once per subtask before any of them start.
     ///
     /// @param taskSize The size of the task that its [CompactionProgress#total] will report.
-    public void registerExpectedSubtask(long taskSize)
+    public void registerExpectedSubtask(long taskSize, long taskCompressedSize, long taskUncompressedSize)
     {
         toComplete.incrementAndGet();
         totalSize.addAndGet(taskSize);
+        totalCompressedSize.addAndGet(taskCompressedSize);
+        totalUncompressedSize.addAndGet(taskUncompressedSize);
     }
 
     public void addSubtask(CompactionProgress progress)
@@ -170,21 +174,13 @@ public class SharedCompactionProgress implements CompactionProgress
     @Override
     public long inputDiskSize()
     {
-        long sum = 0L;
-        for (CompactionProgress source : sources)
-            sum += source.inputDiskSize();
-
-        return sum;
+        return totalCompressedSize.get();
     }
 
     @Override
     public long inputUncompressedSize()
     {
-        long sum = 0L;
-        for (CompactionProgress source : sources)
-            sum += source.inputUncompressedSize();
-
-        return sum;
+        return totalUncompressedSize.get();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
@@ -270,11 +270,11 @@ public class SharedCompactionProgress implements CompactionProgress
     }
 
     @Override
-    public long startTimeNanos()
+    public long startTimeMillis()
     {
         long min = Long.MAX_VALUE;
         for (CompactionProgress source : sources)
-            min = Math.min(min, source.startTimeNanos());
+            min = Math.min(min, source.startTimeMillis());
 
         return min;
     }

--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionProgress.java
@@ -304,4 +304,10 @@ public class SharedCompactionProgress implements CompactionProgress
         }
         return merged;
     }
+
+    @Override
+    public String toString()
+    {
+        return progressToString();
+    }
 }

--- a/src/java/org/apache/cassandra/db/compaction/SharedTableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedTableOperation.java
@@ -37,7 +37,7 @@ public class SharedTableOperation extends AbstractTableOperation implements Tabl
     private final List<TableOperation> components = new CopyOnWriteArrayList<>();
     private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicInteger toClose = new AtomicInteger(0);
-    private final AtomicReference<TableOperationObserver> observer = new AtomicReference(null);
+    private final AtomicReference<TableOperationObserver> observer = new AtomicReference<>(null);
     private volatile boolean isGlobal;
 
     public SharedTableOperation(Progress sharedProgress)

--- a/src/java/org/apache/cassandra/db/compaction/SharedTableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedTableOperation.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.cassandra.utils.NonThrowingCloseable;
+
+public class SharedTableOperation extends AbstractTableOperation implements TableOperation
+{
+    private final Progress sharedProgress;
+    private NonThrowingCloseable obsCloseable;
+    private final List<TableOperation> components = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicInteger toClose = new AtomicInteger(0);
+
+    public SharedTableOperation(Progress sharedProgress)
+    {
+        this.sharedProgress = sharedProgress;
+    }
+
+    public void registerExpectedSubtask()
+    {
+        toClose.incrementAndGet();
+    }
+
+    @Override
+    public Progress getProgress()
+    {
+        return sharedProgress;
+    }
+
+    @Override
+    public void stop(StopTrigger trigger)
+    {
+        super.stop(trigger);
+        for (TableOperation component : components)
+            component.stop(trigger);
+    }
+
+    @Override
+    public boolean isGlobal()
+    {
+        if (components.isEmpty())
+            return false;
+        else
+            return components.get(0).isGlobal();
+    }
+
+    public TableOperationObserver wrapObserver(TableOperationObserver observer)
+    {
+        // Note: if the observer is Noop, we still want to wrap to complete the shared operation when all subtasks complete
+        return operation -> onOperationStart(observer, operation);
+    }
+
+    public NonThrowingCloseable onOperationStart(TableOperationObserver observer, TableOperation operation)
+    {
+        if (started.compareAndSet(false, true))
+            obsCloseable = observer.onOperationStart(this);
+        components.add(operation);
+        if (isStopRequested())
+            operation.stop(trigger());
+        return this::closeOne;
+    }
+
+    private void closeOne()
+    {
+        if (toClose.decrementAndGet() == 0 && obsCloseable != null)
+            obsCloseable.close();
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/TableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/TableOperation.java
@@ -216,7 +216,7 @@ public interface TableOperation
          */
         Set<SSTableReader> sstables();
 
-        default String defaultToString()
+        default String progressToString()
         {
             StringBuilder buff = new StringBuilder();
             buff.append(String.format("%s(%s, %s / %s %s)", operationType(), operationId(), completed(), total(), unit()));

--- a/src/java/org/apache/cassandra/db/compaction/TableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/TableOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.db.compaction;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -44,7 +46,7 @@ public interface TableOperation
     /**
      * @return the progress of the operation, see {@link Progress}.
      */
-    AbstractTableOperation.OperationProgress getProgress();
+    TableOperation.Progress getProgress();
 
     /**
      * Interrupt the current operation if possible.
@@ -213,5 +215,32 @@ public interface TableOperation
          * @return a set of SSTables participating in this operation
          */
         Set<SSTableReader> sstables();
+
+        default String defaultToString()
+        {
+            StringBuilder buff = new StringBuilder();
+            buff.append(String.format("%s(%s, %s / %s %s)", operationType(), operationId(), completed(), total(), unit()));
+            TableMetadata metadata = metadata();
+            if (metadata != null)
+            {
+                buff.append(String.format("@%s(%s, %s)", metadata.id, metadata.keyspace, metadata.name));
+            }
+            return buff.toString();
+        }
+
+        default Map<String, String> asMap()
+        {
+            Map<String, String> ret = new HashMap<>(8);
+            TableMetadata metadata = metadata();
+            ret.put(ID, metadata != null ? metadata.id.toString() : "");
+            ret.put(KEYSPACE, keyspace().orElse(null));
+            ret.put(COLUMNFAMILY, table().orElse(null));
+            ret.put(COMPLETED, Long.toString(completed()));
+            ret.put(TOTAL, Long.toString(total()));
+            ret.put(OPERATION_TYPE, operationType().toString());
+            ret.put(UNIT, unit().toString());
+            ret.put(OPERATION_ID, operationId() == null ? "" : operationId().toString());
+            return ret;
+        }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -650,7 +650,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     /// @return a sharded compaction task that in turn will create a sharded compaction writer.
     private UnifiedCompactionTask createCompactionTask(LifecycleTransaction transaction, Range<Token> operationRange, boolean keepOriginals, ShardingStats shardingStats, int gcBefore)
     {
-        return new UnifiedCompactionTask(realm, this, transaction, gcBefore, keepOriginals, getShardManager(), shardingStats, operationRange, transaction.originals(), null, null);
+        return new UnifiedCompactionTask(realm, this, transaction, gcBefore, keepOriginals, getShardManager(), shardingStats, operationRange, transaction.originals(), null, null, null);
     }
 
     @Override
@@ -681,6 +681,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         CompositeLifecycleTransaction compositeTransaction = new CompositeLifecycleTransaction(transaction);
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
         SharedCompactionObserver sharedObserver = new SharedCompactionObserver(this);
+        SharedTableOperation sharedOperation = new SharedTableOperation(sharedProgress);
         List<UnifiedCompactionTask> tasks = shardManager.splitSSTablesInShardsLimited(
             sstables,
             operationRange,
@@ -697,7 +698,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                 range,
                                                                 rangeSSTables,
                                                                 sharedProgress,
-                                                                sharedObserver)
+                                                                sharedObserver,
+                                                                sharedOperation)
         );
         compositeTransaction.completeInitialization();
         assert tasks.size() <= parallelism;

--- a/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
@@ -76,7 +76,7 @@ public class UnifiedCompactionTask extends CompactionTask
         this.operationRange = operationRange;
         this.sharedProgress = sharedProgress;
         if (sharedProgress != null)
-            sharedProgress.registerExpectedSubtask();
+            sharedProgress.registerExpectedSubtask(getTotalUncompressedBytes(actuallyCompact, operationRange));
         if (sharedObserver != null)
             sharedObserver.registerExpectedSubtask();
         // To make sure actuallyCompact tracks any removals from txn.originals(), we intersect the given set with it.

--- a/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
@@ -23,11 +23,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.compaction.AbstractCompactionTask;
 import org.apache.cassandra.db.compaction.CompactionRealm;
 import org.apache.cassandra.db.compaction.CompactionTask;
 import org.apache.cassandra.db.compaction.ShardManager;
 import org.apache.cassandra.db.compaction.SharedCompactionObserver;
 import org.apache.cassandra.db.compaction.SharedCompactionProgress;
+import org.apache.cassandra.db.compaction.SharedTableOperation;
+import org.apache.cassandra.db.compaction.TableOperationObserver;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
@@ -41,6 +44,7 @@ public class UnifiedCompactionTask extends CompactionTask
     private final Range<Token> operationRange;
     private final Set<SSTableReader> actuallyCompact;
     private final SharedCompactionProgress sharedProgress;
+    private final SharedTableOperation sharedOperation;
     private final UnifiedCompactionStrategy.ShardingStats shardingStats;
 
     public UnifiedCompactionTask(CompactionRealm cfs,
@@ -50,7 +54,7 @@ public class UnifiedCompactionTask extends CompactionTask
                                  ShardManager shardManager,
                                  UnifiedCompactionStrategy.ShardingStats shardingStats)
     {
-        this(cfs, strategy, txn, gcBefore, false, shardManager, shardingStats, null, null, null, null);
+        this(cfs, strategy, txn, gcBefore, false, shardManager, shardingStats, null, null, null, null, null);
     }
 
 
@@ -64,7 +68,8 @@ public class UnifiedCompactionTask extends CompactionTask
                                  Range<Token> operationRange,
                                  Collection<SSTableReader> actuallyCompact,
                                  SharedCompactionProgress sharedProgress,
-                                 SharedCompactionObserver sharedObserver)
+                                 SharedCompactionObserver sharedObserver,
+                                 SharedTableOperation sharedOperation)
     {
         super(cfs,
               txn,
@@ -85,10 +90,13 @@ public class UnifiedCompactionTask extends CompactionTask
 
         this.operationRange = operationRange;
         this.sharedProgress = sharedProgress;
+        this.sharedOperation = sharedOperation;
         if (sharedProgress != null)
             sharedProgress.registerExpectedSubtask(totals.inputUncompressedSize, totals.inputDiskSize, totals.inputUncompressedSize);
         if (sharedObserver != null)
             sharedObserver.registerExpectedSubtask();
+        if (sharedOperation != null)
+            sharedOperation.registerExpectedSubtask();
         // To make sure actuallyCompact tracks any removals from txn.originals(), we intersect the given set with it.
         // This should not be entirely necessary (as shouldReduceScopeForSpace() is false for ranged tasks), but it
         // is cleaner to enforce inputSSTables()'s requirements.
@@ -139,5 +147,13 @@ public class UnifiedCompactionTask extends CompactionTask
     public Set<SSTableReader> inputSSTables()
     {
         return actuallyCompact;
+    }
+
+    @Override
+    public AbstractCompactionTask setOpObserver(TableOperationObserver opObserver)
+    {
+        if (sharedOperation != null)
+            opObserver = sharedOperation.wrapObserver(opObserver);
+        return super.setOpObserver(opObserver);
     }
 }

--- a/src/java/org/apache/cassandra/db/repair/PendingAntiCompaction.java
+++ b/src/java/org/apache/cassandra/db/repair/PendingAntiCompaction.java
@@ -146,7 +146,7 @@ public class PendingAntiCompaction
                 }
                 return false;
             }
-            Collection<AbstractTableOperation.OperationProgress> ops = CompactionManager.instance.active.getOperationsForSSTable(sstable, OperationType.ANTICOMPACTION);
+            Collection<TableOperation.Progress> ops = CompactionManager.instance.active.getOperationsForSSTable(sstable, OperationType.ANTICOMPACTION);
             if (ops != null && !ops.isEmpty())
             {
                 // todo: start tracking the parent repair session id that created the anticompaction to be able to give a better error messsage here:
@@ -156,7 +156,7 @@ public class PendingAntiCompaction
                 sb.append(" has failed because it encountered intersecting sstables belonging to another incremental repair session. ");
                 sb.append("This is caused by starting multiple conflicting incremental repairs at the same time. ");
                 sb.append("Conflicting anticompactions: ");
-                for (AbstractTableOperation.OperationProgress op : ops)
+                for (TableOperation.Progress op : ops)
                 {
                     sb.append(op.operationId() == null ? "no compaction id" : op.operationId()).append(':').append(op.sstables()).append(',');
                 }

--- a/src/java/org/apache/cassandra/db/virtual/SSTableTasksTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SSTableTasksTable.java
@@ -17,8 +17,8 @@
  */
 package org.apache.cassandra.db.virtual;
 
-import org.apache.cassandra.db.compaction.AbstractTableOperation;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.TableOperation;
 import org.apache.cassandra.db.marshal.DoubleType;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -58,7 +58,7 @@ final class SSTableTasksTable extends AbstractVirtualTable
     {
         SimpleDataSet result = new SimpleDataSet(metadata());
 
-        for (AbstractTableOperation.OperationProgress task : CompactionManager.instance.getSSTableTasks())
+        for (TableOperation.Progress task : CompactionManager.instance.getSSTableTasks())
         {
             long completed = task.completed();
             long total = task.total();

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -1145,14 +1145,14 @@ public class TableMetrics
         flushTime.inc(TimeUnit.NANOSECONDS.toMicros(totalTimeSpentNanos));
     }
 
-    public void incBytesCompacted(long inputDiskSize, long outputDiskSize, long elapsedNanos)
+    public void incBytesCompacted(long inputDiskSize, long outputDiskSize, long elapsedMillis)
     {
         compactionBytesRead.inc(inputDiskSize);
         compactionBytesWritten.inc(outputDiskSize);
-        compactionTime.inc(TimeUnit.NANOSECONDS.toMicros(elapsedNanos));
+        compactionTime.inc(TimeUnit.MILLISECONDS.toMicros(elapsedMillis));
         // only update compactionTimePerKb when there are non-expired sstables (inputDiskSize > 0)
         if (inputDiskSize > 0)
-            compactionTimePerKb.update(1024.0 * elapsedNanos / inputDiskSize);
+            compactionTimePerKb.update(1024.0 * elapsedMillis / inputDiskSize);
     }
 
     public void updateSSTableIterated(int count, int intersectingCount, long elapsedNanos)

--- a/test/microbench/org/apache/cassandra/test/microbench/CompactionBreakdownBenchmark.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CompactionBreakdownBenchmark.java
@@ -201,8 +201,7 @@ public class CompactionBreakdownBenchmark extends BaseCompactionBenchmark
                                                         null,
                                                         controller,
                                                         RateLimiter.create(Double.MAX_VALUE),
-                                                        FBUtilities.nowInSeconds(),
-                                                        UUID.randomUUID()))
+                                                        FBUtilities.nowInSeconds()))
         {
             totalRows = consumeCompactionCursor(ci, bh, totalRows);
         }
@@ -225,8 +224,7 @@ public class CompactionBreakdownBenchmark extends BaseCompactionBenchmark
                                                         null,
                                                         controller,
                                                         RateLimiter.create(Double.MAX_VALUE),
-                                                        FBUtilities.nowInSeconds(),
-                                                        UUID.randomUUID()))
+                                                        FBUtilities.nowInSeconds()))
         {
             totalRows = consumeCompactionCursor(ci, bh, totalRows);
         }

--- a/test/unit/org/apache/cassandra/db/compaction/ActiveOperationsConcurrencyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ActiveOperationsConcurrencyTest.java
@@ -102,7 +102,7 @@ public class ActiveOperationsConcurrencyTest
             private void onOperationStartTest()
             {
                 LockSupport.parkNanos(ThreadLocalRandom.current().nextInt(1000000));
-                AbstractTableOperation.OperationProgress progress = mock(AbstractTableOperation.OperationProgress.class);
+                TableOperation.Progress progress = mock(TableOperation.Progress.class);
                 when(progress.total()).thenReturn(ThreadLocalRandom.current().nextLong());
                 TableOperation operation = mock(TableOperation.class);
                 when(operation.getProgress()).thenReturn(progress);

--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -331,7 +331,7 @@ public class BaseCompactionStrategyTest
         when(progress.inSSTables()).thenReturn(compacting);
         when(progress.uncompressedBytesRead()).thenReturn(compactingLen);
         when(progress.uncompressedBytesWritten()).thenReturn(compactingLen);
-        when(progress.durationInNanos()).thenReturn(TimeUnit.SECONDS.toNanos(30));
+        when(progress.durationInMillis()).thenReturn(TimeUnit.SECONDS.toMillis(30));
 
         return progress;
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionAggregateTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionAggregateTest.java
@@ -136,7 +136,7 @@ public class CompactionAggregateTest
                 CompactionProgress progress = Mockito.mock(CompactionTask.CompactionOperation.class);
                 when(pickMock.progress()).thenReturn(progress);
                 final int timeInSecs = picksCount - i;
-                when(progress.durationInNanos()).thenReturn(TimeUnit.SECONDS.toNanos(timeInSecs));
+                when(progress.durationInMillis()).thenReturn(TimeUnit.SECONDS.toMillis(timeInSecs));
                 when(progress.readThroughput()).thenCallRealMethod();
                 when(progress.writeThroughput()).thenCallRealMethod();
                 when(progress.uncompressedBytesRead()).thenReturn(timeInSecs * readTput);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -652,23 +652,21 @@ public class CompactionsTest
     @Test
     public void testCompactionListener()
     {
-        final long totalByteScanned = 100;
         ColumnFamilyStore cfs = MockSchema.newCFS();
         cfs.addSSTable(MockSchema.sstable(1, true, cfs));
         ActiveOperations.CompactionProgressListener listener = Mockito.mock(ActiveOperations
                                                                             .CompactionProgressListener.class);
-        AbstractTableOperation.OperationProgress progress = new AbstractTableOperation
+        TableOperation.Progress progress = new AbstractTableOperation
                                                                 .OperationProgress(cfs.metadata(),
                                                                                    OperationType.ANTICOMPACTION,
                                                                                    0,
                                                                                    0,
-                                                                                   totalByteScanned,
                                                                                    UUID.randomUUID(),
                                                                                    cfs.getLiveSSTables());
 
         AbstractTableOperation operation = new AbstractTableOperation()
         {
-            public OperationProgress getProgress()
+            public Progress getProgress()
             {
                 return progress;
             }
@@ -680,7 +678,6 @@ public class CompactionsTest
         };
         CompactionManager.instance.active.registerListener(listener);
 
-        Assert.assertEquals(totalByteScanned, operation.getProgress().totalByteScanned());
         try (NonThrowingCloseable cls = CompactionManager.instance.active.onOperationStart(operation))
         {
             verify(listener).onStarted(progress);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsTest.java
@@ -657,12 +657,12 @@ public class CompactionsTest
         ActiveOperations.CompactionProgressListener listener = Mockito.mock(ActiveOperations
                                                                             .CompactionProgressListener.class);
         TableOperation.Progress progress = new AbstractTableOperation
-                                                                .OperationProgress(cfs.metadata(),
-                                                                                   OperationType.ANTICOMPACTION,
-                                                                                   0,
-                                                                                   0,
-                                                                                   UUID.randomUUID(),
-                                                                                   cfs.getLiveSSTables());
+                                               .OperationProgress(cfs.metadata(),
+                                                                  OperationType.ANTICOMPACTION,
+                                                                  0,
+                                                                  0,
+                                                                  UUID.randomUUID(),
+                                                                  cfs.getLiveSSTables());
 
         AbstractTableOperation operation = new AbstractTableOperation()
         {

--- a/test/unit/org/apache/cassandra/db/compaction/CompositeCompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompositeCompactionTaskTest.java
@@ -49,6 +49,7 @@ public class CompositeCompactionTaskTest
     private CompositeCompactionTask compositeCompactionTask;
     private AbstractCompactionTask mockTask1;
     private AbstractCompactionTask mockTask2;
+    private TableOperationObserver mockOpObserver;
 
     @Before
     public void setUp() {
@@ -60,15 +61,17 @@ public class CompositeCompactionTaskTest
 
         mockTask1 = Mockito.mock(AbstractCompactionTask.class, Mockito.withSettings().useConstructor(mockRealm, mockTransaction));
         mockTask2 = Mockito.mock(AbstractCompactionTask.class, Mockito.withSettings().useConstructor(mockRealm, mockTransaction));
+        mockOpObserver = Mockito.mock(TableOperationObserver.class);
         compositeCompactionTask = CompositeCompactionTask.combineTasks(mockTask1, mockTask2);
+        compositeCompactionTask.setOpObserver(mockOpObserver);
     }
 
     @Test
     public void testExecute() {
         // Testing executeInternal() instead of execute() because we cannot mock transaction.close()
         compositeCompactionTask.executeInternal();
-        verify(mockTask1, times(1)).execute();
-        verify(mockTask2, times(1)).execute();
+        verify(mockTask1, times(1)).execute(mockOpObserver);
+        verify(mockTask2, times(1)).execute(mockOpObserver);
     }
 
     @Test
@@ -94,14 +97,6 @@ public class CompositeCompactionTaskTest
     }
 
     @Test
-    public void testSetOpObserver() {
-        TableOperationObserver opObserver = Mockito.mock(TableOperationObserver.class);
-        compositeCompactionTask.setOpObserver(opObserver);
-        verify(mockTask1, times(1)).setOpObserver(opObserver);
-        verify(mockTask2, times(1)).setOpObserver(opObserver);
-    }
-
-    @Test
     public void testAddObserver() {
         CompactionObserver compObserver = Mockito.mock(CompactionObserver.class);
         compositeCompactionTask.addObserver(compObserver);
@@ -111,10 +106,10 @@ public class CompositeCompactionTaskTest
 
     @Test
     public void testExecuteWithException() {
-        doThrow(new RuntimeException("Test Exception")).when(mockTask1).execute();
+        doThrow(new RuntimeException("Test Exception")).when(mockTask1).execute(Mockito.any());
         assertThrows(RuntimeException.class, () -> compositeCompactionTask.executeInternal());
-        verify(mockTask1, times(1)).execute();
-        verify(mockTask2, times(1)).execute();
+        verify(mockTask1, times(1)).execute(mockOpObserver);
+        verify(mockTask2, times(1)).execute(mockOpObserver);
     }
 
     @Test
@@ -145,12 +140,15 @@ public class CompositeCompactionTaskTest
 
         for (AbstractCompactionTask task : result) {
             if (task instanceof CompositeCompactionTask)
+            {
+                task.setOpObserver(mockOpObserver);
                 task.executeInternal(); // can't call execute() because it will call transaction.close()
+            }
             else
-                task.execute();
+                task.execute(mockOpObserver);
         }
         for (AbstractCompactionTask task : tasks) {
-            verify(task, times(1)).execute();
+            verify(task, times(1)).execute(mockOpObserver);
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionProgressTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionProgressTest.java
@@ -96,7 +96,7 @@ public class SharedCompactionProgressTest
         assertTrue(progress.outSSTables().stream().map(Object::toString).allMatch(s -> s.startsWith("o")));
         assertEquals(count, progress.sstables().size());
         assertTrue(progress.sstables().stream().map(Object::toString).allMatch(s -> s.startsWith("s")));
-        assertEquals(100L * count, progress.inputDiskSize());
+        assertEquals(100L * countForTotal, progress.inputDiskSize());
         assertEquals(200L * count, progress.outputDiskSize());
         assertEquals(300L * count, progress.uncompressedBytesRead());
         assertEquals(400L * count, progress.uncompressedBytesWritten());
@@ -105,7 +105,7 @@ public class SharedCompactionProgressTest
         assertEquals(700L * count, progress.completed());
         assertEquals(800L * countForTotal, progress.total());
         assertEquals(900L, progress.startTimeNanos());
-        assertEquals(1000L * count, progress.inputUncompressedSize());
+        assertEquals(1000L * countForTotal, progress.inputUncompressedSize());
         assertEquals(1100L * count, progress.adjustedInputDiskSize());
         assertArrayEquals(new long[]{1 * count, 2 * count, 3 * count}, progress.partitionsHistogram());
         assertArrayEquals(new long[]{4 * count, 5 * count, 6 * count}, progress.rowsHistogram());
@@ -122,7 +122,7 @@ public class SharedCompactionProgressTest
     public void testCompleteSubtask()
     {
         CompactionProgress mockProgress = getMockProgress();
-        sharedCompactionProgress.registerExpectedSubtask(800L);
+        sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
         sharedCompactionProgress.addSubtask(mockProgress);
         checkProgress(sharedCompactionProgress, 1, 1);
         boolean isComplete = sharedCompactionProgress.completeSubtask(mockProgress);
@@ -133,8 +133,8 @@ public class SharedCompactionProgressTest
     @Test
     public void testComplete2Subtasks()
     {
-        sharedCompactionProgress.registerExpectedSubtask(800L);
-        sharedCompactionProgress.registerExpectedSubtask(800L);
+        sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
+        sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
         CompactionProgress mockProgress1 = getMockProgress();
         CompactionProgress mockProgress2 = getMockProgress();
         sharedCompactionProgress.addSubtask(mockProgress1);
@@ -150,8 +150,8 @@ public class SharedCompactionProgressTest
     @Test
     public void testComplete2SubtasksLateStart()
     {
-        sharedCompactionProgress.registerExpectedSubtask(800L);
-        sharedCompactionProgress.registerExpectedSubtask(800L);
+        sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
+        sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
         CompactionProgress mockProgress = getMockProgress();
         sharedCompactionProgress.addSubtask(mockProgress);
         boolean isComplete = sharedCompactionProgress.completeSubtask(mockProgress);
@@ -171,7 +171,7 @@ public class SharedCompactionProgressTest
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
         for (int i = 0; i < threadCount; ++i)
-            sharedCompactionProgress.registerExpectedSubtask(800L);
+            sharedCompactionProgress.registerExpectedSubtask(800L, 100L, 1000L);
 
         AtomicInteger completed = new AtomicInteger(0);
         List<Future<?>> futures = new ArrayList<>();

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionProgressTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionProgressTest.java
@@ -80,7 +80,7 @@ public class SharedCompactionProgressTest
         when(mockProgress.rowsRead()).thenReturn(600L);
         when(mockProgress.completed()).thenReturn(700L);
         when(mockProgress.total()).thenReturn(800L);
-        when(mockProgress.startTimeNanos()).thenReturn(900L);
+        when(mockProgress.startTimeMillis()).thenReturn(900L);
         when(mockProgress.inputUncompressedSize()).thenReturn(1000L);
         when(mockProgress.adjustedInputDiskSize()).thenReturn(1100L);
         when(mockProgress.partitionsHistogram()).thenReturn(new long[]{1, 2, 3});
@@ -104,7 +104,7 @@ public class SharedCompactionProgressTest
         assertEquals(600L * count, progress.rowsRead());
         assertEquals(700L * count, progress.completed());
         assertEquals(800L * countForTotal, progress.total());
-        assertEquals(900L, progress.startTimeNanos());
+        assertEquals(900L, progress.startTimeMillis());
         assertEquals(1000L * countForTotal, progress.inputUncompressedSize());
         assertEquals(1100L * count, progress.adjustedInputDiskSize());
         assertArrayEquals(new long[]{1 * count, 2 * count, 3 * count}, progress.partitionsHistogram());

--- a/test/unit/org/apache/cassandra/db/compaction/SharedTableOperationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedTableOperationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.cassandra.db.compaction.SharedTableOperation;
+import org.apache.cassandra.db.compaction.TableOperation;
+import org.apache.cassandra.db.compaction.TableOperationObserver;
+import org.apache.cassandra.utils.NonThrowingCloseable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class SharedTableOperationTest {
+
+    private SharedTableOperation sharedTableOperation;
+    private TableOperationObserver mockObserver;
+    private TableOperation mockOperation1;
+    private TableOperation mockOperation2;
+    private TableOperation mockOperation3;
+    private TableOperation.Progress mockProgress;
+    private NonThrowingCloseable mockCloseable;
+
+    @Before
+    public void setUp() {
+        mockProgress = Mockito.mock(SharedTableOperation.Progress.class);
+        sharedTableOperation = new SharedTableOperation(mockProgress);
+        mockObserver = Mockito.mock(TableOperationObserver.class);
+        mockCloseable = Mockito.mock(NonThrowingCloseable.class);
+        mockOperation1 = Mockito.mock(TableOperation.class);
+        mockOperation2 = Mockito.mock(TableOperation.class);
+        mockOperation3 = Mockito.mock(TableOperation.class);
+
+        when(mockObserver.onOperationStart(sharedTableOperation)).thenReturn(mockCloseable);
+    }
+
+    @Test
+    public void testGetProgress() {
+        assertEquals(mockProgress, sharedTableOperation.getProgress());
+    }
+
+    @Test
+    public void testOneChild() {
+        // Register expected subtask
+        sharedTableOperation.registerExpectedSubtask();
+
+        // Wrap observer
+        TableOperationObserver wrappedObserver = sharedTableOperation.wrapObserver(mockObserver);
+
+        // Start operation
+        NonThrowingCloseable closeable = wrappedObserver.onOperationStart(mockOperation1);
+        assertNotNull(closeable);
+
+        // Verify observer communication
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+
+        // Close operation
+        closeable.close();
+        verify(mockCloseable, times(1)).close();
+    }
+
+    @Test
+    public void testOneChildStop() {
+        // Register expected subtask
+        sharedTableOperation.registerExpectedSubtask();
+
+        // Wrap observer
+        TableOperationObserver wrappedObserver = sharedTableOperation.wrapObserver(mockObserver);
+
+        // Start operation
+        NonThrowingCloseable closeable = wrappedObserver.onOperationStart(mockOperation1);
+        assertNotNull(closeable);
+        // When stopped, an operation will also close itself
+        Mockito.doAnswer(inv -> {
+            closeable.close();
+            return null;
+        }).when(mockOperation1).stop(any());
+
+        // Verify observer communication
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+
+        sharedTableOperation.stop(TableOperation.StopTrigger.CLEANUP);
+        verify(mockOperation1, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+
+        // Close operation
+        verify(mockCloseable, times(1)).close();
+    }
+
+    @Test
+    public void testThreeChildren() {
+        // Register expected subtasks
+        sharedTableOperation.registerExpectedSubtask();
+        sharedTableOperation.registerExpectedSubtask();
+        sharedTableOperation.registerExpectedSubtask();
+
+        // Wrap observer
+        TableOperationObserver wrappedObserver = sharedTableOperation.wrapObserver(mockObserver);
+
+        // Start operations
+        NonThrowingCloseable closeable1 = wrappedObserver.onOperationStart(mockOperation1);
+        NonThrowingCloseable closeable2 = wrappedObserver.onOperationStart(mockOperation2);
+        assertNotNull(closeable1);
+        assertNotNull(closeable2);
+        closeable1.close();
+
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+        verify(mockCloseable, times(0)).close();
+
+        NonThrowingCloseable closeable3 = wrappedObserver.onOperationStart(mockOperation3);
+        assertNotNull(closeable3);
+
+        // Close operations
+        closeable2.close();
+        closeable3.close();
+
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+        verify(mockCloseable, times(1)).close();
+    }
+
+    @Test
+    public void testThreeChildrenStop() {
+        // Register expected subtasks
+        sharedTableOperation.registerExpectedSubtask();
+        sharedTableOperation.registerExpectedSubtask();
+        sharedTableOperation.registerExpectedSubtask();
+
+        // Wrap observer
+        TableOperationObserver wrappedObserver = sharedTableOperation.wrapObserver(mockObserver);
+
+        // Start first operation
+        NonThrowingCloseable closeable1 = wrappedObserver.onOperationStart(mockOperation1);
+        assertNotNull(closeable1);
+        // When stopped, an operation will also close itself
+        Mockito.doAnswer(inv -> {
+            closeable1.close();
+            return null;
+        }).when(mockOperation1).stop(any());
+
+        // Issue stop before starting the next operations
+        sharedTableOperation.stop(TableOperation.StopTrigger.CLEANUP);
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+        verify(mockCloseable, times(0)).close();
+        verify(mockOperation1, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+
+        // Start remaining operations
+        NonThrowingCloseable closeable2 = wrappedObserver.onOperationStart(mockOperation2);
+        assertNotNull(closeable2);
+        verify(mockOperation2, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+
+        NonThrowingCloseable closeable3 = wrappedObserver.onOperationStart(mockOperation3);
+        assertNotNull(closeable3);
+        verify(mockOperation3, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+
+        // In response to a stop request, the child process will finish and close itself as it executes
+        closeable3.close();
+        verify(mockCloseable, times(0)).close();
+        closeable2.close(); // simulating a bit of disorder here
+
+        // Verify observer communication
+        verify(mockObserver, times(1)).onOperationStart(sharedTableOperation);
+        verify(mockCloseable, times(1)).close();
+        verify(mockOperation1, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+        verify(mockOperation2, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+        verify(mockOperation3, times(1)).stop(TableOperation.StopTrigger.CLEANUP);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/SharedTableOperationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedTableOperationTest.java
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+package org.apache.cassandra.db.compaction;
+
 import org.apache.cassandra.db.compaction.SharedTableOperation;
 import org.apache.cassandra.db.compaction.TableOperation;
 import org.apache.cassandra.db.compaction.TableOperationObserver;

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -788,7 +788,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     private CompactionProgress mockProgress(UnifiedCompactionStrategy strategy, UUID id)
     {
         CompactionProgress progress = Mockito.mock(CompactionProgress.class);
-        when(progress.durationInNanos()).thenReturn(1000L*1000*1000);
+        when(progress.durationInMillis()).thenReturn(1000L);
         when(progress.outputDiskSize()).thenReturn(1L);
         when(progress.operationId()).thenReturn(id);
         return progress;

--- a/test/unit/org/apache/cassandra/db/compaction/unified/BackgroundCompactionTrackingTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/BackgroundCompactionTrackingTest.java
@@ -37,10 +37,10 @@ import org.junit.runner.RunWith;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.compaction.AbstractTableOperation;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionStrategy;
 import org.apache.cassandra.db.compaction.CompactionStrategyStatistics;
+import org.apache.cassandra.db.compaction.TableOperation;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStatistics;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.UUIDGen;
@@ -151,7 +151,7 @@ public class BackgroundCompactionTrackingTest extends CQLTester
             // Check that the background compactions state is correct during the compaction
             Assert.assertTrue("Byteman rule did not fire", !operations.isEmpty());
             printStats();
-            int tasks = parallelize ? shards : 1;
+            int tasks = 1;//parallelize ? shards : 1;
             assertEquals(tasks, operations.size());
             UUID mainOpId = null;
             for (int i = 0; i < operations.size(); ++i)
@@ -178,9 +178,9 @@ public class BackgroundCompactionTrackingTest extends CQLTester
 
                     if (i == 0)
                         Assert.assertEquals(uncompressedSize * 1.0 / tasks, op.total(), uncompressedSize * 0.03);
-                    assertTrue(op.totalByteScanned() <= op.total());
-                    assertFalse(op.totalByteScanned() > op.total());
-                    if (op.totalByteScanned() == op.total())
+                    assertTrue(op.completed() <= op.total());
+                    assertFalse(op.completed() > op.total());
+                    if (op.completed() == op.total())
                         ++finished;
                 }
                 assertTrue(finished > i);
@@ -242,5 +242,5 @@ public class BackgroundCompactionTrackingTest extends CQLTester
 
     static CompactionStrategy strategy;
     static List<List<CompactionStrategyStatistics>> statistics;
-    static List<List<AbstractTableOperation.OperationProgress>> operations;
+    static List<List<TableOperation.Progress>> operations;
 }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.db.compaction.ShardManager;
 import org.apache.cassandra.db.compaction.ShardManagerNoDisks;
 import org.apache.cassandra.db.compaction.SharedCompactionObserver;
 import org.apache.cassandra.db.compaction.SharedCompactionProgress;
+import org.apache.cassandra.db.compaction.SharedTableOperation;
 import org.apache.cassandra.db.compaction.TableOperation;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.db.lifecycle.CompositeLifecycleTransaction;
@@ -103,6 +104,7 @@ public class ParallelizedTasksTest extends ShardingTestBase
         strategy.getCompactionLogger().enable();
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
         SharedCompactionObserver sharedObserver = new SharedCompactionObserver(strategy);
+        SharedTableOperation sharedOperation = new SharedTableOperation(sharedProgress);
 
         List<AbstractCompactionTask> tasks = shardManager.splitSSTablesInShards(
             sstables,
@@ -118,7 +120,8 @@ public class ParallelizedTasksTest extends ShardingTestBase
                                       range,
                                       rangeSSTables,
                                       sharedProgress,
-                                      sharedObserver)
+                                      sharedObserver,
+                                      sharedOperation)
         );
         compositeTransaction.completeInitialization();
         assertEquals(numOutputSSTables, tasks.size());

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -932,7 +932,7 @@ public class SecondaryIndexManagerTest extends CQLTester
                             }
 
                             @Override
-                            public OperationProgress getProgress()
+                            public Progress getProgress()
                             {
                                 return builder.getProgress();
                             }


### PR DESCRIPTION
### What is the issue
Partial compactions only report as total size the size of initiated compaction operations. This underrepresents the size of the operation, which can result in bad progress indications (going to 100% then back to 50% etc.), especially with the current implementation of major compaction in CNDB where partial tasks are started in sequence.

Additionally, CNDB is only using the `ActiveOperations` view to show operation progress, which is currently listing only composite compaction subtasks, with no information about the total size of operations, and way to understand the total progress and expected duration of e.g. a major compaction.

### What does this PR fix and why was it fixed
Starts presenting composite tasks as a single operation in the `ActiveOperations` view. Adds the ability to stop all subtasks through this, aborting them quicker than the shared transaction abort, which could wait until completion to abort started tasks.

Precomputes the totals for the operation, so that we know the total size of the operation as soon as it starts.

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits