### PR TITLE
CNDB-12588: remove check for rpc_ready

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2010,7 +2010,6 @@ public class StorageProxy implements StorageProxyMBean
         // CASSANDRA-13043: filter out those endpoints not accepting clients yet, maybe because still bootstrapping
         // We have a keyspace, so filter by affinity too
         replicas = replicas.filter(IFailureDetector.isReplicaAlive)
-                           .filter(r -> StorageService.instance.isRpcReady(r.endpoint()))
                            .filter(snitch.filterByAffinity(keyspace.getName()));
 
         // CASSANDRA-17411: filter out endpoints that are not alive


### PR DESCRIPTION
I added this to fix test_counter_leader_with_partial_view test in CNDB-11594 but this breaks any counter usage in CNDB.