### PR TITLE
CNDB-13077

### DIFF
--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -227,6 +227,9 @@ public class Dispatcher
                       .addCallback((result, ignored) -> {
                           try
                           {
+                              if (request.isTrackable())
+                                  CoordinatorWarnings.done();
+
                               result.setStreamId(request.getStreamId());
                               result.setWarnings(ClientWarn.instance.getWarnings());
                               result.attach(connection);
@@ -234,8 +237,6 @@ public class Dispatcher
                           }
                           finally
                           {
-                              if (request.isTrackable())
-                                  CoordinatorWarnings.done();
                               CoordinatorWarnings.reset();
                               ClientWarn.instance.resetWarnings();
                           }


### PR DESCRIPTION
### What is the issue
[#13077](https://github.com/riptano/cndb/issues/13077) Dispatcher not setting client warnings

### What does this PR fix and why was it fixed
CNDB-13077 Fix Dispatcher to set coordinator client warnings before warnings are set in the Message response.

