### PR TITLE
CNDB-13203: Use MessagingSuccess's version for cnx version

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -179,7 +179,11 @@ public class ANNOptions
         {
             // ANN options are only supported in DS 11 and above, so don't serialize anything if the messaging version is lower
             if (version < MessagingService.VERSION_DS_11)
+            {
+                if (options != NONE)
+                    throw new IllegalStateException("Unable to serialize ANN options with messaging version: " + version);
                 return;
+            }
 
             int flags = flags(options);
             out.writeInt(flags);

--- a/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
+++ b/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
@@ -37,6 +37,15 @@ public class EndpointMessagingVersions
     // protocol versions of the other nodes in the cluster
     private final ConcurrentMap<InetAddressAndPort, Integer> versions = new NonBlockingHashMap<>();
 
+    public EndpointMessagingVersions()
+    {
+    }
+
+    private EndpointMessagingVersions(EndpointMessagingVersions versions)
+    {
+        this.versions.putAll(versions.versions);
+    }
+
     /**
      * @return the last version associated with address, or @param version if this is the first such version
      */
@@ -90,5 +99,10 @@ public class EndpointMessagingVersions
     public boolean knows(InetAddressAndPort endpoint)
     {
         return versions.containsKey(endpoint);
+    }
+
+    public EndpointMessagingVersions copy()
+    {
+        return new EndpointMessagingVersions(this);
     }
 }

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -75,7 +75,7 @@ public class InboundMessageHandler extends AbstractMessageHandler
     private final ConnectionType type;
     private final InetAddressAndPort self;
     private final InetAddressAndPort peer;
-    private final int version;
+    final int version;
 
     private final InboundMessageCallbacks callbacks;
     private final Consumer<Message<?>> consumer;

--- a/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandlers.java
@@ -437,6 +437,13 @@ public final class InboundMessageHandlers
              + mapping.applyAsLong(legacyCounters);
     }
 
+    @VisibleForTesting
+    public void assertHandlersMessagingVersion(int expectedVersion)
+    {
+        for (InboundMessageHandler handler : handlers)
+            assert handler.version == expectedVersion : "Expected all handlers to be at version " + expectedVersion + " but found " + handler.version;
+    }
+
     interface HandlerProvider
     {
         InboundMessageHandler provide(FrameDecoder decoder,

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -1117,6 +1117,7 @@ public class OutboundConnection
                         assert !state.isClosed();
 
                         MessagingSuccess success = result.success();
+                        messagingVersion = success.messagingVersion;
                         debug.onConnect(success.messagingVersion, settings);
                         state.disconnected().maintenance.cancel(false);
 

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -1118,6 +1118,11 @@ public class OutboundConnection
 
                         MessagingSuccess success = result.success();
                         messagingVersion = success.messagingVersion;
+                        // We store the peer's endpoint version, not the version we connect on, which might
+                        // be lower due to our own preferred version. This is indicated in the `InboundConnectionInitator`.
+                        // We assert here to ensure that this assumption holds.
+                        int endpointVersion = settings.endpointToVersion.get(settings.to);
+                        assert messagingVersion <= endpointVersion : "Found " + messagingVersion + " > " + endpointVersion;
                         debug.onConnect(success.messagingVersion, settings);
                         state.disconnected().maintenance.cancel(false);
 

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -1118,11 +1118,7 @@ public class OutboundConnection
 
                         MessagingSuccess success = result.success();
                         messagingVersion = success.messagingVersion;
-                        // We store the peer's endpoint version, not the version we connect on, which might
-                        // be lower due to our own preferred version. This is indicated in the `InboundConnectionInitator`.
-                        // We assert here to ensure that this assumption holds.
-                        int endpointVersion = settings.endpointToVersion.get(settings.to);
-                        assert messagingVersion <= endpointVersion : "Found " + messagingVersion + " > " + endpointVersion;
+                        settings.endpointToVersion.set(settings.to, messagingVersion);
                         debug.onConnect(success.messagingVersion, settings);
                         state.disconnected().maintenance.cancel(false);
 

--- a/src/java/org/apache/cassandra/net/OutboundConnectionSettings.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionSettings.java
@@ -498,7 +498,10 @@ public class OutboundConnectionSettings
                                               applicationSendQueueReserveGlobalCapacityInBytes(),
                                               tcpNoDelay(), flushLowWaterMark, flushHighWaterMark,
                                               tcpConnectTimeoutInMS(), tcpUserTimeoutInMS(category), acceptVersions(category),
-                                              from(), socketFactory(), callbacks(), debug(), endpointToVersion());
+                                              from(), socketFactory(), callbacks(), debug(),
+                                              // If a set of versions is passed, make sure we do a copy of it, as the version might be later updated
+                                              // depending on the handshake result (i.e. nodes might handshake a different version)
+                                              endpointToVersion().copy());
     }
 
     private static boolean isInLocalDC(IEndpointSnitch snitch, InetAddressAndPort localHost, InetAddressAndPort remoteHost)

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -241,13 +241,26 @@ public class ANNOptionsTest extends CQLTester
 
             // ...with a version that doesn't support ANN options
             out = new DataOutputBuffer();
-            ReadCommand.serializer.serialize(command, out, MessagingService.VERSION_DS_10);
-            Assertions.assertThat(ReadCommand.serializer.serializedSize(command, MessagingService.VERSION_DS_10))
-                      .isEqualTo(out.buffer().remaining());
-            in = new DataInputBuffer(out.buffer(), true);
-            command = ReadCommand.serializer.deserialize(in, MessagingService.VERSION_DS_10);
-            actualOptions = command.rowFilter().annOptions();
-            Assertions.assertThat(actualOptions).isEqualTo(ANNOptions.NONE);
+            if (expectedOptions != ANNOptions.NONE) {
+                try
+                {
+                    ReadCommand.serializer.serialize(command, out, MessagingService.VERSION_DS_10);
+                }
+                catch (IllegalStateException e)
+                {
+                    // expected
+                    Assertions.assertThat(e)
+                              .hasMessageContaining("Unable to serialize ANN options with messaging version: " + MessagingService.VERSION_DS_10);
+                }
+            } else {
+                ReadCommand.serializer.serialize(command, out, MessagingService.VERSION_DS_10);
+                Assertions.assertThat(ReadCommand.serializer.serializedSize(command, MessagingService.VERSION_DS_10))
+                          .isEqualTo(out.buffer().remaining());
+                in = new DataInputBuffer(out.buffer(), true);
+                command = ReadCommand.serializer.deserialize(in, MessagingService.VERSION_DS_10);
+                actualOptions = command.rowFilter().annOptions();
+                Assertions.assertThat(actualOptions).isEqualTo(ANNOptions.NONE);
+            }
         }
         catch (IOException e)
         {

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -336,6 +336,7 @@ public class ConnectionTest
 
             // Ensure version is the same
             inbound.assertHandlersMessagingVersion(outbound.messagingVersion());
+            Assert.assertEquals(outbound.settings().endpointToVersion.get(endpoint), outbound.messagingVersion());
         });
     }
 
@@ -393,6 +394,7 @@ public class ConnectionTest
 
             // Ensure version is the same
             inbound.assertHandlersMessagingVersion(outbound.messagingVersion());
+            Assert.assertEquals(outbound.settings().endpointToVersion.get(endpoint), outbound.messagingVersion());
         });
     }
 

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -124,17 +124,24 @@ public class ConnectionTest
         timeouts.clear();
     }
 
+    private static volatile long originalRpcTimeout = 0;
+
     @BeforeClass
     public static void startup()
     {
         DatabaseDescriptor.daemonInitialization();
         CommitLog.instance.start();
+        // At the time of this commit, the default is 20 seconds and leads to significant delays
+        // in this test class, especially in testMessagePurging and testCloseIfEndpointDown.
+        originalRpcTimeout = DatabaseDescriptor.getRpcTimeout(TimeUnit.MILLISECONDS);
+        DatabaseDescriptor.setRpcTimeout(5000L);
     }
 
     @AfterClass
     public static void cleanup() throws InterruptedException
     {
         factory.shutdownNow();
+        DatabaseDescriptor.setRpcTimeout(originalRpcTimeout);
     }
 
     interface SendTest


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/13203

The underlying problem is that the `OutboundConnection` needs to store the message version from the peer. Otherwise, when the local `current_version` is higher than the remove `current_version`, we store the wrong value (we were storing the local value, not the agreed upon value).

The PR also fixes an issue in the ANN_OPTIONS serialization logic that we can hit in rare cases where the peers haven't yet connected, so the validation logic that would prevent serialization due to a peer having too low of a message version is skipped.

### What does this PR fix and why was it fixed
This PR fixes several issues related to upgrades by improving handshake logic.