### PR TITLE
CNDB-13505: Update PR checklist reminding people about the correct license header in new files

### DIFF
--- a/.github/workflows/pr_checklist.md
+++ b/.github/workflows/pr_checklist.md
@@ -8,3 +8,4 @@
 - [ ] Each commit has a meaningful description
 - [ ] Each commit is not very long and contains related changes
 - [ ] Renames, moves and reformatting are in distinct commits
+- [ ] All new files should contain the DataStax copyright header instead of the Apache License one


### PR DESCRIPTION
…

### What is the issue
...
New files should contain the DataStax copyright header instead of Apache License.

Automatically, we do not do that, but we add the Apache License. Related discussion on the why in the GH issue - linked Slack discussion
### What does this PR fix and why was it fixed
...
