### PR TITLE
Restore NativeLibraryWrapper interace signatures

### DIFF
--- a/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
@@ -84,19 +84,19 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags) throws NativeError
+    public int callMlockall(int flags) throws NativeError
     {
-        int r = mlockall(flags);
-        if (r != 0)
+        if (0 != mlockall(flags))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callMunlockall() throws NativeError
+    public int callMunlockall() throws NativeError
     {
-        int r = munlockall();
-        if (r != 0)
+        if (0 != munlockall())
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -109,15 +109,15 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag)
+    public int callPosixFadvise(int fd, long offset, int len, int flag)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice)
+    public int callPosixMadvise(Pointer addr, long length, int advice)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -130,19 +130,19 @@ public class NativeLibraryDarwin implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd) throws NativeError
+    public int callFsync(int fd) throws NativeError
     {
-        int r = fsync(fd);
-        if (r != 0)
+        if (0 != fsync(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callClose(int fd) throws NativeError
+    public int callClose(int fd) throws NativeError
     {
-        int r = close(fd);
-        if (r != 0)
+        if (0 != close(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
@@ -86,19 +86,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags) throws NativeError
+    public int callMlockall(int flags) throws NativeError
     {
-        int r = mlockall(flags);
-        if (r != 0)
+        if (0 != mlockall(flags))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callMunlockall() throws NativeError
+    public int callMunlockall() throws NativeError
     {
-        int r = munlockall();
-        if (r != 0)
+        if (0 != munlockall())
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -111,19 +111,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError
+    public int callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError
     {
-        int r = posix_fadvise(fd, offset, len, flag);
-        if (r != 0)
+        if (0 != posix_fadvise(fd, offset, len, flag))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice) throws NativeError
+    public int callPosixMadvise(Pointer addr, long length, int advice) throws NativeError
     {
-        int r = posix_madvise(addr, length, advice);
-        if (r != 0)
+        if (0 != posix_madvise(addr, length, advice))
             throwNativeError();
+        return 0;
     }
 
     @Override
@@ -136,19 +136,19 @@ public class NativeLibraryLinux implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd) throws NativeError
+    public int callFsync(int fd) throws NativeError
     {
-        int r = fsync(fd);
-        if (r != 0)
+        if (0 != fsync(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override
-    public void callClose(int fd) throws NativeError
+    public int callClose(int fd) throws NativeError
     {
-        int r = close(fd);
-        if (r != 0)
+        if (0 != close(fd))
             throwNativeError();
+        return 0;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/utils/NativeLibraryWindows.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryWindows.java
@@ -76,15 +76,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callMlockall(int flags)
+    public int callMlockall(int flags)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callMunlockall()
+    public int callMunlockall()
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -94,15 +94,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callPosixFadvise(int fd, long offset, int len, int flag)
+    public int callPosixFadvise(int fd, long offset, int len, int flag)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callPosixMadvise(Pointer addr, long length, int advice)
+    public int callPosixMadvise(Pointer addr, long length, int advice)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
@@ -112,15 +112,15 @@ public class NativeLibraryWindows implements NativeLibraryWrapper
     }
 
     @Override
-    public void callFsync(int fd)
+    public int callFsync(int fd)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     @Override
-    public void callClose(int fd)
+    public int callClose(int fd)
     {
-        // Unsupported
+        throw new UnsatisfiedLinkError();
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/NativeLibraryWrapper.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryWrapper.java
@@ -38,14 +38,14 @@ interface NativeLibraryWrapper
      */
     boolean isAvailable();
 
-    void callMlockall(int flags) throws NativeError;
-    void callMunlockall() throws NativeError;
+    int callMlockall(int flags) throws NativeError;
+    int callMunlockall() throws NativeError;
     int callFcntl(int fd, int command, long flags) throws NativeError;
-    void callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError;
-    void callPosixMadvise(Pointer addr, long length, int advice) throws NativeError;
+    int callPosixFadvise(int fd, long offset, int len, int flag) throws NativeError;
+    int callPosixMadvise(Pointer addr, long length, int advice) throws NativeError;
     int callOpen(String path, int flags) throws NativeError;
-    void callFsync(int fd) throws NativeError;
-    void callClose(int fd) throws NativeError;
+    int callFsync(int fd) throws NativeError;
+    int callClose(int fd) throws NativeError;
     long callGetpid() throws NativeError;
 
     /**


### PR DESCRIPTION
### What is the issue

jvm-dtest-upgrade tests are currently broken in `main` and `main-5.0`


In 9943514 a number of interface method signatures were changed (return types changed to `void`).  This broke jvm-dtest-upgrade tests with errors like
```
NoSuchMethodError: 'int org.apache.cassandra.utils.NativeLibraryWrapper.callFsync(int)'
```
NativeLibraryWrapper is a https://github.com/shared annotated class.  It is shared in the one classloader between different versions of C* when running jvm-dtest-upgrade tests.

### What does this PR fix and why was it fixed

Restore NativeLibraryWrapper interace method signatures. 