### PR TITLE
CNDB-13408 add BM25 tests to compare with CNDB

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -19,10 +19,16 @@
 package org.apache.cassandra.index.sai.cql;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -421,13 +427,19 @@ public class BM25Test extends SAITester
 
     private String createAnalyzedIndex(String column)
     {
+        return createAnalyzedIndex(column, false);
+    }
+
+    private String createAnalyzedIndex(String column, boolean lowercase)
+    {
         return createIndex("CREATE CUSTOM INDEX ON %s(" + column + ") " +
                            "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                            "WITH OPTIONS = {" +
                            "'index_analyzer': '{" +
                            "\"tokenizer\" : {\"name\" : \"standard\"}, " +
-                           "\"filters\" : [{\"name\" : \"porterstem\"}]" +
-                           "}'}"
+                           "\"filters\" : [{\"name\" : \"porterstem\"}" +
+                           (lowercase ? ", {\"name\" : \"lowercase\"}]" : "]")
+                           + "}'}"
         );
     }
 
@@ -640,7 +652,7 @@ public class BM25Test extends SAITester
         createTable("CREATE TABLE %s (id int PRIMARY KEY, category text, score int, title text, body text)");
         createAnalyzedIndex("body");
         createIndex("CREATE CUSTOM INDEX ON %s (score) USING 'StorageAttachedIndex'");
-        insertArticle();
+        insertPrimitiveData();
         beforeAndAfterFlush(
                 () -> {
                     // 10 docs have score 3 and 3 of those have "health"
@@ -655,41 +667,139 @@ public class BM25Test extends SAITester
                 });
     }
 
-    private void insertArticle()
+    @Test
+    public void testComplexOrderingCollections() throws Throwable
     {
-        Object[][] dataset = {
-        { 1, "Climate", 5, "Climate change is a pressing issue. Climate patterns are shifting globally. Scientists study climate data daily." },
-        { 2, "Technology", 3, "Technology is advancing. New technology in AI and robotics is groundbreaking." },
-        { 3, "Economy", 4, "The economy is recovering. Economy experts are optimistic. However, the global economy still faces risks." },
-        { 4, "Health", 3, "Health is wealth. Health policies need to be improved to ensure better public health outcomes." },
-        { 5, "Education", 2, "Education is the foundation of success. Online education is booming." },
-        { 6, "Climate", 4, "Climate and health are closely linked. Climate affects air quality and health outcomes." },
-        { 7, "Education", 3, "Technology and education go hand in hand. EdTech is revolutionizing education through technology." },
-        { 8, "Economy", 3, "The global economy is influenced by technology. Fintech is a key part of the economy today." },
-        { 9, "Health", 3, "Education and health programs must be prioritized. Health education is vital in schools." },
-        { 10, "Mixed", 3, "Technology, economy, and education are pillars of development." },
-        { 11, "Climate", 5, "Climate climate climate. It's everywhere. Climate drives political and economic decisions." },
-        { 12, "Health", 2, "Health concerns rise with climate issues. Health organizations are sounding the alarm." },
-        { 13, "Economy", 3, "The economy is fluctuating. Uncertainty looms over the economy." },
-        { 14, "Health", 3, "Cutting-edge technology is transforming healthcare. Healthtech merges health and technology." },
-        { 15, "Education", 2, "Education reforms are underway. Education experts suggest holistic changes." },
-        { 16, "Climate", 4, "Climate affects the economy and health. Climate events cost billions annually." },
-        { 17, "Technology", 3, "Technology is the backbone of the modern economy. Without technology, economic growth stagnates." },
-        { 18, "Health", 2, "Health is discussed less than economy or climate, but health matters deeply." },
-        { 19, "Climate", 5, "Climate change, climate policies, climate research—climate is the buzzword of our time." },
-        { 20, "Mixed", 3, "Investments in education and technology will shape the future of the global economy." }
-        };
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, category text, score int, " +
+                    "title text, body text, bodyset set<text>, " +
+                    "map_category map<int, text>, map_body map<text, text>)");
+        createAnalyzedIndex("body", true);
+        createAnalyzedIndex("bodyset", true);
+        createAnalyzedIndex("map_body", true);
+        createIndex("CREATE CUSTOM INDEX ON %s (score) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s (category) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s (map_category) USING 'StorageAttachedIndex'");
+        insertCollectionData();
 
-        for (Object[] article : dataset)
+        // Repro CNDB-13515
+        assertThatThrownBy(() -> executeQuery(Arrays.asList(11, 19, 1, 16, 6, 18, 12), "SELECT * FROM %s WHERE map_body CONTAINS KEY 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
+                                              "climate"));
+        assertThatThrownBy(() -> executeQuery(Arrays.asList(4, 18, 12, 9, 14), "SELECT * FROM %s WHERE map_body CONTAINS KEY 'HEALTH' ORDER BY body BM25 OF ? LIMIT 10 ALLOW FILTERING",
+                                              "climate"));
+
+        beforeAndAfterFlush(
+        () -> {
+            executeQuery(Arrays.asList(11, 19, 1, 16, 6, 18, 12), "SELECT * FROM %s ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(11, 19, 1), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(6, 16), "SELECT * FROM %s WHERE score > 3 ORDER BY body BM25 OF ? LIMIT 10",
+                         "health");
+            executeQuery(Arrays.asList(4, 18, 12, 9, 14), "SELECT * FROM %s WHERE category = 'Health' " +
+                                                          "ORDER BY body BM25 OF ? LIMIT 10",
+                         "Health");
+            executeQuery(Arrays.asList(4, 18, 12, 9, 14), "SELECT * FROM %s WHERE score <= 3 AND category = 'Health' " +
+                                                          "ORDER BY body BM25 OF ? LIMIT 10",
+                         "health");
+            executeQuery(Arrays.asList(11, 19, 1, 16, 6, 18, 12), "SELECT * FROM %s WHERE bodyset CONTAINS 'climate' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(16, 6, 18, 12), "SELECT * FROM %s WHERE bodyset CONTAINS 'health' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(11, 19, 1, 16, 6, 18, 12), "SELECT * FROM %s WHERE map_category CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(19, 16, 6, 18, 12), "SELECT * FROM %s WHERE map_category CONTAINS 'Health' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(11, 19, 1, 16, 6, 18, 12), "SELECT * FROM %s WHERE map_body CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+            executeQuery(Arrays.asList(11, 19, 16, 6, 18, 12), "SELECT * FROM %s WHERE map_body CONTAINS 'health' ORDER BY body BM25 OF ? LIMIT 10",
+                         "climate");
+        });
+    }
+
+    private final static Object[][] DATASET = {
+    { 1, "Climate", 5, "Climate change is a pressing issue. Climate patterns are shifting globally. Scientists study climate data daily." },
+    { 2, "Technology", 3, "Technology is advancing. New technology in AI and robotics is groundbreaking." },
+    { 3, "Economy", 4, "The economy is recovering. Economy experts are optimistic. However, the global economy still faces risks." },
+    { 4, "Health", 3, "Health is wealth. Health policies need to be improved to ensure better public health outcomes." },
+    { 5, "Education", 2, "Education is the foundation of success. Online education is booming." },
+    { 6, "Climate", 4, "Climate and health are closely linked. Climate affects air quality and health outcomes." },
+    { 7, "Education", 3, "Technology and education go hand in hand. EdTech is revolutionizing education through technology." },
+    { 8, "Economy", 3, "The global economy is influenced by technology. Fintech is a key part of the economy today." },
+    { 9, "Health", 3, "Education and health programs must be prioritized. Health education is vital in schools." },
+    { 10, "Mixed", 3, "Technology, economy, and education are pillars of development." },
+    { 11, "Climate", 5, "Climate climate climate. It's everywhere. Climate drives political and economic decisions." },
+    { 12, "Health", 2, "Health concerns rise with climate issues. Health organizations are sounding the alarm." },
+    { 13, "Economy", 3, "The economy is fluctuating. Uncertainty looms over the economy." },
+    { 14, "Health", 3, "Cutting-edge technology is transforming healthcare. Healthtech merges health and technology." },
+    { 15, "Education", 2, "Education reforms are underway. Education experts suggest holistic changes." },
+    { 16, "Climate", 4, "Climate affects the economy and health. Climate events cost billions annually." },
+    { 17, "Technology", 3, "Technology is the backbone of the modern economy. Without technology, economic growth stagnates." },
+    { 18, "Health", 2, "Health is discussed less than economy or climate, but health matters deeply." },
+    { 19, "Climate", 5, "Climate change, climate policies, climate research—climate is the buzzword of our time." },
+    { 20, "Mixed", 3, "Investments in education and technology will shape the future of the global economy." }
+    };
+
+    private void insertPrimitiveData()
+    {
+        for (Object[] row : DATASET)
         {
             execute(
             "INSERT INTO %s (id, category, score, body) VALUES (?, ?, ?, ?)",
-            article[0],
-            article[1],
-            article[2],
-            article[3]
+            row[0],
+            row[1],
+            row[2],
+            row[3]
             );
         }
     }
 
+    private void insertCollectionData()
+    {
+        int setsize = 1;
+        for (int row = 0; row < DATASET.length; row++)
+        {
+            var set = new HashSet<String>();
+            for (int j = 0; j < setsize; j++)
+                set.add((String) DATASET[row - j][3]);
+            if (setsize >= 3)
+                setsize -= 2;
+            else
+                setsize++;
+            var map = new HashMap<Integer, String>();
+            var map_text = new HashMap<String, String>();
+            for (int j = 0; j <= row && j < 3; j++)
+            {
+                map.putIfAbsent((Integer) DATASET[row - j][2], (String) DATASET[row - j][1]);
+                map_text.putIfAbsent((String) DATASET[row - j][1], (String) DATASET[row - j][3]);
+            }
+
+            execute(
+            "INSERT INTO %s (id, category, score, body, bodyset, map_category, map_body) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            DATASET[row][0],
+            DATASET[row][1],
+            DATASET[row][2],
+            DATASET[row][3],
+            set,
+            map,
+            map_text
+            );
+        }
+    }
+
+    private void executeQuery(List<Integer> expected, String query, Object... values) throws Throwable
+    {
+        assertResult(execute(query, values), expected);
+        prepare(query);
+        assertResult(execute(query, values), expected);
+    }
+
+    private void assertResult(UntypedResultSet result, List<Integer> expected)
+    {
+        Assertions.assertThat(result).hasSize(expected.size());
+        var ids = result.stream()
+                        .map(row -> row.getInt("id"))
+                        .collect(Collectors.toList());
+        Assertions.assertThat(ids).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
Adds CC's unit tests to help with https://github.com/riptano/cndb/issues/13408, i.e., BM25 queries to use in integration CNDB's tests and expect the same result.

Also adds tests to reproduce https://github.com/riptano/cndb/issues/13514 and https://github.com/riptano/cndb/issues/13408.