### PR TITLE
CNDB-12539: Improve reporting missing SAI indexes

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -111,11 +111,29 @@ public class QueryView implements AutoCloseable
         static class MissingIndexException extends RuntimeException
         {
             final IndexContext context;
+            final String dataObjectName;
 
-            public MissingIndexException(IndexContext context, String message)
+            private MissingIndexException(IndexContext context, String dataObjectName)
             {
-                super(message);
+                super();
                 this.context = context;
+                this.dataObjectName = dataObjectName;
+            }
+
+            public static MissingIndexException forSSTable(IndexContext context, Descriptor descriptor)
+            {
+                return new MissingIndexException(context, "sstable " + descriptor);
+            }
+
+            public static MissingIndexException forMemtable(IndexContext context, Memtable memtable)
+            {
+                return new MissingIndexException(context, "memtable " + memtable);
+            }
+
+            @Override
+            public String getMessage()
+            {
+                return "Index " + context.getIndexName() + " not found for " + dataObjectName;
             }
         }
 
@@ -189,8 +207,7 @@ public class QueryView implements AutoCloseable
                         {
                             // Index was dropped deliberately by the user.
                             // We cannot recover here.
-                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                          " not found for memtable: " + memtable);
+                            throw MissingIndexException.forMemtable(indexContext, memtable);
                         }
                         else if (!processedMemtables.contains(memtable))
                         {
@@ -238,8 +255,7 @@ public class QueryView implements AutoCloseable
                         // The IndexViewManager got the update about this sstable, but there is no index for the sstable
                         // (e.g. index was dropped or got corrupt, etc.). In this case retrying won't fix it.
                         if (index == null)
-                            throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                          " not found for sstable: " + sstable.descriptor);
+                            throw MissingIndexException.forSSTable(indexContext, sstable.descriptor);
 
                         if (!indexInRange(index))
                             continue;
@@ -270,17 +286,14 @@ public class QueryView implements AutoCloseable
                                          indexContext);
                 }
 
-
                 if (unmatchedMemtable != null)
-                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                  " not found for memtable " + unmatchedMemtable);
+                    throw MissingIndexException.forMemtable(indexContext, unmatchedMemtable);
                 if (unmatchedSStable != null)
-                    throw new MissingIndexException(indexContext, "Index " + indexContext.getIndexName() +
-                                                                  " not found for sstable " + unmatchedSStable);
+                    throw MissingIndexException.forSSTable(indexContext, unmatchedSStable);
 
                 // This should be unreachable, because whenever we retry, we always set unmatchedMemtable
                 // or unmatchedSSTable, so we'd log a better message above.
-                throw new MissingIndexException(indexContext, "Failed to build QueryView for index " + indexContext.getIndexName());
+                throw new AssertionError("Failed to build QueryView for index " + indexContext.getIndexName());
             }
             catch (MissingIndexException e)
             {

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.plan;
 
+import java.io.IOError;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,8 +67,6 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.FBUtilities;
-
-import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
 public class StorageAttachedIndexSearcher implements Index.Searcher
 {
@@ -139,8 +138,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
 
                 // If we end up here, this is either a bug or a problem with an index (corrupted / missing components?).
                 controller.abort();
-                logger.error("Index not found", e);
-                throw invalidRequest("Index missing or corrupt: " + e.context.getIndexName());
+                // Throwing IOError here because we want the coordinator to handle it as any other serious storage error
+                // and report it up to the user as failed query. It is better to fail than to return an incomplete
+                // result set.
+                throw new IOError(e);
             }
             catch (Throwable t)
             {

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.index;
 
 import java.io.FileNotFoundException;
+import java.io.IOError;
 import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,6 +56,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -195,7 +197,7 @@ public class SecondaryIndexManagerTest extends CQLTester
         // track sstable again: expect the query that needs the index cannot execute
         cfs.getTracker().addInitialSSTables(sstables);
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
-        assertInvalid("SELECT * FROM %s WHERE c=1");
+        assertThrows(IOError.class, () -> execute("SELECT * FROM %s WHERE c=1"));
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);


### PR DESCRIPTION
### What is the issue
When the index is missing we rethrow it as `InvalidRequestException`, but that exception is not expected to be thrown from the replica and the coordinator reports it as uncaught exception.

The sstable name is not recorded on the exception propagated up to the coordinator (but it is only logged).

### What does this PR fix and why was it fixed
Wrap MissingIndexException in IOError so the coordinator knows how to classify the exception.
Add memtable/sstable information to the exception object.


### Checklist before you submit for review
- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits