### PR TITLE
CNDB-13591: Go back to storing byte buffers in the cache

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -55,10 +55,10 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.RebuffererFactory;
 import org.apache.cassandra.metrics.ChunkCacheMetrics;
+import org.apache.cassandra.utils.FastByteOperations;
 import org.apache.cassandra.utils.PageAware;
 import org.apache.cassandra.utils.memory.BufferPool;
 import org.apache.cassandra.utils.memory.BufferPools;
-import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.github.jamm.Unmetered;
 
 public class ChunkCache
@@ -433,27 +433,18 @@ public class ChunkCache
      */
     public class MultiRegionChunk extends Chunk
     {
-        /** A list of memory addresses, each page has capacity of PageAware.PAGE_SIZE */
-        private final long[] pages;
-        /** List of attachments, necessary to be able to release pool buffers properly */
-        private final Object[] attachments;
+        private final ByteBuffer[] buffers;
 
         public MultiRegionChunk(long offset, ByteBuffer[] buffers)
         {
             super(offset);
-            this.pages = new long[buffers.length];
-            this.attachments = new Object[buffers.length];
-            for (int i = 0; i < buffers.length; ++i)
-            {
-                pages[i] = MemoryUtil.getAddress(buffers[i]);
-                attachments[i] = MemoryUtil.getAttachment(buffers[i]);
-            }
+            this.buffers = buffers;
         }
 
         void releaseBuffers()
         {
-            for (int i = 0; i < pages.length; ++i)
-                bufferPool.put(MemoryUtil.allocateByteBuffer(pages[i], PageAware.PAGE_SIZE, PageAware.PAGE_SIZE, ByteOrder.BIG_ENDIAN, attachments[i]));
+            for (int i = 0; i < buffers.length; ++i)
+                bufferPool.put(buffers[i]);
         }
 
         void read(ChunkReader file)
@@ -468,18 +459,13 @@ public class ChunkCache
                 file.readChunk(offset, scratchBuffer);
                 int limit = scratchBuffer.limit();
                 int idx = 0;
-                int pageEnd;
-                for (pageEnd = PageAware.PAGE_SIZE; pageEnd <= limit; pageEnd += PageAware.PAGE_SIZE)
-                {
-                    scratchBuffer.limit(pageEnd);
-                    MemoryUtil.setBytes(pages[idx++], scratchBuffer);
-                    scratchBuffer.position(pageEnd);
-                }
-                if (scratchBuffer.position() < limit)   // if the limit is not a multiple of the page size
-                {
-                    scratchBuffer.limit(limit);
-                    MemoryUtil.setBytes(pages[idx], scratchBuffer);
-                }
+                int pageStart;
+                for (pageStart = 0; pageStart + PageAware.PAGE_SIZE <= limit; pageStart += PageAware.PAGE_SIZE)
+                    FastByteOperations.copy(scratchBuffer, pageStart, buffers[idx++], 0, PageAware.PAGE_SIZE);
+
+                if (pageStart < limit)   // if the limit is not a multiple of the page size
+                    FastByteOperations.copy(scratchBuffer, pageStart, buffers[idx++], 0, limit - pageStart);
+
                 bytesRead = limit;
             }
             finally
@@ -492,39 +478,36 @@ public class ChunkCache
         Buffer getBuffer(long position)
         {
             int index = PageAware.pageNum(position - offset);
-            Preconditions.checkArgument(index >= 0 && index < pages.length, "Invalid position: %s, index: %s", position, index);
+            Preconditions.checkArgument(index >= 0 && index < buffers.length, "Invalid position: %s, index: %s", position, index);
 
             long pageAlignedPosition = PageAware.pageStart(position);
-            int bufferSize = Math.min(PageAware.PAGE_SIZE, Math.toIntExact(bytesRead - (index * PageAware.PAGE_SIZE)));
-            assert bufferSize > 0 && bufferSize <= PageAware.PAGE_SIZE : "Wrong buffer size: " + bufferSize + " at position " + position;
 
-            return new Buffer(pages[index], pageAlignedPosition, bufferSize);
+            return new Buffer(buffers[index], pageAlignedPosition);
         }
 
         public int capacity()
         {
-            return pages.length * PageAware.PAGE_SIZE;
+            return buffers.length * PageAware.PAGE_SIZE;
         }
 
         class Buffer implements Rebufferer.BufferHolder
         {
-            private final long address;
+            private final ByteBuffer buffer;
             private final long offset;
-            private final int limit;
 
 
-            public Buffer(long address, long offset, int limit)
+            public Buffer(ByteBuffer buffer, long offset)
             {
-                this.address = address;
+                this.buffer = buffer;
                 this.offset = offset;
-                this.limit = limit;
+                buffer.order(ByteOrder.BIG_ENDIAN);
             }
 
             @Override
             public ByteBuffer buffer()
             {
                 assert isReferenced() : "Already unreferenced";
-                return MemoryUtil.allocateByteBuffer(address, limit, PageAware.PAGE_SIZE, ByteOrder.BIG_ENDIAN, null);
+                return buffer.duplicate();
             }
 
             @Override
@@ -552,22 +535,19 @@ public class ChunkCache
      */
     class SingleRegionChunk extends Chunk implements Rebufferer.BufferHolder
     {
-        private final long address;
-        private final int capacity;
-        private final Object attachment;
+        private final ByteBuffer buffer;
 
         public SingleRegionChunk(long offset, ByteBuffer buffer)
         {
             super(offset);
-            this.address = MemoryUtil.getAddress(buffer);
-            this.capacity = buffer.capacity();
-            this.attachment = MemoryUtil.getAttachment(buffer);
+            this.buffer = buffer;
+            buffer.order(ByteOrder.BIG_ENDIAN);
         }
 
         public ByteBuffer buffer()
         {
             assert isReferenced() : "Already unreferenced";
-            return MemoryUtil.allocateByteBuffer(address, bytesRead, capacity, ByteOrder.BIG_ENDIAN, null);
+            return buffer.duplicate();
         }
 
         public long offset()
@@ -577,7 +557,7 @@ public class ChunkCache
 
         void releaseBuffers()
         {
-            bufferPool.put(MemoryUtil.allocateByteBuffer(address, capacity, capacity, ByteOrder.BIG_ENDIAN, attachment));
+            bufferPool.put(buffer);
         }
 
         void read(ChunkReader file)
@@ -595,7 +575,7 @@ public class ChunkCache
 
         int capacity()
         {
-            return capacity;
+            return buffer.capacity();
         }
     }
 

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -152,7 +152,7 @@ public class ChunkCache
             chunk = newChunk(file.chunkSize(), position);  // Note: we need `chunk` to be assigned before we call read to release on error
             chunk.read(file);
         }
-        catch (RuntimeException t)
+        catch (RuntimeException | Error t)
         {
             if (chunk != null)
                 chunk.release();

--- a/src/java/org/apache/cassandra/io/util/ChannelProxy.java
+++ b/src/java/org/apache/cassandra/io/util/ChannelProxy.java
@@ -25,8 +25,12 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.StandardOpenOption;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.utils.INativeLibrary;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.concurrent.RefCounted;
 import org.apache.cassandra.utils.concurrent.SharedCloseableImpl;
 
@@ -41,6 +45,7 @@ import org.apache.cassandra.utils.concurrent.SharedCloseableImpl;
  */
 public final class ChannelProxy extends SharedCloseableImpl
 {
+    private static final Logger log = LoggerFactory.getLogger(ChannelProxy.class);
     private final File file;
 
     private final FileChannel channel;
@@ -139,8 +144,9 @@ public final class ChannelProxy extends SharedCloseableImpl
             // FIXME: consider wrapping in a while loop
             return channel.read(buffer, position);
         }
-        catch (IOException e)
+        catch (Throwable e)
         {
+            JVMStabilityInspector.inspectThrowable(e);
             throw new FSReadError(e, filePath());
         }
     }
@@ -151,8 +157,9 @@ public final class ChannelProxy extends SharedCloseableImpl
         {
             return channel.transferTo(position, count, target);
         }
-        catch (IOException e)
+        catch (Throwable e)
         {
+            JVMStabilityInspector.inspectThrowable(e);
             throw new FSReadError(e, filePath());
         }
     }
@@ -163,8 +170,9 @@ public final class ChannelProxy extends SharedCloseableImpl
         {
             return channel.map(mode, position, size);
         }
-        catch (IOException e)
+        catch (Throwable e)
         {
+            JVMStabilityInspector.inspectThrowable(e);
             throw new FSReadError(e, filePath());
         }
     }

--- a/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.compress.BufferType;
 
 class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
@@ -44,8 +45,12 @@ class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
     @Override
     public void readChunk(long position, ByteBuffer buffer)
     {
+        long readPosition = position - startOffset;
+        if (readPosition < 0)
+            throw new IllegalArgumentException("Trying to read from a negative read position: " + readPosition + " startOffset " + startOffset + " position " + position);
+
         buffer.clear();
-        channel.read(buffer, position - startOffset);
+        channel.read(buffer, readPosition);
         buffer.flip();
     }
 

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheTest.java
@@ -33,11 +33,11 @@ import java.util.concurrent.Future;
 import com.google.common.base.Throwables;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.File;
@@ -49,6 +49,7 @@ import org.apache.cassandra.metrics.ChunkCacheMetrics;
 import org.apache.cassandra.utils.memory.BufferPool;
 import org.awaitility.Awaitility;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -412,7 +413,7 @@ public class ChunkCacheTest
             // file 1 has an error during read, we shouldn't cache the handle
             mockFileControl1.waitOnRead.completeExceptionally(new RuntimeException("some weird runtime error"));
             RandomAccessReader r1 = mockFileControl1.openReader();
-            assertThrows(CompletionException.class, r1::reBuffer);
+            assertThrows(FSReadError.class, r1::reBuffer);
             assertEquals(0, chunkCache.sizeOfFile(mockFileControl1.file));
             assertEquals(0, chunkCache.size());
             assertEquals(0, allocated.size());
@@ -546,7 +547,7 @@ public class ChunkCacheTest
             // in this case thread1 errors before thread2 starts to read
             RuntimeException error = new RuntimeException("some weird runtime error");
             mockFileControl1.waitOnRead.completeExceptionally(error);
-            assertSame(error, assertThrows(CompletionException.class, thread1::join).getCause());
+            assertThatThrownBy(thread1::join).hasCauseInstanceOf(FSReadError.class);
 
             // assert that we didn't leak the buffer
             assertEquals(0, allocated.size());


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/9104 included conversion of `ByteBuffer`s to addresses to decrease the space usage of the chunk cache. This seems to cause a lot of chunk cache corruption (see https://github.com/riptano/cndb/issues/13591).

### What does this PR fix and why was it fixed
Switches back to storing the passed `ByteBuffer`s.
