### PR TITLE
CNDB-13372 Introduce min Paxos backoff time

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -479,6 +479,7 @@ public enum CassandraRelevantProperties
     CUSTOM_KEYSPACES_FILTER_PROVIDER("cassandra.custom_keyspaces_filter_provider_class"),
 
     LWT_LOCKS_PER_THREAD("cassandra.lwt_locks_per_thread", "1024"),
+    LWT_MIN_BACKOFF_MS("cassandra.lwt_min_backoff_ms", "5"),
     LWT_MAX_BACKOFF_MS("cassandra.lwt_max_backoff_ms", "50"),
     COUNTER_LOCK_NUM_STRIPES_PER_THREAD("cassandra.counter_lock.num_stripes_per_thread", "1024"),
     COUNTER_LOCK_FAIR_LOCK("cassandra.counter_lock.fair_lock", "false"),

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
@@ -123,14 +122,13 @@ import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.sensors.ActiveRequestSensors;
 import org.apache.cassandra.sensors.Context;
-import org.apache.cassandra.sensors.NoOpRequestSensors;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.sensors.SensorsFactory;
 import org.apache.cassandra.sensors.Type;
 import org.apache.cassandra.service.paxos.Commit;
 import org.apache.cassandra.service.paxos.PaxosState;
+import org.apache.cassandra.service.paxos.PaxosUtils;
 import org.apache.cassandra.service.paxos.PrepareCallback;
 import org.apache.cassandra.service.paxos.ProposeCallback;
 import org.apache.cassandra.service.reads.AbstractReadExecutor;
@@ -360,6 +358,8 @@ public class StorageProxy implements StorageProxyMBean
         Boolean.parseBoolean(System.getProperty(DISABLE_SERIAL_READ_LINEARIZABILITY_KEY, "false"));
 
     private static volatile Integer maxPaxosBackoffMillis = CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.getInt();
+    private static volatile Integer minPaxosBackoffMillis = CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.getInt();
+
 
     private StorageProxy()
     {
@@ -715,9 +715,7 @@ public class StorageProxy implements StorageProxyMBean
 
                 Tracing.trace("Paxos proposal not accepted (pre-empted by a higher ballot)");
                 contentions++;
-                int sleepInMillis = ThreadLocalRandom.current().nextInt(maxPaxosBackoffMillis);
-                Uninterruptibles.sleepUninterruptibly(sleepInMillis, TimeUnit.MILLISECONDS);
-                casMetrics.contentionBackoffLatency.addNano(sleepInMillis * 1000);
+                PaxosUtils.applyPaxosContentionBackoff(casMetrics);
                 // continue to retry
             }
         }
@@ -785,9 +783,7 @@ public class StorageProxy implements StorageProxyMBean
                     Tracing.trace("Some replicas have already promised a higher ballot than ours; aborting");
                     contentions++;
                     // sleep a random amount to give the other proposer a chance to finish
-                    int sleepInMillis = ThreadLocalRandom.current().nextInt(maxPaxosBackoffMillis);
-                    Uninterruptibles.sleepUninterruptibly(sleepInMillis, MILLISECONDS);
-                    casMetrics.contentionBackoffLatency.addNano(sleepInMillis * 1000);
+                    PaxosUtils.applyPaxosContentionBackoff(casMetrics);
                     continue;
                 }
 
@@ -826,9 +822,7 @@ public class StorageProxy implements StorageProxyMBean
                         Tracing.trace("Some replicas have already promised a higher ballot than ours; aborting");
                         // sleep a random amount to give the other proposer a chance to finish
                         contentions++;
-                        int sleepInMillis = ThreadLocalRandom.current().nextInt(maxPaxosBackoffMillis);
-                        Uninterruptibles.sleepUninterruptibly(sleepInMillis, MILLISECONDS);
-                        casMetrics.contentionBackoffLatency.addNano(sleepInMillis * 1000);
+                        PaxosUtils.applyPaxosContentionBackoff(casMetrics);
                     }
                     continue;
                 }
@@ -3049,17 +3043,5 @@ public class StorageProxy implements StorageProxyMBean
     public void disableCheckForDuplicateRowsDuringCompaction()
     {
         DatabaseDescriptor.setCheckForDuplicateRowsDuringCompaction(false);
-    }
-
-    @Override
-    public int getMaxPaxosBackoffMillis()
-    {
-        return maxPaxosBackoffMillis;
-    }
-
-    @Override
-    public void setMaxPaxosBackoffMillis(int maxPaxosBackoffMillis)
-    {
-        StorageProxy.maxPaxosBackoffMillis = maxPaxosBackoffMillis;
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -365,6 +365,7 @@ public class StorageProxy implements StorageProxyMBean
     {
         MBeanWrapper.instance.registerMBean(instance, MBEAN_NAME);
         HintsService.instance.registerMBean();
+        PaxosUtils.instance.registerMBean();
 
         standardWritePerformer = (mutation, targets, responseHandler, localDataCenter) ->
         {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -357,10 +357,6 @@ public class StorageProxy implements StorageProxyMBean
     private static final boolean disableSerialReadLinearizability =
         Boolean.parseBoolean(System.getProperty(DISABLE_SERIAL_READ_LINEARIZABILITY_KEY, "false"));
 
-    private static volatile Integer maxPaxosBackoffMillis = CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.getInt();
-    private static volatile Integer minPaxosBackoffMillis = CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.getInt();
-
-
     private StorageProxy()
     {
     }

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -103,7 +103,4 @@ public interface StorageProxyMBean
     boolean getCheckForDuplicateRowsDuringCompaction();
     void enableCheckForDuplicateRowsDuringCompaction();
     void disableCheckForDuplicateRowsDuringCompaction();
-
-    int getMaxPaxosBackoffMillis();
-    void setMaxPaxosBackoffMillis(int maxPaxosBackoffMillis);
 }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosUtils.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosUtils.java
@@ -25,14 +25,23 @@ import com.google.common.util.concurrent.Uninterruptibles;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.metrics.CASClientRequestMetrics;
+import org.apache.cassandra.utils.MBeanWrapper;
 
-public final class PaxosUtils
+public final class PaxosUtils implements PaxosUtilsMBean
 {
-    private static final Integer minPaxosBackoffMillis = CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.getInt();
-    private static final Integer maxPaxosBackoffMillis = CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.getInt();
+    public static final PaxosUtils instance = new PaxosUtils();
+
+    private static final String MBEAN_NAME = "org.apache.cassandra.service:type=Paxos";
+    private static volatile Integer maxPaxosBackoffMillis = CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.getInt();
+    private static volatile Integer minPaxosBackoffMillis = CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.getInt();
 
     private PaxosUtils()
     {
+    }
+
+    public void registerMBean()
+    {
+        MBeanWrapper.instance.registerMBean(this, MBEAN_NAME);
     }
 
     /**
@@ -45,5 +54,29 @@ public final class PaxosUtils
         Uninterruptibles.sleepUninterruptibly(sleepInMillis, TimeUnit.MILLISECONDS);
         long sleepInNanos = TimeUnit.MILLISECONDS.toNanos(sleepInMillis);
         casMetrics.contentionBackoffLatency.addNano(sleepInNanos);
+    }
+
+    @Override
+    public int getMaxPaxosBackoffMillis()
+    {
+        return maxPaxosBackoffMillis;
+    }
+
+    @Override
+    public void setMaxPaxosBackoffMillis(int maxPaxosBackoffMillis)
+    {
+        PaxosUtils.maxPaxosBackoffMillis = maxPaxosBackoffMillis;
+    }
+
+    @Override
+    public int getMinPaxosBackoffMillis()
+    {
+        return minPaxosBackoffMillis;
+    }
+
+    @Override
+    public void setMinPaxosBackoffMillis(int minPaxosBackoffMillis)
+    {
+        PaxosUtils.minPaxosBackoffMillis = minPaxosBackoffMillis;
     }
 }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosUtils.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.paxos;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.metrics.CASClientRequestMetrics;
+
+public final class PaxosUtils
+{
+    private static final Integer minPaxosBackoffMillis = CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.getInt();
+    private static final Integer maxPaxosBackoffMillis = CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.getInt();
+
+    private PaxosUtils()
+    {
+    }
+
+    /**
+     * Applies a random sleep time between minPaxosBackoffMillis (inclusive) and maxPaxosBackoffMillis (exclusive)
+     * and emits the contentionBackoffLatency metric.
+     */
+    public static void applyPaxosContentionBackoff(CASClientRequestMetrics casMetrics)
+    {
+        int sleepInMillis = ThreadLocalRandom.current().nextInt(minPaxosBackoffMillis, maxPaxosBackoffMillis);
+        Uninterruptibles.sleepUninterruptibly(sleepInMillis, TimeUnit.MILLISECONDS);
+        long sleepInNanos = TimeUnit.MILLISECONDS.toNanos(sleepInMillis);
+        casMetrics.contentionBackoffLatency.addNano(sleepInNanos);
+    }
+}

--- a/src/java/org/apache/cassandra/service/paxos/PaxosUtilsMBean.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosUtilsMBean.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.paxos;
+
+public interface PaxosUtilsMBean
+{
+    int getMaxPaxosBackoffMillis();
+
+    void setMaxPaxosBackoffMillis(int maxPaxosBackoffMillis);
+
+    int getMinPaxosBackoffMillis();
+
+    void setMinPaxosBackoffMillis(int minPaxosBackoffMillis);
+}

--- a/test/unit/org/apache/cassandra/service/PaxosUtilsTest.java
+++ b/test/unit/org/apache/cassandra/service/PaxosUtilsTest.java
@@ -25,10 +25,8 @@ import com.carrotsearch.randomizedtesting.annotations.Timeout;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.metrics.CASClientRequestMetrics;
 import org.apache.cassandra.service.paxos.PaxosUtils;
-import org.apache.tools.ant.types.Assertions;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 

--- a/test/unit/org/apache/cassandra/service/PaxosUtilsTest.java
+++ b/test/unit/org/apache/cassandra/service/PaxosUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.carrotsearch.randomizedtesting.annotations.Timeout;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.metrics.CASClientRequestMetrics;
+import org.apache.cassandra.service.paxos.PaxosUtils;
+import org.apache.tools.ant.types.Assertions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class PaxosUtilsTest
+{
+    private static final int minPaxosBackoffMillis = 1;
+    private static final int maxPaxosBackoffMillis = 5;
+
+    private static final long minPaxosBackoffMicros = minPaxosBackoffMillis * 1000;
+    private static final long maxPaxosBackoffMicros = maxPaxosBackoffMillis * 1000;
+
+    @BeforeClass
+    public static void beforeClass() throws Throwable
+    {
+        CassandraRelevantProperties.LWT_MIN_BACKOFF_MS.setInt(minPaxosBackoffMillis);
+        CassandraRelevantProperties.LWT_MAX_BACKOFF_MS.setInt(maxPaxosBackoffMillis);
+    }
+
+    @Timeout(millis = 500)
+    @Test
+    public void testApplyPaxosContentionBackoff()
+    {
+        CASClientRequestMetrics casMetrics = new CASClientRequestMetrics("test", "");
+        long totalLatencyMicrosFromPreviousIteration = 0;
+        for (int i = 0; i < 100; i++)
+        {
+            PaxosUtils.applyPaxosContentionBackoff(casMetrics);
+            assertEquals(i + 1, casMetrics.contentionBackoffLatency.latency.getCount());
+
+            double lastRecordedLatencyMicros = casMetrics.contentionBackoffLatency.totalLatency.getCount() - totalLatencyMicrosFromPreviousIteration;
+            totalLatencyMicrosFromPreviousIteration = casMetrics.contentionBackoffLatency.totalLatency.getCount();
+            assertTrue(lastRecordedLatencyMicros >= minPaxosBackoffMicros);
+            assertTrue(lastRecordedLatencyMicros < maxPaxosBackoffMicros);
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue
Resolves: https://github.com/riptano/cndb/issues/13372

Currently min paxos backoff is to `0` which doesn't help there is already contention. 

### What does this PR fix and why was it fixed
Introduced a new property `cassandra.lwt_min_backoff_ms` which defautls to 5ms (10x smaller that the default 50ms to give enough range and be conservative relative to the previous 0 value, but still a magic number) and fix the `contentionBackoffLatency` that accepts nanos 
