### PR TITLE
CC5 fix CQLSSTableWriterTest

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterDaemonMurmur3Test.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterDaemonMurmur3Test.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable;
+
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.service.StorageService;
+
+public class CQLSSTableWriterDaemonMurmur3Test extends CQLSSTableWriterTest
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        DatabaseDescriptor.daemonInitialization(() -> {
+            Config config = DatabaseDescriptor.loadConfig();
+            config.partitioner = Murmur3Partitioner.class.getName();
+            return config;
+        });
+        CommitLog.instance.start();
+        SchemaLoader.cleanupAndLeaveDirs();
+        Keyspace.setInitialized();
+        StorageService.instance.initServer();
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -38,6 +38,7 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -569,6 +570,10 @@ public abstract class CQLSSTableWriterTest
     @SuppressWarnings("unchecked")
     public void testWritesWithUdts() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization with Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || !(DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner));
+
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
                               + "  v1 list<frozen<tuple2>>,"
@@ -639,6 +644,10 @@ public abstract class CQLSSTableWriterTest
     @SuppressWarnings("unchecked")
     public void testWritesWithDependentUdts() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization with Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || !(DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner));
+
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
                               + "  v1 frozen<nested_tuple>,"
@@ -699,6 +708,10 @@ public abstract class CQLSSTableWriterTest
     @Test
     public void testUnsetValues() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization with Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || !(DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner));
+
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
                               + "  c1 int,"
@@ -1238,6 +1251,10 @@ public abstract class CQLSSTableWriterTest
     @Test
     public void testWriteWithSorted() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization with Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || !(DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner));
+
         String schema = "CREATE TABLE " + qualifiedTable + " ("
                         + "  k int PRIMARY KEY,"
                         + "  v blob )";
@@ -1269,6 +1286,10 @@ public abstract class CQLSSTableWriterTest
     @Test
     public void testWriteWithSortedAndMaxSize() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization with Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || !(DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner));
+
         String schema = "CREATE TABLE " + qualifiedTable + " ("
                         + "  k int PRIMARY KEY,"
                         + "  v blob )";
@@ -1359,6 +1380,9 @@ public abstract class CQLSSTableWriterTest
     @Test
     public void testWriteWithSAI() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization without Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner);
         writeWithSaiInternal();
         writeWithSaiInternal();
     }
@@ -1410,6 +1434,10 @@ public abstract class CQLSSTableWriterTest
     @Test
     public void testSkipBuildingIndexesWithSAI() throws Exception
     {
+        Assume.assumeTrue("Skip test when using DaemonInitialization without Murmur3Partitioner",
+                          !DatabaseDescriptor.isDaemonInitialized()
+                          || DatabaseDescriptor.getPartitioner() instanceof Murmur3Partitioner);
+
         String schema = "CREATE TABLE " + qualifiedTable + " ("
                         + "  k int PRIMARY KEY,"
                         + "  v1 text,"


### PR DESCRIPTION
### What is the issue
On `main-5.0`, `CQLSSTableWriterDaemonTest`s `testWriteWithSAI` and `testSkipBuildingIndexesWithSAI` are failing. This has been happening since commit:
```
Reapply "CC5 default memtable to TrieMemtable"	ec7bd7137a	Brandon Williams <brandonwilliams@apache.org>	Mar 6, 2025 at 9:25 AM
```
The error reported is:
```
class org.apache.cassandra.dht.ByteOrderedPartitioner$BytesToken cannot be cast to class org.apache.cassandra.dht.Murmur3Partitioner$LongToken (org.apache.cassandra.dht.ByteOrderedPartitioner$BytesToken and org.apache.cassandra.dht.Murmur3Partitioner$LongToken are in unnamed module of loader 'app')
```

### What does this PR fix and why was it fixed
I am not really sure why changing the memtable default to `TrieMemtable` led to these tests failing, because the `test/conf/cassandra.yaml` that sets the `ByteOrderedPartitioner` has not changed. 

Whatever the interaction that changed, SAI does not work with `ByteOrderedPartitioner`, so these tests started failing.

The best solution I could come up with is to add `CQLSSTableWriterDaemonMurmur3Test` that overrides the test yaml to use `Murmur3Partitioner`.

Along with that I needed to annotate tests in `CQLSSTableWriterTest` to work with the subclass variations: 
* `CQLSSTableWriterClientTest` - all tests pass
* `CQLSSTableWriterDaemonTest` - skip SAI tests, all others pass
* `CQLSSTableWriterDaemonMurmur3Test` - skip certain non-SAI tests, all others pass

It works, but I am open to a better solution or other ideas.

Also any clarification of just why changing to `TrieMemtable` caused the errors would be helpful and might suggest some better solution.
