### PR TITLE
CNDB-13639: Adds optional prefetching for known sequential reads

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -52,6 +52,8 @@ import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.ChunkReader;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.PrefetchingRebufferer;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.io.util.RebuffererFactory;
 import org.apache.cassandra.metrics.ChunkCacheMetrics;
@@ -686,6 +688,12 @@ public class ChunkCache
                 Throwables.propagateIfInstanceOf(t.getCause(), CorruptSSTableException.class);
                 throw Throwables.propagate(t);
             }
+        }
+
+        @Override
+        public int chunkSize()
+        {
+            return source.chunkSize();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.compress.AdaptiveCompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
+import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.sensors.SensorsFactory;
@@ -600,6 +601,29 @@ public enum CassandraRelevantProperties
      * with vnodes.
      */
     SKIP_OPTIMAL_STREAMING_CANDIDATES_CALCULATION("cassandra.skip_optimal_streaming_candidates_calculation", "false"),
+
+    /**
+     * For reads that use prefetching (sequential ones), how much data is prefetced in kilobytes. If the value set is <= 0, then
+     * prefetching is disabled. Also see {@link #READ_PREFETCHING_WINDOW}.
+     * <p>
+     * This is disabled by default because read prefectching is already provided by the OS when working with local disks.
+     * But this is meant for tiered storage extensions, where prefetching may not be provided by the underlying
+     * (custom) "filesystem".
+     */
+    READ_PREFETCHING_SIZE_KB("cassandra.read_prefetching_size_kb", "-1"),
+
+    /**
+     * The window (on the prefetching size) used to triggered prefetching. The prefetching algorithm ensures that at least
+     * {@link #READ_PREFETCHING_WINDOW} * {@link #READ_PREFETCHING_SIZE_KB} prefetching has been requested, and if that's
+     * not the case it requests up to {@link #READ_PREFETCHING_SIZE_KB}.
+     */
+    READ_PREFETCHING_WINDOW("cassandra.read_prefetching_window", "0.5"),
+
+    /**
+     * Number of threads used for read prefetching (when enabled). If unsed, a default based on the number of processors
+     * is used.
+     */
+    READ_PREFETCHING_THREADS("cassandra.read_prefetching_threads"),
 
     /**
      * Allows custom implementation of {@link OperationContext.Factory} to optionally create and configure custom

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.CompactionParams.TombstoneOption;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
@@ -352,6 +353,6 @@ public class CompactionController extends AbstractCompactionController
 
     private FileDataInput openDataFile(SSTableReader reader)
     {
-        return limiter != null ? reader.openDataReader(limiter) : reader.openDataReader();
+        return limiter != null ? reader.openDataReader(limiter, ReadPattern.SEQUENTIAL) : reader.openDataReader(ReadPattern.SEQUENTIAL);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/Scrubber.java
+++ b/src/java/org/apache/cassandra/db/compaction/Scrubber.java
@@ -64,6 +64,7 @@ import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.AbstractIterator;
@@ -157,8 +158,8 @@ public class Scrubber implements Closeable
         // partition header (key or data size) is corrupt. (This means our position in the index file will be one
         // partition "ahead" of the data file.)
         this.dataFile = isOffline
-                        ? sstable.openDataReader()
-                        : sstable.openDataReader(CompactionManager.instance.getRateLimiter());
+                        ? sstable.openDataReader(ReadPattern.SEQUENTIAL)
+                        : sstable.openDataReader(CompactionManager.instance.getRateLimiter(), ReadPattern.SEQUENTIAL);
 
         try
         {

--- a/src/java/org/apache/cassandra/db/compaction/Verifier.java
+++ b/src/java/org/apache/cassandra/db/compaction/Verifier.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageService;
@@ -139,8 +140,8 @@ public class Verifier implements Closeable
 
         this.fileAccessLock = new ReentrantReadWriteLock();
         this.dataFile = isOffline
-                        ? sstable.openDataReader()
-                        : sstable.openDataReader(CompactionManager.instance.getRateLimiter());
+                        ? sstable.openDataReader(ReadPattern.SEQUENTIAL)
+                        : sstable.openDataReader(CompactionManager.instance.getRateLimiter(), ReadPattern.SEQUENTIAL);
         this.verifyInfo = new VerifyInfo(dataFile, sstable, fileAccessLock.readLock());
         this.options = options;
         this.isOffline = isOffline;

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.io.sstable.format.PartitionIndexIterator;
 import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ApproximateTime;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -155,7 +156,7 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
 
         Set<Component> replacedComponents = new HashSet<>();
 
-        try (RandomAccessReader dataFile = sstable.openDataReader();
+        try (RandomAccessReader dataFile = sstable.openDataReader(ReadPattern.SEQUENTIAL);
              LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.INDEX_BUILD, tracker.metadata))
         {
             perSSTableFileLock = shouldWritePerSSTableFiles(sstable, indexDescriptor, replacedComponents);

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndexBuilder.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.UUIDGen;
@@ -80,7 +81,7 @@ class SASIIndexBuilder extends SecondaryIndexBuilder
             Map<ColumnMetadata, ColumnIndex> indexes = e.getValue();
 
             SSTableWatcher.instance.onIndexBuild(sstable, builtIndexes);
-            try (RandomAccessReader dataFile = sstable.openDataReader())
+            try (RandomAccessReader dataFile = sstable.openDataReader(ReadPattern.SEQUENTIAL))
             {
                 PerSSTableIndexWriter indexWriter = SASIIndex.newWriter(keyValidator, sstable.descriptor, indexes, OperationType.COMPACTION);
 

--- a/src/java/org/apache/cassandra/io/sstable/compaction/SortedStringTableCursor.java
+++ b/src/java/org/apache/cassandra/io/sstable/compaction/SortedStringTableCursor.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.io.sstable.format.RowIndexEntry;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -83,17 +84,17 @@ public class SortedStringTableCursor implements SSTableCursor
 
     public SortedStringTableCursor(SSTableReader sstable)
     {
-        this(sstable, sstable.openDataReader(), null);
+        this(sstable, sstable.openDataReader(ReadPattern.SEQUENTIAL), null);
     }
 
     public SortedStringTableCursor(SSTableReader sstable, Range<Token> range)
     {
-        this(sstable, sstable.openDataReader(), range);
+        this(sstable, sstable.openDataReader(ReadPattern.SEQUENTIAL), range);
     }
 
     public SortedStringTableCursor(SSTableReader sstable, Range<Token> tokenRange, RateLimiter limiter)
     {
-        this(sstable, sstable.openDataReader(limiter), tokenRange);
+        this(sstable, sstable.openDataReader(limiter, ReadPattern.SEQUENTIAL), tokenRange);
     }
 
     public SortedStringTableCursor(SSTableReader sstable, RandomAccessReader dataFile, Range<Token> tokenRange)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -125,6 +125,7 @@ import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.io.util.SliceDescriptor;
 import org.apache.cassandra.metrics.RestorableMeter;
 import org.apache.cassandra.schema.CachingParams;
@@ -1966,7 +1967,9 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
     public FileDataInput getFileDataInput(long position)
     {
-        return dfile.createReader(position);
+        // While `FileDataInput` supports a `seek` method in practive, it's an interface predominently made for
+        // sequential access. If random access on the returned input is desired, caller should use `#openDataReader`
+        return dfile.createReader(position, ReadPattern.SEQUENTIAL);
     }
 
     /**
@@ -2321,21 +2324,21 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return sstableMetadata;
     }
 
-    public RandomAccessReader openDataReader(RateLimiter limiter)
+    public RandomAccessReader openDataReader(RateLimiter limiter, ReadPattern accessPattern)
     {
         assert limiter != null;
-        return dfile.createReader(limiter);
+        return dfile.createReader(limiter, accessPattern);
     }
 
-    public RandomAccessReader openDataReader()
+    public RandomAccessReader openDataReader(ReadPattern accessPattern)
     {
-        return dfile.createReader();
+        return dfile.createReader(accessPattern);
     }
 
-    public RandomAccessReader openIndexReader()
+    public RandomAccessReader openIndexReader(ReadPattern accessPattern)
     {
         if (ifile != null)
-            return ifile.createReader();
+            return ifile.createReader(accessPattern);
         return null;
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 
 import static org.apache.cassandra.io.sstable.format.SSTableReader.PartitionPositionBounds;
@@ -71,7 +72,7 @@ implements ISSTableScanner
     {
         assert sstable != null;
 
-        this.dfile = sstable.openDataReader();
+        this.dfile = sstable.openDataReader(ReadPattern.SEQUENTIAL);
         this.sstable = sstable;
         this.sizeInBytes = boundsList.stream().mapToLong(ppb -> ppb.upperPosition - ppb.lowerPosition).sum();
         this.compressedSizeInBytes = sstable.compression ? sstable.onDiskSizeForPartitionPositions(boundsList) : sizeInBytes;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -51,6 +51,7 @@ import org.apache.cassandra.io.sstable.format.ScrubPartitionIterator;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -311,7 +312,7 @@ public class BigTableReader extends SSTableReader
     @Override
     public RandomAccessReader openKeyComponentReader()
     {
-        return openIndexReader();
+        return openIndexReader(ReadPattern.RANDOM);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractIterator;
 
@@ -88,8 +89,8 @@ public class BigTableScanner implements ISSTableScanner
         RandomAccessReader ifile = null;
         try
         {
-            dfile = sstable.openDataReader();
-            ifile = sstable.openIndexReader();
+            dfile = sstable.openDataReader(ReadPattern.SEQUENTIAL);
+            ifile = sstable.openIndexReader(ReadPattern.SEQUENTIAL);
             this.sstable = sstable;
             this.columns = columns;
             this.dataRange = dataRange;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/ScrubIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/ScrubIterator.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import org.apache.cassandra.io.sstable.format.ScrubPartitionIterator;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 public class ScrubIterator implements ScrubPartitionIterator
@@ -37,7 +38,7 @@ public class ScrubIterator implements ScrubPartitionIterator
     public ScrubIterator(FileHandle ifile, BigTableRowIndexEntry.IndexSerializer<IndexInfo> rowIndexEntrySerializer) throws IOException
     {
         this.ifile = ifile.sharedCopy();
-        this.reader = this.ifile.createReader();
+        this.reader = this.ifile.createReader(ReadPattern.SEQUENTIAL);
         this.rowIndexEntrySerializer = rowIndexEntrySerializer;
         advance();
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndex.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.tries.ValueIterator;
 import org.apache.cassandra.io.tries.Walker;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.io.util.Rebufferer;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.PageAware;

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -84,6 +84,7 @@ import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
@@ -833,7 +834,7 @@ public class TrieIndexSSTableReader extends SSTableReader
     }
 
     @Override
-    public RandomAccessReader openIndexReader()
+    public RandomAccessReader openIndexReader(ReadPattern accessPattern)
     {
         throw new UnsupportedOperationException("tries do not have primary index");
     }
@@ -841,7 +842,7 @@ public class TrieIndexSSTableReader extends SSTableReader
     @Override
     public RandomAccessReader openKeyComponentReader()
     {
-        return openDataReader();
+        return openDataReader(ReadPattern.RANDOM);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexScanner.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -87,7 +88,7 @@ public class TrieIndexScanner implements ISSTableScanner
     {
         assert sstable != null;
 
-        this.dfile = sstable.openDataReader();
+        this.dfile = sstable.openDataReader(ReadPattern.SEQUENTIAL);
         this.sstable = sstable;
         this.columns = columns;
         this.dataRange = dataRange;

--- a/src/java/org/apache/cassandra/io/util/EmptyRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/EmptyRebufferer.java
@@ -70,6 +70,12 @@ public class EmptyRebufferer implements Rebufferer, RebuffererFactory
     }
 
     @Override
+    public int chunkSize()
+    {
+        return -1;
+    }
+
+    @Override
     public void invalidateIfCached(long position)
     {
     }

--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -141,17 +141,27 @@ public class FileHandle extends SharedCloseableImpl
      */
     public RandomAccessReader createReader()
     {
-        return createReader(null);
+        return createReader(ReadPattern.RANDOM);
     }
 
-    public RandomAccessReader createReader(RateLimiter limiter)
+    public RandomAccessReader createReader(ReadPattern accessPattern)
     {
-        return createReader(limiter, sliceDescriptor.dataStart);
+        return createReader(null, accessPattern);
+    }
+
+    public RandomAccessReader createReader(RateLimiter limiter, ReadPattern accessPattern)
+    {
+        return createReader(limiter, sliceDescriptor.dataStart, accessPattern);
     }
 
     public RandomAccessReader createReader(long position)
     {
-        return createReader(null, position);
+        return createReader(null, position, ReadPattern.RANDOM);
+    }
+
+    public RandomAccessReader createReader(long position, ReadPattern accessPattern)
+    {
+        return createReader(null, position, accessPattern);
     }
 
     /**
@@ -160,15 +170,18 @@ public class FileHandle extends SharedCloseableImpl
      *
      * @param limiter RateLimiter to use for rate limiting read
      * @param position Position in the file to start reading from
+     * @param accessPattern the access pattern expected for the reads made against the returned reader (this is
+     *                      mostly a hint that may optimize the reader for the provided patter, typically enabling
+     *                      prefetching for {@link ReadPattern#SEQUENTIAL}).
      * @return RandomAccessReader for the file
      */
-    public RandomAccessReader createReader(RateLimiter limiter, long position)
+    public RandomAccessReader createReader(RateLimiter limiter, long position, ReadPattern accessPattern)
     {
         assert position >= 0 : "Position must be non-negative - file: " + channel.filePath() + ", position: " + position;
         Rebufferer.BufferHolder bufferHolder = position > 0
                                                ? Rebufferer.emptyBufferHolderAt(position)
                                                : Rebufferer.EMPTY;
-        return new RandomAccessReader(instantiateRebufferer(limiter), order, bufferHolder);
+        return new RandomAccessReader(instantiateRebufferer(limiter, accessPattern), order, bufferHolder);
     }
 
     /**
@@ -193,12 +206,14 @@ public class FileHandle extends SharedCloseableImpl
 
     public Rebufferer instantiateRebufferer()
     {
-        return instantiateRebufferer(null);
+        return instantiateRebufferer(null, ReadPattern.RANDOM);
     }
 
-    private Rebufferer instantiateRebufferer(RateLimiter limiter)
+    private Rebufferer instantiateRebufferer(RateLimiter limiter, ReadPattern accessPattern)
     {
-        Rebufferer rebufferer = rebuffererFactory.instantiateRebufferer();
+        Rebufferer rebufferer = accessPattern == ReadPattern.SEQUENTIAL
+                                ? PrefetchingRebufferer.withPrefetching(rebuffererFactory)
+                                : rebuffererFactory.instantiateRebufferer();
 
         if (limiter != null)
             rebufferer = new LimitingRebufferer(rebufferer, limiter, DiskOptimizationStrategy.MAX_BUFFER_SIZE);

--- a/src/java/org/apache/cassandra/io/util/MmapRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/MmapRebufferer.java
@@ -47,6 +47,13 @@ class MmapRebufferer extends AbstractReaderFileProxy implements Rebufferer, Rebu
     }
 
     @Override
+    public int chunkSize()
+    {
+        // We're not producing chunks
+        return -1;
+    }
+
+    @Override
     public void invalidateIfCached(long position)
     {
     }

--- a/src/java/org/apache/cassandra/io/util/PrefetchingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/PrefetchingRebufferer.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.util;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.metrics.DefaultNameFactory;
+import org.apache.cassandra.metrics.MetricNameFactory;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.Throwables;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+/// A rebufferer that prefetches the next N buffers in sequential order.
+///
+/// *Not* thread-safe (does not need to be as readers aren't).
+public class PrefetchingRebufferer implements Rebufferer
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrefetchingRebufferer.class);
+    private static final NoSpamLogger NO_SPAM_LOGGER = NoSpamLogger.getLogger(LOGGER, 1, TimeUnit.MINUTES);
+
+    private static final int PREFETCHING_SIZE_KB = CassandraRelevantProperties.READ_PREFETCHING_SIZE_KB.getInt();
+    private static final double PREFETCHING_WINDOW = CassandraRelevantProperties.READ_PREFETCHING_WINDOW.getDouble();
+    private static final int PREFETCHING_THREADS = CassandraRelevantProperties.READ_PREFETCHING_THREADS.getInt(FBUtilities.getAvailableProcessors());
+
+    private static final boolean ENABLED = PREFETCHING_SIZE_KB > 0;
+
+    @VisibleForTesting
+    public static final PrefetchingMetrics metrics;
+
+    private static final ThreadPoolExecutor executor;
+
+    static
+    {
+            if (ENABLED)
+            {
+                // Technically, we re-validate the window in the ctor for good measure, but in practice, not point in waiting
+                // until the first prefetching read happens before erroring if the configuration is incorrect.
+                Preconditions.checkArgument(PREFETCHING_WINDOW >= 0 && PREFETCHING_WINDOW <= 1, "Invalid prefetching window value: %s", PREFETCHING_WINDOW);
+                Preconditions.checkArgument(PREFETCHING_THREADS > 0, "Invalid prefetching threads: %s", PREFETCHING_THREADS);
+
+                LOGGER.info("Prefetching is enabled for sequential reads (e.g. range queries, compactions); size={}kb and window={}", PREFETCHING_SIZE_KB, PREFETCHING_WINDOW);
+
+                metrics = new PrefetchingMetrics();
+                executor = new JMXEnabledThreadPoolExecutor(PREFETCHING_THREADS,
+                                                            Integer.MAX_VALUE,
+                                                            TimeUnit.SECONDS,
+                                                            new LinkedBlockingQueue<>(),
+                                                            new NamedThreadFactory("ReadPrefetching"),
+                                                            "internal");
+            }
+            else
+            {
+                metrics = null;
+                executor = null;
+            }
+    }
+
+    /// Rebufferer factory on top of which prefetching is applied.
+    private final RebuffererFactory source;
+
+    /// Number or [Rebufferer] we're already created. We only create up to [#prefetchSize] + 1 rebufferer and then reuse
+    /// them, but we instantiate them lazily so this tell use if we have created our max already.
+    private int createdRebuffers;
+
+    /// The rebufferer that generated the last [BufferHolder] returned by [#rebuffer]. We cannot reuse that rebufferer
+    /// until the next call to [#rebuffer], because only then can we assume the buffer was released. This rebufferer is
+    /// why we create [#prefetchSize] + 1 rebufferers.
+    private ReusedRebufferer lastReturnedRebufferer;
+
+    /// As mentioned above, we reuse rebufferer (to save allocations) and this queue contains rebufferers that have
+    /// been created but are not currently used by a [PrefetchedEntry] in [#queue].
+    private final Deque<ReusedRebufferer> unusedRebufferers;
+
+    /// The buffers that are being/have been prefetched (but have not yet be requested by [#rebuffer]).
+    private final Deque<PrefetchedEntry> queue;
+
+    /// The number of buffers prefetched when prefect is triggered ().
+    private final int prefetchSize;
+
+    /// The minimum number of buffers that should be prefetched; as soon as we have less than this number of prefetched
+    /// buffers, we fetch up to [#prefetchSize].
+    private final int windowSize;
+
+    /** We expect the buffer size to be a power of 2, this is the mask for aligning to the buffer size */
+    private final int alignmentMask;
+
+    private PrefetchingRebufferer(RebuffererFactory source)
+    {
+        this(source, PREFETCHING_SIZE_KB * 1024, PREFETCHING_WINDOW);
+    }
+
+    @VisibleForTesting
+    PrefetchingRebufferer(RebuffererFactory source, int prefetchingSize, double window)
+    {
+        assert Integer.bitCount(source.chunkSize()) == 1 : String.format("%d must be a power of two", source.chunkSize());
+        assert prefetchingSize > 0 : String.format("prefetching size %d must be > 0", prefetchingSize);
+        assert window >= 0 && window <= 1 : String.format("prefetching window %f must be in [0, 1]", window);
+
+        this.source = source;
+        this.prefetchSize = (int)Math.ceil((double)prefetchingSize / source.chunkSize());
+        this.windowSize = (int)Math.ceil(window * prefetchSize);
+        this.unusedRebufferers = new ArrayDeque<>(prefetchSize);
+        this.queue = new ArrayDeque<>(prefetchSize);
+        this.alignmentMask = -source.chunkSize();
+    }
+
+    public static Rebufferer withPrefetching(RebuffererFactory factory)
+    {
+        if (!ENABLED)
+            return factory.instantiateRebufferer();
+
+        int chunkSize = factory.chunkSize();
+        // No `chunkSize` typically means mmap, where prefetching doesn't make sense anyway (the OS already does it)
+        if (chunkSize <= 0)
+            return factory.instantiateRebufferer();
+
+        if (Integer.bitCount(chunkSize) != 1)
+        {
+            NO_SPAM_LOGGER.debug("Prefecting is enabled for SEQUENTIAL reads on {} but the chunk size {} is not a power of two (should only true for zero-copied files); will not prefetch.", factory.channel().filePath(), chunkSize);
+            return factory.instantiateRebufferer();
+        }
+
+        return new PrefetchingRebufferer(factory);
+    }
+
+    private int chunkSize()
+    {
+        return source.chunkSize();
+    }
+
+    @Override
+    public BufferHolder rebuffer(long position)
+    {
+        // Only now do we know it is safe to reuse the rebufferer from the previous call to this method.
+        if (lastReturnedRebufferer != null)
+            unusedRebufferers.add(lastReturnedRebufferer);
+
+        if (position >= fileLength())
+            return Rebufferer.EMPTY;
+
+        long pageAlignedPos = position & alignmentMask;
+
+        PrefetchedEntry entry = queue.poll();
+        boolean isNonSequential = false;
+
+        // Release any prefetched buffers that are before the requested position.
+        while (entry != null && entry.position < pageAlignedPos)
+        {
+            isNonSequential = true;
+            unusedRebufferers.add(entry.release());
+            entry = queue.poll();
+        }
+
+        // If the next entry matches, use it, but also trigger futher prefetch if necessary.
+        if (entry != null && entry.position == pageAlignedPos)
+        {
+            prefetch(pageAlignedPos + chunkSize());
+
+            if (!entry.isReady())
+                metrics.notReady.mark();
+
+            BufferHolder holder = entry.get();
+            lastReturnedRebufferer = entry.forReuse();
+            return holder;
+        }
+
+        // We get here in 2 cases:
+        // 1. `entry == null`: this is either the first call to this rebufferer, or we've seeked forward since the
+        //    last `rebuffer` and all the prefected entries where discared by the loop above.
+        // 2. `entry.position > pageAlignedPos` (we have prefected entries, but they are "later" in the file). This
+        //    means the code has seeked backward since the last `rebuffer`. We don't want our prefetching queue to grow
+        //    unbounded if we get a series of backward seek, so we need to release those prefecth, at least if they
+        //    don't fall within the "current" prefetching window. But for now, we simply release all the prefect
+        //    because:
+        //    - if this is used for a genuinely sequential process, like compaction/scrub, then we shouldn't seek
+        //      backward at all, and if we do it's exceptional, to handle some problem/retry, and being optimal in those
+        //      rare case is not a priority.
+        //    - if this is used for actual user reads, then this rebuffer should sit on top of the chunk cache anyway,
+        //      and so those prefected entries will still be in the cache even if we remove them from our own queue, and
+        //      we're not really losing anything (arguably the queue of this rebuffer is a tad superfluous when we sit
+        //      on top of the chunk cache for that reason, but that queue exists mainly for when that's not the case).
+        // In both cases, we ensure the prefecth queue is empty, then prefetch from the current position, and wait on
+        // the first entry.
+        while (entry != null)
+        {
+            isNonSequential = true;
+            unusedRebufferers.add(entry.release());
+            entry = queue.poll();
+        }
+        prefetch(pageAlignedPos);
+
+        if (isNonSequential)
+            metrics.nonSequentialRequest.mark();
+
+        entry = queue.poll();
+        assert entry != null; // the call to `prefetch` should ensure this.
+
+        // We call prefetch for the next entry again because we just pulled an entry so we may have to restore our
+        // correct number of prefetched. But depending on the window, this will probably not do anything.
+        // We do this before waiting on our current entry to trigger prefetch as soon as possible.
+        prefetch(pageAlignedPos + chunkSize());
+
+        // Note that we don't increment the `notReady` metric here, because we just triggered the read, so we know
+        // it's not going to be ready (unless we're extremely lucky) and if this is due to prior seek, we're already
+        // recorded it (and if it's just the first call to `rebuffer`, it's normal, we don't need to track it).
+        BufferHolder holder = entry.get();
+        lastReturnedRebufferer = entry.forReuse();
+
+        return holder;
+    }
+
+     /// Trigger prefetches the next N buffers unless they are already in the queue.
+     ///
+     /// This method does not block, it just submits prefetch to the executor and then return immediately.
+     ///
+     /// @param pageAlignedPosition the position in the file, already aligned to a page
+    private void prefetch(long pageAlignedPosition)
+    {
+        // see caller, prefetch is only called with an empty queue or if the requested position is exactly at the
+        // beginning of the queue after purging all older entries
+        assert queue.isEmpty() || pageAlignedPosition == queue.peekFirst().position :
+            String.format("Unexpected prefetching position %d, first: %s, last: %s", pageAlignedPosition, queue.peekFirst(), queue.peekLast());
+
+        // Only trigger prefetch if we have less than our window already prefetech.
+        if (queue.size() > windowSize)
+            return;
+
+        long firstPositionToPrefetch = queue.isEmpty() ? pageAlignedPosition : queue.peekLast().position + chunkSize();
+        int toPrefetch = prefetchSize - queue.size();
+
+        // We trigger all the prefetch on the executor, and so in parallel (within the constraint of the executor).
+        for (int i = 0; i < toPrefetch; i++)
+        {
+            long prefetchPosition = firstPositionToPrefetch + ((long)i * chunkSize());
+            if (prefetchPosition >= source.fileLength())
+                break;
+
+            ReusedRebufferer rebufferer = unusedRebufferers.poll();
+            // The +1 is because we also have `lastReturnedRebufferer` on top of what is prefetched
+            if (rebufferer == null && createdRebuffers < prefetchSize + 1)
+            {
+                rebufferer = ReusedRebufferer.create(source);
+                ++createdRebuffers;
+            }
+            // We must have gotten a rebufferer: we know the queue is smaller than `prefetchSize`, so either we had
+            // created less than `prefetchSize` rebuffererer yet, and we just created one above, or some rebuffere must
+            // have been unused.
+            assert rebufferer != null;
+            PrefetchedEntry newEntry = new PrefetchedEntry(prefetchPosition, rebufferer);
+            queue.addLast(newEntry);
+
+            CompletableFuture<?> prevUseFuture = rebufferer.prevUseFuture;
+            // If `prevUseFuture` is not null, this effectively means that the rebufferer previous usage was for a
+            // prefetched entry we didn't wait on before release (we discarded the entry). But even though we didn't
+            // need the prefetched value, the prefetching was triggered, and we need to make certain it is done before
+            // we reuse the underlying buffer.
+            executor.execute(() -> {
+                if (prevUseFuture != null)
+                {
+                    try
+                    {
+                        prevUseFuture.join();
+                    }
+                    catch (Exception e)
+                    {
+                        // We ignore expections here because it has already been handling (_including_ being logged
+                        // within `PrefetchedEntry#release`.
+                    }
+                }
+                newEntry.triggerPrefetch();
+            });
+        }
+    }
+
+    @Override
+    public ChannelProxy channel()
+    {
+        return source.channel();
+    }
+
+    @Override
+    public long fileLength()
+    {
+        return source.fileLength();
+    }
+
+    @Override
+    public double getCrcCheckChance()
+    {
+        return source.getCrcCheckChance();
+    }
+
+    @Override
+    public void close()
+    {
+        assert unusedRebufferers.isEmpty() : "buffers should have been released";
+        assert queue.isEmpty() : "Prefetched buffers should have been released";
+        source.close();
+    }
+
+    @Override
+    public void closeReader()
+    {
+        // First, release any inflight prefetch (moving the rebuffer to `unusedRebufferers` temporarily)
+        queue.forEach(entry -> unusedRebufferers.add(entry.release()));
+        queue.clear();
+
+        unusedRebufferers.forEach(r -> {
+            if (r.prevUseFuture == null)
+                r.rebufferer.closeReader();
+            else
+                r.prevUseFuture.whenComplete((_1, _2) -> r.rebufferer.closeReader());
+        });
+        unusedRebufferers.clear();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("Prefetching rebufferer: (%d/%d) buffers, %d buffer size", prefetchSize, windowSize, chunkSize());
+    }
+
+    /// Represents an ongoing or completed prefetching of one "chunk" (buffed)
+    private static final class PrefetchedEntry
+    {
+        private final long position;
+        private final ReusedRebufferer rebufferer;
+        private final CompletableFuture<BufferHolder> future;
+        private boolean reused;
+
+        PrefetchedEntry(long position, ReusedRebufferer rebufferer)
+        {
+            this.position = position;
+            this.rebufferer = rebufferer;
+            this.future = new CompletableFuture<>();
+
+            metrics.prefetched.mark();
+        }
+
+        /// Called on an [PrefetchingRebufferer#executor] to do the actual (blocking) prefetching.
+        /// This is the only method of this class that is not executed on the thread of the [PrefetchingRebufferer]
+        /// that creates it (meaning, the thread on which the [PrefetchingRebufferer#rebuffer(long)] method is called).
+        void triggerPrefetch()
+        {
+            try
+            {
+                future.complete(rebufferer.rebuffer(position));
+            }
+            catch (Exception e)
+            {
+                future.completeExceptionally(e);
+            }
+        }
+
+        /// Must only be called after a successfull [#get] (when the prefetched entry has been consumed and the
+        /// buffer returned); returns a [ReusedRebufferer] ready for reuse.
+        ReusedRebufferer forReuse()
+        {
+            assert !reused;
+            assert isReady() : "Should not have been called on incomplete prefetc";
+            reused = true;
+            return rebufferer.prepareForReuse(null);
+        }
+
+        /// Called when the entry is discarded, to release the underlying buffer once the prefetch complete (since we
+        /// won't use the result of that prefetch, we need to release the buffer ourselves).
+        ReusedRebufferer release()
+        {
+            // We should call one of `forReuse` or this for each entry, but only one, or we risk putting the same
+            // rebufferer in `unusedRebufferers` twice, which would be a problem
+            assert !reused;
+            reused = true;
+
+            return rebufferer.prepareForReuse(future.whenComplete((buffer, error) -> {
+                try
+                {
+                    if (buffer != null)
+                    {
+                        buffer.release();
+                        metrics.unused.mark();
+                    }
+
+                    // We shouldn't fail, but we're also explicitely not using the result of that prefetch, so no reason
+                    // to do more than warn.
+                    if (error != null)
+                        LOGGER.warn("Error during prefetching; but this prefetch is discarded", error);
+                }
+                catch (Throwable t)
+                {
+                    // Erroring during release "could" be more problematic, so log a genuine error
+                    LOGGER.error("Failed to release (discarded) prefetched buffer", t);
+                }
+            }));
+        }
+
+        boolean isReady()
+        {
+            return future.isDone();
+        }
+
+        BufferHolder get()
+        {
+            try
+            {
+                return future.join();
+            }
+            catch (Throwable t)
+            {
+                // Remove `CompletionException` and any other wrapping as code upstream may not expect them.
+                throw Throwables.cleaned(t);
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("Position: %d, Status: %s", position, future.isDone());
+        }
+    }
+
+    private static class ReusedRebufferer
+    {
+        private final @Nullable CompletableFuture<?> prevUseFuture;
+        private final Rebufferer rebufferer;
+
+        private ReusedRebufferer(@Nullable CompletableFuture<?> prevUseFuture, Rebufferer rebufferer)
+        {
+            this.prevUseFuture = prevUseFuture;
+            this.rebufferer = rebufferer;
+        }
+
+        static ReusedRebufferer create(RebuffererFactory factory)
+        {
+            return new ReusedRebufferer(null, factory.instantiateRebufferer());
+        }
+
+        BufferHolder rebuffer(long position)
+        {
+            return rebufferer.rebuffer(position);
+        }
+
+        ReusedRebufferer prepareForReuse(@Nullable CompletableFuture<?> lastUseFuture)
+        {
+            return new ReusedRebufferer(lastUseFuture, rebufferer);
+        }
+    }
+
+    @VisibleForTesting
+    public static class PrefetchingMetrics
+    {
+        /// Total number of buffers that were prefetched.
+        final Meter prefetched;
+
+        /// Total number of buffers that were prefetched but were not used (either due to a non-sequential access, or
+        /// to the rebufferer being closed before the end of the underlying file).
+        final Meter unused;
+
+        /// Total number of buffers that were prefetched but were not ready when they were requested and the caller
+        /// had to wait. A large number of those means that the configuration of pre-fetching should be adjusted.
+        final Meter notReady;
+
+        /// Number of times a [PrefetchingRebufferer#rebuffer] call was not respecting sequential acess (meaning the
+        /// position requested was not exactly for the chunk following the previous call)
+        final Meter nonSequentialRequest;
+
+        PrefetchingMetrics()
+        {
+            MetricNameFactory factory = new DefaultNameFactory("ReadPrefetching", "");
+            prefetched = Metrics.meter(factory.createMetricName("Prefetched"));
+            unused = Metrics.meter(factory.createMetricName("Unused"));
+            notReady = Metrics.meter(factory.createMetricName("NotReady"));
+            nonSequentialRequest = Metrics.meter(factory.createMetricName("NonSequentialRequest"));
+        }
+
+        @VisibleForTesting
+        void reset()
+        {
+            prefetched.mark(-prefetched.getCount());
+            unused.mark(-unused.getCount());
+            notReady.mark(-notReady.getCount());
+            nonSequentialRequest.mark(-nonSequentialRequest.getCount());
+        }
+
+        @Override
+        public String toString()
+        {
+            if (prefetched.getCount() == 0)
+                return "No prefetching yet";
+
+            return String.format("Prefetched: [%s], Unused: [%s], Not ready: [%s] (%.2f), Non sequential request: [%s]",
+                                 prefetched.getCount(),
+                                 unused.getCount(),
+                                 notReady.getCount(), (double)notReady.getCount() / prefetched.getCount(),
+                                 nonSequentialRequest.getCount());
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/util/ReadPattern.java
+++ b/src/java/org/apache/cassandra/io/util/ReadPattern.java
@@ -20,4 +20,5 @@ package org.apache.cassandra.io.util;
 
 public enum ReadPattern
 {
-    SEQUENTIAL, RANDOM}
+    SEQUENTIAL, RANDOM
+}

--- a/src/java/org/apache/cassandra/io/util/ReadPattern.java
+++ b/src/java/org/apache/cassandra/io/util/ReadPattern.java
@@ -18,23 +18,6 @@
 
 package org.apache.cassandra.io.util;
 
-/**
- * Interface for the classes that can be used to instantiate rebufferers over a given file.
- *
- * These are one of two types:
- *  - chunk sources (e.g. SimpleReadRebufferer) which instantiate a buffer managing rebufferer referencing
- *    themselves.
- *  - thread-safe shared rebufferers (e.g. MmapRebufferer) which directly return themselves.
- */
-public interface RebuffererFactory extends ReaderFileProxy
+public enum ReadPattern
 {
-    Rebufferer instantiateRebufferer();
-
-    /**
-     * If the {@link Rebufferer} created by this factory rebuffered in "chunks" of a fixed size, the size (> 0) of those
-     * chunks. Otherwise, this should return a value <= 0.
-     */
-    int chunkSize();
-
-    void invalidateIfCached(long position);
-}
+    SEQUENTIAL, RANDOM}

--- a/src/java/org/apache/cassandra/io/util/Rebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/Rebufferer.java
@@ -19,10 +19,6 @@
 package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
 
 /**
  * Rebufferer for reading data by a RandomAccessReader.

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.metrics.RestorableMeter;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
@@ -568,21 +569,21 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     }
 
     @Override
-    public RandomAccessReader openDataReader(RateLimiter limiter)
+    public RandomAccessReader openDataReader(RateLimiter limiter, ReadPattern accessPattern)
     {
-        return delegate.openDataReader(limiter);
+        return delegate.openDataReader(limiter, accessPattern);
     }
 
     @Override
-    public RandomAccessReader openDataReader()
+    public RandomAccessReader openDataReader(ReadPattern accessPattern)
     {
-        return delegate.openDataReader();
+        return delegate.openDataReader(accessPattern);
     }
 
     @Override
-    public RandomAccessReader openIndexReader()
+    public RandomAccessReader openIndexReader(ReadPattern accessPattern)
     {
-        return delegate.openIndexReader();
+        return delegate.openIndexReader(accessPattern);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
@@ -118,6 +118,12 @@ public class ChunkCacheInterceptingTest
         }
 
         @Override
+        public int chunkSize()
+        {
+            return wrapped.chunkSize();
+        }
+
+        @Override
         public void invalidateIfCached(long position)
         {
         }

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheLoadingTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheLoadingTest.java
@@ -381,6 +381,12 @@ public class ChunkCacheLoadingTest
             return this;
         }
 
+        @Override
+        public int chunkSize()
+        {
+            return -1;
+        }
+
         public void invalidateIfCached(long position)
         {
             // do nothing

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.db.compaction.CompactionInterruptedException;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
@@ -157,8 +158,8 @@ public class CrcCheckChanceTest extends CQLTester
         // note: only compressed files currently perform crc checks, so only the dfile reader is relevant here
         SSTableReader baseSSTable = cfs.getLiveSSTables().iterator().next();
         SSTableReader idxSSTable = indexCfs.getLiveSSTables().iterator().next();
-        try (RandomAccessReader baseDataReader = baseSSTable.openDataReader();
-             RandomAccessReader idxDataReader = idxSSTable.openDataReader())
+        try (RandomAccessReader baseDataReader = baseSSTable.openDataReader(ReadPattern.RANDOM);
+             RandomAccessReader idxDataReader = idxSSTable.openDataReader(ReadPattern.RANDOM))
         {
             Assert.assertEquals(0.03, baseDataReader.getCrcCheckChance(), 0.0);
             Assert.assertEquals(0.03, idxDataReader.getCrcCheckChance(), 0.0);

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableWithZeroCopyMetadataTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableWithZeroCopyMetadataTest.java
@@ -59,6 +59,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.format.ScrubPartitionIterator;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.ReadPattern;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.Schema;
@@ -234,7 +235,7 @@ public class SSTableWithZeroCopyMetadataTest
     private void checkSSTableReader(SSTableReader sstable) throws IOException
     {
         List<DecoratedKey> keys = new ArrayList<>();
-        try (RandomAccessReader dataReader = sstable.openDataReader())
+        try (RandomAccessReader dataReader = sstable.openDataReader(ReadPattern.RANDOM))
         {
             checkAllKeysIterator(sstable, dataReader, keys);
             checkSrubPartitionsIterator(sstable, dataReader, keys);

--- a/test/unit/org/apache/cassandra/io/util/PrefetchingRebuffererTest.java
+++ b/test/unit/org/apache/cassandra/io/util/PrefetchingRebuffererTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.util;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class PrefetchingRebuffererTest
+{
+    private static final int PAGE_SIZE = 4096;
+
+    private RebuffererFactory source;
+    private final Map<Long, TestBufferHolder> buffers = new ConcurrentHashMap<>();
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CassandraRelevantProperties.READ_PREFETCHING_SIZE_KB.setInt((PAGE_SIZE / 1024) * 2);
+        CassandraRelevantProperties.READ_PREFETCHING_WINDOW.setDouble(0.5);
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    private Rebufferer newMockedRebuffer()
+    {
+        Rebufferer mock = Mockito.mock(Rebufferer.class);
+        when(mock.rebuffer(anyLong())).thenAnswer(inv -> buffer(inv.getArgument(0)));
+        return mock;
+    }
+
+    Rebufferer.BufferHolder buffer(long offset)
+    {
+        TestBufferHolder ret = buffers.computeIfAbsent(offset, o -> new TestBufferHolder(ByteBuffer.allocate(PAGE_SIZE), o));
+        ret.numRequested++;
+        return ret;
+    }
+
+    @Before
+    public void setUp() throws IOException
+    {
+        source = Mockito.mock(RebuffererFactory.class);
+        when(source.chunkSize()).thenReturn(PAGE_SIZE);
+        when(source.fileLength()).thenReturn(Long.MAX_VALUE);
+        when(source.instantiateRebufferer()).thenAnswer(__ -> newMockedRebuffer());
+        buffers.clear();
+        PrefetchingRebufferer.metrics.reset();
+    }
+
+    @Test
+    public void testPrefetchSamePage()
+    {
+        Rebufferer rebufferer = PrefetchingRebufferer.withPrefetching(source);
+        assertNotNull(rebufferer);
+        assertSame(PrefetchingRebufferer.class, rebufferer.getClass());
+
+        for (int i = 0; i < PAGE_SIZE; i ++)
+        {
+            Rebufferer.BufferHolder buf = rebufferer.rebuffer(i);
+            assertNotNull(buf);
+            assertEquals(0L, buf.offset());
+            assertEquals(PAGE_SIZE, buf.buffer().capacity());
+            buf.release();
+        }
+
+        rebufferer.closeReader();
+        rebufferer.close();
+
+        assertEquals(3, buffers.size()); // 1 requested and 2 prefetched
+        assertTrue(buffers.containsKey(0L));
+        assertTrue(buffers.containsKey((long)PAGE_SIZE));
+        assertTrue(buffers.containsKey((long)PAGE_SIZE * 2));
+        assertFalse(buffers.containsKey((long)PAGE_SIZE * 3)); // never prefetched
+
+        // This test is not super realistic: by requesting the same page over and over, it is effectively "seeking
+        // backward", which effectively drop all pretch, so we will re-fetch all buffers every time.
+        assertEquals(PAGE_SIZE, buffers.get(0L).numRequested); // requested many times
+        assertEquals(PAGE_SIZE, buffers.get((long)PAGE_SIZE).numRequested); // prefetched only once
+        assertEquals(PAGE_SIZE, buffers.get((long)PAGE_SIZE * 2).numRequested); // prefetched only once
+
+        for (TestBufferHolder buffer : buffers.values())
+            assertTrue(buffer.released); // make sure closeReader is effective in releasing prefetched buffers
+
+        verify(source, times(1)).close();
+    }
+
+    @Test
+    public void testPrefetchAtPageBoundaries()
+    {
+        final int prefetchSize = 8;
+        final int windowSize = 4;
+        final int numPages = 10;
+        PrefetchingRebufferer rebufferer = new PrefetchingRebufferer(source, prefetchSize * PAGE_SIZE, (double)windowSize / prefetchSize);
+        assertNotNull(rebufferer);
+
+        for (int i = 0; i < numPages; i++)
+        {
+            Rebufferer.BufferHolder buf = rebufferer.rebuffer(i * PAGE_SIZE);
+            assertNotNull(buf);
+            assertEquals(i * PAGE_SIZE, buf.offset());
+            assertEquals(PAGE_SIZE, buf.buffer().capacity());
+            buf.release();
+
+            // Prefetching is trigger on a separate thread pool, and it should be fast but not necessarily immediate,
+            // so give it some time.
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+            for (int k = i; k <= i + windowSize; k ++)
+            {
+                long pos = (long)k * PAGE_SIZE;
+                assertTrue("Should have buffer at position " + pos, buffers.containsKey(pos));
+                assertEquals(1, buffers.get(pos).numRequested);
+            }
+        }
+
+        rebufferer.closeReader();
+        rebufferer.close();
+
+        assertTrue(String.format("We should have prefetched at least num pages + window size (%d + %d = %d), but instead got %d", numPages, windowSize, numPages + windowSize, PrefetchingRebufferer.metrics.prefetched.getCount()),
+                   numPages + windowSize <= PrefetchingRebufferer.metrics.prefetched.getCount());
+
+        assertTrue(String.format("We should have not used at least window size (%d), not %d", windowSize, PrefetchingRebufferer.metrics.unused.getCount()),
+                   windowSize <= PrefetchingRebufferer.metrics.unused.getCount());
+    }
+
+    @Test
+    public void testSequentialAccess()
+    {
+        int numPages = 20;
+        // Simulate a file with exactly that number of pages to make sure we handle a full scan of the file correctly,
+        // including the end of the file.
+        when(source.fileLength()).thenReturn((long)numPages * PAGE_SIZE);
+
+        Rebufferer rebufferer = PrefetchingRebufferer.withPrefetching(source);
+        assertNotNull(rebufferer);
+
+        for (int i = 0; i < numPages; i++)
+        {
+            long offset = (long)i * PAGE_SIZE;
+            Rebufferer.BufferHolder buf = rebufferer.rebuffer(offset);
+            assertNotNull(buf);
+            assertEquals(offset, buf.offset());
+            assertEquals(PAGE_SIZE, buf.buffer().capacity());
+
+            // This "simulate" some "processing" time for the buffer. Mostly, this ensures prefetched buffers are ready
+            // when we try using them (prefetching is "near immediate" in those tests, but so is this loop if we don't
+            // have that sleep).
+            Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+            buf.release();
+        }
+
+        rebufferer.closeReader();
+        rebufferer.close();
+
+        assertEquals(numPages, buffers.size());
+
+        // We should only request every buffer once.
+        for (int i = 0; i < numPages; i++)
+        {
+            TestBufferHolder buffer = buffers.get((long) i * PAGE_SIZE);
+            assertNotNull(buffer);
+            assertEquals(1, buffer.numRequested);
+            assertTrue(buffer.released);
+        }
+
+        assertEquals(numPages, PrefetchingRebufferer.metrics.prefetched.getCount());
+
+        assertEquals(0, PrefetchingRebufferer.metrics.notReady.getCount());
+
+        assertEquals(0, PrefetchingRebufferer.metrics.unused.getCount());
+        assertEquals(0, PrefetchingRebufferer.metrics.nonSequentialRequest.getCount());
+    }
+
+    @Test
+    public void testNonSequentialAccess()
+    {
+        Rebufferer rebufferer = PrefetchingRebufferer.withPrefetching(source);
+        assertNotNull(rebufferer);
+
+        long[] offsets = new long[] { 0, PAGE_SIZE * 2, PAGE_SIZE };
+
+        for (long offset : offsets)
+        {
+            Rebufferer.BufferHolder buf = rebufferer.rebuffer(offset);
+            assertNotNull(buf);
+            assertEquals(offset, buf.offset());
+            assertEquals(PAGE_SIZE, buf.buffer().capacity());
+            buf.release();
+        }
+
+        rebufferer.closeReader();
+        rebufferer.close();
+
+        assertEquals(5, buffers.size());
+
+        // requesting PAGE_SIZE after PAGE_SIZE * 2 is non-sequential
+        assertEquals(1, PrefetchingRebufferer.metrics.nonSequentialRequest.getCount());
+
+        for (int i = 0; i < 5; i++)
+        {
+            TestBufferHolder buffer = buffers.get((long) i * PAGE_SIZE);
+            assertNotNull(buffer);
+            // In order, we've requested indexes 0, 2 and then 1. We expect:
+            // - 0 to fetch 0 and prefetch 1 and 2.
+            // - 2 to find 2 prefetched above (having discared 1) and prefetch 3 and 4.
+            // - 1 is a seek backward so it discard everything, fetch 1 and prefetch 2 and 3.
+            // Overall, 0 and 4 are only requested once, but the other indexes are requested twice.
+            assertEquals("For index " + i, i == 0 || i == 4 ? 1 : 2, buffer.numRequested);
+            assertTrue(buffer.released);
+        }
+
+        // As mentioned above, we'd discarded 1 when getting 2, and then discard 3 and 4 when getting 1. And then
+        // when we close the rebufferer, we discard 2 and 3.
+        assertEquals(5, PrefetchingRebufferer.metrics.unused.getCount());
+    }
+
+    @Test
+    public void testSkippingBuffers()
+    {
+        final int prefetchSize = 8;
+        final int windowSize = 4;
+        final int numPages = 24;
+        PrefetchingRebufferer rebufferer = new PrefetchingRebufferer(source,
+                                                                     prefetchSize * PAGE_SIZE,
+                                                                     (double)windowSize / prefetchSize);
+        assertNotNull(rebufferer);
+
+        for (int i = 0; i < numPages; i+=2)
+        {
+            Rebufferer.BufferHolder buf = rebufferer.rebuffer(i * PAGE_SIZE);
+            assertNotNull(buf);
+            assertEquals(i * PAGE_SIZE, buf.offset());
+            assertEquals(PAGE_SIZE, buf.buffer().capacity());
+            buf.release();
+
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+            for (int k = i; k <= i + windowSize; k ++)
+            {
+                assertTrue(buffers.containsKey((long)k * PAGE_SIZE));
+                assertEquals(1, buffers.get((long)k * PAGE_SIZE).numRequested);
+            }
+        }
+
+        rebufferer.closeReader();
+        rebufferer.close();
+
+        // we skip every other page so we requested this many buffers
+        int numBuffersRequested = numPages / 2;
+
+        assertTrue(String.format("We should have prefetched at least num pages + window size (%d + %d = %d), but instead got %d",
+                                 numPages, windowSize, numPages + windowSize, PrefetchingRebufferer.metrics.prefetched.getCount()),
+                   numBuffersRequested + windowSize <= PrefetchingRebufferer.metrics.prefetched.getCount());
+
+        // each request discards 1 buffer
+        assertTrue(String.format("We should have not used at least window size (%d), not %d",
+                                 windowSize, PrefetchingRebufferer.metrics.unused.getCount()),
+                   numBuffersRequested + windowSize <= PrefetchingRebufferer.metrics.unused.getCount());
+    }
+
+    @Test(expected = CorruptSSTableException.class)
+    public void testExceptionInSourceRebuffer()
+    {
+        Rebufferer rebufferer = PrefetchingRebufferer.withPrefetching(source);
+        assertNotNull(rebufferer);
+
+        when(source.instantiateRebufferer()).thenAnswer(__ -> {
+            Rebufferer mock = Mockito.mock(Rebufferer.class);
+            when(mock.rebuffer(anyLong())).thenThrow(CorruptSSTableException.class);
+            return mock;
+        });
+
+        rebufferer.rebuffer(0);
+    }
+
+    @Test
+    public void testExceptionInSourceRebufferDuringPrefetch()
+    {
+        Rebufferer rebufferer = PrefetchingRebufferer.withPrefetching(source);
+        assertNotNull(rebufferer);
+
+        when(source.instantiateRebufferer()).thenAnswer(__ -> {
+            Rebufferer mock = Mockito.mock(Rebufferer.class);
+            when(mock.rebuffer(anyLong())).thenAnswer(inv -> {
+                long pos = inv.getArgument(0);
+                if (pos == PAGE_SIZE * 2)
+                    throw new CorruptSSTableException(new RuntimeException("Corrupted"), "fakeFile");
+                return buffer(pos);
+            });
+            return mock;
+        });
+
+        try
+        {
+            // We should have no issue until we _use_ the position that throw.
+            rebufferer.rebuffer(0);
+            rebufferer.rebuffer(PAGE_SIZE);
+
+            assertThrows(CorruptSSTableException.class, () -> rebufferer.rebuffer(PAGE_SIZE * 2));
+        }
+        finally
+        {
+            rebufferer.closeReader();
+            rebufferer.close();
+        }
+    }
+
+    private static class TestBufferHolder implements Rebufferer.BufferHolder
+    {
+        final ByteBuffer buffer;
+        boolean released;
+        long offset;
+        int numRequested;
+
+        TestBufferHolder(ByteBuffer buffer, long offset)
+        {
+            this.buffer = buffer;
+            this.released = false;
+            this.offset = offset;
+        }
+
+        @Override
+        public ByteBuffer buffer()
+        {
+            return buffer;
+        }
+
+        @Override
+        public long offset()
+        {
+            return offset;
+        }
+
+        @Override
+        public void release()
+        {
+            released = true;
+        }
+
+    }
+}


### PR DESCRIPTION
This introduces a `PrefetchingRebufferer` that, when enabled, prefetches (read from the underlying reader) a configurable number of chunks in advance (so only work on top of rebufferer factories that work with chunks, i.e. not uncompressed mmap).

Prefetching must first be enabled globally by setting `-Dcassandra.read_prefetching_size_kb` to the desired value. With that, and assuming the disk access mode allows it (meaning, it's not uncompressed mmap), then prefetching will be applied to reads that are "clearly" sequential. Mostly, as of this patch, this means the sstable "scanners" and `SortedStringTableCursor`, so compaction, SAI index building and tools that read sstable fully (scrub, verifier) will benefit from it.

Since rebufferers are synchronous, prefetching is done through a fixed thread pool. The number of thread of that pool can be set with `-Dcassandra.read_prefetching_threads` (but default to the number of "processors").

The `-Dcassandra.read_prefetching_window` can also be set to define how often prefetching is re-triggered. By default, when there is less than half of the value of `-Dcassandra.read_prefetching_size_kb` prefetched, then prefetching is triggered.

See https://github.com/riptano/cndb/issues/13639 for additional motivation.

I'll note that this patch is adapted from the similar DSE behavior. However, there is a fair bit of modification since the DSE version was relying on the asynchronous nature of rebufferers there (it also had a few behavior I didn't fully understood and I didn't dig when it felt a bit specific to DSE).

One point worth mentioning was that the DSE version was relying on the ability of the underlying channel to create batches when multiple chunks are prefetched. This is something that could have advantages and we could try to add back over time, but it's a lot harder to see how to do that in the non-async world of C*. Typically, in DSE, since all the prefetches were initiated on the current thread (without blocking it), building the "batch" was relatively easy, but it doesn't translate in this patch. Not to mention that currently the underlying channels have no batching options and those would have to be added (in a way that trickled down to the channel implementation within CNDB). Anyway, as of this patch, chunks are prefetched in parallel but with no batching optimization. Which does mean the `window' parameter is probably not as useful as for DSE, but I've kept it nonetheless as it's not exactly adding complexity.

In the context of compaction in CNDB though, I think this mean that it would kind of be ideal if we could use a relatively large "chunk size" for the readers: we read the full file anyway, so there is no waste there to use a large-ish chunk size, and it would kind of provide batching for prefetching "for free" (in the sense that if we want to prefetch, say, 128kb in advance, then we only need 2 chunks with a 64kb chunk, but need a lot more with a 4kb chunk size).
