### PR TITLE
CNDB-12905: Allow usage of ReadQuery#execute rather than only executeInternal in CQL utests

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -524,13 +524,14 @@ public class QueryProcessor implements QueryHandler
             return null;
     }
 
-    public static UntypedResultSet executeOnce(String query, ConsistencyLevel cl, Object... values)
+    /**
+     * Same than {@link #execute(String, ConsistencyLevel, Object...)}, but to use for queries we know are only executed
+     * once so that the created statement object is not cached.
+     */
+    @VisibleForTesting
+    static UntypedResultSet executeOnce(String query, ConsistencyLevel cl, Object... values)
     {
-        return executeOnce(query, cl, internalQueryState(), values);
-    }
-
-    public static UntypedResultSet executeOnce(String query, ConsistencyLevel cl, QueryState queryState, Object... values)
-    {
+        QueryState queryState = internalQueryState();
         CQLStatement statement = parseStatement(query, queryState.getClientState());
         statement.validate(queryState);
         ResultMessage<?> result = statement.execute(queryState, makeInternalOptions(statement, values, cl), System.nanoTime());

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1536,6 +1536,7 @@ public abstract class CQLTester
      */
     protected static void enableExternalExecution()
     {
+        requireNetworkWithoutDriver();
         externalExecution = true;
     }
 

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1539,6 +1539,15 @@ public abstract class CQLTester
     }
 
     /**
+     * Disables distributed execution in {@link #execute(String, Object...)}, so queries won't get full validation nor
+     * go through reconciliation.
+     */
+    protected static void disableDistributedExecution()
+    {
+        distributedExecution = false;
+    }
+
+    /**
      * Execute the specified query as either an internal query or a distributed query depending on the value of
      * {@link #distributedExecution}.
      * </p>

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -224,8 +224,9 @@ public class SAITester extends CQLTester
      * simulate the application of the entire row filter in the coordinator node, even if unit tests are not multinode.
      */
     @BeforeClass
-    public static void enableExternalExecution()
+    public static void setUpClass()
     {
+        CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -22,8 +22,6 @@ package org.apache.cassandra.index.sai;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -48,6 +46,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 
@@ -72,8 +71,6 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
-import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
-import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.ResourceLeakDetector;
 import org.apache.cassandra.inject.ActionBuilder;
@@ -91,10 +88,8 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.ReflectionUtils;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.lucene.codecs.CodecUtil;
-import org.awaitility.Awaitility;
 
 import static org.apache.cassandra.inject.ActionBuilder.newActionBuilder;
 import static org.apache.cassandra.inject.Expression.expr;
@@ -222,6 +217,14 @@ public class SAITester extends CQLTester
     public void removeAllInjections()
     {
         Injections.deleteAll();
+    }
+
+    @BeforeClass
+    public static void enableDistributedExecution()
+    {
+        // We want to use reconciliation in SELECT queries so that we can simulate the application of the entire row
+        // filter in the coordinator node, even if unit tests are not multinode.
+        CQLTester.enableDistributedExecution();
     }
 
     public static IndexContext createIndexContext(String name, AbstractType<?> validator, ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -220,13 +220,13 @@ public class SAITester extends CQLTester
     }
 
     /**
-     * Enable external execution of all queries because want to use reconciliation in SELECT queries so that we can
+     * Enable external execution of all queries because we want to use reconciliation in SELECT queries so that we can
      * simulate the application of the entire row filter in the coordinator node, even if unit tests are not multinode.
      */
     @BeforeClass
     public static void enableExternalExecution()
     {
-        CQLTester.enableExternalExecution();
+        CQLTester.enableCoordinatorExecution();
     }
 
     public static IndexContext createIndexContext(String name, AbstractType<?> validator, ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -219,12 +219,14 @@ public class SAITester extends CQLTester
         Injections.deleteAll();
     }
 
+    /**
+     * Enable external execution of all queries because want to use reconciliation in SELECT queries so that we can
+     * simulate the application of the entire row filter in the coordinator node, even if unit tests are not multinode.
+     */
     @BeforeClass
-    public static void enableDistributedExecution()
+    public static void enableExternalExecution()
     {
-        // We want to use reconciliation in SELECT queries so that we can simulate the application of the entire row
-        // filter in the coordinator node, even if unit tests are not multinode.
-        CQLTester.enableDistributedExecution();
+        CQLTester.enableExternalExecution();
     }
 
     public static IndexContext createIndexContext(String name, AbstractType<?> validator, ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.inject.InvokePointBuilder;
 import org.junit.Test;
 
 import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
 public class DropIndexWhileQueryingTest extends SAITester
@@ -47,8 +48,8 @@ public class DropIndexWhileQueryingTest extends SAITester
 
         execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "car", 0, "y0", "z0");
         String query = "SELECT * FROM %s WHERE x IN (0, 1) OR (y IN ('Y0', 'Y1' ) OR z IN ('z1', 'z2'))";
-        assertInvalidMessage(QueryController.INDEX_MAY_HAVE_BEEN_DROPPED, query);
-        assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE, query);
+        assertThatThrownBy(() -> executeInternal(query)).hasMessage(QueryController.INDEX_MAY_HAVE_BEEN_DROPPED);
+        assertThatThrownBy(() -> executeInternal(query)).hasMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
     }
 
     @Test
@@ -84,8 +85,8 @@ public class DropIndexWhileQueryingTest extends SAITester
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
 
         String query = "SELECT pk FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 2";
-        assertInvalidMessage(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED, query);
-        assertInvalidMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"), query);
+        assertThatThrownBy(() -> executeInternal(query)).hasMessage(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED);
+        assertThatThrownBy(() -> executeInternal(query)).hasMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"));
     }
 
     private static void injectIndexDrop(String injectionName, String indexName, String methodName, boolean atEntry) throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
@@ -114,7 +114,7 @@ public class GenericOrderByTest extends SAITester
 
         // Insert many rows and then ensure we can get each of them when querying with specific bounds.
         for (int i = 0; i < 100; i++)
-            execute("INSERT INTO %s (pk, x, val, str_val) VALUES (?, ?, ?, ?)", i, i, i, String.valueOf(i));
+            execute("INSERT INTO %s (pk, x, val, str_val) VALUES (?, ?, ?, ?)", i, i, i, i);
 
         // Test caught a bug in the way we created boundaries.
         beforeAndAfterFlush(() -> {

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
@@ -114,7 +114,7 @@ public class GenericOrderByTest extends SAITester
 
         // Insert many rows and then ensure we can get each of them when querying with specific bounds.
         for (int i = 0; i < 100; i++)
-            execute("INSERT INTO %s (pk, x, val, str_val) VALUES (?, ?, ?, ?)", i, i, i, i);
+            execute("INSERT INTO %s (pk, x, val, str_val) VALUES (?, ?, ?, ?)", i, i, i, String.valueOf(i));
 
         // Test caught a bug in the way we created boundaries.
         beforeAndAfterFlush(() -> {

--- a/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
@@ -33,13 +33,13 @@ import org.apache.cassandra.index.sai.cql.types.InetTest;
  */
 public class InetAddressTypeEquivalencyTest extends SAITester
 {
-    // TODO: Disables external execution because we know SAI indexing for inet works differently than RowFilter,
+    // TODO: Disables coordinator execution because we know SAI indexing for inet works differently than RowFilter,
     //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
     //  distributed execution again once we have a fix.
     @BeforeClass
-    public static void disableExternalExecution()
+    public static void disableCoordinatorExecution()
     {
-        CQLTester.disableExternalExecution();
+        CQLTester.disableCoordinatorExecution();
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
@@ -19,8 +19,10 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.net.InetAddress;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.cql.types.InetTest;
 
@@ -31,6 +33,15 @@ import org.apache.cassandra.index.sai.cql.types.InetTest;
  */
 public class InetAddressTypeEquivalencyTest extends SAITester
 {
+    // TODO: Disables distributed execution because we know SAI indexing for inet works differently than RowFilter,
+    //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
+    //  distributed execution again once we have a fix.
+    @BeforeClass
+    public static void disableDistributedExecution()
+    {
+        CQLTester.disableDistributedExecution();
+    }
+
     @Before
     public void createTableAndIndex()
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/InetAddressTypeEquivalencyTest.java
@@ -33,13 +33,13 @@ import org.apache.cassandra.index.sai.cql.types.InetTest;
  */
 public class InetAddressTypeEquivalencyTest extends SAITester
 {
-    // TODO: Disables distributed execution because we know SAI indexing for inet works differently than RowFilter,
+    // TODO: Disables external execution because we know SAI indexing for inet works differently than RowFilter,
     //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
     //  distributed execution again once we have a fix.
     @BeforeClass
-    public static void disableDistributedExecution()
+    public static void disableExternalExecution()
     {
-        CQLTester.disableDistributedExecution();
+        CQLTester.disableExternalExecution();
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
@@ -30,9 +30,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class VectorTracingTest extends VectorTester.VersionedWithChecksums
 {
     @BeforeClass
-    public static void setupClass()
+    public static void setUpClass()
     {
         System.setProperty("cassandra.custom_tracing_class", "org.apache.cassandra.tracing.TracingTestImpl");
+        VectorTester.setUpClass();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -79,9 +79,10 @@ public class VectorTypeTest extends VectorTester
     private static final IPartitioner partitioner = Murmur3Partitioner.instance;
 
     @BeforeClass
-    public static void setupClass()
+    public static void setUpClass()
     {
         System.setProperty("cassandra.custom_tracing_class", "org.apache.cassandra.tracing.TracingTestImpl");
+        VectorTester.setUpClass();
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -1012,7 +1012,7 @@ public class VectorTypeTest extends VectorTester
         // Ensure that we fail, as expected, and that a subsequent call to search is successful.
         beforeAndAfterFlush(() -> {
             injection.enable();
-            assertThatThrownBy(() -> execute("SELECT pk FROM %s ORDER BY vec ANN OF [1,1] LIMIT 2")).hasMessageContaining("Injected failure!");
+            assertThatThrownBy(() -> executeInternal("SELECT pk FROM %s ORDER BY vec ANN OF [1,1] LIMIT 2")).hasMessageContaining("Injected failure!");
             injection.disable();
             assertRows(execute("SELECT pk FROM %s ORDER BY vec ANN OF [1,1] LIMIT 2"), row(1));
         });

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
@@ -19,15 +19,26 @@ package org.apache.cassandra.index.sai.cql.types;
 
 import java.util.Collection;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.index.sai.disk.format.Version;
 
 @RunWith(Parameterized.class)
 public class InetTest extends IndexingTypeSupport
 {
+    // TODO: Disables distributed execution because we know SAI indexing for inet works differently than RowFilter,
+    //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
+    //  distributed execution again once we have a fix.
+    @BeforeClass
+    public static void disableDistributedExecution()
+    {
+        CQLTester.disableDistributedExecution();
+    }
+
     @Parameterized.Parameters(name = "version={0},dataset={1},wide={2},scenario={3}")
     public static Collection<Object[]> generateParameters()
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
@@ -30,13 +30,13 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 @RunWith(Parameterized.class)
 public class InetTest extends IndexingTypeSupport
 {
-    // TODO: Disables distributed execution because we know SAI indexing for inet works differently than RowFilter,
+    // TODO: Disables external execution because we know SAI indexing for inet works differently than RowFilter,
     //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
     //  distributed execution again once we have a fix.
     @BeforeClass
-    public static void disableDistributedExecution()
+    public static void disableExternalExecution()
     {
-        CQLTester.disableDistributedExecution();
+        CQLTester.disableExternalExecution();
     }
 
     @Parameterized.Parameters(name = "version={0},dataset={1},wide={2},scenario={3}")

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/InetTest.java
@@ -30,13 +30,13 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 @RunWith(Parameterized.class)
 public class InetTest extends IndexingTypeSupport
 {
-    // TODO: Disables external execution because we know SAI indexing for inet works differently than RowFilter,
+    // TODO: Disables coordinator execution because we know SAI indexing for inet works differently than RowFilter,
     //  which can wrongly discard rows in the coordinator. This is reported in CNDB-12978, and we should enable
     //  distributed execution again once we have a fix.
     @BeforeClass
-    public static void disableExternalExecution()
+    public static void disableCoordinatorExecution()
     {
-        CQLTester.disableExternalExecution();
+        CQLTester.disableCoordinatorExecution();
     }
 
     @Parameterized.Parameters(name = "version={0},dataset={1},wide={2},scenario={3}")

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -199,7 +199,7 @@ public class NodeStartupTest extends SAITester
     }
 
     // TODO: Disable the coordinator execution used by SAITester until we have a way to simulate node restarts combined
-    //  with CQLTester#requireNetwork and CQLTester#requireNetworkWithoutDriver.
+    //  with CQLTester#requireNetwork and CQLTester#requireNetworkWithoutDriver. This should be improved in CNDB-13125.
     @BeforeClass
     public static void setUpClass()
     {

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -26,8 +26,10 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ObjectArrays;
+import org.apache.cassandra.cql3.CQLTester;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -194,6 +196,14 @@ public class NodeStartupTest extends SAITester
         {
             Stream.of(injections).forEach(Injection::enable);
         }
+    }
+
+    // TODO: Disable the coordinator execution used by SAITester until we have a way to simulate node restarts combined
+    //  with CQLTester#requireNetwork and CQLTester#requireNetworkWithoutDriver.
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CQLTester.setUpClass();
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -46,7 +46,6 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.index.sai.IndexContext;
-import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter;
 import org.apache.cassandra.index.sai.metrics.AbstractMetricsTest;
 import org.apache.cassandra.inject.ActionBuilder;
@@ -184,7 +183,7 @@ public class CompactionTest extends AbstractMetricsTest
             verifySSTableIndexes(v2IndexName, 1);
 
             // But index queries should not be allowed.
-            assertThrows(IndexNotAvailableException.class, () -> execute("SELECT id1 FROM %s WHERE v1>=0"));
+            assertThrows(IndexNotAvailableException.class, () -> executeInternal("SELECT id1 FROM %s WHERE v1>=0"));
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
@@ -60,7 +60,7 @@ public class FailureTest extends SAITester
         flush();
 
         // Verify that, while the node is still operational, the index is not.
-        Assertions.assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE v1 > 1"))
+        Assertions.assertThatThrownBy(() -> executeInternal("SELECT * FROM %s WHERE v1 > 1"))
                   .isInstanceOf(IndexNotAvailableException.class);
 
         ssTableContextCreationFailure.disable();
@@ -97,7 +97,7 @@ public class FailureTest extends SAITester
         compact();
 
         // Verify that the index is not available.
-        Assertions.assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE v1 > 1"))
+        Assertions.assertThatThrownBy(() -> executeInternal("SELECT * FROM %s WHERE v1 > 1"))
                   .isInstanceOf(IndexNotAvailableException.class);
     }
 
@@ -124,7 +124,7 @@ public class FailureTest extends SAITester
         verifySSTableIndexes(v2IndexName, 0);
 
         // ...and then verify that, while the node is still operational, the index is not.
-        Assertions.assertThatThrownBy(() -> execute("SELECT * FROM %s WHERE v2 = '1'"))
+        Assertions.assertThatThrownBy(() -> executeInternal("SELECT * FROM %s WHERE v2 = '1'"))
                   .isInstanceOf(IndexNotAvailableException.class);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.index.sai.memory;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.io.compress.BufferType;
 
@@ -29,8 +30,9 @@ import static org.junit.Assert.assertEquals;
 public class TrieMemtableIndexTest extends TrieMemtableIndexTestBase
 {
     @BeforeClass
-    public static void setShardCount()
+    public static void setUpClass()
     {
+        CQLTester.setUpClass();
         System.setProperty("cassandra.trie.memtable.shard.count", "8");
         setup(Config.MemtableAllocationType.offheap_buffers);
         assertEquals(TrieMemtable.BUFFER_TYPE, BufferType.OFF_HEAP);

--- a/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
+++ b/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
@@ -67,7 +67,6 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
-import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.cql3.QueryProcessor.executeOnceInternal;
 import static org.apache.cassandra.nodes.virtual.NodeConstants.LEGACY_PEERS;
 import static org.apache.cassandra.nodes.virtual.NodeConstants.LOCAL;
@@ -163,8 +162,8 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
             removeTruncated(SystemKeyspace.BATCHES);
 
             umappedViews(() -> {
-                assertEquals(1, executeInternal("SELECT * FROM system.local").size());
-                assertTrue(executeInternal("SELECT * FROM system.peers").isEmpty());
+                assertEquals(1, QueryProcessor.executeInternal("SELECT * FROM system.local").size());
+                assertTrue(QueryProcessor.executeInternal("SELECT * FROM system.peers").isEmpty());
             });
 
             LegacySystemKeyspaceToNodes legacySystemKeyspaceToNodes = new LegacySystemKeyspaceToNodes(nodes);
@@ -179,8 +178,8 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
             assertEquals(0, legacySystemKeyspaceToNodes2.peersMigrated);
 
             umappedViews(() -> {
-                assertTrue(executeInternal("SELECT * FROM system.local").isEmpty());
-                assertTrue(executeInternal("SELECT * FROM system.peers").isEmpty());
+                assertTrue(QueryProcessor.executeInternal("SELECT * FROM system.local").isEmpty());
+                assertTrue(QueryProcessor.executeInternal("SELECT * FROM system.peers").isEmpty());
             });
 
             assertEquals(1, Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME)
@@ -247,8 +246,8 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
                 tokens.add(i, persistPeerMetadata(i));
 
             umappedViews(() -> {
-                assertEquals(1, executeInternal("SELECT * FROM system.local").size());
-                assertEquals(peersCount, executeInternal("SELECT * FROM system.peers").size());
+                assertEquals(1, QueryProcessor.executeInternal("SELECT * FROM system.local").size());
+                assertEquals(peersCount, QueryProcessor.executeInternal("SELECT * FROM system.peers").size());
             });
 
             LegacySystemKeyspaceToNodes legacySystemKeyspaceToNodes = new LegacySystemKeyspaceToNodes(nodes);
@@ -257,8 +256,8 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
             assertEquals(1000, legacySystemKeyspaceToNodes.peersMigrated);
 
             umappedViews(() -> {
-                assertTrue(executeInternal("SELECT * FROM system.local").isEmpty());
-                assertTrue(executeInternal("SELECT * FROM system.peers").isEmpty());
+                assertTrue(QueryProcessor.executeInternal("SELECT * FROM system.local").isEmpty());
+                assertTrue(QueryProcessor.executeInternal("SELECT * FROM system.peers").isEmpty());
             });
 
             // a following upgrade must not do anything
@@ -367,7 +366,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
                      ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
         Collection<Token> tokens = makeTokens();
-        umappedViews(() -> executeInternal(format(req, LOCAL),
+        umappedViews(() -> QueryProcessor.executeInternal(format(req, LOCAL),
                                                      LOCAL,
                                                      DatabaseDescriptor.getClusterName(),
                                                      releaseVersion,
@@ -415,7 +414,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
         UUID tableId = tableId(table);
 
         String req = "DELETE truncated_at[?] from system.%s WHERE key = '%s'";
-        umappedViews(() -> executeInternal(format(req, LOCAL, LOCAL), tableId));
+        umappedViews(() -> QueryProcessor.executeInternal(format(req, LOCAL, LOCAL), tableId));
     }
 
     private static UUID tableId(String table)
@@ -435,7 +434,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
         Random r = new Random();
         CommitLogPosition position = new CommitLogPosition(r.nextLong(), r.nextInt(Integer.MAX_VALUE - 1) + 1);
         long truncatedAt = System.currentTimeMillis();
-        umappedViews(() -> executeInternal(format(req, LOCAL, LOCAL), truncationAsMapEntry(cfs, truncatedAt, position)));
+        umappedViews(() -> QueryProcessor.executeInternal(format(req, LOCAL, LOCAL), truncationAsMapEntry(cfs, truncatedAt, position)));
         return new LocalInfo.TruncationRecord(position, truncatedAt);
     }
 


### PR DESCRIPTION
Many if not most of our unit tests extend `CQLTester`. `CQLTester#execute` executes CQL queries with `ReadQuery#executeInternal`, which is what is used for internal system queries, and it's pretty similar to the local execution done by replica nodes. This misses the full validation and all the reconciliation patch used by `ReadQuery#execute`. 

Missing reconciliation is particularly problematic for utests querying secondary indexes, because they miss the application of the full `RowFilter` by the coordinator.

A more realistic behaviour can be achieved by using `CQLTester#executeNet`, which will use a driver session that will exercise the entire path. However, this has to be done manually in every test and it's easy to miss when `executeNet` is necessary. Also, `executeNet` enables more serialization stuff that is costly in terms of resources and not that interesting for most cases.

This PR adds a new `CQLTester#executeDistributed` method that makes the query go through `ReadQuery#execute` rather than `ReadQuery#executeInternal`. 

It also adds a new `CQLTester.enableDistributedExecution` method that changes the default behaviour of `CQLTester#execute`, so we can easily modify the query execution behaviour of entire tests. I haven't been brave enough to update all `CQLTester`-based unit tests, but I have changed all SAI tests to use this new way of running queries. Let's see how many things this breaks in CI.

CC @michaeljmarshall 
