### PR TITLE
HCD-63: Upgrade Netty to 4.1.117 and BoringSSL to 2.0.69

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -665,9 +665,9 @@
           <dependency groupId="io.airlift" artifactId="airline" version="0.8">
             <exclusion groupId="com.google.code.findbugs" artifactId="jsr305" />
            </dependency>
-          <dependency groupId="io.netty" artifactId="netty-bom" version="4.1.58.Final" type="pom" scope="provided"/>
-          <dependency groupId="io.netty" artifactId="netty-all" version="4.1.58.Final" />
-          <dependency groupId="io.netty" artifactId="netty-tcnative-boringssl-static" version="2.0.36.Final"/>
+          <dependency groupId="io.netty" artifactId="netty-bom" version="4.1.117.Final" type="pom" scope="provided"/>
+          <dependency groupId="io.netty" artifactId="netty-all" version="4.1.117.Final" />
+          <dependency groupId="io.netty" artifactId="netty-tcnative-boringssl-static" version="2.0.69.Final"/>
           <dependency groupId="net.openhft" artifactId="chronicle-queue" version="${chronicle-queue.version}">
             <exclusion groupId="com.sun" artifactId="tools" />
           </dependency>


### PR DESCRIPTION
The primary motivation for this change is a bug that manifests in loading
the cipher list for inter-node connections, which is slightly wider than the
configured list. This bug appears to be a consequence of how OpenSSL handles
cipher loading. Changing it doesn't seem feasible.

Netty introduced changes to mitigate this misbehavior:
- https://github.com/netty/netty/issues/13810
- https://github.com/netty/netty/issues/13840

To take advantage of these fixes, we need to upgrade Netty to at least
version 4.1.108. Upgrading Netty also necessitates bumping BoringSSL.

I have found some old CC tests in fallout that I decided to reuse to ensure the performance stays unchanged:
- http://fallout.aws.dsinternal.org/tests/ui/szymon.miezal@datastax.com/cc-write-throughput
- http://fallout.aws.dsinternal.org/tests/ui/szymon.miezal@datastax.com/cc-stargazer-dse-db-lwt-fixed-1000-partitions
- http://fallout.aws.dsinternal.org/tests/ui/szymon.miezal@datastax.com/cc-stargazer-dse-db-write-throughput-batch-100
- http://fallout.aws.dsinternal.org/tests/ui/szymon.miezal@datastax.com/cc-sai-single-node-wide-row
- http://fallout.aws.dsinternal.org/tests/ui/szymon.miezal@datastax.com/cc-stargazer-dsedb-density-1TB

I have used the fallout perf tool to compare the results with `main` and they seem pretty comparable to me. Example chart:
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/e5ae1cde-30c5-468c-a953-fcaea4810757" />

I am unsure whether there are other tests that exercise CC which could be reused.