### PR TITLE
CNDB-13624: Silence snakeyaml warnings in test-cdc by removing duplicate cdc_enabled key in base yaml

### DIFF
--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -12,7 +12,6 @@ commitlog_directory: build/test/cassandra/commitlog
 # commitlog_compression:
 # - class_name: LZ4Compressor
 cdc_raw_directory: build/test/cassandra/cdc_raw
-cdc_enabled: false
 hints_directory: build/test/cassandra/hints
 metadata_directory: build/test/cassandra/metadata
 partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner


### PR DESCRIPTION
### What is the issue
#1563 upgraded our version of snakeyaml. This new version logs when duplicate keys are found. The test-cdc target concatenates a CDC-specific yaml to the base yaml. Both contain entries for the cdc_enabled key, causing tests that load this yaml to log the warning. This causes CDC CI failures.

### What does this PR fix and why was it fixed
This PR removes the cdc_enabled entry in the base yaml, as it's the same as the default. This is consistent with how we handle other default keys that might be duplicated across multiple yaml fragments in the test commands.
