### PR TITLE
CNDB-12683 validate table name length for not-internal

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -108,12 +108,10 @@ public final class CreateTableStatement extends AlterSchemaStatement
     public void validate(QueryState state)
     {
         super.validate(state);
-        logger.debug("Table {}, internal state {}", tableName, state.getClientState().isInternal);
 
-        int separatorLength = 1;
-        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
+        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
-                      SchemaConstants.NAME_LENGTH - separatorLength, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
+                      SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -111,7 +111,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         logger.debug("Table {}, internal state {}", tableName, state.getClientState().isInternal);
 
         int separatorLength = 1;
-        if (tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
+        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
                       SchemaConstants.NAME_LENGTH - separatorLength, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -41,7 +41,6 @@ import org.apache.cassandra.exceptions.AlreadyExistsException;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.guardrails.UserKeyspaceFilter;
 import org.apache.cassandra.guardrails.UserKeyspaceFilterProvider;
-import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.schema.Keyspaces.KeyspacesDiff;
 import org.apache.cassandra.service.ClientState;
@@ -113,8 +112,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         int separatorLength = 1;
         if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
-            throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s)",
-                      SchemaConstants.NAME_LENGTH - separatorLength, keyspaceName.length(), tableName.length(), tableName);
+            throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
+                      SchemaConstants.NAME_LENGTH - separatorLength, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -111,7 +111,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         logger.debug("Table {}, internal state {}", tableName, state.getClientState().isInternal);
 
         int separatorLength = 1;
-        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
+        if (tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length() - separatorLength)
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
                       SchemaConstants.NAME_LENGTH - separatorLength, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -107,19 +107,14 @@ public class CreateTableValidationTest extends CQLTester
     @Test
     public void failCreatingNewTableWithLongName()
     {
-        String keyspace = "38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
         String table = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-
-        execute(String.format("CREATE KEYSPACE \"%s\" with replication = " +
-                              "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
-                              keyspace));
         assertThatExceptionOfType(InvalidQueryException.class)
         .isThrownBy(() -> executeNet(String.format("CREATE TABLE \"%s\".%s (" +
                                                    "key int PRIMARY KEY," +
                                                    "val int)",
-                                                   keyspace, table)))
+                                                   KEYSPACE, table)))
         .withMessageContaining(String.format("Keyspace and table names combined shouldn't be more than 221 characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
-                                             keyspace.length(), table.length(), keyspace, table));
+                                             KEYSPACE.length(), table.length(), KEYSPACE, table));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -113,8 +113,8 @@ public class CreateTableValidationTest extends CQLTester
                                                    "key int PRIMARY KEY," +
                                                    "val int)",
                                                    KEYSPACE, table)))
-        .withMessageContaining(String.format("Keyspace and table names combined shouldn't be more than 221 characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
-                                             KEYSPACE.length(), table.length(), KEYSPACE, table));
+        .withMessageContaining(String.format("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
+                                             SchemaConstants.NAME_LENGTH, KEYSPACE.length(), table.length(), KEYSPACE, table));
     }
 
     @Test


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/12683

Table names are used in file names. Since the table names were not validated on its length, creating or flushing a table with too long name fails on too long file name.
There are two cases with using table names in file names:
- keyspace name `. ` table name `-controller-config.JSON`
- table name `-` 32 chars table id 

The maximum allowed file name size is 255 chars. Thus, 
- keyspace and table name, which are together longer than 231 chars, will fail.
- a table name, which is longer than 222 chars, will fail.

### What does this PR fix and why was it fixed
This PR checks that creating new table name should not have too long table name.
New tables are identified through the query's client state, which should not be internal.
The limit is 222 chars for combined keyspace and table names. This is more restrictive than necessary, but is easier to explain in the documentation.

The change is tested in CNDB that creating new tables with long names are prevented, but existing tables still work.
