### PR TITLE
Fix jvm-dtest-upgrade tests

### DIFF
--- a/.build/run-python-dtests.sh
+++ b/.build/run-python-dtests.sh
@@ -65,6 +65,7 @@ command -v virtualenv >/dev/null 2>&1 || { echo >&2 "virtualenv needs to be inst
 [ -d "${DIST_DIR}" ] || { mkdir -p "${DIST_DIR}" ; }
 
 java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F. '{print $1}')
+project_name=$(grep '<project\s*basedir=' build.xml |sed -ne 's/.*name=\"\([^"]*\)\".*/\1/p')
 version=$(grep 'property\s*name=\"base.version\"' ${CASSANDRA_DIR}/build.xml |sed -ne 's/.*value=\"\([^"]*\)\".*/\1/p')
 java_version_default=`grep 'property\s*name="java.default"' ${CASSANDRA_DIR}/build.xml |sed -ne 's/.*value="\([^"]*\)".*/\1/p'`
 
@@ -78,7 +79,7 @@ python_regx_supported_versions="^(3.8|3.9|3.10|3.11)$"
 [[ $python_version =~ $python_regx_supported_versions ]] || { echo "Python ${python_version} not supported."; exit 1; }
 
 # check project is already built. no cleaning is done, so jenkins unstash works, beware.
-[[ -f "${DIST_DIR}/apache-cassandra-${version}.jar" ]] || [[ -f "${DIST_DIR}/apache-cassandra-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${DIST_DIR} with: $(ls ${DIST_DIR})"; exit 1; }
+[[ -f "${DIST_DIR}/${project_name}-${version}.jar" ]] || [[ -f "${DIST_DIR}/${project_name}-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${DIST_DIR} with: $(ls ${DIST_DIR})"; exit 1; }
 
 # check if dist artifacts exist, this breaks the dtests
 [[ -d "${DIST_DIR}/dist" ]] && { echo "dtests don't work when build/dist ("${DIST_DIR}/dist") exists (from \`ant artifacts\`)"; exit 1; }

--- a/.build/run-tests.sh
+++ b/.build/run-tests.sh
@@ -163,6 +163,7 @@ _main() {
 
   # jdk check
   local -r java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F. '{print $1}')
+  local -r project_name=$(grep '<project\s*basedir=' build.xml |sed -ne 's/.*name=\"\([^"]*\)\".*/\1/p')
   local -r version=$(grep 'property\s*name=\"base.version\"' build.xml |sed -ne 's/.*value=\"\([^"]*\)\".*/\1/p')
   local -r java_version_default=`grep 'property\s*name="java.default"' build.xml |sed -ne 's/.*value="\([^"]*\)".*/\1/p'`
 
@@ -172,7 +173,7 @@ _main() {
   fi
 
   # check project is already built. no cleaning is done, so jenkins unstash works, beware.
-  [[ -f "${DIST_DIR}/apache-cassandra-${version}.jar" ]] || [[ -f "${DIST_DIR}/apache-cassandra-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${DIST_DIR} with: $(ls ${DIST_DIR})"; exit 1; }
+  [[ -f "${DIST_DIR}/${project_name}-${version}.jar" ]] || [[ -f "${DIST_DIR}/${project_name}-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${DIST_DIR} with: $(ls ${DIST_DIR} | xargs)"; exit 1; }
 
   # check if dist artifacts exist, this breaks the dtests
   [[ -d "${DIST_DIR}/dist" ]] && { echo "tests don't work when build/dist ("${DIST_DIR}/dist") exists (from \`ant artifacts\`)"; exit 1; }

--- a/pylib/cassandra-cqlsh-tests.sh
+++ b/pylib/cassandra-cqlsh-tests.sh
@@ -61,7 +61,8 @@ export TESTSUITE_NAME="cqlshlib.python${python_version}.jdk${java_version}"
 pushd ${CASSANDRA_DIR} >/dev/null
 
 # check project is already built. no cleaning is done, so jenkins unstash works, beware.
-[[ -f "${BUILD_DIR}/dse-db-${version}.jar" ]] || [[ -f "${BUILD_DIR}/dse-db-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${BUILD_DIR} with: $(ls ${BUILD_DIR})"; exit 1; }
+project_name=$(grep '<project\s*basedir=' build.xml |sed -ne 's/.*name=\"\([^"]*\)\".*/\1/p')
+[[ -f "${BUILD_DIR}/${project_name}-${version}.jar" ]] || [[ -f "${BUILD_DIR}/${project_name}-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${BUILD_DIR} with: $(ls ${BUILD_DIR})"; exit 1; }
 
 # Set up venv with dtest dependencies
 set -e # enable immediate exit if venv setup fails

--- a/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
@@ -85,19 +85,19 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags) throws NativeError
+    public int callMlockall(int flags) throws NativeError
     {
-        int r = mlockall(flags);
-        if (r != 0)
+        if (0 != mlockall(flags))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callMunlockall() throws NativeError
+    public int callMunlockall() throws NativeError
     {
-        int r = munlockall();
-        if (r != 0)
+        if (0 != munlockall())
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -110,15 +110,15 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag)
+    public int callPosixFadvise(int fd, long offset, int len, int flag)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice)
+    public int callPosixMadvise(Pointer addr, long length, int advice)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -131,19 +131,19 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd) throws NativeError
+    public int callFsync(int fd) throws NativeError
     {
-        int r = fsync(fd);
-        if (r != 0)
+        if (0 != fsync(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callClose(int fd) throws NativeError
+    public int callClose(int fd) throws NativeError
     {
-        int r = close(fd);
-        if (r != 0)
+        if (0 != close(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
@@ -87,19 +87,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags) throws NativeError
+    public int callMlockall(int flags) throws NativeError
     {
-        int r = mlockall(flags);
-        if (r != 0)
+        if (0 != mlockall(flags))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callMunlockall() throws NativeError
+    public int callMunlockall() throws NativeError
     {
-        int r = munlockall();
-        if (r != 0)
+        if (0 != munlockall())
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -112,19 +112,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError
+    public int callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError
     {
-        int r = posix_fadvise(fd, offset, len, flag);
-        if (r != 0)
+        if (0 != posix_fadvise(fd, offset, len, flag))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice) throws NativeError
+    public int callPosixMadvise(Pointer addr, long length, int advice) throws NativeError
     {
-        int r = posix_madvise(addr, length, advice);
-        if (r != 0)
+        if (0 != posix_madvise(addr, length, advice))
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -137,19 +137,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd) throws NativeError
+    public int callFsync(int fd) throws NativeError
     {
-        int r = fsync(fd);
-        if (r != 0)
+        if (0 != fsync(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callClose(int fd) throws NativeError
+    public int callClose(int fd) throws NativeError
     {
-        int r = close(fd);
-        if (r != 0)
+        if (0 != close(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/utils/NativeLibraryWindows.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryWindows.java
@@ -77,15 +77,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags)
+    public int callMlockall(int flags)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callMunlockall()
+    public int callMunlockall()
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -95,15 +95,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag)
+    public int callPosixFadvise(int fd, long offset, int len, int flag)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice)
+    public int callPosixMadvise(Pointer addr, long length, int advice)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -113,15 +113,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd)
+    public int callFsync(int fd)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callClose(int fd)
+    public int callClose(int fd)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/NativeLibraryWrapper.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryWrapper.java
@@ -39,14 +39,14 @@ public interface NativeLibraryWrapper
      */
     boolean isAvailable();
 
-    void callMlockall(int flags) throws NativeError;
-    void callMunlockall() throws NativeError;
+    int callMlockall(int flags) throws NativeError;
+    int callMunlockall() throws NativeError;
     int callFcntl(int fd, int command, long flags) throws NativeError;
-    void callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError;
-    void callPosixMadvise(Pointer addr, long length, int advice) throws NativeError;
+    int callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError;
+    int callPosixMadvise(Pointer addr, long length, int advice) throws NativeError;
     int callOpen(String path, int flags) throws NativeError;
-    void callFsync(int fd) throws NativeError;
-    void callClose(int fd) throws NativeError;
+    int callFsync(int fd) throws NativeError;
+    int callClose(int fd) throws NativeError;
     long callGetpid() throws NativeError;
 
     /**


### PR DESCRIPTION
### What is the issue

jvm-dtest-upgrade tests are currently broken in `main` and `main-5.0`

in main-5.0 we have help testing scripts under `build/`, but they don't work because CC has changed the ant build's project name.  The first commit fixes that.

In 9943514 a number of interface method signatures were changed (return types changed to `void`).  This broke jvm-dtest-upgrade tests with errors like
```
NoSuchMethodError: 'int org.apache.cassandra.utils.NativeLibraryWrapper.callFsync(int)'
```
NativeLibraryWrapper is a https://github.com/shared annotated class.  It is shared in the one classloader between different versions of C* when running jvm-dtest-upgrade tests.

### What does this PR fix and why was it fixed

1. The test helper scripts honour the ant build's project name.
2. Restore NativeLibraryWrapper interace method signatures. 