### PR TITLE
CNDB-13342: Add 4th component to the version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,7 @@
     <property name="debuglevel" value="source,lines,vars"/>
 
     <!-- default version and SCM information -->
-    <property name="base.version" value="4.0.11"/>
+    <property name="base.version" value="4.0.11.0"/>
     <property name="scm.connection" value="scm:git:ssh://git@github.com:datastax/cassandra.git"/>
     <property name="scm.developerConnection" value="scm:git:ssh://git@github.com:datastax/cassandra.git"/>
     <property name="scm.url" value="scm:git:ssh://git@github.com:datastax/cassandra.git"/>

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -253,7 +253,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                     minVersion = version;
             }
 
-            // remember the minumum version for the expiration duration
+            // remember the minimum version for the expiration duration
             if (minVersion.compareTo(SystemKeyspace.CURRENT_VERSION) < 0)
                 return new ExpiringMemoizingSupplier.Memoized<>(minVersion);
 


### PR DESCRIPTION
The 4th component can be used to distinguish version which introduce breaking changes, especially we want to retain the appropriate version ordering.

### What is the issue
...

### What does this PR fix and why was it fixed
...
