### PR TITLE
CNDB-13718: Switch to official Apache Lucene 9.8.0 dep

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -751,9 +751,9 @@
           </dependency>
           <dependency groupId="org.hamcrest" artifactId="hamcrest" version="2.2" scope="test"/>
           <dependency groupId="org.agrona" artifactId="agrona" version="1.20.0" />
-          <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0-5ea8bb4f21" />
-          <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0-5ea8bb4f21" />
+          <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0" />
+          <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0" />
+          <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0" />
           <dependency groupId="io.github.jbellis" artifactId="jvector" version="4.0.0-beta.3" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/13718

### What does this PR fix and why was it fixed
We had adopted this version of lucene https://github.com/datastax/lucene/commit/5ea8bb4f21cb8ad14cb2a861248e24a0aaf1af09 in order to support our custom modifications of HNSW on top of lucene. We now use https://github.com/datastax/jvector for vector search and no longer need a custom build.

I propose we use 9.8.0 since that is the closest release to the one we have been using.

CNDB test pr: https://github.com/riptano/cndb/pull/13757