### PR TITLE
CNDB-12220: Make SASI reject disjunctions

### DIFF
--- a/src/java/org/apache/cassandra/index/sasi/plan/SASIIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/SASIIndexQueryPlan.java
@@ -34,7 +34,8 @@ public class SASIIndexQueryPlan extends SingletonIndexQueryPlan
     @Nullable
     public static SASIIndexQueryPlan create(SASIIndex index, RowFilter rowFilter)
     {
-        for (RowFilter.Expression e : rowFilter.expressions())
+        // SASI doesn't support disjunctions, so we only consider the top-level AND expressions for index selection.
+        for (RowFilter.Expression e : rowFilter.withoutDisjunctions().expressions())
         {
             if (index.supportsExpression(e.column(), e.operator()))
                 return new SASIIndexQueryPlan(index, index.getPostIndexQueryFilter(rowFilter));


### PR DESCRIPTION
SASI doesn't support disjunction queries, which means that there shouldn't be a SASI-based query plan for these queries. However, SASI produces a plan for these queries that it later fails to execute. This breaks `ComplexQueryTest` and `AllIndexImplementationsTest`.

This malfunction happens in `main-5.0` because in that branch there is a dedicated `SASIIndexQueryPlan` added to 5.0 by [CASSANDRA-16092](https://issues.apache.org/jira/browse/CASSANDRA-16092). That class wasn't updated by [CNDB-10718](https://github.com/datastax/cassandra/commit/3800dfe16c4d3c88d4c49f49a3d78a73778d39e6) because it doesn't exist on `main`, where SASI still uses the generic `SingletonIndexQueryPlan`.

This PR simply modifies `SASIIndexQueryPlan` to only consider first-level conjuncted indexes as candidates for building an index plan, so it behaves the same as `SingletonIndexGroup#queryPlanFor`.
