### PR TITLE
CNDB-12526 remove PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,14 +3,3 @@
 
 ### What does this PR fix and why was it fixed
 ...
-
-### Checklist before you submit for review
-- [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
-- [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
-- [ ] Verify test results on Butler
-- [ ] Test coverage for new/modified code is > 80%
-- [ ] Proper code formatting
-- [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
-- [ ] Each commit has a meaningful description
-- [ ] Each commit is not very long and contains related changes
-- [ ] Renames, moves and reformatting are in distinct commits


### PR DESCRIPTION
PR checklist is already delivered in a comment in https://github.com/datastax/cassandra/pull/1541
Removing the checklist from the PR template, which was missed.

Closes https://github.com/riptano/cndb/issues/12526