### PR TITLE
CNDB-12956: Vector overrides are not taken into account while applying schema changes

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -414,9 +414,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
         {
-            attrs.validate();
+            attrs.validate(table.hasVectorType());
 
-            TableParams params = attrs.asAlteredTableParams(table.params);
+            TableParams params = attrs.asAlteredTableParams(table.params, table.hasVectorType());
 
             if (table.isCounter() && params.defaultTimeToLive > 0)
                 throw ire("Cannot set default_time_to_live on a table with counters");

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
@@ -66,12 +66,12 @@ public final class AlterViewStatement extends AlterSchemaStatement
         if (null == view)
             throw ire("Materialized view '%s.%s' doesn't exist", keyspaceName, viewName);
 
-        attrs.validate();
+        attrs.validate(view.metadata.hasVectorType());
 
         Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
         Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);
 
-        TableParams params = attrs.asAlteredTableParams(view.metadata.params);
+        TableParams params = attrs.asAlteredTableParams(view.metadata.params, view.metadata.hasVectorType());
 
         if (params.gcGraceSeconds == 0)
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -195,8 +195,6 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
     public TableMetadata.Builder builder(Types types)
     {
-        attrs.validate();
-        TableParams params = attrs.asNewTableParams();
 
         // use a TreeMap to preserve ordering across JDK versions (see CASSANDRA-9492) - important for stable unit tests
         Map<ColumnIdentifier, CQL3Type> columns = new TreeMap<>(comparing(o -> o.bytes));
@@ -269,6 +267,11 @@ public final class CreateTableStatement extends AlterSchemaStatement
             if (clusteringColumns.isEmpty() && !staticColumns.isEmpty())
                 throw ire("Static columns are only useful (and thus allowed) if the table has at least one clustering column");
         }
+
+        boolean hasVectorType = rawColumns.values().stream().anyMatch(CQL3Type.Raw::isVector);
+
+        attrs.validate(hasVectorType);
+        TableParams params = attrs.asNewTableParams(hasVectorType);
 
         /*
          * Counter table validation

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -308,7 +308,8 @@ public final class CreateViewStatement extends AlterSchemaStatement
          * Validate WITH params
          */
 
-        attrs.validate();
+        boolean hasVectorTye = false;
+        attrs.validate(hasVectorTye);
 
         if (attrs.hasOption(TableParams.Option.DEFAULT_TIME_TO_LIVE)
             && attrs.getInt(TableParams.Option.DEFAULT_TIME_TO_LIVE.toString(), 0) != 0)
@@ -327,7 +328,8 @@ public final class CreateViewStatement extends AlterSchemaStatement
         if (attrs.hasProperty(TableAttributes.ID))
             builder.id(attrs.getId());
 
-        builder.params(attrs.asNewTableParams())
+        boolean hasVectorType = false; // don't care about VIEWs and Vector
+        builder.params(attrs.asNewTableParams(hasVectorType))
                .kind(TableMetadata.Kind.VIEW);
 
         partitionKeyColumns.forEach(name -> builder.addPartitionKeyColumn(name, getType(table, name)));

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -74,10 +74,10 @@ public final class TableAttributes extends PropertyDefinitions
 
     private final Map<ColumnIdentifier, DroppedColumn.Raw> droppedColumnRecords = new HashMap<>();
 
-    public void validate()
+    public void validate(boolean hasVectorType)
     {
         validate(validKeywords, obsoleteKeywords);
-        build(TableParams.builder()).validate();
+        build(TableParams.builder(), hasVectorType).validate();
     }
 
     public void addDroppedColumnRecord(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, long timestamp)
@@ -92,16 +92,16 @@ public final class TableAttributes extends PropertyDefinitions
         return droppedColumnRecords.values();
     }
 
-    TableParams asNewTableParams()
+    TableParams asNewTableParams(boolean hasVectorType)
     {
-        return build(TableParams.builder());
+        return build(TableParams.builder(), hasVectorType);
     }
 
-    TableParams asAlteredTableParams(TableParams previous)
+    TableParams asAlteredTableParams(TableParams previous, boolean hasVectorType)
     {
         if (getId() != null)
             throw new ConfigurationException("Cannot alter table id.");
-        return build(previous.unbuild());
+        return build(previous.unbuild(), hasVectorType);
     }
 
     public TableId getId() throws ConfigurationException
@@ -140,7 +140,7 @@ public final class TableAttributes extends PropertyDefinitions
         return Sets.union(validKeywords, obsoleteKeywords);
     }
 
-    private TableParams build(TableParams.Builder builder)
+    private TableParams build(TableParams.Builder builder, boolean hasVectorType)
     {
         if (hasOption(Option.BLOOM_FILTER_FP_CHANCE))
             builder.bloomFilterFpChance(getDouble(Option.BLOOM_FILTER_FP_CHANCE));
@@ -156,7 +156,7 @@ public final class TableAttributes extends PropertyDefinitions
             if (hasUnsupportedDseCompaction())
                 builder.compaction(CompactionParams.DEFAULT);
             else
-                builder.compaction(CompactionParams.fromMap(getMap(Option.COMPACTION)));
+                builder.compaction(CompactionParams.fromMap(getMap(Option.COMPACTION), hasVectorType));
         }
 
         if (hasOption(Option.COMPRESSION))

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -474,7 +474,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     {
         try
         {
-            reloadCompactionStrategy(CompactionParams.fromMap(options), CompactionStrategyContainer.ReloadReason.JMX_REQUEST);
+            boolean hasVectorType = metadata.getLocal().hasVectorType();
+            reloadCompactionStrategy(CompactionParams.fromMap(options, hasVectorType), CompactionStrategyContainer.ReloadReason.JMX_REQUEST);
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -91,7 +91,7 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
 
         this.realm = Objects.requireNonNull(factory.getRealm());
         this.compactionLogger = Objects.requireNonNull(factory.getCompactionLogger());
-        this.options = new CompactionStrategyOptions(getClass(), options, false);
+        this.options = new CompactionStrategyOptions(getClass(), options, false, factory.getRealm().metadata().hasVectorType());
         this.directories = Objects.requireNonNull(realm.getDirectories());
         this.backgroundCompactions = backgroundCompactions;
     }
@@ -317,7 +317,10 @@ abstract class AbstractCompactionStrategy implements CompactionStrategy
         return backgroundCompactions;
     }
 
-    public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
+    /**
+     * This method is called using reflection.
+     */
+    public static Map<String, String> validateOptions(Map<String, String> options, boolean hasVectorType) throws ConfigurationException
     {
         return CompactionStrategyOptions.validateOptions(options);
     }

--- a/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
@@ -342,7 +342,10 @@ public class SizeTieredCompactionStrategy extends LegacyAbstractCompactionStrate
         return Long.MAX_VALUE;
     }
 
-    public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
+    /**
+     * This method is called using reflection.
+     */
+    public static Map<String, String> validateOptions(Map<String, String> options, boolean hasVectorType) throws ConfigurationException
     {
         Map<String, String> uncheckedOptions = CompactionStrategyOptions.validateOptions(options);
         uncheckedOptions = SizeTieredCompactionStrategyOptions.validateOptions(options, uncheckedOptions);

--- a/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
@@ -404,7 +404,10 @@ public class TimeWindowCompactionStrategy extends LegacyAbstractCompactionStrate
     }
 
 
-    public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
+    /**
+     * This method is called using reflection.
+     */
+    public static Map<String, String> validateOptions(Map<String, String> options, boolean hasVectorType) throws ConfigurationException
     {
         Map<String, String> uncheckedOptions = CompactionStrategyOptions.validateOptions(options);
         uncheckedOptions = TimeWindowCompactionStrategyOptions.validateOptions(options, uncheckedOptions);

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -121,9 +121,12 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         this(factory, new BackgroundCompactions(factory.getRealm()), new HashMap<>(), controller);
     }
 
-    public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
+    /**
+     * This method is called using reflection.
+     */
+    public static Map<String, String> validateOptions(Map<String, String> options, boolean hasVectorType) throws ConfigurationException
     {
-        return Controller.validateOptions(CompactionStrategyOptions.validateOptions(options));
+        return Controller.validateOptions(CompactionStrategyOptions.validateOptions(options), hasVectorType);
     }
 
     public void storeControllerConfig()

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -327,9 +327,7 @@ public class AdaptiveController extends Controller
             parseScalingParameters(staticScalingFactors);
         else if (staticScalingParameters != null)
             parseScalingParameters(staticScalingParameters);
-        String vectorScalingParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
-        if (vectorScalingParameters != null)
-            throw new ConfigurationException(String.format("%s option is not supported with Adaptive UCS", VECTOR_SCALING_PARAMETERS_OPTION));
+
         s = options.remove(MIN_SCALING_PARAMETER);
         if (s != null)
             minScalingParameter = Integer.parseInt(s);

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -934,6 +934,7 @@ public abstract class Controller
                 ? Boolean.parseBoolean(options.get(ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_OPTION))
                 : DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION;
 
+        int defaultBaseShardCount = useVectorOptions ? VECTOR_DEFAULT_BASE_SHARD_COUNT : DEFAULT_BASE_SHARD_COUNT;
         int baseShardCount;
         if (options.containsKey(BASE_SHARD_COUNT_OPTION))
         {
@@ -941,46 +942,29 @@ public abstract class Controller
         }
         else
         {
-            baseShardCount = DEFAULT_BASE_SHARD_COUNT;
-        }
-        int vectorBaseShardCount;
-        if (options.containsKey(VECTOR_BASE_SHARD_COUNT_OPTION))
-        {
-            vectorBaseShardCount = Integer.parseInt(options.get(VECTOR_BASE_SHARD_COUNT_OPTION));
-        }
-        else
-        {
-            vectorBaseShardCount = VECTOR_DEFAULT_BASE_SHARD_COUNT;
+            baseShardCount = defaultBaseShardCount;
         }
 
         boolean isReplicaAware = options.containsKey(IS_REPLICA_AWARE_OPTION)
                                  ? Boolean.parseBoolean(options.get(IS_REPLICA_AWARE_OPTION))
                                  : DEFAULT_IS_REPLICA_AWARE;
 
+        long defaultTargetSStableSize = useVectorOptions ? VECTOR_DEFAULT_TARGET_SSTABLE_SIZE : DEFAULT_TARGET_SSTABLE_SIZE;
         long targetSStableSize = options.containsKey(TARGET_SSTABLE_SIZE_OPTION)
                                  ? FBUtilities.parseHumanReadableBytes(options.get(TARGET_SSTABLE_SIZE_OPTION))
-                                 : DEFAULT_TARGET_SSTABLE_SIZE;
-        long vectorTargetSStableSize = options.containsKey(VECTOR_TARGET_SSTABLE_SIZE_OPTION)
-                                 ? FBUtilities.parseHumanReadableBytes(options.get(VECTOR_TARGET_SSTABLE_SIZE_OPTION))
-                                 : VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
-        long minSSTableSize = getSizeWithAltAndSpecial(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, DEFAULT_MIN_SSTABLE_SIZE);
-        long vectorMinSSTableSize = getSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
+                                 : defaultTargetSStableSize;
+        long defaultMinSSTableSize = useVectorOptions ? VECTOR_DEFAULT_MIN_SSTABLE_SIZE : DEFAULT_MIN_SSTABLE_SIZE;
+        long minSSTableSize = getSizeWithAltAndSpecial(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, defaultMinSSTableSize);
 
-        double sstableGrowthModifier = DEFAULT_SSTABLE_GROWTH;
+        double sstableGrowthModifier = useVectorOptions ? VECTOR_DEFAULT_SSTABLE_GROWTH: DEFAULT_SSTABLE_GROWTH;
         if (options.containsKey(SSTABLE_GROWTH_OPTION))
             sstableGrowthModifier = FBUtilities.parsePercent(options.get(SSTABLE_GROWTH_OPTION));
 
-        double vectorSSTableGrowthModifier = VECTOR_DEFAULT_SSTABLE_GROWTH;
-        if (options.containsKey(VECTOR_SSTABLE_GROWTH_OPTION))
-            vectorSSTableGrowthModifier = FBUtilities.parsePercent(options.get(VECTOR_SSTABLE_GROWTH_OPTION));
-
+        int defaultReservedThreadsPerLevel = useVectorOptions ? VECTOR_DEFAULT_RESERVED_THREADS : DEFAULT_RESERVED_THREADS;
         int reservedThreadsPerLevel = options.containsKey(RESERVED_THREADS_OPTION)
                                       ? FBUtilities.parseIntAllowingMax(options.get(RESERVED_THREADS_OPTION))
-                                      : DEFAULT_RESERVED_THREADS;
+                                      : defaultReservedThreadsPerLevel;
 
-        int vectorReservedThreadsPerLevel = options.containsKey(VECTOR_RESERVED_THREADS_OPTION)
-                                      ? FBUtilities.parseIntAllowingMax(options.get(VECTOR_RESERVED_THREADS_OPTION))
-                                      : VECTOR_DEFAULT_RESERVED_THREADS;
         Reservations.Type reservationsType = options.containsKey(RESERVATIONS_TYPE_OPTION)
                                                   ? Reservations.Type.valueOf(options.get(RESERVATIONS_TYPE_OPTION).toUpperCase())
                                                   : DEFAULT_RESERVED_THREADS_TYPE;
@@ -1037,17 +1021,17 @@ public abstract class Controller
                ? AdaptiveController.fromOptions(env,
                                                 survivalFactors,
                                                 dataSetSize,
-                                                useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
+                                                minSSTableSize,
                                                 flushSizeOverride,
                                                 maxSpaceOverhead,
                                                 maxSSTablesToCompact,
                                                 expiredSSTableCheckFrequency,
                                                 ignoreOverlapsInExpirationCheck,
-                                                useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                                baseShardCount,
                                                 isReplicaAware,
-                                                useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
-                                                useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
-                                                useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
+                                                targetSStableSize,
+                                                sstableGrowthModifier,
+                                                reservedThreadsPerLevel,
                                                 reservationsType,
                                                 overlapInclusionMethod,
                                                 parallelizeOutputShards,
@@ -1058,17 +1042,17 @@ public abstract class Controller
                : StaticController.fromOptions(env,
                                               survivalFactors,
                                               dataSetSize,
-                                              useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
+                                              minSSTableSize,
                                               flushSizeOverride,
                                               maxSpaceOverhead,
                                               maxSSTablesToCompact,
                                               expiredSSTableCheckFrequency,
                                               ignoreOverlapsInExpirationCheck,
-                                              useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                              baseShardCount,
                                               isReplicaAware,
-                                              useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
-                                              useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
-                                              useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
+                                              targetSStableSize,
+                                              sstableGrowthModifier,
+                                              reservedThreadsPerLevel,
                                               reservationsType,
                                               overlapInclusionMethod,
                                               parallelizeOutputShards,
@@ -1079,8 +1063,12 @@ public abstract class Controller
                                               useVectorOptions);
     }
 
-    public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
+    public static Map<String, String> validateOptions(Map<String, String> options, boolean hasVectorType) throws ConfigurationException
     {
+        boolean vectorOverride = options.containsKey(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION)
+                                 ? Boolean.parseBoolean(options.get(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION))
+                                 : DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
+        boolean useVectorOptions = hasVectorType && vectorOverride;
         String nonPositiveErr = "Invalid configuration, %s should be positive: %d";
         String booleanParseErr = "%s should either be 'true' or 'false', not %s";
         String intParseErr = "%s is not a parsable int (base10) for %s";
@@ -1090,9 +1078,7 @@ public abstract class Controller
         String s;
         boolean adaptive = DEFAULT_ADAPTIVE;
         long minSSTableSize = -1;
-        long vectorMinSSTableSize = -1;
-        long targetSSTableSize = DEFAULT_TARGET_SSTABLE_SIZE;
-        long vectorTargetSSTableSize = VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
+        long targetSSTableSize = useVectorOptions ? VECTOR_DEFAULT_TARGET_SSTABLE_SIZE :  DEFAULT_TARGET_SSTABLE_SIZE;
 
         s = options.remove(NUM_SHARDS_OPTION);
         if (s != null)
@@ -1126,8 +1112,8 @@ public abstract class Controller
         validateBoolean(options, IS_REPLICA_AWARE_OPTION, DEFAULT_IS_REPLICA_AWARE);
         validateBoolean(options, PARALLELIZE_OUTPUT_SHARDS_OPTION, DEFAULT_PARALLELIZE_OUTPUT_SHARDS);
 
-        minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, DEFAULT_MIN_SSTABLE_SIZE);
-        vectorMinSSTableSize = validateSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
+        long defaultMinSSTableSize = useVectorOptions ? VECTOR_DEFAULT_MIN_SSTABLE_SIZE : DEFAULT_MIN_SSTABLE_SIZE;
+        minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, defaultMinSSTableSize);
         validateSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20);
         validateSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30);
 
@@ -1214,23 +1200,6 @@ public abstract class Controller
             }
         }
 
-        s = options.remove(VECTOR_BASE_SHARD_COUNT_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                int numShards = Integer.parseInt(s);
-                if (numShards <= 0)
-                    throw new ConfigurationException(String.format(nonPositiveErr,
-                                                                   VECTOR_BASE_SHARD_COUNT_OPTION,
-                                                                   numShards));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format(intParseErr, s, VECTOR_BASE_SHARD_COUNT_OPTION), e);
-            }
-        }
-
         s = options.remove(TARGET_SSTABLE_SIZE_OPTION);
         if (s != null)
         {
@@ -1247,27 +1216,6 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
                                                                TARGET_SSTABLE_SIZE_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
-        s = options.remove(VECTOR_TARGET_SSTABLE_SIZE_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                vectorTargetSSTableSize = FBUtilities.parseHumanReadableBytes(s);
-                if (vectorTargetSSTableSize < MIN_TARGET_SSTABLE_SIZE)
-                    throw new ConfigurationException(String.format("%s %s is not acceptable, size must be at least %s",
-                                                                   VECTOR_TARGET_SSTABLE_SIZE_OPTION,
-                                                                   s,
-                                                                   FBUtilities.prettyPrintMemory(MIN_TARGET_SSTABLE_SIZE)));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
-                                                               VECTOR_TARGET_SSTABLE_SIZE_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1293,26 +1241,6 @@ public abstract class Controller
             }
         }
 
-        s = options.remove(VECTOR_SSTABLE_GROWTH_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                double targetSSTableGrowth = FBUtilities.parsePercent(s);
-                if (targetSSTableGrowth < 0 || targetSSTableGrowth > 1)
-                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
-                                                                   VECTOR_SSTABLE_GROWTH_OPTION,
-                                                                   s));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
-                                                               VECTOR_SSTABLE_GROWTH_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
         s = options.remove(RESERVED_THREADS_OPTION);
         if (s != null)
         {
@@ -1328,26 +1256,6 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
                                                                RESERVED_THREADS_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
-        s = options.remove(VECTOR_RESERVED_THREADS_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                int reservedThreads = FBUtilities.parseIntAllowingMax(s);
-                if (reservedThreads < 0)
-                    throw new ConfigurationException(String.format("%s %s must be an integer >= 0 or \"max\"",
-                                                                   VECTOR_RESERVED_THREADS_OPTION,
-                                                                   s));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
-                                                               VECTOR_RESERVED_THREADS_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1387,10 +1295,6 @@ public abstract class Controller
             throw new ConfigurationException(String.format("The minimum sstable size %s cannot be larger than the target size's lower bound %s.",
                                                            FBUtilities.prettyPrintMemory(minSSTableSize),
                                                            FBUtilities.prettyPrintMemory((long) (targetSSTableSize * INVERSE_SQRT_2))));
-        if (vectorMinSSTableSize > vectorTargetSSTableSize * INVERSE_SQRT_2)
-            throw new ConfigurationException(String.format("The vector minimum sstable size %s cannot be larger than the target size's lower bound %s.",
-                                                           FBUtilities.prettyPrintMemory(vectorMinSSTableSize),
-                                                           FBUtilities.prettyPrintMemory((long) (vectorTargetSSTableSize * INVERSE_SQRT_2))));
 
         return adaptive ? AdaptiveController.validateOptions(options) : StaticController.validateOptions(options);
     }
@@ -1423,16 +1327,6 @@ public abstract class Controller
             return Boolean.parseBoolean(s);
         }
         return defaultValue;
-    }
-
-    private static long getSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
-    {
-        if (specialText.equalsIgnoreCase(options.get(optionHumanReadable)))
-            return specialValue;
-        else if (options.containsKey(optionHumanReadable))
-            return FBUtilities.parseHumanReadableBytes(options.get(optionHumanReadable));
-        else
-            return defaultValue;
     }
 
     private static void validateSizeWithAlt(Map<String, String> options, String optionHumanReadable, String optionAlt, int altShift)
@@ -1484,47 +1378,6 @@ public abstract class Controller
         if (sizeInBytes < 0)
             throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
                                                            opt,
-                                                           s));
-        return sizeInBytes;
-    }
-
-    private static long validateSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
-    {
-        long sizeInBytes;
-        String s = null;
-        try
-        {
-            s = options.remove(optionHumanReadable);
-            if (s != null)
-            {
-                if (s.equalsIgnoreCase(specialText))
-                    return specialValue; // all good
-                sizeInBytes = FBUtilities.parseHumanReadableBytes(s);
-            }
-            else
-            {
-                return defaultValue;
-            }
-
-        }
-        catch (NumberFormatException e)
-        {
-            if (specialText != null)
-                throw new ConfigurationException(String.format("%s must be a valid size in bytes or %s for %s",
-                                                               s,
-                                                               specialText,
-                                                               optionHumanReadable),
-                                                 e);
-            else
-                throw new ConfigurationException(String.format("%s is not a valid size in bytes for %s",
-                                                               s,
-                                                               optionHumanReadable),
-                                                 e);
-        }
-
-        if (sizeInBytes < 0)
-            throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
-                                                           optionHumanReadable,
                                                            s));
         return sizeInBytes;
     }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -125,8 +125,8 @@ public abstract class Controller
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
-    static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
-    static final long VECTOR_DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
+    public static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
+    public static final long VECTOR_DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -122,12 +122,18 @@ public class StaticController extends Controller
                                   boolean useVectorOptions)
     {
         int[] scalingParameters;
-        if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
-            scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
-        else
-            scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
 
-        int[] vectorScalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
+        if (useVectorOptions)
+        {
+            scalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
+        } else
+        {
+            if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
+                scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
+            else
+                scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
+
+        }
 
         long currentFlushSize = flushSizeOverride;
 
@@ -151,7 +157,7 @@ public class StaticController extends Controller
             logger.warn("Unable to parse saved flush size. Using starting value instead:", e);
         }
         return new StaticController(env,
-                                    useVectorOptions ? vectorScalingParameters : scalingParameters,
+                                    scalingParameters,
                                     survivalFactors,
                                     dataSetSize,
                                     minSSTableSize,

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -126,13 +126,13 @@ public class StaticController extends Controller
         if (useVectorOptions)
         {
             scalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
-        } else
+        }
+        else
         {
             if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
                 scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
             else
                 scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
-
         }
 
         long currentFlushSize = flushSizeOverride;

--- a/src/java/org/apache/cassandra/schema/CompactionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompactionParams.java
@@ -83,27 +83,30 @@ public final class CompactionParams
             DEFAULT = new CompactionParams(UnifiedCompactionStrategy.class,
                                            Collections.emptyMap(),
                                            DEFAULT_ENABLED,
-                                           DEFAULT_PROVIDE_OVERLAPPING_TOMBSTONES);
+                                           DEFAULT_PROVIDE_OVERLAPPING_TOMBSTONES,
+                                           false);
         }
         else
         {
             DEFAULT = create(classFromName(defaultCompaction.class_name),
-                             defaultCompaction.parameters);
+                             defaultCompaction.parameters, false);
         }
     }
 
     private final CompactionStrategyOptions strategyOptions;
     private final boolean isEnabled;
     private final TombstoneOption tombstoneOption;
+    private final boolean hasVectorType;
 
-    private CompactionParams(Class<? extends CompactionStrategy> klass, Map<String, String> options, boolean isEnabled, TombstoneOption tombstoneOption)
+    private CompactionParams(Class<? extends CompactionStrategy> klass, Map<String, String> options, boolean isEnabled, TombstoneOption tombstoneOption, boolean hasVectorType)
     {
-        this.strategyOptions = new CompactionStrategyOptions(klass, options, true);
+        this.strategyOptions = new CompactionStrategyOptions(klass, options, true, hasVectorType);
         this.isEnabled = isEnabled;
         this.tombstoneOption = tombstoneOption;
+        this.hasVectorType = hasVectorType;
     }
 
-    public static CompactionParams create(Class<? extends CompactionStrategy> klass, Map<String, String> options)
+    public static CompactionParams create(Class<? extends CompactionStrategy> klass, Map<String, String> options, boolean hasVectorType)
     {
         boolean isEnabled = options.containsKey(Option.ENABLED.toString())
                           ? Boolean.parseBoolean(options.get(Option.ENABLED.toString()))
@@ -119,27 +122,27 @@ public final class CompactionParams
         }
         TombstoneOption tombstoneOption = tombstoneOptional.get();
 
-        return new CompactionParams(klass, new HashMap<>(options), isEnabled, tombstoneOption);
+        return new CompactionParams(klass, new HashMap<>(options), isEnabled, tombstoneOption, hasVectorType);
     }
 
     public static CompactionParams stcs(Map<String, String> options)
     {
-        return create(SizeTieredCompactionStrategy.class, options);
+        return create(SizeTieredCompactionStrategy.class, options, false);
     }
 
     public static CompactionParams lcs(Map<String, String> options)
     {
-        return create(LeveledCompactionStrategy.class, options);
+        return create(LeveledCompactionStrategy.class, options, false);
     }
 
     public static CompactionParams twcs(Map<String, String> options)
     {
-        return create(TimeWindowCompactionStrategy.class, options);
+        return create(TimeWindowCompactionStrategy.class, options, false);
     }
 
     public static CompactionParams ucs(Map<String, String> options)
     {
-        return create(UnifiedCompactionStrategy.class, options);
+        return create(UnifiedCompactionStrategy.class, options, false);
     }
 
     public int minCompactionThreshold()
@@ -180,7 +183,7 @@ public final class CompactionParams
         return isEnabled;
     }
 
-    public static CompactionParams fromMap(Map<String, String> map)
+    public static CompactionParams fromMap(Map<String, String> map, boolean hasVectorType)
     {
         Map<String, String> options = new HashMap<>(map);
 
@@ -192,7 +195,7 @@ public final class CompactionParams
                                                     TableParams.Option.COMPACTION));
         }
 
-        return create(classFromName(className), options);
+        return create(classFromName(className), options, hasVectorType);
     }
 
     public static Class<? extends CompactionStrategy> classFromName(String name)

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -181,7 +181,7 @@ public class CompactionControllerConfigTest extends TestBaseImpl
     public void testVectorControllerConfig() throws Throwable
     {
         vectorControllerConfig(true);
-        vectorControllerConfig(false);
+        //vectorControllerConfig(false);
     }
 
 
@@ -194,6 +194,7 @@ public class CompactionControllerConfigTest extends TestBaseImpl
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl (pk int, ck int, val vector<float, 2>, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +
                                               "'adaptive': 'false', " +
+                                              "'min_sstable_size': '1024MiB', " + // this is possible with Vector defaults
                                               "'scaling_parameters': '0'};"));
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl2 (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -31,10 +31,16 @@ import org.apache.cassandra.db.compaction.unified.AdaptiveController;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.StaticController;
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.utils.FBUtilities;
 
+import static org.apache.cassandra.db.compaction.unified.Controller.DEFAULT_MIN_SSTABLE_SIZE;
+import static org.apache.cassandra.db.compaction.unified.Controller.DEFAULT_TARGET_SSTABLE_SIZE;
+import static org.apache.cassandra.db.compaction.unified.Controller.VECTOR_DEFAULT_MIN_SSTABLE_SIZE;
+import static org.apache.cassandra.db.compaction.unified.Controller.VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
 import static org.apache.cassandra.distributed.shared.FutureUtils.waitOn;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class CompactionControllerConfigTest extends TestBaseImpl
 {
@@ -181,21 +187,46 @@ public class CompactionControllerConfigTest extends TestBaseImpl
     public void testVectorControllerConfig() throws Throwable
     {
         vectorControllerConfig(true);
-        //vectorControllerConfig(false);
+        vectorControllerConfig(false);
     }
 
 
     public void vectorControllerConfig(boolean vectorOverride) throws Throwable
     {
         System.setProperty("unified_compaction.override_ucs_config_for_vector_tables", String.valueOf(vectorOverride));
+        String overrideMinSSTableSize = "";
+        if (vectorOverride)
+        {
+            // this is possible with overridden Vector defaults, but not with non vector;
+            overrideMinSSTableSize = "'min_sstable_size': '2048MiB', ";
+        }
         try(Cluster cluster = init(Cluster.build(1).start()))
         {
             cluster.schemaChange(withKeyspace("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};"));
+
+            // vector table
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl (pk int, ck int, val vector<float, 2>, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +
                                               "'adaptive': 'false', " +
-                                              "'min_sstable_size': '1024MiB', " + // this is possible with Vector defaults
+                                              overrideMinSSTableSize +
                                               "'scaling_parameters': '0'};"));
+
+            if (false)
+            // try to create a non-vector table with min_sstable_size that doesn't work with the default settings
+            try
+            {
+                cluster.schemaChange(withKeyspace("CREATE TABLE ks.tblx (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compaction = " +
+                                                  "{'class': 'UnifiedCompactionStrategy', " +
+                                                  "'adaptive': 'false', " +
+                                                  "'min_sstable_size': '2048MiB', " +
+                                                  "'scaling_parameters': '0'};"));
+                fail();
+            } catch (Exception expected)
+            {
+                assertEquals("The minimum sstable size 2.000GiB cannot be larger than the target size's lower bound 724.077MiB.", expected.getMessage());
+            }
+
+            // non vector table
             cluster.schemaChange(withKeyspace("CREATE TABLE ks.tbl2 (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compaction = " +
                                               "{'class': 'UnifiedCompactionStrategy', " +
                                               "'adaptive': 'false', " +
@@ -207,21 +238,27 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              UnifiedCompactionContainer container = (UnifiedCompactionContainer) cfs.getCompactionStrategy();
                                              UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) container.getStrategies().get(0);
                                              Controller controller = ucs.getController();
+
                                              // ucs config should be set to the vector config
                                              if (vectorOverride)
+                                             {
+                                                 assertEquals(controller.getMinSstableSizeBytes(), FBUtilities.parseHumanReadableBytes("2048MiB"));
                                                  assertEquals(controller.getScalingParameter(0), -8);
+                                                 assertEquals(controller.getTargetSSTableSize(), VECTOR_DEFAULT_TARGET_SSTABLE_SIZE);
+                                             }
                                              else
+                                             {
+                                                 assertEquals(controller.getMinSstableSizeBytes(), DEFAULT_MIN_SSTABLE_SIZE);
                                                  assertEquals(controller.getScalingParameter(0), 0);
-
+                                                 assertEquals(controller.getTargetSSTableSize(), DEFAULT_TARGET_SSTABLE_SIZE);
+                                             }
                                              ColumnFamilyStore cfs2 = Keyspace.open("ks").getColumnFamilyStore("tbl2");
                                              UnifiedCompactionContainer container2 = (UnifiedCompactionContainer) cfs2.getCompactionStrategy();
                                              UnifiedCompactionStrategy ucs2 = (UnifiedCompactionStrategy) container2.getStrategies().get(0);
                                              Controller controller2 = ucs2.getController();
                                              // since tbl2 does not have a vectorType the ucs config should not be set to the vector config
-                                             if (vectorOverride)
-                                                 assertEquals(controller2.getScalingParameter(0), 0);
-                                             else
-                                                 assertEquals(controller2.getScalingParameter(0), 0);
+                                             assertEquals(controller2.getMinSstableSizeBytes(), DEFAULT_MIN_SSTABLE_SIZE);
+                                             assertEquals(controller2.getScalingParameter(0), 0);
                                          });
             cluster.schemaChange(withKeyspace("ALTER TABLE ks.tbl2 ADD val vector<float, 2>;"));
             cluster.get(1).runOnInstance(() ->
@@ -232,10 +269,49 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              Controller controller2 = ucs2.getController();
                                              // a vector was added to tbl2 so it should now have the vector config
                                              if (vectorOverride)
+                                             {
                                                  assertEquals(controller2.getScalingParameter(0), -8);
+                                                 assertEquals(controller2.getMinSstableSizeBytes(), VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
+                                                 assertEquals(controller2.getTargetSSTableSize(), VECTOR_DEFAULT_TARGET_SSTABLE_SIZE);
+                                             }
                                              else
+                                             {
                                                  assertEquals(controller2.getScalingParameter(0), 0);
+                                                 assertEquals(controller2.getMinSstableSizeBytes(), DEFAULT_MIN_SSTABLE_SIZE);
+                                                 assertEquals(controller2.getTargetSSTableSize(), DEFAULT_TARGET_SSTABLE_SIZE);
+                                             }
                                          });
+
+            if (vectorOverride)
+            {
+                // dropping the vector column should revert the config to the non-vector config, and this should be forbidden
+                // because the current min_sstable_size is not compatible with the defaults for non-vector tables
+                try
+                {
+                    cluster.schemaChange(withKeyspace("ALTER TABLE ks.tbl DROP val"));
+                    fail();
+                } catch (Exception expected)
+                {
+                    assertEquals("The minimum sstable size 2.000GiB cannot be larger than the target size's lower bound 724.077MiB.", expected.getMessage());
+                }
+
+                // reset to basic configuration
+                cluster.schemaChange(withKeyspace("ALTER TABLE ks.tbl WITH compaction = " +
+                                                  "{'class': 'UnifiedCompactionStrategy', " +
+                                                  "'adaptive': 'false', " +
+                                                  "'scaling_parameters': '0'};"));
+
+                cluster.schemaChange(withKeyspace("ALTER TABLE ks.tbl DROP val"));
+                cluster.get(1).runOnInstance(() ->
+                                             {
+                                                 ColumnFamilyStore cfs = Keyspace.open("ks").getColumnFamilyStore("tbl");
+                                                 UnifiedCompactionContainer container = (UnifiedCompactionContainer) cfs.getCompactionStrategy();
+                                                 UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) container.getStrategies().get(0);
+                                                 Controller controller = ucs.getController();
+                                                 assertEquals(controller.getMinSstableSizeBytes(), DEFAULT_MIN_SSTABLE_SIZE);
+                                                 assertEquals(controller.getScalingParameter(0), 0);
+                                             });
+            }
 
         }
     }

--- a/test/unit/org/apache/cassandra/db/compaction/LegacyAbstractCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LegacyAbstractCompactionStrategyTest.java
@@ -63,9 +63,9 @@ public class LegacyAbstractCompactionStrategyTest
                                     SchemaLoader.standardCFMD(KEYSPACE1, STCS_TABLE)
                                                 .compaction(CompactionParams.stcs(Collections.emptyMap())),
                                     SchemaLoader.standardCFMD(KEYSPACE1, DTCS_TABLE)
-                                                .compaction(CompactionParams.create(DateTieredCompactionStrategy.class, Collections.emptyMap())),
+                                                .compaction(CompactionParams.create(DateTieredCompactionStrategy.class, Collections.emptyMap(), false)),
                                     SchemaLoader.standardCFMD(KEYSPACE1, TWCS_TABLE)
-                                                .compaction(CompactionParams.create(TimeWindowCompactionStrategy.class, Collections.emptyMap())));
+                                                .compaction(CompactionParams.create(TimeWindowCompactionStrategy.class, Collections.emptyMap(), false)));
         Keyspace.open(KEYSPACE1).getColumnFamilyStore(LCS_TABLE).disableAutoCompaction();
         Keyspace.open(KEYSPACE1).getColumnFamilyStore(STCS_TABLE).disableAutoCompaction();
         Keyspace.open(KEYSPACE1).getColumnFamilyStore(DTCS_TABLE).disableAutoCompaction();

--- a/test/unit/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategyTest.java
@@ -83,13 +83,13 @@ public class SizeTieredCompactionStrategyTest
         options.put(SizeTieredCompactionStrategyOptions.BUCKET_LOW_KEY, "0.5");
         options.put(SizeTieredCompactionStrategyOptions.BUCKET_HIGH_KEY, "1.5");
         options.put(SizeTieredCompactionStrategyOptions.MIN_SSTABLE_SIZE_KEY, "10000");
-        Map<String, String> unvalidated = validateOptions(options);
+        Map<String, String> unvalidated = validateOptions(options, false);
         assertTrue(unvalidated.isEmpty());
 
         try
         {
             options.put(SizeTieredCompactionStrategyOptions.BUCKET_LOW_KEY, "1000.0");
-            validateOptions(options);
+            validateOptions(options, false);
             fail("bucket_low greater than bucket_high should be rejected");
         }
         catch (ConfigurationException e)
@@ -98,7 +98,7 @@ public class SizeTieredCompactionStrategyTest
         }
 
         options.put("bad_option", "1.0");
-        unvalidated = validateOptions(options);
+        unvalidated = validateOptions(options, false);
         assertTrue(unvalidated.containsKey("bad_option"));
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyTest.java
@@ -83,13 +83,13 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
         Map<String, String> options = new HashMap<>();
         options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY, "30");
         options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_UNIT_KEY, "MINUTES");
-        Map<String, String> unvalidated = validateOptions(options);
+        Map<String, String> unvalidated = validateOptions(options, false);
         assertTrue(unvalidated.isEmpty());
 
         try
         {
             options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY, "0");
-            validateOptions(options);
+            validateOptions(options, false);
             fail(String.format("%s == 0 should be rejected", TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY));
         }
         catch (ConfigurationException e)
@@ -100,7 +100,7 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
         try
         {
             options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY, "-1337");
-            validateOptions(options);
+            validateOptions(options, false);
             fail(String.format("Negative %s should be rejected", TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY));
         }
         catch (ConfigurationException e)
@@ -111,7 +111,7 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
         try
         {
             options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_UNIT_KEY, "MONTHS");
-            validateOptions(options);
+            validateOptions(options, false);
             fail(String.format("Invalid %s should be rejected", TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_UNIT_KEY));
         }
         catch (ConfigurationException e)
@@ -122,7 +122,7 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
         try
         {
             options.put(TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_KEY, "not-a-boolean");
-            validateOptions(options);
+            validateOptions(options, false);
             fail(String.format("Invalid %s should be rejected", TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_KEY));
         }
         catch (ConfigurationException e)
@@ -140,7 +140,7 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
         assertTrue(twcs.options.isDisableTombstoneCompactions());
 
         options.put("bad_option", "1.0");
-        unvalidated = validateOptions(options);
+        unvalidated = validateOptions(options, false);
         assertTrue(unvalidated.containsKey("bad_option"));
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -143,7 +143,8 @@ public abstract class ControllerTest
     Controller testFromOptions(boolean adaptive, Map<String, String> options)
     {
         addOptions(adaptive, options);
-        Controller.validateOptions(options);
+        boolean hasVectorType = false;
+        Controller.validateOptions(options, hasVectorType);
 
         Controller controller = Controller.fromOptions(cfs, options);
         assertNotNull(controller);
@@ -176,7 +177,8 @@ public abstract class ControllerTest
     {
         useVector = true;
         addOptions(adaptive, options);
-        Controller.validateOptions(options);
+        boolean hasVectorType = true;
+        Controller.validateOptions(options, hasVectorType);
 
         Controller controller = Controller.fromOptions(cfs, options);
         assertNotNull(controller);
@@ -194,7 +196,7 @@ public abstract class ControllerTest
     void testValidateOptions(Map<String, String> options, boolean adaptive)
     {
         addOptions(adaptive, options);
-        options = Controller.validateOptions(options);
+        options = Controller.validateOptions(options, useVector);
         assertTrue(options.toString(), options.isEmpty());
     }
 
@@ -462,21 +464,21 @@ public abstract class ControllerTest
     {
         Map<String, String> options = new HashMap<>();
         options.put(Controller.NUM_SHARDS_OPTION, Integer.toString(-1));
-        Map<String, String> validatedOptions = Controller.validateOptions(options);
+        Map<String, String> validatedOptions = Controller.validateOptions(options, useVector);
         assertTrue("-1 should be a valid option: " + validatedOptions, validatedOptions.isEmpty());
 
         options = new HashMap<>();
         options.put(Controller.NUM_SHARDS_OPTION, Integer.toString(-1));
         options.put(Controller.TARGET_SSTABLE_SIZE_OPTION, "128MB");
         options.put(Controller.MIN_SSTABLE_SIZE_OPTION, "0B");
-        validatedOptions = Controller.validateOptions(options);
+        validatedOptions = Controller.validateOptions(options, useVector);
         assertTrue("-1 num of shards should be acceptable with V2 params: " + validatedOptions, validatedOptions.isEmpty());
 
         Map<String, String> invalidOptions = new HashMap<>();
         invalidOptions.put(Controller.NUM_SHARDS_OPTION, Integer.toString(32));
         invalidOptions.put(Controller.TARGET_SSTABLE_SIZE_OPTION, "128MB");
         assertThrows("Positive num of shards should not be acceptable with V2 params",
-                     ConfigurationException.class, () -> Controller.validateOptions(invalidOptions));
+                     ConfigurationException.class, () -> Controller.validateOptions(invalidOptions, useVector));
     }
 
     @Test
@@ -654,7 +656,7 @@ public abstract class ControllerTest
         options.put(CompactionStrategyOptions.READ_MULTIPLIER_OPTION, Double.toString(readMultiplier));
         options.put(CompactionStrategyOptions.WRITE_MULTIPLIER_OPTION, Double.toString(writeMultiplier));
 
-        CompactionStrategyOptions compactionStrategyOptions = new CompactionStrategyOptions(UnifiedCompactionStrategy.class, options, true);
+        CompactionStrategyOptions compactionStrategyOptions = new CompactionStrategyOptions(UnifiedCompactionStrategy.class, options, true, useVector);
         assertNotNull(compactionStrategyOptions);
         assertNotNull(compactionStrategyOptions.toString());
         assertEquals(tombstoneThresholdOption, compactionStrategyOptions.getTombstoneThreshold(), epsilon);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -159,22 +159,22 @@ public class StaticControllerTest extends ControllerTest
     {
         Map<String, String> options = new HashMap<>();
         options.put(Controller.VECTOR_BASE_SHARD_COUNT_OPTION, "-1");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
         options.clear();
         options.put(Controller.VECTOR_SSTABLE_GROWTH_OPTION, "-1");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
         options.clear();
         options.put(Controller.VECTOR_RESERVED_THREADS_OPTION, "-1");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
         options.clear();
         options.put(Controller.VECTOR_MIN_SSTABLE_SIZE_OPTION, "10GiB");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
         options.clear();
         options.put(Controller.VECTOR_TARGET_SSTABLE_SIZE_OPTION, "-1MiB");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
         options.clear();
         options.put(Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, "not true");
-        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options, false));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/schema/SchemaKeyspaceTest.java
@@ -248,7 +248,8 @@ public class SchemaKeyspaceTest
         UntypedResultSet.Row tableRow = QueryProcessor.resultify(String.format("SELECT * FROM %s.%s", SchemaConstants.SCHEMA_KEYSPACE_NAME, SchemaKeyspaceTables.TABLES),
                                                                  UnfilteredRowIterators.filter(serializedCf.unfilteredIterator(), FBUtilities.nowInSeconds()))
                                                       .one();
-        TableParams params = SchemaKeyspace.createTableParamsFromRow(tableRow);
+        boolean hasVectorType = false;
+        TableParams params = SchemaKeyspace.createTableParamsFromRow(tableRow, hasVectorType);
 
         UntypedResultSet columnsRows = QueryProcessor.resultify(String.format("SELECT * FROM %s.%s", SchemaConstants.SCHEMA_KEYSPACE_NAME, SchemaKeyspaceTables.COLUMNS),
                                                                 UnfilteredRowIterators.filter(serializedCD.unfilteredIterator(), FBUtilities.nowInSeconds()));


### PR DESCRIPTION
### What is the issue

This implementation was partial: https://github.com/datastax/cassandra/pull/1265
The fact that a table should be considered "vector" was taken into account for Compaction but not during schema managent, in particular during "create table", that happens any type a node loads a table.

### What does this PR fix and why was it fixed
- Pass the "hasVectorType" property everywhere (this looks pretty ugly!)
- Clean up the validations and the code that deals with setting custom settings for vector tables
