### PR TITLE
CNDB 13650: fix SSTableCorruptionDetectionTest.testSSTableScanner

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/SSTableCorruptionDetectionTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableCorruptionDetectionTest.java
@@ -189,7 +189,7 @@ public class SSTableCorruptionDetectionTest extends SSTableWriterTestBase
             finally
             {
                 if (ChunkCache.instance != null)
-                    ChunkCache.instance.invalidateFile(ssTableReader.getDataFile());
+                    ChunkCache.instance.invalidateFileNow(ssTableReader.getDataFile());
 
                 restore(fc, corruptionPosition, backup);
             }


### PR DESCRIPTION
### What is the issue
ChunkCache needs to invalidate the test file with invalidateFileNow