### PR TITLE
CNDB-12991: getMaxOverlapsMap does not correctly deal with multiple disks

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/ShardTracker.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardTracker.java
@@ -38,15 +38,12 @@ public interface ShardTracker
 
     double shardSpanSize();
 
-    /**
-     * Advance to the given token (e.g. before writing a key). Returns true if this resulted in advancing to a new
-     * shard, and false otherwise.
-     */
+    /// Advance to the given token (e.g. before writing a key). Returns true if this resulted in advancing to a new
+    /// shard, and false otherwise.
     boolean advanceTo(Token nextToken);
 
-    /**
-     * Returns the number of shards tracked by this tracker.
-     */
+    /// Returns the number of shards tracked by this tracker. This is not necessarily the number of shards requested
+    /// when [ShardManager#boundaries] was called, because this requests the per-disk number.
     int count();
 
     /**
@@ -57,9 +54,7 @@ public interface ShardTracker
 
     double rangeSpanned(PartitionPosition first, PartitionPosition last);
 
-    /**
-     * The index of the shard this tracker is currently on.
-     */
+    /// The index of the shard this tracker is currently on, between `0` and `count() - 1`.
     int shardIndex();
 
     default long shardAdjustedKeyCount(Set<? extends CompactionSSTable> sstables)

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -1312,10 +1312,15 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         int[] overlapsMap = new int[shardCount];
         shardManager.assignSSTablesToShardIndexes(sstables, null, shardCount,
                                                   (shardSSTables, shard) ->
-                                                  overlapsMap[shard] = Overlaps.maxOverlap(shardSSTables,
-                                                                                           CompactionSSTable.startsAfter,
-                                                                                           CompactionSSTable.firstKeyComparator,
-                                                                                           CompactionSSTable.lastKeyComparator));
+                                                  // Note: the shard index we are given is the global index, which includes
+                                                  // other arenas. The modulo below converts it to an index for the arena.
+                                                  // If an sstable extends outside a disk's region (because e.g. local
+                                                  // ownership changed and disk boundaries moved), it will be incorrectly
+                                                  // counted. This is not trivial to recognize here and is not corrected.
+                                                  overlapsMap[shard % shardCount] = Overlaps.maxOverlap(shardSSTables,
+                                                                                                        CompactionSSTable.startsAfter,
+                                                                                                        CompactionSSTable.firstKeyComparator,
+                                                                                                        CompactionSSTable.lastKeyComparator));
         // Indexes that do not have sstables are left with 0 overlaps.
         return overlapsMap;
     }

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -268,6 +268,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertEquals(expectedCount, selectedCount);
             }
         }
+        // Make sure getMaxOverlapsMap does not fail.
+        System.out.println(strategy.getMaxOverlapsMap());
     }
 
     @Test
@@ -389,6 +391,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertThat(selectedCount).isGreaterThanOrEqualTo(1);
             }
         }
+        // Make sure getMaxOverlapsMap does not fail.
+        System.out.println(strategy.getMaxOverlapsMap());
     }
 
     private BufferDecoratedKey key(long token)
@@ -1135,6 +1139,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
             for (int i = 0; i < currentArenaSpecs.expectedBuckets.length; i++)
                 assertEquals(currentArenaSpecs.expectedBuckets[i], levels.get(i).sstables.size());
         }
+        // Make sure getMaxOverlapsMap does not fail.
+        System.out.println(strategy.getMaxOverlapsMap());
     }
 
     @Test
@@ -1978,6 +1984,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         }
 
         Mockito.when(controller.getNumShards(anyDouble())).thenReturn(16);  // co-prime with counts to ensure multiple sstables fall in each shard
+        // Make sure getMaxOverlapsMap does not fail.
         System.out.println(strategy.getMaxOverlapsMap());
 
         dataTracker.removeUnsafe(allSSTables);


### PR DESCRIPTION
### What is the issue
When multiple disks are defined, `getMaxOverlapsMap` fails. This is because the shard manager returns shard indexes that cover the whole space, including shards in other disks to be able to properly split files after the boundaries change.

### What does this PR fix and why was it fixed
Change `getMaxOverlapsMap` to correct the returned shard indexes.
