### PR TITLE
CNDB-10468: Port CNDB-8538 for C*5.0 codebase

### DIFF
--- a/src/java/org/apache/cassandra/schema/Schema.java
+++ b/src/java/org/apache/cassandra/schema/Schema.java
@@ -712,7 +712,7 @@ public class Schema implements SchemaProvider
         // we send mutations to the correct set of bootstrapping nodes. Refer CASSANDRA-15433.
         if (keyspace.params.replication.klass != LocalStrategy.class && instance != null)
         {
-            PendingRangeCalculatorService.calculatePendingRanges(instance.getReplicationStrategy(), keyspace.name);
+            PendingRangeCalculatorService.instance.calculatePendingRanges(instance.getReplicationStrategy(), keyspace.name);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
+++ b/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
@@ -112,7 +112,9 @@ public class PendingRangeCalculatorService
         this(executorFactory().withJmxInternal()
                               .configureSequential(executorName)
                               .withRejectedExecutionHandler((r, e) -> {})  // silently handle rejected tasks, this::update takes care of bookkeeping
-                              .build(), TokenMetadataProvider.instance, schema);
+                              .build(),
+             TokenMetadataProvider.instance,
+             schema);
     }
 
     public PendingRangeCalculatorService(SequentialExecutorPlus executor, TokenMetadataProvider tokenMetadataProvider, Schema schema)

--- a/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
+++ b/src/java/org/apache/cassandra/service/PendingRangeCalculatorService.java
@@ -19,6 +19,10 @@
 package org.apache.cassandra.service;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -32,11 +36,12 @@ import org.apache.cassandra.concurrent.SequentialExecutorPlus;
 import org.apache.cassandra.concurrent.SequentialExecutorPlus.AtLeastOnceTrigger;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.locator.TokenMetadataProvider;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.utils.ExecutorUtils;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
-import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 
 public class PendingRangeCalculatorService
 {
@@ -46,47 +51,87 @@ public class PendingRangeCalculatorService
 
     // the executor will only run a single range calculation at a time while keeping at most one task queued in order
     // to trigger an update only after the most recent state change and not for each update individually
-    private final SequentialExecutorPlus executor = executorFactory()
-            .withJmxInternal()
-            .configureSequential("PendingRangeCalculator")
-            .withRejectedExecutionHandler((r, e) -> {})  // silently handle rejected tasks, this::update takes care of bookkeeping
-            .build();
+    private final SequentialExecutorPlus executor;
 
-    private final AtLeastOnceTrigger update = executor.atLeastOnceTrigger(() -> doUpdate(keyspaceName -> true));
+    private final Schema schema;
 
-    private void doUpdate(Predicate<String> keyspaceNamePredicate)
+    private final AtLeastOnceTrigger update;
+
+    private final Set<String> keyspacesWithPendingRanges = new CopyOnWriteArraySet<>();
+
+    private final TokenMetadataProvider tokenMetadataProvider;
+
+    private void doUpdate()
     {
-        PendingRangeCalculatorServiceDiagnostics.taskStarted(1);
-        long start = currentTimeMillis();
-        Collection<String> keyspaces = Schema.instance.distributedKeyspaces().names().stream()
-                                                      .filter(keyspaceNamePredicate)
-                                                      .collect(Collectors.toList());
+        // repeat until all keyspaced are consumed
+        while (!keyspacesWithPendingRanges.isEmpty())
+        {
+            long start = System.currentTimeMillis();
 
-        for (String keyspaceName : keyspaces)
-            calculatePendingRanges(Keyspace.open(keyspaceName).getReplicationStrategy(), keyspaceName);
-        if (logger.isTraceEnabled())
-            logger.trace("Finished PendingRangeTask for {} keyspaces in {}ms", keyspaces.size(), currentTimeMillis() - start);
-        PendingRangeCalculatorServiceDiagnostics.taskFinished();
+            int updated = 0;
+            int total = 0;
+            PendingRangeCalculatorServiceDiagnostics.taskStarted(1);
+            try
+            {
+                Set<String> keyspaces = new HashSet<>(keyspacesWithPendingRanges);
+                total = keyspaces.size();
+                keyspacesWithPendingRanges.removeAll(keyspaces); // only remove those which were consumed
+
+                Iterator<String> it = keyspaces.iterator();
+                while (it.hasNext())
+                {
+                    String keyspaceName = it.next();
+                    try
+                    {
+                        calculatePendingRanges(keyspaceName);
+                        it.remove();
+                        updated++;
+                    }
+                    catch (RuntimeException | Error ex)
+                    {
+                        logger.error("Error calculating pending ranges for keyspace {}", keyspaceName, ex);
+                    }
+                }
+            }
+            finally
+            {
+                PendingRangeCalculatorServiceDiagnostics.taskFinished();
+                if (logger.isTraceEnabled())
+                    logger.trace("Finished PendingRangeTask for {} keyspaces out of {} in {}ms", updated, total, System.currentTimeMillis() - start);
+            }
+        }
     }
 
     public PendingRangeCalculatorService()
     {
+        this("PendingRangeCalculator", Schema.instance);
+    }
+
+    public PendingRangeCalculatorService(String executorName, Schema schema)
+    {
+        this(executorFactory().withJmxInternal()
+                              .configureSequential(executorName)
+                              .withRejectedExecutionHandler((r, e) -> {})  // silently handle rejected tasks, this::update takes care of bookkeeping
+                              .build(), TokenMetadataProvider.instance, schema);
+    }
+
+    public PendingRangeCalculatorService(SequentialExecutorPlus executor, TokenMetadataProvider tokenMetadataProvider, Schema schema)
+    {
+        this.executor = requireNonNull(executor);
+        this.tokenMetadataProvider = requireNonNull(tokenMetadataProvider);
+        this.schema = requireNonNull(schema);
+        this.update = executor.atLeastOnceTrigger(this::doUpdate);
     }
 
     public void update()
     {
-        boolean success = update.trigger();
-        if (!success) PendingRangeCalculatorServiceDiagnostics.taskRejected(1);
-        else PendingRangeCalculatorServiceDiagnostics.taskCountChanged(1);
+        update(keyspaceName -> true);
     }
 
     public void update(Predicate<String> keyspaceNamePredicate)
     {
-        // TODO this is probably wrong. The implementation of this class assumes that if the update is scheduled, there
-        //  is no need to schedule another update, because each update would update all keyspaces. However this is not
-        //  the case when we can trigger update with a predicate. Such update can be skipped because an update with
-        //  different filter was scheduled and in the end we may end up with a pending range that is not updated (silently).
-        AtLeastOnceTrigger update = executor.atLeastOnceTrigger(() -> doUpdate(keyspaceNamePredicate));
+        Collection<String> affectedKeyspaces = schema.distributedKeyspaces().names().stream().filter(keyspaceNamePredicate).collect(Collectors.toList());
+        keyspacesWithPendingRanges.addAll(affectedKeyspaces);
         boolean success = update.trigger();
         if (!success) PendingRangeCalculatorServiceDiagnostics.taskRejected(1);
         else PendingRangeCalculatorServiceDiagnostics.taskCountChanged(1);
@@ -97,16 +142,23 @@ public class PendingRangeCalculatorService
         update.sync();
     }
 
-
     public void executeWhenFinished(Runnable runnable)
     {
         update.runAfter(runnable);
     }
 
-    // public & static for testing purposes
-    public static void calculatePendingRanges(AbstractReplicationStrategy strategy, String keyspaceName)
+    @VisibleForTesting
+    protected void calculatePendingRanges(String keyspaceName)
     {
-        StorageService.instance.getTokenMetadataForKeyspace(keyspaceName).calculatePendingRanges(strategy, keyspaceName);
+        Keyspace keyspace = Keyspace.open(keyspaceName);
+        AbstractReplicationStrategy strategy = keyspace.getReplicationStrategy();
+        calculatePendingRanges(strategy, keyspaceName);
+    }
+
+    @VisibleForTesting
+    public void calculatePendingRanges(AbstractReplicationStrategy strategy, String keyspaceName)
+    {
+        tokenMetadataProvider.getTokenMetadataForKeyspace(keyspaceName).calculatePendingRanges(strategy, keyspaceName);
     }
 
     @VisibleForTesting

--- a/test/unit/org/apache/cassandra/gms/PendingRangeCalculatorServiceTest.java
+++ b/test/unit/org/apache/cassandra/gms/PendingRangeCalculatorServiceTest.java
@@ -24,6 +24,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.BeforeClass;
@@ -31,17 +35,26 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.Keyspaces;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.service.PendingRangeCalculatorService;
 import org.apache.cassandra.service.StorageService;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.mockito.Mockito;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.GOSSIP_DISABLE_THREAD_VALIDATION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -130,5 +143,48 @@ public class PendingRangeCalculatorServiceTest
         Map<InetAddressAndPort, EndpointState> states = new HashMap<>();
         states.put(otherNodeAddr, state);
         return states;
+    }
+
+    @Test
+    public void testPendingRangesCalculatedForAllRequestedKeyspaces() throws InterruptedException, TimeoutException
+    {
+        DatabaseDescriptor.daemonInitialization();
+
+        // mock schema with 100 keyspaces ks0, ks1, ..., ks99
+        Schema schema = Mockito.mock(Schema.class);
+        Keyspaces.Builder keyspaces = Keyspaces.builder();
+        for (int i = 0; i < 100; i++)
+            keyspaces.add(KeyspaceMetadata.create("ks" + i, KeyspaceParams.simple(1)));
+        when(schema.distributedKeyspaces()).thenReturn(keyspaces.build());
+
+        // a set of keyspaces for which pending ranges have been calculated - once the calculation is requested, we put a keyspace name into this set
+        Map<String, Boolean> processedKeyspaces = new ConcurrentHashMap<>();
+
+        // create a PendingRangeCalculatorService that will take 1 ms to calculate pending ranges for each keyspace
+        PendingRangeCalculatorService prcs = new PendingRangeCalculatorService("PendingRangeCalculator" + System.currentTimeMillis(), schema) {
+            @Override
+            public void calculatePendingRanges(String keyspace)
+            {
+                processedKeyspaces.put(keyspace, true);
+                LockSupport.parkNanos(1000000); // 1 ms processing time
+            }
+        };
+
+        // request pending range calculation for each keyspace with 100 µs interval
+        // Note that, those parkNanos are optional and are added to increse the visibility of the problem
+        for (int i = 0; i < 100; i++)
+        {
+            String name = "ks" + i;
+            prcs.update(ks -> ks.equals(name));
+            LockSupport.parkNanos(100000); // 100 µs schedule interval
+        }
+
+        // wait for all pending range calculations to finish
+        prcs.blockUntilFinished();
+        prcs.shutdownAndWait(10, TimeUnit.SECONDS);
+
+        // verify that pending ranges have been calculated for all keyspaces
+        assertThat(processedKeyspaces).withFailMessage("Test is broken or outdated. Expected at least 2 keyspaces to be calculated.").hasSizeGreaterThan(1);
+        assertThat(processedKeyspaces).hasSize(100);
     }
 }

--- a/test/unit/org/apache/cassandra/locator/SimpleStrategyTest.java
+++ b/test/unit/org/apache/cassandra/locator/SimpleStrategyTest.java
@@ -230,7 +230,7 @@ public class SimpleStrategyTest
         {
             strategy = getStrategy(keyspaceName, tmd, new SimpleSnitch());
 
-            PendingRangeCalculatorService.calculatePendingRanges(strategy, keyspaceName);
+            PendingRangeCalculatorService.instance.calculatePendingRanges(strategy, keyspaceName);
 
             int replicationFactor = strategy.getReplicationFactor().allReplicas;
 


### PR DESCRIPTION
### What is the issue
Pending ranges calculator service in the original (C*5.0) version always processes all the keyspaces but don't allow to queue more than one run (in order to not do the work multiple times needlessly)

In CC we want to limit the processed keyspaces to those belonging to certain tenants - from CC point of view, this is just a keyspace name filter. However, running for different sets of keyspaces and not enqueueing more than one run was not achieved in 5.0 so far.

In particular, in this case the pending ranges calculation were run as much times as we scheduled it.

### What does this PR fix and why was it fixed
This change ports the fix from CNDB-8538 and adjust it to C*5.0 codebase. That is, when we request PRC for a set of the keyspaces, a PRC is guaranteed to run at least once after requesting it. 

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits