### PR TITLE
CNDB-13403: Add source column to synthetic column's ColumnMetadata

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1282,7 +1282,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
             // Create synthetic score column
             ColumnMetadata sourceColumn = expr.getColumn();
-            var cm = ColumnMetadata.syntheticColumn(sourceColumn.ksName, sourceColumn.cfName, ColumnMetadata.SYNTHETIC_SCORE_ID, FloatType.instance);
+            var cm = ColumnMetadata.syntheticScoreColumn(sourceColumn, FloatType.instance);
             return Map.of(cm, orderings.get(0));
         }
 

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -487,6 +487,7 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                 if (column.isSynthetic())
                 {
                     ByteBufferUtil.writeWithVIntLength(column.name.bytes, out);
+                    ByteBufferUtil.writeWithVIntLength(column.sythenticSourceColumn.bytes, out);
                     typeSerializer.serialize(column.type, out);
                 }
             }
@@ -519,6 +520,7 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                 {
                     syntheticCount++;
                     size += ByteBufferUtil.serializedSizeWithVIntLength(column.name.bytes);
+                    size += ByteBufferUtil.serializedSizeWithVIntLength(column.sythenticSourceColumn.bytes);
                     size += typeSerializer.serializedSize(column.type);
                 }
                 else
@@ -544,12 +546,22 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                 for (int i = 0; i < syntheticCount; i++)
                 {
                     ByteBuffer name = ByteBufferUtil.readWithVIntLength(in);
+                    ByteBuffer sourceColumnName = ByteBufferUtil.readWithVIntLength(in);
                     AbstractType<?> type = typeSerializer.deserialize(in);
 
                     if (!name.equals(ColumnMetadata.SYNTHETIC_SCORE_ID.bytes))
                         throw new IllegalStateException("Unknown synthetic column " + UTF8Type.instance.getString(name));
 
-                    ColumnMetadata column = ColumnMetadata.syntheticColumn(metadata.keyspace, metadata.name, ColumnMetadata.SYNTHETIC_SCORE_ID, type);
+                    ColumnMetadata sourceColumn = metadata.getColumn(sourceColumnName);
+                    if (sourceColumn == null)
+                    {
+                        // If we don't find the definition, it could be we have data for a dropped column
+                        sourceColumn = metadata.getDroppedColumn(name);
+                        if (sourceColumn == null)
+                            throw new RuntimeException("Unknown column " + UTF8Type.instance.getString(name) + " during deserialization of " + metadata.keyspace + '.' + metadata.name);
+                    }
+
+                    ColumnMetadata column = ColumnMetadata.syntheticScoreColumn(sourceColumn, type);
                     builder.add(column);
                 }
 

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -1062,7 +1062,8 @@ public abstract class ReadCommand extends AbstractReadQuery
                 // synthetic columns sort first, so when we hit the first non-synthetic, we're done
                 if (!c.isSynthetic())
                     break;
-                tmb.addColumn(ColumnMetadata.syntheticColumn(c.ksName, c.cfName, c.name, c.type));
+                assert c.sythenticSourceColumn != null;
+                tmb.addColumn(c);
             }
             metadata = tmb.build();
 

--- a/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/TopKProcessor.java
@@ -110,7 +110,7 @@ public class TopKProcessor
         else
             this.queryVector = null;
         this.limit = command.limits().count();
-        this.scoreColumn = ColumnMetadata.syntheticColumn(indexContext.getKeyspace(), indexContext.getTable(), ColumnMetadata.SYNTHETIC_SCORE_ID, FloatType.instance);
+        this.scoreColumn = ColumnMetadata.syntheticScoreColumn(expression.column(), FloatType.instance);
     }
 
     /**


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/13403 by implementing one of the solutions.

### What does this PR fix and why was it fixed

The current synthetic column logic relies on convention to know that the synthetic column's source column is the SAI ORDER BY column. This seems fragile and will break if we find a reason to introduce a new synthetic column. I propose that we serialize the source column name so that we can more easily support multiple synthetic columns.

The urgency for this change is that we want to get it in before we are locked into a given serde protocol.

Note however, that I haven't solved the primary issue described in https://github.com/riptano/cndb/issues/13402.

CNDB tests https://github.com/riptano/cndb/pull/13418