### PR TITLE
CNDB-13457: Fix problems with byte-comparable versions in SAI 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1723,6 +1723,7 @@
             <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
             <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
             <jvmarg value="-Dcassandra.sai.latest.version=aa"/>
+            <jvmarg value="-Dcassandra.trie_index_format_version=bb"/>
             <jvmarg value="-Dcassandra.skip_sync=true" />
             <jvmarg value="-Dlogback.configurationFile=file://${test.logback.configurationFile}"/>
         </testmacrohelper>

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -729,11 +729,11 @@ public class TrieMemtable extends AbstractAllocatorMemtable
 
         private DecoratedKey firstPartitionKey(Direction direction)
         {
-            Iterator<Map.Entry<ByteComparable, PartitionData>> iter = data.filteredEntryIterator(direction, PartitionData.class);
+            Iterator<Map.Entry<ByteComparable.Preencoded, PartitionData>> iter = data.filteredEntryIterator(direction, PartitionData.class);
             if (!iter.hasNext())
                 return null;
 
-            Map.Entry<ByteComparable, PartitionData> entry = iter.next();
+            Map.Entry<ByteComparable.Preencoded, PartitionData> entry = iter.next();
             return getPartitionKeyFromPath(metadata.get(), entry.getKey());
         }
 

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
@@ -404,7 +404,7 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
         return new MemtablePartition(metadata, ensureOnHeap, key, data);
     }
 
-    private static MemtablePartition getPartitionFromTrieEntry(TableMetadata metadata, EnsureOnHeap ensureOnHeap, Map.Entry<ByteComparable, BTreePartitionData> en)
+    private static MemtablePartition getPartitionFromTrieEntry(TableMetadata metadata, EnsureOnHeap ensureOnHeap, Map.Entry<? extends ByteComparable, BTreePartitionData> en)
     {
         DecoratedKey key = BufferDecoratedKey.fromByteComparable(en.getKey(),
                                                                  BYTE_COMPARABLE_VERSION,
@@ -423,11 +423,10 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
         long keySize = 0;
         int keyCount = 0;
 
-        for (Iterator<Map.Entry<ByteComparable, BTreePartitionData>> it = toFlush.entryIterator(); it.hasNext(); )
+        for (Iterator<Map.Entry<ByteComparable.Preencoded, BTreePartitionData>> it = toFlush.entryIterator(); it.hasNext(); )
         {
-            Map.Entry<ByteComparable, BTreePartitionData> en = it.next();
-            ByteComparable byteComparable = v -> en.getKey().asPeekableBytes(BYTE_COMPARABLE_VERSION);
-            byte[] keyBytes = DecoratedKey.keyFromByteComparable(byteComparable, BYTE_COMPARABLE_VERSION, metadata().partitioner);
+            Map.Entry<ByteComparable.Preencoded, BTreePartitionData> en = it.next();
+            byte[] keyBytes = DecoratedKey.keyFromByteComparable(en.getKey(), BYTE_COMPARABLE_VERSION, metadata().partitioner);
             keySize += keyBytes.length;
             keyCount++;
         }
@@ -629,11 +628,11 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
 
         private DecoratedKey firstPartitionKey(Direction direction)
         {
-            Iterator<Map.Entry<ByteComparable, BTreePartitionData>> iter = data.entryIterator(direction);
+            Iterator<Map.Entry<ByteComparable.Preencoded, BTreePartitionData>> iter = data.entryIterator(direction);
             if (!iter.hasNext())
                 return null;
 
-            Map.Entry<ByteComparable, BTreePartitionData> entry = iter.next();
+            Map.Entry<ByteComparable.Preencoded, BTreePartitionData> entry = iter.next();
             return getPartitionKeyFromPath(metadata.get(), entry.getKey());
         }
 
@@ -653,7 +652,7 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
         private final TableMetadata metadata;
         private final EnsureOnHeap ensureOnHeap;
         private final Trie<BTreePartitionData> source;
-        private final Iterator<Map.Entry<ByteComparable, BTreePartitionData>> iter;
+        private final Iterator<Map.Entry<ByteComparable.Preencoded, BTreePartitionData>> iter;
         private final ColumnFilter columnFilter;
         private final DataRange dataRange;
 

--- a/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
@@ -1132,6 +1132,11 @@ public class InMemoryReadTrie<T> extends Trie<T>
         return isNull(root);
     }
 
+    public ByteComparable.Version byteComparableVersion()
+    {
+        return byteComparableVersion;
+    }
+
     /**
      * Override of dump to provide more detailed printout that includes the type of each node in the trie.
      * We do this via a wrapping cursor that returns a content string for the type of node for every node we return.

--- a/src/java/org/apache/cassandra/db/tries/Trie.java
+++ b/src/java/org/apache/cassandra/db/tries/Trie.java
@@ -375,7 +375,7 @@ public abstract class Trie<T>
     /**
      * Call the given consumer on all (path, content) pairs with non-null content in the trie in order.
      */
-    public void forEachEntry(BiConsumer<ByteComparable, T> consumer)
+    public void forEachEntry(BiConsumer<ByteComparable.Preencoded, T> consumer)
     {
         forEachEntry(Direction.FORWARD, consumer);
     }
@@ -383,7 +383,7 @@ public abstract class Trie<T>
     /**
      * Call the given consumer on all (path, content) pairs with non-null content in the trie in order.
      */
-    public void forEachEntry(Direction direction, BiConsumer<ByteComparable, T> consumer)
+    public void forEachEntry(Direction direction, BiConsumer<ByteComparable.Preencoded, T> consumer)
     {
         Cursor<T> cursor = cursor(direction);
         process(new TrieEntriesWalker.WithConsumer<T>(consumer, cursor.byteComparableVersion()), cursor);
@@ -427,7 +427,7 @@ public abstract class Trie<T>
      * Call the given consumer on all (path, content) pairs with non-null content in the trie in order, skipping all
      * branches below the top content-bearing node.
      */
-    public void forEachEntrySkippingBranches(Direction direction, BiConsumer<ByteComparable, T> consumer)
+    public void forEachEntrySkippingBranches(Direction direction, BiConsumer<ByteComparable.Preencoded, T> consumer)
     {
         Cursor<T> cursor = cursor(direction);
         processSkippingBranches(new TrieEntriesWalker.WithConsumer<T>(consumer, cursor.byteComparableVersion()), cursor);
@@ -545,7 +545,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content as an iterable.
      */
-    public Iterable<Map.Entry<ByteComparable, T>> entrySet()
+    public Iterable<Map.Entry<ByteComparable.Preencoded, T>> entrySet()
     {
         return this::entryIterator;
     }
@@ -553,7 +553,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content as an iterable.
      */
-    public Iterable<Map.Entry<ByteComparable, T>> entrySet(Direction direction)
+    public Iterable<Map.Entry<ByteComparable.Preencoded, T>> entrySet(Direction direction)
     {
         return () -> entryIterator(direction);
     }
@@ -561,7 +561,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content in an iterator.
      */
-    public Iterator<Map.Entry<ByteComparable, T>> entryIterator()
+    public Iterator<Map.Entry<ByteComparable.Preencoded, T>> entryIterator()
     {
         return entryIterator(Direction.FORWARD);
     }
@@ -569,7 +569,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content in an iterator.
      */
-    public Iterator<Map.Entry<ByteComparable, T>> entryIterator(Direction direction)
+    public Iterator<Map.Entry<ByteComparable.Preencoded, T>> entryIterator(Direction direction)
     {
         return new TrieEntriesIterator.AsEntries<>(cursor(direction));
     }
@@ -577,7 +577,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content in an iterable, filtered by the given type.
      */
-    public <U extends T> Iterable<Map.Entry<ByteComparable, U>> filteredEntrySet(Class<U> clazz)
+    public <U extends T> Iterable<Map.Entry<ByteComparable.Preencoded, U>> filteredEntrySet(Class<U> clazz)
     {
         return filteredEntrySet(Direction.FORWARD, clazz);
     }
@@ -585,7 +585,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content in an iterable, filtered by the given type.
      */
-    public <U extends T> Iterable<Map.Entry<ByteComparable, U>> filteredEntrySet(Direction direction, Class<U> clazz)
+    public <U extends T> Iterable<Map.Entry<ByteComparable.Preencoded, U>> filteredEntrySet(Direction direction, Class<U> clazz)
     {
         return () -> filteredEntryIterator(direction, clazz);
     }
@@ -593,7 +593,7 @@ public abstract class Trie<T>
     /**
      * Returns the ordered entry set of this trie's content in an iterator, filtered by the given type.
      */
-    public <U extends T> Iterator<Map.Entry<ByteComparable, U>> filteredEntryIterator(Direction direction, Class<U> clazz)
+    public <U extends T> Iterator<Map.Entry<ByteComparable.Preencoded, U>> filteredEntryIterator(Direction direction, Class<U> clazz)
     {
         return new TrieEntriesIterator.AsEntriesFilteredByType<>(cursor(direction), clazz);
     }
@@ -801,7 +801,7 @@ public abstract class Trie<T>
      * Returns an entry set containing all tail tree constructed at the points that contain content of
      * the given type.
      */
-    public Iterable<Map.Entry<ByteComparable, Trie<T>>> tailTries(Direction direction, Class<? extends T> clazz)
+    public Iterable<Map.Entry<ByteComparable.Preencoded, Trie<T>>> tailTries(Direction direction, Class<? extends T> clazz)
     {
         return () -> new TrieTailsIterator.AsEntries<>(cursor(direction), clazz);
     }

--- a/src/java/org/apache/cassandra/db/tries/TrieEntriesIterator.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieEntriesIterator.java
@@ -86,7 +86,7 @@ public abstract class TrieEntriesIterator<T, V> extends TriePathReconstructor im
     /**
      * Iterator representing the content of the trie a sequence of (path, content) pairs.
      */
-    static class AsEntries<T> extends TrieEntriesIterator<T, Map.Entry<ByteComparable, T>>
+    static class AsEntries<T> extends TrieEntriesIterator<T, Map.Entry<ByteComparable.Preencoded, T>>
     {
         public AsEntries(Trie.Cursor<T> cursor)
         {
@@ -94,7 +94,7 @@ public abstract class TrieEntriesIterator<T, V> extends TriePathReconstructor im
         }
 
         @Override
-        protected Map.Entry<ByteComparable, T> mapContent(T content, byte[] bytes, int byteLength)
+        protected Map.Entry<ByteComparable.Preencoded, T> mapContent(T content, byte[] bytes, int byteLength)
         {
             return toEntry(byteComparableVersion(), content, bytes, byteLength);
         }
@@ -103,7 +103,7 @@ public abstract class TrieEntriesIterator<T, V> extends TriePathReconstructor im
     /**
      * Iterator representing the content of the trie a sequence of (path, content) pairs.
      */
-    static class AsEntriesFilteredByType<T, U extends T> extends TrieEntriesIterator<T, Map.Entry<ByteComparable, U>>
+    static class AsEntriesFilteredByType<T, U extends T> extends TrieEntriesIterator<T, Map.Entry<ByteComparable.Preencoded, U>>
     {
         public AsEntriesFilteredByType(Trie.Cursor<T> cursor, Class<U> clazz)
         {
@@ -112,13 +112,13 @@ public abstract class TrieEntriesIterator<T, V> extends TriePathReconstructor im
 
         @Override
         @SuppressWarnings("unchecked")  // checked by the predicate
-        protected Map.Entry<ByteComparable, U> mapContent(T content, byte[] bytes, int byteLength)
+        protected Map.Entry<ByteComparable.Preencoded, U> mapContent(T content, byte[] bytes, int byteLength)
         {
             return toEntry(byteComparableVersion(), (U) content, bytes, byteLength);
         }
     }
 
-    static <T> java.util.Map.Entry<ByteComparable, T> toEntry(ByteComparable.Version version, T content, byte[] bytes, int byteLength)
+    static <T> java.util.Map.Entry<ByteComparable.Preencoded, T> toEntry(ByteComparable.Version version, T content, byte[] bytes, int byteLength)
     {
         return new AbstractMap.SimpleImmutableEntry<>(toByteComparable(version, bytes, byteLength), content);
     }

--- a/src/java/org/apache/cassandra/db/tries/TrieEntriesWalker.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieEntriesWalker.java
@@ -40,10 +40,10 @@ public abstract class TrieEntriesWalker<T, V> extends TriePathReconstructor impl
      */
     static class WithConsumer<T> extends TrieEntriesWalker<T, Void>
     {
-        private final BiConsumer<ByteComparable, T> consumer;
+        private final BiConsumer<ByteComparable.Preencoded, T> consumer;
         private final ByteComparable.Version byteComparableVersion;
 
-        public WithConsumer(BiConsumer<ByteComparable, T> consumer, ByteComparable.Version byteComparableVersion)
+        public WithConsumer(BiConsumer<ByteComparable.Preencoded, T> consumer, ByteComparable.Version byteComparableVersion)
         {
             this.consumer = consumer;
             this.byteComparableVersion = byteComparableVersion;

--- a/src/java/org/apache/cassandra/db/tries/TriePathReconstructor.java
+++ b/src/java/org/apache/cassandra/db/tries/TriePathReconstructor.java
@@ -49,7 +49,7 @@ public class TriePathReconstructor implements Trie.ResettingTransitionsReceiver
         keyPos = newLength;
     }
 
-    static ByteComparable toByteComparable(ByteComparable.Version byteComparableVersion, byte[] bytes, int byteLength)
+    static ByteComparable.Preencoded toByteComparable(ByteComparable.Version byteComparableVersion, byte[] bytes, int byteLength)
     {
         // Taking a copy here to make sure it does not get modified when the cursor advances.
         return ByteComparable.preencoded(byteComparableVersion, Arrays.copyOf(bytes, byteLength));

--- a/src/java/org/apache/cassandra/db/tries/TrieTailsIterator.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieTailsIterator.java
@@ -101,7 +101,7 @@ public abstract class TrieTailsIterator<T, V> extends TriePathReconstructor impl
      * {@code tail} is the branch of the trie rooted at the selected content node (reachable by following
      * {@code path}). The tail trie will have the selected content at its root.
      */
-    static class AsEntries<T> extends TrieTailsIterator<T, Map.Entry<ByteComparable, Trie<T>>>
+    static class AsEntries<T> extends TrieTailsIterator<T, Map.Entry<ByteComparable.Preencoded, Trie<T>>>
     {
         public AsEntries(Trie.Cursor<T> cursor, Class<? extends T> clazz)
         {
@@ -109,9 +109,9 @@ public abstract class TrieTailsIterator<T, V> extends TriePathReconstructor impl
         }
 
         @Override
-        protected Map.Entry<ByteComparable, Trie<T>> mapContent(T value, Trie<T> tailTrie, byte[] bytes, int byteLength)
+        protected Map.Entry<ByteComparable.Preencoded, Trie<T>> mapContent(T value, Trie<T> tailTrie, byte[] bytes, int byteLength)
         {
-            ByteComparable key = toByteComparable(byteComparableVersion(), bytes, byteLength);
+            ByteComparable.Preencoded key = toByteComparable(byteComparableVersion(), bytes, byteLength);
             return new AbstractMap.SimpleImmutableEntry<>(key, tailTrie);
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/MemtableTermsIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/MemtableTermsIterator.java
@@ -34,16 +34,16 @@ public class MemtableTermsIterator implements TermsIterator
 {
     private final ByteBuffer minTerm;
     private final ByteBuffer maxTerm;
-    private final Iterator<Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>>> iterator;
+    private final Iterator<Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>>> iterator;
 
-    private Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> current;
+    private Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> current;
 
     private int maxSSTableRowId = -1;
     private int minSSTableRowId = Integer.MAX_VALUE;
 
     public MemtableTermsIterator(ByteBuffer minTerm,
                                  ByteBuffer maxTerm,
-                                 Iterator<Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>>> iterator)
+                                 Iterator<Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>>> iterator)
     {
         Preconditions.checkArgument(iterator != null);
         this.minTerm = minTerm;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -157,14 +157,14 @@ public class MemtableIndexWriter implements PerIndexWriter
                 var docLengths = new Int2IntHashMap(Integer.MIN_VALUE);
                 Arrays.stream(((TrieMemtableIndex) memtableIndex).getRangeIndexes())
                       .map(TrieMemoryIndex.class::cast)
-                      .forEach(trieMemoryIndex -> 
+                      .forEach(trieMemoryIndex ->
                           trieMemoryIndex.getDocLengths().forEach((pk, length) -> {
                               int rowId = rowMapping.get(pk);
                               if (rowId >= 0)
                                   docLengths.put(rowId, (int) length);
                           })
                       );
-                
+
                 indexMetas = writer.writeAll(metadataBuilder.intercept(terms), docLengths);
                 numRows = writer.getPostingsCount();
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -33,6 +33,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.MutableOneDimPointValues;
@@ -57,6 +58,7 @@ public class SegmentMetadataBuilder
     private final long segmentRowIdOffset;
 
     private final List<Closeable> interceptors = new ArrayList<>();
+    private final ByteComparable.Version byteComparableVersion;
 
     private boolean built = false;
 
@@ -79,10 +81,11 @@ public class SegmentMetadataBuilder
     {
         IndexContext context = Objects.requireNonNull(components.context());
         this.segmentRowIdOffset = segmentRowIdOffset;
+        this.byteComparableVersion = components.byteComparableVersionFor(IndexComponentType.TERMS_DATA);
 
         int histogramSize = context.getIntOption(HISTOGRAM_SIZE_OPTION, 128);
         int mostFrequentTermsCount = context.getIntOption(MFT_COUNT_OPTION, 128);
-        this.termsDistributionBuilder = new TermsDistribution.Builder(context.getValidator(), histogramSize, mostFrequentTermsCount);
+        this.termsDistributionBuilder = new TermsDistribution.Builder(context.getValidator(), byteComparableVersion, histogramSize, mostFrequentTermsCount);
     }
 
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
@@ -347,7 +350,7 @@ public class SegmentMetadataBuilder
                 if (!Arrays.equals(term, lastTerm))
                 {
                     if (lastTerm != null)
-                        builder.add(ByteComparable.preencoded(TypeUtil.BYTE_COMPARABLE_VERSION, lastTerm), count);
+                        builder.add(ByteComparable.preencoded(builder.byteComparableVersion, lastTerm), count);
 
 
                     count = 0;
@@ -363,7 +366,7 @@ public class SegmentMetadataBuilder
         {
             if (lastTerm != null)
             {
-                builder.add(ByteComparable.preencoded(TypeUtil.BYTE_COMPARABLE_VERSION, lastTerm), count);
+                builder.add(ByteComparable.preencoded(builder.byteComparableVersion, lastTerm), count);
             }
         }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValues.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
 import org.apache.cassandra.index.sai.disk.oldlucene.MutablePointValues;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.lucene.util.bkd.BKDWriter;
 
@@ -55,7 +56,7 @@ public class ImmutableOneDimPointValues extends MutableOneDimPointValues
     {
         while (termEnum.hasNext())
         {
-            ByteSourceInverse.readBytesMustFit(termEnum.next().asComparableBytes(TypeUtil.BYTE_COMPARABLE_VERSION),
+            ByteSourceInverse.readBytesMustFit(((ByteComparable.Preencoded) termEnum.next()).getPreencodedBytes(),
                                                scratch);
 
             try (final PostingList postings = termEnum.postings())

--- a/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
@@ -440,6 +440,7 @@ public class TermsDistribution
     public static class Builder
     {
         final AbstractType<?> termType;
+        final ByteComparable.Version byteComparableVersion;
         final int histogramSize;
         final int mostFrequentTermsTableSize;
 
@@ -453,10 +454,12 @@ public class TermsDistribution
         long cumulativeRowCount;
 
         public Builder(AbstractType<?> termType,
+                       ByteComparable.Version byteComparableVersion,
                        int histogramSize,
                        int mostFrequentTermsTableSize)
         {
             this.termType = termType;
+            this.byteComparableVersion = byteComparableVersion;
             this.histogramSize = histogramSize;
             this.mostFrequentTermsTableSize = mostFrequentTermsTableSize;
 
@@ -500,13 +503,12 @@ public class TermsDistribution
 
             shrink();
 
-            var bcVersion = TypeUtil.BYTE_COMPARABLE_VERSION;
-            var mft = new TreeMap<ByteComparable, Long>((b1, b2) -> ByteComparable.compare(b1, b2, bcVersion));
+            var mft = new TreeMap<ByteComparable, Long>((b1, b2) -> ByteComparable.compare(b1, b2, byteComparableVersion));
             for (Point point : mostFrequentTerms) {
                 mft.put(point.term, point.rowCount);
             }
 
-            return new TermsDistribution(termType, buckets, mft, Version.latest(), bcVersion);
+            return new TermsDistribution(termType, buckets, mft, Version.latest(), byteComparableVersion);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -432,7 +432,7 @@ public class VectorMemtableIndex implements MemtableIndex
     }
 
     @Override
-    public Iterator<Pair<ByteComparable, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max)
+    public Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max)
     {
         // This method is only used when merging an in-memory index with a RowMapping. This is done a different
         // way with the graph using the writeData method below.

--- a/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
@@ -87,7 +87,7 @@ public abstract class MemoryIndex
     /**
      * Iterate all Term->PrimaryKeys mappings in sorted order
      */
-    public abstract Iterator<Pair<ByteComparable, List<PkWithFrequency>>> iterator();
+    public abstract Iterator<Pair<ByteComparable.Preencoded, List<PkWithFrequency>>> iterator();
 
     public static class PkWithFrequency
     {

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -77,7 +77,7 @@ public interface MemtableIndex extends MemtableOrdering
 
     long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
-    Iterator<Pair<ByteComparable, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
+    Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 
     static MemtableIndex createIndex(IndexContext indexContext, Memtable mt)
     {

--- a/src/java/org/apache/cassandra/index/sai/memory/RowMapping.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/RowMapping.java
@@ -45,7 +45,7 @@ public class RowMapping
     public static final RowMapping DUMMY = new RowMapping()
     {
         @Override
-        public Iterator<Pair<ByteComparable, List<RowIdWithFrequency>>> merge(MemtableIndex index) { return Collections.emptyIterator(); }
+        public Iterator<Pair<ByteComparable.Preencoded, List<RowIdWithFrequency>>> merge(MemtableIndex index) { return Collections.emptyIterator(); }
 
         @Override
         public void complete() {}
@@ -99,7 +99,7 @@ public class RowMapping
             this.frequency = frequency;
         }
     }
-    
+
     /**
      * Merge IndexMemtable(index term to PrimaryKeys mappings) with row mapping of a sstable
      * (PrimaryKey to RowId mappings).
@@ -108,7 +108,7 @@ public class RowMapping
      *
      * @return iterator of index term to postings mapping exists in the sstable
      */
-    public Iterator<Pair<ByteComparable, List<RowIdWithFrequency>>> merge(MemtableIndex index)
+    public Iterator<Pair<ByteComparable.Preencoded, List<RowIdWithFrequency>>> merge(MemtableIndex index)
     {
         assert complete : "RowMapping is not built.";
 
@@ -116,7 +116,7 @@ public class RowMapping
         return new AbstractGuavaIterator<>()
         {
             @Override
-            protected Pair<ByteComparable, List<RowIdWithFrequency>> computeNext()
+            protected Pair<ByteComparable.Preencoded, List<RowIdWithFrequency>> computeNext()
             {
                 while (it.hasNext())
                 {

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -273,9 +273,9 @@ public class TrieMemoryIndex extends MemoryIndex
     }
 
     @Override
-    public Iterator<Pair<ByteComparable, List<PkWithFrequency>>> iterator()
+    public Iterator<Pair<ByteComparable.Preencoded, List<PkWithFrequency>>> iterator()
     {
-        Iterator<Map.Entry<ByteComparable, PrimaryKeys>> iterator = data.entrySet().iterator();
+        Iterator<Map.Entry<ByteComparable.Preencoded, PrimaryKeys>> iterator = data.entrySet().iterator();
         return new Iterator<>()
         {
             @Override
@@ -285,9 +285,9 @@ public class TrieMemoryIndex extends MemoryIndex
             }
 
             @Override
-            public Pair<ByteComparable, List<PkWithFrequency>> next()
+            public Pair<ByteComparable.Preencoded, List<PkWithFrequency>> next()
             {
-                Map.Entry<ByteComparable, PrimaryKeys> entry = iterator.next();
+                Map.Entry<ByteComparable.Preencoded, PrimaryKeys> entry = iterator.next();
                 var pairs = new ArrayList<PkWithFrequency>(entry.getValue().size());
                 Iterators.addAll(pairs, entry.getValue().iterator());
                 return Pair.create(entry.getKey(), pairs);
@@ -356,7 +356,8 @@ public class TrieMemoryIndex extends MemoryIndex
                 // Before version DB, we encoded composite types using a non order-preserving function. In order to
                 // perform a range query on a map, we use the bounds to get all entries for a given map key and then
                 // only keep the map entries that satisfy the expression.
-                byte[] key = ByteSourceInverse.readBytes(entry.getKey().asComparableBytes(TypeUtil.BYTE_COMPARABLE_VERSION));
+                assert entry.getKey().encodingVersion() == TypeUtil.BYTE_COMPARABLE_VERSION || Version.latest() == Version.AA;
+                byte[] key = ByteSourceInverse.readBytes(entry.getKey().getPreencodedBytes());
                 if (expression.isSatisfiedBy(ByteBuffer.wrap(key)))
                     mergingIteratorBuilder.add(entry.getValue());
             });
@@ -863,11 +864,11 @@ public class TrieMemoryIndex extends MemoryIndex
      */
     private class AllTermsIterator extends AbstractIterator<PrimaryKeyWithSortKey>
     {
-        private final Iterator<Map.Entry<ByteComparable, PrimaryKeys>> iterator;
+        private final Iterator<Map.Entry<ByteComparable.Preencoded, PrimaryKeys>> iterator;
         private Iterator<PrimaryKey> primaryKeysIterator = CloseableIterator.emptyIterator();
-        private ByteComparable byteComparableTerm = null;
+        private ByteComparable.Preencoded byteComparableTerm = null;
 
-        public AllTermsIterator(Iterator<Map.Entry<ByteComparable, PrimaryKeys>> iterator)
+        public AllTermsIterator(Iterator<Map.Entry<ByteComparable.Preencoded, PrimaryKeys>> iterator)
         {
             this.iterator = iterator;
         }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -119,7 +119,7 @@ public class TrieMemoryIndex extends MemoryIndex
         this.primaryKeysAccumulator = new PrimaryKeysAccumulator(primaryKeysHeapAllocations);
         this.primaryKeysRemover = new PrimaryKeysRemover(primaryKeysHeapAllocations);
         this.analyzerTransformsValue = indexContext.getAnalyzerFactory().create().transformValue();
-        this.data = InMemoryTrie.longLived(TypeUtil.BYTE_COMPARABLE_VERSION, TrieMemtable.BUFFER_TYPE, indexContext.columnFamilyStore().readOrdering());
+        this.data = InMemoryTrie.longLived(TypeUtil.byteComparableVersionForTermsData(), TrieMemtable.BUFFER_TYPE, indexContext.columnFamilyStore().readOrdering());
         this.memtable = memtable;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
@@ -45,8 +45,10 @@ import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ComplexColumnData;
 import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -660,5 +662,10 @@ public class TypeUtil
     {
         var peekableValue = ByteSource.peekable(ByteSource.preencoded(value));
         return DecimalType.instance.fromComparableBytes(peekableValue, BYTE_COMPARABLE_VERSION);
+    }
+
+    public static ByteComparable.Version byteComparableVersionForTermsData()
+    {
+        return Version.latest().byteComparableVersionFor(IndexComponentType.TERMS_DATA, SSTableFormat.Type.current().info.getLatestVersion());
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
@@ -125,24 +125,6 @@ public class TypeUtil
     }
 
     /**
-     * Returns the lesser of two {@code ByteComparable} values, based on the result of {@link
-     * ByteComparable#compare(ByteComparable, ByteComparable, ByteComparable.Version)} comparision.
-     */
-    public static ByteComparable min(ByteComparable a, ByteComparable b)
-    {
-        return a == null ?  b : (b == null || ByteComparable.compare(b, a, BYTE_COMPARABLE_VERSION) > 0) ? a : b;
-    }
-
-    /**
-     * Returns the greater of two {@code ByteComparable} values, based on the result of {@link
-     * ByteComparable#compare(ByteComparable, ByteComparable, ByteComparable.Version)} comparision.
-     */
-    public static ByteComparable max(ByteComparable a, ByteComparable b)
-    {
-        return a == null ?  b : (b == null || ByteComparable.compare(b, a, BYTE_COMPARABLE_VERSION) < 0) ? a : b;
-    }
-
-    /**
      * Returns the value length for the given {@link AbstractType}, selecting 16 for types
      * that officially use VARIABLE_LENGTH but are, in fact, of a fixed length.
      */

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
@@ -98,48 +98,51 @@ public interface ByteComparable
         return v -> ByteSource.of(value);
     }
 
-    private static void checkVersion(Version expected, Version actual)
+    interface Preencoded extends ByteComparable
     {
-        Preconditions.checkState(actual == expected,
-                                 "Preprocessed byte-source at version %s queried at version %s",
-                                 actual,
-                                 expected);
+        Version encodingVersion();
+
+        @Override
+        ByteSource.Duplicatable asComparableBytes(Version version);
+
+        @Override
+        default ByteSource.Peekable asPeekableBytes(Version version)
+        {
+            return asComparableBytes(version);
+        }
+
+        @Override
+        default byte[] asByteComparableArray(Version version)
+        {
+            return asComparableBytes(version).remainingBytesToArray();
+        }
     }
 
     /**
      * A ByteComparable value that is already encoded for a specific version. Requesting the source with a different
      * version will result in an exception.
      */
-    static ByteComparable preencoded(Version version, ByteBuffer bytes)
+    static Preencoded preencoded(Version version, ByteBuffer bytes)
     {
-        return v -> {
-            checkVersion(version, v);
-            return ByteSource.preencoded(bytes);
-        };
+        return new PreencodedByteComparable.Buffer(version, bytes);
     }
 
     /**
      * A ByteComparable value that is already encoded for a specific version. Requesting the source with a different
      * version will result in an exception.
      */
-    static ByteComparable preencoded(Version version, byte[] bytes)
+    static Preencoded preencoded(Version version, byte[] bytes)
     {
-        return v -> {
-            checkVersion(version, v);
-            return ByteSource.preencoded(bytes);
-        };
+        return new PreencodedByteComparable.Array(version, bytes);
     }
 
     /**
      * A ByteComparable value that is already encoded for a specific version. Requesting the source with a different
      * version will result in an exception.
      */
-    static ByteComparable preencoded(Version version, byte[] bytes, int offset, int len)
+    static Preencoded preencoded(Version version, byte[] bytes, int offset, int len)
     {
-        return v -> {
-            checkVersion(version, v);
-            return ByteSource.preencoded(bytes, offset, len);
-        };
+        return new PreencodedByteComparable.Array(version, bytes, offset, len);
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.java
@@ -109,7 +109,7 @@ public interface ByteComparable
         default ByteSource.Duplicatable asComparableBytes(Version version)
         {
             Preconditions.checkState(version == encodingVersion(),
-                                     "Preprocessed byte-source at version %s queried at version %s",
+                                     "Preencoded byte-source at version %s queried at version %s",
                                      encodingVersion(),
                                      version);
             return getPreencodedBytes();
@@ -126,15 +126,6 @@ public interface ByteComparable
         {
             return asComparableBytes(version).remainingBytesToArray();
         }
-    }
-
-    static int compare(Preencoded a, Preencoded b)
-    {
-        Preconditions.checkArgument(a.encodingVersion() == b.encodingVersion(),
-                                    "Cannot compare preencoded byte-comparables of different versions %s vs %s",
-                                    a.encodingVersion(),
-                                    b.encodingVersion());
-        return ByteSource.compare(a.getPreencodedBytes(), b.getPreencodedBytes());
     }
 
     /**
@@ -211,6 +202,21 @@ public interface ByteComparable
     static int compare(ByteComparable bytes1, ByteComparable bytes2, Version version)
     {
         return ByteSource.compare(bytes1.asComparableBytes(version), bytes2.asComparableBytes(version));
+    }
+
+    /**
+     * Compare two preencoded byte-comparable values, using their encoding versions.
+     *
+     * @return the result of the lexicographic unsigned byte comparison of the byte-comparable representations of the
+     *         two arguments
+     */
+    static int compare(Preencoded a, Preencoded b)
+    {
+        Preconditions.checkArgument(a.encodingVersion() == b.encodingVersion(),
+                                    "Cannot compare preencoded byte-comparables of different versions %s vs %s",
+                                    a.encodingVersion(),
+                                    b.encodingVersion());
+        return ByteSource.compare(a.getPreencodedBytes(), b.getPreencodedBytes());
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/bytecomparable/ByteSource.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/ByteSource.java
@@ -1020,4 +1020,21 @@ public interface ByteSource
 
         return preencoded(ByteSourceInverse.readBytes(src));
     }
+
+    static int compare(ByteSource s1, ByteSource s2)
+    {
+        if (s1 == null || s2 == null)
+            return Boolean.compare(s1 != null, s2 != null);
+
+        while (true)
+        {
+            int b1 = s1.next();
+            int b2 = s2.next();
+            int cmp = Integer.compare(b1, b2);
+            if (cmp != 0)
+                return cmp;
+            if (b1 == END_OF_STREAM)
+                return 0;
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.bytecomparable;
+
+import com.google.common.base.Preconditions;
+
+import java.nio.ByteBuffer;
+
+abstract class PreencodedByteComparable implements ByteComparable.Preencoded
+{
+    private final Version version;
+
+    PreencodedByteComparable(Version version)
+    {
+        this.version = version;
+    }
+
+    public ByteSource.Duplicatable asComparableBytes(Version version)
+    {
+        checkVersion(version);
+        return getBytes();
+    }
+
+    abstract ByteSource.Duplicatable getBytes();
+
+    @Override
+    public Version encodingVersion()
+    {
+        return version;
+    }
+
+    private void checkVersion(Version actual)
+    {
+        Preconditions.checkState(actual == version,
+                                 "Preprocessed byte-source at version %s queried at version %s",
+                                 version,
+                                 actual);
+    }
+
+    static class Array extends PreencodedByteComparable
+    {
+        private final byte[] bytes;
+        private final int offset;
+        private final int length;
+
+        Array(Version version, byte[] bytes)
+        {
+            this(version, bytes, 0, bytes.length);
+        }
+
+        Array(Version version, byte[] bytes, int offset, int length)
+        {
+            super(version);
+            this.bytes = bytes;
+            this.offset = offset;
+            this.length = length;
+        }
+
+        @Override
+        ByteSource.Duplicatable getBytes()
+        {
+            return ByteSource.preencoded(bytes, offset, length);
+        }
+    }
+
+    static class Buffer extends PreencodedByteComparable
+    {
+        private final ByteBuffer bytes;
+
+        Buffer(Version version, ByteBuffer bytes)
+        {
+            super(version);
+            this.bytes = bytes;
+        }
+
+        @Override
+        ByteSource.Duplicatable getBytes()
+        {
+            return ByteSource.preencoded(bytes);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
@@ -25,10 +25,12 @@ import java.nio.ByteBuffer;
 abstract class PreencodedByteComparable implements ByteComparable.Preencoded
 {
     private final Version version;
+    private final Exception stackTrace;
 
     PreencodedByteComparable(Version version)
     {
         this.version = version;
+        this.stackTrace = new Exception();
     }
 
     public ByteSource.Duplicatable asComparableBytes(Version version)

--- a/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
+++ b/src/java/org/apache/cassandra/utils/bytecomparable/PreencodedByteComparable.java
@@ -24,27 +24,11 @@ import java.nio.ByteBuffer;
 
 abstract class PreencodedByteComparable implements ByteComparable.Preencoded
 {
-    static final boolean DEBUG = true;
-
     private final Version version;
-    private final Exception stackTrace;
 
     PreencodedByteComparable(Version version)
     {
         this.version = version;
-        this.stackTrace = DEBUG ? new Exception("Constructed at") : null;
-    }
-
-    @Override
-    public ByteSource.Duplicatable asComparableBytes(Version version)
-    {
-        if (version == this.version)
-            return getPreencodedBytes();
-
-        IllegalArgumentException e = new IllegalArgumentException("Preencoded byte-comparable at version " + this.version + " queried at version " + version);
-        if (DEBUG)
-            e.addSuppressed(stackTrace);
-        throw e;
     }
 
     @Override

--- a/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieReadBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieReadBench.java
@@ -117,12 +117,12 @@ public class InMemoryTrieReadBench
     @Benchmark
     public int consumeEntries()
     {
-        class Counter implements BiConsumer<ByteComparable, Byte>
+        class Counter implements BiConsumer<ByteComparable.Preencoded, Byte>
         {
             int sum = 0;
 
             @Override
-            public void accept(ByteComparable byteComparable, Byte aByte)
+            public void accept(ByteComparable.Preencoded byteComparable, Byte aByte)
             {
                 sum += aByte;
             }
@@ -169,7 +169,7 @@ public class InMemoryTrieReadBench
     public int iterateEntries()
     {
         int sum = 0;
-        for (Map.Entry<ByteComparable, Byte> en : trie.entrySet(direction))
+        for (Map.Entry<ByteComparable.Preencoded, Byte> en : trie.entrySet(direction))
             sum += en.getValue();
         return sum;
     }

--- a/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieUnionBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/tries/InMemoryTrieUnionBench.java
@@ -128,7 +128,7 @@ public class InMemoryTrieUnionBench
     public int iterateEntries()
     {
         int sum = 0;
-        for (Map.Entry<ByteComparable, Byte> en : trie.entrySet())
+        for (Map.Entry<ByteComparable. Preencoded, Byte> en : trie.entrySet())
             sum += en.getValue();
         return sum;
     }

--- a/test/unit/org/apache/cassandra/db/tries/InMemoryTrieTestBase.java
+++ b/test/unit/org/apache/cassandra/db/tries/InMemoryTrieTestBase.java
@@ -655,15 +655,15 @@ public abstract class InMemoryTrieTestBase
         return list;
     }
 
-    static void assertMapEquals(Iterator<Map.Entry<ByteComparable, ByteBuffer>> it1,
-                                Iterator<Map.Entry<ByteComparable, ByteBuffer>> it2)
+    static <B extends ByteComparable, C extends ByteComparable>
+    void assertMapEquals(Iterator<Map.Entry<B, ByteBuffer>> it1, Iterator<Map.Entry<C, ByteBuffer>> it2)
     {
         List<ByteComparable> failedAt = new ArrayList<>();
         StringBuilder b = new StringBuilder();
         while (it1.hasNext() && it2.hasNext())
         {
-            Map.Entry<ByteComparable, ByteBuffer> en1 = it1.next();
-            Map.Entry<ByteComparable, ByteBuffer> en2 = it2.next();
+            Map.Entry<? extends ByteComparable, ByteBuffer> en1 = it1.next();
+            Map.Entry<? extends ByteComparable, ByteBuffer> en2 = it2.next();
             b.append(String.format("TreeSet %s:%s\n", asString(en2.getKey()), ByteBufferUtil.bytesToHex(en2.getValue())));
             b.append(String.format("Trie    %s:%s\n", asString(en1.getKey()), ByteBufferUtil.bytesToHex(en1.getValue())));
             if (ByteComparable.compare(en1.getKey(), en2.getKey(), byteComparableVersion) != 0 || ByteBufferUtil.compareUnsigned(en1.getValue(), en2.getValue()) != 0)
@@ -671,13 +671,13 @@ public abstract class InMemoryTrieTestBase
         }
         while (it1.hasNext())
         {
-            Map.Entry<ByteComparable, ByteBuffer> en1 = it1.next();
+            Map.Entry<? extends ByteComparable, ByteBuffer> en1 = it1.next();
             b.append(String.format("Trie    %s:%s\n", asString(en1.getKey()), ByteBufferUtil.bytesToHex(en1.getValue())));
             failedAt.add(en1.getKey());
         }
         while (it2.hasNext())
         {
-            Map.Entry<ByteComparable, ByteBuffer> en2 = it2.next();
+            Map.Entry<? extends ByteComparable, ByteBuffer> en2 = it2.next();
             b.append(String.format("TreeSet %s:%s\n", asString(en2.getKey()), ByteBufferUtil.bytesToHex(en2.getValue())));
             failedAt.add(en2.getKey());
         }

--- a/test/unit/org/apache/cassandra/db/tries/InMemoryTrieThreadedTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/InMemoryTrieThreadedTest.java
@@ -102,7 +102,7 @@ public class InMemoryTrieThreadedTest
                         int count = 0;
                         try (OpOrder.Group group = readOrder.start())
                         {
-                            for (Map.Entry<ByteComparable, String> en : trie.entrySet())
+                            for (Map.Entry<? extends ByteComparable, String> en : trie.entrySet())
                             {
                                 String v = value(en.getKey());
                                 Assert.assertEquals(en.getKey().byteComparableAsString(byteComparableVersion), v, en.getValue());
@@ -385,7 +385,7 @@ public class InMemoryTrieThreadedTest
                             int min = writeProgress.get();
                             try (OpOrder.Group group = readOrder.start())
                             {
-                                Iterable<Map.Entry<ByteComparable, Content>> entries = trie.entrySet();
+                                Iterable<Map.Entry<ByteComparable.Preencoded, Content>> entries = trie.entrySet();
                                 checkEntries("", min, true, checkAtomicity, false, PER_MUTATION, entries);
                             }
                         }
@@ -415,7 +415,7 @@ public class InMemoryTrieThreadedTest
                         {
                             ByteComparable key = srcLocal[r.nextInt(srcLocal.length)];
                             int min = writeProgress.get() / (pkeys.length * PER_MUTATION) * PER_MUTATION;
-                            Iterable<Map.Entry<ByteComparable, Content>> entries;
+                            Iterable<Map.Entry<ByteComparable.Preencoded, Content>> entries;
 
                             try (OpOrder.Group group = readOrder.start())
                             {
@@ -558,7 +558,7 @@ public class InMemoryTrieThreadedTest
                              boolean checkAtomicity,
                              boolean checkConsecutiveIds,
                              int PER_MUTATION,
-                             Iterable<Map.Entry<ByteComparable, Content>> entries)
+                             Iterable<Map.Entry<ByteComparable.Preencoded, Content>> entries)
     {
         long sum = 0;
         int count = 0;

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexBuilder.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -31,6 +30,7 @@ import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.memory.RowMapping;
+import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
@@ -64,7 +64,7 @@ public class InvertedIndexBuilder
 
             // This logic feels a bit fragile, but it mimics the way we call unescape in the TrieMemoryIndex
             // before writing to the on disk format.
-            var encoded = version.onDiskFormat().encodeForTrie(term, UTF8Type.instance);
+            var encoded = version.onDiskFormat().encodeForTrie(term, UTF8Type.instance).preencode(TypeUtil.BYTE_COMPARABLE_VERSION);
             termsEnum.add(new TermsEnum(term, encoded, postingsList));
         }
         return termsEnum;
@@ -77,10 +77,10 @@ public class InvertedIndexBuilder
     {
         // Store the original term to ensure that searching by it is successful
         final ByteBuffer originalTermBytes;
-        final ByteComparable byteComparableBytes;
+        final ByteComparable.Preencoded byteComparableBytes;
         final IntArrayList postings;
 
-        TermsEnum(ByteBuffer originalTermBytes, ByteComparable byteComparableBytes, IntArrayList postings)
+        TermsEnum(ByteBuffer originalTermBytes, ByteComparable.Preencoded byteComparableBytes, IntArrayList postings)
         {
             this.originalTermBytes = originalTermBytes;
             this.byteComparableBytes = byteComparableBytes;
@@ -91,7 +91,7 @@ public class InvertedIndexBuilder
     /**
      * Adds default frequency of 1 to postings
      */
-    static Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> toTermWithFrequency(TermsEnum te)
+    static Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> toTermWithFrequency(TermsEnum te)
     {
         return Pair.create(te.byteComparableBytes, Arrays.stream(te.postings.toArray()).boxed()
                                                          .map(p -> new RowMapping.RowIdWithFrequency(p, 1))

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/TermsReaderTest.java
@@ -175,7 +175,7 @@ public class TermsReaderTest extends SaiRandomizedTest
             var iter = termsEnum.stream()
                     .map(InvertedIndexBuilder::toTermWithFrequency)
                     .collect(Collectors.toList());
-            for (Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> pair : iter)
+            for (Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> pair : iter)
             {
                 final byte[] bytes = ByteSourceInverse.readBytes(pair.left.asComparableBytes(VERSION));
                 try (PostingList actualPostingList = reader.exactMatch(ByteComparable.preencoded(VERSION, bytes),

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/ImmutableOneDimPointValuesTest.java
@@ -113,12 +113,12 @@ public class ImmutableOneDimPointValuesTest
         final ByteBuffer minTerm = Int32Type.instance.decompose(from);
         final ByteBuffer maxTerm = Int32Type.instance.decompose(to);
 
-        final AbstractGuavaIterator<Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>>> iterator = new AbstractGuavaIterator<>()
+        final AbstractGuavaIterator<Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>>> iterator = new AbstractGuavaIterator<>()
         {
             private int currentTerm = from;
 
             @Override
-            protected Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> computeNext()
+            protected Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> computeNext()
             {
                 if (currentTerm <= to)
                 {
@@ -129,7 +129,7 @@ public class ImmutableOneDimPointValuesTest
                     new RowMapping.RowIdWithFrequency(0, 1),
                     new RowMapping.RowIdWithFrequency(1, 1),
                     new RowMapping.RowIdWithFrequency(2, 1));
-                return Pair.create(v -> ByteSource.preencoded(term), postings);
+                return Pair.create(ByteComparable.preencoded(TypeUtil.BYTE_COMPARABLE_VERSION, term), postings);
             }
         };
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -66,6 +66,7 @@ import org.apache.cassandra.utils.AbstractGuavaIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -123,14 +124,14 @@ public class KDTreeIndexBuilder
 
     private final IndexDescriptor indexDescriptor;
     private final AbstractType<?> type;
-    private final AbstractGuavaIterator<Pair<ByteComparable, IntArrayList>> terms;
+    private final AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>> terms;
     private final int size;
     private final int minSegmentRowId;
     private final int maxSegmentRowId;
 
     public KDTreeIndexBuilder(IndexDescriptor indexDescriptor,
                               AbstractType<?> type,
-                              AbstractGuavaIterator<Pair<ByteComparable, IntArrayList>> terms,
+                              AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>> terms,
                               int size,
                               int minSegmentRowId,
                               int maxSegmentRowId)
@@ -290,15 +291,15 @@ public class KDTreeIndexBuilder
      * Returns inverted index where each posting list contains exactly one element equal to the terms ordinal number +
      * given offset.
      */
-    public static AbstractGuavaIterator<Pair<ByteComparable, IntArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
+    public static AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
     {
-        return new AbstractGuavaIterator<Pair<ByteComparable, IntArrayList>>()
+        return new AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>>()
         {
             private long currentTerm = 0;
             private int currentSegmentRowId = segmentRowIdOffset;
 
             @Override
-            protected Pair<ByteComparable, IntArrayList> computeNext()
+            protected Pair<ByteComparable.Preencoded, IntArrayList> computeNext()
             {
                 if (currentTerm++ >= size)
                 {
@@ -310,7 +311,7 @@ public class KDTreeIndexBuilder
                 assertTrue(terms.hasNext());
 
                 final ByteSource encoded = TypeUtil.asComparableBytes(terms.next(), type, TypeUtil.BYTE_COMPARABLE_VERSION);
-                return Pair.create(v -> encoded, postings);
+                return Pair.create(ByteComparable.preencoded(TypeUtil.BYTE_COMPARABLE_VERSION, ByteSourceInverse.readBytes(encoded)), postings);
             }
         };
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -150,12 +150,12 @@ public class KDTreeIndexBuilder
         final TermsIterator termEnum = new MemtableTermsIterator(null, null, new AbstractGuavaIterator<>()
         {
             @Override
-            protected Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> computeNext()
+            protected Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> computeNext()
             {
                 if (!terms.hasNext())
                     return endOfData();
 
-                Pair<ByteComparable, IntArrayList> pair = terms.next();
+                Pair<ByteComparable.Preencoded, IntArrayList> pair = terms.next();
                 List<RowMapping.RowIdWithFrequency> postings = new ArrayList<>(pair.right.size());
                 for (int i = 0; i < pair.right.size(); i++)
                     postings.add(new RowMapping.RowIdWithFrequency(pair.right.get(i), 1));

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.utils.AbstractGuavaIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
+import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Counter;
@@ -193,13 +194,13 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
         final ByteBuffer minTerm = Int32Type.instance.decompose(startTermInclusive);
         final ByteBuffer maxTerm = Int32Type.instance.decompose(endTermExclusive);
 
-        final AbstractGuavaIterator<Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>>> iterator = new AbstractGuavaIterator<>()
+        final AbstractGuavaIterator<Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>>> iterator = new AbstractGuavaIterator<>()
         {
             private int currentTerm = startTermInclusive;
             private int currentRowId = 0;
 
             @Override
-            protected Pair<ByteComparable, List<RowMapping.RowIdWithFrequency>> computeNext()
+            protected Pair<ByteComparable.Preencoded, List<RowMapping.RowIdWithFrequency>> computeNext()
             {
                 if (currentTerm >= endTermExclusive)
                 {
@@ -209,7 +210,9 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
                 final List<RowMapping.RowIdWithFrequency> postings = new ArrayList<>();
                 postings.add(new RowMapping.RowIdWithFrequency(currentRowId++, 1));
                 final ByteSource encoded = Int32Type.instance.asComparableBytes(term, TypeUtil.BYTE_COMPARABLE_VERSION);
-                return Pair.create(v -> encoded, postings);
+                byte[] bytes = new byte[4];
+                encoded.nextBytes(bytes);
+                return Pair.create(ByteComparable.preencoded(TypeUtil.BYTE_COMPARABLE_VERSION, bytes), postings);
             }
         };
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
@@ -42,12 +42,13 @@ import static org.junit.Assert.*;
 
 public class TermsDistributionTest
 {
+    ByteComparable.Version VERSION = ByteComparable.Version.OSS41;
 
     @Test
     public void testEmpty()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        TermsDistribution td = new TermsDistribution.Builder(type, 10, 10).build();
+        TermsDistribution td = new TermsDistribution.Builder(type, VERSION,10, 10).build();
         assertEquals(0, td.estimateNumRowsMatchingExact(encode(1)));
         assertEquals(0, td.estimateNumRowsInRange(encode(0), encode(1000)));
     }
@@ -56,7 +57,7 @@ public class TermsDistributionTest
     public void testExactMatch()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, 10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), 1);
         var td = builder.build();
@@ -75,7 +76,7 @@ public class TermsDistributionTest
     public void testRangeMatch()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, 10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), 1);
         var td = builder.build();
@@ -119,7 +120,7 @@ public class TermsDistributionTest
         int frequentCount = 100; // whatever > 1
 
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, 10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), (i == frequentValue) ? frequentCount : 1);
         var td = builder.build();
@@ -151,7 +152,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<Double> type = DoubleType.instance;
-        var builder = new TermsDistribution.Builder(type, 13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encode((double) i / COUNT), 1);
@@ -189,7 +190,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<BigInteger> type = IntegerType.instance;
-        var builder = new TermsDistribution.Builder(type, 13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encodeAsBigInt(i), 1);
@@ -218,7 +219,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<BigDecimal> type = DecimalType.instance;
-        var builder = new TermsDistribution.Builder(type, 13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encodeAsDecimal((double) i / COUNT), 1);
@@ -253,7 +254,7 @@ public class TermsDistributionTest
     public void testSerde() throws IOException
     {
         AbstractType<Double> type = DoubleType.instance;
-        var builder = new TermsDistribution.Builder(type, 10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encode((double) i / COUNT), 1);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
@@ -42,13 +42,13 @@ import static org.junit.Assert.*;
 
 public class TermsDistributionTest
 {
-    ByteComparable.Version VERSION = ByteComparable.Version.OSS41;
+    static final ByteComparable.Version VERSION = ByteComparable.Version.OSS41;
 
     @Test
     public void testEmpty()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        TermsDistribution td = new TermsDistribution.Builder(type, VERSION,10, 10).build();
+        TermsDistribution td = new TermsDistribution.Builder(type, VERSION, 10, 10).build();
         assertEquals(0, td.estimateNumRowsMatchingExact(encode(1)));
         assertEquals(0, td.estimateNumRowsInRange(encode(0), encode(1000)));
     }
@@ -57,7 +57,7 @@ public class TermsDistributionTest
     public void testExactMatch()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION, 10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), 1);
         var td = builder.build();
@@ -76,7 +76,7 @@ public class TermsDistributionTest
     public void testRangeMatch()
     {
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION, 10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), 1);
         var td = builder.build();
@@ -120,7 +120,7 @@ public class TermsDistributionTest
         int frequentCount = 100; // whatever > 1
 
         AbstractType<Integer> type = Int32Type.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION, 10, 10);
         for (int i = 0; i < 1000; i++)
             builder.add(encode(i), (i == frequentValue) ? frequentCount : 1);
         var td = builder.build();
@@ -152,7 +152,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<Double> type = DoubleType.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION, 13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encode((double) i / COUNT), 1);
@@ -190,7 +190,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<BigInteger> type = IntegerType.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION, 13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encodeAsBigInt(i), 1);
@@ -219,7 +219,7 @@ public class TermsDistributionTest
         // Test if we get reasonable range estimates when selecting a fraction of a single bucket:
 
         AbstractType<BigDecimal> type = DecimalType.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,13, 13);
+        var builder = new TermsDistribution.Builder(type, VERSION, 13, 13);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encodeAsDecimal((double) i / COUNT), 1);
@@ -254,7 +254,7 @@ public class TermsDistributionTest
     public void testSerde() throws IOException
     {
         AbstractType<Double> type = DoubleType.instance;
-        var builder = new TermsDistribution.Builder(type, VERSION,10, 10);
+        var builder = new TermsDistribution.Builder(type, VERSION, 10, 10);
         var COUNT = 100000;
         for (int i = 0; i < COUNT; i++)
             builder.add(encode((double) i / COUNT), 1);

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
@@ -328,10 +328,10 @@ public abstract class TrieMemtableIndexTestBase extends SAITester
         assertFalse(result.hasNext());
     }
 
-    private void assertNextEntryInIterator(Iterator<Pair<ByteComparable, List<MemoryIndex.PkWithFrequency>>> iter, int term, int... primaryKeys)
+    private void assertNextEntryInIterator(Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iter, int term, int... primaryKeys)
     {
         assertTrue(iter.hasNext());
-        Pair<ByteComparable, List<MemoryIndex.PkWithFrequency>> entry = iter.next();
+        Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>> entry = iter.next();
         assertEquals(term, termFromComparable(entry.left));
         for (int i = 0; i < primaryKeys.length; i++)
         {


### PR DESCRIPTION
### What is the issue
The original AA SAI format was writing to disk with different byte-comparable version depending on the version of the sstable files. This causes problems with the ByteComparable version checking that was recently introduced.

### What does this PR fix and why was it fixed
- Introduces a new `ByteComparable.Preencoded` interface meant to store and surface the byte-comparable version something was encoded with.
- Changes tries to always return `Preencoded` type, so that callers may easily query the version.
- Changes SAI code to use the correct byte-comparable version when that is necessary, and to ignore or use Preencoded's version when we it is not feasible or important.