### PR TITLE
CNDB-13524 Adds a timeout to Future.get calls in PendingAntiCompactionTest

### DIFF
--- a/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/repair/PendingAntiCompactionTest.java
@@ -151,7 +151,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
         try
         {
             pac = new PendingAntiCompaction(sessionID, tables, atEndpoint(ranges, NO_RANGES), executor, () -> false);
-            pac.run().get();
+            pac.run().get(30, TimeUnit.SECONDS);
         }
         finally
         {
@@ -637,7 +637,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
     }
 
     @Test
-    public void testRetries() throws InterruptedException, ExecutionException
+    public void testRetries() throws InterruptedException, ExecutionException, TimeoutException
     {
         ColumnFamilyStore cfs = MockSchema.newCFS();
         cfs.addSSTable(MockSchema.sstable(1, true, cfs));
@@ -671,7 +671,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
             PendingAntiCompaction.AcquisitionCallable acquisitionCallable = new PendingAntiCompaction.AcquisitionCallable(cfs, UUID.randomUUID(), 10, 1, acp);
             Future f = es.submit(acquisitionCallable);
             cdl.await();
-            assertNotNull(f.get());
+            assertNotNull(f.get(30, TimeUnit.SECONDS));
         }
         catch (IOException ex)
         {
@@ -684,7 +684,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
     }
 
     @Test
-    public void testRetriesTimeout() throws InterruptedException, ExecutionException, IOException
+    public void testRetriesTimeout() throws InterruptedException, ExecutionException, IOException, TimeoutException
     {
         ColumnFamilyStore cfs = MockSchema.newCFS();
         cfs.addSSTable(MockSchema.sstable(1, true, cfs));
@@ -713,7 +713,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
             };
             PendingAntiCompaction.AcquisitionCallable acquisitionCallable = new PendingAntiCompaction.AcquisitionCallable(cfs, UUID.randomUUID(), 2, 1000, acp);
             Future fut = es.submit(acquisitionCallable);
-            assertNull(fut.get());
+            assertNull(fut.get(30, TimeUnit.SECONDS));
         }
         finally
         {
@@ -722,7 +722,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
     }
 
     @Test
-    public void testWith2i() throws ExecutionException, InterruptedException
+    public void testWith2i() throws ExecutionException, InterruptedException, TimeoutException
     {
         cfs2.disableAutoCompaction();
         makeSSTables(2, cfs2, 100);
@@ -738,7 +738,7 @@ public class PendingAntiCompactionTest extends AbstractPendingAntiCompactionTest
             try (LifecycleTransaction txn = idx.getTracker().tryModify(idx.getLiveSSTables(), OperationType.COMPACTION))
             {
                 PendingAntiCompaction pac = new PendingAntiCompaction(prsid, Collections.singleton(cfs2), atEndpoint(FULL_RANGE, NO_RANGES), es, () -> false);
-                pac.run().get();
+                pac.run().get(30, TimeUnit.SECONDS);
             }
             // and make sure it succeeded;
             for (SSTableReader sstable : cfs2.getLiveSSTables())


### PR DESCRIPTION
### What is the issue
`PendingAntiCompactionTest.testRetriesTimeout` is flaky on `main` failing with a timeout reported in the junit test task. https://github.com/riptano/cndb/issues/13524 

### What does this PR fix and why was it fixed
`PendingAntiCompactionTest.testRetriesTimeout`, and a couple other tests, are calling `Future.get` without any timeout. This change adds a 30 seconds timeout to prevent an indefinite wait for the future and a log in the failing test rather than in the junit test task.
