### PR TITLE
CNDB-13582: Ignore TOC when discovering SAI components of sstables fr…

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -951,7 +951,7 @@ public class IndexContext
 
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
                 long count = context.primaryKeyMapFactory().count();
-                logger.debug(logMessage("Successfully created index for SSTable {} with {} rows."), context.descriptor(), count);
+                logger.debug(logMessage("Successfully loaded index for SSTable {} with {} rows."), context.descriptor(), count);
 
                 // Try to add new index to the set, if set already has such index, we'll simply release and move on.
                 // This covers situation when SSTable collection has the same SSTable multiple

--- a/src/java/org/apache/cassandra/index/sai/disk/format/DefaultIndexComponentDiscovery.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/DefaultIndexComponentDiscovery.java
@@ -25,11 +25,16 @@ import org.apache.cassandra.schema.TableMetadata;
 public class DefaultIndexComponentDiscovery extends IndexComponentDiscovery
 {
     @Override
-    public SSTableIndexComponentsState discoverComponents(SSTableReader sstable)
-    {
-        SSTableIndexComponentsState groups = tryDiscoverComponentsFromTOC(sstable.getDescriptor());
+    public SSTableIndexComponentsState discoverComponents(SSTableReader sstable) {
+        Descriptor descriptor = sstable.getDescriptor();
+
+        // Older versions might not have all components in the TOC, we should not trust it (fix for CNDB-13582):
+        if (descriptor.version.getVersion().compareTo("ca") < 0)
+           return discoverComponentsFromDiskFallback(descriptor);
+
+        SSTableIndexComponentsState groups = tryDiscoverComponentsFromTOC(descriptor);
         return groups == null
-               ? discoverComponentsFromDiskFallback(sstable.getDescriptor())
+               ? discoverComponentsFromDiskFallback(descriptor)
                : groups;
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
@@ -217,6 +217,32 @@ public class IndexDescriptorTest
         assertTrue(components.has(IndexComponentType.KD_TREE_POSTING_LISTS));
     }
 
+    // CNDB-13582
+    @Test
+    public void componentsAreLoadedAfterUpgradeDespiteBrokenTOC() throws Throwable
+    {
+        setLatestVersion(Version.AA);
+
+        // Force old version of sstables to simulate upgrading from DSE
+        Descriptor descriptor = Descriptor.fromFilename(temporaryFolder.newFolder().getAbsolutePath() + "/bb-2-bti-Data.db");
+
+        IndexContext indexContext = SAITester.createIndexContext("test_index", Int32Type.instance);
+
+        createFakeDataFile(descriptor);
+        createFakeTOCFile(descriptor);
+        createFakePerSSTableComponents(descriptor, Version.AA, 0);
+        createFakePerIndexComponents(descriptor, indexContext, Version.AA, 0);
+
+        IndexDescriptor indexDescriptor = loadDescriptor(descriptor, indexContext);
+
+        IndexComponents.ForRead components = indexDescriptor.perIndexComponents(indexContext);
+        assertTrue(components.has(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(components.has(IndexComponentType.META));
+        assertTrue(components.has(IndexComponentType.KD_TREE));
+        assertTrue(components.has(IndexComponentType.KD_TREE_POSTING_LISTS));
+    }
+
+
     @Test
     public void testReload() throws Throwable
     {
@@ -257,6 +283,11 @@ public class IndexDescriptorTest
     static void createFakeDataFile(Descriptor descriptor) throws IOException
     {
         createFileOnDisk(descriptor, Component.DATA.name());
+    }
+
+    static void createFakeTOCFile(Descriptor descriptor) throws IOException
+    {
+        createFileOnDisk(descriptor, Component.TOC.name());
     }
 
     static void createFakePerSSTableComponents(Descriptor descriptor, Version version, int generation) throws IOException


### PR DESCRIPTION
…om DSE

### What is the issue
After upgrading Astra from DSE to CC, some SAI components cannot be found and SAI becomes non-queryable.
DSE can load components fine.

### What does this PR fix and why was it fixed
TOC component on old sstable was found to be missing some components, even though the components were present on-disk. This fix forces discovery of components of old sstables directly from disk instead of trusting the TOC.
