### PR TITLE
CNDB-13067: Fix flaky TraceTest

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/TraceTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/TraceTest.java
@@ -39,14 +39,15 @@ import static org.junit.Assert.assertEquals;
 
 public class TraceTest extends TestBaseImpl
 {
-    private static int ROWS = 100;
-    private static Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
+    private final static int ROWS = 100;
+    private final static int MATCHED_ROWS = 30;
+
+    private final static Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
     @Test
     public void testMultiIndexTracing() throws Throwable
     {
         String originalTraceTimeout = TracingUtil.setWaitForTracingEventTimeoutSecs("1");
-        TokenSupplier even = TokenSupplier.evenlyDistributedTokens(3);
 
         try (Cluster cluster = init(Cluster.build(3)
                                            .withConfig(config -> config.with(Feature.NETWORK, Feature.GOSSIP))
@@ -54,13 +55,12 @@ public class TraceTest extends TestBaseImpl
                                            .start()))
         {
             cluster.schemaChange("CREATE KEYSPACE trace_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
-            cluster.schemaChange("CREATE TABLE trace_ks.tbl (pk int primary key, v1 int, v2 text)");
+            cluster.schemaChange("CREATE TABLE trace_ks.tbl (pk int primary key, v1 int)");
             cluster.schemaChange("CREATE CUSTOM INDEX tbl_v1_idx ON trace_ks.tbl(v1) USING 'StorageAttachedIndex'");
-            cluster.schemaChange("CREATE CUSTOM INDEX tbl_v2_idx ON trace_ks.tbl(v2) USING 'StorageAttachedIndex'");
 
             for (int row = 0; row < ROWS; row++)
             {
-                cluster.coordinator(1).execute(String.format("INSERT INTO trace_ks.tbl (pk, v1, v2) VALUES (%s, %s, '0')", row, row), ConsistencyLevel.ONE);
+                cluster.coordinator(1).execute(String.format("INSERT INTO trace_ks.tbl (pk, v1) VALUES (%s, %s)", row, row), ConsistencyLevel.ONE);
             }
 
             cluster.forEach(c -> c.flush(KEYSPACE));
@@ -68,21 +68,21 @@ public class TraceTest extends TestBaseImpl
             SAIUtil.waitForIndexQueryable(cluster, "trace_ks");
 
             UUID sessionId = UUID.randomUUID();
-            cluster.coordinator(1).executeWithTracingWithResult(sessionId, "SELECT * from trace_ks.tbl WHERE v1 < 30 AND v2 = '0'", ConsistencyLevel.ONE);
+            cluster.coordinator(1).executeWithTracingWithResult(sessionId, "SELECT * from trace_ks.tbl WHERE v1 < " + MATCHED_ROWS, ConsistencyLevel.ONE);
 
             await().atMost(5, TimeUnit.SECONDS).until(() -> {
                 List<TracingUtil.TraceEntry> traceEntries = TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ONE);
                 return traceEntries.stream().map(traceEntry -> traceEntry.activity)
-                                            .filter(activity -> activity.contains("post-filtered"))
-                                            .mapToLong(activity -> fetchPartitionCount(activity)).sum() == 30;
+                                   .filter(activity -> activity.contains("post-filtered"))
+                                   .mapToLong(this::fetchPartitionCount).sum() == MATCHED_ROWS;
             });
             
             //TODO We can improve the asserts for this when we have improved tracing and multi-node support
-            assertEquals(30, TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ONE)
+            assertEquals(MATCHED_ROWS, TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ONE)
                                         .stream()
                                         .map(traceEntry -> traceEntry.activity)
                                         .filter(activity -> activity.contains("post-filtered"))
-                                        .mapToLong(activity -> fetchPartitionCount(activity)).sum());
+                                        .mapToLong(this::fetchPartitionCount).sum());
         }
         finally
         {


### PR DESCRIPTION
The optimizer sometimes decided to use another index which messed
up the post-filtering metrics. The test does not really need
the second index at all to test tracing. Removed.
