### PR TITLE
CNDB-13171: Fix query_filters guardrail using the index analyzer instead of the query analyzer

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -1164,9 +1164,9 @@ public class RowFilter
         @Override
         public int numFilteredValues()
         {
-            return indexAnalyzer == null
+            return queryAnalyzer == null
                    ? super.numFilteredValues()
-                   : indexAnalyzer().analyze(value).size();
+                   : queryAnalyzer().analyze(value).size();
         }
     }
 

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailQueryFiltersTest.java
@@ -203,6 +203,29 @@ public class GuardrailQueryFiltersTest extends GuardrailTester
     }
 
     @Test
+    public void testQueryFiltersWithIndexAndQueryAnalyzers() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"ngram\", \"args\":{\"minGramSize\":\"1\", \"maxGramSize\":\"10\"}}," +
+                    "\t\"filters\":[{\"name\":\"lowercase\"}]\n" +
+                    "}'," +
+                    "'query_analyzer': '{\n" +
+                    "\t\"tokenizer\":{\"name\":\"whitespace\"},\n" +
+                    "\t\"filters\":[{\"name\":\"porterstem\"}]\n" +
+                    "}'};");
+
+        // only the query analyzer should be used to calculate the number of filters
+        assertValid("SELECT * FROM %s WHERE v = 'abcdef'");
+        assertValid("SELECT * FROM %s WHERE v = 'abcdef ghijkl'");
+        assertWarns("SELECT * FROM %s WHERE v = 'abcdef ghijkl mnopqr'", 3);
+        assertWarns("SELECT * FROM %s WHERE v = 'abcdef ghijkl mnopqr stuvwx'", 4);
+        assertFails("SELECT * FROM %s WHERE v = 'abcdef ghijkl mnopqr stuvwx xyz'", 5);
+    }
+
+    @Test
     public void testExcludedUsers() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, x text, y text)");


### PR DESCRIPTION
The method `RowFilter.AnalyzableExpression#numFilteredValues`, which is used by the `query_filters` guardrail, uses the index analyzer, whereas it should use the query analyzer. This could lead to wrongly triggering the guardrail in some cases.