### PR TITLE
HCD-74: Fix CorruptSSTableException in UCS with compression

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1557,8 +1557,12 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
             long lastEnd = 0;
             for (PartitionPositionBounds position : positionBounds)
             {
-                assert position.lowerPosition >= 0 : "the partition lower position has to be non-negative";
-                assert position.upperPosition > position.lowerPosition : "the partition upper position has to be greater than lower position";
+                assert position.lowerPosition >= 0 : "the partition lower cannot be negative";
+                if (position.upperPosition == position.lowerPosition)
+                {
+                    continue;
+                }
+                assert position.upperPosition >= position.lowerPosition : "the partition upper position cannot be lower than lower position";
 
                 long upperChunkEnd = compressionMetadata.chunkFor(position.upperPosition - 1).chunkEnd();
                 long lowerChunkStart = compressionMetadata.chunkFor(position.lowerPosition).offset;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1557,7 +1557,10 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
             long lastEnd = 0;
             for (PartitionPositionBounds position : positionBounds)
             {
-                long upperChunkEnd = compressionMetadata.chunkFor(position.upperPosition).chunkEnd();
+                assert position.lowerPosition >= 0 : "the partition lower position has to be non-negative";
+                assert position.upperPosition > position.lowerPosition : "the partition upper position has to be greater than lower position";
+
+                long upperChunkEnd = compressionMetadata.chunkFor(position.upperPosition - 1).chunkEnd();
                 long lowerChunkStart = compressionMetadata.chunkFor(position.lowerPosition).offset;
                 if (lowerChunkStart < lastEnd)  // if regions include the same chunk, count it only once
                     lowerChunkStart = lastEnd;

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -103,6 +103,7 @@ import org.apache.cassandra.utils.PageAware;
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
 import static org.apache.cassandra.io.sstable.format.SSTableReader.selectOnlyBigTableReaders;
+import static org.apache.cassandra.schema.CompressionParams.DEFAULT_CHUNK_LENGTH;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -411,8 +412,6 @@ public class SSTableReaderTest
         SSTableReader sstable = getNewSSTable(cfs);
         partitioner = sstable.getPartitioner();
 
-        assertThatThrownBy(() -> sstable.onDiskSizeForPartitionPositions(Collections.singleton(new PartitionPositionBounds(0, 0))))
-                .isInstanceOf(AssertionError.class);
         assertThatThrownBy(() -> sstable.onDiskSizeForPartitionPositions(Collections.singleton(new PartitionPositionBounds(-1, 0))))
                 .isInstanceOf(AssertionError.class);
         assertThatThrownBy(() -> sstable.onDiskSizeForPartitionPositions(Collections.singleton(new PartitionPositionBounds(2, 1))))
@@ -420,13 +419,28 @@ public class SSTableReaderTest
     }
 
     @Test
+    public void testDiskSizeForEmptyPosition()
+    {
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_COMPRESSED);
+        SSTableReader sstable = getNewSSTable(cfs);
+        partitioner = sstable.getPartitioner();
+
+        long size = sstable.onDiskSizeForPartitionPositions(Collections.singleton(new PartitionPositionBounds(0, 0)));
+        assertEquals(0, size);
+    }
+
+    @Test
     public void testDoNotFailOnChunkEndingPosition()
     {
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_COMPRESSED);
-        int count = 530;
+
+        // we want the last row to align to the end of chunk
+        int rowCount = DEFAULT_CHUNK_LENGTH;
+
         // insert data and compact to a single sstable
-        for (int j = 0; j < count; j++)
+        for (int j = 0; j < rowCount; j++)
         {
             new RowUpdateBuilder(cfs.metadata(), 15000, k0(j))
                     .clustering("0")
@@ -437,15 +451,10 @@ public class SSTableReaderTest
         cfs.forceBlockingFlush(UNIT_TESTS);
         cfs.forceMajorCompaction();
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
-
         partitioner = sstable.getPartitioner();
-        int chunkLength = sstable.getCompressionMetadata().parameters.chunkLength();
-        long chunkCount = (long) Math.ceil((double) sstable.uncompressedLength() / chunkLength);
-        assertEquals(2, chunkCount);
-        long endPosition = chunkLength * chunkCount;
 
-        long size = sstable.onDiskSizeForPartitionPositions(Collections.singleton(new PartitionPositionBounds(0, endPosition)));
-        assertNotEquals(0, size);
+        long totalDiskSizeForTheWholeRange = onDiskSizeForRanges(sstable, Collections.singleton(new Range<>(t(cut(k0(0), 1)), t0(rowCount))));
+        assertEquals(sstable.onDiskLength(), totalDiskSizeForTheWholeRange);
     }
 
     long onDiskSizeForRanges(SSTableReader sstable, Collection<Range<Token>> ranges)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -108,7 +108,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
Adjust the partition position by 1 when reading the compression metadata.
