### PR TITLE
CNDB 13202: Only measure task execution time if CUSTOM_TASK_EXECUTION_CALLBACK_CLASS is set

### DIFF
--- a/src/java/org/apache/cassandra/schema/MemtableParams.java
+++ b/src/java/org/apache/cassandra/schema/MemtableParams.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.InheritingClass;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.db.memtable.Memtable;
-import org.apache.cassandra.db.memtable.SkipListMemtableFactory;
+import org.apache.cassandra.db.memtable.TrieMemtableFactory;
 import org.apache.cassandra.exceptions.ConfigurationException;
 
 /**
@@ -96,8 +96,8 @@ public final class MemtableParams
     }
 
     private static final String DEFAULT_CONFIGURATION_KEY = "default";
-    private static final Memtable.Factory DEFAULT_MEMTABLE_FACTORY = SkipListMemtableFactory.INSTANCE;
-    private static final ParameterizedClass DEFAULT_CONFIGURATION = SkipListMemtableFactory.CONFIGURATION;
+    private static final Memtable.Factory DEFAULT_MEMTABLE_FACTORY = TrieMemtableFactory.INSTANCE;
+    private static final ParameterizedClass DEFAULT_CONFIGURATION = TrieMemtableFactory.CONFIGURATION;
     private static final Map<String, ParameterizedClass>
         CONFIGURATION_DEFINITIONS = expandDefinitions(DatabaseDescriptor.getMemtableConfigurations());
     private static final Map<String, MemtableParams> CONFIGURATIONS = new HashMap<>();


### PR DESCRIPTION
### What is the issue

withTimeMeasurement breaks system queries and some fuzz tests

### What does this PR fix and why was it fixed

conditionally enable only when CUSTOM_TASK_EXECUTION_CALLBACK_CLASS is used
