### PR TITLE
CNDB-13464: Ordering on non-clustering column requires the column to be indexed with a non-analyzed index

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -84,7 +84,8 @@ public class StatementRestrictions
 
     public static final String GEO_DISTANCE_REQUIRES_INDEX_MESSAGE = "GEO_DISTANCE requires the vector column to be indexed";
     public static final String BM25_ORDERING_REQUIRES_ANALYZED_INDEX_MESSAGE = "BM25 ordering on column %s requires an analyzed index";
-    public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE = "Ordering on non-clustering column %s requires the column to be indexed.";
+    public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE =
+    "Ordering on non-clustering column %s requires the column to be indexed with a non-analyzed index.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE =
     "Ordering on non-clustering column requires each restricted column to be indexed except for fully-specified partition keys";
 

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -738,7 +738,8 @@ public class IndexContext
         if (op == Operator.ORDER_BY_ASC || op == Operator.ORDER_BY_DESC)
             return !isCollection()
                    && column.isRegular()
-                   &&  !(column.type instanceof InetAddressType  // Possible, but need to add decoding logic based on
+                   && !isAnalyzed
+                   && !(column.type instanceof InetAddressType  // Possible, but need to add decoding logic based on
                                                                  // SAI's TypeUtil.encode method.
                          || column.type instanceof DecimalType   // Currently truncates to 24 bytes
                          || column.type instanceof IntegerType); // Currently truncates to 20 bytes

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByInvalidQueryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByInvalidQueryTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
+import static org.apache.cassandra.cql3.restrictions.StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -55,6 +56,27 @@ public class GenericOrderByInvalidQueryTest extends SAITester
         createTable("CREATE TABLE %s (pk int primary key, val varint)");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
         executeOrderByAndAssertInvalidRequestException("varint");
+    }
+
+    @Test
+    public void cannotOrderWithAnalyzedIndex()
+    {
+        createTable("CREATE TABLE %s (pk int primary key, val text)");
+        createIndex("CREATE CUSTOM INDEX test_v1_idx ON %s(val) USING 'StorageAttachedIndex'" +
+                    " WITH OPTIONS = {'index_analyzer': '{\"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }}'}");
+
+        execute("INSERT INTO %s (pk, val) VALUES (1, 'ciao amico')");
+        execute("INSERT INTO %s (pk, val) VALUES (2, 'ciao amico')");
+        assertRows(execute("SELECT * FROM %s"), row(1, "ciao amico"), row(2, "ciao amico"));
+
+        // Verify ORDER BY fails with analyzed index
+        assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val LIMIT 10"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"));
+
+        // Verify ORDER BY works with non-analyzed index
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        assertRows(execute("SELECT * FROM %s ORDER BY val LIMIT 10"), row(1, "ciao amico"), row(2, "ciao amico"));
     }
 
     @Test
@@ -77,10 +99,10 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     {
         createTable("CREATE TABLE %s (pk int, val text, PRIMARY KEY(pk))");
 
-        assertInvalidMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"),
+        assertInvalidMessage(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"),
                              "SELECT * FROM %s ORDER BY val ASC LIMIT 1");
         // Also confirm filtering does not make it work.
-        assertInvalidMessage(String.format(StatementRestrictions.NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"),
+        assertInvalidMessage(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, "val"),
                              "SELECT * FROM %s ORDER BY val LIMIT 5 ALLOW FILTERING");
     }
 
@@ -109,7 +131,7 @@ public class GenericOrderByInvalidQueryTest extends SAITester
     public void testInvalidColumnName()
     {
         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
-        assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + "." + table),
+        assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + '.' + table),
                              "SELECT k from %s ORDER BY bad_col LIMIT 1");
     }
 


### PR DESCRIPTION
### What is the issue
...
ORDER BY queries return wrong result if we have an analyzed index, as reported in CNDB-13464

### What does this PR fix and why was it fixed
...
ORDER BY should not work with an analyzed index at all. This PR fixes it and improves the error message.