### PR TITLE
CNDB-12382 Implement Counter locks without Striped locks

### DIFF
--- a/src/java/org/apache/cassandra/db/CounterMutation.java
+++ b/src/java/org/apache/cassandra/db/CounterMutation.java
@@ -249,14 +249,13 @@ public class CounterMutation implements IMutation
         long startTime = System.nanoTime();
 
         AbstractReplicationStrategy replicationStrategy = keyspace.getReplicationStrategy();
-        Iterable<CounterLockManager.Lock> sortedLocks = CounterLockManager.instance.grabLocks(getCounterLockKeys());
-        locksPerUpdate.update(countDistinctLocks(sortedLocks));
-
+        List<CounterLockManager.Lock> sortedLocks = CounterLockManager.instance.grabLocks(getCounterLockKeys());
         // always return all the locks to the caller, this way they can be released even in case of errors
-        sortedLocks.forEach(locks::add);
+        locks.addAll(sortedLocks);
+        locksPerUpdate.update(countDistinctLocks(sortedLocks));
         try
         {
-            for (CounterLockManager.Lock lock : locks)
+            for (CounterLockManager.Lock lock : sortedLocks)
             {
                 long timeout = getTimeout(NANOSECONDS) - (System.nanoTime() - startTime);
                 try

--- a/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.db.counters;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -37,11 +39,12 @@ public class CachedCounterLockManager implements CounterLockManager
     private final static int EXPECTED_CONCURRENCY = DatabaseDescriptor.getConcurrentCounterWriters() * 16;
 
     @Override
-    public Iterable<Lock> grabLocks(Iterable<Integer> keys)
+    public List<Lock> grabLocks(Iterable<Integer> keys)
     {
-        return Iterables.transform(keys, k -> {
-            return makeLockForKey(k);
-        });
+        List<Lock> result = new ArrayList<>();
+        for (Integer key : keys)
+            result.add(makeLockForKey(key));
+        return result;
     }
 
     private StampedLock makeLock()
@@ -91,6 +94,13 @@ public class CachedCounterLockManager implements CounterLockManager
         this.locks.clear();
     }
 
+    @Override
+    public boolean hasNumKeys()
+    {
+        return true;
+    }
+
+    @Override
     public int getNumKeys()
     {
         return locks.size();
@@ -143,5 +153,4 @@ public class CachedCounterLockManager implements CounterLockManager
             return "RefCountedStampedLock{" + "lock=" + lock + ", count=" + count + '}';
         }
     }
-
 }

--- a/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.counters;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.StampedLock;
+
+import com.google.common.collect.Iterables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.CounterMutation;
+
+public class CachedCounterLockManager implements CounterLockManager
+{
+    private static final Logger logger = LoggerFactory.getLogger(CachedCounterLockManager.class);
+    private final static int EXPECTED_CONCURRENCY = DatabaseDescriptor.getConcurrentCounterWriters() * 16;
+
+    @Override
+    public Iterable<Lock> grabLocks(Iterable<Integer> keys)
+    {
+        return Iterables.transform(keys, k -> {
+            return makeLockForKey(k);
+        });
+    }
+
+    private StampedLock makeLock()
+    {
+        return new StampedLock();
+    }
+
+
+    private final ConcurrentMap<Integer, RefCountedStampedLock> locks = new ConcurrentHashMap<>(EXPECTED_CONCURRENCY);
+
+    private LockHandle makeLockForKey(Integer key)
+    {
+        RefCountedStampedLock instance = locks.compute(key, (k, existing) -> {
+            if (existing != null)
+            {
+                existing.count++;
+                return existing;
+            }
+            else
+            {
+                return new RefCountedStampedLock(makeLock(), 1);
+            }
+        });
+        return new LockHandle(key, instance);
+    }
+
+    private void returnLockForKey(RefCountedStampedLock instance, Integer key) throws IllegalStateException
+    {
+        locks.compute(key, (Integer t, RefCountedStampedLock u) -> {
+            if (instance != u)
+            {
+                throw new IllegalStateException("trying to release un-owned lock");
+            }
+            if (--u.count == 0)
+            {
+                return null;
+            }
+            else
+            {
+                return u;
+            }
+        });
+    }
+
+    public void clear()
+    {
+        this.locks.clear();
+    }
+
+    public int getNumKeys()
+    {
+        return locks.size();
+    }
+
+    private class LockHandle implements Lock
+    {
+
+        public volatile long stamp;
+        public final Integer key;
+        public final RefCountedStampedLock handle;
+
+        public LockHandle(Integer key, RefCountedStampedLock handle)
+        {
+            this.key = key;
+            this.handle = handle;
+        }
+
+        @Override
+        public void release()
+        {
+            if (stamp != 0)
+                handle.lock.unlockWrite(stamp);
+            returnLockForKey(handle, key);
+        }
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit timeUnit) throws InterruptedException
+        {
+            stamp = handle.lock.tryWriteLock(timeout, timeUnit);
+            return stamp != 0;
+        }
+    }
+
+    private static class RefCountedStampedLock
+    {
+
+        private final StampedLock lock;
+        private int count;
+
+        public RefCountedStampedLock(StampedLock lock, int count)
+        {
+            this.lock = lock;
+            this.count = count;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "RefCountedStampedLock{" + "lock=" + lock + ", count=" + count + '}';
+        }
+    }
+
+}

--- a/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CachedCounterLockManager.java
@@ -29,9 +29,13 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 
 /**
  * Implemetation of {@link CounterLockManager} that uses a cache of locks.
- * Note: this implemetation tries to reduce the change of having two counters lock each other, but as the counters
+ * Note: this implemetation tries to reduce the chance of having two counters lock each other, but as the counters
  * are identified by the hash of the primary key of the row, it is still possible to
  * have some cross-counter contention for counters with different primary keys but the same hash.
+ *
+ * This code is copied from
+ * <a href="https://github.com/diennea/herddb/blob/master/herddb-utils/src/main/java/herddb/utils/LocalLockManager.java">LocalLockManager</a> from the HerdDB project (Apache 2 licensed).
+ *
  */
 public class CachedCounterLockManager implements CounterLockManager
 {

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.counters;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public interface CounterLockManager
@@ -44,5 +45,13 @@ public interface CounterLockManager
         void release();
     }
 
-    Iterable<Lock> grabLocks(Iterable<Integer> keys);
+    List<Lock> grabLocks(Iterable<Integer> keys);
+
+    boolean hasNumKeys();
+
+    default int getNumKeys()
+    {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -58,6 +58,8 @@ public interface CounterLockManager
 
     /**
      * Grab locks for the given keys. The returned handles must be released by calling {@link LockHandle#release()}.
+     * The returned list is re-ordered in order to prevent deadlocks.
+     * It is expected that the caller will release the locks in the inverse order they were acquired.
      *
      * @param keys list of keys, the Iterable is scanned only once in order to prevent side effects.
      * @return a list of lock handles. The List can be iterated multiple times without side effects.

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -60,7 +60,7 @@ public interface CounterLockManager
      * Grab locks for the given keys. The returned handles must be released by calling {@link LockHandle#release()}.
      * The returned list is re-ordered in order to prevent deadlocks.
      * It is expected that the caller will release the locks in the inverse order they were acquired.
-     * The initial set may contain duplicates, it is expected tha this method will return a list with the same number of elements.
+     * The initial set may contain duplicates, it is expected that this method will return a list with the same number of elements.
      *
      * @param keys list of keys, the Iterable is scanned only once in order to prevent side effects.
      * @return a list of lock handles. The List can be iterated multiple times without side effects.

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -60,6 +60,7 @@ public interface CounterLockManager
      * Grab locks for the given keys. The returned handles must be released by calling {@link LockHandle#release()}.
      * The returned list is re-ordered in order to prevent deadlocks.
      * It is expected that the caller will release the locks in the inverse order they were acquired.
+     * The initial set may contain duplicates, it is expected tha this method will return a list with the same number of elements.
      *
      * @param keys list of keys, the Iterable is scanned only once in order to prevent side effects.
      * @return a list of lock handles. The List can be iterated multiple times without side effects.

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -58,6 +58,7 @@ public interface CounterLockManager
 
     /**
      * Grab locks for the given keys. The returned handles must be released by calling {@link LockHandle#release()}.
+     *
      * @param keys list of keys, the Iterable is scanned only once in order to prevent side effects.
      * @return a list of lock handles. The List can be iterated multiple times without side effects.
      */
@@ -66,6 +67,7 @@ public interface CounterLockManager
     /**
      * Check if the implementation can return the number of keys that are handled by the lock manager.
      * This method is useful only for testing.
+     *
      * @return true if the implementation can return the number of keys.
      */
     boolean hasNumKeys();
@@ -73,11 +75,11 @@ public interface CounterLockManager
     /**
      * Get the number of keys that are handled by the lock manager.
      * This method is useful only for testing.
+     *
      * @return the number of keys.
      */
     default int getNumKeys()
     {
         throw new UnsupportedOperationException();
     }
-
 }

--- a/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/CounterLockManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.counters;
+
+import java.util.concurrent.TimeUnit;
+
+public interface CounterLockManager
+{
+    boolean USE_STRIPED_COUNTER_LOCK_MANAGER = Boolean.getBoolean("cassandra.use_striped_counter_lock_manager");
+    CounterLockManager instance = USE_STRIPED_COUNTER_LOCK_MANAGER ? new StripedCounterLockManager() : new CachedCounterLockManager();
+
+    interface Lock
+    {
+        /**
+         * Try to get the lock.
+         *
+         * @param timeout  timeout.
+         * @param timeUnit time unit.
+         * @return false in case the lock could not be acquired within the timeout.
+         * @throws InterruptedException
+         */
+        boolean tryLock(long timeout, TimeUnit timeUnit) throws InterruptedException;
+
+        /**
+         * Unlock the lock. This method is to be called even if the acquire method failed.
+         * This method is to be called only once.
+         */
+        void release();
+    }
+
+    Iterable<Lock> grabLocks(Iterable<Integer> keys);
+}

--- a/src/java/org/apache/cassandra/db/counters/StripedCounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/StripedCounterLockManager.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.counters;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Striped;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_FAIR_LOCK;
+import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_NUM_STRIPES_PER_THREAD;
+
+public class StripedCounterLockManager implements CounterLockManager
+{
+    private static final Striped<java.util.concurrent.locks.Lock> LOCKS;
+
+    static
+    {
+        int numStripes = COUNTER_LOCK_NUM_STRIPES_PER_THREAD.getInt() * DatabaseDescriptor.getConcurrentCounterWriters();
+        if (COUNTER_LOCK_FAIR_LOCK.getBoolean())
+        {
+            try
+            {
+                Class<?> stripedClass = Striped.class;
+
+                // Get the custom method Striped.custom
+                Method customMethod = stripedClass.getDeclaredMethod("custom", int.class, Supplier.class);
+                customMethod.setAccessible(true);
+
+                Supplier<java.util.concurrent.locks.Lock> lockSupplier = () -> new ReentrantLock(true);
+                LOCKS = (Striped<java.util.concurrent.locks.Lock>) customMethod.invoke(null, numStripes, lockSupplier);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        else
+        {
+            LOCKS = Striped.lock(numStripes);
+        }
+    }
+
+    @Override
+    public Iterable<Lock> grabLocks(Iterable<Integer> keys)
+    {
+        return Iterables.transform(LOCKS.bulkGet(keys), LockImpl::new);
+    }
+
+    private static class LockImpl implements Lock
+    {
+        private final java.util.concurrent.locks.Lock lock;
+        private boolean acquired;
+
+        public LockImpl(java.util.concurrent.locks.Lock lock)
+        {
+            this.lock = lock;
+        }
+
+        @Override
+        public void release()
+        {
+            if (acquired)
+                lock.unlock();
+        }
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit timeUnit) throws InterruptedException
+        {
+            acquired = lock.tryLock(timeout, timeUnit);
+            return acquired;
+        }
+    }
+
+}

--- a/src/java/org/apache/cassandra/db/counters/StripedCounterLockManager.java
+++ b/src/java/org/apache/cassandra/db/counters/StripedCounterLockManager.java
@@ -32,14 +32,15 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_FAIR_LOCK;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COUNTER_LOCK_NUM_STRIPES_PER_THREAD;
 /**
- * Legacy implemetation of {@link CounterLockManager} that uses a fixes set of locks.
+ * Legacy implementation of {@link CounterLockManager} that uses a fixed set of locks.
  * On a workload with many different counters it is likely to see two counters sharing the same lock.
  */
 public class StripedCounterLockManager implements CounterLockManager
 {
     private final Striped<java.util.concurrent.locks.Lock> locks;
 
-    StripedCounterLockManager () {
+    StripedCounterLockManager()
+    {
         int numStripes = COUNTER_LOCK_NUM_STRIPES_PER_THREAD.getInt() * DatabaseDescriptor.getConcurrentCounterWriters();
         if (COUNTER_LOCK_FAIR_LOCK.getBoolean())
         {

--- a/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
@@ -57,20 +57,20 @@ public class CounterLockManagerTest
     private static void basicTest(CounterLockManager manager) throws Exception
     {
         List<Integer> keys = List.of(1, 2, 3, 4, 5);
-        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
-        for (CounterLockManager.Lock l : lockHandles)
+        List<CounterLockManager.LockHandle> lockHandleHandles = manager.grabLocks(keys);
+        for (CounterLockManager.LockHandle l : lockHandleHandles)
             assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
 
         if (manager.hasNumKeys())
             assertThat(manager.getNumKeys()).isEqualTo(keys.size());
 
-        lockHandles.forEach(CounterLockManager.Lock::release);
+        lockHandleHandles.forEach(CounterLockManager.LockHandle::release);
 
         if (manager.hasNumKeys())
             assertThat(manager.getNumKeys()).isZero();
 
         // double release is not allowed (expecting IllegalMonitorStateException)
-        for (CounterLockManager.Lock l : lockHandles)
+        for (CounterLockManager.LockHandle l : lockHandleHandles)
             assertThatThrownBy(l::release).isInstanceOf(IllegalMonitorStateException.class);
 
         // the number of keys is still zero
@@ -94,8 +94,8 @@ public class CounterLockManagerTest
     private static void lockTimeout(CounterLockManager manager) throws Exception
     {
         List<Integer> keys = List.of(1, 2, 3, 4, 5);
-        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
-        for (CounterLockManager.Lock l : lockHandles)
+        List<CounterLockManager.LockHandle> lockHandleHandles = manager.grabLocks(keys);
+        for (CounterLockManager.LockHandle l : lockHandleHandles)
             assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
 
         if (manager.hasNumKeys())
@@ -106,10 +106,10 @@ public class CounterLockManagerTest
             try
             {
                 int numAcquired = 0;
-                List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+                List<CounterLockManager.LockHandle> newLockHandleHandles = manager.grabLocks(keys);
                 try
                 {
-                    for (CounterLockManager.Lock l : newLockHandles)
+                    for (CounterLockManager.LockHandle l : newLockHandleHandles)
                     {
                         if (l.tryLock(1, TimeUnit.SECONDS))
                             numAcquired++;
@@ -117,7 +117,7 @@ public class CounterLockManagerTest
                 }
                 finally
                 {
-                    newLockHandles.forEach(CounterLockManager.Lock::release);
+                    newLockHandleHandles.forEach(CounterLockManager.LockHandle::release);
                 }
                 return numAcquired;
             }
@@ -128,7 +128,7 @@ public class CounterLockManagerTest
         }).join();
         assertThat(count).isZero();
 
-        lockHandles.forEach(CounterLockManager.Lock::release);
+        lockHandleHandles.forEach(CounterLockManager.LockHandle::release);
 
         if (manager.hasNumKeys())
             assertThat(manager.getNumKeys()).isZero();
@@ -137,10 +137,10 @@ public class CounterLockManagerTest
             try
             {
                 int numAcquired = 0;
-                List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+                List<CounterLockManager.LockHandle> newLockHandleHandles = manager.grabLocks(keys);
                 try
                 {
-                    for (CounterLockManager.Lock l : newLockHandles)
+                    for (CounterLockManager.LockHandle l : newLockHandleHandles)
                     {
                         if (l.tryLock(1, TimeUnit.SECONDS))
                             numAcquired++;
@@ -148,7 +148,7 @@ public class CounterLockManagerTest
                 }
                 finally
                 {
-                    newLockHandles.forEach(CounterLockManager.Lock::release);
+                    newLockHandleHandles.forEach(CounterLockManager.LockHandle::release);
                 }
                 return numAcquired;
             }
@@ -178,8 +178,8 @@ public class CounterLockManagerTest
     private static void testInterruptedException(CounterLockManager manager) throws Exception
     {
         List<Integer> keys = List.of(1, 2, 3, 4, 5);
-        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
-        for (CounterLockManager.Lock l : lockHandles)
+        List<CounterLockManager.LockHandle> lockHandleHandles = manager.grabLocks(keys);
+        for (CounterLockManager.LockHandle l : lockHandleHandles)
             assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
 
         if (manager.hasNumKeys())
@@ -187,12 +187,12 @@ public class CounterLockManagerTest
 
         CompletableFuture<Void> result = new CompletableFuture<>();
         Thread otherThread = new Thread(() -> {
-            List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+            List<CounterLockManager.LockHandle> newLockHandleHandles = manager.grabLocks(keys);
             try
             {
                 try
                 {
-                    for (CounterLockManager.Lock l : newLockHandles)
+                    for (CounterLockManager.LockHandle l : newLockHandleHandles)
                     {
                         // the first of these locks will be interrupted
                         l.tryLock(1, TimeUnit.HOURS);
@@ -207,7 +207,7 @@ public class CounterLockManagerTest
             finally
             {
                 // in any case all the locks have to be released
-                newLockHandles.forEach(CounterLockManager.Lock::release);
+                newLockHandleHandles.forEach(CounterLockManager.LockHandle::release);
             }
         });
 
@@ -215,7 +215,7 @@ public class CounterLockManagerTest
         otherThread.interrupt();
         assertThatThrownBy(result::join).hasCauseInstanceOf(InterruptedException.class);
 
-        lockHandles.forEach(CounterLockManager.Lock::release);
+        lockHandleHandles.forEach(CounterLockManager.LockHandle::release);
 
         if (manager.hasNumKeys())
             assertThat(manager.getNumKeys()).isZero();

--- a/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.counters;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit Tests for {@link CounterLockManager} implementations
+ */
+public class CounterLockManagerTest
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        DatabaseDescriptor.setConfig(new Config());
+    }
+
+    @Test
+    public void basicTestCachedCounterLockManager() throws Exception
+    {
+        basicTest(new CachedCounterLockManager());
+    }
+
+
+    @Test
+    public void basicTestStripedCounterLockManager() throws Exception
+    {
+        basicTest(new StripedCounterLockManager());
+    }
+
+
+    private static void basicTest(CounterLockManager manager) throws Exception
+    {
+        List<Integer> keys = List.of(1, 2, 3, 4, 5);
+        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
+        for (CounterLockManager.Lock l : lockHandles)
+            assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isEqualTo(keys.size());
+
+        lockHandles.forEach(CounterLockManager.Lock::release);
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isZero();
+
+        // double release is not allowed (expecting IllegalMonitorStateException)
+        for (CounterLockManager.Lock l : lockHandles)
+            assertThatThrownBy(l::release).isInstanceOf(IllegalMonitorStateException.class);
+
+        // the number of keys is still zero
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isZero();
+    }
+
+
+    @Test
+    public void lockTimeoutTestCachedCounterLockManager() throws Exception
+    {
+        lockTimeout(new CachedCounterLockManager());
+    }
+
+    @Test
+    public void lockTimeoutTestStripedCounterLockManager() throws Exception
+    {
+        lockTimeout(new StripedCounterLockManager());
+    }
+
+    private static void lockTimeout(CounterLockManager manager) throws Exception
+    {
+        List<Integer> keys = List.of(1, 2, 3, 4, 5);
+        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
+        for (CounterLockManager.Lock l : lockHandles)
+            assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isEqualTo(keys.size());
+
+        // some implementations use reentrant locks, so we have to try to get the lock from another thread
+        int count = CompletableFuture.supplyAsync(() -> {
+            try
+            {
+                int numAcquired = 0;
+                List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+                try
+                {
+                    for (CounterLockManager.Lock l : newLockHandles)
+                    {
+                        if (l.tryLock(1, TimeUnit.SECONDS))
+                            numAcquired++;
+                    }
+                }
+                finally
+                {
+                    newLockHandles.forEach(CounterLockManager.Lock::release);
+                }
+                return numAcquired;
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }).join();
+        assertThat(count).isZero();
+
+        lockHandles.forEach(CounterLockManager.Lock::release);
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isZero();
+
+        count = CompletableFuture.supplyAsync(() -> {
+            try
+            {
+                int numAcquired = 0;
+                List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+                try
+                {
+                    for (CounterLockManager.Lock l : newLockHandles)
+                    {
+                        if (l.tryLock(1, TimeUnit.SECONDS))
+                            numAcquired++;
+                    }
+                }
+                finally
+                {
+                    newLockHandles.forEach(CounterLockManager.Lock::release);
+                }
+                return numAcquired;
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }).join();
+        assertThat(count).isEqualTo(keys.size());
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isZero();
+    }
+
+    @Test
+    public void testInterruptedExceptionCachedCounterLockManager() throws Exception
+    {
+        testInterruptedException(new CachedCounterLockManager());
+    }
+
+    @Test
+    public void testInterruptedExceptionStripedCounterLockManager() throws Exception
+    {
+        testInterruptedException(new StripedCounterLockManager());
+    }
+
+    private static void testInterruptedException(CounterLockManager manager) throws Exception
+    {
+        List<Integer> keys = List.of(1, 2, 3, 4, 5);
+        List<CounterLockManager.Lock> lockHandles = manager.grabLocks(keys);
+        for (CounterLockManager.Lock l : lockHandles)
+            assertThat(l.tryLock(1, TimeUnit.SECONDS)).isTrue();
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isEqualTo(keys.size());
+
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Thread otherThread = new Thread(() -> {
+            List<CounterLockManager.Lock> newLockHandles = manager.grabLocks(keys);
+            try
+            {
+                try
+                {
+                    for (CounterLockManager.Lock l : newLockHandles)
+                    {
+                        // the first of these locks will be interrupted
+                        l.tryLock(1, TimeUnit.HOURS);
+                    }
+                    result.complete(null);
+                }
+                catch (InterruptedException error)
+                {
+                    result.completeExceptionally(error);
+                }
+            }
+            finally
+            {
+                // in any case all the locks have to be released
+                newLockHandles.forEach(CounterLockManager.Lock::release);
+            }
+        });
+
+        otherThread.start();
+        otherThread.interrupt();
+        assertThatThrownBy(result::join).hasCauseInstanceOf(InterruptedException.class);
+
+        lockHandles.forEach(CounterLockManager.Lock::release);
+
+        if (manager.hasNumKeys())
+            assertThat(manager.getNumKeys()).isZero();
+    }
+}


### PR DESCRIPTION
### What is the issue
While working on CNDB-12382 I have seen that increasing the number of stripes helps to solve the timeout problems.

### What does this PR fix and why was it fixed
This PR introduces an abstraction over the LOCKS mechanism in CounterMutation and provides a different implementation.

The new implementation is not based on striping the locks (that is about sharing the same lock for different keys) but it maintains a set of reference counted objects that wrap the actual locks.

(The implementation of the Lock manager is the adaptaction of a similar mechanism taken from another OSS project)

This implementation also makes it clearer that the key for the locks is an Integer, computed  by summing some hash codes, and this already creates some kind of bucketing.
It is still possible that two mutations fall into the same lock key.

When do the new implementation works better ?
- it should generally works better for most of the workloads
- when there are few active counter mutations (the number of locks is usually expected to be like the size of the Counters Mutation Stage thread pool)

Rollback:
Add -Dcassandra.use_striped_counter_lock_manager=true to the writers JVM options


Licensing: this code is copied and adapted  from
[LocalLockManager](https://github.com/diennea/herddb/blob/master/herddb-utils/src/main/java/herddb/utils/LocalLockManager.java) from the HerdDB project (Apache 2 licensed).

