### PR TITLE
CNDB-13417: Reduce object alloc. on brute force hybrid ann path

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/NodeQueueRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/NodeQueueRowIdIterator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.cassandra.index.sai.disk.vector;
 
 import io.github.jbellis.jvector.graph.NodeQueue;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/NodeQueueRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/NodeQueueRowIdIterator.java
@@ -1,0 +1,28 @@
+package org.apache.cassandra.index.sai.disk.vector;
+
+import io.github.jbellis.jvector.graph.NodeQueue;
+import org.apache.cassandra.index.sai.utils.RowIdWithScore;
+import org.apache.cassandra.utils.AbstractIterator;
+
+/**
+ * An iterator over {@link RowIdWithScore} that lazily consumes a {@link NodeQueue}.
+ */
+public class NodeQueueRowIdIterator extends AbstractIterator<RowIdWithScore>
+{
+    private final NodeQueue scoreQueue;
+
+    public NodeQueueRowIdIterator(NodeQueue scoreQueue)
+    {
+        this.scoreQueue = scoreQueue;
+    }
+
+    @Override
+    protected RowIdWithScore computeNext()
+    {
+        if (scoreQueue.size() == 0)
+            return endOfData();
+        float score = scoreQueue.topScore();
+        int rowId = scoreQueue.pop();
+        return new RowIdWithScore(rowId, score);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairs.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairs.java
@@ -23,10 +23,10 @@ import java.util.function.IntConsumer;
 import org.agrona.collections.IntIntConsumer;
 
 /**
- * A simple array of int pairs that avoids boxing. Implemented as an alternative to the
- * {@link org.agrona.collections.Int2IntHashMap} for uses that do not require lookups.
+ * A specialized data structure that stores segment row id to ordinal pairs efficiently. Implemented as an array of int
+ * pairs that avoids boxing.
  */
-public class IntIntPairArray
+public class SegmentRowIdOrdinalPairs
 {
     private final int capacity;
     private int size;
@@ -36,7 +36,7 @@ public class IntIntPairArray
      * Create a new IntIntPairArray with the given capacity.
      * @param capacity
      */
-    public IntIntPairArray(int capacity)
+    public SegmentRowIdOrdinalPairs(int capacity)
     {
         assert capacity < Integer.MAX_VALUE / 2 : "capacity is too large " + capacity;
         this.capacity = capacity;
@@ -46,15 +46,15 @@ public class IntIntPairArray
 
     /**
      * Add a pair to the array.
-     * @param x the first value
-     * @param y the second value
+     * @param segmentRowId the first value
+     * @param ordinal the second value
      */
-    public void add(int x, int y)
+    public void add(int segmentRowId, int ordinal)
     {
         if (size == capacity)
             throw new IndexOutOfBoundsException(size);
-        array[size * 2] = x;
-        array[size * 2 + 1] = y;
+        array[size * 2] = segmentRowId;
+        array[size * 2 + 1] = ordinal;
         size++;
     }
 
@@ -71,7 +71,7 @@ public class IntIntPairArray
      * Iterate over the pairs in the array, calling the consumer for each pair.
      * @param consumer the consumer to call for each pair
      */
-    public void forEachIntPair(IntIntConsumer consumer)
+    public void forEachPair(IntIntConsumer consumer)
     {
         for (int i = 0; i < size; i++)
             consumer.accept(array[i * 2], array[i * 2 + 1]);
@@ -81,7 +81,7 @@ public class IntIntPairArray
      * Calls the consumer for each right value in each pair of the array.
      * @param consumer the consumer to call for each right value
      */
-    public void forEachRightInt(IntConsumer consumer)
+    public void forEachOrdinal(IntConsumer consumer)
     {
         for (int i = 0; i < size; i++)
             consumer.accept(array[i * 2 + 1]);

--- a/src/java/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairs.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairs.java
@@ -34,7 +34,7 @@ public class SegmentRowIdOrdinalPairs
 
     /**
      * Create a new IntIntPairArray with the given capacity.
-     * @param capacity
+     * @param capacity the capacity
      */
     public SegmentRowIdOrdinalPairs(int capacity)
     {
@@ -52,10 +52,34 @@ public class SegmentRowIdOrdinalPairs
     public void add(int segmentRowId, int ordinal)
     {
         if (size == capacity)
-            throw new IndexOutOfBoundsException(size);
+            throw new ArrayIndexOutOfBoundsException(size);
         array[size * 2] = segmentRowId;
         array[size * 2 + 1] = ordinal;
         size++;
+    }
+
+    /**
+     * Get the row id at the given index.
+     * @param index the index
+     * @return the row id
+     */
+    public int getSegmentRowId(int index)
+    {
+        if ( index < 0 || index >= size)
+            throw new ArrayIndexOutOfBoundsException(index);
+        return array[index * 2];
+    }
+
+    /**
+     * Get the ordinal at the given index.
+     * @param index the index
+     * @return the ordinal
+     */
+    public int getOrdinal(int index)
+    {
+        if ( index < 0 || index >= size)
+            throw new ArrayIndexOutOfBoundsException(index);
+        return array[index * 2 + 1];
     }
 
     /**
@@ -68,14 +92,25 @@ public class SegmentRowIdOrdinalPairs
     }
 
     /**
-     * Iterate over the pairs in the array, calling the consumer for each pair.
+     * Iterate over the pairs in the array, calling the consumer for each pair passing (index, x, y).
      * @param consumer the consumer to call for each pair
      */
-    public void forEachPair(IntIntConsumer consumer)
+    public void forEachSegmentRowIdOrdinalPair(IntIntConsumer consumer)
     {
         for (int i = 0; i < size; i++)
             consumer.accept(array[i * 2], array[i * 2 + 1]);
     }
+
+    /**
+     * Iterate over the pairs in the array, calling the consumer for each pair passing (index, x, y).
+     * @param consumer the consumer to call for each pair
+     */
+    public void forEachIndexOrdinalPair(IntIntConsumer consumer)
+    {
+        for (int i = 0; i < size; i++)
+            consumer.accept(i, array[i * 2 + 1]);
+    }
+
 
     /**
      * Calls the consumer for each right value in each pair of the array.

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -18,21 +18,21 @@
 
 package org.apache.cassandra.index.sai.disk.vector;
 
-import java.util.Comparator;
 import java.util.NoSuchElementException;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import io.github.jbellis.jvector.graph.GraphIndex;
+import io.github.jbellis.jvector.graph.NodeQueue;
 import io.github.jbellis.jvector.graph.NodesIterator;
 import io.github.jbellis.jvector.graph.similarity.ScoreFunction;
 import io.github.jbellis.jvector.util.Bits;
+import io.github.jbellis.jvector.util.BoundedLongHeap;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
-import org.apache.cassandra.utils.SortingIterator;
+import org.apache.cassandra.index.sai.utils.SegmentRowIdOrdinalPairs;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -46,14 +46,14 @@ public class BruteForceRowIdIteratorTest
     public void testBruteForceRowIdIteratorForEmptyPQAndTopKEqualsLimit()
     {
         var queryVector = vts.createFloatVector(new float[] { 1f, 0f });
-        var pq = SortingIterator.create(BruteForceRowIdIterator.RowWithApproximateScore::compare, ImmutableList.of());
+        var heap = new NodeQueue(new BoundedLongHeap(10), NodeQueue.Order.MAX_HEAP);
         var topK = 10;
         var limit = 10;
 
         // Should work for an empty pq
         var view = new TestView();
         CloseableReranker reranker = new CloseableReranker(VectorSimilarityFunction.COSINE, queryVector, view);
-        var iter = new BruteForceRowIdIterator(pq, reranker, limit, topK);
+        var iter = new BruteForceRowIdIterator(heap, new SegmentRowIdOrdinalPairs(10), reranker, limit, topK);
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
         assertFalse(view.isClosed);

--- a/test/unit/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairsTest.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/unit/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SegmentRowIdOrdinalPairsTest.java
@@ -24,12 +24,12 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class IntIntPairArrayTest
+public class SegmentRowIdOrdinalPairsTest
 {
     @Test
     public void testOperationsOnIntIntPairArray()
     {
-        IntIntPairArray array = new IntIntPairArray(2);
+        SegmentRowIdOrdinalPairs array = new SegmentRowIdOrdinalPairs(2);
         assertEquals(0, array.size());
         array.add(1, 2);
         array.add(3, 4);
@@ -37,11 +37,11 @@ public class IntIntPairArrayTest
 
         // Validate the iteration
         var accumulator = new AtomicInteger();
-        array.forEachRightInt(accumulator::addAndGet);
+        array.forEachOrdinal(accumulator::addAndGet);
         assertEquals(6, accumulator.get());
 
         accumulator.set(0);
-        array.forEachIntPair((x,y) -> {
+        array.forEachPair((x, y) -> {
             accumulator.addAndGet(x);
             accumulator.addAndGet(y);
         });
@@ -51,7 +51,7 @@ public class IntIntPairArrayTest
     @Test(expected = IndexOutOfBoundsException.class)
     public void testAddToFullArray()
     {
-        IntIntPairArray array = new IntIntPairArray(1);
+        SegmentRowIdOrdinalPairs array = new SegmentRowIdOrdinalPairs(1);
         array.add(1, 2);
         array.add(3, 4);
     }
@@ -59,6 +59,6 @@ public class IntIntPairArrayTest
     @Test(expected = AssertionError.class)
     public void testCapacityTooLarge()
     {
-        new IntIntPairArray(Integer.MAX_VALUE / 2 + 1);
+        new SegmentRowIdOrdinalPairs(Integer.MAX_VALUE / 2 + 1);
     }
 }


### PR DESCRIPTION
### What is the issue
Relates to https://github.com/riptano/cndb/issues/13417 (the issue has multiple PRs)

### What does this PR fix and why was it fixed

In hybrid ANN search resulting in brute force row sorting, we see many object allocations per row materialized (so O(n) space complexity), and this creates memory pressure leading to reduced performance. This PR reduces object allocation by using jvector's `NodeQueue` data structure that encodes an int and a float into a long and then sorts based on the float. I also renamed the IntIntPairArray because I needed more specialized methods.

- **Rename IntIntPairArray to SegmentRowIdOrdinalPairs**
- **CNDB-13417: Reduce object alloc. on brute force hybrid ann path**