### PR TITLE
CNDB-13534: Add RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -357,6 +357,9 @@ public enum CassandraRelevantProperties
     /** Watcher used when opening sstables to discover extra components, eg. archive component */
     CUSTOM_SSTABLE_WATCHER("cassandra.custom_sstable_watcher"),
 
+    /** The current version of the SAI on-disk index format. */
+    SAI_CURRENT_VERSION("cassandra.sai.latest.version", "dc"),
+
     /** Controls the maximum top-k limit for vector search */
     SAI_VECTOR_SEARCH_MAX_TOP_K("cassandra.sai.vector_search.max_top_k", "1000"),
 

--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -26,6 +26,7 @@ import com.google.common.primitives.Ints;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.IndexNotAvailableException;
+import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -46,7 +47,8 @@ public enum RequestFailureReason
     UNKNOWN_COLUMN           (500),
     UNKNOWN_TABLE            (501),
     REMOTE_STORAGE_FAILURE   (502),
-    INDEX_BUILD_IN_PROGRESS  (503);
+    INDEX_BUILD_IN_PROGRESS  (503),
+    FEATURE_NEEDS_INDEX_REBUILD(504); // The index uses an old version that doesn't support the requested feature
 
     public static final Serializer serializer = new Serializer();
 
@@ -84,6 +86,7 @@ public enum RequestFailureReason
         exceptionToReasonMap.put(UnknownColumnException.class, UNKNOWN_COLUMN);
         exceptionToReasonMap.put(UnknownTableException.class, UNKNOWN_TABLE);
         exceptionToReasonMap.put(IndexBuildInProgressException.class, INDEX_BUILD_IN_PROGRESS);
+        exceptionToReasonMap.put(FeatureNeedsIndexRebuildException.class, FEATURE_NEEDS_INDEX_REBUILD);
 
         if (exceptionToReasonMap.size() != reasons.length-2)
             throw new RuntimeException("A new RequestFailureReasons was probably added and you may need to update the exceptionToReasonMap");

--- a/src/java/org/apache/cassandra/index/FeatureNeedsIndexRebuildException.java
+++ b/src/java/org/apache/cassandra/index/FeatureNeedsIndexRebuildException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.exceptions.UncheckedInternalRequestExecutionException;
+
+/**
+ * Thrown if a secondary index is still in an old version that doesn't support the requested feature.
+ * </p>
+ * Users hitting this exception should probably rebuild their index to a newer version.
+ */
+public final class FeatureNeedsIndexRebuildException extends UncheckedInternalRequestExecutionException
+{
+    /**
+     * Creates a new {@link FeatureNeedsIndexRebuildException} for the specified message.
+     *
+     * @param message the explanation of the error
+     */
+    public FeatureNeedsIndexRebuildException(String message)
+    {
+        super(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD, message);
+    }
+}

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -843,7 +843,7 @@ public interface Index
          * Returns the set of sstable-attached components that this group will create for a newly flushed sstable.
          *
          * Note that the result of this method is only valid for newly flushed/written sstables as the components
-         * returned will assume a version of {@link Version#latest()} and a generation of 0. SSTables for which some
+         * returned will assume a version of {@link Version#current()} and a generation of 0. SSTables for which some
          * index have been rebuild may have index components that do not match what this method return in particular.
          */
         Set<Component> componentsForNewSSTable();

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -176,7 +176,7 @@ public class IndexContext
         this.viewManager = new IndexViewManager(this);
         this.validator = TypeUtil.cellValueType(column, indexType);
         this.cfs = cfs;
-        this.primaryKeyFactory = Version.latest().onDiskFormat().newPrimaryKeyFactory(clusteringComparator);
+        this.primaryKeyFactory = Version.current().onDiskFormat().newPrimaryKeyFactory(clusteringComparator);
 
         String columnName = column.name.toString();
 
@@ -658,7 +658,7 @@ public class IndexContext
      */
     public int openPerIndexFiles()
     {
-        return viewManager.getView().size() * Version.latest().onDiskFormat().openFilesPerIndex(this);
+        return viewManager.getView().size() * Version.current().onDiskFormat().openFilesPerIndex(this);
     }
 
     public void prepareSSTablesForRebuild(Collection<SSTableReader> sstablesToRebuild)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -78,10 +77,10 @@ import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.dht.OrderPreservingPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexBuildDecider;
 import org.apache.cassandra.index.IndexRegistry;
+import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.SecondaryIndexBuilder;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.TargetParser;
@@ -91,6 +90,7 @@ import org.apache.cassandra.index.sai.analyzer.LuceneAnalyzer;
 import org.apache.cassandra.index.sai.analyzer.NonTokenizingOptions;
 import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.index.sai.view.View;
@@ -448,7 +448,17 @@ public class StorageAttachedIndex implements Index
             return CompletableFuture.completedFuture(null);
         }
 
-        // stop in-progress compaction tasks to prevent compacted sstable not being index.
+        if (indexContext.isVector() && Version.current().compareTo(Version.JVECTOR_EARLIEST) < 0)
+        {
+            throw new FeatureNeedsIndexRebuildException(String.format("The current configured on-disk format version %s does not support vector indexes. " +
+                                                                      "The minimum version that supports vectors is %s. " +
+                                                                      "The on-disk format version can be set via the -D%s system property.",
+                                                                      Version.current(),
+                                                                      Version.JVECTOR_EARLIEST,
+                                                                      CassandraRelevantProperties.SAI_CURRENT_VERSION.name()));
+        }
+
+        // stop in-progress compaction tasks to prevent compacted sstables not being indexed.
         logger.debug(indexContext.logMessage("Stopping active compactions to make sure all sstables are indexed after initial build."));
         CompactionManager.instance.interruptCompactionFor(Collections.singleton(baseCfs.metadata()),
                                                           OperationType.REWRITES_SSTABLES,

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -312,10 +312,10 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
         // The current components are "replaced" (by "other" components) if the build create different components than
         // the existing ones. This will happen in the following cases:
         // 1. if we use immutable components, that's the point of immutable components.
-        // 2. when we do not use immutable components, the rebuild components will always be for the latest version and
+        // 2. when we do not use immutable components, the rebuild components will always be for the current version and
         // for generation 0, so if the current components are not for that specific built, then we won't be rebuilding
         // the exact same components, and we're "replacing", not "overwriting" ()
-        //   a) the old components are from an older version: a new build will alawys be for `Version.latest()` and
+        //   a) the old components are from an older version: a new build will alawys be for `Version.current()` and
         //     so will create new files in that case (Note that "normally" we should not have non-0 generation in the
         //     first place if immutable components are not used, but we handle this case to better support "downgrades"
         //     where immutable components was enabled, but then disabled for some reason. If that happens, we still

--- a/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
@@ -91,9 +91,9 @@ public class StorageAttachedIndexWriter implements SSTableFlushObserver
                                       TableMetrics tableMetrics) throws IOException
     {
         // We always write at the latest version (through what that version is can be configured for specific cases)
-        var onDiskFormat = Version.latest().onDiskFormat();
+        var onDiskFormat = Version.current().onDiskFormat();
         this.indexDescriptor = indexDescriptor;
-        // Note: I think there is a silent assumption here. That is, the PK factory we use here must be for the latest
+        // Note: I think there is a silent assumption here. That is, the PK factory we use here must be for the current
         // format version, because that is what `IndexContext.keyFactory` always uses (see ctor)
         this.primaryKeyFactory = onDiskFormat.newPrimaryKeyFactory(tableMetadata.comparator);
         this.indices = indices;

--- a/src/java/org/apache/cassandra/index/sai/disk/format/ComponentsBuildId.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/ComponentsBuildId.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.index.sai.IndexContext;
 
 /**
@@ -32,7 +31,7 @@ import org.apache.cassandra.index.sai.IndexContext;
  */
 public class ComponentsBuildId implements Comparable<ComponentsBuildId>
 {
-    private static final ComponentsBuildId FOR_NEW_SSTABLE = ComponentsBuildId.latest(0);
+    private static final ComponentsBuildId FOR_NEW_SSTABLE = ComponentsBuildId.current(0);
 
     private final Version version;
     private final int generation;
@@ -48,9 +47,9 @@ public class ComponentsBuildId implements Comparable<ComponentsBuildId>
         return new ComponentsBuildId(version, generation);
     }
 
-    public static ComponentsBuildId latest(int generation)
+    public static ComponentsBuildId current(int generation)
     {
-        return of(Version.latest(), generation);
+        return of(Version.current(), generation);
     }
 
     public static ComponentsBuildId forNewSSTable()
@@ -60,7 +59,7 @@ public class ComponentsBuildId implements Comparable<ComponentsBuildId>
 
     public static ComponentsBuildId forNewBuild(@Nullable ComponentsBuildId previousBuild, Predicate<ComponentsBuildId> newBuildIsUsablePredicate)
     {
-        Version version = Version.latest();
+        Version version = Version.current();
         // If we're not using immutable components, we always use generation 0, and we're fine if that overrides existing files
         if (!version.useImmutableComponentFiles())
             return new ComponentsBuildId(version, 0);

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -75,7 +75,7 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
  * of the completion marker, but not of the other component of the group). The bumping of generations takes incomplete
  * groups into account, and so incomplete groups are not overridden either. Essentially, the generation used by a new
  * build is always one more than the highest generation of any component found on disk (for the group in question, and
- * the version we writting, usually {@link Version#latest()}).
+ * the version we writting, usually {@link Version#current()}).
  */
 public interface IndexComponents
 {

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -77,7 +77,7 @@ public class IndexDescriptor
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
-    private static final ComponentsBuildId EMPTY_GROUP_MARKER = ComponentsBuildId.latest(-1);
+    private static final ComponentsBuildId EMPTY_GROUP_MARKER = ComponentsBuildId.current(-1);
 
     // TODO Because indexes can be added at any time to existing data, the Version of a column index
     // may not match the Version of the base sstable.  OnDiskFormat + IndexFeatureSet + IndexDescriptor

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
@@ -52,9 +52,9 @@ public interface IndexFeatureSet
      * multiple sources. This will include all the SSTables included in a query and all the indexes
      * attached to those SSTables, added using {@link Accumulator#accumulate}.
      * <p>
-     * The feature set of the latest version denoted by {@link Version#latest()}
+     * The feature set of the current version denoted by {@link Version#current()}
      * is implicitly added, so the result feature set will include only the features supported by the
-     * latest version.
+     * current version.
      * <p>
      * The {@code Accumulator} creates an {@code IndexFeatureSet} this contains the features from
      * all the associated feature sets where {@code false} is the highest priority. This means if any
@@ -70,7 +70,7 @@ public interface IndexFeatureSet
 
         public Accumulator()
         {
-            accumulate(Version.latest().onDiskFormat().indexFeatureSet());
+            accumulate(Version.current().onDiskFormat().indexFeatureSet());
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -61,19 +61,22 @@ public class Version implements Comparable<Version>
     public static final Version DC = new Version("dc", V5OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "dc"));
     // histograms in index metadata
     public static final Version EB = new Version("eb", V6OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "eb"));
-    // term frequencies index component
+    // term frequencies index component (support for BM25)
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
-    // are more likely to match the latest version so we want to test that one first.
+    // are more likely to match the latest version, so we want to test that one first.
     public static final List<Version> ALL = Lists.newArrayList(EC, EB, DC, DB, CA, BA, AA);
 
     public static final Version EARLIEST = AA;
     public static final Version VECTOR_EARLIEST = BA;
-    // The latest version can be configured to be an earlier version to support partial upgrades that don't
+    public static final Version JVECTOR_EARLIEST = CA;
+    public static final Version BM25_EARLIEST = EC;
+    public static final Version LATEST = EC;
+    // The current version can be configured to be an earlier version to support partial upgrades that don't
     // write newer versions of the on-disk formats. This is volatile rather than final so that tests may
     // use reflection to change it and safely publish across threads.
-    private static volatile Version LATEST = parse(System.getProperty("cassandra.sai.latest.version", DC.version));
+    public static volatile Version CURRENT = parse(currentVersionProperty());
 
     private static final Pattern GENERATION_PATTERN = Pattern.compile("\\d+");
 
@@ -88,6 +91,11 @@ public class Version implements Comparable<Version>
         this.fileNameFormatter = fileNameFormatter;
     }
 
+    private static String currentVersionProperty()
+    {
+        return CassandraRelevantProperties.SAI_CURRENT_VERSION.getString();
+    }
+
     public static Version parse(String input)
     {
         checkArgument(input != null);
@@ -100,9 +108,9 @@ public class Version implements Comparable<Version>
         throw new IllegalArgumentException("Unrecognized SAI version string " + input);
     }
 
-    public static Version latest()
+    public static Version current()
     {
-        return LATEST;
+        return CURRENT;
     }
 
     /**
@@ -126,7 +134,7 @@ public class Version implements Comparable<Version>
     private static int getAddedLengthFromDescriptorAndVersion()
     {
         // Prefixes and suffixes constructed by Version.stargazerFileNameFormat
-        int versionNameLength = latest().toString().length();
+        int versionNameLength = current().toString().length();
         // room for up to 999 generations
         int generationLength = 3 + SAI_SEPARATOR.length();
         int addedLength = SAI_DESCRIPTOR.length()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -212,7 +212,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private boolean writeFrequencies()
     {
-        return indexContext().isAnalyzed() && Version.latest().onOrAfter(Version.EC);
+        return indexContext().isAnalyzed() && Version.current().onOrAfter(Version.BM25_EARLIEST);
     }
 
     private void flushVectorIndex(DecoratedKey minKey, DecoratedKey maxKey, long startTime, Stopwatch stopwatch) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -203,7 +203,7 @@ public abstract class SegmentBuilder
 
         private boolean writeFrequencies()
         {
-            return !(analyzer instanceof NoOpAnalyzer) && Version.latest().onOrAfter(Version.EC);
+            return !(analyzer instanceof NoOpAnalyzer) && Version.current().onOrAfter(Version.BM25_EARLIEST);
         }
 
         public boolean isEmpty()
@@ -500,8 +500,8 @@ public abstract class SegmentBuilder
         // Update term boundaries for all terms in this row
         for (ByteBuffer term : terms)
         {
-            minTerm = TypeUtil.min(term, minTerm, termComparator, Version.latest());
-            maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.latest());
+            minTerm = TypeUtil.min(term, minTerm, termComparator, Version.current());
+            maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.current());
         }
 
         // segmentRowIdOffset should encode sstableRowId into Integer

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -118,7 +118,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         Objects.requireNonNull(minTerm);
         Objects.requireNonNull(maxTerm);
 
-        this.version = Version.latest();
+        this.version = Version.current();
         this.segmentRowIdOffset = segmentRowIdOffset;
         this.minSSTableRowId = minSSTableRowId;
         this.maxSSTableRowId = maxSSTableRowId;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/TermsReader.java
@@ -371,7 +371,7 @@ public class TermsReader implements Closeable
 
     private boolean readFrequencies()
     {
-        return indexContext.isAnalyzed() && version.onOrAfter(Version.EC);
+        return indexContext.isAnalyzed() && version.onOrAfter(Version.BM25_EARLIEST);
     }
 
     private class TermsScanner implements TermsIterator

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -221,8 +221,8 @@ public class V1OnDiskFormat implements OnDiskFormat
         Version earliest = Version.EARLIEST;
         if (isVectorDataComponent(context, indexComponentType))
         {
-            if (!Version.latest().onOrAfter(Version.VECTOR_EARLIEST))
-                throw new IllegalStateException("Configured latest version " + Version.latest() + " is not compatible with vector index");
+            if (!Version.current().onOrAfter(Version.VECTOR_EARLIEST))
+                throw new IllegalStateException("Configured current version " + Version.current() + " is not compatible with vector index");
             earliest = Version.VECTOR_EARLIEST;
         }
         return earliest;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
@@ -56,7 +56,7 @@ public class InvertedIndexWriter implements Closeable
     {
         this.termsDictionaryWriter = new TrieTermsDictionaryWriter(components);
         this.postingsWriter = new PostingsWriter(components, writeFrequencies);
-        this.docLengthsWriter = Version.latest().onOrAfter(Version.EC) ? new DocLengthsWriter(components) : null;
+        this.docLengthsWriter = Version.current().onOrAfter(Version.BM25_EARLIEST) ? new DocLengthsWriter(components) : null;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskFormat.java
@@ -34,7 +34,7 @@ public class V5OnDiskFormat extends V4OnDiskFormat
 
     public static boolean writeV5VectorPostings()
     {
-        return Version.latest().onOrAfter(Version.DC);
+        return Version.current().onOrAfter(Version.DC);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
@@ -508,7 +508,7 @@ public class TermsDistribution
                 mft.put(point.term, point.rowCount);
             }
 
-            return new TermsDistribution(termType, buckets, mft, Version.latest(), byteComparableVersion);
+            return new TermsDistribution(termType, buckets, mft, Version.current(), byteComparableVersion);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -351,12 +351,12 @@ public class TrieMemoryIndex extends MemoryIndex
         var mergingIteratorBuilder = MergingKeyRangeIterator.builder(keyBounds, indexContext.keyFactory(), capacity);
         lastQueueSize.set(mergingIteratorBuilder.size());
 
-        if (!Version.latest().onOrAfter(Version.DB) && TypeUtil.isComposite(expression.validator))
+        if (!Version.current().onOrAfter(Version.DB) && TypeUtil.isComposite(expression.validator))
             subtrie.entrySet().forEach(entry -> {
                 // Before version DB, we encoded composite types using a non order-preserving function. In order to
                 // perform a range query on a map, we use the bounds to get all entries for a given map key and then
                 // only keep the map entries that satisfy the expression.
-                assert entry.getKey().encodingVersion() == TypeUtil.BYTE_COMPARABLE_VERSION || Version.latest() == Version.AA;
+                assert entry.getKey().encodingVersion() == TypeUtil.BYTE_COMPARABLE_VERSION || Version.current() == Version.AA;
                 byte[] key = ByteSourceInverse.readBytes(entry.getKey().getPreencodedBytes());
                 if (expression.isSatisfiedBy(ByteBuffer.wrap(key)))
                     mergingIteratorBuilder.add(entry.getValue());
@@ -417,7 +417,7 @@ public class TrieMemoryIndex extends MemoryIndex
             return 0;
 
         AbstractType<?> termType = indexContext.getValidator();
-        ByteBuffer endTerm = expression.upper != null && TypeUtil.compare(expression.upper.value.encoded, maxTerm, termType, Version.latest()) < 0
+        ByteBuffer endTerm = expression.upper != null && TypeUtil.compare(expression.upper.value.encoded, maxTerm, termType, Version.current()) < 0
                              ? expression.upper.value.encoded
                              : maxTerm;
 
@@ -469,7 +469,7 @@ public class TrieMemoryIndex extends MemoryIndex
      */
     private BigDecimal toBigDecimal(ByteBuffer endTerm)
     {
-        ByteComparable bc = Version.latest().onDiskFormat().encodeForTrie(endTerm, indexContext.getValidator());
+        ByteComparable bc = Version.current().onDiskFormat().encodeForTrie(endTerm, indexContext.getValidator());
         return toBigDecimal(bc);
     }
 
@@ -481,7 +481,7 @@ public class TrieMemoryIndex extends MemoryIndex
     private BigDecimal toBigDecimal(ByteComparable term)
     {
         AbstractType<?> type = indexContext.getValidator();
-        return TermsDistribution.toBigDecimal(term, type, Version.latest(), TypeUtil.BYTE_COMPARABLE_VERSION);
+        return TermsDistribution.toBigDecimal(term, type, Version.current(), TypeUtil.BYTE_COMPARABLE_VERSION);
     }
 
     private Trie<PrimaryKeys> getSubtrie(@Nullable Expression expression)
@@ -493,7 +493,7 @@ public class TrieMemoryIndex extends MemoryIndex
         boolean lowerInclusive, upperInclusive;
         if (expression.lower != null)
         {
-            lowerBound = expression.getEncodedLowerBoundByteComparable(Version.latest());
+            lowerBound = expression.getEncodedLowerBoundByteComparable(Version.current());
             lowerInclusive = expression.lower.inclusive;
         }
         else
@@ -504,7 +504,7 @@ public class TrieMemoryIndex extends MemoryIndex
 
         if (expression.upper != null)
         {
-            upperBound = expression.getEncodedUpperBoundByteComparable(Version.latest());
+            upperBound = expression.getEncodedUpperBoundByteComparable(Version.current());
             upperInclusive = expression.upper.inclusive;
         }
         else
@@ -534,13 +534,13 @@ public class TrieMemoryIndex extends MemoryIndex
         // An alternative solution could use the trie to find the min/max term, but the trie has ByteComparable
         // objects, not the ByteBuffer, and we would need to implement a custom decoder to undo the encodeForTrie
         // mapping.
-        minTerm = TypeUtil.min(term, minTerm, indexContext.getValidator(), Version.latest());
-        maxTerm = TypeUtil.max(term, maxTerm, indexContext.getValidator(), Version.latest());
+        minTerm = TypeUtil.min(term, minTerm, indexContext.getValidator(), Version.current());
+        maxTerm = TypeUtil.max(term, maxTerm, indexContext.getValidator(), Version.current());
     }
 
     private ByteComparable asByteComparable(ByteBuffer input)
     {
-        return Version.latest().onDiskFormat().encodeForTrie(input, indexContext.getValidator());
+        return Version.current().onDiskFormat().encodeForTrie(input, indexContext.getValidator());
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -32,7 +31,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Runnables;
 
@@ -162,7 +160,7 @@ public class TrieMemtableIndex implements MemtableIndex
         return Arrays.stream(rangeIndexes)
                      .map(MemoryIndex::getMinTerm)
                      .filter(Objects::nonNull)
-                     .reduce((a, b) -> TypeUtil.min(a, b, validator, Version.latest()))
+                     .reduce((a, b) -> TypeUtil.min(a, b, validator, Version.current()))
                      .orElse(null);
     }
 
@@ -179,7 +177,7 @@ public class TrieMemtableIndex implements MemtableIndex
         return Arrays.stream(rangeIndexes)
                      .map(MemoryIndex::getMaxTerm)
                      .filter(Objects::nonNull)
-                     .reduce((a, b) -> TypeUtil.max(a, b, validator, Version.latest()))
+                     .reduce((a, b) -> TypeUtil.max(a, b, validator, Version.current()))
                      .orElse(null);
     }
 
@@ -465,7 +463,7 @@ public class TrieMemtableIndex implements MemtableIndex
 
     private ByteComparable encode(ByteBuffer input)
     {
-        return Version.latest().onDiskFormat().encodeForTrie(input, indexContext.getValidator());
+        return Version.current().onDiskFormat().encodeForTrie(input, indexContext.getValidator());
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1987,11 +1987,11 @@ abstract public class Plan
 
         /** Cost to begin processing PKs into index ordinals for estimateAnnSortCost */
         // DC introduced the one-to-many ordinal mapping optimization
-        public final static double ANN_SORT_OPEN_COST = Version.latest().onOrAfter(Version.DC) ? 370 : 4200;
+        public final static double ANN_SORT_OPEN_COST = Version.current().onOrAfter(Version.DC) ? 370 : 4200;
 
         /** Additional overhead needed to process each input key fed to the ANN index searcher */
         // DC introduced the one-to-many ordinal mapping optimization
-        public final static double ANN_SORT_KEY_COST = Version.latest().onOrAfter(Version.DC) ? 0.03 : 0.2;
+        public final static double ANN_SORT_KEY_COST = Version.current().onOrAfter(Version.DC) ? 0.03 : 0.2;
 
         /** Cost to get a scored key from DiskANN (~rerank cost). Affected by cache hit rate */
         public final static double ANN_SCORED_KEY_COST = 15;

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -27,6 +27,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +96,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 {
     public static final String INDEX_MAY_HAVE_BEEN_DROPPED = "An index may have been dropped. " +
                                                              StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE;
+    public static final String INDEX_VERSION_DOES_NOT_SUPPORT_BM25 = "%s does not support BM25 scoring until it is rebuilt";
     private static final Logger logger = LoggerFactory.getLogger(QueryController.class);
 
     /**
@@ -587,6 +590,14 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     @Override
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(Expression predicate, int softLimit)
     {
+        // Only the disk format limits the features of the index, but we also fail for in memory indexes because they
+        // will fail when flushed.
+        if (orderer.isBM25() && !Version.current().onOrAfter(Version.BM25_EARLIEST))
+        {
+            throw new FeatureNeedsIndexRebuildException(String.format(INDEX_VERSION_DOES_NOT_SUPPORT_BM25,
+                                                                      orderer.context.getIndexName()));
+        }
+
         List<CloseableIterator<PrimaryKeyWithSortKey>> memtableResults = new ArrayList<>();
         try
         {

--- a/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
@@ -58,7 +58,7 @@ public class SAICodecUtils
     public static void writeHeader(DataOutput out) throws IOException
     {
         writeBEInt(out, CODEC_MAGIC);
-        out.writeString(Version.latest().toString());
+        out.writeString(Version.current().toString());
     }
 
     public static int headerSize() {

--- a/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/TypeUtil.java
@@ -648,6 +648,6 @@ public class TypeUtil
 
     public static ByteComparable.Version byteComparableVersionForTermsData()
     {
-        return Version.latest().byteComparableVersionFor(IndexComponentType.TERMS_DATA, SSTableFormat.Type.current().info.getLatestVersion());
+        return Version.current().byteComparableVersionFor(IndexComponentType.TERMS_DATA, SSTableFormat.Type.current().info.getLatestVersion());
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/BM25DistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/BM25DistributedTest.java
@@ -60,7 +60,7 @@ public class BM25DistributedTest extends TestBaseImpl
                         .start();
 
         cluster.schemaChange(withKeyspace(String.format(CREATE_KEYSPACE, RF)));
-        cluster.forEach(i -> i.runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setLatestVersion(Version.EC)));
+        cluster.forEach(i -> i.runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.BM25_EARLIEST)));
     }
 
     @AfterClass

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SAIUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SAIUtil.java
@@ -71,7 +71,7 @@ public class SAIUtil
     }
 
     /**
-     * Checks if index is known to be queryable, by pulling index state from {{@link SecondaryIndexManager}}.
+     * Checks if index is known to be queryable, by pulling index state from {@link SecondaryIndexManager}.
      * Requires gossip.
      */
     public static void assertIndexQueryable(Cluster cluster, String keyspace, String index)
@@ -80,7 +80,7 @@ public class SAIUtil
     }
 
     /**
-     * Checks if all indexes are known to be queryable, by pulling index state from local {{@link SecondaryIndexManager}}.
+     * Checks if all indexes are known to be queryable, by pulling index state from local {@link SecondaryIndexManager}.
      * Requires gossip.
      */
     private static void assertIndexesQueryable(Cluster cluster, String keyspace, final Iterable<String> indexes)
@@ -137,5 +137,20 @@ public class SAIUtil
                                     .map(IInstance::schemaVersion)
                                     .collect(Collectors.toSet());
         return versions.size() == 1;
+    }
+
+    /**
+     * Checks if an index is known to have failed its build, by pulling index state from {@link SecondaryIndexManager}.
+     * Requires gossip.
+     */
+    public static void assertIndexBuildFailed(IInvokableInstance coordinator, IInvokableInstance replica, String keyspace, String index)
+    {
+        InetAddressAndPort nodeAddress = nodeAddress(replica.broadcastAddress());
+
+        coordinator.runsOnInstance(() -> {
+            Index.Status status = SecondaryIndexManager.getIndexStatus(nodeAddress, keyspace, index);
+            assert status == Index.Status.BUILD_FAILED
+                : "Index " + index + " not failed on node " + nodeAddress + " (status = " + status + ')';
+        });
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportAATest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportAATest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#AA}.
+ */
+public class FeaturesVersionSupportAATest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.AA);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportBATest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportBATest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#BA}.
+ */
+public class FeaturesVersionSupportBATest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.BA);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportCATest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportCATest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#CA}.
+ */
+public class FeaturesVersionSupportCATest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.CA);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportDBTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportDBTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#DB}.
+ */
+public class FeaturesVersionSupportDBTest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.DB);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportDCTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportDCTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#DC}.
+ */
+public class FeaturesVersionSupportDCTest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.DC);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportEBTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportEBTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#EB}.
+ */
+public class FeaturesVersionSupportEBTest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.EB);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportECTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportECTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#EC}.
+ */
+public class FeaturesVersionSupportECTest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.EC);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.FixedValue;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.distributed.test.sai.SAIUtil;
+import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.assertj.core.api.Assertions;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+/**
+ * Tests the availabilty of features in different versions of the SAI on-disk format in a multinode, multiversion cluster.
+ * </p>
+ * This is done with a 2-node cluster where the first node has the newer version of the SAI on-disk format and the
+ * second node has the older version being tested.
+ */
+public abstract class FeaturesVersionSupportTester extends TestBaseImpl
+{
+    private static Version version;
+    private static Cluster cluster;
+
+    // To be called by inheritors in a method annotated with @BeforeClass
+    protected static void initCluster(Version version) throws IOException
+    {
+        FeaturesVersionSupportTester.version = version;
+        cluster = init(Cluster.build(2)
+                              .withInstanceInitializer((cl, n) -> BB.install(cl, n, version))
+                              .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                              .start(), 1);
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        cluster.close();
+    }
+
+    /**
+     * Test that vector indexes are supported with on-disk format versions from {@link Version#CA}.
+     * Nodes using older versions should fail their index build, although the index will still exist.
+     */
+    @Test
+    public void testANN()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.ann (k int PRIMARY KEY, v vector<float, 2>)"));
+
+        ICoordinator coordinator = cluster.coordinator(1);
+        coordinator.execute(withKeyspace("INSERT INTO %s.ann (k, v) VALUES (0, [1.0, 2.0])"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.ann (k, v) VALUES (1, [2.0, 3.0])"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.ann (k, v) VALUES (2, [3.0, 4.0])"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.ann (k, v) VALUES (3, [4.0, 5.0])"), ALL);
+        cluster.forEach(node -> node.flush(KEYSPACE));
+
+        String createIndexQuery = withKeyspace("CREATE CUSTOM INDEX ann_idx ON %s.ann(v) USING 'StorageAttachedIndex'" +
+                                               " WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        String annSelectQuery = withKeyspace("SELECT k FROM %s.ann ORDER BY v ANN OF [2.5, 3.5] LIMIT 3");
+        String geoSelectQuery = withKeyspace("SELECT k FROM %s.ann WHERE GEO_DISTANCE(v, [2.5, 3.5]) < 157000");
+
+        if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            cluster.schemaChange(createIndexQuery);
+            SAIUtil.waitForIndexQueryable(cluster, KEYSPACE, "ann_idx");
+            Assertions.assertThat(coordinator.execute(withKeyspace(annSelectQuery), ONE)).hasNumberOfRows(3);
+            Assertions.assertThat(coordinator.execute(withKeyspace(geoSelectQuery), ONE)).hasNumberOfRows(2);
+        }
+        else
+        {
+            // The on-disk format version in node 2 is too old to support indexes on vector columns.
+            cluster.setUncaughtExceptionsFilter((i, t) -> i == 2 &&
+                                                          t.getClass().getName().contains(FeatureNeedsIndexRebuildException.class.getName()) &&
+                                                          t.getMessage().contains("does not support vector indexes"));
+            cluster.schemaChange(createIndexQuery);
+            SAIUtil.assertIndexBuildFailed(cluster.get(1), cluster.get(2), KEYSPACE, "ann_idx");
+        }
+    }
+
+    /**
+     * Test that BM25 queries are supported with on-disk format versions from {@link Version#EC}.
+     * Older versions should reject BM25 queries with {@link RequestFailureReason#FEATURE_NEEDS_INDEX_REBUILD} errors.
+     */
+    @Test
+    public void testBM25()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.bm25 (k int PRIMARY KEY, v text)"));
+
+        ICoordinator coordinator = cluster.coordinator(1);
+        coordinator.execute(withKeyspace("INSERT INTO %s.bm25 (k, v) VALUES (1, 'apple')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.bm25 (k, v) VALUES (2, 'orange')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.bm25 (k, v) VALUES (3, 'banana')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.bm25 (k, v) VALUES (4, 'kiwi')"), ALL);
+        cluster.forEach(node -> node.flush(KEYSPACE));
+
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX bm25_idx ON %s.bm25(v) " +
+                                          "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                                          "WITH OPTIONS = {" +
+                                          "'index_analyzer': '{" +
+                                          "\"tokenizer\" : {\"name\" : \"standard\"}, " +
+                                          "\"filters\" : [{\"name\" : \"porterstem\"}]}'}"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE, "bm25_idx");
+
+        String query = withKeyspace("SELECT k FROM %s.bm25 ORDER BY v BM25 OF 'apple' LIMIT 3");
+
+        if (version.onOrAfter(Version.BM25_EARLIEST))
+        {
+            Assertions.assertThat(coordinator.execute(withKeyspace(query), ONE)).hasNumberOfRows(1);
+        }
+        else
+        {
+            Assertions.assertThatThrownBy(() -> coordinator.execute(query, ONE))
+                      .hasMessageContaining(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD.name());
+        }
+    }
+
+    /**
+     * Test that index-time analyzers are supported with all on-disk format versions.
+     */
+    @Test
+    public void testIndexAnalyzer()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.analyzer (k int PRIMARY KEY, v text)"));
+
+        ICoordinator coordinator = cluster.coordinator(1);
+        coordinator.execute(withKeyspace("INSERT INTO %s.analyzer (k, v) VALUES (0, 'Quick fox')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.analyzer (k, v) VALUES (1, 'Lazy dogs')"), ALL);
+        cluster.forEach(node -> node.flush(KEYSPACE));
+
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX analyzer_idx ON %s.analyzer(v)" +
+                                          " USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'" +
+                                          "WITH OPTIONS = { 'index_analyzer': 'standard' }"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE, "analyzer_idx");
+
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT * FROM %s.analyzer WHERE v = 'dogs'"), ONE))
+                  .hasNumberOfRows(1);
+    }
+
+    /**
+     * Test that query-time analyzers are supported with all on-disk format versions.
+     */
+    @Test
+    public void testQueryAnalyzer()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.q_analyzer (k int PRIMARY KEY, v text)"));
+
+        ICoordinator coordinator = cluster.coordinator(1);
+        coordinator.execute(withKeyspace("INSERT INTO %s.q_analyzer (k, v) VALUES (1, 'astra quick fox')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.q_analyzer (k, v) VALUES (2, 'astra2 quick fox')"), ALL);
+        coordinator.execute(withKeyspace("INSERT INTO %s.q_analyzer (k, v) VALUES (3, 'astra3 quick foxes')"), ALL);
+        cluster.forEach(node -> node.flush(KEYSPACE));
+
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX q_analyzer_idx ON %s.q_analyzer(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                                          "'index_analyzer': '{" +
+                                          "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                          "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
+                                          "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
+                                          "  \"charFilters\" : []}', " +
+                                          "'query_analyzer': '{" +
+                                          "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                          "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}"));
+        SAIUtil.waitForIndexQueryable(cluster, KEYSPACE, "q_analyzer_idx");
+
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT k FROM %s.q_analyzer WHERE v : 'ast'"), ONE))
+                  .hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT k FROM %s.q_analyzer WHERE v : 'astra'"), ONE))
+                  .hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT k FROM %s.q_analyzer WHERE v : 'astra2'"), ONE))
+                  .hasNumberOfRows(1);
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT k FROM %s.q_analyzer WHERE v : 'fox'"), ONE))
+                  .hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(withKeyspace("SELECT k FROM %s.q_analyzer WHERE v : 'foxes'"), ONE))
+                  .hasNumberOfRows(1);
+    }
+
+    /**
+     * Injection to set the SAI on-disk version on the first one to the most recent one, and the tested version to the second node.
+     */
+    public static class BB
+    {
+        @SuppressWarnings("resource")
+        public static void install(ClassLoader classLoader, int node, Version version)
+        {
+            new ByteBuddy().rebase(Version.class)
+                           .method(named("currentVersionProperty"))
+                           .intercept(FixedValue.value(node == 1 ? Version.LATEST.toString() : version.toString()))
+                           .make()
+                           .load(classLoader, ClassLoadingStrategy.Default.INJECTION);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
+++ b/test/unit/org/apache/cassandra/exceptions/RequestFailureReasonTest.java
@@ -36,7 +36,8 @@ public class RequestFailureReasonTest
     { 500, "UNKNOWN_COLUMN" },
     { 501, "UNKNOWN_TABLE" },
     { 502, "REMOTE_STORAGE_FAILURE" },
-    { 503, "INDEX_BUILD_IN_PROGRESS" }
+    { 503, "INDEX_BUILD_IN_PROGRESS" },
+    { 504, "FEATURE_NEEDS_INDEX_REBUILD" }
     };
     @Test
     public void testEnumCodesAndNames()

--- a/test/unit/org/apache/cassandra/index/sai/MultiVersionComposabilityTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/MultiVersionComposabilityTest.java
@@ -61,7 +61,7 @@ public class MultiVersionComposabilityTest extends SAITester
             // Flush before writing so we have a memtable to test as well.
             if (!compactFirst)
                 flush();
-            SAIUtil.setLatestVersion(version);
+            SAIUtil.setCurrentVersion(version);
             // Insert 100 random rows with mostly the same keys.
             for (int i = 0; i < 100; i++)
             {

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -139,7 +139,7 @@ public class SAITester extends CQLTester
 
     public static final ClusteringComparator EMPTY_COMPARATOR = new ClusteringComparator();
 
-    public static final PrimaryKey.Factory TEST_FACTORY = Version.latest().onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+    public static final PrimaryKey.Factory TEST_FACTORY = Version.current().onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
 
     static
@@ -585,21 +585,21 @@ public class SAITester extends CQLTester
     {
         Set<File> indexFiles = indexFiles();
 
-        for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perSSTableComponentTypes())
+        for (IndexComponentType indexComponentType : Version.current().onDiskFormat().perSSTableComponentTypes())
         {
-            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.latest().fileNameFormatter().format(indexComponentType, (String)null, 0)));
+            Set<File> tableFiles = componentFiles(indexFiles, new Component(Component.Type.CUSTOM, Version.current().fileNameFormatter().format(indexComponentType, (String)null, 0)));
             assertEquals(tableFiles.toString(), perSSTableFiles, tableFiles.size());
         }
 
         if (literalIndexContext != null)
         {
-            for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perIndexComponentTypes(literalIndexContext))
+            for (IndexComponentType indexComponentType : Version.current().onDiskFormat().perIndexComponentTypes(literalIndexContext))
             {
                 Set<File> stringIndexFiles = componentFiles(indexFiles,
                                                             new Component(Component.Type.CUSTOM,
-                                                                          Version.latest().fileNameFormatter().format(indexComponentType,
-                                                                                                                      literalIndexContext,
-                                                                                                                      0)));
+                                                                          Version.current().fileNameFormatter().format(indexComponentType,
+                                                                                                                       literalIndexContext,
+                                                                                                                       0)));
                 if (isBuildCompletionMarker(indexComponentType))
                     assertEquals(literalCompletionMarkers, stringIndexFiles.size());
                 else
@@ -609,13 +609,13 @@ public class SAITester extends CQLTester
 
         if (numericIndexContext != null)
         {
-            for (IndexComponentType indexComponentType : Version.latest().onDiskFormat().perIndexComponentTypes(numericIndexContext))
+            for (IndexComponentType indexComponentType : Version.current().onDiskFormat().perIndexComponentTypes(numericIndexContext))
             {
                 Set<File> numericIndexFiles = componentFiles(indexFiles,
                                                              new Component(Component.Type.CUSTOM,
-                                                                           Version.latest().fileNameFormatter().format(indexComponentType,
-                                                                                                                       numericIndexContext,
-                                                                                                                       0)));
+                                                                           Version.current().fileNameFormatter().format(indexComponentType,
+                                                                                                                        numericIndexContext,
+                                                                                                                        0)));
                 if (isBuildCompletionMarker(indexComponentType))
                     assertEquals(numericCompletionMarkers, numericIndexFiles.size());
                 else
@@ -873,7 +873,7 @@ public class SAITester extends CQLTester
 
     protected Set<File> componentFiles(Collection<File> indexFiles, IndexComponentType indexComponentType, IndexContext indexContext)
     {
-        String componentName = Version.latest().fileNameFormatter().format(indexComponentType, indexContext, 0);
+        String componentName = Version.current().fileNameFormatter().format(indexComponentType, indexContext, 0);
         return indexFiles.stream().filter(c -> c.name().endsWith(componentName)).collect(Collectors.toSet());
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -19,23 +19,22 @@
 package org.apache.cassandra.index.sai;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.utils.ReflectionUtils;
 
 public class SAIUtil
 {
-    public static void setLatestVersion(Version version)
+    public static void setCurrentVersion(Version version)
     {
-        Field latest = null;
+        Field current = null;
         try
         {
-            latest = Version.class.getDeclaredField("LATEST");
-            latest.setAccessible(true);
+            current = Version.class.getDeclaredField("CURRENT");
+            current.setAccessible(true);
             Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
             modifiersField.setAccessible(true);
-            latest.set(null, version);
+            current.set(null, version);
         }
         catch (Exception e)
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -55,7 +55,7 @@ public class BM25Test extends SAITester
     @Before
     public void setup() throws Throwable
     {
-        SAIUtil.setLatestVersion(Version.EC);
+        SAIUtil.setCurrentVersion(Version.BM25_EARLIEST);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.exceptions.ReadFailureException;
+import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the availabilty of features in different versions of the SAI on-disk format.
+ */
+@RunWith(Parameterized.class)
+public class FeaturesVersionSupportTest extends VectorTester
+{
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+    }
+
+    @Before
+    @Override
+    public void setup() throws Throwable
+    {
+        super.setup();
+        requireNetwork();
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    /**
+     * Test that ANN queries are supported with on-disk format versions from {@link Version#CA}.
+     * Nodes using older versions should fail their index build, although the index will still exist.
+     */
+    @Test
+    public void testANNSupport()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, x int, v vector<float, 3>)");
+
+        execute("INSERT INTO %s (k, x, v) VALUES (0, 0, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (k, x, v) VALUES (1, 0, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (k, x, v) VALUES (2, 0, [3.0, 4.0, 5.0])");
+        execute("INSERT INTO %s (k, x, v) VALUES (3, 0, [4.0, 5.0, 6.0])");
+        flush();
+
+        // create a non-vector index with the old version, so there are some per-sstable components around
+        createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+
+        // vector index creation will be rejected in older versions
+        String idx = createIndexAsync("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        waitForIndexBuilds(idx);
+        boolean isIndexQueryable = isIndexQueryable(keyspace(), idx);
+        if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            assertThat(isIndexQueryable).isTrue();
+
+            // the index is marked as queryable, so we should be able to query it
+            assertRows(execute("SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5, 4.5] LIMIT 3"), row(2), row(1), row(3));
+            assertRows(execute("SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5, 4.5] LIMIT 3 WITH ann_options = {'rerank_k':3}"), row(2), row(1), row(3));
+        }
+        else
+        {
+            assertThat(isIndexQueryable).isFalse();
+        }
+
+        // vector index creation will be accepted on newer versions, even if there is still another index in the older version
+        dropIndex("DROP INDEX %s." + idx);
+        SAIUtil.setCurrentVersion(Version.LATEST);
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+        // once the index has been created, we can query it
+        assertRows(execute("SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5, 4.5] LIMIT 3"), row(2), row(1), row(3));
+        assertRows(execute("SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5, 4.5] LIMIT 3 WITH ann_options = {'rerank_k':3}"), row(2), row(1), row(3));
+    }
+
+    /**
+     * Test that geo distance queries are supported with on-disk format versions from {@link Version#CA}.
+     * Nodes using older versions should fail their index build, although the index will still exist.
+     */
+    @Test
+    public void testGeoDistance()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, x int, v vector<float, 2>)");
+
+        // Distances computed using GeoDistanceAccuracyTest#strictHaversineDistance
+        execute("INSERT INTO %s (k, x, v) VALUES (0, 0, [1, 2])"); // distance is 555661 m from [5,5]
+        execute("INSERT INTO %s (k, x, v) VALUES (1, 0, [4, 4])"); // distance is 157010 m from [5,5]
+        execute("INSERT INTO %s (k, x, v) VALUES (2, 0, [5, 5])"); // distance is 0 m from [5,5]
+        execute("INSERT INTO %s (k, x, v) VALUES (3, 0, [6, 6])"); // distance is 156891 m from [5,5]
+        execute("INSERT INTO %s (k, x, v) VALUES (4, 0, [8, 9])"); // distance is 553647 m from [5,5]
+        execute("INSERT INTO %s (k, x, v) VALUES (5, 0, [10, 10])"); // distance is 782780 m from [5,5]
+        flush();
+
+        // create a non-vector index with the old version, so there are some per-sstable components around
+        createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+
+        // vector index creation will be rejected in older versions
+        String idx = createIndexAsync("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        waitForIndexBuilds(idx);
+        boolean isIndexQueryable = isIndexQueryable(keyspace(), idx);
+        if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            assertThat(isIndexQueryable).isTrue();
+
+            // the index is marked as queryable, so we should be able to query it
+            assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157000"), row(2), row(3));
+            assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157011"), row(1), row(2), row(3));
+        }
+        else
+        {
+            assertThat(isIndexQueryable).isFalse();
+        }
+
+        // vector index creation will be accepted on newer versions, even if there is still an index in the older version
+        dropIndex("DROP INDEX %s." + idx);
+        SAIUtil.setCurrentVersion(Version.LATEST);
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+        // once the index has been created, we can query it
+        assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157000"), row(2), row(3));
+        assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157011"), row(1), row(2), row(3));
+    }
+
+    /**
+     * Test that BM25 queries are supported with on-disk format versions from {@link Version#EC}.
+     * Older versions should reject BM25 queries with {@link RequestFailureReason#FEATURE_NEEDS_INDEX_REBUILD} errors.
+     */
+    @Test
+    public void testBM25() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) " +
+                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = {" +
+                    "'index_analyzer': '{" +
+                    "\"tokenizer\" : {\"name\" : \"standard\"}, " +
+                    "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
+        String query = "SELECT k FROM %s WHERE v : 'apple' ORDER BY v BM25 OF 'apple' LIMIT 3";
+        beforeAndAfterFlush(() -> {
+            if (version.onOrAfter(Version.BM25_EARLIEST))
+            {
+                assertRows(execute(query), row(1));
+            }
+            else
+            {
+                Assertions.assertThatThrownBy(() -> execute(query))
+                          .isInstanceOf(ReadFailureException.class)
+                          .hasMessageContaining(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD.name());
+            }
+        });
+    }
+
+    /**
+     * Test that index-time analyzers are supported with all on-disk format versions.
+     */
+    @Test
+    public void testIndexAnalyzer()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+        execute("INSERT INTO %s (k, v) VALUES (0, 'Quick fox')");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'Lazy dogs')");
+        flush();
+
+        UntypedResultSet result = execute("SELECT * FROM %s WHERE v = 'dogs'");
+        assertThat(result).hasSize(1);
+    }
+
+    /**
+     * Test that query-time analyzers are supported with all on-disk format versions.
+     */
+    @Test
+    public void testQueryAnalyzer()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': '{" +
+                    "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                    "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
+                    "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
+                    "  \"charFilters\" : []}', " +
+                    "'query_analyzer': '{" +
+                    "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                    "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}");
+
+        execute("INSERT INTO %s (k, v) VALUES (1, 'astra quick fox')");
+        execute("INSERT INTO %s (k, v) VALUES (2, 'astra2 quick fox')");
+        execute("INSERT INTO %s (k, v) VALUES (3, 'astra3 quick foxes')");
+        flush();
+
+        assertRows(execute("SELECT k FROM %s WHERE v : 'ast'"), row(1), row(2), row(3));
+        assertRows(execute("SELECT k FROM %s WHERE v : 'astra'"), row(1), row(2), row(3));
+        assertRows(execute("SELECT k FROM %s WHERE v : 'astra2'"), row(2));
+        assertRows(execute("SELECT k FROM %s WHERE v : 'fox'"), row(1), row(2), row(3));
+        assertRows(execute("SELECT k FROM %s WHERE v : 'foxes'"), row(3));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -23,7 +23,6 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.FileSystemException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -992,13 +991,13 @@ public class NativeIndexDDLTest extends SAITester
         IndexContext numericIndexContext = getIndexContext(numericIndexName);
         IndexContext stringIndexContext = getIndexContext(stringIndexName);
 
-        for (IndexComponentType component : Version.latest().onDiskFormat().perSSTableComponentTypes())
+        for (IndexComponentType component : Version.current().onDiskFormat().perSSTableComponentTypes())
             verifyRebuildIndexComponent(numericIndexContext, stringIndexContext, component, null, corruptionType, true, true, rebuild);
 
-        for (IndexComponentType component : Version.latest().onDiskFormat().perIndexComponentTypes(numericIndexContext))
+        for (IndexComponentType component : Version.current().onDiskFormat().perIndexComponentTypes(numericIndexContext))
             verifyRebuildIndexComponent(numericIndexContext, stringIndexContext, component, numericIndexContext, corruptionType, false, true, rebuild);
 
-        for (IndexComponentType component : Version.latest().onDiskFormat().perIndexComponentTypes(stringIndexContext))
+        for (IndexComponentType component : Version.current().onDiskFormat().perIndexComponentTypes(stringIndexContext))
             verifyRebuildIndexComponent(numericIndexContext, stringIndexContext, component, stringIndexContext, corruptionType, true, false, rebuild);
     }
 
@@ -1104,10 +1103,10 @@ public class NativeIndexDDLTest extends SAITester
     @Test
     public void verifyCanRebuildAndReloadInPlaceToNewerVersion()
     {
-        Version current = Version.latest();
+        Version current = Version.current();
         try
         {
-            SAIUtil.setLatestVersion(Version.AA);
+            SAIUtil.setCurrentVersion(Version.AA);
 
             // prepare schema and data
             createTable(CREATE_TABLE_TEMPLATE);
@@ -1129,7 +1128,7 @@ public class NativeIndexDDLTest extends SAITester
 
             verifySAIVersionInUse(Version.AA, numericIndexContext, stringIndexContext);
 
-            SAIUtil.setLatestVersion(current);
+            SAIUtil.setCurrentVersion(current);
 
             rebuildIndexes(numericIndexName, stringIndexName);
             reloadSSTableIndexInPlace();
@@ -1145,7 +1144,7 @@ public class NativeIndexDDLTest extends SAITester
         finally
         {
             // If we haven't failed, we should already have done this, but if we did fail ...
-            SAIUtil.setLatestVersion(current);
+            SAIUtil.setCurrentVersion(current);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 public class NonNumericTermsDistributionTest extends SAITester
 {
     static {
-        SAIUtil.setLatestVersion(Version.latest().onOrAfter(Version.EB) ? Version.latest() : Version.EB);
+        SAIUtil.setCurrentVersion(Version.current().onOrAfter(Version.EB) ? Version.current() : Version.EB);
     }
 
     private StorageAttachedIndex getIndex()

--- a/test/unit/org/apache/cassandra/index/sai/cql/NotOnTruncatedKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NotOnTruncatedKeyTest.java
@@ -40,19 +40,19 @@ public class NotOnTruncatedKeyTest extends SAITester
     @Parameterized.Parameter(1)
     public String truncatedType;
 
-    private Version latest;
+    private Version current;
 
     @Before
     public void setup() throws Throwable
     {
-        latest = Version.latest();
-        SAIUtil.setLatestVersion(version);
+        current = Version.current();
+        SAIUtil.setCurrentVersion(version);
     }
 
     @After
     public void teardown() throws Throwable
     {
-        SAIUtil.setLatestVersion(latest);
+        SAIUtil.setCurrentVersion(current);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 public class NumericTermsDistributionTest extends SAITester
 {
     static {
-        SAIUtil.setLatestVersion(Version.latest().onOrAfter(Version.EB) ? Version.latest() : Version.EB);
+        SAIUtil.setCurrentVersion(Version.current().onOrAfter(Version.EB) ? Version.current() : Version.EB);
     }
 
     @Parameterized.Parameter

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -61,7 +61,7 @@ public class VectorMetricsTest extends VectorTester
     public void setup() throws Throwable
     {
         super.setup();
-        SAIUtil.setLatestVersion(version);
+        SAIUtil.setCurrentVersion(version);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -194,7 +194,7 @@ public class VectorTester extends SAITester
         public void setup() throws Throwable
         {
             super.setup();
-            SAIUtil.setLatestVersion(version);
+            SAIUtil.setCurrentVersion(version);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -91,7 +91,7 @@ public class VectorTypeTest extends VectorTester
     public void setup() throws Throwable
     {
         super.setup();
-        SAIUtil.setLatestVersion(version);
+        SAIUtil.setCurrentVersion(version);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
@@ -54,13 +54,13 @@ abstract class SingleNodeQueryTester extends SAITester
 
     protected DataModel.Executor executor;
 
-    private Version latest;
+    private Version current;
 
     @Before
     public void setup() throws Throwable
     {
-        latest = Version.latest();
-        SAIUtil.setLatestVersion(version);
+        current = Version.current();
+        SAIUtil.setCurrentVersion(version);
         requireNetwork();
 
         schemaChange(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", DataModel.KEYSPACE));
@@ -73,7 +73,7 @@ abstract class SingleNodeQueryTester extends SAITester
     @After
     public void teardown() throws Throwable
     {
-        SAIUtil.setLatestVersion(latest);
+        SAIUtil.setCurrentVersion(current);
     }
 
     @Parameterized.Parameters(name = "{0}_{1}")

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/IndexingTypeSupport.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/IndexingTypeSupport.java
@@ -36,7 +36,7 @@ public abstract class IndexingTypeSupport extends SAITester
     protected final DataSet<?> dataset;
 
     private final Version version;
-    private Version latest;
+    private Version current;
     private final boolean widePartitions;
     private final Scenario scenario;
     private Object[][] allRows;
@@ -81,8 +81,8 @@ public abstract class IndexingTypeSupport extends SAITester
     @Before
     public void setup()
     {
-        latest = Version.latest();
-        SAIUtil.setLatestVersion(version);
+        current = Version.current();
+        SAIUtil.setCurrentVersion(version);
 
         dataset.init();
 
@@ -96,7 +96,7 @@ public abstract class IndexingTypeSupport extends SAITester
     @After
     public void teardown()
     {
-        SAIUtil.setLatestVersion(latest);
+        SAIUtil.setCurrentVersion(current);
     }
 
     protected void runIndexQueryScenarios() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/types/QuerySet.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/types/QuerySet.java
@@ -46,7 +46,7 @@ public abstract class QuerySet extends CQLTester
 
     protected static boolean isOrderBySupported()
     {
-        return Version.latest().onOrAfter(Version.BA);
+        return Version.current().onOrAfter(Version.BA);
     }
 
     public static class NumericQuerySet extends QuerySet

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -368,8 +368,8 @@ public class NodeStartupTest extends SAITester
             case VALID:
                 break;
             case ALL_EMPTY:
-                Version.latest().onDiskFormat().perSSTableComponentTypes().forEach(this::remove);
-                Version.latest().onDiskFormat().perIndexComponentTypes(indexContext).forEach(c -> remove(c, indexContext));
+                Version.current().onDiskFormat().perSSTableComponentTypes().forEach(this::remove);
+                Version.current().onDiskFormat().perIndexComponentTypes(indexContext).forEach(c -> remove(c, indexContext));
                 break;
             case PER_SSTABLE_INCOMPLETE:
                 remove(IndexComponentType.GROUP_COMPLETION_MARKER);

--- a/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
@@ -75,14 +75,14 @@ public class SingleNodeQueryFailureTest extends SAITester
     @Test
     public void testFailedKeyFetcherOnMultiIndexesQuery() throws Throwable
     {
-        assumeTrue(Version.latest() == Version.AA);
+        assumeTrue(Version.current() == Version.AA);
         testFailedMultiIndexesQuery("key_fetcher", KeyFetcher.class, "apply");
     }
 
     @Test
     public void testFailedKeyReaderOnMultiIndexesQuery() throws Throwable
     {
-        assumeTrue(Version.latest() == Version.AA);
+        assumeTrue(Version.current() == Version.AA);
         testFailedMultiIndexesQuery("key_reader", KeyFetcher.class, "createReader");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
@@ -43,7 +43,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.PathUtils;
 import org.mockito.Mockito;
 
-import static org.apache.cassandra.index.sai.SAIUtil.setLatestVersion;
+import static org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -59,7 +59,7 @@ public class IndexDescriptorTest
 {
     private TemporaryFolder temporaryFolder = new TemporaryFolder();
     private Descriptor descriptor;
-    private Version latest;
+    private Version current;
 
     @BeforeClass
     public static void initialise()
@@ -72,13 +72,13 @@ public class IndexDescriptorTest
     {
         temporaryFolder.create();
         descriptor = Descriptor.fromFilename(temporaryFolder.newFolder().getAbsolutePath() + "/ca-1-bti-Data.db");
-        latest = Version.latest();
+        current = Version.current();
     }
 
     @After
     public void teardown() throws Throwable
     {
-        setLatestVersion(latest);
+        setCurrentVersion(current);
         temporaryFolder.delete();
     }
 
@@ -99,7 +99,7 @@ public class IndexDescriptorTest
     @Test
     public void versionAAPerSSTableComponentIsParsedCorrectly() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         // As mentioned in the class javadoc, we rely on the no-TOC fallback path and that only kick in if there is a
         // data file. Otherwise, it assumes the SSTable simply does not exist at all.
@@ -115,7 +115,7 @@ public class IndexDescriptorTest
     @Test
     public void versionAAPerIndexComponentIsParsedCorrectly() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
@@ -132,7 +132,7 @@ public class IndexDescriptorTest
     @Test
     public void versionBAPerSSTableComponentIsParsedCorrectly() throws Throwable
     {
-        setLatestVersion(Version.BA);
+        setCurrentVersion(Version.BA);
 
         createFakeDataFile(descriptor);
         createFakePerSSTableComponents(descriptor, Version.BA, 0);
@@ -146,7 +146,7 @@ public class IndexDescriptorTest
     @Test
     public void versionBAPerIndexComponentIsParsedCorrectly() throws Throwable
     {
-        setLatestVersion(Version.BA);
+        setCurrentVersion(Version.BA);
 
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
@@ -162,7 +162,7 @@ public class IndexDescriptorTest
     @Test
     public void allVersionAAPerSSTableComponentsAreLoaded() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         createFakeDataFile(descriptor);
         createFakePerSSTableComponents(descriptor, Version.AA, 0);
@@ -178,7 +178,7 @@ public class IndexDescriptorTest
     @Test
     public void allVersionAAPerIndexLiteralComponentsAreLoaded() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         IndexContext indexContext = SAITester.createIndexContext("test_index", UTF8Type.instance);
 
@@ -198,7 +198,7 @@ public class IndexDescriptorTest
     @Test
     public void allVersionAAPerIndexNumericComponentsAreLoaded() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         IndexContext indexContext = SAITester.createIndexContext("test_index", Int32Type.instance);
 
@@ -219,7 +219,7 @@ public class IndexDescriptorTest
     @Test
     public void componentsAreLoadedAfterUpgradeDespiteBrokenTOC() throws Throwable
     {
-        setLatestVersion(Version.AA);
+        setCurrentVersion(Version.AA);
 
         // Force old version of sstables to simulate upgrading from DSE
         Descriptor descriptor = Descriptor.fromFilename(temporaryFolder.newFolder().getAbsolutePath() + "/bb-2-bti-Data.db");
@@ -244,7 +244,7 @@ public class IndexDescriptorTest
     @Test
     public void testReload() throws Throwable
     {
-        setLatestVersion(latest);
+        setCurrentVersion(current);
 
         // We create the descriptor first, with no files, so it should initially be empty.
         IndexContext indexContext = SAITester.createIndexContext("test_index", Int32Type.instance);
@@ -255,8 +255,8 @@ public class IndexDescriptorTest
 
         // We then create the proper files and call reload
         createFakeDataFile(descriptor);
-        createFakePerSSTableComponents(descriptor, latest, 0);
-        createFakePerIndexComponents(descriptor, indexContext, latest, 0);
+        createFakePerSSTableComponents(descriptor, current, 0);
+        createFakePerIndexComponents(descriptor, indexContext, current, 0);
 
         SSTableReader sstable = Mockito.mock(SSTableReader.class);
         Mockito.when(sstable.getDescriptor()).thenReturn(descriptor);

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/SSTableIndexComponentsStateTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/SSTableIndexComponentsStateTest.java
@@ -344,8 +344,8 @@ public class SSTableIndexComponentsStateTest
             IndexContext idx2 = SAITester.createIndexContext("test_index2", UTF8Type.instance);
 
             createFakeDataFile(descriptor);
-            createFakePerSSTableComponents(descriptor, Version.latest(), 0, 1 * 1024 * 1024); // 1mb per file
-            createFakePerIndexComponents(descriptor, idx1, Version.latest(), 1, 2 * 1024 * 1024); // 2mb per file
+            createFakePerSSTableComponents(descriptor, Version.current(), 0, 1 * 1024 * 1024); // 1mb per file
+            createFakePerIndexComponents(descriptor, idx1, Version.current(), 1, 2 * 1024 * 1024); // 2mb per file
             createFakePerIndexComponents(descriptor, idx2, Version.DB, 0, 3 * 1024 * 1024); // 3mb per file
 
             SSTableReader sstable = Mockito.mock(SSTableReader.class);
@@ -363,11 +363,11 @@ public class SSTableIndexComponentsStateTest
 
             assertEquals(Set.of(idx1.getIndexName(), idx2.getIndexName()), state.includedIndexes());
 
-            assertEquals(Version.latest(), state.perSSTable().buildId.version());
+            assertEquals(Version.current(), state.perSSTable().buildId.version());
             assertEquals(0, state.perSSTable().buildId.generation());
             assertEquals(6, state.perSSTable().sizeInMB);
 
-            assertEquals(Version.latest(), state.perIndex(idx1.getIndexName()).buildId.version());
+            assertEquals(Version.current(), state.perIndex(idx1.getIndexName()).buildId.version());
             assertEquals(1, state.perIndex(idx1.getIndexName()).buildId.generation());
             assertEquals(8, state.perIndex(idx1.getIndexName()).sizeInMB);
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -108,7 +108,7 @@ public class SegmentFlushTest
     @Before
     public void setVersion()
     {
-        SAIUtil.setLatestVersion(version);
+        SAIUtil.setCurrentVersion(version);
     }
 
     @After

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -190,7 +190,7 @@ public class KDTreeIndexBuilder
             when(sstableContext.primaryKeyMapFactory()).thenReturn(KDTreeIndexBuilder.TEST_PRIMARY_KEY_MAP_FACTORY);
             when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
 
-            IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
+            IndexSearcher searcher = Version.current().onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
             assertThat(searcher).isInstanceOf(KDTreeIndexSearcher.class);
             return (KDTreeIndexSearcher) searcher;
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMapTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMapTest.java
@@ -64,7 +64,7 @@ public class V5OnDiskOrdinalsMapTest extends VectorTester
     {
         super.setup();
         // this can be removed once LATEST is >= DC
-        SAIUtil.setLatestVersion(Version.DC);
+        SAIUtil.setCurrentVersion(Version.DC);
     }
 
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -52,7 +52,7 @@ public class GroupComponentsTest extends SAITester
         SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
 
         Set<Component> components = group.activeComponents(sstable);
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
+        assertEquals(Version.current().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
 
         // index files are released but not removed
         cfs.invalidate(true, false);
@@ -77,7 +77,7 @@ public class GroupComponentsTest extends SAITester
 
         Set<Component> components = group.activeComponents(sstables.iterator().next());
 
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
+        assertEquals(Version.current().onDiskFormat().perSSTableComponentTypes().size() + 1, components.size());
     }
 
     @Test
@@ -96,8 +96,8 @@ public class GroupComponentsTest extends SAITester
 
         Set<Component> components = group.activeComponents(sstables.iterator().next());
 
-        assertEquals(Version.latest().onDiskFormat().perSSTableComponentTypes().size() +
-                     Version.latest().onDiskFormat().perIndexComponentTypes(indexContext).size(),
+        assertEquals(Version.current().onDiskFormat().perSSTableComponentTypes().size() +
+                     Version.current().onDiskFormat().perIndexComponentTypes(indexContext).size(),
                      components.size());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexGroupMetricsTest.java
@@ -66,8 +66,8 @@ public class IndexGroupMetricsTest extends AbstractMetricsTest
 
         // with 10 sstable
         int indexopenFileCountWithOnlyNumeric = getOpenIndexFiles();
-        assertEquals(sstables * (Version.latest().onDiskFormat().openFilesPerSSTable() +
-                                 Version.latest().onDiskFormat().openFilesPerIndex(v1IndexContext)),
+        assertEquals(sstables * (Version.current().onDiskFormat().openFilesPerSSTable() +
+                                 Version.current().onDiskFormat().openFilesPerIndex(v1IndexContext)),
                      indexopenFileCountWithOnlyNumeric);
 
         long diskUsageWithOnlyNumeric = getDiskUsage();
@@ -89,15 +89,15 @@ public class IndexGroupMetricsTest extends AbstractMetricsTest
         compact();
 
         long perSSTableFileDiskUsage = getDiskUsage();
-        assertEquals(Version.latest().onDiskFormat().openFilesPerSSTable() +
-                     Version.latest().onDiskFormat().openFilesPerIndex(v2IndexContext) +
-                     Version.latest().onDiskFormat().openFilesPerIndex(v1IndexContext),
+        assertEquals(Version.current().onDiskFormat().openFilesPerSSTable() +
+                     Version.current().onDiskFormat().openFilesPerIndex(v2IndexContext) +
+                     Version.current().onDiskFormat().openFilesPerIndex(v1IndexContext),
                      getOpenIndexFiles());
 
         // drop string index, reduce open string index files, per-sstable file disk usage remains the same
         dropIndex("DROP INDEX %s." + v2IndexName);
-        assertEquals(Version.latest().onDiskFormat().openFilesPerSSTable() +
-                     Version.latest().onDiskFormat().openFilesPerIndex(v1IndexContext),
+        assertEquals(Version.current().onDiskFormat().openFilesPerSSTable() +
+                     Version.current().onDiskFormat().openFilesPerIndex(v1IndexContext),
                      getOpenIndexFiles());
         assertEquals(perSSTableFileDiskUsage, getDiskUsage());
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -352,7 +352,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
         assertEquals(3, actualRows);
 
         //TODO This needs revisiting with STAR-903 because we are now reading rows one at a time
-        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), Version.latest() == Version.AA ? 2 : 3);
+        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), Version.current() == Version.AA ? 2 : 3);
         waitForVerifyHistogram(objectNameNoIndex("RowsFiltered", keyspace, table, PER_QUERY_METRIC_TYPE), 1);
         waitForEquals(objectNameNoIndex("TotalRowsFiltered", keyspace, table, TABLE_QUERY_METRIC_TYPE), 3);
     }

--- a/test/unit/org/apache/cassandra/index/sai/metrics/SegmentFlushingFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/SegmentFlushingFailureTest.java
@@ -141,9 +141,9 @@ public abstract class SegmentFlushingFailureTest extends SAITester
     @Test
     public void shouldZeroMemoryTrackerOnOffsetsRuntimeFailure() throws Throwable
     {
-        shouldZeroMemoryTrackerOnFailure(Version.latest() == Version.AA ? v1sstableComponentsWriterFailure : v2sstableComponentsWriterFailure, "v1");
+        shouldZeroMemoryTrackerOnFailure(Version.current() == Version.AA ? v1sstableComponentsWriterFailure : v2sstableComponentsWriterFailure, "v1");
         resetCounters();
-        shouldZeroMemoryTrackerOnFailure(Version.latest() == Version.AA ? v1sstableComponentsWriterFailure : v2sstableComponentsWriterFailure, "v2");
+        shouldZeroMemoryTrackerOnFailure(Version.current() == Version.AA ? v1sstableComponentsWriterFailure : v2sstableComponentsWriterFailure, "v2");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -106,7 +106,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
     {
         for (Version version : versions)
         {
-            SAIUtil.setLatestVersion(version);
+            SAIUtil.setCurrentVersion(version);
             for (CQL3Type.Native type : types)
             {
                 createTable("CREATE TABLE %s (pk text PRIMARY KEY, age " + type + ')');


### PR DESCRIPTION
The new request failure reason should be used when the on-disk format of an index in a replica doesn't support a requested feature.