### PR TITLE
CNDB-13004 don't fail on too long file name for options

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,7 +210,12 @@ public class AdaptiveController extends Controller
         {
             logger.warn("Unable to parse saved options. Using starting value instead:", e);
         }
-        catch (Throwable e) {
+        catch (FSError e)
+        {
+            logger.warn("Unable to read controller config file. Using starting value instead:", e);
+        }
+        catch (Throwable e)
+        {
             logger.warn("Unable to read controller config file. Using starting value instead:", e);
             JVMStabilityInspector.inspectThrowable(e);
         }

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,6 +207,10 @@ public class AdaptiveController extends Controller
         catch (ParseException e)
         {
             logger.warn("Unable to parse saved options. Using starting value instead:", e);
+        }
+        catch (Throwable e) {
+            logger.warn("Unable to read controller config file. Using starting value instead:", e);
+            JVMStabilityInspector.inspectThrowable(e);
         }
 
         if (scalingParameters == null)

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -426,6 +427,7 @@ public abstract class Controller
         catch(Throwable e)
         {
             logger.warn("Unable to save current scaling parameters and flush size. Current controller configuration will be lost if a node restarts: ", e);
+            JVMStabilityInspector.inspectThrowable(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -423,7 +423,7 @@ public abstract class Controller
 
             logger.debug(String.format("Writing current scaling parameters and flush size to file %s: %s", f.toPath().toString(), jsonObject));
         }
-        catch(IOException e)
+        catch(Throwable e)
         {
             logger.warn("Unable to save current scaling parameters and flush size. Current controller configuration will be lost if a node restarts: ", e);
         }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -424,7 +425,11 @@ public abstract class Controller
 
             logger.debug(String.format("Writing current scaling parameters and flush size to file %s: %s", f.toPath().toString(), jsonObject));
         }
-        catch(Throwable e)
+        catch (IOException | FSError e)
+        {
+            logger.warn("Unable to save current scaling parameters and flush size. Current controller configuration will be lost if a node restarts: ", e);
+        }
+        catch (Throwable e)
         {
             logger.warn("Unable to save current scaling parameters and flush size. Current controller configuration will be lost if a node restarts: ", e);
             JVMStabilityInspector.inspectThrowable(e);

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileReader;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -150,6 +151,10 @@ public class StaticController extends Controller
         catch (ParseException e)
         {
             logger.warn("Unable to parse saved flush size. Using starting value instead:", e);
+        }
+        catch (FSError e)
+        {
+            logger.warn("Unable to read controller config file. Using starting value instead:", e);
         }
         catch (Throwable e)
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -178,6 +178,28 @@ public class CompactionControllerConfigTest extends TestBaseImpl
     }
 
     @Test
+    public void testStoreLongNameControllerConfig() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(1).start()))
+        {
+            cluster.get(1).runOnInstance(() ->
+                                         {
+                                             String keyspaceName = "keyspace_name";
+                                             String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+                                             CompactionManager.storeControllerConfig();
+
+                                             // try to store controller config for a table with a long name
+                                             int[] scalingParameters = new int[32];
+                                             Arrays.fill(scalingParameters, 5);
+                                             AdaptiveController.storeOptions(keyspaceName, longTableName, scalingParameters, 10 << 20);
+
+                                             // verify that the file wasn't created
+                                             assert !Controller.getControllerConfigPath(keyspaceName, longTableName).exists();
+                                         });
+        }
+    }
+
+    @Test
     public void testVectorControllerConfig() throws Throwable
     {
         vectorControllerConfig(true);
@@ -234,7 +256,6 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                                           controller2.getTargetSSTableSize());
                                              assertEquals(0, controller2.getScalingParameter(0));
                                          });
-
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -184,8 +184,8 @@ public class CompactionControllerConfigTest extends TestBaseImpl
         {
             cluster.get(1).runOnInstance(() ->
                                          {
-                                             String keyspaceName = "keyspace_name";
-                                             String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+                                             String keyspaceName = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
+                                             String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
                                              CompactionManager.storeControllerConfig();
 
                                              // try to store controller config for a table with a long name

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -178,17 +178,17 @@ public class CompactionControllerConfigTest extends TestBaseImpl
     }
 
     @Test
-    public void testStoreLongNameControllerConfig() throws Throwable
+    public void testStoreLongTableName() throws Throwable
     {
         try (Cluster cluster = init(Cluster.build(1).start()))
         {
             cluster.get(1).runOnInstance(() ->
                                          {
-                                             String keyspaceName = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
-                                             String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
                                              CompactionManager.storeControllerConfig();
 
                                              // try to store controller config for a table with a long name
+                                             String keyspaceName = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
+                                             String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
                                              int[] scalingParameters = new int[32];
                                              Arrays.fill(scalingParameters, 5);
                                              AdaptiveController.storeOptions(keyspaceName, longTableName, scalingParameters, 10 << 20);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -103,16 +103,12 @@ public class AdaptiveControllerTest extends ControllerTest
         String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
         when(cfs.getTableName()).thenReturn(longTableName);
 
-        int[] scalingParameters = new int[30];
-        Arrays.fill(scalingParameters, 1);
-        AdaptiveController.storeOptions(keyspaceName, longTableName, scalingParameters, 10 << 20);
         Map<String, String> options = new HashMap<>();
         options.put(AdaptiveController.THRESHOLD, "0.15");
-        // Call fromOptions on long table name, which tries to write options into a file
+        // Calls fromOptions on long table name, which tries to read options from a file.
+        // The too long file name should not lead to a failure.
         Controller controller = testFromOptions(true, options);
         assertTrue(controller instanceof AdaptiveController);
-        // Test that writing the file failed
-        assert !Controller.getControllerConfigPath(keyspaceName, longTableName).exists();
 
         when(cfs.getTableName()).thenReturn(tableName);
     }
@@ -136,8 +132,6 @@ public class AdaptiveControllerTest extends ControllerTest
 
         Controller controller = testFromOptions(true, options);
         assertTrue(controller instanceof AdaptiveController);
-        // Controls that fromOptions successfully written options into a file
-        assert Controller.getControllerConfigPath(keyspaceName, tableName).exists();
 
         for (int i = 0; i < 10; i++)
         {


### PR DESCRIPTION
Fixes [#13004](https://github.com/riptano/cndb/issues/13004)

### What is the issue
When a compaction controller config options are being written or read for a table with long keyspace + table names, FileSystemException happens.

### What does this PR fix and why was it fixed
This commit fixes that such exception is caught and logged. Thus existing table with long name will continue to function.
Also it catches other exceptions.