### PR TITLE
CNDB-12406: Make CachedReplicaRows thresholds flexible to be set via …

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -578,10 +578,21 @@ public enum CassandraRelevantProperties
     SENSORS_VIA_NATIVE_PROTOCOL("cassandra.sensors_via_native_protocol", "false"),
 
     /**
+     * Set the number of rows from all replicas individual index and filtering queries that can materialize on-heap before warning
+     */
+    CACHED_REPLICA_ROWS_WARN_THRESHOLD("cassandra.cached_replica_rows_warn_threshold"),
+
+    /**
+     * Set the number of rows from all replicas individual index and filtering queries that can materialize on-heap before failing
+     */
+    CACHED_REPLICA_ROWS_FAIL_THRESHOLD("cassandra.cached_replica_rows_fail_threshold"),
+
+    /**
      * The current messaging version. This is used when we add new messaging versions without adopting them immediately,
      * or to force the node to use a specific version for testing purposes.
      */
     DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_10));
+
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -75,6 +75,9 @@ import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.btree.BTreeSet;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.CACHED_REPLICA_ROWS_FAIL_THRESHOLD;
+import static org.apache.cassandra.config.CassandraRelevantProperties.CACHED_REPLICA_ROWS_WARN_THRESHOLD;
+
 /**
  * Helper in charge of collecting additional queries to be done on the coordinator to protect against invalid results
  * being included due to replica-side filtering (secondary indexes or {@code ALLOW * FILTERING}).
@@ -137,8 +140,9 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
 
         tableMetrics = ColumnFamilyStore.metricsFor(command.metadata().id);
 
-        this.cachedRowsWarnThreshold = cachedRowsWarnThreshold;
-        this.cachedRowsFailThreshold = cachedRowsFailThreshold;
+        this.cachedRowsWarnThreshold = CACHED_REPLICA_ROWS_WARN_THRESHOLD.getInt(cachedRowsWarnThreshold);
+        this.cachedRowsFailThreshold = CACHED_REPLICA_ROWS_FAIL_THRESHOLD.getInt(cachedRowsFailThreshold);
+
     }
 
     private UnfilteredPartitionIterator executeReadCommand(ReadCommand cmd, Replica source, ReplicaPlan.Shared<EndpointsForToken, ReplicaPlan.ForTokenRead> replicaPlan)


### PR DESCRIPTION
### What is the issue
cached_replica_rows_[warn,fail]_threshold can only be set at in the yaml or via JMX.

### What does this PR fix and why was it fixed
Adds system properties for these.
