### PR TITLE
DSP-24615: Fix reading mmapped trie-index exceeding 2GiB

### DIFF
--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -515,9 +515,9 @@ public class FileHandle extends SharedCloseableImpl
             }
 
             if (regions == null)
-                regions = MmappedRegions.map(channel, length, startOffset, adviseRandom);
+                regions = MmappedRegions.map(channel, length, bufferSize, startOffset, adviseRandom);
             else
-                regions.extend(length);
+                regions.extend(length, bufferSize);
         }
     }
 

--- a/src/java/org/apache/cassandra/io/util/MmappedRegions.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegions.java
@@ -19,10 +19,6 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 
@@ -61,34 +57,22 @@ public class MmappedRegions extends SharedCloseableImpl
      */
     private volatile State copy;
 
-    private MmappedRegions(ChannelProxy channel, CompressionMetadata metadata, long length, long uncompressedSliceOffset, boolean adviseRandom)
+    private MmappedRegions(State state, CompressionMetadata metadata, long uncompressedSliceOffset)
     {
-        this(new State(channel, offsetFrom(metadata, uncompressedSliceOffset), adviseRandom),
-             metadata,
-             length,
-             uncompressedSliceOffset);
+        super(new Tidier(state));
+        this.state = state;
+        updateState(metadata, uncompressedSliceOffset);
+        this.copy = new State(state);
     }
 
-    private static long offsetFrom(CompressionMetadata metadata, long uncompressedSliceOffset)
-    {
-        return metadata == null ? uncompressedSliceOffset : metadata.chunkFor(uncompressedSliceOffset).offset;
-    }
-
-    private MmappedRegions(State state, CompressionMetadata metadata, long length, long uncompressedOffset)
+    private MmappedRegions(State state, long length, int chunkSize)
     {
         super(new Tidier(state));
 
         this.state = state;
 
-        if (metadata != null)
-        {
-            assert length == 0 : "expected no length with metadata";
-            updateState(metadata, uncompressedOffset);
-        }
-        else if (length > 0)
-        {
-            updateState(length);
-        }
+        if (length > 0)
+            updateState(length, chunkSize);
 
         this.copy = new State(state);
     }
@@ -101,7 +85,7 @@ public class MmappedRegions extends SharedCloseableImpl
 
     public static MmappedRegions empty(ChannelProxy channel)
     {
-        return new MmappedRegions(channel, null, 0, 0, false);
+        return new MmappedRegions(new State(channel, 0, false), 0, 0);
     }
 
     /**
@@ -119,16 +103,17 @@ public class MmappedRegions extends SharedCloseableImpl
     {
         if (metadata == null)
             throw new IllegalArgumentException("metadata cannot be null");
-
-        return new MmappedRegions(channel, metadata, 0, uncompressedSliceOffset, adviseRandom);
+        State state = new State(channel, metadata.chunkFor(uncompressedSliceOffset).offset, adviseRandom);
+        return new MmappedRegions(state, metadata, uncompressedSliceOffset);
     }
 
-    public static MmappedRegions map(ChannelProxy channel, long length, long uncompressedSliceOffset, boolean adviseRandom)
+    public static MmappedRegions map(ChannelProxy channel, long length, int chunkSize, long uncompressedSliceOffset, boolean adviseRandom)
     {
         if (length <= 0)
             throw new IllegalArgumentException("Length must be positive");
 
-        return new MmappedRegions(channel, null, length, uncompressedSliceOffset, adviseRandom);
+        State state = new State(channel, uncompressedSliceOffset, adviseRandom);
+        return new MmappedRegions(state, length, chunkSize);
     }
 
     /**
@@ -145,8 +130,10 @@ public class MmappedRegions extends SharedCloseableImpl
         return copy == null;
     }
 
-    public void extend(long length)
+    public void extend(long length, int chunkSize)
     {
+        // We cannot enforce length to be a multiple of chunkSize (at the very least the last extend on a file
+        // will not satisfy this), so we hope the caller knows what they are doing.
         if (length < 0)
             throw new IllegalArgumentException("Length must not be negative");
 
@@ -155,17 +142,19 @@ public class MmappedRegions extends SharedCloseableImpl
         if (length <= state.length)
             return;
 
-        updateState(length);
+        updateState(length, chunkSize);
         copy = new State(state);
     }
 
-    private void updateState(long length)
+    private void updateState(long length, int chunkSize)
     {
+        // make sure the regions span whole chunks
+        long maxSize = (long) (MAX_SEGMENT_SIZE / chunkSize) * chunkSize;
         state.length = length;
         long pos = state.getPosition();
         while (pos < length)
         {
-            long size = Math.min(MAX_SEGMENT_SIZE, length - pos);
+            long size = Math.min(maxSize, length - pos);
             state.add(pos, size);
             pos += size;
         }
@@ -292,7 +281,7 @@ public class MmappedRegions extends SharedCloseableImpl
         private final long onDiskSliceOffset;
 
         /** whether to apply fadv_random to mapped regions */
-        private boolean adviseRandom;
+        private final boolean adviseRandom;
 
         private State(ChannelProxy channel, long onDiskSliceOffset, boolean adviseRandom)
         {


### PR DESCRIPTION
### What is the issue
Memory-mapping is done in buffers of size less than 2GiB.
When these buffers aren't aligned to 4KiB and the trie-index file
spans many buffers then reading it results in going out of buffer bounds.

### What does this PR fix and why was it fixed
This patch fixes it by making sure that the buffers are correctly aligned.
