### PR TITLE
CNDB-12922 ANNOptions validation now checks the endpoint connection m…

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -77,7 +77,7 @@ public class ANNOptions
 
         // Ensure that all nodes in the cluster are in a version that supports ANN options, including this one
         assert keyspace != null;
-        Set<InetAddressAndPort> badNodes = MessagingService.instance().endpointsWithVersionBelow(keyspace, MessagingService.VERSION_DS_11);
+        Set<InetAddressAndPort> badNodes = MessagingService.instance().connectionsWithVersionBelow(keyspace, MessagingService.VERSION_DS_11);
         if (MessagingService.current_version < MessagingService.VERSION_DS_11)
             badNodes.add(FBUtilities.getBroadcastAddressAndPort());
         if (!badNodes.isEmpty())

--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -77,7 +77,7 @@ public class ANNOptions
 
         // Ensure that all nodes in the cluster are in a version that supports ANN options, including this one
         assert keyspace != null;
-        Set<InetAddressAndPort> badNodes = MessagingService.instance().connectionsWithVersionBelow(keyspace, MessagingService.VERSION_DS_11);
+        Set<InetAddressAndPort> badNodes = MessagingService.instance().endpointsWithConnectionsOnVersionBelow(keyspace, MessagingService.VERSION_DS_11);
         if (MessagingService.current_version < MessagingService.VERSION_DS_11)
             badNodes.add(FBUtilities.getBroadcastAddressAndPort());
         if (!badNodes.isEmpty())

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/ANNOptionsDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/ANNOptionsDistributedTest.java
@@ -16,6 +16,8 @@
 
 package org.apache.cassandra.distributed.test.sai;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.junit.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -118,9 +120,9 @@ public class ANNOptionsDistributedTest extends TestBaseImpl
     {
         public static void install(ClassLoader classLoader, int node)
         {
-            if (node == 1)
+            // inject randomly first or second node to make sure it works if the node is a coordinator or replica
+            if (node == ThreadLocalRandom.current().nextInt(1, 3))
             {
-                // set the current verson to DS 11, which suppors ANN options
                 new ByteBuddy().rebase(MessagingService.class)
                                .method(named("currentVersion"))
                                .intercept(MethodDelegation.to(BB.class))


### PR DESCRIPTION
…essaging version: this makes sure the proper version is used, as following CNDB-13203, each connection maintains its own version, separated from the one recorded in the MessagingService.

### What is the issue
`ANNOptions#validate()` was previously checking endpoint versions via `MessagingService#versions`: but following #13203, in order to resolve a race condition, each endpoint connection tracks its own `EndpointMessagingVersions` object, with the version negotiated during handshake, while `MessagingService#versions` is updated with the max version of each endpoint. It follows checking `MessagingService#versions` might not rely on the right version used for the connection.

### What does this PR fix and why was it fixed
This PR introduces a new `MessagingService` method to check the connection version, and uses it inside `ANNOptions#validate()`.
