### PR TITLE
CNDB-13299 prevent too long index names

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -93,6 +93,10 @@ public final class CreateIndexStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
+        if (!state.getClientState().isInternal && indexName.length() > SchemaConstants.INDEX_NAME_LENGTH)
+            throw ire("Index name shouldn't be more than %s characters long (got %s chars for %s)",
+                      SchemaConstants.INDEX_NAME_LENGTH, indexName.length(), indexName);
+
         // save the query state to use it for guardrails validation in #apply
         this.state = state;
     }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -93,7 +93,12 @@ public final class CreateIndexStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        if (!state.getClientState().isInternal && indexName.length() > SchemaConstants.INDEX_NAME_LENGTH)
+        // Check the length of a valid index name.
+        // Non-valid indexes are validated in IndexMetadata#validate.
+        if (!state.getClientState().isInternal
+            && SchemaConstants.isValidName(indexName, true)
+            && indexName.length() > SchemaConstants.INDEX_NAME_LENGTH)
+
             throw ire("Index name shouldn't be more than %s characters long (got %s chars for %s)",
                       SchemaConstants.INDEX_NAME_LENGTH, indexName.length(), indexName);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -109,7 +109,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
+        if (!state.getClientState().isInternal && tableName.length() + keyspaceName.length() > SchemaConstants.NAME_LENGTH)
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
                       SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -109,7 +109,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     {
         super.validate(state);
 
-        if (!state.getClientState().isInternal && tableName.length() + keyspaceName.length() > SchemaConstants.NAME_LENGTH)
+        if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
             throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
                       SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -76,6 +76,14 @@ public final class SchemaConstants
      */
     public static final int NAME_LENGTH = FILENAME_LENGTH - 32 - 1;
 
+    /**
+     * Longest permissible index name, so no index can fail on file name error.
+     * It is based on the most restrictive requirement coming from SAI and calculated by
+     * {@link org.apache.cassandra.index.sai.disk.format.Version#calculateIndexNameAllowedLength}.
+     * The exact number is used here, since it will be in user's documentation.
+     */
+    public static final int INDEX_NAME_LENGTH = 182;
+
     // 59adb24e-f3cd-3e02-97f0-5b395827453f
     public static final UUID emptyVersion;
 

--- a/test/unit/org/apache/cassandra/index/IndexNameTest.java
+++ b/test/unit/org/apache/cassandra/index/IndexNameTest.java
@@ -121,4 +121,24 @@ public class IndexNameTest extends CQLTester
         assertThatThrownBy(() -> execute(String.format(createIndexQuery, "\"unacceptable index name\"", "%s", columnName)))
         .isInstanceOf(ConfigurationException.class);
     }
+
+    @Test
+    public void testLongNamesInternal()
+    {
+        String longName = "a".repeat(183);
+
+        createTable("CREATE TABLE %s (" +
+                    "key int PRIMARY KEY," +
+                    "value int)"
+        );
+        createIndex(String.format(createIndexQuery, longName, "%s", "value"));
+        execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (1, 1)", "value"));
+        execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (2, 2)", "value"));
+
+        assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1));
+
+        flush();
+
+        assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1));
+    }
 }

--- a/test/unit/org/apache/cassandra/index/IndexNameTest.java
+++ b/test/unit/org/apache/cassandra/index/IndexNameTest.java
@@ -22,10 +22,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.schema.SchemaConstants;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class IndexNameTest extends CQLTester
@@ -123,7 +127,7 @@ public class IndexNameTest extends CQLTester
     }
 
     @Test
-    public void testLongNamesInternal()
+    public void testTooLongNamesInternal() throws Throwable
     {
         String longName = "a".repeat(183);
 
@@ -135,10 +139,37 @@ public class IndexNameTest extends CQLTester
         execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (1, 1)", "value"));
         execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (2, 2)", "value"));
 
-        assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1));
+        beforeAndAfterFlush(() -> assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1)));
+    }
 
-        flush();
+    @Test
+    public void testMaxAcceptableLongNamesNewIndex() throws Throwable
+    {
+        assertEquals(182, Version.calculateIndexNameAllowedLength());
+        String longName = "a".repeat(182);
+        createTable("CREATE TABLE %s (" +
+                    "key int PRIMARY KEY," +
+                    "value int)"
+        );
+        executeNet(String.format(createIndexQuery, longName, "%s", "value"));
 
-        assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1));
+        execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (1, 1)", "value"));
+        execute(String.format("INSERT INTO %%s (\"key\", %s) VALUES (2, 2)", "value"));
+
+        beforeAndAfterFlush(() -> assertRows(execute(String.format("SELECT key, %s FROM %%s WHERE %<s = 1", "value")), row(1, 1)));
+    }
+
+    @Test
+    public void failTooLongNamesNewIndex()
+    {
+        String longName = "a".repeat(183);
+        createTable("CREATE TABLE %s (" +
+                    "key int PRIMARY KEY," +
+                    "value int)"
+        );
+        assertThatThrownBy(() -> executeNet(String.format(createIndexQuery, longName, "%s", "value")))
+        .isInstanceOf(InvalidQueryException.class)
+        .hasMessage(String.format("Index name shouldn't be more than %s characters long (got %s chars for %s)",
+                                  SchemaConstants.INDEX_NAME_LENGTH, longName.length(), longName));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/13299

Creating an index with too long index names leads to file errors or incorrect results.

### What does this PR fix and why was it fixed

This PR prevents creating new indexes, i.e., not internal, with provided index names longer than 182 characters. This constant is based on the most restrictive requirement from different index types. It comes from SAI by subtracting the longest file name addition from the file name limit of 255 characters.
