### PR TITLE
CNDB-13583: Add vector ann and brute force metrics

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -193,7 +193,8 @@ public class IndexContext
             this.hasEuclideanSimilarityFunc = vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN;
 
             this.indexMetrics = new IndexMetrics(this);
-            this.columnQueryMetrics = isLiteral() ? new ColumnQueryMetrics.TrieIndexMetrics(keyspace, table, getIndexName())
+            this.columnQueryMetrics = isVector() ? new ColumnQueryMetrics.VectorIndexMetrics(keyspace, table, getIndexName()) :
+                                      isLiteral() ? new ColumnQueryMetrics.TrieIndexMetrics(keyspace, table, getIndexName())
                                                   : new ColumnQueryMetrics.BKDIndexMetrics(keyspace, table, getIndexName());
 
         }

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -60,7 +60,8 @@ public class QueryContext
 
     private final LongAdder queryTimeouts = new LongAdder();
 
-    private final LongAdder annNodesVisited = new LongAdder();
+    private final LongAdder annGraphSearchLatency = new LongAdder();
+
     private float annRerankFloor = 0.0f; // only called from single-threaded setup code
 
     private final LongAdder shadowedPrimaryKeyCount = new LongAdder();
@@ -138,9 +139,10 @@ public class QueryContext
     {
         queryTimeouts.add(val);
     }
-    public void addAnnNodesVisited(long val)
+
+    public void addAnnGraphSearchLatency(long val)
     {
-        annNodesVisited.add(val);
+        annGraphSearchLatency.add(val);
     }
 
     public void setFilterSortOrder(FilterSortOrder filterSortOrder)
@@ -201,9 +203,9 @@ public class QueryContext
     {
         return queryTimeouts.longValue();
     }
-    public long annNodesVisited()
+    public long annGraphSearchLatency()
     {
-        return annNodesVisited.longValue();
+        return annGraphSearchLatency.longValue();
     }
 
     public FilterSortOrder filterSortOrder()

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskOrdinalsMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskOrdinalsMap.java
@@ -99,6 +99,12 @@ public class V2OnDiskOrdinalsMap implements OnDiskOrdinalsMap
     }
 
     @Override
+    public long cachedBytesUsed()
+    {
+        return 0;
+    }
+
+    @Override
     public RowIdsView getRowIdsView()
     {
         if (canFastMapRowIdsView) {

--- a/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMap.java
@@ -354,4 +354,26 @@ public class V5OnDiskOrdinalsMap implements OnDiskOrdinalsMap
             // no-op
         }
     }
+
+    @Override
+    public long cachedBytesUsed()
+    {
+        if (structure != V5VectorPostingsWriter.Structure.ONE_TO_MANY) {
+            return 0;
+        }
+
+        long bytes = 0;
+        if (extraRowIds != null) {
+            bytes += extraRowIds.length * 4L;
+        }
+        if (extraOrdinals != null) {
+            bytes += extraOrdinals.length * 4L;
+        }
+        if (extraRowsByOrdinal != null) {
+            for (int[] rowIds : extraRowsByOrdinal.values()) {
+                bytes += rowIds.length * 4L;
+            }
+        }
+        return bytes;
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AutoResumingNodeScoreIterator.java
@@ -24,6 +24,8 @@ import java.util.function.IntConsumer;
 
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.SearchResult;
+import org.apache.cassandra.index.sai.QueryContext;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.AbstractIterator;
 
@@ -41,6 +43,8 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
     private final int rerankK;
     private final boolean inMemory;
     private final String source;
+    private final QueryContext context;
+    private final ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics;
     private final IntConsumer nodesVisitedConsumer;
     private Iterator<SearchResult.NodeScore> nodeScores;
     private int cumulativeNodesVisited;
@@ -51,6 +55,8 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
      * no more results.
      * @param searcher the {@link GraphSearcher} to use to resume search.
      * @param result the first {@link SearchResult} to iterate over
+     * @param context the {@link QueryContext} to use to record metrics
+     * @param columnQueryMetrics object to record metrics
      * @param nodesVisitedConsumer a consumer that accepts the total number of nodes visited
      * @param limit the limit to pass to the {@link GraphSearcher} when resuming search
      * @param rerankK the rerankK to pass to the {@link GraphSearcher} when resuming search
@@ -60,6 +66,8 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
     public AutoResumingNodeScoreIterator(GraphSearcher searcher,
                                          GraphSearcherAccessManager accessManager,
                                          SearchResult result,
+                                         QueryContext context,
+                                         ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics,
                                          IntConsumer nodesVisitedConsumer,
                                          int limit,
                                          int rerankK,
@@ -69,7 +77,9 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         this.searcher = searcher;
         this.accessManager = accessManager;
         this.nodeScores = Arrays.stream(result.getNodes()).iterator();
-        this.cumulativeNodesVisited = result.getVisitedCount();
+        this.context = context;
+        this.columnQueryMetrics = columnQueryMetrics;
+        this.cumulativeNodesVisited = 0;
         this.nodesVisitedConsumer = nodesVisitedConsumer;
         this.limit = max(1, limit / 2); // we shouldn't need as many results on resume
         this.rerankK = rerankK;
@@ -83,19 +93,27 @@ public class AutoResumingNodeScoreIterator extends AbstractIterator<SearchResult
         if (nodeScores.hasNext())
             return nodeScores.next();
 
+        long start = System.nanoTime();
+
+        // Search deeper into the graph
         var nextResult = searcher.resume(limit, rerankK);
-        maybeLogTrace(nextResult);
+
+        // Record metrics
+        long elapsed = System.nanoTime() - start;
+        columnQueryMetrics.onSearchResult(nextResult, elapsed, true);
+        context.addAnnGraphSearchLatency(elapsed);
         cumulativeNodesVisited += nextResult.getVisitedCount();
+
+        if (Tracing.isTracing())
+        {
+            String msg = inMemory ? "Memory based ANN resume for {}/{} visited {} nodes, reranked {} to return {} results from {}"
+                                  : "Disk based ANN resume for {}/{} visited {} nodes, reranked {} to return {} results from {}";
+            Tracing.trace(msg, limit, rerankK, nextResult.getVisitedCount(), nextResult.getRerankedCount(), nextResult.getNodes().length, source);
+        }
+
         // If the next result is empty, we are done searching.
         nodeScores = Arrays.stream(nextResult.getNodes()).iterator();
         return nodeScores.hasNext() ? nodeScores.next() : endOfData();
-    }
-
-    private void maybeLogTrace(SearchResult result)
-    {
-        String msg = inMemory ? "ANN resume for {}/{} visited {} nodes, reranked {} to return {} results from {}"
-                              : "DiskANN resume for {}/{} visited {} nodes, reranked {} to return {} results from {}";
-        Tracing.trace(msg, limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter.Structure;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.PQVersion;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.utils.RowIdWithScore;
 import org.apache.cassandra.io.sstable.SSTableId;
 import org.apache.cassandra.io.util.FileHandle;
@@ -63,6 +64,7 @@ public class CassandraDiskAnn
 
     public static final int PQ_MAGIC = 0xB011A61C; // PQ_MAGIC, with a lot of liberties taken
     protected final PerIndexFiles indexFiles;
+    private final ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics;
     protected final SegmentMetadata.ComponentMetadataMap componentMetadatas;
 
     private final SSTableId<?> source;
@@ -85,6 +87,7 @@ public class CassandraDiskAnn
         this.source = sstableContext.sstable().getId();
         this.componentMetadatas = componentMetadatas;
         this.indexFiles = indexFiles;
+        this.columnQueryMetrics = (ColumnQueryMetrics.VectorIndexMetrics) context.getColumnQueryMetrics();
 
         similarityFunction = context.getIndexWriterConfig().getSimilarityFunction();
 
@@ -152,8 +155,16 @@ public class CassandraDiskAnn
 
         SegmentMetadata.ComponentMetadata postingListsMetadata = this.componentMetadatas.get(IndexComponentType.POSTING_LISTS);
         ordinalsMap = omFactory.create(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
+        if (ordinalsMap.getStructure() == Structure.ZERO_OR_ONE_TO_MANY)
+            logger.warn("Index {} has structure ZERO_OR_ONE_TO_MANY, which requires on reading the on disk row id" +
+                        " to ordinal mapping for each search. This will be slower.", source);
 
         searchers = ExplicitThreadLocal.withInitial(() -> new GraphSearcherAccessManager(new GraphSearcher(graph)));
+
+        // Record metrics for this graph
+        columnQueryMetrics.onGraphLoaded(compressedVectors == null ? 0 : compressedVectors.ramBytesUsed(),
+                                         ordinalsMap.cachedBytesUsed(),
+                                         graph.size(0));
     }
 
     public Structure getPostingsStructure()
@@ -231,11 +242,15 @@ public class CassandraDiskAnn
                 var rr = view.rerankerFor(queryVector, similarityFunction);
                 ssp = new SearchScoreProvider(asf, rr);
             }
+            long start = System.nanoTime();
             var result = searcher.search(ssp, limit, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));
+            long elapsed = System.nanoTime() - start;
             if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
                 context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
             Tracing.trace("DiskANN search for {}/{} visited {} nodes, reranked {} to return {} results from {}",
                           limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
+            columnQueryMetrics.onSearchResult(result, elapsed, false);
+            context.addAnnGraphSearchLatency(elapsed);
             if (threshold > 0)
             {
                 // Threshold based searches are comprehensive and do not need to resume the search.
@@ -246,7 +261,7 @@ public class CassandraDiskAnn
             }
             else
             {
-                var nodeScores = new AutoResumingNodeScoreIterator(searcher, graphAccessManager, result, nodesVisitedConsumer, limit, rerankK, false, source.toString());
+                var nodeScores = new AutoResumingNodeScoreIterator(searcher, graphAccessManager, result, context, columnQueryMetrics, nodesVisitedConsumer, limit, rerankK, false, source.toString());
                 return new NodeScoreToRowIdWithScoreIterator(nodeScores, ordinalsMap.getRowIdsView());
             }
         }
@@ -271,6 +286,9 @@ public class CassandraDiskAnn
     public void close() throws IOException
     {
         FileUtils.close(ordinalsMap, searchers, graph, graphHandle);
+        columnQueryMetrics.onGraphClosed(compressedVectors == null ? 0 : compressedVectors.ramBytesUsed(),
+                                         ordinalsMap.cachedBytesUsed(),
+                                         graph.size(0));
     }
 
     public OrdinalsView getOrdinalsView()

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -83,6 +83,7 @@ import org.apache.cassandra.index.sai.disk.v5.V5OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter.Structure;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.util.SequentialWriter;
@@ -110,6 +111,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
     // We use the metable reference for easier tracing.
     private final String source;
+    private final ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics;
     private final ConcurrentVectorValues vectorValues;
     private final GraphIndexBuilder builder;
     private final VectorType.VectorSerializer serializer;
@@ -134,6 +136,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         this.source = memtable == null
                       ? "null"
                       : memtable.getClass().getSimpleName() + '@' + Integer.toHexString(memtable.hashCode());
+        this.columnQueryMetrics = (ColumnQueryMetrics.VectorIndexMetrics) context.getColumnQueryMetrics();
         var indexConfig = context.getIndexWriterConfig();
         var termComparator = context.getValidator();
         serializer = (VectorType.VectorSerializer) termComparator.getSerializer();
@@ -327,17 +330,20 @@ public class CassandraOnHeapGraph<T> implements Accountable
         try
         {
             var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
+            long start = System.nanoTime();
             var result = searcher.search(ssf, limit, rerankK, threshold, 0.0f, bits);
+            long elapsed = System.nanoTime() - start;
             Tracing.trace("ANN search for {}/{} visited {} nodes, reranked {} to return {} results from {}",
                           limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
-            context.addAnnNodesVisited(result.getVisitedCount());
+            columnQueryMetrics.onSearchResult(result, elapsed, false);
+            context.addAnnGraphSearchLatency(elapsed);
             if (threshold > 0)
             {
                 // Threshold based searches do not support resuming the search.
                 graphAccessManager.release();
                 return CloseableIterator.wrap(Arrays.stream(result.getNodes()).iterator());
             }
-            return new AutoResumingNodeScoreIterator(searcher, graphAccessManager, result, context::addAnnNodesVisited, limit, rerankK, true, source);
+            return new AutoResumingNodeScoreIterator(searcher, graphAccessManager, result, context, columnQueryMetrics, visited -> {}, limit, rerankK, true, source);
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskOrdinalsMap.java
@@ -44,6 +44,12 @@ public interface OnDiskOrdinalsMap extends AutoCloseable
 
     V5VectorPostingsWriter.Structure getStructure();
 
+    /**
+     * Ignoring the constant overhead of the object, return the variable overhead of the object. This helps
+     * identify the cost of caching.
+     */
+    long cachedBytesUsed();
+
     class OneToOneRowIdsView implements RowIdsView {
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -56,6 +56,7 @@ import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.memory.MemoryIndex;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
@@ -83,6 +84,7 @@ public class VectorMemtableIndex implements MemtableIndex
     public static int GLOBAL_BRUTE_FORCE_ROWS = Integer.MAX_VALUE; // not final so test can inject its own setting
 
     private final IndexContext indexContext;
+    private final ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics;
     private final CassandraOnHeapGraph<PrimaryKey> graph;
     private final LongAdder writeCount = new LongAdder();
     private final LongAdder overwriteCount = new LongAdder();
@@ -97,6 +99,7 @@ public class VectorMemtableIndex implements MemtableIndex
     public VectorMemtableIndex(IndexContext indexContext, Memtable mt)
     {
         this.indexContext = indexContext;
+        this.columnQueryMetrics = (ColumnQueryMetrics.VectorIndexMetrics) indexContext.getColumnQueryMetrics();
         this.graph = new CassandraOnHeapGraph<>(indexContext, true, mt);
         this.mt = mt;
     }
@@ -271,14 +274,18 @@ public class VectorMemtableIndex implements MemtableIndex
             Tracing.trace("Search range covers {} rows; max brute force rows is {} for memtable index with {} nodes, rerankK {}, LIMIT {}",
                           resultKeys.size(), bruteForceRows, graph.size(), rerankK, limit);
             if (resultKeys.size() <= bruteForceRows)
+            {
                 // When we have a threshold, we only need to filter the results, not order them, because it means we're
                 // evaluating a boolean predicate in the SAI pipeline that wants to collate by PK
                 if (threshold > 0)
                     return filterByBruteForce(queryVector, threshold, resultKeys);
                 else
                     return orderByBruteForce(queryVector, resultKeys);
+            }
             else
+            {
                 bits = new KeyRangeFilteringBits(keyRange);
+            }
         }
 
         var nodeScoreIterator = graph.search(context, queryVector, limit, rerankK, threshold, bits);
@@ -344,6 +351,7 @@ public class VectorMemtableIndex implements MemtableIndex
      */
     private CloseableIterator<PrimaryKeyWithSortKey> filterByBruteForce(VectorFloat<?> queryVector, float threshold, NavigableSet<PrimaryKey> keys)
     {
+        columnQueryMetrics.onBruteForceNodesReranked(keys.size());
         // Keys are already ordered in ascending PK order, so just use an ArrayList to collect the results.
         var results = new ArrayList<PrimaryKeyWithSortKey>(keys.size());
         scoreKeysAndAddToCollector(queryVector, keys, threshold, results);
@@ -352,6 +360,7 @@ public class VectorMemtableIndex implements MemtableIndex
 
     private CloseableIterator<PrimaryKeyWithSortKey> orderByBruteForce(VectorFloat<?> queryVector, Collection<PrimaryKey> keys)
     {
+        columnQueryMetrics.onBruteForceNodesReranked(keys.size());
         // Use a sorting iterator because we often don't need to consume the entire iterator
         var similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
         return SortingIterator.createCloseable(Comparator.naturalOrder(),

--- a/src/java/org/apache/cassandra/index/sai/metrics/QueryEventListener.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/QueryEventListener.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.index.sai.metrics;
 
 import java.util.concurrent.TimeUnit;
 
+import io.github.jbellis.jvector.graph.SearchResult;
+
 /**
  * Listener that gets notified during storage-attached index query execution.
  */
@@ -112,5 +114,18 @@ public interface QueryEventListener
 
             }
         };
+    }
+
+    interface VectorIndexEventListener
+    {
+        void onGraphLoaded(long quantizationBytes, long ordinalsMapCachedBytes, long vectorsLoaded);
+
+        void onGraphClosed(long pqBytes, long ordinalsMapCachedBytes, long vectorsLoaded);
+
+        void onSearchResult(SearchResult result, long latencyNs, boolean isResume);
+
+        void onBruteForceNodesVisited(int visited);
+
+        void onBruteForceNodesReranked(int visited);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.index.sai.metrics;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
@@ -42,7 +41,6 @@ public class TableQueryMetrics extends AbstractMetrics
 
     private final Counter sortThenFilterQueriesCompleted;
     private final Counter filterThenSortQueriesCompleted;
-
 
     public TableQueryMetrics(TableMetadata table)
     {
@@ -108,7 +106,10 @@ public class TableQueryMetrics extends AbstractMetrics
         private final Histogram postingsSkips;
         private final Histogram postingsDecodes;
 
-        private final LongAdder annNodesVisited = new LongAdder();
+        /**
+         * Cumulative time spent searching ANN graph.
+         */
+        private final Timer annGraphSearchLatency;
 
         public PerQueryMetrics(TableMetadata table)
         {
@@ -131,6 +132,9 @@ public class TableQueryMetrics extends AbstractMetrics
             rowsFiltered = Metrics.histogram(createMetricName("RowsFiltered"), false);
 
             shadowedKeysScannedHistogram = Metrics.histogram(createMetricName("ShadowedKeysScannedHistogram"), false);
+
+            // Key vector metrics that translate to performance
+            annGraphSearchLatency = Metrics.timer(createMetricName("ANNGraphSearchLatency"));
         }
 
         private void recordStringIndexCacheMetrics(QueryContext events)
@@ -147,9 +151,9 @@ public class TableQueryMetrics extends AbstractMetrics
             kdTreePostingsDecodes.update(events.bkdPostingsDecodes());
         }
 
-        private void recordAnnIndexMetrics(QueryContext queryContext)
+        private void recordVectorIndexMetrics(QueryContext queryContext)
         {
-            annNodesVisited.add(queryContext.annNodesVisited());
+            annGraphSearchLatency.update(queryContext.annGraphSearchLatency(), TimeUnit.NANOSECONDS);
         }
 
         public void record(QueryContext queryContext)
@@ -205,8 +209,11 @@ public class TableQueryMetrics extends AbstractMetrics
                 recordStringIndexCacheMetrics(queryContext);
             if (queryContext.bkdSegmentsHit() > 0)
                 recordNumericIndexCacheMetrics(queryContext);
-            if (queryContext.annNodesVisited() > 0)
-                recordAnnIndexMetrics(queryContext);
+            // If ann brute forced the whole search, this is 0. We don't measure brute force latency. Maybe we should?
+            // At the very least, we collect brute force comparison metrics, which should give a reasonable indicator
+            // of work done.
+            if (queryContext.annGraphSearchLatency() > 0)
+                recordVectorIndexMetrics(queryContext);
 
             shadowedKeysScannedHistogram.update(queryContext.getShadowedPrimaryKeyCount());
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class VectorMetricsTest extends VectorTester
+{
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        VectorTester.setUpClass();
+    }
+
+    @Before
+    @Override
+    public void setup() throws Throwable
+    {
+        super.setup();
+        SAIUtil.setLatestVersion(version);
+    }
+
+    @Test
+    public void testBasicColumnQueryMetricsVectorIndexMetrics()
+    {
+        createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        disableCompaction();
+
+        // Get the metrics
+        var index = getCurrentColumnFamilyStore().indexManager.listIndexes().iterator().next();
+        assert index instanceof StorageAttachedIndex;
+        var saiIndex = (StorageAttachedIndex) index;
+        var vectorMetrics = (ColumnQueryMetrics.VectorIndexMetrics) saiIndex.getIndexContext().getColumnQueryMetrics();
+
+        // Expect all metrics to be 0
+        assertEquals(0, vectorMetrics.annNodesVisited.getCount());
+        assertEquals(0, vectorMetrics.annNodesReranked.getCount());
+        assertEquals(0, vectorMetrics.annNodesExpanded.getCount());
+        assertEquals(0, vectorMetrics.annNodesExpandedBaseLayer.getCount());
+        assertEquals(0, vectorMetrics.annGraphSearches.getCount());
+        assertEquals(0, vectorMetrics.annGraphResumes.getCount());
+        assertEquals(0, vectorMetrics.bruteForceNodesVisited.getCount());
+        assertEquals(0, vectorMetrics.bruteForceNodesReranked.getCount());
+        assertEquals(0, vectorMetrics.quantizationMemoryBytes.sum());
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum());
+        assertEquals(0, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals(0, vectorMetrics.onDiskGraphVectorsCount.sum());
+        assertEquals(0, vectorMetrics.annGraphSearchLatency.getCount());
+
+        // Insert 10 rows to simplify some of the assertions
+        for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
+            execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
+        flush();
+
+        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
+        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+
+        // Compaction should not impact metrics
+        compact();
+        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
+        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+
+        // Now run a pure ann query and verify we hit the ann graph
+        var result = execute("SELECT pk FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 2");
+        assertThat(result).hasSize(2);
+
+        assertTrue(vectorMetrics.annNodesVisited.getCount() > 0);
+        assertTrue(vectorMetrics.annNodesReranked.getCount() > 0);
+        assertTrue(vectorMetrics.annNodesExpanded.getCount() > 0);
+        assertTrue(vectorMetrics.annNodesExpandedBaseLayer.getCount() > 0);
+        assertEquals(1, vectorMetrics.annGraphSearches.getCount());
+        // We shouldn't need to resume when searching in this scenario
+        assertEquals(0, vectorMetrics.annGraphResumes.getCount());
+        assertEquals(1, vectorMetrics.annGraphSearchLatency.getCount());
+
+        // Now do a hybrid query that is guaranteed to use brute force. (We have to override this because
+        // the super class sets it with a random value that can lead to graph search.)
+        setMaxBruteForceRows(100);
+        result = execute("SELECT pk FROM %s WHERE pk = 0 ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 2");
+        assertThat(result).hasSize(1);
+
+        // We don't do approximate scores if there are few enough rows
+        assertEquals(0, vectorMetrics.bruteForceNodesVisited.getCount());
+        assertEquals(1, vectorMetrics.bruteForceNodesReranked.getCount());
+        assertEquals(1, vectorMetrics.annGraphSearchLatency.getCount());
+
+        // Confirm that truncating the table which will remove the index also drops the gauges
+        truncate(false);
+        assertEquals(0, vectorMetrics.quantizationMemoryBytes.sum());
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum());
+        assertEquals(0, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals(0, vectorMetrics.onDiskGraphVectorsCount.sum());
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -32,6 +32,7 @@ import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.utils.SegmentRowIdOrdinalPairs;
 
 import static org.junit.Assert.assertFalse;
@@ -53,7 +54,8 @@ public class BruteForceRowIdIteratorTest
         // Should work for an empty pq
         var view = new TestView();
         CloseableReranker reranker = new CloseableReranker(VectorSimilarityFunction.COSINE, queryVector, view);
-        var iter = new BruteForceRowIdIterator(heap, new SegmentRowIdOrdinalPairs(10), reranker, limit, topK);
+        var metrics = new ColumnQueryMetrics.VectorIndexMetrics("ks", "cf", "index");
+        var iter = new BruteForceRowIdIterator(heap, new SegmentRowIdOrdinalPairs(10), reranker, limit, topK, metrics);
         assertFalse(iter.hasNext());
         assertThrows(NoSuchElementException.class, iter::next);
         assertFalse(view.isClosed);


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/13583

### What does this PR fix and why was it fixed
This PR adds comprehensive metrics for Storage Attached Indexes (SAI) vector search operations, providing crucial insights into both ANN (Approximate Nearest Neighbor) graph searches and brute force operations.

New Vector Search Metrics:

Search Operation Counters:
- `ANNNodesVisited`: Total number of nodes visited during ANN searches (this is equivalent to approximate similarity score computations)
- `ANNNodesReranked`: Number of nodes that underwent exact distance computation for reranking (this is equivalent to exact similarity score computations)
- `ANNNodesExpanded`: Total number of nodes whose edges were explored
- `ANNNodesExpandedBaseLayer`: Number of nodes expanded in the base layer of the graph
- `ANNGraphSearches`: Count of new graph searches initiated
- `ANNGraphResumes`: Count of resumed graph searches (when a search continues from previous results)
- `ANNGraphSearchLatency`: Timer measuring individual graph search latency (Note: This measures per-graph search time, not total query time which may involve multiple graphs)

Brute Force Operation Counters:
- `BruteForceNodesVisited`: Number of nodes visited during brute force searches (approximate similarity comparisons)
- `BruteForceNodesReranked`: Number of nodes that underwent exact similarity computation during brute force searches

Memory Usage Tracking:
- `quantizationMemoryBytes`: Current memory usage by the quantization (PQ or BQ) data structures
- `ordinalsMapMemoryBytes`: Current memory usage by ordinals mapping structures (only matters in some cases)
- `onDiskGraphsCount`: Number of currently loaded graph segments
- `onDiskGraphVectorsCount`: Total number of vectors in currently loaded graphs

These metrics will help us:
1. Understand if we are performing more comparisons than expected
2. Get insight into number of graphs queried
3. Get insight into the brute force vs graph query path 
4. Understand current memory utilization

The counters provide operations/second metrics, allowing calculation of per-query averages by dividing by the number of queries. The memory tracking metrics help monitor resource usage across graph segments as they are loaded and unloaded.
