### PR TITLE
CNDB-13330: Fix wildcard select with BM25 order

### DIFF
--- a/src/java/org/apache/cassandra/cql3/selection/Selection.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selection.java
@@ -146,20 +146,26 @@ public abstract class Selection
 
     public static Selection wildcard(TableMetadata table, Set<ColumnMetadata> orderingColumns, boolean isJson, boolean returnStaticContentOnPartitionWithNoRows)
     {
+        // Add all table columns, but skip orderingColumns:
         List<ColumnMetadata> all = new ArrayList<>(table.columns().size());
         Iterators.addAll(all, table.allColumnsInSelectOrder());
-        return new SimpleSelection(table, all, orderingColumns, true, isJson, returnStaticContentOnPartitionWithNoRows);
+
+        Set<ColumnMetadata> newOrderingColumns = new HashSet<>(orderingColumns);
+        all.forEach(newOrderingColumns::remove);
+
+        return new SimpleSelection(table, all, newOrderingColumns, true, isJson, returnStaticContentOnPartitionWithNoRows);
     }
 
     public static Selection wildcardWithGroupBy(TableMetadata table,
                                                 VariableSpecifications boundNames,
+                                                Set<ColumnMetadata> orderingColumns,
                                                 boolean isJson,
                                                 boolean returnStaticContentOnPartitionWithNoRows)
     {
         return fromSelectors(table,
                              Lists.newArrayList(table.allColumnsInSelectOrder()),
                              boundNames,
-                             Collections.emptySet(),
+                             orderingColumns,
                              Collections.emptySet(),
                              true,
                              isJson,

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1304,8 +1304,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             if (selectables.isEmpty()) // wildcard query
             {
                 return hasGroupBy
-                       ? Selection.wildcardWithGroupBy(table, boundNames, parameters.isJson, restrictions.returnStaticContentOnPartitionWithNoRows())
-                       : Selection.wildcard(table, parameters.isJson, restrictions.returnStaticContentOnPartitionWithNoRows());
+                       ? Selection.wildcardWithGroupBy(table, boundNames, resultSetOrderingColumns, parameters.isJson, restrictions.returnStaticContentOnPartitionWithNoRows())
+                       : Selection.wildcard(table, resultSetOrderingColumns, parameters.isJson, restrictions.returnStaticContentOnPartitionWithNoRows());
             }
 
             return Selection.fromSelectors(table,

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -547,4 +547,18 @@ public class BM25Test extends SAITester
         // Shutdown executor
         assertEquals(0, executor.shutdownNow().size());
     }
+
+    @Test
+    public void testWildcardSelection()
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
+        analyzeIndex();
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 'apple')");
+
+        var result = execute("SELECT * FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");
+        assertThat(result).hasSize(1);
+
+        var result2 = execute("SELECT * FROM %s GROUP BY k, c ORDER BY v BM25 OF 'apple' LIMIT 3");
+        assertThat(result2).hasSize(1);
+    }
 }


### PR DESCRIPTION
When a wildcard selection is used, the score column
must be included in the selection.

Fixes:
NoHostAvailable: ('Unable to complete the operation against any hosts', {<Host: 10.87.217.86:9042 us-central1>: <Error from server: code=0000 [Server error] message="java.lang.ClassCastException:
class org.apache.cassandra.serializers.UTF8Serializer cannot be cast to class org.apache.cassandra.db.marshal.VectorType$VectorSerializer
(org.apache.cassandra.serializers.UTF8Serializer and org.apache.cassandra.db.marshal.VectorType$VectorSerializer are in unnamed module of loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @446c3920)">})
