### PR TITLE
CNDB-12451 validate keyspace+table names length

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -279,7 +279,11 @@ public enum CassandraRelevantProperties
      */
     SCHEMA_PULL_BACKOFF_DELAY_MS("cassandra.schema_pull_backoff_delay_ms", "3000"),
 
-    /** Maximum length allowed for schema names to be short enough for a file or directory name */
+    /**
+     * Maximum length allowed for schema names to be short enough for a file or directory name.
+     * The main concern is that filename not be more than 255 characters;
+     * the filename will contain both the KS and CF names and 32-chars id with a separator char.
+     */
     SCHEMA_FILE_NAME_LENGTH("cassandra.schema_file_name_length", "222"),
 
     /** When enabled, recursive directory deletion will be executed using a unix command `rm -rf` instead of traversing

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -279,6 +279,9 @@ public enum CassandraRelevantProperties
      */
     SCHEMA_PULL_BACKOFF_DELAY_MS("cassandra.schema_pull_backoff_delay_ms", "3000"),
 
+    /** Maximum length allowed for schema names to be short enough for a file or directory name */
+    SCHEMA_FILE_NAME_LENGTH("cassandra.schema_file_name_length", "222"),
+
     /** When enabled, recursive directory deletion will be executed using a unix command `rm -rf` instead of traversing
      * and removing individual files. This is now used only tests, but eventually we will make it true by default.*/
     USE_NIX_RECURSIVE_DELETE("cassandra.use_nix_recursive_delete"),

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
@@ -39,6 +39,8 @@ import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Event.SchemaChange;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
+
 public abstract class AlterSchemaStatement implements CQLStatement.SingleKeyspaceCqlStatement, SchemaTransformation
 {
     private final String rawCQLStatement;
@@ -150,7 +152,7 @@ public abstract class AlterSchemaStatement implements CQLStatement.SingleKeyspac
         {
             throw ire("Keyspace name must not be empty, more than %d characters long, " +
                       "or contain non-alphanumeric-underscore characters (got '%s')",
-                      SchemaConstants.NAME_LENGTH, keyspaceName);
+                      SCHEMA_FILE_NAME_LENGTH.getInt(), keyspaceName);
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.statements.RawKeyspaceAwareStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Keyspaces.KeyspacesDiff;
@@ -147,7 +146,7 @@ public abstract class AlterSchemaStatement implements CQLStatement.SingleKeyspac
 
     private void validateKeyspaceName()
     {
-        if (!SchemaConstants.isValidName(keyspaceName))
+        if (!SchemaConstants.isNameSafeForFilename(keyspaceName))
         {
             throw ire("Keyspace name must not be empty, more than %d characters long, " +
                       "or contain non-alphanumeric-underscore characters (got '%s')",

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.transport.Event.SchemaChange.Target;
 
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Iterables.tryFind;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
 
 public final class CreateIndexStatement extends AlterSchemaStatement
 {
@@ -226,7 +227,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
 
         if ((kind == IndexMetadata.Kind.CUSTOM) && !SchemaConstants.isNameSafeForFilename(target.column.toString()))
             throw ire("Column '%s' is longer than the permissible name length of %d characters or" +
-                      " contains non-alphanumeric-underscore characters", target.column, SchemaConstants.NAME_LENGTH);
+                      " contains non-alphanumeric-underscore characters", target.column, SCHEMA_FILE_NAME_LENGTH.getInt());
 
         if (column.type.referencesDuration())
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -224,7 +224,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (null == column)
             throw ire("Column '%s' doesn't exist", target.column);
 
-        if ((kind == IndexMetadata.Kind.CUSTOM) && !SchemaConstants.isValidName(target.column.toString()))
+        if ((kind == IndexMetadata.Kind.CUSTOM) && !SchemaConstants.isNameSafeForFilename(target.column.toString()))
             throw ire("Column '%s' is longer than the permissible name length of %d characters or" +
                       " contains non-alphanumeric-underscore characters", target.column, SchemaConstants.NAME_LENGTH);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -88,6 +88,13 @@ public final class CreateTableStatement extends AlterSchemaStatement
                                 boolean useCompactStorage)
     {
         super(queryString, keyspaceName);
+
+        if (!isSafeLengthForFilename(keyspaceName + tableName))
+        {
+            String combinedName = keyspaceName + tableName;
+            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
+        }
+
         this.tableName = tableName;
 
         this.rawColumns = rawColumns;
@@ -111,12 +118,6 @@ public final class CreateTableStatement extends AlterSchemaStatement
     public void validate(QueryState state)
     {
         super.validate(state);
-
-        if (!isSafeLengthForFilename(keyspaceName + tableName))
-        {
-            String combinedName = keyspaceName + tableName;
-            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
-        }
 
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -54,7 +54,6 @@ import org.apache.cassandra.transport.Event.SchemaChange.Target;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Comparator.comparing;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
-import static org.apache.cassandra.schema.SchemaConstants.NAME_LENGTH;
 import static org.apache.cassandra.schema.SchemaConstants.isSafeLengthForFilename;
 
 public final class CreateTableStatement extends AlterSchemaStatement
@@ -161,7 +160,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
         {
             String combinedName = keyspaceName + '.' + tableName;
-            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", NAME_LENGTH, combinedName.length(), combinedName));
+            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
         }
 
         TableMetadata table = builder(keyspace.types).build();

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -53,6 +53,7 @@ import org.apache.cassandra.transport.Event.SchemaChange.Target;
 
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Comparator.comparing;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
 import static org.apache.cassandra.schema.SchemaConstants.isSafeLengthForFilename;
 
 public final class CreateTableStatement extends AlterSchemaStatement
@@ -159,7 +160,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
         {
             String combinedName = keyspaceName + '.' + tableName;
-            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SchemaConstants.NAME_LENGTH, combinedName.length(), combinedName));
+            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
         }
 
         TableMetadata table = builder(keyspace.types).build();

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.transport.Event.SchemaChange.Target;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Comparator.comparing;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
+import static org.apache.cassandra.schema.SchemaConstants.NAME_LENGTH;
 import static org.apache.cassandra.schema.SchemaConstants.isSafeLengthForFilename;
 
 public final class CreateTableStatement extends AlterSchemaStatement
@@ -160,7 +161,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
         {
             String combinedName = keyspaceName + '.' + tableName;
-            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
+            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", NAME_LENGTH, combinedName.length(), combinedName));
         }
 
         TableMetadata table = builder(keyspace.types).build();

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -112,9 +112,9 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
+        if (!isSafeLengthForFilename(keyspaceName + tableName))
         {
-            String combinedName = keyspaceName + '.' + tableName;
+            String combinedName = keyspaceName + tableName;
             throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
         }
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -112,6 +112,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
+        if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
+        {
+            String combinedName = keyspaceName + '.' + tableName;
+            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
+        }
+
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.
         if (Guardrails.ready())
@@ -155,12 +161,6 @@ public final class CreateTableStatement extends AlterSchemaStatement
                 return schema;
 
             throw new AlreadyExistsException(keyspaceName, tableName);
-        }
-
-        if (!isSafeLengthForFilename(keyspaceName + '.' + tableName))
-        {
-            String combinedName = keyspaceName + '.' + tableName;
-            throw new ConfigurationException(String.format("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SCHEMA_FILE_NAME_LENGTH.getInt(), combinedName.length(), combinedName));
         }
 
         TableMetadata table = builder(keyspace.types).build();

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -46,6 +46,8 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.UUIDSerializer;
 
+import static org.apache.cassandra.schema.SchemaConstants.isValidCharsName;
+
 /**
  * An immutable representation of secondary index metadata.
  */
@@ -108,11 +110,6 @@ public final class IndexMetadata
         return new IndexMetadata(name, newOptions, kind);
     }
 
-    public static boolean isNameValid(String name)
-    {
-        return name != null && !name.isEmpty() && PATTERN_WORD_CHARS.matcher(name).matches();
-    }
-
     public static String generateDefaultIndexName(String table, ColumnIdentifier column)
     {
         return PATTERN_NON_WORD_CHAR.matcher(table + "_" + column.toString() + "_idx").replaceAll("");
@@ -125,7 +122,7 @@ public final class IndexMetadata
 
     public void validate(TableMetadata table)
     {
-        if (!isNameValid(name))
+        if (!isValidCharsName(name))
             throw new ConfigurationException("Illegal index name " + name);
 
         if (kind == null)

--- a/src/java/org/apache/cassandra/schema/KeyspaceMetadata.java
+++ b/src/java/org/apache/cassandra/schema/KeyspaceMetadata.java
@@ -363,7 +363,7 @@ public final class KeyspaceMetadata implements SchemaElement
 
     public void validate()
     {
-        if (!SchemaConstants.isValidName(name))
+        if (!SchemaConstants.isNameSafeForFilename(name))
         {
             throw new ConfigurationException(format("Keyspace name must not be empty, more than %s characters long, "
                                                     + "or contain non-alphanumeric-underscore characters (got \"%s\")",

--- a/src/java/org/apache/cassandra/schema/KeyspaceMetadata.java
+++ b/src/java/org/apache/cassandra/schema/KeyspaceMetadata.java
@@ -45,6 +45,7 @@ import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Maps.transformValues;
 import static java.lang.String.format;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
 
 /**
  * An immutable representation of keyspace metadata (name, params, tables, types, and functions).
@@ -367,7 +368,7 @@ public final class KeyspaceMetadata implements SchemaElement
         {
             throw new ConfigurationException(format("Keyspace name must not be empty, more than %s characters long, "
                                                     + "or contain non-alphanumeric-underscore characters (got \"%s\")",
-                                                    SchemaConstants.NAME_LENGTH,
+                                                    SCHEMA_FILE_NAME_LENGTH.getInt(),
                                                     name));
         }
 

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableSet;
 
 import org.apache.cassandra.db.Digest;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
+
 public final class SchemaConstants
 {
     public static final Pattern PATTERN_WORD_CHARS = Pattern.compile("\\w+");
@@ -65,7 +67,7 @@ public final class SchemaConstants
      * Note: This extended to 222 for CNDB tenant specific keyspaces. The windows restriction is not valid here
      * because CNDB does not support windows.
      */
-    public static final int NAME_LENGTH = 222;
+    public static final int NAME_LENGTH = SCHEMA_FILE_NAME_LENGTH.getInt();
 
     // 59adb24e-f3cd-3e02-97f0-5b395827453f
     public static final UUID emptyVersion;
@@ -74,7 +76,7 @@ public final class SchemaConstants
 
     public static boolean isSafeLengthForFilename(String name)
     {
-        return name.length() <= NAME_LENGTH;
+        return name.length() <= SCHEMA_FILE_NAME_LENGTH.getInt();
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -77,9 +77,26 @@ public final class SchemaConstants
         return name.length() <= NAME_LENGTH;
     }
 
-    public static boolean isValidName(String name)
+    /**
+     * Names such as keyspace, table, index names are used in file paths and file names,
+     * so, they need to be safe for the use there, i.e., short enough and
+     * containing only alphanumeric characters and underscores.
+     * @param name the name to check
+     * @return whether the name is safe for use in file paths and file names
+     */
+    public static boolean isNameSafeForFilename(String name)
     {
         return name != null && !name.isEmpty() && isSafeLengthForFilename(name) && PATTERN_WORD_CHARS.matcher(name).matches();
+    }
+
+    /**
+     * Checks if the name contains only alphanumeric characters and underscores and is not empty.
+     * @param name the name to check
+     * @return true if the name is valid, false otherwise
+     */
+    public static boolean isValidCharsName(String name)
+    {
+        return name != null && !name.isEmpty() && PATTERN_WORD_CHARS.matcher(name).matches();
     }
 
     static

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -58,17 +58,6 @@ public final class SchemaConstants
     /* virtual keyspace names */
     public static final Set<String> VIRTUAL_KEYSPACE_NAMES = ImmutableSet.of(SCHEMA_VIRTUAL_KEYSPACE_NAME, SYSTEM_VIEWS_KEYSPACE_NAME);
 
-    /**
-     * longest permissible KS or CF name.  Our main concern is that filename not be more than 255 characters;
-     * the filename will contain both the KS and CF names. Since non-schema-name components only take up
-     * ~64 characters, we could allow longer names than this, but on Windows, the entire path should be not greater than
-     * 255 characters, so a lower limit here helps avoid problems.  See CASSANDRA-4110.
-     *
-     * Note: This extended to 222 for CNDB tenant specific keyspaces. The windows restriction is not valid here
-     * because CNDB does not support windows.
-     */
-    public static int NAME_LENGTH = SCHEMA_FILE_NAME_LENGTH.getInt();
-
     // 59adb24e-f3cd-3e02-97f0-5b395827453f
     public static final UUID emptyVersion;
 

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -76,7 +76,7 @@ public final class SchemaConstants
 
     public static boolean isSafeLengthForFilename(String name)
     {
-        return name.length() <= NAME_LENGTH;
+        return name.length() <= SCHEMA_FILE_NAME_LENGTH.getInt();
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -72,9 +72,14 @@ public final class SchemaConstants
 
     public static final List<String> LEGACY_AUTH_TABLES = Arrays.asList("credentials", "users", "permissions");
 
+    public static boolean isSafeLengthForFilename(String name)
+    {
+        return name.length() <= NAME_LENGTH;
+    }
+
     public static boolean isValidName(String name)
     {
-        return name != null && !name.isEmpty() && name.length() <= NAME_LENGTH && PATTERN_WORD_CHARS.matcher(name).matches();
+        return name != null && !name.isEmpty() && isSafeLengthForFilename(name) && PATTERN_WORD_CHARS.matcher(name).matches();
     }
 
     static

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -67,7 +67,7 @@ public final class SchemaConstants
      * Note: This extended to 222 for CNDB tenant specific keyspaces. The windows restriction is not valid here
      * because CNDB does not support windows.
      */
-    public static final int NAME_LENGTH = SCHEMA_FILE_NAME_LENGTH.getInt();
+    public static int NAME_LENGTH = SCHEMA_FILE_NAME_LENGTH.getInt();
 
     // 59adb24e-f3cd-3e02-97f0-5b395827453f
     public static final UUID emptyVersion;
@@ -76,7 +76,7 @@ public final class SchemaConstants
 
     public static boolean isSafeLengthForFilename(String name)
     {
-        return name.length() <= SCHEMA_FILE_NAME_LENGTH.getInt();
+        return name.length() <= NAME_LENGTH;
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -440,10 +440,10 @@ public class TableMetadata implements SchemaElement
     public void validate(boolean durationLegacyMode)
     {
         if (!isValidCharsName(keyspace))
-            except("Keyspace name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, keyspace);
+            except("Keyspace name must not be empty or contain non-alphanumeric-underscore characters (got \"%s\")", keyspace);
 
         if (!isValidCharsName(name))
-            except("Table name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, name);
+            except("Table name must not be empty or contain non-alphanumeric-underscore characters (got \"%s\")", keyspace);
 
         params.validate();
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -51,8 +51,7 @@ import static com.google.common.collect.Maps.transformValues;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.cassandra.schema.SchemaConstants.isSafeLengthForFilename;
-import static org.apache.cassandra.schema.SchemaConstants.isValidName;
+import static org.apache.cassandra.schema.SchemaConstants.isValidCharsName;
 
 @Unmetered
 public class TableMetadata implements SchemaElement
@@ -440,17 +439,11 @@ public class TableMetadata implements SchemaElement
 
     public void validate(boolean durationLegacyMode)
     {
-        if (!isValidName(keyspace))
+        if (!isValidCharsName(keyspace))
             except("Keyspace name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, keyspace);
 
-        if (!isValidName(name))
+        if (!isValidCharsName(name))
             except("Table name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, name);
-
-        if (!isSafeLengthForFilename(keyspace + '.' + name))
-        {
-            String combinedName = keyspace + '.' + name;
-            except("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SchemaConstants.NAME_LENGTH, combinedName.length(), combinedName);
-        }
 
         params.validate();
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -51,7 +51,8 @@ import static com.google.common.collect.Maps.transformValues;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.cassandra.schema.IndexMetadata.isNameValid;
+import static org.apache.cassandra.schema.SchemaConstants.isSafeLengthForFilename;
+import static org.apache.cassandra.schema.SchemaConstants.isValidName;
 
 @Unmetered
 public class TableMetadata implements SchemaElement
@@ -439,11 +440,14 @@ public class TableMetadata implements SchemaElement
 
     public void validate(boolean durationLegacyMode)
     {
-        if (!isNameValid(keyspace))
-            except("Keyspace name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, keyspace);
-
-        if (!isNameValid(name))
+        if (!isValidName(name))
             except("Table name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, name);
+
+        if (!isSafeLengthForFilename(keyspace + '.' + name))
+        {
+            String combinedName = keyspace + '.' + name;
+            except("Keyspace and table names combined must fit %s characters to be safe for filenames. Got %s chars for %s", SchemaConstants.NAME_LENGTH, combinedName.length(), combinedName);
+        }
 
         params.validate();
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -440,6 +440,9 @@ public class TableMetadata implements SchemaElement
 
     public void validate(boolean durationLegacyMode)
     {
+        if (!isValidName(keyspace))
+            except("Keyspace name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, keyspace);
+
         if (!isValidName(name))
             except("Table name must not be empty, more than %s characters long, or contain non-alphanumeric-underscore characters (got \"%s\")", SchemaConstants.NAME_LENGTH, name);
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -62,6 +62,7 @@ import org.apache.cassandra.triggers.ITrigger;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static java.lang.String.format;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
 import static org.apache.cassandra.cql3.Duration.NANOS_PER_HOUR;
 import static org.apache.cassandra.cql3.Duration.NANOS_PER_MICRO;
 import static org.apache.cassandra.cql3.Duration.NANOS_PER_MILLI;
@@ -457,7 +458,7 @@ public class CreateTest extends CQLTester
 
         execute("CREATE KEYSPACE testXYZ WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
 
-        String tooLongKeyspace = IntStream.range(0, SchemaConstants.NAME_LENGTH + 1).mapToObj(i ->"x").collect(Collectors.joining());
+        String tooLongKeyspace = IntStream.range(0, SCHEMA_FILE_NAME_LENGTH.getInt() + 1).mapToObj(i ->"x").collect(Collectors.joining());
         assertInvalid("CREATE KEYSPACE " + tooLongKeyspace + " WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
 
         execute("DROP KEYSPACE testXYZ");

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -75,7 +75,6 @@ import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.IndexMetadata;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
@@ -83,6 +82,7 @@ import org.mockito.Mockito;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.fail;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SCHEMA_FILE_NAME_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -273,7 +273,7 @@ public class NativeIndexDDLTest extends SAITester
                                                           " USING 'StorageAttachedIndex'", invalidColumn)))
                 .isInstanceOf(InvalidQueryException.class)
                 .hasMessage(String.format("Column '%s' is longer than the permissible name length of %d characters or" +
-                                          " contains non-alphanumeric-underscore characters", invalidColumn, SchemaConstants.NAME_LENGTH));
+                                          " contains non-alphanumeric-underscore characters", invalidColumn, SCHEMA_FILE_NAME_LENGTH.getInt()));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -19,14 +19,12 @@
 package org.apache.cassandra.schema;
 
 import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.functions.types.ParseUtils;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.fail;
 
@@ -110,7 +108,7 @@ public class CreateTableValidationTest extends CQLTester
         String veryLongName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab";
         String longName = veryLongName.substring(0, 200);
 
-        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 241 chars for %s.%s", KEYSPACE, veryLongName),
+        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 240 chars for %s%s", KEYSPACE, veryLongName),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", KEYSPACE, veryLongName));
@@ -118,7 +116,7 @@ public class CreateTableValidationTest extends CQLTester
         execute(String.format("CREATE KEYSPACE %s WITH replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
                               keyspaceName));
-        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 313 chars for %s.%s", ParseUtils.unDoubleQuote(keyspaceName), veryLongName),
+        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 312 chars for %s%s", ParseUtils.unDoubleQuote(keyspaceName), veryLongName),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", keyspaceName, veryLongName));
@@ -126,7 +124,7 @@ public class CreateTableValidationTest extends CQLTester
         execute(String.format("CREATE KEYSPACE %s with replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
                               longName));
-        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 248 chars for %s.%s", veryLongName, "rather_longer_table_name"),
+        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 247 chars for %s%s", veryLongName, "rather_longer_table_name"),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", veryLongName, "rather_longer_table_name"));

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -121,6 +121,29 @@ public class CreateTableValidationTest extends CQLTester
         assertThat(result.size()).isEqualTo(1);
     }
 
+    @Test
+    public void testLongTableNames()
+    {
+
+        String longName = "very_very_very_very_very_very_very_very_very_" +
+                          "very_very_very_very_very_very_very_very_very_very_very_very_" +
+                          "very_very_very_very_very_very_very_very_very_very_very_" +
+                          "very_very_very_very_very_very_very_very_long_keyspace_name";
+
+        assertInvalidMessage("Expected compaction params for legacy strategy: CompactionStrategyOptions{class=org.apache.cassandra.db.compaction.UnifiedCompactionStrategy, options={base_shard_count=1}}",
+                             String.format("CREATE TABLE %s.%s (" +
+                                           "key int PRIMARY KEY," +
+                                           "\"a very very very very very very very very long field\" int)", KEYSPACE, longName));
+
+        execute(String.format("CREATE KEYSPACE %s with replication = " +
+                              "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
+                              longName));
+        assertInvalidMessage("Expected compaction params for legacy strategy: CompactionStrategyOptions{class=org.apache.cassandra.db.compaction.UnifiedCompactionStrategy, options={base_shard_count=1}}",
+                             String.format("CREATE TABLE %s.%s (" +
+                                           "key int PRIMARY KEY," +
+                                           "\"a very very very very very very very very long field\" int)", longName, "rather_longer_table_name"));
+    }
+
     private void expectedFailure(String statement, String errorMsg)
     {
 

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -143,7 +143,7 @@ public class CreateTableValidationTest extends CQLTester
                           "very_very_very_very_very_very_very_very_very_very_very_" +
                           "very_very_very_very_very_very_very_very_very_very_long_name";
 
-        assertInvalidMessage(String.format("%1$s.%2$s: Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 237 chars for %1$s.%2$s", KEYSPACE, longName),
+        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 237 chars for %s.%s", KEYSPACE, longName),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", KEYSPACE, longName));
@@ -151,7 +151,7 @@ public class CreateTableValidationTest extends CQLTester
         execute(String.format("CREATE KEYSPACE %s with replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
                               longName));
-        assertInvalidMessage(String.format("%1$s.%2$s: Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 244 chars for %1$s.%2$s", longName, "rather_longer_table_name"),
+        assertInvalidMessage(String.format("Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 244 chars for %s.%s", longName, "rather_longer_table_name"),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", longName, "rather_longer_table_name"));

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -122,15 +122,28 @@ public class CreateTableValidationTest extends CQLTester
     }
 
     @Test
+    public void reproCndb12451()
+    {
+        String keyspaceName = "a6326636663663342d363939312d343261362d613137302d386431653238643836626234_default_keyspace";
+        String tableName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab";
+
+        execute(String.format("CREATE KEYSPACE %s WITH replication = " +
+                              "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
+                              keyspaceName));
+        assertInvalidMessage(String.format("%s.%s: Table name must not be empty, more than 222 characters long, or contain non-alphanumeric-underscore characters (got \"%<s\")", keyspaceName, tableName),String.format("CREATE TABLE %s.%s (" +
+                              "key int PRIMARY KEY," +
+                              "value int)", keyspaceName, tableName));
+    }
+
+    @Test
     public void testLongTableNames()
     {
-
         String longName = "very_very_very_very_very_very_very_very_very_" +
                           "very_very_very_very_very_very_very_very_very_very_very_very_" +
                           "very_very_very_very_very_very_very_very_very_very_very_" +
-                          "very_very_very_very_very_very_very_very_long_keyspace_name";
+                          "very_very_very_very_very_very_very_very_very_very_long_name";
 
-        assertInvalidMessage("Expected compaction params for legacy strategy: CompactionStrategyOptions{class=org.apache.cassandra.db.compaction.UnifiedCompactionStrategy, options={base_shard_count=1}}",
+        assertInvalidMessage(String.format("%1$s.%2$s: Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 237 chars for %1$s.%2$s", KEYSPACE, longName),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", KEYSPACE, longName));
@@ -138,7 +151,7 @@ public class CreateTableValidationTest extends CQLTester
         execute(String.format("CREATE KEYSPACE %s with replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
                               longName));
-        assertInvalidMessage("Expected compaction params for legacy strategy: CompactionStrategyOptions{class=org.apache.cassandra.db.compaction.UnifiedCompactionStrategy, options={base_shard_count=1}}",
+        assertInvalidMessage(String.format("%1$s.%2$s: Keyspace and table names combined must fit 222 characters to be safe for filenames. Got 244 chars for %1$s.%2$s", longName, "rather_longer_table_name"),
                              String.format("CREATE TABLE %s.%s (" +
                                            "key int PRIMARY KEY," +
                                            "\"a very very very very very very very very long field\" int)", longName, "rather_longer_table_name"));

--- a/test/unit/org/apache/cassandra/schema/IndexMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/IndexMetadataTest.java
@@ -25,27 +25,28 @@ import org.junit.Test;
 
 import org.apache.cassandra.cql3.ColumnIdentifier;
 
+import static org.apache.cassandra.schema.SchemaConstants.isValidCharsName;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class IndexMetadataTest {
     
     @Test
-    public void testIsNameValidPositive()
+    public void testIsValidCharsNamePositive()
     {
-        assertTrue(IndexMetadata.isNameValid("abcdefghijklmnopqrstuvwxyz"));
-        assertTrue(IndexMetadata.isNameValid("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
-        assertTrue(IndexMetadata.isNameValid("_01234567890"));
+        assertTrue(isValidCharsName("abcdefghijklmnopqrstuvwxyz"));
+        assertTrue(isValidCharsName("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+        assertTrue(isValidCharsName("_01234567890"));
     }
     
     @Test
-    public void testIsNameValidNegative()
+    public void testIsValidCharsNameNegative()
     {
-        assertFalse(IndexMetadata.isNameValid(null));
-        assertFalse(IndexMetadata.isNameValid(""));
-        assertFalse(IndexMetadata.isNameValid(" "));
-        assertFalse(IndexMetadata.isNameValid("@"));
-        assertFalse(IndexMetadata.isNameValid("!"));
+        assertFalse(isValidCharsName(null));
+        assertFalse(isValidCharsName(""));
+        assertFalse(isValidCharsName(" "));
+        assertFalse(isValidCharsName("@"));
+        assertFalse(isValidCharsName("!"));
     }
     
     @Test

--- a/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
@@ -138,11 +138,11 @@ public class MigrationManagerTest
     {
         String[] valid = {"1", "a", "_1", "b_", "__", "1_a"};
         for (String s : valid)
-            assertTrue(SchemaConstants.isValidName(s));
+            assertTrue(SchemaConstants.isNameSafeForFilename(s));
 
         String[] invalid = {"b@t", "dash-y", "", " ", "dot.s", ".hidden"};
         for (String s : invalid)
-            assertFalse(SchemaConstants.isValidName(s));
+            assertFalse(SchemaConstants.isNameSafeForFilename(s));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/ValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/ValidationTest.java
@@ -32,19 +32,19 @@ public class ValidationTest
     @Test
     public void testIsNameValidPositive()
     {
-         assertTrue(SchemaConstants.isValidName("abcdefghijklmnopqrstuvwxyz"));
-         assertTrue(SchemaConstants.isValidName("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
-         assertTrue(SchemaConstants.isValidName("_01234567890"));
+         assertTrue(SchemaConstants.isNameSafeForFilename("abcdefghijklmnopqrstuvwxyz"));
+         assertTrue(SchemaConstants.isNameSafeForFilename("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+         assertTrue(SchemaConstants.isNameSafeForFilename("_01234567890"));
     }
     
     @Test
     public void testIsNameValidNegative()
     {
-        assertFalse(SchemaConstants.isValidName(null));
-        assertFalse(SchemaConstants.isValidName(""));
-        assertFalse(SchemaConstants.isValidName(" "));
-        assertFalse(SchemaConstants.isValidName("@"));
-        assertFalse(SchemaConstants.isValidName("!"));
+        assertFalse(SchemaConstants.isNameSafeForFilename(null));
+        assertFalse(SchemaConstants.isNameSafeForFilename(""));
+        assertFalse(SchemaConstants.isNameSafeForFilename(" "));
+        assertFalse(SchemaConstants.isNameSafeForFilename("@"));
+        assertFalse(SchemaConstants.isNameSafeForFilename("!"));
     }
 
     private static Set<String> primitiveTypes =


### PR DESCRIPTION
### What is the issue

The length of table names were not validated for acceptable size for a
file name, since the creation was invoking a validation function with
similar name but without length validation.
Furthermore, a file name is constructed by concatenating keyspace and
table names through a separator. This was never validated if the
combined name will be too large for a file name.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/12683, ~~fixes~~ prevents https://github.com/riptano/cndb/issues/12451 to appear in future.

This commit adds validation that combined table and keyspace names provided in a create table statement do not 
exceed 222, which is configurable for the CNDB test purpose.
Since the table name was never validated for the length, the validation exception is corrected.
Also the names of validate functions are improved to make sure that they are used correctly and placed in the same file.

CNDB's PR with this artifact: https://github.com/riptano/cndb/pull/12779.
It tests that an existing table with an unacceptably long name will continue to work.