### PR TITLE
CNDB-12915: --add-opens for java.nio.charset

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -302,6 +302,7 @@
         <string>--add-opens java.base/java.math=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.net=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.nio=ALL-UNNAMED</string>
+        <string>--add-opens java.base/java.nio.charset=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.nio.file.spi=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.util=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED</string>

--- a/conf/jvm17-server.options
+++ b/conf/jvm17-server.options
@@ -80,6 +80,7 @@
 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED
 --add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.nio.charset=ALL-UNNAMED
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
 --add-opens=java.base/java.io=ALL-UNNAMED
 --add-opens=java.base/java.util=ALL-UNNAMED

--- a/conf/jvm22-server.options
+++ b/conf/jvm22-server.options
@@ -56,6 +56,7 @@
 --add-opens java.base/java.lang.module=ALL-UNNAMED
 --add-opens java.base/java.lang=ALL-UNNAMED
 --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens java.base/java.nio.charset=ALL-UNNAMED
 --add-opens java.base/java.nio.file.spi=ALL-UNNAMED
 --add-opens java.base/java.nio=ALL-UNNAMED
 --add-opens java.base/java.net=ALL-UNNAMED


### PR DESCRIPTION
### What is the issue
Missing add-opens causes an error while caching PreparedStatement on the server

```
     java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.String java.nio.charset.Charset.name accessible: module java.base does not "opens java.nio.charset" to unnamed module @6009bea
     	at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:388)
     	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:364)
     	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:312)
     	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:183)
     	at java.base/java.lang.reflect.Field.setAccessible(Field.java:177)
     	at org.github.jamm.MemoryMeter.addFieldChildren(MemoryMeter.java:330)
     	at org.github.jamm.MemoryMeter.measureDeep(MemoryMeter.java:269)
     	at org.apache.cassandra.utils.ObjectSizes.measureDeep(ObjectSizes.java:216)
     	at org.apache.cassandra.cql3.QueryProcessor.measurePStatementCacheEntrySize(QueryProcessor.java:894)
     	at org.apache.cassandra.cql3.QueryProcessor.storePreparedStatement(QueryProcessor.java:757)
```

### What does this PR fix and why was it fixed
Add opens to the JVM arguments
