### PR TITLE
CNDB-12899: Add a cached version of the estimatedPartitionCount metric

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionRealm.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionRealm.java
@@ -31,7 +31,6 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.DiskBoundaries;
 import org.apache.cassandra.db.compaction.unified.Environment;
-import org.apache.cassandra.db.compaction.unified.RealEnvironment;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.memtable.Memtable;
@@ -126,12 +125,12 @@ public interface CompactionRealm
      * Return the estimated partition count, used when the number of partitions in an sstable is not sufficient to give
      * a sensible range estimation.
      */
-    default long estimatedPartitionCount()
+    default long estimatedPartitionCountInSSTables()
     {
         final long INITIAL_ESTIMATED_PARTITION_COUNT = 1 << 16; // If we don't yet have a count, use a sensible default.
         if (metrics() == null)
             return INITIAL_ESTIMATED_PARTITION_COUNT;
-        final Long estimation = metrics().estimatedPartitionCount.getValue();
+        final Long estimation = metrics().estimatedPartitionCountInSSTablesCached.getValue();
         if (estimation == null || estimation == 0)
             return INITIAL_ESTIMATED_PARTITION_COUNT;
         return estimation;

--- a/src/java/org/apache/cassandra/db/compaction/DelegatingShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/DelegatingShardManager.java
@@ -60,7 +60,7 @@ public class DelegatingShardManager implements ShardManager
     @Override
     public double minimumPerPartitionSpan()
     {
-        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCount());
+        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCountInSSTables());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerNoDisks.java
@@ -87,7 +87,7 @@ public class ShardManagerNoDisks implements ShardManager
 
     public double minimumPerPartitionSpan()
     {
-        return localSpaceCoverage() / Math.max(1, localRanges.getRealm().estimatedPartitionCount());
+        return localSpaceCoverage() / Math.max(1, localRanges.getRealm().estimatedPartitionCountInSSTables());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerReplicaAware.java
@@ -20,21 +20,15 @@ package org.apache.cassandra.db.compaction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.dht.tokenallocator.IsolatedTokenAllocator;
-import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.TokenMetadata;
 
@@ -94,7 +88,7 @@ public class ShardManagerReplicaAware implements ShardManager
     @Override
     public double minimumPerPartitionSpan()
     {
-        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCount());
+        return localSpaceCoverage() / Math.max(1, realm.estimatedPartitionCountInSSTables());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -332,7 +332,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         long count = -1;
 
         if (Iterables.isEmpty(sstables))
-            return count;
+            return 0;
 
         boolean failed = false;
         ICardinality cardinality = null;

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.metrics;
 
+import java.lang.ref.WeakReference;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -30,6 +31,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -44,6 +47,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -74,6 +78,7 @@ import org.apache.cassandra.utils.ExpMovingAverage;
 import org.apache.cassandra.utils.Hex;
 import org.apache.cassandra.utils.MovingAverage;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.concurrent.Refs;
 
 import static org.apache.cassandra.io.sstable.format.SSTableReader.selectOnlyBigTableReaders;
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
@@ -174,6 +179,12 @@ public class TableMetrics
     public final Gauge<long[]> estimatedPartitionSizeHistogram;
     /** Approximate number of keys in table. */
     public final Gauge<Long> estimatedPartitionCount;
+    /** This function is used to calculate estimated partition count in sstables and store the calculated value for the
+     *  current set of sstables. */
+    public final LongSupplier estimatedPartitionCountInSSTables;
+    /** A cached version of the estimated partition count in sstables, used by compaction. This value will be more
+     *  precise when the table has a small number of partitions that keep getting written to. */
+    public final Gauge<Long> estimatedPartitionCountInSSTablesCached;
     /** Histogram of estimated number of columns. */
     public final Gauge<long[]> estimatedColumnCountHistogram;
 
@@ -605,20 +616,53 @@ public class TableMetrics
         estimatedPartitionSizeHistogram = createTableGauge("EstimatedPartitionSizeHistogram", "EstimatedRowSizeHistogram",
                                                            () -> combineHistograms(cfs.getSSTables(SSTableSet.CANONICAL),
                                                                                    SSTableReader::getEstimatedPartitionSize), null);
-        
+
+        estimatedPartitionCountInSSTables = new LongSupplier()
+        {
+            // Since the sstables only change when the tracker view changes, we can cache the value.
+            AtomicReference<Pair<WeakReference<View>, Long>> collected = new AtomicReference<>(Pair.create(new WeakReference<>(null), 0L));
+
+            public long getAsLong()
+            {
+                final View currentView = cfs.getTracker().getView();
+                final Pair<WeakReference<View>, Long> currentCollected = collected.get();
+                if (currentView != currentCollected.left.get())
+                {
+                    Refs refs = Refs.tryRef(currentView.select(SSTableSet.CANONICAL));
+                    if (refs != null)
+                    {
+                        try (refs)
+                        {
+                            long collectedValue = SSTableReader.getApproximateKeyCount(refs);
+                            final Pair<WeakReference<View>, Long> newCollected = Pair.create(new WeakReference<>(currentView), collectedValue);
+                            collected.compareAndSet(currentCollected, newCollected); // okay if failed, a different thread did it
+                            return collectedValue;
+                        }
+                    }
+                    // If we can't reference, simply return the previous collected value; it can only result in a delay
+                    // in reporting the correct key count.
+                }
+                return currentCollected.right;
+            }
+        };
         estimatedPartitionCount = createTableGauge("EstimatedPartitionCount", "EstimatedRowCount", new Gauge<Long>()
         {
             public Long getValue()
             {
-                long memtablePartitions = 0;
+                long estimatedPartitions = estimatedPartitionCountInSSTables.getAsLong();
                 for (Memtable memtable : cfs.getTracker().getView().getAllMemtables())
-                   memtablePartitions += memtable.partitionCount();
-                try(ColumnFamilyStore.RefViewFragment refViewFragment = cfs.selectAndReference(View.selectFunction(SSTableSet.CANONICAL)))
-                {
-                    return SSTableReader.getApproximateKeyCount(refViewFragment.sstables) + memtablePartitions;
-                }
+                    estimatedPartitions += memtable.partitionCount();
+                return estimatedPartitions;
             }
         }, null);
+        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(1, TimeUnit.SECONDS)
+        {
+            public Long loadValue()
+            {
+                return estimatedPartitionCountInSSTables.getAsLong();
+            }
+        };
+
         estimatedColumnCountHistogram = createTableGauge("EstimatedColumnCountHistogram", "EstimatedColumnCountHistogram",
                                                          () -> combineHistograms(cfs.getSSTables(SSTableSet.CANONICAL), 
                                                                                  SSTableReader::getEstimatedCellPerPartitionCount), null);

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -628,7 +628,7 @@ public class TableMetrics
                 final Pair<WeakReference<View>, Long> currentCollected = collected.get();
                 if (currentView != currentCollected.left.get())
                 {
-                    Refs refs = Refs.tryRef(currentView.select(SSTableSet.CANONICAL));
+                    Refs<SSTableReader> refs = Refs.tryRef(currentView.select(SSTableSet.CANONICAL));
                     if (refs != null)
                     {
                         try (refs)

--- a/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/DelegatingShardManagerTest.java
@@ -42,7 +42,7 @@ public class DelegatingShardManagerTest
     {
         CompactionRealm realm = Mockito.mock(CompactionRealm.class);
         when(realm.getPartitioner()).thenReturn(partitioner);
-        when(realm.estimatedPartitionCount()).thenReturn(1L << 16);
+        when(realm.estimatedPartitionCountInSSTables()).thenReturn(1L << 16);
         SortedLocalRanges localRanges = SortedLocalRanges.forTestingFull(realm);
         ShardManager delegate = new ShardManagerNoDisks(localRanges);
 

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerReplicaAwareTest.java
@@ -49,7 +49,7 @@ public class ShardManagerReplicaAwareTest
     public void testRangeEndsForShardCountEqualtToNumTokensPlusOne() throws UnknownHostException
     {
         var mockCompationRealm = mock(CompactionRealm.class);
-        when(mockCompationRealm.estimatedPartitionCount()).thenReturn(1L<<16);
+        when(mockCompationRealm.estimatedPartitionCountInSSTables()).thenReturn(1L<<16);
 
         for (int numTokens = 1; numTokens < 32; numTokens++)
         {
@@ -75,7 +75,7 @@ public class ShardManagerReplicaAwareTest
     public void testRangeEndsAreFromTokenListAndContainLowerRangeEnds() throws UnknownHostException
     {
         var mockCompationRealm = mock(CompactionRealm.class);
-        when(mockCompationRealm.estimatedPartitionCount()).thenReturn(1L<<16);
+        when(mockCompationRealm.estimatedPartitionCountInSSTables()).thenReturn(1L<<16);
 
         for (int nodeCount = 1; nodeCount <= 6; nodeCount++)
         {

--- a/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/ShardManagerTest.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,7 +68,7 @@ public class ShardManagerTest
         localRanges = Mockito.mock(SortedLocalRanges.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
         Mockito.when(localRanges.getRanges()).thenAnswer(invocation -> weightedRanges);
         Mockito.when(localRanges.getRealm()).thenReturn(realm);
-        Mockito.when(realm.estimatedPartitionCount()).thenReturn(10000L);
+        Mockito.when(realm.estimatedPartitionCountInSSTables()).thenReturn(10000L);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
@@ -404,20 +404,12 @@ public class TableMetricsTest
         assertEquals(partitionCount, cfs.metric.estimatedPartitionCount.getValue().longValue());
 
         // The cached estimatedPartitionCountInSSTables lags one second, check that.
-        estimatedPartitionCountInSSTables = cfs.metric.estimatedPartitionCountInSSTablesCached.getValue().longValue();
-        elapsedTime = System.currentTimeMillis() - startTime;
-        if (elapsedTime < 980)
-            assertEquals(0, estimatedPartitionCountInSSTables);
-        else if (elapsedTime >= 1020)
-            assertEquals(partitionCount, estimatedPartitionCountInSSTables);
-
-        // Wait to let it update.
-        if (elapsedTime < 1020)
-            Thread.sleep(1200 - elapsedTime);
-
-        // It must now report the correct value.
-        estimatedPartitionCountInSSTables = cfs.metric.estimatedPartitionCountInSSTablesCached.getValue().longValue();
-        assertEquals(partitionCount, estimatedPartitionCountInSSTables);
+        // Assert that the metric will return a correct value after at least a second passes
+        await().atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    long value = cfs.metric.estimatedPartitionCountInSSTablesCached.getValue();
+                    assertEquals(partitionCount, value);            
+                });
     }
 
 


### PR DESCRIPTION
### What is the issue
[CNDB-12899](https://github.com/riptano/cndb/issues/12899) `CompactionRealm.estimatedPartitionCount()` is very expensive

### What does this PR fix and why was it fixed
Adds a cached version of the metric and removes the memtable partitions from the calculation to make it more precise for the compaction use case.

Also makes sure that the `estimatedPartitionCount` metric is not recalculated if the table's data view (i.e. sstable and memtable set) has not changed.