### PR TITLE
CNDB-11460 another fix for cqlsh unicode tests in TestCqlshUnicode

### DIFF
--- a/pylib/cqlshlib/test/run_cqlsh.py
+++ b/pylib/cqlshlib/test/run_cqlsh.py
@@ -249,6 +249,7 @@ class ProcRunner:
         cqlshlog.debug("Searching for %r" % (until.pattern,))
         got = self.readbuf
         self.readbuf = ''
+        empty_reads = 0
         with timing_out(timeout):
             while True:
                 val = self.read(blksize, ptty_timeout)
@@ -257,7 +258,13 @@ class ProcRunner:
                         val = val.replace(replace_target, '')
                 cqlshlog.debug("read %r from subproc" % (val,))
                 if val == '':
-                    raise EOFError("'until' pattern %r not found" % (until.pattern,))
+                    empty_reads += 1
+                    if empty_reads > 1:
+                        raise EOFError("'until' pattern %r not found" % (until.pattern,))
+                    # Read again to allow decoding of UTF-8 characters that span multiple reads
+                    continue
+
+                empty_reads = 0
                 got += val
                 m = until.search(got)
                 if m is not None:


### PR DESCRIPTION
CNDB-11460 another fix for cqlsh unicode tests in TestCqlshUnicode - make a second read in read_until to get UTF-8 characters that are split across reads.

### What is the issue
The original fix for CNDB-11460 added the ability for the `read_tty` method to decode UTF-8 characters that get split across reads, by saving a partial buffer when a `UnicodeDecodeError` happens, and use the partial buffer with the next read. When this happens, `read_tty` will return `''` to the `read_until` method. The first fix lacked having `read_until` initiate a second read to `read_tty` and still failed with an `EOFError`.

### What does this PR fix and why was it fixed
In this PR, the `read_until` method will make a second call to `read_tty` (via `self.read`), allowing `read_tty` to read another `blksize` buffer of characters and the chance to decode UTF-8 characters that were split across reads.

To better validate the fix, the test was run locally with a forced `blksize = 1` to consistently generate failures and validate that the second read resolves the issue.

Correct me if this is wrong, but afaict our CC CI doesn't have multiplexing capability for cqhsh tests, having separate build parameters in `ds-cassandra-build` from JVM tests using `DSJVMTestRepetitions` or DTests using `DSDTestRepetitions`.
