### PR TITLE
CNDB-13499: Optimize simple BM25 by deferring PrK creation

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.Slice;
 import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.dht.AbstractBounds;
@@ -45,6 +46,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
+import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.Version;
@@ -55,11 +57,13 @@ import org.apache.cassandra.index.sai.metrics.QueryEventListener;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
 import org.apache.cassandra.index.sai.utils.BM25Utils;
-import org.apache.cassandra.index.sai.utils.BM25Utils.DocTF;
+import org.apache.cassandra.index.sai.utils.BM25Utils.EagerDocTF;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.index.sai.utils.PrimaryKeyWithScore;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.RowIdWithByteComparable;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
+import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.util.FileHandle;
@@ -200,20 +204,23 @@ public class InvertedIndexSearcher extends IndexSearcher
         var docLengthsReader = new DocLengthsReader(docLengths, docLengthsMeta);
 
         // Wrap the iterator with resource management
-        var it = new AbstractIterator<DocTF>() { // Anonymous class extends AbstractIterator
+        var it = new AbstractIterator<BM25Utils.DocTF>() { // Anonymous class extends AbstractIterator
             private boolean closed;
 
             @Override
-            protected DocTF computeNext()
+            protected BM25Utils.DocTF computeNext()
             {
                 try
                 {
                     int rowId = merged.nextPosting();
                     if (rowId == PostingList.END_OF_STREAM)
                         return endOfData();
+                    // Reads from disk.
                     int docLength = docLengthsReader.get(rowId); // segment-local rowid
-                    var pk = pkm.primaryKeyFromRowId(segmentRowIdOffset + rowId); // sstable-global rowid
-                    return new DocTF(pk, docLength, merged.frequencies());
+                    // We defer creating the primary key because it reads the token from disk, which is only needed
+                    // for the top rows just before they are materialized from disk, so we wait until after scoring
+                    // and sorting to read the token.
+                    return new LazyDocTF(pkm, segmentRowIdOffset + rowId, docLength, merged.frequencies());
                 }
                 catch (IOException e)
                 {
@@ -232,7 +239,7 @@ public class InvertedIndexSearcher extends IndexSearcher
         return bm25Internal(it, queryTerms, documentFrequencies);
     }
 
-    private CloseableIterator<PrimaryKeyWithSortKey> bm25Internal(CloseableIterator<DocTF> keyIterator,
+    private CloseableIterator<PrimaryKeyWithSortKey> bm25Internal(CloseableIterator<BM25Utils.DocTF> keyIterator,
                                                                   List<ByteBuffer> queryTerms,
                                                                   Map<ByteBuffer, Long> documentFrequencies)
     {
@@ -269,7 +276,7 @@ public class InvertedIndexSearcher extends IndexSearcher
         }
         var analyzer = indexContext.getAnalyzerFactory().create();
         var it = keys.stream()
-                     .map(pk -> DocTF.createFromDocument(pk, readColumn(sstable, pk), analyzer, queryTerms))
+                     .map(pk -> EagerDocTF.createFromDocument(pk, readColumn(sstable, pk), analyzer, queryTerms))
                      .filter(Objects::nonNull)
                      .iterator();
         return bm25Internal(CloseableIterator.wrap(it), queryTerms, documentFrequencies);
@@ -332,6 +339,52 @@ public class InvertedIndexSearcher extends IndexSearcher
         public void close()
         {
             FileUtils.closeQuietly(source, currentPostingList);
+        }
+    }
+
+    /**
+     * A {@link BM25Utils.DocTF} that is lazy in that it does not create the {@link PrimaryKey} until it is required.
+     */
+    private static class LazyDocTF implements BM25Utils.DocTF
+    {
+        private final PrimaryKeyMap pkm;
+        private final long sstableRowId;
+        private final int docLength;
+        private final Map<ByteBuffer, Integer> frequencies;
+
+        LazyDocTF(PrimaryKeyMap pkm, long sstableRowId, int docLength, Map<ByteBuffer, Integer> frequencies)
+        {
+            this.pkm = pkm;
+            this.sstableRowId = sstableRowId;
+            this.docLength = docLength;
+            this.frequencies = frequencies;
+        }
+
+        @Override
+        public int getTermFrequency(ByteBuffer term)
+        {
+            return frequencies.getOrDefault(term, 0);
+        }
+
+        @Override
+        public int termCount()
+        {
+            return docLength;
+        }
+
+        @Override
+        public PrimaryKeyWithSortKey primaryKey(IndexContext context, Memtable source, float score)
+        {
+            // Only sstables use this class, so this should never be called
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PrimaryKeyWithSortKey primaryKey(IndexContext context, SSTableId<?> source, float score)
+        {
+            // We can eagerly get the token now, even though it might not technically be required until we know
+            // we have the best score. (Perhaps this should be lazy too?)
+            return new PrimaryKeyWithScore(context, source, pkm.primaryKeyFromRowId(sstableRowId), score);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -324,7 +324,7 @@ public class TrieMemtableIndex implements MemtableIndex
         var docStats = computeDocumentFrequencies(queryContext, queryTerms);
         var analyzer = indexContext.getAnalyzerFactory().create();
         var it = Streams.stream(intersectedIterator)
-                 .map(pk -> BM25Utils.DocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
+                 .map(pk -> BM25Utils.EagerDocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
                  .filter(Objects::nonNull)
                  .iterator();
 
@@ -393,7 +393,7 @@ public class TrieMemtableIndex implements MemtableIndex
         var queryTerms = orderer.getQueryTerms();
         var docStats = computeDocumentFrequencies(queryContext, queryTerms);
         var it = keys.stream()
-                     .map(pk -> BM25Utils.DocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
+                     .map(pk -> BM25Utils.EagerDocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
                      .filter(Objects::nonNull)
                      .iterator();
         return BM25Utils.computeScores(CloseableIterator.wrap(it),


### PR DESCRIPTION
This commit has two key optimizations.

First, we defer materializing the PrimaryKey in simple
BM25 queries until we know that the PrimaryKey is
among the best scored rows in the sstable. This buys
us two things. The most important is that we can
defer reading the PrK's token from disk. The second
is that we materialize one less object per row, which
saves us essentially O(n) memory.

Second, we defer creating the PrimaryKeyWithSortKey
objects by using the jvector NodeQueue to sort based
on a long packed by an index (int) and a score (float).
This is a more compact way to sort because it takes less
space and uses a slightly better sort algorithm for our
use case since it is unlikely that we'll need to consume
all of the rows being sorted.

Initial testing on a 1 million document table with shows
that this optimization improves query latency by about
40 percent.

### What is the issue
...

### What does this PR fix and why was it fixed
...
