### PR TITLE
CNDB-13541: Adjust NTR to respect CQL router's new CNDB_START_TIME

### DIFF
--- a/src/java/org/apache/cassandra/transport/Message.java
+++ b/src/java/org/apache/cassandra/transport/Message.java
@@ -243,6 +243,12 @@ public abstract class Message
         protected long elapsedTimeSinceCreation(TimeUnit timeUnit)
         {
             Map<String, ByteBuffer> customPayload = getCustomPayload();
+            if (customPayload == null)
+                noSpam.warn("Custom payload is null, falling back to creationTimeNanos");
+            else if (customPayload.containsKey(CNDB_START_TIME))
+                noSpam.info("CNDB_START_TIME is present in custom payload");
+            else
+                noSpam.warn("Custom payload does not contain CNDB_START_TIME, falling back to creationTimeNanos");
             if (customPayload != null && customPayload.containsKey(CNDB_START_TIME))
             {
                 ByteBuffer startTime = customPayload.get(CNDB_START_TIME);
@@ -250,7 +256,7 @@ public abstract class Message
                 {
                     long startTimeMillis = timeUnit.convert(startTime.getLong(), TimeUnit.MILLISECONDS);
                     // TODO: Remove logline
-                    noSpam.info("Start time: {}", startTimeMillis);
+                    noSpam.info("CNDB_START_TIME time: {}", startTimeMillis);
                     return timeUnit.convert(System.currentTimeMillis() - startTime.getLong(), TimeUnit.MILLISECONDS);
                 }
                 catch (Exception e)

--- a/src/java/org/apache/cassandra/transport/Message.java
+++ b/src/java/org/apache/cassandra/transport/Message.java
@@ -249,6 +249,12 @@ public abstract class Message
                 noSpam.info("CNDB_START_TIME is present in custom payload");
             else
                 noSpam.warn("Custom payload does not contain CNDB_START_TIME, falling back to creationTimeNanos");
+            if (customPayload != null)
+                for (Map.Entry<String, ByteBuffer> entry : customPayload.entrySet()) {
+                    String key = entry.getKey();
+                    ByteBuffer value = entry.getValue();
+                    logger.info("Custom payload key: {}, value: {}", key, value);
+                }
             if (customPayload != null && customPayload.containsKey(CNDB_START_TIME))
             {
                 ByteBuffer startTime = customPayload.get(CNDB_START_TIME);

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -26,6 +26,7 @@ package org.apache.cassandra.utils;
 import java.io.*;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -533,6 +534,21 @@ public class ByteBufferUtil
     public static long toLong(ByteBuffer bytes)
     {
         return bytes.getLong(bytes.position());
+    }
+
+    public static long getLongFromBuffer(byte[] bytes) {
+        if (bytes == null || bytes.length < Long.BYTES) {
+            throw new IllegalArgumentException("Input must contain at least " + Long.BYTES + " bytes");
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        if (buffer.remaining() < Long.BYTES) {
+            throw new IllegalStateException("Insufficient bytes remaining in buffer");
+        }
+
+        return buffer.getLong();
     }
 
     public static float toFloat(ByteBuffer bytes)

--- a/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteBufferUtil.java
@@ -26,7 +26,6 @@ package org.apache.cassandra.utils;
 import java.io.*;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -534,21 +533,6 @@ public class ByteBufferUtil
     public static long toLong(ByteBuffer bytes)
     {
         return bytes.getLong(bytes.position());
-    }
-
-    public static long getLongFromBuffer(byte[] bytes) {
-        if (bytes == null || bytes.length < Long.BYTES) {
-            throw new IllegalArgumentException("Input must contain at least " + Long.BYTES + " bytes");
-        }
-
-        ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        buffer.order(ByteOrder.BIG_ENDIAN);
-
-        if (buffer.remaining() < Long.BYTES) {
-            throw new IllegalStateException("Insufficient bytes remaining in buffer");
-        }
-
-        return buffer.getLong();
     }
 
     public static float toFloat(ByteBuffer bytes)


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/13541

NTR timeouts calcualted elapsed time since request creation (post deserialziation) which discounts and extra time the request has spent in the system (i.e. when an upstream router exist, such as CQL router)

### What does this PR fix and why was it fixed
CQL router (or any other upstream system for that matter) could now pass the creation time of the request in customer payload using a key called `CNDB_START_TIME` (will probably change the name). The NTR timeout would now respect that time if present, otherwise would fallback to post deserialzation time 
