### PR TITLE
Port CASSANDRA-19906 from Cassandra 5.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
  * Enables IAuthenticator's to return own AuthenticateMessage (CASSANDRA-19984)
  * Use ParameterizedClass for all auth-related implementations (CASSANDRA-19946)
 
+5.0.1
+ * Make configuration entries in memtable section order-independent (CASSANDRA-19906)
+ 
 Future version (tbd)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
 

--- a/src/java/org/apache/cassandra/schema/MemtableParams.java
+++ b/src/java/org/apache/cassandra/schema/MemtableParams.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -158,8 +159,58 @@ public final class MemtableParams
         if (!memtableConfigurations.containsKey(DEFAULT_CONFIGURATION_KEY))
             configs.put(DEFAULT_CONFIGURATION_KEY, DEFAULT_CONFIGURATION);
 
-        for (Map.Entry<String, InheritingClass> en : memtableConfigurations.entrySet())
-            configs.put(en.getKey(), en.getValue().resolve(configs));
+        Map<String, InheritingClass> inheritingClasses = new LinkedHashMap<>();
+
+        for (Map.Entry<String, InheritingClass> entry : memtableConfigurations.entrySet())
+        {
+            if (entry.getValue().inherits != null)
+            {
+                if (entry.getKey().equals(entry.getValue().inherits))
+                    throw new ConfigurationException(String.format("Configuration entry %s can not inherit itself.", entry.getKey()));
+
+                if (memtableConfigurations.get(entry.getValue().inherits) == null && !entry.getValue().inherits.equals(DEFAULT_CONFIGURATION_KEY))
+                    throw new ConfigurationException(String.format("Configuration entry %s inherits non-existing entry %s.",
+                                                                   entry.getKey(), entry.getValue().inherits));
+
+                inheritingClasses.put(entry.getKey(), entry.getValue());
+            }
+            else
+                configs.put(entry.getKey(), entry.getValue().resolve(configs));
+        }
+
+        for (Map.Entry<String, InheritingClass> inheritingEntry : inheritingClasses.entrySet())
+        {
+            String inherits = inheritingEntry.getValue().inherits;
+            while (inherits != null)
+            {
+                InheritingClass nextInheritance = inheritingClasses.get(inherits);
+                if (nextInheritance == null)
+                    inherits = null;
+                else
+                    inherits = nextInheritance.inherits;
+
+                if (inherits != null && inherits.equals(inheritingEntry.getKey()))
+                    throw new ConfigurationException(String.format("Detected loop when processing key %s", inheritingEntry.getKey()));
+            }
+        }
+
+        while (!inheritingClasses.isEmpty())
+        {
+            Set<String> forRemoval = new HashSet<>();
+            for (Map.Entry<String, InheritingClass> inheritingEntry : inheritingClasses.entrySet())
+            {
+                if (configs.get(inheritingEntry.getValue().inherits) != null)
+                {
+                    configs.put(inheritingEntry.getKey(), inheritingEntry.getValue().resolve(configs));
+                    forRemoval.add(inheritingEntry.getKey());
+                }
+            }
+
+            assert !forRemoval.isEmpty();
+
+            for (String toRemove : forRemoval)
+                inheritingClasses.remove(toRemove);
+        }
 
         return ImmutableMap.copyOf(configs);
     }

--- a/test/unit/org/apache/cassandra/schema/MemtableParamsTest.java
+++ b/test/unit/org/apache/cassandra/schema/MemtableParamsTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.cassandra.schema;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.cassandra.config.InheritingClass;
@@ -30,6 +30,8 @@ import org.apache.cassandra.db.memtable.SkipListMemtableFactory;
 import org.apache.cassandra.exceptions.ConfigurationException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MemtableParamsTest
 {
@@ -62,6 +64,41 @@ public class MemtableParamsTest
         assertEquals(ImmutableMap.of("default", DEFAULT,
                                      "one", one),
                      map);
+    }
+
+    @Test
+    public void testOrderingDoesNotMatter()
+    {
+        // linked hash map preserves insertion order
+        Map<String, InheritingClass> config = new LinkedHashMap<>();
+
+        config.put("default", new InheritingClass("trie", null, null));
+        config.put("abc", new InheritingClass(null, "Abc", ImmutableMap.of("c", "d")));
+        config.put("skiplist", new InheritingClass("skiplistOnSteroids", "SkipListMemtable", ImmutableMap.of("e", "f")));
+        config.put("skiplistOnSteroids", new InheritingClass("abc", null, ImmutableMap.of("a", "b")));
+        config.put("trie", new InheritingClass(null, "TrieMemtable", null));
+
+        Map<String, ParameterizedClass> map = MemtableParams.expandDefinitions(config);
+        assertEquals("TrieMemtable", map.get("default").class_name);
+
+        // this inherits abc which has c as config parameter
+        assertTrue(map.get("skiplistOnSteroids").parameters.containsKey("a"));
+        assertTrue(map.get("skiplistOnSteroids").parameters.containsKey("c"));
+        assertEquals(map.get("skiplistOnSteroids").class_name, config.get("abc").class_name);
+
+        // this inherits from skiplistOnSteroids which so params are carried over as well
+        assertTrue(map.get("skiplist").parameters.containsKey("a"));
+        assertTrue(map.get("skiplist").parameters.containsKey("c"));
+        assertTrue(map.get("skiplist").parameters.containsKey("e"));
+        assertEquals(map.get("skiplist").class_name, "SkipListMemtable");
+
+        Map<String, InheritingClass> config2 = new LinkedHashMap<>();
+        config2.put("skiplist", new InheritingClass(null, "SkipListMemtable", null));
+        config2.put("trie", new InheritingClass(null, "TrieMemtable", null));
+        config2.put("default", new InheritingClass("trie", null, null));
+
+        Map<String, ParameterizedClass> map2 = MemtableParams.expandDefinitions(config2);
+        assertEquals("TrieMemtable", map2.get("default").class_name);
     }
 
     @Test
@@ -132,27 +169,6 @@ public class MemtableParamsTest
     }
 
     @Test
-    public void testInvalidExtends()
-    {
-        final InheritingClass one = new InheritingClass(null, "SkipList", null);
-        try
-        {
-            Map<String, ParameterizedClass> map = MemtableParams.expandDefinitions
-            (
-                ImmutableMap.of("two", new InheritingClass("one",
-                                                           null,
-                                                           ImmutableMap.of("extra", "value")),
-                                "one", one)
-            );
-            Assert.fail("Expected exception.");
-        }
-        catch (ConfigurationException e)
-        {
-            // expected
-        }
-    }
-
-    @Test
     public void testInvalidSelfExtends()
     {
         try
@@ -163,7 +179,7 @@ public class MemtableParamsTest
                                                            null,
                                                            ImmutableMap.of("extra", "value")))
             );
-            Assert.fail("Expected exception.");
+            fail("Expected exception.");
         }
         catch (ConfigurationException e)
         {
@@ -197,4 +213,69 @@ public class MemtableParamsTest
                      map);
     }
     // Note: The factories constructed from these parameters are tested in the CreateTest and AlterTest.
+
+    @Test
+    public void testInheritsNonExistent()
+    {
+        try
+        {
+            Map<String, ParameterizedClass> map = MemtableParams.expandDefinitions
+            (
+            ImmutableMap.of("one", new InheritingClass("two",
+                                                       null,
+                                                       ImmutableMap.of("extra", "value")),
+                            "two", new InheritingClass("three",
+                                                       null,
+                                                       ImmutableMap.of("extra2", "value2")))
+            );
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException e)
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidLoops()
+    {
+        try
+        {
+            Map<String, ParameterizedClass> map = MemtableParams.expandDefinitions
+            (
+            ImmutableMap.of("one", new InheritingClass("two",
+                                                       null,
+                                                       ImmutableMap.of("extra", "value")),
+                            "two", new InheritingClass("one",
+                                                       null,
+                                                       ImmutableMap.of("extra2", "value2")))
+            );
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException e)
+        {
+            // expected
+        }
+
+        try
+        {
+            Map<String, ParameterizedClass> map = MemtableParams.expandDefinitions
+            (
+            ImmutableMap.of("one", new InheritingClass("two",
+                                                       null,
+                                                       ImmutableMap.of("extra", "value")),
+                            "two", new InheritingClass("three",
+                                                       null,
+                                                       ImmutableMap.of("extra2", "value2")),
+                            "three", new InheritingClass("one",
+                                                         null,
+                                                         ImmutableMap.of("extra3", "value3")))
+            );
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException e)
+        {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
Make configuration entries in memtable section order-independent
patch by Stefan Miklosovic; reviewed by David Capwell for CASSANDRA-19906

### What is the issue
The configuration bug reported in [CASSANDRA-19906](https://issues.apache.org/jira/browse/CASSANDRA-19906) currently blocks HCD 1.2 from being used in [cass-operator](https://github.com/k8ssandra/cass-operator) as the server will not start.

### What does this PR fix and why was it fixed
This PR cherry-picks the Cassandra 5.0.1 patch for CASSANDRA-19906 which will allow HCD 1.2 versions based on it to start in k82 environments (cass-operator and other projects that use it). The upstream commit is [here](https://github.com/apache/cassandra/commit/971747e3e25b7dec6a8ed50ed56ac0d14a3de6b1)

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits