### PR TITLE
CNDB-12733: Make ANN a separate, unreserved keyword

### DIFF
--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -226,7 +226,7 @@ K_LABEL:       L A B E L;
 K_DROPPED:     D R O P P E D;
 K_COLUMN:      C O L U M N;
 K_RECORD:      R E C O R D;
-K_ANN_OF:      A N N WS+ O F;
+K_ANN:         A N N;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -462,7 +462,7 @@ orderByClause[List<Ordering.Raw> orderings]
     @init{
         Ordering.Direction direction = Ordering.Direction.ASC;
     }
-    : c=cident (K_ANN_OF t=term)? (K_ASC | K_DESC { direction = Ordering.Direction.DESC; })?
+    : c=cident (K_ANN K_OF t=term)? (K_ASC | K_DESC { direction = Ordering.Direction.DESC; })?
     {
         Ordering.Raw.Expression expr = (t == null)
             ? new Ordering.Raw.SingleColumn(c)
@@ -1968,7 +1968,7 @@ basic_unreserved_keyword returns [String str]
         | K_DROPPED
         | K_COLUMN
         | K_RECORD
-        | K_ANN_OF
+        | K_ANN
         | K_OFFSET
         ) { $str = $k.text; }
     ;

--- a/test/unit/org/apache/cassandra/cql3/KeywordTestBase.java
+++ b/test/unit/org/apache/cassandra/cql3/KeywordTestBase.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.service.StorageService;
+import org.assertj.core.api.Assertions;
 
 /**
  * This class tests all keywords which took a long time. Hence it was split into multiple
@@ -46,6 +47,12 @@ public abstract class KeywordTestBase extends CQLTester
                                                       return new Object[] { keyword,ReservedKeywords.isReserved(keyword) };
                                                   })
                                                   .collect(Collectors.toList());
+
+    static
+    {
+        // ensure that ANN is a separate keyword, so it's included on this tests (see CNDB-12733)
+        Assertions.assertThat(keywords).contains(new Object[]{"ANN", false});
+    }
     
     public static Collection<Object[]> getKeywordsForSplit(int split, int totalSplits)
     {


### PR DESCRIPTION
Make ANN a separate, unreserved keyword, so we can create a table named `ann` without using quotes.