### PR TITLE
CNDB-12683 handle too long controller config file names  (#1565)

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileReader;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.Overlaps;
 import org.json.simple.JSONObject;
@@ -141,6 +142,11 @@ public class StaticController extends Controller
         catch (ParseException e)
         {
             logger.warn("Unable to parse saved flush size. Using starting value instead:", e);
+        }
+        catch (Throwable e)
+        {
+            logger.warn("Unable to read controller config file. Using starting value instead:", e);
+            JVMStabilityInspector.inspectThrowable(e);
         }
         return new StaticController(env,
                                     scalingParameters,

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -19,11 +19,13 @@
 package org.apache.cassandra.schema;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.fail;
 
@@ -98,6 +100,25 @@ public class CreateTableValidationTest extends CQLTester
     {
         expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC);",
                         "Missing CLUSTERING ORDER for column ck1");
+    }
+
+    @Test
+    public void testCreatingTableWithLongName() throws Throwable
+    {
+        String keyspace = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
+        String table = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+
+        execute(String.format("CREATE KEYSPACE %s with replication = " +
+                              "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
+                              keyspace));
+        createTableMayThrow(String.format("CREATE TABLE %s.%s (" +
+                                           "key int PRIMARY KEY," +
+                                           "val int)", keyspace, table));
+
+        execute(String.format("INSERT INTO %s.%s (key,val) VALUES (1,1)", keyspace, table));
+        flush(keyspace, table);
+        UntypedResultSet result = execute(String.format("SELECT * from %s.%s", keyspace, table));
+        assertThat(result.size()).isEqualTo(1);
     }
 
     private void expectedFailure(String statement, String errorMsg)


### PR DESCRIPTION
Handle FSError thrown when the controller config file name is too long. Otherwise, the exception causes failures to create CFS instance.

### What is the issue
...

### What does this PR fix and why was it fixed
...
