### PR TITLE
HCD-79: Upgrade ASM to 9.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -159,7 +159,7 @@
     <!-- When updating ASM, please, do consider whether you might need to update also FBUtilities#ASM_BYTECODE_VERSION
        and the simulator InterceptClasses#BYTECODE_VERSION, in particular if we are looking to provide Cassandra support
        for newer JDKs (CASSANDRA-17873). -->
-    <property name="asm.version" value="7.1"/>
+    <property name="asm.version" value="9.4"/>
     <property name="allocation-instrumenter.version" value="3.1.0"/>
     <property name="bytebuddy.version" value="1.14.17"/>
     <property name="jflex.version" value="1.8.2"/>

--- a/build.xml
+++ b/build.xml
@@ -156,6 +156,9 @@
     <property name="jamm.version" value="0.3.2"/>
     <property name="ecj.version" value="3.33.0"/>
     <property name="ohc.version" value="0.5.1"/>
+    <!-- When updating ASM, please, do consider whether you might need to update also FBUtilities#ASM_BYTECODE_VERSION
+       and the simulator InterceptClasses#BYTECODE_VERSION, in particular if we are looking to provide Cassandra support
+       for newer JDKs (CASSANDRA-17873). -->
     <property name="asm.version" value="7.1"/>
     <property name="allocation-instrumenter.version" value="3.1.0"/>
     <property name="bytebuddy.version" value="1.14.17"/>

--- a/src/java/org/apache/cassandra/cql3/functions/UDFByteCodeVerifier.java
+++ b/src/java/org/apache/cassandra/cql3/functions/UDFByteCodeVerifier.java
@@ -35,6 +35,8 @@ import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import static org.apache.cassandra.utils.FBUtilities.ASM_BYTECODE_VERSION;
+
 /**
  * Verifies Java UDF byte code.
  * Checks for disallowed method calls (e.g. {@code Object.finalize()}),
@@ -84,7 +86,7 @@ public final class UDFByteCodeVerifier
     {
         String clsNameSl = clsName.replace('.', '/');
         Set<String> errors = new TreeSet<>(); // it's a TreeSet for unit tests
-        ClassVisitor classVisitor = new ClassVisitor(Opcodes.ASM7)
+        ClassVisitor classVisitor = new ClassVisitor(ASM_BYTECODE_VERSION)
         {
             public FieldVisitor visitField(int access, String name, String desc, String signature, Object value)
             {
@@ -160,7 +162,7 @@ public final class UDFByteCodeVerifier
 
         ExecuteImplVisitor(Set<String> errors)
         {
-            super(Opcodes.ASM7);
+            super(ASM_BYTECODE_VERSION);
             this.errors = errors;
         }
 
@@ -210,7 +212,7 @@ public final class UDFByteCodeVerifier
 
         ConstructorVisitor(Set<String> errors)
         {
-            super(Opcodes.ASM7);
+            super(ASM_BYTECODE_VERSION);
             this.errors = errors;
         }
 

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -137,7 +137,7 @@ public class FBUtilities
 
     public static final int MAX_UNSIGNED_SHORT = 0xFFFF;
 
-    public static final int ASM_BYTECODE_VERSION = Opcodes.ASM7;
+    public static final int ASM_BYTECODE_VERSION = Opcodes.ASM9;
 
     public static MessageDigest newMessageDigest(String algorithm)
     {

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -66,6 +66,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.StringUtils;
+import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,6 +136,8 @@ public class FBUtilities
     }
 
     public static final int MAX_UNSIGNED_SHORT = 0xFFFF;
+
+    public static final int ASM_BYTECODE_VERSION = Opcodes.ASM7;
 
     public static MessageDigest newMessageDigest(String algorithm)
     {


### PR DESCRIPTION
The mandate I was given was to align the version with what is currently used on main-5.0, but I will note that this is not strictly needed, ASM 7.1 can handle Java 11 bytecode.
