### PR TITLE
CNDB-12471: expose metric about Native memory used by CompressionMetadata

### DIFF
--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -60,6 +61,7 @@ import org.apache.cassandra.utils.concurrent.Transactional;
  */
 public class CompressionMetadata implements AutoCloseable
 {
+    private static final AtomicLong NATIVE_MEMORY_USAGE = new AtomicLong(0);
     /**
      * DataLength can represent either the true length of the file
      * or some shorter value, in the case we want to impose a shorter limit on readers
@@ -206,6 +208,11 @@ public class CompressionMetadata implements AutoCloseable
         this.startChunkIndex = 0;
     }
 
+    public static long nativeMemoryAllocated()
+    {
+        return NATIVE_MEMORY_USAGE.get();
+    }
+
     public ICompressor compressor()
     {
         return parameters.getSstableCompressor();
@@ -283,6 +290,7 @@ public class CompressionMetadata implements AutoCloseable
             }
 
             lastOffset = endIndex < chunkCount ? input.readLong() - offsets.get(0) : compressedFileLength;
+            NATIVE_MEMORY_USAGE.addAndGet(offsets.memoryUsed());
             return Pair.create(offsets, lastOffset);
         }
         catch (EOFException e)
@@ -394,6 +402,7 @@ public class CompressionMetadata implements AutoCloseable
 
     public void close()
     {
+        NATIVE_MEMORY_USAGE.addAndGet(-chunkOffsets.memoryUsed());
         chunkOffsets.close();
     }
 
@@ -403,7 +412,7 @@ public class CompressionMetadata implements AutoCloseable
         private final CompressionParams parameters;
         private final File filePath;
         private int maxCount = 100;
-        private SafeMemory offsets = new SafeMemory(maxCount * 8L);
+        private SafeMemory offsets;
         private int count = 0;
 
         // provided by user when setDescriptor
@@ -413,6 +422,8 @@ public class CompressionMetadata implements AutoCloseable
         {
             this.parameters = parameters;
             filePath = path;
+            offsets = new SafeMemory(maxCount * 8L);
+            NATIVE_MEMORY_USAGE.addAndGet(offsets.size());
         }
 
         public static Writer open(CompressionParams parameters, File path)
@@ -425,6 +436,7 @@ public class CompressionMetadata implements AutoCloseable
             if (count == maxCount)
             {
                 SafeMemory newOffsets = offsets.copy((maxCount *= 2L) * 8L);
+                NATIVE_MEMORY_USAGE.addAndGet(newOffsets.size() - offsets.size());
                 offsets.close();
                 offsets = newOffsets;
             }
@@ -474,7 +486,8 @@ public class CompressionMetadata implements AutoCloseable
             {
                 SafeMemory tmp = offsets;
                 offsets = offsets.copy(count * 8L);
-                tmp.free();
+                NATIVE_MEMORY_USAGE.addAndGet(offsets.size() - tmp.size());
+                tmp.close();
             }
 
             // flush the data to disk
@@ -500,6 +513,7 @@ public class CompressionMetadata implements AutoCloseable
         @SuppressWarnings("resource")
         public CompressionMetadata open(long dataLength, long compressedLength)
         {
+            // no need to update NATIVE_MEMORY_USAGE here
             SafeMemory tOffsets = this.offsets.sharedCopy();
 
             // calculate how many entries we need, if our dataLength is truncated
@@ -540,6 +554,7 @@ public class CompressionMetadata implements AutoCloseable
 
         protected Throwable doPostCleanup(Throwable failed)
         {
+            NATIVE_MEMORY_USAGE.addAndGet(-offsets.size());
             return offsets.close(failed);
         }
 

--- a/src/java/org/apache/cassandra/io/util/Memory.java
+++ b/src/java/org/apache/cassandra/io/util/Memory.java
@@ -434,13 +434,6 @@ public class Memory implements AutoCloseable
         public final Memory memory;
         private final long size;
 
-        public LongArray(Memory memory)
-        {
-            assert (memory.size & 7) == 0;
-            this.memory = memory;
-            this.size = memory.size >> 3;
-        }
-
         public LongArray(long size)
         {
             assert size >= 0;
@@ -470,6 +463,11 @@ public class Memory implements AutoCloseable
         public long size()
         {
             return size;
+        }
+
+        public long memoryUsed()
+        {
+            return memory != null ? memory.size() : 0;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerNativeMemoryMetrics.java
@@ -32,6 +32,7 @@ public class MicrometerNativeMemoryMetrics extends MicrometerMetrics implements 
 
     public static final String RAW_NATIVE_MEMORY = METRICS_PREFIX + "_raw_native_memory";
     public static final String BLOOM_FILTER_MEMORY = METRICS_PREFIX + "_bloom_filter_memory";
+    public static final String COMPRESSION_METADATA_MEMORY = METRICS_PREFIX + "_compression_metadata_memory";
     public static final String NETWORK_DIRECT_MEMORY = METRICS_PREFIX + "_network_direct_memory";
     public static final String USED_NIO_DIRECT_MEMORY = METRICS_PREFIX + "_used_nio_direct_memory";
     public static final String TOTAL_NIO_MEMORY = METRICS_PREFIX + "_total_nio_direct_memory";
@@ -51,6 +52,7 @@ public class MicrometerNativeMemoryMetrics extends MicrometerMetrics implements 
 
         gauge(RAW_NATIVE_MEMORY, this, NativeMemoryMetrics::rawNativeMemory);
         gauge(BLOOM_FILTER_MEMORY, this, NativeMemoryMetrics::bloomFilterMemory);
+        gauge(COMPRESSION_METADATA_MEMORY, this, NativeMemoryMetrics::compressionMetadataMemory);
         gauge(NETWORK_DIRECT_MEMORY, this, NativeMemoryMetrics::networkDirectMemory);
         gauge(USED_NIO_DIRECT_MEMORY, this, NativeMemoryMetrics::usedNioDirectMemory);
         gauge(TOTAL_NIO_MEMORY, this, NativeMemoryMetrics::totalNioDirectMemory);

--- a/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/NativeMemoryMetrics.java
@@ -23,6 +23,7 @@ import java.lang.management.ManagementFactory;
 
 import io.netty.util.internal.PlatformDependent;
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.utils.BloomFilter;
 import org.apache.cassandra.utils.memory.MemoryUtil;
 
@@ -48,6 +49,11 @@ public interface NativeMemoryMetrics
     default long bloomFilterMemory()
     {
         return BloomFilter.memoryLimiter.memoryAllocated();
+    }
+
+    default long compressionMetadataMemory()
+    {
+        return CompressionMetadata.nativeMemoryAllocated();
     }
 
     default long usedNioDirectMemory()


### PR DESCRIPTION
### What is the issue
In CNDB-12471 we are deciding new setting for the memory for Cassandra nodes, but we lack metrics about how much native memory is used by CompressionMetadata.

### What does this PR fix and why was it fixed
Add a new metric

### Checklist before you submit for review
- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ ] Verify test results on Butler
- [ ] Test coverage for new/modified code is > 80%
- [ ] Proper code formatting
- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [ ] Each commit has a meaningful description
- [ ] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits