### PR TITLE
CNDB-13480: NullPointerException when using ORDER BY BM25 after deleting a row

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
@@ -83,9 +83,10 @@ public class BM25Utils
                                              AbstractAnalyzer docAnalyzer,
                                              Collection<ByteBuffer> queryTerms)
         {
+            assert cell != null : "Cannot find a cell for pk " + pk;
+
             int count = 0;
             Map<ByteBuffer, Integer> frequencies = new HashMap<>();
-
             docAnalyzer.reset(cell.buffer());
             try
             {

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -65,6 +65,22 @@ public class BM25Test extends SAITester
     }
 
     @Test
+    public void testDeletedRow()
+    {
+        // create un-analyzed index
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        // create analyzed index
+        analyzeIndex();
+        execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
+        execute("INSERT INTO %s (k, v) VALUES (2, 'apple juice')");
+        var result = execute("SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");
+        assertThat(result).hasSize(2);
+        execute("DELETE FROM %s WHERE k=2");
+        result = execute("SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
     public void testTwoIndexesAmbiguousPredicate() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -57,27 +57,51 @@ public class BM25Test extends SAITester
         assertInvalidMessage("BM25 ordering on column v requires an analyzed index",
                              "SELECT k FROM %s WHERE v : 'apple' ORDER BY v BM25 OF 'apple' LIMIT 3");
 
-        // create analyzed index
-        analyzeIndex();
+        createAnalyzedIndex();
         // BM25 query should work now
         var result = execute("SELECT k FROM %s WHERE v : 'apple' ORDER BY v BM25 OF 'apple' LIMIT 3");
         assertRows(result, row(1));
     }
 
     @Test
-    public void testDeletedRow()
+    public void testDeletedRow() throws Throwable
     {
-        // create un-analyzed index
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
-        // create analyzed index
-        analyzeIndex();
+        createAnalyzedIndex();
         execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
         execute("INSERT INTO %s (k, v) VALUES (2, 'apple juice')");
         var result = execute("SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");
         assertThat(result).hasSize(2);
         execute("DELETE FROM %s WHERE k=2");
-        result = execute("SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");
-        assertThat(result).hasSize(1);
+        String select = "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3";
+        beforeAndAfterFlush(() -> assertRows(execute(select), row(1)));
+    }
+
+    @Test
+    public void testDeletedColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createAnalyzedIndex();
+        execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
+        execute("INSERT INTO %s (k, v) VALUES (2, 'apple juice')");
+        String select = "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3";
+        assertRows(execute(select), row(1), row(2));
+        execute("DELETE v FROM %s WHERE k = 2");
+        beforeAndAfterFlush(() -> assertRows(execute(select), row(1)));
+    }
+
+    @Test
+    public void testDeletedRowWithPredicate() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text, n int)");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createAnalyzedIndex();
+        execute("INSERT INTO %s (k, v, n) VALUES (1, 'apple', 0)");
+        execute("INSERT INTO %s (k, v, n) VALUES (2, 'apple juice', 0)");
+        String select = "SELECT k FROM %s WHERE n = 0 ORDER BY v BM25 OF 'apple' LIMIT 3";
+        assertRows(execute(select), row(1), row(2));
+        execute("DELETE FROM %s WHERE k=2");
+        beforeAndAfterFlush(() -> assertRows(execute(select), row(1)));
     }
 
     @Test
@@ -85,8 +109,8 @@ public class BM25Test extends SAITester
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
 
-        // Create analyzed and un-analyzed indexes
-        analyzeIndex();
+        createAnalyzedIndex();
+        // Create  un-analyzed indexes
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
 
         execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
@@ -384,10 +408,10 @@ public class BM25Test extends SAITester
     private void createSimpleTable()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
-        analyzeIndex();
+        createAnalyzedIndex();
     }
 
-    private String analyzeIndex()
+    private String createAnalyzedIndex()
     {
         return createIndex("CREATE CUSTOM INDEX ON %s(v) " +
                            "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
@@ -403,7 +427,7 @@ public class BM25Test extends SAITester
     public void testWithPredicate() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, p int, v text)");
-        analyzeIndex();
+        createAnalyzedIndex();
         execute("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
 
         // Insert documents with varying frequencies of the term "apple"
@@ -428,7 +452,7 @@ public class BM25Test extends SAITester
     public void testWidePartition() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, v text, PRIMARY KEY (k1, k2))");
-        analyzeIndex();
+        createAnalyzedIndex();
 
         // Insert documents with varying frequencies of the term "apple"
         execute("INSERT INTO %s (k1, k2, v) VALUES (0, 1, 'apple')");
@@ -450,7 +474,7 @@ public class BM25Test extends SAITester
     public void testWidePartitionWithPkPredicate() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, v text, PRIMARY KEY (k1, k2))");
-        analyzeIndex();
+        createAnalyzedIndex();
 
         // Insert documents with varying frequencies of the term "apple"
         execute("INSERT INTO %s (k1, k2, v) VALUES (0, 1, 'apple')");
@@ -474,7 +498,7 @@ public class BM25Test extends SAITester
     public void testWidePartitionWithPredicate() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, p int, v text, PRIMARY KEY (k1, k2))");
-        analyzeIndex();
+        createAnalyzedIndex();
         execute("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
 
         // Insert documents with varying frequencies of the term "apple"
@@ -535,7 +559,7 @@ public class BM25Test extends SAITester
     public void testBM25RaceConditionConcurrentQueriesInInvertedIndexSearcher() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, v text, PRIMARY KEY (pk))");
-        analyzeIndex();
+        createAnalyzedIndex();
 
         // Create 3 docs that have the same BM25 score and will be our top docs
         execute("INSERT INTO %s (pk, v) VALUES (1, 'apple apple apple')");
@@ -568,7 +592,7 @@ public class BM25Test extends SAITester
     public void testWildcardSelection()
     {
         createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
-        analyzeIndex();
+        createAnalyzedIndex();
         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 'apple')");
 
         var result = execute("SELECT * FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3");


### PR DESCRIPTION
### What is the issue
see CNDB-13480

When BM25 processes a delete row there is a NPE

```
2025-03-27 11:53:55 ERROR [ReadStage-2] 2025-03-26 22:53:55,397 AbstractLocalAwareExecutorService.java:169 - Uncaught exception on thread Thread[ReadStage-2,5,main]
2025-03-27 11:53:55 java.lang.NullPointerException: null
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.utils.BM25Utils$DocTF.createFromDocument(BM25Utils.java:89)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.memory.TrieMemtableIndex.lambda$orderBy$5(TrieMemtableIndex.java:269)
2025-03-27 11:53:55     at com.google.common.collect.Iterators$6.transform(Iterators.java:783)
2025-03-27 11:53:55     at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
2025-03-27 11:53:55     at org.apache.cassandra.utils.CloseableIterator$1.next(CloseableIterator.java:57)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.utils.BM25Utils.computeScores(BM25Utils.java:122)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.memory.TrieMemtableIndex.orderBy(TrieMemtableIndex.java:270)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:594)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.plan.QueryController.getTopKRows(QueryController.java:92)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.plan.Plan$ScoredIndexScan.execute(Plan.java:1360)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.plan.QueryController.buildIterator(QueryController.java:433)
2025-03-27 11:53:55     at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:114)
2025-03-27 11:53:55     at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:521)
2025-03-27 11:53:55     at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:418)
```

### What does this PR fix and why was it fixed
Exclude deleted rows while computing terms frequencies and preparing for computing the scores


Please note that there is another code path (orderResultsBy) that may lead to a missing cell, but I was not able to reproduce the problem in a test. IIUC that's the "pre-filtering" case.

I have pushed the fix there, because it seems that the code for non-BM25 handles the case of missing cell.