### PR TITLE
CNDB-13696 fix empty iterator access in BM25 search on partial SSTable

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -168,6 +168,9 @@ public class InvertedIndexSearcher extends IndexSearcher
         var slices = Slices.with(indexContext.comparator(), Slice.make(primaryKey.clustering()));
         try (var rowIterator = sstable.iterator(dk, slices, columnFilter, false, SSTableReadsListener.NOOP_LISTENER))
         {
+            // primaryKey might not belong to this sstable, thus the iterator will be empty
+            if (rowIterator.isEmpty())
+                return null;
             var unfiltered = rowIterator.next();
             assert unfiltered.isRow() : unfiltered;
             Row row = (Row) unfiltered;

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -760,21 +760,24 @@ public class BM25Test extends SAITester
         flush();
         insertPrimitiveData(10, 20);
 
-        // One memtable, one sstable - different from the reference in testCollections
-        // ID 1 and 6 contains 3 and 2 climate occurences, while 11 and 19 contains 4 climate occurances
+        // One memtable, one sstable - different result from the reference in testCollections
+        // ID 1 and 6 contain 3 and 2 climate occurrences correspondingly,
+        // while ID 11 and 19 - 4 climate occurrences. However,
+        // since the segment with 0-9 IDs have only 2 rows with climate and 10-19 - 5,
+        // 1 and 6 win over 11 and 19.
         executeQuery(Arrays.asList(1, 6, 11, 19, 16, 12, 18), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
         executeQuery(Arrays.asList(1, 11, 19), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
-        // Flush into Two sstables - same as different
+        // Flush into Two sstables - same result as the different above
         flush();
         executeQuery(Arrays.asList(1, 6, 11, 19, 16, 12, 18), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
         executeQuery(Arrays.asList(1, 11, 19), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
-        // Compact into One sstable - same as reference from testCollections
+        // Compact into one sstable - same as reference from testCollections
         compact();
         executeQuery(Arrays.asList(11, 19, 1, 16, 6, 12, 18), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");


### PR DESCRIPTION
### What is the issue
Executing a query with BM25 search and a condition on partial SSTable results in empty iterator access error. And there was no test with storing data in segments.

### What does this PR fix and why was it fixed
The PR implements BM25 search tests with splitting data into two tables. This reproduced this bug, CNDB-13696, and demonstrates current confusion on the BM25 ordering result to be fixed by CNDB-13553.

This PR adds a check for empty iterator created for a PK belonging to another segment. This fixes the bug of trying to get the first element of an empty iterator.

Fixes https://github.com/riptano/cndb/issues/13696, fixes https://github.com/riptano/cndb/issues/13553
It's based on #1688, which fixes https://github.com/riptano/cndb/issues/13671

~~It's planned to be two commits on top of the commit in #1688.~~ (it's okay to squash as the test reproduces the issue)