### PR TITLE
CNDB-13075: Reuse the analyzed tokens of the right operand of an analyzed expression

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -24,10 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import org.apache.cassandra.db.marshal.*;
-import org.apache.cassandra.index.Index;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 public enum Operator
@@ -41,16 +38,15 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            if (indexAnalyzer != null)
-                return ANALYZER_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
-
             return type.compareForCQL(leftOperand, rightOperand) == 0;
+        }
+
+        @Override
+        public boolean isSatisfiedByAnalyzed(AbstractType<?> type, List<ByteBuffer> leftTokens, List<ByteBuffer> rightTokens)
+        {
+            return ANALYZER_MATCHES.isSatisfiedByAnalyzed(type, leftTokens, rightTokens);
         }
     },
     LT(4)
@@ -62,11 +58,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return type.compareForCQL(leftOperand, rightOperand) < 0;
         }
@@ -80,11 +72,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return type.compareForCQL(leftOperand, rightOperand) <= 0;
         }
@@ -98,11 +86,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return type.compareForCQL(leftOperand, rightOperand) >= 0;
         }
@@ -116,11 +100,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return type.compareForCQL(leftOperand, rightOperand) > 0;
         }
@@ -133,11 +113,7 @@ public enum Operator
             return "IN";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             List<?> inValues = ListType.getInstance(type, false).getSerializer().deserialize(rightOperand);
             return inValues.contains(type.getSerializer().deserialize(leftOperand));
@@ -152,11 +128,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             CollectionType<?> collectionType = (CollectionType<?>) type;
             return collectionType.contains(leftOperand, rightOperand);
@@ -171,11 +143,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             MapType<?, ?> mapType = (MapType<?, ?>) type;
             return mapType.containsKey(leftOperand, rightOperand);
@@ -191,11 +159,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return type.compareForCQL(leftOperand, rightOperand) != 0;
 
@@ -210,11 +174,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -228,11 +188,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return ByteBufferUtil.startsWith(leftOperand, rightOperand);
         }
@@ -246,11 +202,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return ByteBufferUtil.endsWith(leftOperand, rightOperand);
         }
@@ -264,11 +216,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return ByteBufferUtil.contains(leftOperand, rightOperand);
         }
@@ -281,11 +229,7 @@ public enum Operator
             return "LIKE '<term>'";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             return ByteBufferUtil.contains(leftOperand, rightOperand);
         }
@@ -299,11 +243,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -317,11 +257,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -334,13 +270,10 @@ public enum Operator
             return "NOT IN";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !IN.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !IN.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_CONTAINS(17)
@@ -352,13 +285,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand);
         }
 
     },
@@ -371,13 +300,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !CONTAINS_KEY.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !CONTAINS_KEY.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_LIKE_PREFIX(19)
@@ -389,13 +314,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !LIKE_PREFIX.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !LIKE_PREFIX.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_LIKE_SUFFIX(20)
@@ -407,13 +328,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !LIKE_SUFFIX.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !LIKE_SUFFIX.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_LIKE_CONTAINS(21)
@@ -425,13 +342,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !LIKE_CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !LIKE_CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_LIKE_MATCHES(22)
@@ -442,13 +355,10 @@ public enum Operator
             return "NOT LIKE '<term>'";
         }
 
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !LIKE_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !LIKE_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
     NOT_LIKE(23)
@@ -460,13 +370,9 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            return !LIKE.isSatisfiedBy(type, leftOperand, rightOperand, indexAnalyzer, queryAnalyzer);
+            return !LIKE.isSatisfiedBy(type, leftOperand, rightOperand);
         }
     },
 
@@ -482,25 +388,14 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
-            assert indexAnalyzer != null && queryAnalyzer != null : ": operation can only be computed by an indexed column with a configured analyzer";
-
-            List<ByteBuffer> rightTokens = queryAnalyzer.analyze(rightOperand);
-            return isSatisfiedBy(type, leftOperand, rightTokens, indexAnalyzer);
+            throw new UnsupportedOperationException(": operation can only be computed by an indexed column with a configured analyzer");
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftValue,
-                                     List<ByteBuffer> rightTokens,
-                                     Index.Analyzer indexAnalyzer)
+        public boolean isSatisfiedByAnalyzed(AbstractType<?> type, List<ByteBuffer> leftTokens, List<ByteBuffer> rightTokens)
         {
-            List<ByteBuffer> leftTokens = indexAnalyzer.analyze(leftValue);
             Iterator<ByteBuffer> it = rightTokens.iterator();
 
             do
@@ -540,11 +435,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -559,11 +450,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -577,11 +464,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type, 
-                                     ByteBuffer leftOperand, 
-                                     ByteBuffer rightOperand, 
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -595,11 +478,7 @@ public enum Operator
         }
 
         @Override
-        public boolean isSatisfiedBy(AbstractType<?> type,
-                                     ByteBuffer leftOperand,
-                                     ByteBuffer rightOperand,
-                                     @Nullable Index.Analyzer indexAnalyzer,
-                                     @Nullable Index.Analyzer queryAnalyzer)
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
         {
             throw new UnsupportedOperationException();
         }
@@ -658,31 +537,19 @@ public enum Operator
      * @param type the type of the values to compare.
      * @param leftOperand the left operand of the comparison.
      * @param rightOperand the right operand of the comparison.
-     * @param indexAnalyzer an index-provided function to transform the left-side compared value before comparison,
-     * or {@code null} if the values don't need to be transformed.
-     * @param queryAnalyzer an index-provided function to transform the right-side compared value before comparison,
-     * or {@code null} if the values don't need to be transformed.
      */
-    public abstract boolean isSatisfiedBy(AbstractType<?> type,
-                                          ByteBuffer leftOperand,
-                                          ByteBuffer rightOperand,
-                                          @Nullable Index.Analyzer indexAnalyzer,
-                                          @Nullable Index.Analyzer queryAnalyzer);
+    public abstract boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand);
+
     /**
-     * Whether 2 analyzable values satisfy this operator (given the type they should be compared with).
+     * Whether 2 index-analyzed values satisfy this operator (given the type they should be compared with).
      *
-     * @param type the type of the values to compare.
-     * @param leftOperand the left operand of the comparison.
-     * @param rightTokens the right operand of the comparison decomposed as analyzed tokens.
-     * @param indexAnalyzer an index-provided function to transform the left-side compared value before comparison,
-     * it shouldn't be {@code null}.
+     * @param type the type of the index-analyzed tokens to compare.
+     * @param leftTokens the left operand of the comparison, decomposed as index-analyzed tokens.
+     * @param rightTokens the right operand of the comparison, decomposed as index-analyzed tokens.
      */
-    public boolean isSatisfiedBy(AbstractType<?> type,
-                                 ByteBuffer leftOperand,
-                                 List<ByteBuffer> rightTokens,
-                                 Index.Analyzer indexAnalyzer)
+    public boolean isSatisfiedByAnalyzed(AbstractType<?> type, List<ByteBuffer> leftTokens, List<ByteBuffer> rightTokens)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(this + " operation does not support analyzers");
     }
 
     public int serializedSize()

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnCondition.java
@@ -257,7 +257,7 @@ public abstract class ColumnCondition
                 // the condition value is not null, so only NEQ can return true
                 return operator == Operator.NEQ;
             }
-            return operator.isSatisfiedBy(type, otherValue, value, null, null); // We don't use any analyzers in LWT, see CNDB-11658
+            return operator.isSatisfiedBy(type, otherValue, value); // We don't use any analyzers in LWT, see CNDB-11658
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/conditions/ColumnConditions.java
+++ b/src/java/org/apache/cassandra/cql3/conditions/ColumnConditions.java
@@ -93,7 +93,7 @@ public final class ColumnConditions extends AbstractConditions implements Iterab
 
         for (ColumnCondition condition : this)
         {
-            if (indexRegistry.getIndexAnalyzerFor(condition.column, condition.operator).isPresent())
+            if (indexRegistry.getAnalyzerFor(condition.column, condition.operator, null).isPresent())
             {
                 analyzedColumns.add(condition.column);
             }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -1211,7 +1211,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         {
             var index = findSupportingIndex(indexRegistry);
             var valueBytes = value.bindAndGet(options);
-            var terms = index.getQueryAnalyzer().get().analyze(valueBytes);
+            var terms = index.getAnalyzer(valueBytes).get().queriedTokens();
             if (terms.isEmpty())
                 throw invalidRequest("BM25 query must contain at least one term (perhaps your analyzer is discarding tokens you didn't expect)");
             filter.add(columnDef, Operator.BM25, valueBytes);

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -261,7 +261,8 @@ public class RowFilter
             ByteBuffer value = keyValidator instanceof CompositeType
                              ? ((CompositeType) keyValidator).split(key.getKey())[e.column.position()]
                              : key.getKey();
-            if (!e.operator().isSatisfiedBy(e.column.type, value, e.value, e.indexAnalyzer(), e.queryAnalyzer()))
+
+            if (!e.isSatisfiedBy(e.column.type, value))
                 return false;
         }
         return true;
@@ -278,7 +279,9 @@ public class RowFilter
             if (!e.column.isClusteringColumn())
                 continue;
 
-            if (!e.operator().isSatisfiedBy(e.column.type, clustering.bufferAt(e.column.position()), e.value, e.indexAnalyzer(), e.queryAnalyzer()))
+            ByteBuffer value = clustering.bufferAt(e.column.position());
+
+            if (!e.isSatisfiedBy(e.column.type, value))
                 return false;
         }
         return true;
@@ -465,7 +468,7 @@ public class RowFilter
         public SimpleExpression add(ColumnMetadata def, Operator op, ByteBuffer value)
         {
             assert op != Operator.ANN : "ANN expressions should be added with the addANNExpression method";
-            SimpleExpression expression = new SimpleExpression(def, op, value, indexAnalyzer(def, op), queryAnalyzer(def, op), null);
+            SimpleExpression expression = new SimpleExpression(def, op, value, analyzer(def, op, value), null);
             add(expression);
             return expression;
         }
@@ -479,24 +482,18 @@ public class RowFilter
          */
         public void addANNExpression(ColumnMetadata def, ByteBuffer value, ANNOptions annOptions)
         {
-            add(new SimpleExpression(def, Operator.ANN, value, null, null, annOptions));
+            add(new SimpleExpression(def, Operator.ANN, value, null, annOptions));
         }
 
         public void addMapComparison(ColumnMetadata def, ByteBuffer key, Operator op, ByteBuffer value)
         {
-            add(new MapComparisonExpression(def, key, op, value, indexAnalyzer(def, op), queryAnalyzer(def, op)));
+            add(new MapComparisonExpression(def, key, op, value));
         }
 
         @Nullable
-        private Index.Analyzer indexAnalyzer(ColumnMetadata def, Operator op)
+        private Index.Analyzer analyzer(ColumnMetadata def, Operator op, ByteBuffer value)
         {
-            return indexRegistry == null ? null : indexRegistry.getIndexAnalyzerFor(def, op).orElse(null);
-        }
-
-        @Nullable
-        private Index.Analyzer queryAnalyzer(ColumnMetadata def, Operator op)
-        {
-            return indexRegistry == null ? null : indexRegistry.getQueryAnalyzerFor(def, op).orElse(null);
+            return indexRegistry == null ? null : indexRegistry.getAnalyzerFor(def, op, value).orElse(null);
         }
 
         public void addGeoDistanceExpression(ColumnMetadata def, ByteBuffer point, Operator op, ByteBuffer distance)
@@ -876,15 +873,22 @@ public class RowFilter
         }
 
         @Nullable
-        public Index.Analyzer indexAnalyzer()
+        public Index.Analyzer analyzer()
         {
             return null;
         }
 
-        @Nullable
-        public Index.Analyzer queryAnalyzer()
+        protected boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer foundValue)
         {
-            return null;
+            if (foundValue == null)
+                return false;
+
+            Index.Analyzer analyzer = analyzer();
+
+            // Note that CQL expression are always of the form 'x < 4', i.e. the tested value is on the left.
+            return analyzer == null
+                   ? operator.isSatisfiedBy(type, foundValue, value)
+                   : operator.isSatisfiedByAnalyzed(type, analyzer.indexedTokens(foundValue), analyzer.queriedTokens());
         }
 
         @Nullable
@@ -1059,8 +1063,6 @@ public class RowFilter
                 Operator operator = Operator.readFrom(in);
                 ColumnMetadata column = metadata.getColumn(name);
                 IndexRegistry indexRegistry = IndexRegistry.obtain(metadata);
-                Index.Analyzer indexAnalyzer = indexRegistry.getIndexAnalyzerFor(column, operator).orElse(null);
-                Index.Analyzer queryAnalyzer = indexRegistry.getQueryAnalyzerFor(column, operator).orElse(null);
 
                 // Compact storage tables, when used with thrift, used to allow falling through this withouot throwing an
                 // exception. However, since thrift was removed in 4.0, this behaviour was not restored in CASSANDRA-16217
@@ -1072,11 +1074,12 @@ public class RowFilter
                     case SIMPLE:
                         ByteBuffer value = ByteBufferUtil.readWithShortLength(in);
                         ANNOptions annOptions = operator == Operator.ANN ? ANNOptions.serializer.deserialize(in, version) : null;
-                        return new SimpleExpression(column, operator, value, indexAnalyzer, queryAnalyzer, annOptions);
+                        Index.Analyzer analyzer = indexRegistry.getAnalyzerFor(column, operator, value).orElse(null);
+                        return new SimpleExpression(column, operator, value, analyzer, annOptions);
                     case MAP_COMPARISON:
                         ByteBuffer key = ByteBufferUtil.readWithShortLength(in);
                         ByteBuffer val = ByteBufferUtil.readWithShortLength(in);
-                        return new MapComparisonExpression(column, key, operator, val, indexAnalyzer, queryAnalyzer);
+                        return new MapComparisonExpression(column, key, operator, val);
                     case VECTOR_RADIUS:
                         Operator boundaryOperator = Operator.readFrom(in);
                         ByteBuffer distance = ByteBufferUtil.readWithShortLength(in);
@@ -1128,65 +1131,40 @@ public class RowFilter
     }
 
     /**
-     * An expression that can be associated with an {@link Index.Analyzer}.
-     */
-    public abstract static class AnalyzableExpression extends Expression
-    {
-        @Nullable
-        protected final Index.Analyzer indexAnalyzer;
-
-        @Nullable
-        protected final Index.Analyzer queryAnalyzer;
-
-        public AnalyzableExpression(ColumnMetadata column,
-                                    Operator operator,
-                                    ByteBuffer value,
-                                    @Nullable Index.Analyzer indexAnalyzer,
-                                    @Nullable Index.Analyzer queryAnalyzer)
-        {
-            super(column, operator, value);
-            this.indexAnalyzer = indexAnalyzer;
-            this.queryAnalyzer = queryAnalyzer;
-        }
-
-        @Nullable
-        public final Index.Analyzer indexAnalyzer()
-        {
-            return indexAnalyzer;
-        }
-
-        @Nullable
-        public final Index.Analyzer queryAnalyzer()
-        {
-            return queryAnalyzer;
-        }
-
-        @Override
-        public int numFilteredValues()
-        {
-            return queryAnalyzer == null
-                   ? super.numFilteredValues()
-                   : queryAnalyzer().analyze(value).size();
-        }
-    }
-
-    /**
      * An expression of the form 'column' 'op' 'value'.
      */
-    public static class SimpleExpression extends AnalyzableExpression
+    public static class SimpleExpression extends Expression
     {
+        @Nullable
+        protected final Index.Analyzer analyzer;
+
         @Nullable
         private final ANNOptions annOptions;
 
         public SimpleExpression(ColumnMetadata column,
                                 Operator operator,
                                 ByteBuffer value,
-                                @Nullable Index.Analyzer indexAnalyzer,
-                                @Nullable Index.Analyzer queryAnalyzer,
+                                @Nullable Index.Analyzer analyzer,
                                 @Nullable ANNOptions annOptions)
         {
-            super(column, operator, value, indexAnalyzer, queryAnalyzer);
+            super(column, operator, value);
+            this.analyzer = analyzer;
             this.annOptions = annOptions;
+        }
+
+        @Override
+        @Nullable
+        public Index.Analyzer analyzer()
+        {
+            return analyzer;
+        }
+
+        @Override
+        public int numFilteredValues()
+        {
+            return analyzer == null
+                    ? super.numFilteredValues()
+                    : analyzer.queriedTokens().size();
         }
 
         @Nullable
@@ -1214,22 +1192,21 @@ public class RowFilter
                     {
                         assert !column.isComplex() : "Only CONTAINS and CONTAINS_KEY are supported for 'complex' types";
 
+                        ByteBuffer foundValue = getValue(metadata, partitionKey, row);
+
+                        if (foundValue == null)
+                            return false;
+
                         // In order to support operators on Counter types, their value has to be extracted from internal
                         // representation. See CASSANDRA-11629
                         if (column.type.isCounter())
                         {
-                            ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                            if (foundValue == null)
-                                return false;
-
                             ByteBuffer counterValue = LongType.instance.decompose(CounterContext.instance().total(foundValue, ByteBufferAccessor.instance));
-                            return operator.isSatisfiedBy(LongType.instance, counterValue, value, indexAnalyzer, queryAnalyzer);
+                            return isSatisfiedBy(LongType.instance, counterValue);
                         }
                         else
                         {
-                            // Note that CQL expression are always of the form 'x < 4', i.e. the tested value is on the left.
-                            ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                            return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value, indexAnalyzer, queryAnalyzer);
+                            return isSatisfiedBy(column.type, foundValue);
                         }
                     }
                 case NEQ:
@@ -1244,7 +1221,7 @@ public class RowFilter
                         assert !column.isComplex() : "Only CONTAINS and CONTAINS_KEY are supported for 'complex' types";
                         ByteBuffer foundValue = getValue(metadata, partitionKey, row);
                         // Note that CQL expression are always of the form 'x < 4', i.e. the tested value is on the left.
-                        return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value, indexAnalyzer, queryAnalyzer);
+                        return isSatisfiedBy(column.type, foundValue);
                     }
                 case CONTAINS:
                     return contains(metadata, partitionKey, row);
@@ -1261,10 +1238,8 @@ public class RowFilter
         private boolean contains(TableMetadata metadata, DecoratedKey partitionKey, Row row)
         {
             assert column.type.isCollection();
-            assert (indexAnalyzer == null) == (queryAnalyzer == null);
 
             CollectionType<?> type = (CollectionType<?>) column.type;
-            List<ByteBuffer> analyzedValues = queryAnalyzer == null ? null : queryAnalyzer.analyze(value);
 
             if (column.isComplex())
             {
@@ -1275,14 +1250,16 @@ public class RowFilter
                     for (Cell<?> cell : complexData)
                     {
                         ByteBuffer elementValue = type.kind == CollectionType.Kind.SET ? cell.path().get(0) : cell.buffer();
-                        if (analyzedValues == null)
+                        if (analyzer != null)
                         {
-                            if (elementType.compare(elementValue, value) == 0)
+                            List<ByteBuffer> elementTokens = analyzer.indexedTokens(elementValue);
+                            List<ByteBuffer> queriedTokens = analyzer.queriedTokens();
+                            if (Operator.ANALYZER_MATCHES.isSatisfiedByAnalyzed(elementType, elementTokens, queriedTokens))
                                 return true;
                         }
                         else
                         {
-                            if (Operator.ANALYZER_MATCHES.isSatisfiedBy(elementType, elementValue, analyzedValues, indexAnalyzer))
+                            if (Operator.EQ.isSatisfiedBy(elementType, elementValue, value))
                                 return true;
                         }
                     }
@@ -1291,8 +1268,9 @@ public class RowFilter
             }
             else
             {
+                assert analyzer == null : "Analyzers are not supported on frozen collections";
                 ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                return foundValue != null && Operator.CONTAINS.isSatisfiedBy(type, foundValue, value, indexAnalyzer, queryAnalyzer);
+                return foundValue != null && Operator.CONTAINS.isSatisfiedBy(type, foundValue, value);
             }
         }
 
@@ -1302,15 +1280,15 @@ public class RowFilter
             MapType<?, ?> mapType = (MapType<?, ?>) column.type;
             if (column.isComplex())
             {
-                if (queryAnalyzer != null)
+                if (analyzer != null)
                 {
-                    assert indexAnalyzer != null;
-                    List<ByteBuffer> values = queryAnalyzer.analyze(value);
                     for (Cell<?> cell : row.getComplexColumnData(column))
                     {
                         AbstractType<?> elementType = mapType.nameComparator();
                         ByteBuffer elementValue = cell.path().get(0);
-                        if (Operator.ANALYZER_MATCHES.isSatisfiedBy(elementType, elementValue, values, indexAnalyzer))
+                        List<ByteBuffer> elementTokens = analyzer.indexedTokens(elementValue);
+                        List<ByteBuffer> queriedTokens = analyzer.queriedTokens();
+                        if (Operator.ANALYZER_MATCHES.isSatisfiedByAnalyzed(elementType, elementTokens, queriedTokens))
                             return true;
                     }
                     return false;
@@ -1319,8 +1297,9 @@ public class RowFilter
             }
             else
             {
+                assert analyzer == null : "Analyzers are not supported on frozen collections";
                 ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                return foundValue != null && Operator.CONTAINS_KEY.isSatisfiedBy(mapType, foundValue, value, indexAnalyzer, queryAnalyzer);
+                return foundValue != null && Operator.CONTAINS_KEY.isSatisfiedBy(mapType, foundValue, value);
             }
         }
 
@@ -1370,7 +1349,7 @@ public class RowFilter
      * supported when 'column' is a map) and where the operator can be {@link Operator#EQ}, {@link Operator#NEQ},
      * {@link Operator#LT}, {@link Operator#LTE}, {@link Operator#GT}, or {@link Operator#GTE}.
      */
-    public static class MapComparisonExpression extends AnalyzableExpression
+    public static class MapComparisonExpression extends Expression
     {
         private final ByteBuffer key;
         private ByteBuffer indexValue = null;
@@ -1378,11 +1357,9 @@ public class RowFilter
         public MapComparisonExpression(ColumnMetadata column,
                                        ByteBuffer key,
                                        Operator operator,
-                                       ByteBuffer value,
-                                       @Nullable Index.Analyzer indexAnalyzer,
-                                       @Nullable Index.Analyzer queryAnalyzer)
+                                       ByteBuffer value)
         {
-            super(column, operator, value, indexAnalyzer, queryAnalyzer);
+            super(column, operator, value);
             assert column.type instanceof MapType && (operator == Operator.EQ || operator == Operator.NEQ || operator.isSlice());
             this.key = key;
         }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -431,23 +431,12 @@ public interface Index
     }
 
     /**
-     * Returns the write-time {@link Analyzer} for this index, if any. If the index doesn't transform the column values,
+     * Returns the {@link Analyzer} for this index, if any. If the index doesn't transform the column values,
      * this method will return an empty optional.
      *
-     * @return the write-time transforming column value analyzer for the index, if any
+     * @return the transforming column value analyzer for the index, if any
      */
-    default Optional<Analyzer> getIndexAnalyzer()
-    {
-        return Optional.empty();
-    }
-
-    /**
-     * Returns the query-time {@link Analyzer} for this index, if any. If the index doesn't transform the column values,
-     * this method will return an empty optional.
-     *
-     * @return the query-time transforming column value analyzer for the index, if any
-     */
-    default Optional<Analyzer> getQueryAnalyzer()
+    default Optional<Analyzer> getAnalyzer(ByteBuffer queriedValue)
     {
         return Optional.empty();
     }
@@ -459,10 +448,11 @@ public interface Index
      * index. It can be used to perform the same transformation on values that the index does when indexing. That way,
      * the CQL operator can replicate the index behaviour when filtering results.
      */
-    @FunctionalInterface
     interface Analyzer
     {
-        List<ByteBuffer> analyze(ByteBuffer value);
+        List<ByteBuffer> indexedTokens(ByteBuffer indexedValue);
+
+        List<ByteBuffer> queriedTokens();
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -20,8 +20,8 @@
  */
 package org.apache.cassandra.index;
 
+import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -304,25 +304,13 @@ public interface IndexRegistry
     Index getIndex(IndexMetadata indexMetadata);
     Collection<Index> listIndexes();
 
-    default Optional<Index.Analyzer> getIndexAnalyzerFor(ColumnMetadata column, Operator operator)
-    {
-        return getAnalyzerFor(column, operator, Index::getIndexAnalyzer);
-    }
-
-    default Optional<Index.Analyzer> getQueryAnalyzerFor(ColumnMetadata column, Operator operator)
-    {
-        return getAnalyzerFor(column, operator, Index::getQueryAnalyzer);
-    }
-
-    default Optional<Index.Analyzer> getAnalyzerFor(ColumnMetadata column,
-                                                    Operator operator,
-                                                    Function<Index, Optional<Index.Analyzer>> analyzerGetter)
+    default Optional<Index.Analyzer> getAnalyzerFor(ColumnMetadata column, Operator operator, ByteBuffer value)
     {
         for (Index index : listIndexes())
         {
             if (index.supportsExpression(column, operator))
             {
-                Optional<Index.Analyzer> analyzer = analyzerGetter.apply(index);
+                Optional<Index.Analyzer> analyzer = index.getAnalyzer(value);
                 if (analyzer.isPresent())
                     return analyzer;
             }

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -679,23 +679,34 @@ public class StorageAttachedIndex implements Index
     }
 
     @Override
-    public Optional<Analyzer> getIndexAnalyzer()
+    public Optional<Analyzer> getAnalyzer(ByteBuffer queriedValue)
     {
-        return indexContext.isAnalyzed()
-               ? Optional.of(value -> analyze(indexContext.getAnalyzerFactory(), value))
-               : Optional.empty();
-    }
+        if (!indexContext.isAnalyzed())
+            return Optional.empty();
 
-    @Override
-    public Optional<Analyzer> getQueryAnalyzer()
-    {
-        return indexContext.isAnalyzed()
-               ? Optional.of(value -> analyze(indexContext.getQueryAnalyzerFactory(), value))
-               : Optional.empty();
+        // memoize the analyzed queried value, so we don't have to re-analyze it for every evaluated column value
+        List<ByteBuffer> queriedTokens = analyze(indexContext.getQueryAnalyzerFactory(), queriedValue);
+
+        return Optional.of(new Analyzer() {
+            @Override
+            public List<ByteBuffer> indexedTokens(ByteBuffer value)
+            {
+                return analyze(indexContext.getAnalyzerFactory(), value);
+            }
+
+            @Override
+            public List<ByteBuffer> queriedTokens()
+            {
+                return queriedTokens;
+            }
+        });
     }
 
     private static List<ByteBuffer> analyze(AbstractAnalyzer.AnalyzerFactory factory, ByteBuffer value)
     {
+        if (value == null)
+            return null;
+
         List<ByteBuffer> tokens = new ArrayList<>();
         AbstractAnalyzer analyzer = factory.create();
         try

--- a/src/java/org/apache/cassandra/index/sai/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Operation.java
@@ -312,8 +312,7 @@ public class Operation
                                                                                                         ByteBufferAccessor.instance,
                                                                                                         offset,
                                                                                                         ProtocolVersion.V3),
-                                                                               expression.indexAnalyzer(),
-                                                                               expression.queryAnalyzer(),
+                                                                               expression.analyzer(),
                                                                                expression.annOptions())));
                     offset += TypeSizes.INT_SIZE + ByteBufferAccessor.instance.getInt(expression.getIndexValue(), offset);
                 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneAnalyzerTest.java
@@ -1054,6 +1054,94 @@ public class LuceneAnalyzerTest extends SAITester
         });
     }
 
+    @Test
+    public void testAnalyzerOnMapValues() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, genres map<int, text>)");
+        execute("INSERT INTO %s (id, genres) VALUES ('1', {1: 'Horror', 2: 'comedy'})");
+
+        assertRowsNet(executeNet("SELECT id FROM %s WHERE genres CONTAINS 'Horror' ALLOW FILTERING"), row("1"));
+        assertRowsNet(executeNet("SELECT id FROM %s WHERE genres NOT CONTAINS 'Horror' ALLOW FILTERING"));
+        assertRowsNet(executeNet("SELECT id FROM %s WHERE genres CONTAINS 'horror' ALLOW FILTERING"));
+        assertRowsNet(executeNet("SELECT id FROM %s WHERE genres NOT CONTAINS 'horror' ALLOW FILTERING"), row("1"));
+
+        createIndex("CREATE CUSTOM INDEX ON %s(VALUES(genres)) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer':'STANDARD'}");
+
+        beforeAndAfterFlush(() -> {
+            assertRowsNet(executeNet("SELECT id FROM %s WHERE genres CONTAINS 'horror'"), row("1"));
+            assertRowsNet(executeNet("SELECT id FROM %s WHERE genres NOT CONTAINS 'horror'"));
+
+            // map comparisson with analyzer matches operator is not supported with or without filtering
+            Assertions.assertThatThrownBy(() -> execute("SELECT id FROM %s WHERE genres[1] : 'horror'"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("can't be used with collections");
+            Assertions.assertThatThrownBy(() -> execute("SELECT id FROM %s WHERE genres[1] : 'horror' ALLOW FILTERING"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("can't be used with collections");
+
+            // map comparison with eq operator is not supported by the index, and it's not analyzing when filtering
+            Assertions.assertThatThrownBy(() -> execute("SELECT id FROM %s WHERE genres[1] = 'horror'"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("Column 'genres' has an index but does not support the operators specified in the query.");
+            assertRows(execute("SELECT id FROM %s WHERE genres[1] = 'horror' ALLOW FILTERING"));
+            assertRows(execute("SELECT id FROM %s WHERE genres[1] = 'Horror' ALLOW FILTERING"), row("1"));
+        });
+    }
+
+    @Test
+    public void testAnalyzerOnMapValuesWithDistinctQueryAnalyzer() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v map<int, text>, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(VALUES(v)) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                "'index_analyzer': '{" +
+                "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
+                "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
+                "  \"charFilters\" : []}', " +
+                "'query_analyzer': '{" +
+                "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}");
+
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, {0: 'astra quick fox', 1: 'astra quick foxes', 2: 'astra4', 3: 'astra5 -1@a#', 4: 'lazy dog'})");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 2, {0: 'astra quick fox'})");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 3, {0: 'astra quick foxes'})");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 4, {0: 'astra4'})");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 5, {0: 'astra5 -1@a#'})");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 6, {0: 'lazy dog'})");
+
+        beforeAndAfterFlush(() -> {
+
+            // contains
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v CONTAINS 'ast'"), row(1), row(2), row(3), row(4), row(5));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v CONTAINS 'astra'"), row(1), row(2), row(3), row(4), row(5));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v CONTAINS 'astra4'"), row(1), row(4));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v CONTAINS 'astra5'"), row(1), row(5));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v CONTAINS 'astra9'"));
+
+            // not contains
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v NOT CONTAINS 'ast'"), row(6));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v NOT CONTAINS 'astra'"), row(6));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v NOT CONTAINS 'astra4'"), row(2), row(3), row(5), row(6));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v NOT CONTAINS 'astra5'"), row(2), row(3), row(4), row(6));
+            assertRowsNet(executeNet("SELECT c FROM %s WHERE v NOT CONTAINS 'astra9'"), row(1), row(2), row(3), row(4), row(5), row(6));
+
+            // map comparisson with analyzer matches operator is not supported with or without filtering
+            Assertions.assertThatThrownBy(() -> execute("SELECT c FROM %s WHERE v[0] : 'ast'"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("can't be used with collections");
+            Assertions.assertThatThrownBy(() -> execute("SELECT c FROM %s WHERE v[0] : 'ast' ALLOW FILTERING"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("can't be used with collections");
+
+            // map comparison with eq operator is not supported by the index, and it's not analyzing when filtering
+            Assertions.assertThatThrownBy(() -> execute("SELECT c FROM %s WHERE v[0] = 'ast'"))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("Column 'v' has an index but does not support the operators specified in the query.");
+            assertRows(execute("SELECT c FROM %s WHERE v[0] = 'ast' ALLOW FILTERING"));
+            assertRows(execute("SELECT c FROM %s WHERE v[0] = 'astra quick fox' ALLOW FILTERING"), row(1), row(2));
+        });
+    }
+
     private void assertClientWarningOnNGram(String indexOptions)
     {
         createIndexFromOptions(indexOptions);


### PR DESCRIPTION
[CNDB-10731](https://github.com/riptano/cndb/issues/10731) added support for index analyzers to `RowFilter`. Currently, both the left and right operands of an expression are analyzed on every evaluation. However, the right operand has the same fixed value over the life of the expression, so we are doing the same analysis once and again. 

This PR memoizes the analyzed tokens of the right operand. It also adds some refactoring and simplifications around how analysis is dealt with in `RowFilter` and `Operator`.
