### PR TITLE
HCD-62 Upgrade of several libraries

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -574,15 +574,14 @@
         <license name="The Apache Software License, Version 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
         <dependencyManagement>
-          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.10.1"/>
+          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.10.7"/>
           <dependency groupId="org.lz4" artifactId="lz4-java" version="1.8.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4" scope="provided"/>
           <dependency groupId="com.github.luben" artifactId="zstd-jni" version="1.5.5-1"/>
-          <dependency groupId="com.google.guava" artifactId="guava" version="27.0-jre">
+          <dependency groupId="com.google.guava" artifactId="guava" version="33.4.0-jre">
             <exclusion groupId="com.google.code.findbugs" artifactId="jsr305" />
             <exclusion groupId="org.codehaus.mojo" artifactId="animal-sniffer-annotations" />
             <exclusion groupId="com.google.guava" artifactId="listenablefuture" />
-            <exclusion groupId="com.google.guava" artifactId="failureaccess" />
             <exclusion groupId="org.checkerframework" artifactId="checker-qual" />
             <exclusion groupId="com.google.errorprone" artifactId="error_prone_annotations" />
           </dependency>
@@ -604,15 +603,15 @@
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.9" />
           <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.4.14"/>
           <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.4.14"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.13.2"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.13.2.2"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.13.2"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.18.3"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.18.3"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.18.3"/>
           <dependency groupId="org.msgpack" artifactId="jackson-dataformat-msgpack" version="0.8.16"/>
 
           <dependency groupId="com.googlecode.json-simple" artifactId="json-simple" version="1.1"/>
           <dependency groupId="com.boundary" artifactId="high-scale-lib" version="1.0.6"/>
           <dependency groupId="com.github.jbellis" artifactId="jamm" version="${jamm.version}"/>
-          <dependency groupId="org.yaml" artifactId="snakeyaml" version="1.33"/>
+          <dependency groupId="org.yaml" artifactId="snakeyaml" version="2.4"/>
           <dependency groupId="junit" artifactId="junit" version="4.13" scope="test">
             <exclusion groupId="org.hamcrest" artifactId="hamcrest-core"/>
           </dependency>

--- a/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
+++ b/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.composer.Composer;
@@ -55,6 +56,8 @@ import org.yaml.snakeyaml.introspector.MissingProperty;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.parser.ParserImpl;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 public class YamlConfigurationLoader implements ConfigurationLoader
 {
@@ -157,7 +160,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
         constructor.setPropertyUtils(propertiesChecker);
         Yaml yaml = new Yaml(constructor);
         Node node = yaml.represent(map);
-        constructor.setComposer(new Composer(null, null)
+        constructor.setComposer(new Composer(new ParserImpl(null), new Resolver(), new LoaderOptions())
         {
             @Override
             public Node getSingleNode()
@@ -175,7 +178,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
     {
         CustomConstructor(Class<?> theRoot, ClassLoader classLoader)
         {
-            super(theRoot, classLoader);
+            super(theRoot, classLoader, new LoaderOptions());
 
             TypeDescription seedDesc = new TypeDescription(ParameterizedClass.class);
             seedDesc.putMapPropertyType("parameters", String.class, String.class);

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -166,7 +166,7 @@ public class JMXTool
             {
                 void dump(OutputStream output, Map<String, Info> map) throws IOException
                 {
-                    Representer representer = new Representer();
+                    Representer representer = new Representer(new DumperOptions());
                     representer.addClassTag(Info.class, Tag.MAP); // avoid the auto added tag
                     Yaml yaml = new Yaml(representer);
                     yaml.dump(map, new OutputStreamWriter(output));
@@ -388,7 +388,8 @@ public class JMXTool
             {
                 Map<String, Info> load(InputStream input) throws IOException
                 {
-                    Yaml yaml = new Yaml(new CustomConstructor(), new Representer(), new DumperOptions(), LOADER_CONFIG);
+                    DumperOptions dOpts = new DumperOptions();
+                    Yaml yaml = new Yaml(new CustomConstructor(), new Representer(dOpts), dOpts, LOADER_CONFIG);
                     return (Map<String, Info>) yaml.load(input);
                 }
             };

--- a/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/FailingRepairTest.java
@@ -151,7 +151,11 @@ public class FailingRepairTest extends TestBaseImpl implements Serializable
                               .start());
         CLUSTER.setUncaughtExceptionsFilter((throwable) -> {
             if (throwable.getClass().toString().contains("InstanceShutdown") || // can't check instanceof as it is thrown by a different classloader
-                throwable.getMessage() != null && throwable.getMessage().contains("Parent repair session with id"))
+                (throwable.getMessage() != null && throwable.getMessage().contains("Parent repair session with id")) ||
+                (throwable.getClass().toString().contains("RepairException") &&
+                 throwable.getMessage() != null &&
+                 throwable.getMessage().contains("Validation failed"))
+                )
                 return true;
             return false;
         });

--- a/test/distributed/org/apache/cassandra/distributed/test/IncRepairTruncationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/IncRepairTruncationTest.java
@@ -53,6 +53,9 @@ public class IncRepairTruncationTest extends TestBaseImpl
                                                                       .with(NETWORK))
                                           .start()))
         {
+            cluster.setUncaughtExceptionsFilter(t -> t.getMessage() != null &&
+                                                t.getMessage().contains("Parent repair session with id") &&
+                                                t.getMessage().contains("has failed"));
             cluster.schemaChange("create table " + KEYSPACE + ".tbl (id int primary key, t int)");
 
             insert(cluster.coordinator(1), 0, 100);

--- a/test/distributed/org/apache/cassandra/distributed/test/PreviewRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PreviewRepairTest.java
@@ -199,6 +199,9 @@ public class PreviewRepairTest extends TestBaseImpl
                                                                 config.with(GOSSIP)
                                                                       .with(NETWORK)).start()))
         {
+            cluster.setUncaughtExceptionsFilter(t -> t.getClass().toString().contains("RepairException") &&
+                                                     t.getMessage() != null &&
+                                                     t.getMessage().contains("Validation failed"));
             cluster.schemaChange("create table " + KEYSPACE + ".tbl (id int primary key, t int)");
             insert(cluster.coordinator(1), 0, 100);
             cluster.forEach((node) -> node.flush(KEYSPACE));

--- a/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.*;
 import org.apache.cassandra.stress.util.JavaDriverClient;
 import org.apache.cassandra.stress.util.ResultLogger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -810,7 +811,7 @@ public class StressProfile implements Serializable
     {
         try
         {
-            Constructor constructor = new Constructor(StressYaml.class);
+            Constructor constructor = new Constructor(StressYaml.class, new LoaderOptions());
 
             Yaml yaml = new Yaml(constructor);
 


### PR DESCRIPTION
### What is the issue
The customer requested an upgrade for some libraries (CVEs)

### What does this PR fix and why was it fixed
This PR upgrades to latest stable versions

- snappy to 1.1.10.7 fixing CVE-2023-43642
- guava to 33.4.0-jre fixing CVE-2023-2976 and CVE-2020-8908
- jackson to 2.18.0 fixing CWE-400
- snakeyaml to 2.4 fixing CVE-2022-1471