### PR TITLE
CNDB-12981: Revert ADA002 VectorSourceModel change to BINARY_QUANTIZATION

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -34,7 +34,7 @@ import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.Compr
 
 public enum VectorSourceModel
 {
-    ADA002((dimension) -> new VectorCompression(BINARY_QUANTIZATION, dimension, 0.125), 2.0),
+    ADA002((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.125), 1.25),
     OPENAI_V3_SMALL((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.5),
     OPENAI_V3_LARGE((dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.0625), 1.25),
     BERT(COSINE, (dimension) -> new VectorCompression(PRODUCT_QUANTIZATION, dimension, 0.25), __ -> 1.0),


### PR DESCRIPTION
CNDB-12981: Revert ADA002 VectorSourceModel change to BINARY_QUANTIZATION

Reverting the change to BINARY_QUANTIZATION from PRODUCT_QUANTIZATION.  A simple change to VectorSourceModel. 

Ensures that both new and existing indexes the using the ada002 embedding model continue to use PQ for now.  All of the other changes that were originally committed with it in 655080c43054fa9bf205106f93ef68a404c80aab remain intact.

