### PR TITLE
CNDB-12683 validate table name length for not-internal (#1623)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -109,7 +109,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
+        if (!state.getClientState().isInternal && tableName.length() + keyspaceName.length() > SchemaConstants.NAME_LENGTH)
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
                       SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -109,6 +109,10 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
+        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
+            throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
+                      SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
+
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.
         if (Guardrails.ready())

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cassandra.schema;
 
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -103,7 +104,20 @@ public class CreateTableValidationTest extends CQLTester
     }
 
     @Test
-    public void testCreatingTableWithLongName() throws Throwable
+    public void failCreatingNewTableWithLongName()
+    {
+        String table = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+        assertThatExceptionOfType(InvalidQueryException.class)
+        .isThrownBy(() -> executeNet(String.format("CREATE TABLE \"%s\".%s (" +
+                                                   "key int PRIMARY KEY," +
+                                                   "val int)",
+                                                   KEYSPACE, table)))
+        .withMessageContaining(String.format("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
+                                             SchemaConstants.NAME_LENGTH, KEYSPACE.length(), table.length(), KEYSPACE, table));
+    }
+
+    @Test
+    public void testCreatingInternalTableWithLongName() throws Throwable
     {
         String keyspace = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
         String table = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/12683

Table names are used in file names. Since the table names were not validated on its length, creating or flushing a table with too long name fails on too long file name.
There are two cases with using table names in file names:
- keyspace_name .table_name-controller-config.JSON
- table_name-32chars_table_id 

The maximum allowed file name size is 255 chars. Thus, 
- keyspace and table names, which are together longer than 231 chars, will fail.
- a table name, which is longer than 222 chars, will fail.

This PR checks that creating new table name should not have too long table name.
New tables are identified through the query's client state, which should not be internal.
The limit is 222 chars for combined keyspace and table names. This is more restrictive than necessary, but is easier to explain in the documentation.

The change is tested in CNDB that creating new tables with long names are prevented, but existing tables still work.
