### PR TITLE
CNDB-13618 remove long index name test after fix

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -264,32 +264,6 @@ public class NativeIndexDDLTest extends SAITester
         assertTrue(tuple.isTuple());
     }
 
-    /**
-     * The test reproduces CNDB-13198
-     */
-    @Test
-    public void reproFailOnLongIndexName()
-    {
-        // Generate an index name of the maximum allowed length, adding four chars accounting for components with a
-        // generation number of the form "-XXX", which won't be included in the first index segment, and
-        // the difference between actual index component representation and longest (4 chars).
-        String longIndexName = "a".repeat(Version.calculateIndexNameAllowedLength() + 4 + 4);
-        createTable("CREATE TABLE %s (key int PRIMARY KEY, value1 int, value2 int)");
-        createIndex(String.format("CREATE CUSTOM INDEX %s ON %%s(value1) USING 'StorageAttachedIndex'", longIndexName));
-        execute("INSERT INTO %s (\"key\", value1) VALUES (1, 1)");
-        execute("INSERT INTO %s (\"key\", value2) VALUES (2, 2)");
-        flush();
-
-        // Now try to create an index with a name that is one character longer than the maximum allowed length.
-        longIndexName += "a";
-        createTable("CREATE TABLE %s (key int PRIMARY KEY, value1 int, value2 int)");
-        createIndex(String.format("CREATE CUSTOM INDEX %s ON %%s(value1) USING 'StorageAttachedIndex'", longIndexName));
-        execute("INSERT INTO %s (\"key\", value1) VALUES (1, 1)");
-        execute("INSERT INTO %s (\"key\", value2) VALUES (2, 2)");
-        RuntimeException e = assertThrows(RuntimeException.class, this::flush);
-        assertTrue(e.getCause() instanceof FileSystemException);
-    }
-
     @Test
     public void shouldCreateIndexIfExists()
     {


### PR DESCRIPTION

### What is the issue
Fixes CNDB-13618
This test was reproducing the bug of creating an index with too long index name. CNDB-13299 prevents creating indexes with too long index names and adds corresponding tests. 

### What does this PR fix and why was it fixed

This PR removes the repro test as not needed.
