### PR TITLE
CNDB-13074: Reject analysis options on frozen collections

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -178,14 +178,16 @@ public class IndexContext
         this.cfs = cfs;
         this.primaryKeyFactory = Version.latest().onDiskFormat().newPrimaryKeyFactory(clusteringComparator);
 
+        String columnName = column.name.toString();
+
         if (config != null)
         {
             String fullIndexName = String.format("%s.%s.%s", this.keyspace, this.table, this.config.name);
             this.indexWriterConfig = IndexWriterConfig.fromOptions(fullIndexName, validator, config.options);
             this.isAnalyzed = AbstractAnalyzer.isAnalyzed(config.options);
-            this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), config.options);
+            this.analyzerFactory = AbstractAnalyzer.fromOptions(columnName, validator, config.options);
             this.queryAnalyzerFactory = AbstractAnalyzer.hasQueryAnalyzer(config.options)
-                                        ? AbstractAnalyzer.fromOptionsQueryAnalyzer(getValidator(), config.options)
+                                        ? AbstractAnalyzer.fromOptionsQueryAnalyzer(validator, config.options)
                                         : this.analyzerFactory;
             this.vectorSimilarityFunction = indexWriterConfig.getSimilarityFunction();
             this.hasEuclideanSimilarityFunc = vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN;
@@ -199,7 +201,7 @@ public class IndexContext
         {
             this.indexWriterConfig = IndexWriterConfig.emptyConfig();
             this.isAnalyzed = AbstractAnalyzer.isAnalyzed(Collections.EMPTY_MAP);
-            this.analyzerFactory = AbstractAnalyzer.fromOptions(getValidator(), Collections.EMPTY_MAP);
+            this.analyzerFactory = AbstractAnalyzer.fromOptions(columnName, validator, Collections.EMPTY_MAP);
             this.queryAnalyzerFactory = this.analyzerFactory;
             this.vectorSimilarityFunction = null;
             this.hasEuclideanSimilarityFunc = false;

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -330,7 +330,7 @@ public class StorageAttachedIndex implements Index
         AbstractType<?> type = TypeUtil.cellValueType(target.left, target.right);
 
         // Validate analyzers by building them
-        try (AbstractAnalyzer.AnalyzerFactory analyzerFactory = AbstractAnalyzer.fromOptions(type, options))
+        try (AbstractAnalyzer.AnalyzerFactory analyzerFactory = AbstractAnalyzer.fromOptions(targetColumn, type, options))
         {
             if (AbstractAnalyzer.hasQueryAnalyzer(options))
                 AbstractAnalyzer.fromOptionsQueryAnalyzer(type, options).close();

--- a/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sai/analyzer/AbstractAnalyzer.java
@@ -187,7 +187,7 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
         return options.containsKey(LuceneAnalyzer.INDEX_ANALYZER) || NonTokenizingOptions.hasNonDefaultOptions(options);
     }
 
-    public static AnalyzerFactory fromOptions(AbstractType<?> type, Map<String, String> options)
+    public static AnalyzerFactory fromOptions(String target, AbstractType<?> type, Map<String, String> options)
     {
         boolean containsIndexAnalyzer = options.containsKey(LuceneAnalyzer.INDEX_ANALYZER);
         boolean containsNonTokenizingOptions = NonTokenizingOptions.hasNonDefaultOptions(options);
@@ -205,6 +205,9 @@ public abstract class AbstractAnalyzer implements Iterator<ByteBuffer>
             throw new InvalidRequestException("Cannot specify query_analyzer without an index_analyzer option or any" +
                                               " combination of case_sensitive, normalize, or ascii options. options=" + options);
         }
+
+        if ((containsIndexAnalyzer || containsNonTokenizingOptions) && type.isCollection() && !type.isMultiCell())
+            throw new InvalidRequestException("Cannot use an analyzer on " + target + " because it's a frozen collection.");
 
         if (containsIndexAnalyzer)
         {

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -204,7 +204,7 @@ public abstract class CQLTester
     private static final User SUPER_USER = new User("cassandra", "cassandra");
 
     /**
-     * Whether to use coorfinator execution in {@link #execute(String, Object...)}, so queries get full validation and
+     * Whether to use coordinator execution in {@link #execute(String, Object...)}, so queries get full validation and
      * go through reconciliation. When enabled, calls to {@link #execute(String, Object...)} will behave as calls to
      * {@link #executeWithCoordinator(String, Object...)}. Otherwise, they will behave as calls to
      * {@link #executeInternal(String, Object...)}.

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -230,6 +230,23 @@ public class SAITester extends CQLTester
         CQLTester.enableCoordinatorExecution();
     }
 
+    /**
+     * Creates a SAI index on the current table, waiting for it to become queryable.
+     *
+     * @param column the name of the indexed column, maybe with {@code FULL()}, {@code KEYS()} or {@code VALUES()} spec
+     * @param options the index options, of the form {@code "{'option1': value1, 'option2': value2, ...}"}.
+     * @return the name of the created index
+     */
+    public String createSAIIndex(String column, @Nullable String options)
+    {
+        String query = String.format(CREATE_INDEX_TEMPLATE, column);
+
+        if (options != null)
+            query += " WITH OPTIONS = " + options;
+
+        return createIndex(query);
+    }
+
     public static IndexContext createIndexContext(String name, AbstractType<?> validator, ColumnFamilyStore cfs)
     {
         return new IndexContext(cfs.getKeyspaceName(),


### PR DESCRIPTION
It's not allowed to create an index with non-Lucene analysis options on a frozen collection. For example:
```
CREATE TABLE t(k int PRIMARY KEY, v frozen<set<text>>);
CREATE CUSTOM INDEX ON t(FULL(v)) 
   USING 'StorageAttachedIndex' 
   WITH OPTIONS = {'case_sensitive': false}; -- InvalidRequestException: CQL type frozen<set<text>> cannot be analyzed
```
This IMO makes sense because it won't support any meaningful operator. However, we don't get that rejection if we try to specify an `index_analyzer`. For example:
```
CREATE TABLE t(k int PRIMARY KEY, v frozen<set<text>>);
INSERT INTO %s (k, v) VALUES (0, {'apples'})
CREATE CUSTOM INDEX ON t(FULL(v)) 
   USING 'StorageAttachedIndex' 
   WITH OPTIONS = {'index_analyzer':'STANDARD'}; -- Accepted
SELECT k FROM %s WHERE v CONTAINS 'ABC'; -- Column 'v' has an index but does not support the operators specified in the query.
SELECT k FROM %s WHERE v = {'apple'}; -- Accepted, but results are erratic
```
In this case, the entire serialized collection is treated as a single string and analyzed. This interpretation of the serialized collection as a string includes the metadata at the beginning, it doesn't use any kind of token separators between fields, etc., so it ends up as a bunch of non-printable characters.

This PR simply rejects creating indexes with analysis options on frozen collections, given that we don't have a way to correctly index them, and we don't support querying either.
