### PR TITLE
CNDB-13375 don't use keyspace name length in error message

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -110,8 +110,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
         super.validate(state);
 
         if (!state.getClientState().isInternal && tableName.length() > SchemaConstants.NAME_LENGTH - keyspaceName.length())
-            throw ire("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
-                      SchemaConstants.NAME_LENGTH, keyspaceName.length(), tableName.length(), keyspaceName, tableName);
+            throw ire("Table name is too long, it needs to fit %s characters (got table name of %s chars for %s.%s)",
+                      SchemaConstants.NAME_LENGTH - keyspaceName.length(), tableName.length(), keyspaceName, tableName);
 
         // Some tools use CreateTableStatement, and the guardrails below both don't make too much sense for tools and
         // require the server to be initialized, so skipping them if it isn't.

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -113,8 +113,8 @@ public class CreateTableValidationTest extends CQLTester
                                                    "key int PRIMARY KEY," +
                                                    "val int)",
                                                    KEYSPACE, table)))
-        .withMessageContaining(String.format("Keyspace and table names combined shouldn't be more than %s characters long (got keyspace of %s chars and table of %s chars for %s.%s)",
-                                             SchemaConstants.NAME_LENGTH, KEYSPACE.length(), table.length(), KEYSPACE, table));
+        .withMessageContaining(String.format("Table name is too long, it needs to fit %s characters (got table name of %s chars for %s.%s)",
+                                             SchemaConstants.NAME_LENGTH - KEYSPACE.length(), table.length(), KEYSPACE, table));
     }
 
     @Test


### PR DESCRIPTION
Part of https://github.com/riptano/cndb/issues/13375

### What is the issue

Using keyspace name length in the error message for too long table name is confusing, since the length might include CNDB's generated prefix invisible to users.

### What does this PR fix and why was it fixed

Reformulates the error message for too long table name to avoid using the keyspace name length, since it might contain CNDB generated prefix, which is not visible to users.
