### PR TITLE
CNDB-12962: Change the vector-specific config to only apply different defaults…

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
@@ -463,10 +463,6 @@ the span of the lower-density ones.
 
 UCS accepts these compaction strategy parameters:
 
-* `override_ucs_config_for_vector_tables` Allows different configurations for vector and non-vector tables.  When set
-  to `true`, if a table has a column of `VectorType`, the "vector" parameters will be used instead of the regular
-  parameters. For example, `vector_min_sstable_size` will be used, and `min_sstable_size` will be ignored.   
-  The default value is `false` which disables this feature.
 * `scaling_parameters` A list of per-level scaling parameters, specified as L*f*, T*f*, N, or an integer value
   specifying $w$ directly. If more levels are present than the length of this list, the last value is used for all
   higher levels. Often this will be a single parameter, specifying the behaviour for all levels of the
@@ -479,10 +475,8 @@ UCS accepts these compaction strategy parameters:
   expense of making reads more difficult.  
   N is the middle ground that has the features of levelled (one sstable run per level) as well as tiered (one
   compaction to be promoted to the next level) and a fan factor of 2. This can also be specified as T2 or L2.  
-  The default value is T4, matching the default STCS behaviour with threshold 4. To select an equivalent of LCS
-  with its default fan factor 10, use L10.
-* `vector_scaling_parameters` A list of per-level scaling parameters used for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is -8 or L10.
+  The default value is T4, matching the default STCS behaviour with threshold 4. The default value in vector mode (see
+  paragraph below) is L10, equivalent to LCS with its default fan factor 10.
 * `target_sstable_size` The target sstable size $t$, specified as a human-friendly size in bytes (e.g. 100 MiB =
   $100\cdot 2^{20}$ B or (10 MB = 10,000,000 B)). The strategy will split data in shards that aim to produce sstables
   of size between $t / \sqrt 2$ and $t \cdot \sqrt 2$.  
@@ -490,15 +484,12 @@ UCS accepts these compaction strategy parameters:
   on disk has a non-trivial in-memory footprint that also affects garbage collection times.  
   Increase this if the memory pressure from the number of sstables in the system becomes too high. Also see
   `sstable_growth` below.  
-  The default value is 1 GiB.
-* `vector_target_sstable_size` The target sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is 5GiB.
+  The default value is 1 GiB. The default value in vector mode is 5GiB.
 * `base_shard_count` The minimum number of shards $b$, used for levels with the smallest density. This gives the
   minimum compaction concurrency for the lowest levels. A low number would result in larger L0 sstables but may limit
-  the overall maximum write throughput (as every piece of data has to go through L0). The base shard count only applies after `min_sstable_size` is reached.  
-  The default value is 4 for all tables.
-* `vector_base_shard_count` The base shard count used for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is 1.
+  the overall maximum write throughput (as every piece of data has to go through L0). The base shard count only applies 
+  after `min_sstable_size` is reached.  
+  The default value is 4. The default value in vector mode is 1. 
 * `sstable_growth` The sstable growth component $\lambda$, applied as a factor in the shard exponent calculation.
   This is a number between 0 and 1 that controls what part of the density growth should apply to individual sstable
   size and what part should increase the number of shards. Using a value of 1 has the effect of fixing the shard
@@ -513,14 +504,12 @@ UCS accepts these compaction strategy parameters:
   two can be further tweaked by increasing $\lambda$ to get fewer but bigger sstables on the top level, and decreasing
   it to favour a higher count of smaller sstables.  
   The default value is 0.333 meaning the sstable size grows with the square root of the growth of the shard count.
-* `vector_sstable_growth` The sstable growth component used for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is 1 which means the shard count will be fixed to the base value.
+  The default value in vector mode is 1 which means the shard count will be fixed to the base value.
 * `min_sstable_size` The minimum sstable size $m$, applicable when the base shard count will result is sstables
   that are considered too small. If set, the strategy will split the space into fewer than the base count shards, to
-  make the estimated sstables size at least as large as this value. A value of 0 disables this feature. A value of `auto` sets the minimum sstable size to the size
-  of sstables resulting from flushes. The default value is 100MiB.
-* `vector_min_sstable_size` The minimum sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is 1024MiB.
+  make the estimated sstables size at least as large as this value. A value of 0 disables this feature. 
+  A value of `auto` sets the minimum sstable size to the size of sstables resulting from flushes. 
+  The default value is 100MiB. The default value in vector mode is 1GiB.
 * `reserved_threads` Specifies the number of threads to reserve per level. Any remaining threads will take
   work according to the prioritization mechanism (i.e. higher overlap first). Higher reservations mean better
   responsiveness of the compaction strategy to new work, or smoother performance, at the expense of reducing the
@@ -528,8 +517,6 @@ UCS accepts these compaction strategy parameters:
   The default value is `max`, which spreads all threads as close to evenly between levels as possible. It is recommended
   to keep this option and the next at their defaults, which should offer a good balance between responsiveness and
   thread utilization.
-* `vector_reserved_threads` Specifies the number of threads to reserve per level for vector tables when `override_ucs_config_for_vector_tables=true`.   
-  The default value is `max`.
 * `reservations_type` Specifies whether reservations can be used by lower levels. If set to `per_level`, the
   reservations are only used by the specific level. If set to `level_or_below`, the reservations can be used by this
   level as well as any one below it.  
@@ -546,6 +533,17 @@ UCS accepts these compaction strategy parameters:
   Sets $b$ to the specified value, $\lambda$ to 1, and the default minimum sstable size to 'auto'.  
   Disabled by default and cannot be used in combination with `base_shard_count`, `target_sstable_size` or
   `sstable_growth`.
+
+All UCS options can also be supplied as system properties, using the prefix `unified_compaction.`, e.g. 
+`-Dunified_compaction.sstable_growth=0.5` sets the default `sstable_growth` to 0.5.
+
+In addition to this, the strategy permits different defaults to be applied to tables that have a vector column when the 
+system property `unified_compaction.override_ucs_config_for_vector_tables` is set to `true`. If this is enabled and the
+table has a column of type `vector`, the "vector mode" defaults in the list above apply. These vector defaults can be 
+altered using the prefix `unified_compaction.vector_`, e.g. 
+`-Dunified_compaction.vector_sstable_growth=1` in combination with 
+`-Dunified_compaction.override_ucs_config_for_vector_tables=true` sets the growth to 1 only for tables with a vector
+column.
 
 In `cassandra.yaml`:
 

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
@@ -463,6 +463,10 @@ the span of the lower-density ones.
 
 UCS accepts these compaction strategy parameters:
 
+* `override_ucs_config_for_vector_tables` Allows different configurations for vector and non-vector tables.  When set
+  to `true`, if a table has a column of `VectorType`, the "vector" parameters will be used instead of the regular
+  parameters. For example, `vector_min_sstable_size` will be used, and `min_sstable_size` will be ignored.   
+  The default value is `false` which disables this feature.
 * `scaling_parameters` A list of per-level scaling parameters, specified as L*f*, T*f*, N, or an integer value
   specifying $w$ directly. If more levels are present than the length of this list, the last value is used for all
   higher levels. Often this will be a single parameter, specifying the behaviour for all levels of the
@@ -477,6 +481,8 @@ UCS accepts these compaction strategy parameters:
   compaction to be promoted to the next level) and a fan factor of 2. This can also be specified as T2 or L2.  
   The default value is T4, matching the default STCS behaviour with threshold 4. To select an equivalent of LCS
   with its default fan factor 10, use L10.
+* `vector_scaling_parameters` A list of per-level scaling parameters used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is -8 or L10.
 * `target_sstable_size` The target sstable size $t$, specified as a human-friendly size in bytes (e.g. 100 MiB =
   $100\cdot 2^{20}$ B or (10 MB = 10,000,000 B)). The strategy will split data in shards that aim to produce sstables
   of size between $t / \sqrt 2$ and $t \cdot \sqrt 2$.  
@@ -485,10 +491,14 @@ UCS accepts these compaction strategy parameters:
   Increase this if the memory pressure from the number of sstables in the system becomes too high. Also see
   `sstable_growth` below.  
   The default value is 1 GiB.
+* `vector_target_sstable_size` The target sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 5GiB.
 * `base_shard_count` The minimum number of shards $b$, used for levels with the smallest density. This gives the
   minimum compaction concurrency for the lowest levels. A low number would result in larger L0 sstables but may limit
   the overall maximum write throughput (as every piece of data has to go through L0). The base shard count only applies after `min_sstable_size` is reached.  
   The default value is 4 for all tables.
+* `vector_base_shard_count` The base shard count used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1.
 * `sstable_growth` The sstable growth component $\lambda$, applied as a factor in the shard exponent calculation.
   This is a number between 0 and 1 that controls what part of the density growth should apply to individual sstable
   size and what part should increase the number of shards. Using a value of 1 has the effect of fixing the shard
@@ -503,10 +513,14 @@ UCS accepts these compaction strategy parameters:
   two can be further tweaked by increasing $\lambda$ to get fewer but bigger sstables on the top level, and decreasing
   it to favour a higher count of smaller sstables.  
   The default value is 0.333 meaning the sstable size grows with the square root of the growth of the shard count.
+* `vector_sstable_growth` The sstable growth component used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1 which means the shard count will be fixed to the base value.
 * `min_sstable_size` The minimum sstable size $m$, applicable when the base shard count will result is sstables
   that are considered too small. If set, the strategy will split the space into fewer than the base count shards, to
   make the estimated sstables size at least as large as this value. A value of 0 disables this feature. A value of `auto` sets the minimum sstable size to the size
   of sstables resulting from flushes. The default value is 100MiB.
+* `vector_min_sstable_size` The minimum sstable size used for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is 1024MiB.
 * `reserved_threads` Specifies the number of threads to reserve per level. Any remaining threads will take
   work according to the prioritization mechanism (i.e. higher overlap first). Higher reservations mean better
   responsiveness of the compaction strategy to new work, or smoother performance, at the expense of reducing the
@@ -514,6 +528,8 @@ UCS accepts these compaction strategy parameters:
   The default value is `max`, which spreads all threads as close to evenly between levels as possible. It is recommended
   to keep this option and the next at their defaults, which should offer a good balance between responsiveness and
   thread utilization.
+* `vector_reserved_threads` Specifies the number of threads to reserve per level for vector tables when `override_ucs_config_for_vector_tables=true`.   
+  The default value is `max`.
 * `reservations_type` Specifies whether reservations can be used by lower levels. If set to `per_level`, the
   reservations are only used by the specific level. If set to `level_or_below`, the reservations can be used by this
   level as well as any one below it.  

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -327,9 +327,6 @@ public class AdaptiveController extends Controller
             parseScalingParameters(staticScalingFactors);
         else if (staticScalingParameters != null)
             parseScalingParameters(staticScalingParameters);
-        String vectorScalingParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
-        if (vectorScalingParameters != null)
-            throw new ConfigurationException(String.format("%s option is not supported with Adaptive UCS", VECTOR_SCALING_PARAMETERS_OPTION));
         s = options.remove(MIN_SCALING_PARAMETER);
         if (s != null)
             minScalingParameter = Integer.parseInt(s);

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -119,6 +119,7 @@ public class AdaptiveController extends Controller
                               Reservations.Type reservationsType,
                               Overlaps.InclusionMethod overlapInclusionMethod,
                               boolean parallelizeOutputShards,
+                              boolean hasVectorType,
                               int intervalSec,
                               int minScalingParameter,
                               int maxScalingParameter,
@@ -146,7 +147,8 @@ public class AdaptiveController extends Controller
               reservedThreadsPerLevel,
               reservationsType,
               overlapInclusionMethod,
-              parallelizeOutputShards);
+              parallelizeOutputShards,
+              hasVectorType);
 
         this.scalingParameters = scalingParameters;
         this.previousScalingParameters = previousScalingParameters;
@@ -175,8 +177,9 @@ public class AdaptiveController extends Controller
                                   double sstableGrowthModifier,
                                   int reservedThreadsPerLevel,
                                   Reservations.Type reservationsType,
-                                  boolean parallelizeOutputShards,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
+                                  boolean parallelizeOutputShards,
+                                  boolean hasVectorType,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options)
@@ -276,6 +279,7 @@ public class AdaptiveController extends Controller
                                       reservationsType,
                                       overlapInclusionMethod,
                                       parallelizeOutputShards,
+                                      hasVectorType,
                                       intervalSec,
                                       minScalingParameter,
                                       maxScalingParameter,
@@ -323,6 +327,9 @@ public class AdaptiveController extends Controller
             parseScalingParameters(staticScalingFactors);
         else if (staticScalingParameters != null)
             parseScalingParameters(staticScalingParameters);
+        String vectorScalingParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
+        if (vectorScalingParameters != null)
+            throw new ConfigurationException(String.format("%s option is not supported with Adaptive UCS", VECTOR_SCALING_PARAMETERS_OPTION));
         s = options.remove(MIN_SCALING_PARAMETER);
         if (s != null)
             minScalingParameter = Integer.parseInt(s);

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.CompactionRealm;
 import org.apache.cassandra.db.compaction.CompactionStrategy;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
+import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileWriter;
@@ -119,11 +120,13 @@ public abstract class Controller
      * In UCS V1 mode (engaged by using "num_shards" above) the default 'auto'.
      */
     static final String MIN_SSTABLE_SIZE_OPTION = "min_sstable_size";
+    static final String VECTOR_MIN_SSTABLE_SIZE_OPTION = "vector_min_sstable_size";
     @Deprecated
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
     static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
+    static final long VECTOR_DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */
@@ -151,20 +154,25 @@ public abstract class Controller
     static final double MAX_SPACE_OVERHEAD_UPPER_BOUND = 1.0;
 
     static final String BASE_SHARD_COUNT_OPTION = "base_shard_count";
+    static final String VECTOR_BASE_SHARD_COUNT_OPTION = "vector_base_shard_count";
     /**
-     * Default base shard count, used when a base count is not explicitly supplied. This value applies as long as the
-     * table is not a system one, and directories are not defined.
+     * Default base shard count, used when a base count is not explicitly supplied. This value applies to all tables as
+     * long as they are larger than the minimum sstable size.
      *
      * For others a base count of 1 is used as system tables are usually small and do not need as much compaction
      * parallelism, while having directories defined provides for parallelism in a different way.
      */
     public static final int DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(getSystemProperty(BASE_SHARD_COUNT_OPTION, "4"));
 
+    public static final int VECTOR_DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(System.getProperty(PREFIX + VECTOR_BASE_SHARD_COUNT_OPTION, "1"));
+
     /**
      * The target SSTable size. This is the size of the SSTables that the controller will try to create.
      */
     static final String TARGET_SSTABLE_SIZE_OPTION = "target_sstable_size";
-    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
+    static final String VECTOR_TARGET_SSTABLE_SIZE_OPTION = "vector_target_sstable_size";
+    public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "1GiB"));
+    public static final long VECTOR_DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
     static final long MIN_TARGET_SSTABLE_SIZE = 1L << 20;
 
     static final String IS_REPLICA_AWARE_OPTION = "is_replica_aware";
@@ -196,7 +204,9 @@ public abstract class Controller
      * a growth value of 0.333, and 64 (~16GiB each) for a growth value of 0.5.
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
-    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.5"));
+    static final String VECTOR_SSTABLE_GROWTH_OPTION = "vector_sstable_growth";
+    static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.333"));
+    static final double VECTOR_DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + VECTOR_SSTABLE_GROWTH_OPTION, "1.0"));
 
     /**
      * Number of reserved threads to keep for each compaction level. This is used to ensure that there are always
@@ -210,7 +220,9 @@ public abstract class Controller
      * The default value is max, all compaction threads are distributed among the levels.
      */
     static final String RESERVED_THREADS_OPTION = "reserved_threads";
+    static final String VECTOR_RESERVED_THREADS_OPTION = "vector_reserved_threads";
     public static final int DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(getSystemProperty(RESERVED_THREADS_OPTION, "max"));
+    public static final int VECTOR_DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(System.getProperty(PREFIX + VECTOR_RESERVED_THREADS_OPTION, "max"));
 
     /**
      * Reservation type, defining whether reservations can be used by lower levels. If set to `per_level`, the
@@ -253,6 +265,15 @@ public abstract class Controller
     static final boolean ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = Boolean.parseBoolean(System.getProperty(ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_PROPERTY));
     static final boolean DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = false;
 
+    /**
+     * This property allows seperate configurations for vector and non-vector tables.  If this property is set to true
+     * and the table has a {@link VectorType}, the "vector" options are used over the regular options.  For instance,
+     * "vector_sstable_growth" will be used over "sstable_growth"
+     */
+    static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION = "override_ucs_config_for_vector_tables";
+    static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY = PREFIX + "override_ucs_config_for_vector_tables";
+    static final boolean DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES = Boolean.parseBoolean(System.getProperty(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY, "false"));
+
     static final int DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS = 60 * 10;
     static final String EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_OPTION = "expired_sstable_check_frequency_seconds";
 
@@ -293,6 +314,7 @@ public abstract class Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     static final String SCALING_PARAMETERS_OPTION = "scaling_parameters";
+    static final String VECTOR_SCALING_PARAMETERS_OPTION = "vector_scaling_parameters";
     @Deprecated
     static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
 
@@ -326,6 +348,7 @@ public abstract class Controller
     protected final Overlaps.InclusionMethod overlapInclusionMethod;
 
     final boolean l0ShardsEnabled;
+    final boolean hasVectorType;
 
     Controller(MonotonicClock clock,
                Environment env,
@@ -345,7 +368,8 @@ public abstract class Controller
                int reservedThreads,
                Reservations.Type reservationsType,
                Overlaps.InclusionMethod overlapInclusionMethod,
-               boolean parallelizeOutputShards)
+               boolean parallelizeOutputShards,
+               boolean hasVectorType)
     {
         this.clock = clock;
         this.env = env;
@@ -365,6 +389,7 @@ public abstract class Controller
         this.maxSpaceOverhead = maxSpaceOverhead;
         this.l0ShardsEnabled = Boolean.parseBoolean(getSystemProperty(L0_SHARDS_ENABLED_OPTION, "false")); // FIXME VECTOR-23
         this.parallelizeOutputShards = parallelizeOutputShards;
+        this.hasVectorType = hasVectorType;
 
         if (maxSSTablesToCompact <= 0)  // use half the maximum permitted compaction size as upper bound by default
             maxSSTablesToCompact = (int) (dataSetSize * this.maxSpaceOverhead * 0.5 / getMinSstableSizeBytes());
@@ -646,6 +671,7 @@ public abstract class Controller
         }
     }
 
+
     /**
      * Return the flush sstable size in bytes.
      *
@@ -753,6 +779,11 @@ public abstract class Controller
         }
 
         logger.debug("Stopped compaction controller {}", this);
+    }
+
+    public boolean hasVectorType()
+    {
+        return hasVectorType;
     }
 
     /**
@@ -877,6 +908,18 @@ public abstract class Controller
 
     public static Controller fromOptions(CompactionRealm realm, Map<String, String> options)
     {
+        boolean hasVectorType = realm.metadata().hasVectorType();
+        boolean vectorOverride = options.containsKey(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION)
+                ? Boolean.parseBoolean(options.get(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION))
+                : DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
+        boolean useVectorOptions = hasVectorType && vectorOverride;
+        if (logger.isTraceEnabled())
+        {
+            if (useVectorOptions)
+                logger.trace("Using UCS configuration optimized for vector for {}.{}", realm.getKeyspaceName(), realm.getTableName());
+            else
+                logger.trace("Using non-vector UCS configuration for {}.{}", realm.getKeyspaceName(), realm.getTableName());
+        }
         boolean adaptive = options.containsKey(ADAPTIVE_OPTION) ? Boolean.parseBoolean(options.get(ADAPTIVE_OPTION)) : DEFAULT_ADAPTIVE;
         long dataSetSize = getSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30, DEFAULT_DATASET_SIZE);
         long flushSizeOverride = getSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20, 0);
@@ -900,6 +943,15 @@ public abstract class Controller
         {
             baseShardCount = DEFAULT_BASE_SHARD_COUNT;
         }
+        int vectorBaseShardCount;
+        if (options.containsKey(VECTOR_BASE_SHARD_COUNT_OPTION))
+        {
+            vectorBaseShardCount = Integer.parseInt(options.get(VECTOR_BASE_SHARD_COUNT_OPTION));
+        }
+        else
+        {
+            vectorBaseShardCount = VECTOR_DEFAULT_BASE_SHARD_COUNT;
+        }
 
         boolean isReplicaAware = options.containsKey(IS_REPLICA_AWARE_OPTION)
                                  ? Boolean.parseBoolean(options.get(IS_REPLICA_AWARE_OPTION))
@@ -908,15 +960,27 @@ public abstract class Controller
         long targetSStableSize = options.containsKey(TARGET_SSTABLE_SIZE_OPTION)
                                  ? FBUtilities.parseHumanReadableBytes(options.get(TARGET_SSTABLE_SIZE_OPTION))
                                  : DEFAULT_TARGET_SSTABLE_SIZE;
+        long vectorTargetSStableSize = options.containsKey(VECTOR_TARGET_SSTABLE_SIZE_OPTION)
+                                 ? FBUtilities.parseHumanReadableBytes(options.get(VECTOR_TARGET_SSTABLE_SIZE_OPTION))
+                                 : VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
         long minSSTableSize = getSizeWithAltAndSpecial(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, DEFAULT_MIN_SSTABLE_SIZE);
+        long vectorMinSSTableSize = getSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
 
         double sstableGrowthModifier = DEFAULT_SSTABLE_GROWTH;
         if (options.containsKey(SSTABLE_GROWTH_OPTION))
             sstableGrowthModifier = FBUtilities.parsePercent(options.get(SSTABLE_GROWTH_OPTION));
 
+        double vectorSSTableGrowthModifier = VECTOR_DEFAULT_SSTABLE_GROWTH;
+        if (options.containsKey(VECTOR_SSTABLE_GROWTH_OPTION))
+            vectorSSTableGrowthModifier = FBUtilities.parsePercent(options.get(VECTOR_SSTABLE_GROWTH_OPTION));
+
         int reservedThreadsPerLevel = options.containsKey(RESERVED_THREADS_OPTION)
                                       ? FBUtilities.parseIntAllowingMax(options.get(RESERVED_THREADS_OPTION))
                                       : DEFAULT_RESERVED_THREADS;
+
+        int vectorReservedThreadsPerLevel = options.containsKey(VECTOR_RESERVED_THREADS_OPTION)
+                                      ? FBUtilities.parseIntAllowingMax(options.get(VECTOR_RESERVED_THREADS_OPTION))
+                                      : VECTOR_DEFAULT_RESERVED_THREADS;
         Reservations.Type reservationsType = options.containsKey(RESERVATIONS_TYPE_OPTION)
                                                   ? Reservations.Type.valueOf(options.get(RESERVATIONS_TYPE_OPTION).toUpperCase())
                                                   : DEFAULT_RESERVED_THREADS_TYPE;
@@ -973,43 +1037,46 @@ public abstract class Controller
                ? AdaptiveController.fromOptions(env,
                                                 survivalFactors,
                                                 dataSetSize,
-                                                minSSTableSize,
+                                                useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
                                                 flushSizeOverride,
                                                 maxSpaceOverhead,
                                                 maxSSTablesToCompact,
                                                 expiredSSTableCheckFrequency,
                                                 ignoreOverlapsInExpirationCheck,
-                                                baseShardCount,
+                                                useVectorOptions ? vectorBaseShardCount : baseShardCount,
                                                 isReplicaAware,
-                                                targetSStableSize,
-                                                sstableGrowthModifier,
-                                                reservedThreadsPerLevel,
+                                                useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
+                                                useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
+                                                useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
                                                 reservationsType,
-                                                parallelizeOutputShards,
                                                 overlapInclusionMethod,
+                                                parallelizeOutputShards,
+                                                hasVectorType,
                                                 realm.getKeyspaceName(),
                                                 realm.getTableName(),
                                                 options)
                : StaticController.fromOptions(env,
                                               survivalFactors,
                                               dataSetSize,
-                                              minSSTableSize,
+                                              useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
                                               flushSizeOverride,
                                               maxSpaceOverhead,
                                               maxSSTablesToCompact,
                                               expiredSSTableCheckFrequency,
                                               ignoreOverlapsInExpirationCheck,
-                                              baseShardCount,
+                                              useVectorOptions ? vectorBaseShardCount : baseShardCount,
                                               isReplicaAware,
-                                              targetSStableSize,
-                                              sstableGrowthModifier,
-                                              reservedThreadsPerLevel,
+                                              useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
+                                              useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
+                                              useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
                                               reservationsType,
                                               overlapInclusionMethod,
                                               parallelizeOutputShards,
+                                              hasVectorType,
                                               realm.getKeyspaceName(),
                                               realm.getTableName(),
-                                              options);
+                                              options,
+                                              useVectorOptions);
     }
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
@@ -1023,7 +1090,9 @@ public abstract class Controller
         String s;
         boolean adaptive = DEFAULT_ADAPTIVE;
         long minSSTableSize = -1;
+        long vectorMinSSTableSize = -1;
         long targetSSTableSize = DEFAULT_TARGET_SSTABLE_SIZE;
+        long vectorTargetSSTableSize = VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
 
         s = options.remove(NUM_SHARDS_OPTION);
         if (s != null)
@@ -1058,6 +1127,7 @@ public abstract class Controller
         validateBoolean(options, PARALLELIZE_OUTPUT_SHARDS_OPTION, DEFAULT_PARALLELIZE_OUTPUT_SHARDS);
 
         minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, DEFAULT_MIN_SSTABLE_SIZE);
+        vectorMinSSTableSize = validateSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
         validateSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20);
         validateSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30);
 
@@ -1120,6 +1190,13 @@ public abstract class Controller
 
         validateBoolean(options, ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_OPTION, false);
 
+        s = options.remove(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION);
+        if (s != null && !s.equalsIgnoreCase("true") && !s.equalsIgnoreCase("false"))
+        {
+            throw new ConfigurationException(String.format(booleanParseErr,
+                                                           OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, s));
+        }
+
         s = options.remove(BASE_SHARD_COUNT_OPTION);
         if (s != null)
         {
@@ -1134,6 +1211,23 @@ public abstract class Controller
             catch (NumberFormatException e)
             {
                 throw new ConfigurationException(String.format(intParseErr, s, BASE_SHARD_COUNT_OPTION), e);
+            }
+        }
+
+        s = options.remove(VECTOR_BASE_SHARD_COUNT_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                int numShards = Integer.parseInt(s);
+                if (numShards <= 0)
+                    throw new ConfigurationException(String.format(nonPositiveErr,
+                                                                   VECTOR_BASE_SHARD_COUNT_OPTION,
+                                                                   numShards));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format(intParseErr, s, VECTOR_BASE_SHARD_COUNT_OPTION), e);
             }
         }
 
@@ -1153,6 +1247,27 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
                                                                TARGET_SSTABLE_SIZE_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
+        s = options.remove(VECTOR_TARGET_SSTABLE_SIZE_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                vectorTargetSSTableSize = FBUtilities.parseHumanReadableBytes(s);
+                if (vectorTargetSSTableSize < MIN_TARGET_SSTABLE_SIZE)
+                    throw new ConfigurationException(String.format("%s %s is not acceptable, size must be at least %s",
+                                                                   VECTOR_TARGET_SSTABLE_SIZE_OPTION,
+                                                                   s,
+                                                                   FBUtilities.prettyPrintMemory(MIN_TARGET_SSTABLE_SIZE)));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
+                                                               VECTOR_TARGET_SSTABLE_SIZE_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1178,6 +1293,26 @@ public abstract class Controller
             }
         }
 
+        s = options.remove(VECTOR_SSTABLE_GROWTH_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                double targetSSTableGrowth = FBUtilities.parsePercent(s);
+                if (targetSSTableGrowth < 0 || targetSSTableGrowth > 1)
+                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
+                                                                   VECTOR_SSTABLE_GROWTH_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
+                                                               VECTOR_SSTABLE_GROWTH_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
         s = options.remove(RESERVED_THREADS_OPTION);
         if (s != null)
         {
@@ -1193,6 +1328,26 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
                                                                RESERVED_THREADS_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
+        }
+
+        s = options.remove(VECTOR_RESERVED_THREADS_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                int reservedThreads = FBUtilities.parseIntAllowingMax(s);
+                if (reservedThreads < 0)
+                    throw new ConfigurationException(String.format("%s %s must be an integer >= 0 or \"max\"",
+                                                                   VECTOR_RESERVED_THREADS_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
+                                                               VECTOR_RESERVED_THREADS_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1232,6 +1387,10 @@ public abstract class Controller
             throw new ConfigurationException(String.format("The minimum sstable size %s cannot be larger than the target size's lower bound %s.",
                                                            FBUtilities.prettyPrintMemory(minSSTableSize),
                                                            FBUtilities.prettyPrintMemory((long) (targetSSTableSize * INVERSE_SQRT_2))));
+        if (vectorMinSSTableSize > vectorTargetSSTableSize * INVERSE_SQRT_2)
+            throw new ConfigurationException(String.format("The vector minimum sstable size %s cannot be larger than the target size's lower bound %s.",
+                                                           FBUtilities.prettyPrintMemory(vectorMinSSTableSize),
+                                                           FBUtilities.prettyPrintMemory((long) (vectorTargetSSTableSize * INVERSE_SQRT_2))));
 
         return adaptive ? AdaptiveController.validateOptions(options) : StaticController.validateOptions(options);
     }
@@ -1264,6 +1423,16 @@ public abstract class Controller
             return Boolean.parseBoolean(s);
         }
         return defaultValue;
+    }
+
+    private static long getSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
+    {
+        if (specialText.equalsIgnoreCase(options.get(optionHumanReadable)))
+            return specialValue;
+        else if (options.containsKey(optionHumanReadable))
+            return FBUtilities.parseHumanReadableBytes(options.get(optionHumanReadable));
+        else
+            return defaultValue;
     }
 
     private static void validateSizeWithAlt(Map<String, String> options, String optionHumanReadable, String optionAlt, int altShift)
@@ -1315,6 +1484,47 @@ public abstract class Controller
         if (sizeInBytes < 0)
             throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
                                                            opt,
+                                                           s));
+        return sizeInBytes;
+    }
+
+    private static long validateSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
+    {
+        long sizeInBytes;
+        String s = null;
+        try
+        {
+            s = options.remove(optionHumanReadable);
+            if (s != null)
+            {
+                if (s.equalsIgnoreCase(specialText))
+                    return specialValue; // all good
+                sizeInBytes = FBUtilities.parseHumanReadableBytes(s);
+            }
+            else
+            {
+                return defaultValue;
+            }
+
+        }
+        catch (NumberFormatException e)
+        {
+            if (specialText != null)
+                throw new ConfigurationException(String.format("%s must be a valid size in bytes or %s for %s",
+                                                               s,
+                                                               specialText,
+                                                               optionHumanReadable),
+                                                 e);
+            else
+                throw new ConfigurationException(String.format("%s is not a valid size in bytes for %s",
+                                                               s,
+                                                               optionHumanReadable),
+                                                 e);
+        }
+
+        if (sizeInBytes < 0)
+            throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
+                                                           optionHumanReadable,
                                                            s));
         return sizeInBytes;
     }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -74,6 +74,7 @@ public abstract class Controller
 
     static final String PREFIX = "unified_compaction.";
     static final String LEGACY_PREFIX = "dse.unified_compaction.";
+    static final String VECTOR_PREFIX = "vector_";
 
     /**
      * The data size in GB, it will be assumed that the node will have on disk roughly this size of data when it
@@ -120,13 +121,12 @@ public abstract class Controller
      * In UCS V1 mode (engaged by using "num_shards" above) the default 'auto'.
      */
     static final String MIN_SSTABLE_SIZE_OPTION = "min_sstable_size";
-    static final String VECTOR_MIN_SSTABLE_SIZE_OPTION = "vector_min_sstable_size";
     @Deprecated
     static final String MIN_SSTABLE_SIZE_OPTION_MB = "min_sstable_size_in_mb";
     static final String MIN_SSTABLE_SIZE_OPTION_AUTO = "auto";
 
     static final long DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(MIN_SSTABLE_SIZE_OPTION, "100MiB"));
-    static final long VECTOR_DEFAULT_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
+    static final long DEFAULT_VECTOR_MIN_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(VECTOR_PREFIX + MIN_SSTABLE_SIZE_OPTION, "1024MiB"));
     /**
      * Value to use to set the min sstable size from the flush size.
      */
@@ -154,7 +154,6 @@ public abstract class Controller
     static final double MAX_SPACE_OVERHEAD_UPPER_BOUND = 1.0;
 
     static final String BASE_SHARD_COUNT_OPTION = "base_shard_count";
-    static final String VECTOR_BASE_SHARD_COUNT_OPTION = "vector_base_shard_count";
     /**
      * Default base shard count, used when a base count is not explicitly supplied. This value applies to all tables as
      * long as they are larger than the minimum sstable size.
@@ -163,16 +162,14 @@ public abstract class Controller
      * parallelism, while having directories defined provides for parallelism in a different way.
      */
     public static final int DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(getSystemProperty(BASE_SHARD_COUNT_OPTION, "4"));
-
-    public static final int VECTOR_DEFAULT_BASE_SHARD_COUNT = Integer.parseInt(System.getProperty(PREFIX + VECTOR_BASE_SHARD_COUNT_OPTION, "1"));
+    public static final int DEFAULT_VECTOR_BASE_SHARD_COUNT = Integer.parseInt(getSystemProperty(VECTOR_PREFIX + BASE_SHARD_COUNT_OPTION, "1"));
 
     /**
      * The target SSTable size. This is the size of the SSTables that the controller will try to create.
      */
     static final String TARGET_SSTABLE_SIZE_OPTION = "target_sstable_size";
-    static final String VECTOR_TARGET_SSTABLE_SIZE_OPTION = "vector_target_sstable_size";
     public static final long DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(TARGET_SSTABLE_SIZE_OPTION, "1GiB"));
-    public static final long VECTOR_DEFAULT_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(System.getProperty(PREFIX + VECTOR_TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
+    public static final long DEFAULT_VECTOR_TARGET_SSTABLE_SIZE = FBUtilities.parseHumanReadableBytes(getSystemProperty(VECTOR_PREFIX + TARGET_SSTABLE_SIZE_OPTION, "5GiB"));
     static final long MIN_TARGET_SSTABLE_SIZE = 1L << 20;
 
     static final String IS_REPLICA_AWARE_OPTION = "is_replica_aware";
@@ -204,9 +201,8 @@ public abstract class Controller
      * a growth value of 0.333, and 64 (~16GiB each) for a growth value of 0.5.
      */
     static final String SSTABLE_GROWTH_OPTION = "sstable_growth";
-    static final String VECTOR_SSTABLE_GROWTH_OPTION = "vector_sstable_growth";
     static final double DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(SSTABLE_GROWTH_OPTION, "0.333"));
-    static final double VECTOR_DEFAULT_SSTABLE_GROWTH = FBUtilities.parsePercent(System.getProperty(PREFIX + VECTOR_SSTABLE_GROWTH_OPTION, "1.0"));
+    static final double DEFAULT_VECTOR_SSTABLE_GROWTH = FBUtilities.parsePercent(getSystemProperty(VECTOR_PREFIX + SSTABLE_GROWTH_OPTION, "1.0"));
 
     /**
      * Number of reserved threads to keep for each compaction level. This is used to ensure that there are always
@@ -220,9 +216,8 @@ public abstract class Controller
      * The default value is max, all compaction threads are distributed among the levels.
      */
     static final String RESERVED_THREADS_OPTION = "reserved_threads";
-    static final String VECTOR_RESERVED_THREADS_OPTION = "vector_reserved_threads";
     public static final int DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(getSystemProperty(RESERVED_THREADS_OPTION, "max"));
-    public static final int VECTOR_DEFAULT_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(System.getProperty(PREFIX + VECTOR_RESERVED_THREADS_OPTION, "max"));
+    public static final int DEFAULT_VECTOR_RESERVED_THREADS = FBUtilities.parseIntAllowingMax(getSystemProperty(VECTOR_PREFIX + RESERVED_THREADS_OPTION, "max"));
 
     /**
      * Reservation type, defining whether reservations can be used by lower levels. If set to `per_level`, the
@@ -266,13 +261,12 @@ public abstract class Controller
     static final boolean DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = false;
 
     /**
-     * This property allows seperate configurations for vector and non-vector tables.  If this property is set to true
-     * and the table has a {@link VectorType}, the "vector" options are used over the regular options.  For instance,
-     * "vector_sstable_growth" will be used over "sstable_growth"
+     * This property allows seperate defaults for vector and non-vector tables.  If this property is set to true
+     * and the table has a {@link VectorType}, the "vector" defaults are used over the regular defaults.  For instance,
+     * "-Dunified_compaction.vector_sstable_growth" will be used over "-Dunified_compaction.sstable_growth".
      */
-    static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION = "override_ucs_config_for_vector_tables";
     static final String OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY = PREFIX + "override_ucs_config_for_vector_tables";
-    static final boolean DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES = Boolean.parseBoolean(System.getProperty(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY, "false"));
+    static final boolean OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES = Boolean.parseBoolean(System.getProperty(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_PROPERTY, "false"));
 
     static final int DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS = 60 * 10;
     static final String EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_OPTION = "expired_sstable_check_frequency_seconds";
@@ -314,7 +308,6 @@ public abstract class Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     static final String SCALING_PARAMETERS_OPTION = "scaling_parameters";
-    static final String VECTOR_SCALING_PARAMETERS_OPTION = "vector_scaling_parameters";
     @Deprecated
     static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
 
@@ -671,7 +664,6 @@ public abstract class Controller
         }
     }
 
-
     /**
      * Return the flush sstable size in bytes.
      *
@@ -908,10 +900,12 @@ public abstract class Controller
 
     public static Controller fromOptions(CompactionRealm realm, Map<String, String> options)
     {
+        // Note: These options have been validated, but the defaults are configured with -D options that may be
+        // different. We thus may end up with configurations combinations that do not make sense.
+        // We will attempt to correct such combinations and issue warnings where possible.
+
         boolean hasVectorType = realm.metadata().hasVectorType();
-        boolean vectorOverride = options.containsKey(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION)
-                ? Boolean.parseBoolean(options.get(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION))
-                : DEFAULT_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
+        boolean vectorOverride = OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
         boolean useVectorOptions = hasVectorType && vectorOverride;
         if (logger.isTraceEnabled())
         {
@@ -941,16 +935,7 @@ public abstract class Controller
         }
         else
         {
-            baseShardCount = DEFAULT_BASE_SHARD_COUNT;
-        }
-        int vectorBaseShardCount;
-        if (options.containsKey(VECTOR_BASE_SHARD_COUNT_OPTION))
-        {
-            vectorBaseShardCount = Integer.parseInt(options.get(VECTOR_BASE_SHARD_COUNT_OPTION));
-        }
-        else
-        {
-            vectorBaseShardCount = VECTOR_DEFAULT_BASE_SHARD_COUNT;
+            baseShardCount = useVectorOptions ? DEFAULT_VECTOR_BASE_SHARD_COUNT : DEFAULT_BASE_SHARD_COUNT;
         }
 
         boolean isReplicaAware = options.containsKey(IS_REPLICA_AWARE_OPTION)
@@ -959,28 +944,25 @@ public abstract class Controller
 
         long targetSStableSize = options.containsKey(TARGET_SSTABLE_SIZE_OPTION)
                                  ? FBUtilities.parseHumanReadableBytes(options.get(TARGET_SSTABLE_SIZE_OPTION))
-                                 : DEFAULT_TARGET_SSTABLE_SIZE;
-        long vectorTargetSStableSize = options.containsKey(VECTOR_TARGET_SSTABLE_SIZE_OPTION)
-                                 ? FBUtilities.parseHumanReadableBytes(options.get(VECTOR_TARGET_SSTABLE_SIZE_OPTION))
-                                 : VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
-        long minSSTableSize = getSizeWithAltAndSpecial(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, DEFAULT_MIN_SSTABLE_SIZE);
-        long vectorMinSSTableSize = getSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, MIN_SSTABLE_SIZE_AUTO, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
+                                 : useVectorOptions ? DEFAULT_VECTOR_TARGET_SSTABLE_SIZE : DEFAULT_TARGET_SSTABLE_SIZE;
 
-        double sstableGrowthModifier = DEFAULT_SSTABLE_GROWTH;
+        long minSSTableSize;
+        if (MIN_SSTABLE_SIZE_OPTION_AUTO.equalsIgnoreCase(options.get(MIN_SSTABLE_SIZE_OPTION)))
+            minSSTableSize = MIN_SSTABLE_SIZE_AUTO;
+        else
+            minSSTableSize = getSizeWithAlt(options,
+                                            MIN_SSTABLE_SIZE_OPTION,
+                                            MIN_SSTABLE_SIZE_OPTION_MB,
+                                            20,
+                                            useVectorOptions ? DEFAULT_VECTOR_MIN_SSTABLE_SIZE : DEFAULT_MIN_SSTABLE_SIZE);
+
+        double sstableGrowthModifier = useVectorOptions ? DEFAULT_VECTOR_SSTABLE_GROWTH : DEFAULT_SSTABLE_GROWTH;
         if (options.containsKey(SSTABLE_GROWTH_OPTION))
             sstableGrowthModifier = FBUtilities.parsePercent(options.get(SSTABLE_GROWTH_OPTION));
 
-        double vectorSSTableGrowthModifier = VECTOR_DEFAULT_SSTABLE_GROWTH;
-        if (options.containsKey(VECTOR_SSTABLE_GROWTH_OPTION))
-            vectorSSTableGrowthModifier = FBUtilities.parsePercent(options.get(VECTOR_SSTABLE_GROWTH_OPTION));
-
         int reservedThreadsPerLevel = options.containsKey(RESERVED_THREADS_OPTION)
                                       ? FBUtilities.parseIntAllowingMax(options.get(RESERVED_THREADS_OPTION))
-                                      : DEFAULT_RESERVED_THREADS;
-
-        int vectorReservedThreadsPerLevel = options.containsKey(VECTOR_RESERVED_THREADS_OPTION)
-                                      ? FBUtilities.parseIntAllowingMax(options.get(VECTOR_RESERVED_THREADS_OPTION))
-                                      : VECTOR_DEFAULT_RESERVED_THREADS;
+                                      : useVectorOptions ? DEFAULT_VECTOR_RESERVED_THREADS : DEFAULT_RESERVED_THREADS;
         Reservations.Type reservationsType = options.containsKey(RESERVATIONS_TYPE_OPTION)
                                                   ? Reservations.Type.valueOf(options.get(RESERVATIONS_TYPE_OPTION).toUpperCase())
                                                   : DEFAULT_RESERVED_THREADS_TYPE;
@@ -1017,6 +999,18 @@ public abstract class Controller
             }
         }
 
+        if (baseShardCount > 1 && sstableGrowthModifier != 1.0 && minSSTableSize != MIN_SSTABLE_SIZE_AUTO && minSSTableSize > targetSStableSize * INVERSE_SQRT_2)
+        {
+            // Note: not checked for baseShardCount == 1 as min size is irrelevant when the base count is 1.
+            // Note: not checked for sstableGrowthModifier = 1.0 as target size is irrelevant when the growth is 1.
+            long newTargetSize = (long) (minSSTableSize / INVERSE_SQRT_2);
+            logger.warn("Minimum sstable size {} is larger than target sstable size's minimum bound {}. Adjusting target size to {}.",
+                        FBUtilities.prettyPrintMemory(minSSTableSize),
+                        FBUtilities.prettyPrintMemory((long) (targetSStableSize * INVERSE_SQRT_2)),
+                        FBUtilities.prettyPrintMemory(newTargetSize));
+            targetSStableSize = newTargetSize;
+        }
+
         Environment env = realm.makeUCSEnvironment();
 
         // For remote storage, the sstables on L0 are created by the different replicas, and therefore it is likely
@@ -1037,17 +1031,17 @@ public abstract class Controller
                ? AdaptiveController.fromOptions(env,
                                                 survivalFactors,
                                                 dataSetSize,
-                                                useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
+                                                minSSTableSize,
                                                 flushSizeOverride,
                                                 maxSpaceOverhead,
                                                 maxSSTablesToCompact,
                                                 expiredSSTableCheckFrequency,
                                                 ignoreOverlapsInExpirationCheck,
-                                                useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                                baseShardCount,
                                                 isReplicaAware,
-                                                useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
-                                                useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
-                                                useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
+                                                targetSStableSize,
+                                                sstableGrowthModifier,
+                                                reservedThreadsPerLevel,
                                                 reservationsType,
                                                 overlapInclusionMethod,
                                                 parallelizeOutputShards,
@@ -1058,17 +1052,17 @@ public abstract class Controller
                : StaticController.fromOptions(env,
                                               survivalFactors,
                                               dataSetSize,
-                                              useVectorOptions ? vectorMinSSTableSize : minSSTableSize,
+                                              minSSTableSize,
                                               flushSizeOverride,
                                               maxSpaceOverhead,
                                               maxSSTablesToCompact,
                                               expiredSSTableCheckFrequency,
                                               ignoreOverlapsInExpirationCheck,
-                                              useVectorOptions ? vectorBaseShardCount : baseShardCount,
+                                              baseShardCount,
                                               isReplicaAware,
-                                              useVectorOptions ? vectorTargetSStableSize : targetSStableSize,
-                                              useVectorOptions ? vectorSSTableGrowthModifier : sstableGrowthModifier,
-                                              useVectorOptions ? vectorReservedThreadsPerLevel : reservedThreadsPerLevel,
+                                              targetSStableSize,
+                                              sstableGrowthModifier,
+                                              reservedThreadsPerLevel,
                                               reservationsType,
                                               overlapInclusionMethod,
                                               parallelizeOutputShards,
@@ -1081,18 +1075,18 @@ public abstract class Controller
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
     {
+        // Note: Validation must ignore the defaults set with -D options, because this node may be getting a configuration
+        // applied via a different coordinator which had different -D settings. If we abort because of such differences,
+        // we may cause schema mismatches between nodes which can quickly become a serious problem.
+
         String nonPositiveErr = "Invalid configuration, %s should be positive: %d";
-        String booleanParseErr = "%s should either be 'true' or 'false', not %s";
         String intParseErr = "%s is not a parsable int (base10) for %s";
         String longParseErr = "%s is not a parsable long (base10) for %s";
         String floatParseErr = "%s is not a parsable float for %s";
         options = new HashMap<>(options);
         String s;
-        boolean adaptive = DEFAULT_ADAPTIVE;
         long minSSTableSize = -1;
-        long vectorMinSSTableSize = -1;
-        long targetSSTableSize = DEFAULT_TARGET_SSTABLE_SIZE;
-        long vectorTargetSSTableSize = VECTOR_DEFAULT_TARGET_SSTABLE_SIZE;
+        long targetSSTableSize = -1;
 
         s = options.remove(NUM_SHARDS_OPTION);
         if (s != null)
@@ -1101,8 +1095,8 @@ public abstract class Controller
             {
                 int numShards = Integer.parseInt(s);
                 if (numShards <= 0 && numShards != -1)
-                    throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %d or -1 " +
-                                                                   "if static sharding is explicitly disabled for this table.",
+                    throw new ConfigurationException(String.format("Invalid configuration, %s=%d should be positive, or -1 " +
+                                                                   "to explicitly disable static sharding for this table.",
                                                                    NUM_SHARDS_OPTION,
                                                                    numShards));
                 if (numShards != -1)
@@ -1122,12 +1116,10 @@ public abstract class Controller
             }
         }
 
-        adaptive = validateBoolean(options, ADAPTIVE_OPTION, DEFAULT_ADAPTIVE);
+        boolean adaptive = validateBoolean(options, ADAPTIVE_OPTION, DEFAULT_ADAPTIVE);
         validateBoolean(options, IS_REPLICA_AWARE_OPTION, DEFAULT_IS_REPLICA_AWARE);
         validateBoolean(options, PARALLELIZE_OUTPUT_SHARDS_OPTION, DEFAULT_PARALLELIZE_OUTPUT_SHARDS);
 
-        minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, DEFAULT_MIN_SSTABLE_SIZE);
-        vectorMinSSTableSize = validateSizeWithSpecial(options, VECTOR_MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, VECTOR_DEFAULT_MIN_SSTABLE_SIZE);
         validateSizeWithAlt(options, FLUSH_SIZE_OVERRIDE_OPTION, FLUSH_SIZE_OVERRIDE_OPTION_MB, 20);
         validateSizeWithAlt(options, DATASET_SIZE_OPTION, DATASET_SIZE_OPTION_GB, 30);
 
@@ -1190,11 +1182,24 @@ public abstract class Controller
 
         validateBoolean(options, ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_OPTION, false);
 
-        s = options.remove(OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION);
-        if (s != null && !s.equalsIgnoreCase("true") && !s.equalsIgnoreCase("false"))
+        s = options.remove(SSTABLE_GROWTH_OPTION);
+        if (s != null)
         {
-            throw new ConfigurationException(String.format(booleanParseErr,
-                                                           OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, s));
+            try
+            {
+                double ssTableGrowthModifier = FBUtilities.parsePercent(s);
+                if (ssTableGrowthModifier < 0 || ssTableGrowthModifier > 1)
+                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
+                                                                   SSTABLE_GROWTH_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
+                                                               SSTABLE_GROWTH_OPTION,
+                                                               e.getMessage()),
+                                                 e);
+            }
         }
 
         s = options.remove(BASE_SHARD_COUNT_OPTION);
@@ -1202,32 +1207,15 @@ public abstract class Controller
         {
             try
             {
-                int numShards = Integer.parseInt(s);
-                if (numShards <= 0)
+                int baseShardCount = Integer.parseInt(s);
+                if (baseShardCount <= 0)
                     throw new ConfigurationException(String.format(nonPositiveErr,
                                                                    BASE_SHARD_COUNT_OPTION,
-                                                                   numShards));
+                                                                   baseShardCount));
             }
             catch (NumberFormatException e)
             {
                 throw new ConfigurationException(String.format(intParseErr, s, BASE_SHARD_COUNT_OPTION), e);
-            }
-        }
-
-        s = options.remove(VECTOR_BASE_SHARD_COUNT_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                int numShards = Integer.parseInt(s);
-                if (numShards <= 0)
-                    throw new ConfigurationException(String.format(nonPositiveErr,
-                                                                   VECTOR_BASE_SHARD_COUNT_OPTION,
-                                                                   numShards));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format(intParseErr, s, VECTOR_BASE_SHARD_COUNT_OPTION), e);
             }
         }
 
@@ -1252,66 +1240,12 @@ public abstract class Controller
             }
         }
 
-        s = options.remove(VECTOR_TARGET_SSTABLE_SIZE_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                vectorTargetSSTableSize = FBUtilities.parseHumanReadableBytes(s);
-                if (vectorTargetSSTableSize < MIN_TARGET_SSTABLE_SIZE)
-                    throw new ConfigurationException(String.format("%s %s is not acceptable, size must be at least %s",
-                                                                   VECTOR_TARGET_SSTABLE_SIZE_OPTION,
-                                                                   s,
-                                                                   FBUtilities.prettyPrintMemory(MIN_TARGET_SSTABLE_SIZE)));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid size in bytes: %s",
-                                                               VECTOR_TARGET_SSTABLE_SIZE_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
-        s = options.remove(SSTABLE_GROWTH_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                double targetSSTableGrowth = FBUtilities.parsePercent(s);
-                if (targetSSTableGrowth < 0 || targetSSTableGrowth > 1)
-                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
-                                                                   SSTABLE_GROWTH_OPTION,
-                                                                   s));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
-                                                               SSTABLE_GROWTH_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
-        s = options.remove(VECTOR_SSTABLE_GROWTH_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                double targetSSTableGrowth = FBUtilities.parsePercent(s);
-                if (targetSSTableGrowth < 0 || targetSSTableGrowth > 1)
-                    throw new ConfigurationException(String.format("%s %s must be between 0 and 1",
-                                                                   VECTOR_SSTABLE_GROWTH_OPTION,
-                                                                   s));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid number between 0 and 1: %s",
-                                                               VECTOR_SSTABLE_GROWTH_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
+        minSSTableSize = validateSizeWithAlt(options, MIN_SSTABLE_SIZE_OPTION, MIN_SSTABLE_SIZE_OPTION_MB, 20, MIN_SSTABLE_SIZE_OPTION_AUTO, -1, -1);
+        // If both target and min sstable size are defined, check that they are compatible.
+        if (minSSTableSize > 0 && targetSSTableSize > 0 && minSSTableSize > targetSSTableSize * INVERSE_SQRT_2)
+            throw new ConfigurationException(String.format("The minimum sstable size %s cannot be larger than the target size's lower bound %s.",
+                                                           FBUtilities.prettyPrintMemory(minSSTableSize),
+                                                           FBUtilities.prettyPrintMemory((long) (targetSSTableSize * INVERSE_SQRT_2))));
 
         s = options.remove(RESERVED_THREADS_OPTION);
         if (s != null)
@@ -1328,26 +1262,6 @@ public abstract class Controller
             {
                 throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
                                                                RESERVED_THREADS_OPTION,
-                                                               e.getMessage()),
-                                                 e);
-            }
-        }
-
-        s = options.remove(VECTOR_RESERVED_THREADS_OPTION);
-        if (s != null)
-        {
-            try
-            {
-                int reservedThreads = FBUtilities.parseIntAllowingMax(s);
-                if (reservedThreads < 0)
-                    throw new ConfigurationException(String.format("%s %s must be an integer >= 0 or \"max\"",
-                                                                   VECTOR_RESERVED_THREADS_OPTION,
-                                                                   s));
-            }
-            catch (NumberFormatException e)
-            {
-                throw new ConfigurationException(String.format("%s is not a valid integer >= 0 or \"max\": %s",
-                                                               VECTOR_RESERVED_THREADS_OPTION,
                                                                e.getMessage()),
                                                  e);
             }
@@ -1383,15 +1297,6 @@ public abstract class Controller
             }
         }
 
-        if (minSSTableSize > targetSSTableSize * INVERSE_SQRT_2)
-            throw new ConfigurationException(String.format("The minimum sstable size %s cannot be larger than the target size's lower bound %s.",
-                                                           FBUtilities.prettyPrintMemory(minSSTableSize),
-                                                           FBUtilities.prettyPrintMemory((long) (targetSSTableSize * INVERSE_SQRT_2))));
-        if (vectorMinSSTableSize > vectorTargetSSTableSize * INVERSE_SQRT_2)
-            throw new ConfigurationException(String.format("The vector minimum sstable size %s cannot be larger than the target size's lower bound %s.",
-                                                           FBUtilities.prettyPrintMemory(vectorMinSSTableSize),
-                                                           FBUtilities.prettyPrintMemory((long) (vectorTargetSSTableSize * INVERSE_SQRT_2))));
-
         return adaptive ? AdaptiveController.validateOptions(options) : StaticController.validateOptions(options);
     }
 
@@ -1405,14 +1310,6 @@ public abstract class Controller
             return defaultValue;
     }
 
-    private static long getSizeWithAltAndSpecial(Map<String, String> options, String optionHumanReadable, String optionAlt, int altShift, String specialText, long specialValue, long defaultValue)
-    {
-        if (specialText.equalsIgnoreCase(options.get(optionHumanReadable)))
-            return specialValue;
-        else
-            return getSizeWithAlt(options, optionHumanReadable, optionAlt, altShift, defaultValue);
-    }
-
     private static boolean validateBoolean(Map<String, String> options, String option, boolean defaultValue) throws ConfigurationException
     {
         var s = options.remove(option);
@@ -1423,16 +1320,6 @@ public abstract class Controller
             return Boolean.parseBoolean(s);
         }
         return defaultValue;
-    }
-
-    private static long getSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
-    {
-        if (specialText.equalsIgnoreCase(options.get(optionHumanReadable)))
-            return specialValue;
-        else if (options.containsKey(optionHumanReadable))
-            return FBUtilities.parseHumanReadableBytes(options.get(optionHumanReadable));
-        else
-            return defaultValue;
     }
 
     private static void validateSizeWithAlt(Map<String, String> options, String optionHumanReadable, String optionAlt, int altShift)
@@ -1484,47 +1371,6 @@ public abstract class Controller
         if (sizeInBytes < 0)
             throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
                                                            opt,
-                                                           s));
-        return sizeInBytes;
-    }
-
-    private static long validateSizeWithSpecial(Map<String, String> options, String optionHumanReadable, String specialText, long specialValue, long defaultValue)
-    {
-        long sizeInBytes;
-        String s = null;
-        try
-        {
-            s = options.remove(optionHumanReadable);
-            if (s != null)
-            {
-                if (s.equalsIgnoreCase(specialText))
-                    return specialValue; // all good
-                sizeInBytes = FBUtilities.parseHumanReadableBytes(s);
-            }
-            else
-            {
-                return defaultValue;
-            }
-
-        }
-        catch (NumberFormatException e)
-        {
-            if (specialText != null)
-                throw new ConfigurationException(String.format("%s must be a valid size in bytes or %s for %s",
-                                                               s,
-                                                               specialText,
-                                                               optionHumanReadable),
-                                                 e);
-            else
-                throw new ConfigurationException(String.format("%s is not a valid size in bytes for %s",
-                                                               s,
-                                                               optionHumanReadable),
-                                                 e);
-        }
-
-        if (sizeInBytes < 0)
-            throw new ConfigurationException(String.format("Invalid configuration, %s should be positive: %s",
-                                                           optionHumanReadable,
                                                            s));
         return sizeInBytes;
     }

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -47,6 +47,7 @@ public class StaticController extends Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     private static final String DEFAULT_STATIC_SCALING_PARAMETERS = getSystemProperty(SCALING_PARAMETERS_OPTION, "T4");
+    private static final String VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + VECTOR_SCALING_PARAMETERS_OPTION, "-8");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation
@@ -69,6 +70,7 @@ public class StaticController extends Controller
                             Reservations.Type reservationsType,
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
+                            boolean hasVectorType,
                             String keyspaceName,
                             String tableName)
     {
@@ -90,7 +92,8 @@ public class StaticController extends Controller
               reservedThreadsPerLevel,
               reservationsType,
               overlapInclusionMethod,
-              parallelizeOutputShards);
+              parallelizeOutputShards,
+              hasVectorType);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
         this.tableName = tableName;
@@ -113,15 +116,20 @@ public class StaticController extends Controller
                                   Reservations.Type reservationsType,
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
+                                  boolean hasVectorType,
                                   String keyspaceName,
                                   String tableName,
-                                  Map<String, String> options)
+                                  Map<String, String> options,
+                                  boolean useVectorOptions)
     {
         int[] scalingParameters;
         if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
             scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
         else
             scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
+
+        int[] vectorScalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
+
         long currentFlushSize = flushSizeOverride;
 
         File f = getControllerConfigPath(keyspaceName, tableName);
@@ -149,7 +157,7 @@ public class StaticController extends Controller
             JVMStabilityInspector.inspectThrowable(e);
         }
         return new StaticController(env,
-                                    scalingParameters,
+                                    useVectorOptions ? vectorScalingParameters : scalingParameters,
                                     survivalFactors,
                                     dataSetSize,
                                     minSSTableSize,
@@ -167,6 +175,7 @@ public class StaticController extends Controller
                                     reservationsType,
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
+                                    hasVectorType,
                                     keyspaceName,
                                     tableName);
     }
@@ -181,6 +190,9 @@ public class StaticController extends Controller
             parseScalingParameters(factors);
         if (parameters != null && factors != null)
             throw new ConfigurationException(String.format("Either '%s' or '%s' should be used, not both", SCALING_PARAMETERS_OPTION, STATIC_SCALING_FACTORS_OPTION));
+        String vectorParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
+        if (vectorParameters != null)
+            parseScalingParameters(vectorParameters);
         return options;
     }
 
@@ -221,6 +233,9 @@ public class StaticController extends Controller
     @Override
     public String toString()
     {
-        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSSTableSize, Arrays.toString(survivalFactors), printScalingParameters(scalingParameters), calculator);
+        return String.format("Static controller, m: %d, o: %s, scalingParameters: %s, cost: %s", minSSTableSize,
+                             Arrays.toString(survivalFactors),
+                             printScalingParameters(scalingParameters),
+                             calculator);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -47,7 +47,7 @@ public class StaticController extends Controller
      * Higher indexes will use the value of the last index with a W specified.
      */
     private static final String DEFAULT_STATIC_SCALING_PARAMETERS = getSystemProperty(SCALING_PARAMETERS_OPTION, "T4");
-    private static final String VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS = System.getProperty(PREFIX + VECTOR_SCALING_PARAMETERS_OPTION, "-8");
+    static final String DEFAULT_VECTOR_STATIC_SCALING_PARAMETERS = getSystemProperty(VECTOR_PREFIX + SCALING_PARAMETERS_OPTION, "L10");
     private final int[] scalingParameters;
 
     @VisibleForTesting // comp. simulation
@@ -126,9 +126,9 @@ public class StaticController extends Controller
         if (options.containsKey(STATIC_SCALING_FACTORS_OPTION))
             scalingParameters = parseScalingParameters(options.get(STATIC_SCALING_FACTORS_OPTION));
         else
-            scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION, DEFAULT_STATIC_SCALING_PARAMETERS));
-
-        int[] vectorScalingParameters = parseScalingParameters(options.getOrDefault(VECTOR_SCALING_PARAMETERS_OPTION, VECTOR_DEFAULT_STATIC_SCALING_PARAMETERS));
+            scalingParameters = parseScalingParameters(options.getOrDefault(SCALING_PARAMETERS_OPTION,
+                                                                            useVectorOptions ? DEFAULT_VECTOR_STATIC_SCALING_PARAMETERS
+                                                                                             : DEFAULT_STATIC_SCALING_PARAMETERS));
 
         long currentFlushSize = flushSizeOverride;
 
@@ -157,7 +157,7 @@ public class StaticController extends Controller
             JVMStabilityInspector.inspectThrowable(e);
         }
         return new StaticController(env,
-                                    useVectorOptions ? vectorScalingParameters : scalingParameters,
+                                    scalingParameters,
                                     survivalFactors,
                                     dataSetSize,
                                     minSSTableSize,
@@ -190,9 +190,6 @@ public class StaticController extends Controller
             parseScalingParameters(factors);
         if (parameters != null && factors != null)
             throw new ConfigurationException(String.format("Either '%s' or '%s' should be used, not both", SCALING_PARAMETERS_OPTION, STATIC_SCALING_FACTORS_OPTION));
-        String vectorParameters = options.remove(VECTOR_SCALING_PARAMETERS_OPTION);
-        if (vectorParameters != null)
-            parseScalingParameters(vectorParameters);
         return options;
     }
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -422,6 +422,16 @@ public class TableMetadata implements SchemaElement
         return !staticColumns().isEmpty();
     }
 
+    public boolean hasVectorType()
+    {
+        for (ColumnMetadata column : columns.values())
+        {
+            if (column.type.isVector())
+                return true;
+        }
+        return false;
+    }
+
     public final void validate()
     {
         validate(false);

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -207,20 +207,19 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) container.getStrategies().get(0);
                                              Controller controller = ucs.getController();
                                              // ucs config should be set to the vector config
-                                             if (vectorOverride)
-                                                 assertEquals(controller.getScalingParameter(0), -8);
-                                             else
-                                                 assertEquals(controller.getScalingParameter(0), 0);
+                                             assertEquals(vectorOverride ? Controller.DEFAULT_VECTOR_TARGET_SSTABLE_SIZE
+                                                                         : Controller.DEFAULT_TARGET_SSTABLE_SIZE,
+                                                          controller.getTargetSSTableSize());
+                                             // but any property set in the table compaction config should override the vector config
+                                             assertEquals(0, controller.getScalingParameter(0));
 
                                              ColumnFamilyStore cfs2 = Keyspace.open("ks").getColumnFamilyStore("tbl2");
                                              UnifiedCompactionContainer container2 = (UnifiedCompactionContainer) cfs2.getCompactionStrategy();
                                              UnifiedCompactionStrategy ucs2 = (UnifiedCompactionStrategy) container2.getStrategies().get(0);
                                              Controller controller2 = ucs2.getController();
                                              // since tbl2 does not have a vectorType the ucs config should not be set to the vector config
-                                             if (vectorOverride)
-                                                 assertEquals(controller2.getScalingParameter(0), 0);
-                                             else
-                                                 assertEquals(controller2.getScalingParameter(0), 0);
+                                             assertEquals(Controller.DEFAULT_TARGET_SSTABLE_SIZE, controller2.getTargetSSTableSize());
+                                             assertEquals(0, controller2.getScalingParameter(0));
                                          });
             cluster.schemaChange(withKeyspace("ALTER TABLE ks.tbl2 ADD val vector<float, 2>;"));
             cluster.get(1).runOnInstance(() ->
@@ -230,10 +229,10 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              UnifiedCompactionStrategy ucs2 = (UnifiedCompactionStrategy) container2.getStrategies().get(0);
                                              Controller controller2 = ucs2.getController();
                                              // a vector was added to tbl2 so it should now have the vector config
-                                             if (vectorOverride)
-                                                 assertEquals(controller2.getScalingParameter(0), -8);
-                                             else
-                                                 assertEquals(controller2.getScalingParameter(0), 0);
+                                             assertEquals(vectorOverride ? Controller.DEFAULT_VECTOR_TARGET_SSTABLE_SIZE
+                                                                         : Controller.DEFAULT_TARGET_SSTABLE_SIZE,
+                                                          controller2.getTargetSSTableSize());
+                                             assertEquals(0, controller2.getScalingParameter(0));
                                          });
 
         }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -410,6 +410,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          Reservations.Type.PER_LEVEL,
                                                          overlapInclusionMethod,
                                                          true,
+                                                         false,
                                                          updateTimeSec,
                                                          minW,
                                                          maxW,
@@ -437,6 +438,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        Reservations.Type.PER_LEVEL,
                                                        overlapInclusionMethod,
                                                        true,
+                                                       false,
                                                        "ks",
                                                        "tbl");
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -86,6 +86,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                       true,
+                                      false,
                                       interval,
                                       minW,
                                       maxW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -111,6 +111,9 @@ public abstract class ControllerTest
     @BeforeClass
     public static void setUpClass()
     {
+        // The def below should match Controller.PREFIX + Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES
+        // We can't reference these, because it would initialize Controller (and get the value before we modify it).
+        System.setProperty("unified_compaction.override_ucs_config_for_vector_tables", "true");
         DatabaseDescriptor.daemonInitialization();
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -106,6 +106,7 @@ public abstract class ControllerTest
 
     protected String keyspaceName = "TestKeyspace";
     protected int numDirectories = 1;
+    protected boolean useVector = false;
 
     @BeforeClass
     public static void setUpClass()
@@ -135,6 +136,8 @@ public abstract class ControllerTest
         when(executorService.scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(fut);
 
         when(env.flushSize()).thenReturn((double) (sstableSizeMB << 20));
+        when(cfs.metadata()).thenReturn(metadata);
+        when(metadata.hasVectorType()).thenAnswer(invocation -> useVector);
     }
 
     Controller testFromOptions(boolean adaptive, Map<String, String> options)
@@ -165,6 +168,25 @@ public abstract class ControllerTest
             assertEquals(numShards, controller.getNumShards(numShards * minSSTableSize));
             assertEquals(numShards, controller.getNumShards(16 * 100 << 20));
         }
+
+        return controller;
+    }
+
+    Controller testFromOptionsVector(boolean adaptive, Map<String, String> options)
+    {
+        useVector = true;
+        addOptions(adaptive, options);
+        Controller.validateOptions(options);
+
+        Controller controller = Controller.fromOptions(cfs, options);
+        assertNotNull(controller);
+        assertNotNull(controller.toString());
+
+        assertEquals(dataSizeGB << 30, controller.getDataSetSizeBytes());
+        assertFalse(controller.isRunning());
+        for (int i = 0; i < 5; i++) // simulate 5 levels
+            assertEquals(Controller.DEFAULT_SURVIVAL_FACTOR, controller.getSurvivalFactor(i), epsilon);
+        assertNull(controller.getCalculator());
 
         return controller;
     }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -29,11 +29,12 @@ import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.ReplicationFactor;
 import org.apache.cassandra.schema.SchemaConstants;
-import org.apache.cassandra.utils.Overlaps;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,13 @@ import static org.mockito.Mockito.when;
 public class StaticControllerTest extends ControllerTest
 {
     static final int[] Ws = new int[] { 30, 2, 0, -6};
+    static final int[] VectorWs = new int[] {-8, -8, -8, -8};
+    static final int vectorBaseShardCount = 1;
+    static final double vectorSstableGrowthModifier = 1;
+    static final int vectorReservedThreads = Integer.MAX_VALUE;
+    static final int vectorScalingParameter = -8;
+    static final String vectorMinSSTableSize = "1024MiB";
+    static final String  vectorTargetSSTableSize = "5GiB";
 
     @Test
     public void testFromOptions()
@@ -64,6 +72,17 @@ public class StaticControllerTest extends ControllerTest
                             .collect(Collectors.joining(","));
         options.put(StaticController.SCALING_PARAMETERS_OPTION, wStr);
         options.put(Controller.SSTABLE_GROWTH_OPTION, "0");
+    }
+
+    private static void addVectorOptions(Map<String, String> options)
+    {
+        options.put(Controller.VECTOR_BASE_SHARD_COUNT_OPTION, String.valueOf(vectorBaseShardCount));
+        options.put(Controller.VECTOR_SSTABLE_GROWTH_OPTION, String.valueOf(vectorSstableGrowthModifier));
+        options.put(Controller.VECTOR_RESERVED_THREADS_OPTION, String.valueOf(vectorReservedThreads));
+        options.put(Controller.VECTOR_SCALING_PARAMETERS_OPTION, String.valueOf(vectorScalingParameter));
+        options.put(Controller.VECTOR_MIN_SSTABLE_SIZE_OPTION, vectorMinSSTableSize);
+        options.put(Controller.VECTOR_TARGET_SSTABLE_SIZE_OPTION, vectorTargetSSTableSize);
+        options.put(Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, String.valueOf(true));
     }
 
     @Test
@@ -101,12 +120,61 @@ public class StaticControllerTest extends ControllerTest
     }
 
     @Test
+    public void testFromOptionsVectorTable()
+    {
+        Map<String, String> options = new HashMap<>();
+        addOptions(false, options);
+        addVectorOptions(options);
+
+        Controller controller = testFromOptions(false, options);
+        assertTrue(controller instanceof StaticController);
+
+        for (int i = 0; i < Ws.length; i++)
+            assertEquals(Ws[i], controller.getScalingParameter(i));
+
+        assertEquals(Ws[Ws.length-1], controller.getScalingParameter(Ws.length));
+
+        controller = testFromOptionsVector(false, options);
+
+        assertEquals(vectorBaseShardCount, controller.baseShardCount);
+        assertEquals(vectorSstableGrowthModifier, controller.sstableGrowthModifier, 0.01);
+        assertEquals(FBUtilities.parseHumanReadableBytes(vectorMinSSTableSize), controller.minSSTableSize);
+        assertEquals(vectorReservedThreads, controller.getReservedThreads());
+        assertEquals(FBUtilities.parseHumanReadableBytes(vectorTargetSSTableSize), controller.getTargetSSTableSize());
+        for (int i = 0; i < Ws.length; i++)
+            assertEquals(vectorScalingParameter, controller.getScalingParameter(i));
+    }
+
+    @Test
     public void testValidateOptions()
     {
         Map<String, String> options = new HashMap<>();
         addOptions(false, options);
 
         super.testValidateOptions(options, false);
+    }
+
+    @Test
+    public void testValidateVectorOptions()
+    {
+        Map<String, String> options = new HashMap<>();
+        options.put(Controller.VECTOR_BASE_SHARD_COUNT_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_SSTABLE_GROWTH_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_RESERVED_THREADS_OPTION, "-1");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_MIN_SSTABLE_SIZE_OPTION, "10GiB");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.VECTOR_TARGET_SSTABLE_SIZE_OPTION, "-1MiB");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+        options.clear();
+        options.put(Controller.OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES_OPTION, "not true");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
     }
 
     @Test
@@ -183,6 +251,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testStartShutdown(controller);
@@ -201,7 +270,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
-                                                           Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
+                                                           Controller.DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
                                                            numShards,
                                                            false,
                                                            sstableSizeMB << 20,
@@ -210,6 +279,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testShutdownNotStarted(controller);
@@ -228,7 +298,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_MAX_SPACE_OVERHEAD,
                                                            0,
                                                            Controller.DEFAULT_EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS,
-                                                           Controller.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
+                                                           Controller.DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION,
                                                            numShards,
                                                            false,
                                                            sstableSizeMB << 20,
@@ -237,6 +307,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_RESERVED_THREADS_TYPE,
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
+                                                           false,
                                                            keyspaceName,
                                                            tableName);
         super.testStartAlreadyStarted(controller);


### PR DESCRIPTION
... as different option names do not really make sense is per-table options (the user will know if the table is a vector one).

Drop validation checks that may depend on -D options (which may differ between replica and coordinator) and adjust invalid min vs target size when -D options create nonsensical combinations.