### PR TITLE
HCD-31 Auto failing prematurely repair sessions

### DIFF
--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -1118,6 +1118,7 @@ public class LocalSessions
         }
         else
         {
+            session.setLastUpdate();
             logger.info("Received StatusResponse for repair session {} with state {}, which is not actionable. Doing nothing.", sessionID, response.state);
         }
     }

--- a/test/unit/org/apache/cassandra/repair/consistent/LocalSessionTest.java
+++ b/test/unit/org/apache/cassandra/repair/consistent/LocalSessionTest.java
@@ -683,8 +683,11 @@ public class LocalSessionTest extends AbstractRepairTest
         sessions.start();
         LocalSession session = sessions.prepareForTest(sessionID);
         session.setState(REPAIRING);
+        int lastUpdatedOriginal = session.getLastUpdate();
+        Thread.sleep(1100);
 
         sessions.handleStatusResponse(PARTICIPANT1, new StatusResponse(sessionID, FINALIZE_PROMISED));
+        Assert.assertNotEquals(lastUpdatedOriginal, session.getLastUpdate());
         Assert.assertEquals(REPAIRING, session.getState());
     }
 


### PR DESCRIPTION
### What is the issue
Long running repairs trigger auto failing prematurely

### What does this PR fix and why was it fixed
Capture status pings as liveness info to prevent early termination of repairs
