### PR TITLE
CNDB-7343 and CNDB-12620:  Fix RequestFailureReason reason codes according to Apache and avoid future conflicts. Add new reason RequestFailureReason.INDEX_BUILD_IN_PROGRESS

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.io.IVersionedSerializer;
@@ -45,7 +46,8 @@ public enum RequestFailureReason
     // We should add new codes in HCD (which do not exist in Apache Cassandra) only with big numbers, to avoid conflicts
     UNKNOWN_COLUMN           (500),
     UNKNOWN_TABLE            (501),
-    REMOTE_STORAGE_FAILURE   (502);
+    REMOTE_STORAGE_FAILURE   (502),
+    INDEX_BUILD_IN_PROGRESS  (503);
 
     public static final Serializer serializer = new Serializer();
 
@@ -82,6 +84,7 @@ public enum RequestFailureReason
         exceptionToReasonMap.put(IndexNotAvailableException.class, INDEX_NOT_AVAILABLE);
         exceptionToReasonMap.put(UnknownColumnException.class, UNKNOWN_COLUMN);
         exceptionToReasonMap.put(UnknownTableException.class, UNKNOWN_TABLE);
+        exceptionToReasonMap.put(IndexBuildInProgressException.class, INDEX_BUILD_IN_PROGRESS);
 
         if (exceptionToReasonMap.size() != reasons.length-2)
             throw new RuntimeException("A new RequestFailureReasons was probably added and you may need to update the exceptionToReasonMap");

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -32,7 +32,6 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.vint.VIntCoding;
 
-import static java.lang.Math.max;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 
 public enum RequestFailureReason
@@ -101,7 +100,15 @@ public enum RequestFailureReason
 
     public static RequestFailureReason forException(Throwable t)
     {
-        return exceptionToReasonMap.getOrDefault(t.getClass(), UNKNOWN);
+        RequestFailureReason r = exceptionToReasonMap.get(t.getClass());
+        if (r != null)
+            return r;
+
+        for (Map.Entry<Class<? extends Throwable>, RequestFailureReason> entry : exceptionToReasonMap.entrySet())
+            if (entry.getKey().isInstance(t))
+                return entry.getValue();
+
+        return UNKNOWN;
     }
 
     public static final class Serializer implements IVersionedSerializer<RequestFailureReason>

--- a/src/java/org/apache/cassandra/index/IndexBuildInProgressException.java
+++ b/src/java/org/apache/cassandra/index/IndexBuildInProgressException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.exceptions.UncheckedInternalRequestExecutionException;
+
+/**
+ * Thrown if a secondary index is not currently available because it is building.
+ */
+public final class IndexBuildInProgressException extends UncheckedInternalRequestExecutionException
+{
+    /**
+     * Creates a new <code>IndexIsBuildingException</code> for the specified index.
+     * @param index the index
+     */
+    public IndexBuildInProgressException(Index index)
+    {
+        super(RequestFailureReason.INDEX_BUILD_IN_PROGRESS,
+                String.format("The secondary index '%s' is not yet available as it is building", index.getIndexMetadata().name));
+    }
+}

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1978,7 +1978,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
             else
                 states.put(keyspaceIndex, status);
 
-            // Make sure to check this after peerIndexStatus is populatedm but before the JSON is built: we don't need
+            // Make sure to check this after peerIndexStatus is populated but before the JSON is built: we don't need
             // the latter if there's no Gossiper (as in CNDB), so we can avoid the related CPU and memory usage.
             if (!Gossiper.instance.isEnabled())
                 return;

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -852,6 +852,8 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
             if (!index.getSupportedLoadTypeOnFailure(isInitialBuild).supportsReads() && queryableIndexes.remove(indexName))
                 logger.info("Index [{}] became not-queryable because of failed build.", indexName);
+
+            makeIndexNonQueryable(index, Index.Status.BUILD_FAILED);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -367,11 +367,14 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
     {
         for (Index index : queryPlan.getIndexes())
         {
-            if (isIndexBuilding(index))
-                throw new IndexBuildInProgressException(index);
-
             if (!isIndexQueryable(index))
+            {
+                // In Astra index can be queryable during index build, thus we need to check both not queryable and building
+                if (isIndexBuilding(index))
+                    throw new IndexBuildInProgressException(index);
+
                 throw new IndexNotAvailableException(index);
+            }
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.distributed.test.sai.SAIUtil.waitForIndexQueryable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -167,6 +168,90 @@ public class IndexAvailabilityTest extends TestBaseImpl
     public void testSkipNonQueryableNodeN1Rf1() throws Exception
     {
         shouldSkipNonQueryableNode(1, Collections.singletonList(1));
+    }
+
+    @Test
+    public void testIndexExceptionsTwoIndexesOn3NodeCluster() throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                .withConfig(config -> config.with(GOSSIP)
+                        .with(NETWORK))
+                .start()))
+        {
+            String ks2 = "ks2";
+            String cf1 = "cf1";
+            String index1 = "cf1_idx1";
+            String index2 = "cf1_idx2";
+            String index3 = "cf2_idx1";
+
+            // Create keyspace, table with correct column types
+            cluster.schemaChange(String.format(CREATE_KEYSPACE, ks2, 2));
+            cluster.schemaChange("CREATE TABLE " + ks2 + "." + cf1 + " (pk int PRIMARY KEY, v1 int, v2 int)");
+            executeOnAllCoordinators(cluster,
+                    "SELECT pk FROM " + ks2 + "." + cf1 + " WHERE v1=0 AND v2=0 ALLOW FILTERING",
+                    ConsistencyLevel.LOCAL_QUORUM,
+                    0);
+            executeOnAllCoordinators(cluster,
+                    "SELECT pk FROM " + ks2 + "." + cf1 + " WHERE v2=0 ALLOW FILTERING",
+                    ConsistencyLevel.LOCAL_QUORUM,
+                    0);
+            executeOnAllCoordinators(cluster,
+                    "SELECT pk FROM " + ks2 + "." + cf1 + " WHERE v1=0 ALLOW FILTERING",
+                    ConsistencyLevel.LOCAL_QUORUM,
+                    0);
+
+            cluster.schemaChange(String.format(CREATE_INDEX, index1, ks2, cf1, "v1"));
+            cluster.schemaChange(String.format(CREATE_INDEX, index2, ks2, cf1, "v2"));
+            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index1, node), Index.Status.BUILD_SUCCEEDED));
+            waitForIndexingStatus(cluster.get(2), ks2, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(2), ks2, index1, cluster.get(2), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(2), ks2, index1, cluster.get(3), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(1), ks2, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(1), ks2, index1, cluster.get(2), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(1), ks2, index1, cluster.get(3), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(3), ks2, index1, cluster.get(1), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(3), ks2, index1, cluster.get(2), Index.Status.BUILD_SUCCEEDED);
+            waitForIndexingStatus(cluster.get(3), ks2, index1, cluster.get(3), Index.Status.BUILD_SUCCEEDED);
+
+            // Mark only index2 as building on node3, leave index1 in BUILD_SUCCEEDED state
+            markIndexBuilding(cluster.get(3), ks2, cf1, index2);
+            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.FULL_REBUILD_STARTED));
+            waitForIndexingStatus(cluster.get(2), ks2, index2, cluster.get(3), Index.Status.FULL_REBUILD_STARTED);
+            waitForIndexingStatus(cluster.get(1), ks2, index2, cluster.get(3), Index.Status.FULL_REBUILD_STARTED);
+            waitForIndexingStatus(cluster.get(3), ks2, index2, cluster.get(3), Index.Status.FULL_REBUILD_STARTED);
+
+            assertThatThrownBy(() ->
+                    executeOnAllCoordinators(cluster,
+                            "SELECT pk FROM " + ks2 + '.' + cf1 + " WHERE v1=0 AND v2=0",
+                            ConsistencyLevel.LOCAL_QUORUM,
+                            0))
+                    .hasMessageContaining("Operation failed - received 1 responses and 1 failures: INDEX_BUILD_IN_PROGRESS");
+
+            // Mark only index2 as failing on node2, leave index1 in BUILD_SUCCEEDED state
+            markIndexBuilding(cluster.get(2), ks2, cf1, index2);
+            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.BUILD_FAILED));
+
+            assertThatThrownBy(() ->
+                    executeOnAllCoordinators(cluster,
+                            "SELECT pk FROM " + ks2 + '.' + cf1 + " WHERE v1=0 AND v2=0",
+                            ConsistencyLevel.LOCAL_QUORUM,
+                            0))
+                    .hasMessageContaining("Operation failed - received 1 responses and 1 failures: INDEX_BUILD_IN_PROGRESS");
+
+            // Mark only index2 as failing on node1, leave index1 in BUILD_SUCCEEDED state
+            markIndexNonQueryable(cluster.get(1), ks2, cf1, index2);
+            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.BUILD_FAILED));
+            waitForIndexingStatus(cluster.get(2), ks2, index2, cluster.get(1), Index.Status.BUILD_FAILED);
+            waitForIndexingStatus(cluster.get(1), ks2, index2, cluster.get(1), Index.Status.BUILD_FAILED);
+            waitForIndexingStatus(cluster.get(3), ks2, index2, cluster.get(1), Index.Status.BUILD_FAILED);
+
+            assertThatThrownBy(() ->
+                    executeOnAllCoordinators(cluster,
+                            "SELECT pk FROM " + ks2 + '.' + cf1 + " WHERE v1=0 AND v2=0",
+                            ConsistencyLevel.LOCAL_QUORUM,
+                            0))
+                    .hasMessageMatching("^Operation failed - received 0 responses and 2 failures: INDEX_BUILD_IN_PROGRESS from .+, INDEX_NOT_AVAILABLE from .+$");
+        }
     }
 
     private void shouldSkipNonQueryableNode(int nodes, List<Integer>... nonQueryableNodesList) throws Exception

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
@@ -1148,7 +1149,7 @@ public class SecondaryIndexTest extends CQLTester
             execute("SELECT value FROM %s WHERE value = 2");
             fail();
         }
-        catch (IndexNotAvailableException e)
+        catch (IndexBuildInProgressException e)
         {
             assertTrue(true);
         }

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CountDownLatch;
 
 import com.google.common.collect.ImmutableSet;
 
-import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
@@ -49,6 +48,7 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.StubIndex;

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -33,7 +33,8 @@ public class RequestFailureReasonTest
     { 6, "INDEX_NOT_AVAILABLE" },
     { 500, "UNKNOWN_COLUMN" },
     { 501, "UNKNOWN_TABLE" },
-    { 502, "REMOTE_STORAGE_FAILURE" }
+    { 502, "REMOTE_STORAGE_FAILURE" },
+    { 503, "INDEX_BUILD_IN_PROGRESS" }
     };
     @Test
     public void testEnumCodesAndNames()
@@ -61,6 +62,7 @@ public class RequestFailureReasonTest
         assertEquals(RequestFailureReason.UNKNOWN_COLUMN, RequestFailureReason.fromCode(500));
         assertEquals(RequestFailureReason.UNKNOWN_TABLE, RequestFailureReason.fromCode(501));
         assertEquals(RequestFailureReason.REMOTE_STORAGE_FAILURE, RequestFailureReason.fromCode(502));
+        assertEquals(RequestFailureReason.INDEX_BUILD_IN_PROGRESS, RequestFailureReason.fromCode(503));
 
         // Test invalid codes
         assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(200));

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class RequestFailureReasonTest
+{
+    private static final RequestFailureReason[] REASONS = RequestFailureReason.values();
+    private static final Object[][] EXPECTED_VALUES =
+    {
+    { 0, "UNKNOWN" },
+    { 1, "READ_TOO_MANY_TOMBSTONES" },
+    { 2, "TIMEOUT" },
+    { 3, "INCOMPATIBLE_SCHEMA" },
+    { 6, "INDEX_NOT_AVAILABLE" },
+    { 500, "UNKNOWN_COLUMN" },
+    { 501, "UNKNOWN_TABLE" },
+    { 502, "REMOTE_STORAGE_FAILURE" }
+    };
+    @Test
+    public void testEnumCodesAndNames()
+    {
+        for (int i = 0; i < REASONS.length; i++)
+        {
+            assertEquals("RequestFailureReason code mismatch for " +
+                         REASONS[i].name(), EXPECTED_VALUES[i][0], REASONS[i].code);
+            assertEquals("RequestFailureReason name mismatch for code " +
+                         REASONS[i].code, EXPECTED_VALUES[i][1], REASONS[i].name());
+        }
+        assertEquals("Number of RequestFailureReason enum constants has changed. Update the test.",
+                     EXPECTED_VALUES.length, REASONS.length);
+    }
+
+    @Test
+    public void testFromCode()
+    {
+        // Test valid codes
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(0));
+        assertEquals(RequestFailureReason.READ_TOO_MANY_TOMBSTONES, RequestFailureReason.fromCode(1));
+        assertEquals(RequestFailureReason.TIMEOUT, RequestFailureReason.fromCode(2));
+        assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, RequestFailureReason.fromCode(3));
+        assertEquals(RequestFailureReason.INDEX_NOT_AVAILABLE, RequestFailureReason.fromCode(6));
+        assertEquals(RequestFailureReason.UNKNOWN_COLUMN, RequestFailureReason.fromCode(500));
+        assertEquals(RequestFailureReason.UNKNOWN_TABLE, RequestFailureReason.fromCode(501));
+        assertEquals(RequestFailureReason.REMOTE_STORAGE_FAILURE, RequestFailureReason.fromCode(502));
+
+        // Test invalid codes
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(200));
+        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(999));
+        assertThrows(IllegalArgumentException.class, () -> RequestFailureReason.fromCode(-1));
+    }
+}

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -98,10 +96,10 @@ public class RequestFailureReasonTest
         
         // Verify the parent class still maps correctly
         assertEquals(RequestFailureReason.UNKNOWN_TABLE,
-                    RequestFailureReason.forException(new UnknownTableException("ks", TableId.generate())));
+                     RequestFailureReason.forException(new UnknownTableException("ks", TableId.generate())));
         
         // Test unmapped exception returns UNKNOWN
         assertEquals(RequestFailureReason.UNKNOWN, 
-                    RequestFailureReason.forException(new RuntimeException("test")));
+                     RequestFailureReason.forException(new RuntimeException("test")));
     }
 }

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -58,15 +58,12 @@ public class RequestFailureReasonTest
     public void testFromCode()
     {
         // Test valid codes
-        assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(0));
-        assertEquals(RequestFailureReason.READ_TOO_MANY_TOMBSTONES, RequestFailureReason.fromCode(1));
-        assertEquals(RequestFailureReason.TIMEOUT, RequestFailureReason.fromCode(2));
-        assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, RequestFailureReason.fromCode(3));
-        assertEquals(RequestFailureReason.INDEX_NOT_AVAILABLE, RequestFailureReason.fromCode(6));
-        assertEquals(RequestFailureReason.UNKNOWN_COLUMN, RequestFailureReason.fromCode(500));
-        assertEquals(RequestFailureReason.UNKNOWN_TABLE, RequestFailureReason.fromCode(501));
-        assertEquals(RequestFailureReason.REMOTE_STORAGE_FAILURE, RequestFailureReason.fromCode(502));
-        assertEquals(RequestFailureReason.INDEX_BUILD_IN_PROGRESS, RequestFailureReason.fromCode(503));
+        for (Object[] expected : EXPECTED_VALUES)
+        {
+            int code = (Integer) expected[0];
+            RequestFailureReason expectedReason = RequestFailureReason.valueOf((String) expected[1]);
+            assertEquals(expectedReason, RequestFailureReason.fromCode(code));
+        }
 
         // Test invalid codes
         assertEquals(RequestFailureReason.UNKNOWN, RequestFailureReason.fromCode(200));

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -17,14 +17,14 @@
  */
 package org.apache.cassandra.index.sai.cql;
 
-import org.apache.cassandra.index.IndexBuildInProgressException;
-import org.apache.cassandra.inject.Injections;
-import org.apache.cassandra.inject.InvokePointBuilder;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertNotNull;
@@ -521,7 +521,7 @@ public class AllowFilteringTest extends SAITester
 
     private final Injections.Barrier blockIndexBuild = Injections.newBarrier("block_index_build", 2, false)
                                                                  .add(InvokePointBuilder.newInvokePoint().onClass(StorageAttachedIndex.class)
-                    .onMethod("startInitialBuild"))
+                                                                 .onMethod("startInitialBuild"))
                                                                  .build();
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -531,11 +531,11 @@ public class AllowFilteringTest extends SAITester
         Injections.inject(blockIndexBuild);
         String idx = createIndexAsync(String.format("CREATE CUSTOM INDEX ON %%s(v) USING '%s'", StorageAttachedIndex.class.getName()));
 
-        assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE v=0"))
+        assertThatThrownBy(() -> executeInternal("SELECT * FROM %s WHERE v=0"))
                 .hasMessage("The secondary index '" + idx + "' is not yet available as it is building")
                 .isInstanceOf(IndexBuildInProgressException.class);
 
-        assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE v=0 ALLOW FILTERING"))
+        assertThatThrownBy(() -> executeInternal("SELECT * FROM %s WHERE v=0 ALLOW FILTERING"))
                 .hasMessage("The secondary index '" + idx + "' is not yet available as it is building")
                 .isInstanceOf(IndexBuildInProgressException.class);
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -370,17 +370,17 @@ public class AllowFilteringTest extends SAITester
         execute("INSERT INTO %s (a, b, c, d) VALUES ('Test3', 'Test3', 'Test3', 'Test3')");
 
         // Single restriction
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "b"), "SELECT * FROM %s WHERE b > 'Test'");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"), "SELECT * FROM %s WHERE c > 'Test'");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "d"), "SELECT * FROM %s WHERE d > 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'b'), "SELECT * FROM %s WHERE b > 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'), "SELECT * FROM %s WHERE c > 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'd'), "SELECT * FROM %s WHERE d > 'Test'");
 
         // Supported and unsupported restriction
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "b"), "SELECT * FROM %s WHERE b > 'Test' AND c = 'Test1'");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "c"), "SELECT * FROM %s WHERE c > 'Test' AND d = 'Test1'");
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "d"), "SELECT * FROM %s WHERE d > 'Test' AND b = 'Test1'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'b'), "SELECT * FROM %s WHERE b > 'Test' AND c = 'Test1'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'c'), "SELECT * FROM %s WHERE c > 'Test' AND d = 'Test1'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'd'), "SELECT * FROM %s WHERE d > 'Test' AND b = 'Test1'");
 
         // Two unsupported restrictions
-        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, "b"), "SELECT * FROM %s WHERE b > 'Test' AND b < 'Test3'");
+        assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_SINGLE, 'b'), "SELECT * FROM %s WHERE b > 'Test' AND b < 'Test3'");
         assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_MULTI, "[b, c]"), "SELECT * FROM %s WHERE c > 'Test' AND b < 'Test3'");
         assertInvalidMessage(String.format(StatementRestrictions.HAS_UNSUPPORTED_INDEX_RESTRICTION_MESSAGE_MULTI, "[b, d]"), "SELECT * FROM %s WHERE d > 'Test' AND b < 'Test3'");
 
@@ -420,9 +420,9 @@ public class AllowFilteringTest extends SAITester
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(d) USING '%s'", StorageAttachedIndex.class.getName()));
 
         // LIKE restriction
-        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, "b"), "SELECT * FROM %s WHERE b LIKE 'Test'");
-        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, "c"), "SELECT * FROM %s WHERE c LIKE 'Test'");
-        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, "d"), "SELECT * FROM %s WHERE d LIKE 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, 'b'), "SELECT * FROM %s WHERE b LIKE 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, 'c'), "SELECT * FROM %s WHERE c LIKE 'Test'");
+        assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_LIKE_MESSAGE, 'd'), "SELECT * FROM %s WHERE d LIKE 'Test'");
     }
 
     @Test
@@ -434,7 +434,7 @@ public class AllowFilteringTest extends SAITester
         createIndex(String.format("CREATE CUSTOM INDEX ON %%s(d) USING '%s'", StorageAttachedIndex.class.getName()));
 
         // Analyzer restriction
-        assertInvalidMessage(String.format(": restriction is only supported on properly indexed columns. a : 'Test' is not valid."), "SELECT * FROM %s WHERE a : 'Test'");
+        assertInvalidMessage(": restriction is only supported on properly indexed columns. a : 'Test' is not valid.", "SELECT * FROM %s WHERE a : 'Test'");
         assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'b'), "SELECT * FROM %s WHERE b : 'Test'");
         assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'c'), "SELECT * FROM %s WHERE c : 'Test'");
         assertInvalidMessage(String.format(StatementRestrictions.INDEX_DOES_NOT_SUPPORT_ANALYZER_MATCHES_MESSAGE, 'd'), "SELECT * FROM %s WHERE d : 'Test'");
@@ -449,11 +449,11 @@ public class AllowFilteringTest extends SAITester
         // Should not fail because allow filtering is set but not required
         assertRows(execute("SELECT * FROM %s ORDER BY vec ANN OF [1,1,1] LIMIT 10 ALLOW FILTERING;"));
 
-        // Do not recommend ALLOW FILTERING for non primary key, non clustering column restrictions
+        // Do not recommend ALLOW FILTERING for non-primary key, non clustering column restrictions
         assertInvalidMessage(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE,
                              "SELECT * FROM %s WHERE k > 0 ORDER BY vec ANN OF [2.5, 3.5, 4.5] LIMIT 10;");
 
-        // Do not let ALLOW FILTERING to lead to query execution for non primary key, non clustering column restrictions
+        // Do not let ALLOW FILTERING to lead to query execution for non-primary key, non clustering column restrictions
         assertInvalidMessage(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE,
                              "SELECT * FROM %s WHERE k > 0 ORDER BY vec ANN OF [2.5, 3.5, 4.5] LIMIT 10 ALLOW FILTERING;");
 
@@ -519,10 +519,10 @@ public class AllowFilteringTest extends SAITester
         assertRows(execute("SELECT partition FROM %s WHERE item_cost['apple'] < 3 AND item_cost['apple'] > 1"), row(0));
     }
 
-    private Injections.Barrier blockIndexBuild = Injections.newBarrier("block_index_build", 2, false)
-            .add(InvokePointBuilder.newInvokePoint().onClass(StorageAttachedIndex.class)
+    private final Injections.Barrier blockIndexBuild = Injections.newBarrier("block_index_build", 2, false)
+                                                                 .add(InvokePointBuilder.newInvokePoint().onClass(StorageAttachedIndex.class)
                     .onMethod("startInitialBuild"))
-            .build();
+                                                                 .build();
 
     @Test
     public void testAllowFilteringDuringIndexBuild() throws Throwable


### PR DESCRIPTION
### What is the issue
...
CNDB-7343: Inconsistent codes and failing to update the forException method in RequestFailureReason lead to inconsistent, confusing, and even incorrect error reasons returned to users when executing queries.
CNDB-12620: Users should get` INDEX_BUILD_IN_PROGRESS` instead of `INDEX NOT AVAILABLE` when they cannot query because an index is building.

### What does this PR fix and why was it fixed
...
CNDB-7343: Fix RequestFailureReason reason codes in consistence with Apache and avoid future conflicts by assigning new HCD-specific codes to higher numbers.
Improve testing to prevent regressions.
CNDB-12620: We add a new reason, `RequestFailureReason.INDEX_BUILD_IN_PROGRESS` to differentiate indexes that are currently building in error messages

### Checklist before you submit for review
- [ x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [ x] Verify test results on Butler
- [x ] Test coverage for new/modified code is > 80%
- [ x] Proper code formatting
- [ x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x ] Each commit has a meaningful description
- [ x] Each commit is not very long and contains related changes
- [ ] Renames, moves and reformatting are in distinct commits