### PR TITLE
CNDB-13695 Set operationContextTracker in ExecutorLocals.set along with other locals.

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/ExecutorLocals.java
+++ b/src/java/org/apache/cassandra/concurrent/ExecutorLocals.java
@@ -106,8 +106,10 @@ public class ExecutorLocals
         TraceState traceState = locals == null ? null : locals.traceState;
         ClientWarn.State clientWarnState = locals == null ? null : locals.clientWarnState;
         RequestSensors sensors = locals == null ? null : locals.sensors;
+        OperationContext operationContext = locals == null ? null : locals.operationContext;
         tracing.set(traceState);
         clientWarn.set(clientWarnState);
         requestTracker.set(sensors);
+        operationContextTracker.set(operationContext);
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes CNDB-13695, the `ExecutorLocals.set` method should set `operationContextTracker`. The intent of this `set` method is to set the current locals using the passed `ExecutorLocals` argument, and `operationContextTracker` was not included.

### What does this PR fix and why was it fixed
Updates `ExecutorLocals.set` to set `operationContextTracker` along with the other locals.

