### PR TITLE
CNDB-11460 Fix cqlsh unicode tests in TestCqlshUnicode by handling UTF-8 characters that are split across reads.

### DIFF
--- a/pylib/cqlshlib/test/run_cqlsh.py
+++ b/pylib/cqlshlib/test/run_cqlsh.py
@@ -155,6 +155,7 @@ class ProcRunner:
             env = {}
         self.env = env
         self.readbuf = ''
+        self._partial_bytes = b''
 
         self.start_proc()
 
@@ -174,6 +175,7 @@ class ProcRunner:
             self.childpty = masterfd
             self.send = self.send_tty
             self.read = self.read_tty
+            self._partial_bytes = b''
         else:
             stdin = stdout = subprocess.PIPE
             stderr = subprocess.STDOUT
@@ -188,6 +190,7 @@ class ProcRunner:
                 self.read = self.read_pipe
 
     def close(self):
+        self._partial_bytes = b''
         cqlshlog.info("Closing %r subprocess." % (self.exe_path,))
         if self.realtty:
             os.close(self.childpty)


### PR DESCRIPTION
### What is the issue
CNDB-11460 - several cqlsh (jvm dtest) tests in TestCqlshUnicode consistently fail, with an error like:
```
E           UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 4-5: unexpected end of data
```

### What does this PR fix and why was it fixed
I took a look at the test code and asked Augment for suggestions - it recommended adding some code to handle UTF-8 characters that may be split across reads. I tried the code and it looks like it does the job.

