### PR TITLE
HCD-63: Upgrade Netty to 4.1.117

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -668,6 +668,8 @@
            </dependency>
           <dependency groupId="io.netty" artifactId="netty-bom" version="4.1.117.Final" type="pom" scope="provided"/>
           <dependency groupId="io.netty" artifactId="netty-all" version="4.1.117.Final" />
+          <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" version="4.1.117.Final"/>
+          <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" version="4.1.117.Final" classifier="linux-x86_64"/>
           <dependency groupId="io.netty" artifactId="netty-tcnative-boringssl-static" version="2.0.69.Final"/>
           <dependency groupId="net.openhft" artifactId="chronicle-queue" version="${chronicle-queue.version}">
             <exclusion groupId="com.sun" artifactId="tools" />
@@ -905,6 +907,8 @@
         <dependency groupId="de.huxhorn.sulky" artifactId="de.huxhorn.sulky.ulid"/>
         <dependency groupId="io.netty" artifactId="netty-bom"  type="pom"  />
         <dependency groupId="io.netty" artifactId="netty-all"/>
+        <dependency groupId="io.netty" artifactId="netty-transport-native-epoll"/>
+        <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" classifier="linux-x86_64"/>
         <dependency groupId="net.openhft" artifactId="chronicle-queue"/>
         <dependency groupId="net.openhft" artifactId="chronicle-core"/>
         <dependency groupId="net.openhft" artifactId="chronicle-bytes"/>


### PR DESCRIPTION
This patch adds the Netty native epoll dependency
that was missing when Netty was upgraded from
4.1.58 to 4.1.117. Since 4.1.58, the bative
libraries are now separated out into new dependencies
and must be explicitly added for them to be bundled into the tarball.

### What is the issue
When Netty was upgraded to 4.1.117, the native epoll libraries that used to be shipped in the `netty-all.jar` were not included. At some point since Netty 4.1.58, the native epoll and native kqueue libraries were split inot their own architecture dependent jarfiles/artifacts and must be included explicitly to pick them up. 

### What does this PR fix and why was it fixed
This patch adds the missing native epol dependencies. This is similar to what was done in OSS Cassandra when they upgraded to Netty 4.1.96 here:
https://github.com/apache/cassandra/commit/53d1644ff4142f4383a773408c142c34954063f5
