### PR TITLE
CNDB-13739 count numRows correctly in SSTable SAI

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -146,7 +146,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
-        long numCells;
+        long numRowsForEachTerm;
         long numRows;
         SegmentMetadataBuilder metadataBuilder = new SegmentMetadataBuilder(0, perIndexComponents);
         SegmentMetadata.ComponentMetadataMap indexMetas;
@@ -167,7 +167,7 @@ public class MemtableIndexWriter implements PerIndexWriter
                       );
 
                 indexMetas = writer.writeAll(metadataBuilder.intercept(terms), docLengths);
-                numCells = writer.getPostingsCount();
+                numRowsForEachTerm = writer.getPostingsCount();
                 numRows = docLengths.size();
             }
         }
@@ -182,14 +182,14 @@ public class MemtableIndexWriter implements PerIndexWriter
             {
                 ImmutableOneDimPointValues values = ImmutableOneDimPointValues.fromTermEnum(terms, termComparator);
                 indexMetas = writer.writeAll(metadataBuilder.intercept(values));
-                numCells = writer.getPointCount();
-                numRows = numCells;
+                numRowsForEachTerm = writer.getPointCount();
+                numRows = numRowsForEachTerm;
             }
         }
 
         // If no rows were written we need to delete any created column index components
         // so that the index is correctly identified as being empty (only having a completion marker)
-        if (numRows == 0)
+        if (numRowsForEachTerm == 0)
         {
             perIndexComponents.forceDeleteAllComponents();
             return 0;
@@ -207,7 +207,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
 
-        return numCells;
+        return numRowsForEachTerm;
     }
 
     private boolean writeFrequencies()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -146,7 +146,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
-        long numRowsForEachTerm;
+        long cellCount;
         long numRows;
         SegmentMetadataBuilder metadataBuilder = new SegmentMetadataBuilder(0, perIndexComponents);
         SegmentMetadata.ComponentMetadataMap indexMetas;
@@ -167,7 +167,7 @@ public class MemtableIndexWriter implements PerIndexWriter
                       );
 
                 indexMetas = writer.writeAll(metadataBuilder.intercept(terms), docLengths);
-                numRowsForEachTerm = writer.getPostingsCount();
+                cellCount = writer.getPostingsCount();
                 numRows = docLengths.size();
             }
         }
@@ -182,14 +182,14 @@ public class MemtableIndexWriter implements PerIndexWriter
             {
                 ImmutableOneDimPointValues values = ImmutableOneDimPointValues.fromTermEnum(terms, termComparator);
                 indexMetas = writer.writeAll(metadataBuilder.intercept(values));
-                numRowsForEachTerm = writer.getPointCount();
-                numRows = numRowsForEachTerm;
+                cellCount = writer.getPointCount();
+                numRows = cellCount;
             }
         }
 
         // If no rows were written we need to delete any created column index components
         // so that the index is correctly identified as being empty (only having a completion marker)
-        if (numRowsForEachTerm == 0)
+        if (cellCount == 0)
         {
             perIndexComponents.forceDeleteAllComponents();
             return 0;
@@ -207,7 +207,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
 
-        return numRowsForEachTerm;
+        return cellCount;
     }
 
     private boolean writeFrequencies()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -146,7 +146,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
-        long cellCount;
+        long numPostings;
         long numRows;
         SegmentMetadataBuilder metadataBuilder = new SegmentMetadataBuilder(0, perIndexComponents);
         SegmentMetadata.ComponentMetadataMap indexMetas;
@@ -167,7 +167,7 @@ public class MemtableIndexWriter implements PerIndexWriter
                       );
 
                 indexMetas = writer.writeAll(metadataBuilder.intercept(terms), docLengths);
-                cellCount = writer.getPostingsCount();
+                numPostings = writer.getPostingsCount();
                 numRows = docLengths.size();
             }
         }
@@ -182,14 +182,14 @@ public class MemtableIndexWriter implements PerIndexWriter
             {
                 ImmutableOneDimPointValues values = ImmutableOneDimPointValues.fromTermEnum(terms, termComparator);
                 indexMetas = writer.writeAll(metadataBuilder.intercept(values));
-                cellCount = writer.getPointCount();
-                numRows = cellCount;
+                numPostings = writer.getPointCount();
+                numRows = numPostings;
             }
         }
 
         // If no rows were written we need to delete any created column index components
         // so that the index is correctly identified as being empty (only having a completion marker)
-        if (cellCount == 0)
+        if (numPostings == 0)
         {
             perIndexComponents.forceDeleteAllComponents();
             return 0;
@@ -207,7 +207,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
 
-        return cellCount;
+        return numPostings;
     }
 
     private boolean writeFrequencies()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -504,8 +504,6 @@ public abstract class SegmentBuilder
             maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.latest());
         }
 
-        rowCount++;
-
         // segmentRowIdOffset should encode sstableRowId into Integer
         int segmentRowId = Math.toIntExact(sstableRowId - segmentRowIdOffset);
 
@@ -600,6 +598,11 @@ public abstract class SegmentBuilder
     int getRowCount()
     {
         return rowCount;
+    }
+
+    void incRowCount()
+    {
+        rowCount++;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -465,6 +465,7 @@ public abstract class SegmentBuilder
         metadataBuilder.setKeyRange(minKey, maxKey);
         metadataBuilder.setRowIdRange(minSSTableRowId, maxSSTableRowId);
         metadataBuilder.setTermRange(minTerm, maxTerm);
+        metadataBuilder.setNumRows(getRowCount());
 
         flushInternal(metadataBuilder);
         return metadataBuilder.build();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -35,11 +35,9 @@ import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.kdtree.MutableOneDimPointValues;
 import org.apache.cassandra.index.sai.disk.v6.TermsDistribution;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
-import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.lucene.util.BytesRef;
@@ -88,6 +86,11 @@ public class SegmentMetadataBuilder
         this.termsDistributionBuilder = new TermsDistribution.Builder(context.getValidator(), byteComparableVersion, histogramSize, mostFrequentTermsCount);
     }
 
+    public void setNumRows(long numRows)
+    {
+        this.numRows = numRows;
+    }
+
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
     {
         assert minKey.compareTo(maxKey) <= 0: "minKey (" + minKey + ") must not be greater than (" + maxKey + ')';
@@ -131,7 +134,6 @@ public class SegmentMetadataBuilder
         if (built)
             throw new IllegalStateException("Segment metadata already built, no more additions allowed");
 
-        numRows += rowCount;
         termsDistributionBuilder.add(term, rowCount);
     }
 
@@ -362,7 +364,7 @@ public class SegmentMetadataBuilder
         }
 
         @Override
-        public void close() throws IOException
+        public void close()
         {
             if (lastTerm != null)
             {
@@ -373,5 +375,3 @@ public class SegmentMetadataBuilder
     }
 
 }
-
-

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -829,24 +829,31 @@ public class BM25Test extends SAITester
     @Test
     public void testIndexMetaForNumRows()
     {
-        createTable("CREATE TABLE %s (id int PRIMARY KEY, category text, score int, title text, body text)");
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, category text, score int, " +
+                    "title text, body text, bodyset set<text>, " +
+                    "map_category map<int, text>, map_body map<text, text>)");
         String bodyIndexName = createAnalyzedIndex("body", true);
         String scoreIndexName = createIndex("CREATE CUSTOM INDEX ON %s (score) USING 'StorageAttachedIndex'");
-        insertPrimitiveData();
+        String mapIndexName = createIndex("CREATE CUSTOM INDEX ON %s (map_category) USING 'StorageAttachedIndex'");
+        insertCollectionData();
 
         assertNumRowsMemtable(scoreIndexName, DATASET.length);
         assertNumRowsMemtable(bodyIndexName, DATASET.length);
+        assertNumRowsMemtable(mapIndexName, DATASET.length);
         execute("DELETE FROM %s WHERE id = ?", 5);
         flush();
         assertNumRowsSSTable(scoreIndexName, DATASET.length - 1);
         assertNumRowsSSTable(bodyIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 1);
         execute("DELETE FROM %s WHERE id = ?", 10);
         flush();
         assertNumRowsSSTable(scoreIndexName, DATASET.length - 1);
         assertNumRowsSSTable(bodyIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 1);
         compact();
         assertNumRowsSSTable(scoreIndexName, DATASET.length - 2);
         assertNumRowsSSTable(bodyIndexName, DATASET.length - 2);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 2);
     }
 
     private void assertNumRowsMemtable(String indexName, int expectedNumRows)

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -49,9 +49,8 @@ import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
+import org.assertj.core.api.Assertions;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -194,6 +193,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             MemtableTermsIterator termsIterator = new MemtableTermsIterator(null, null, iter);
             SegmentMetadata.ComponentMetadataMap indexMetas = writer.writeAll(metadataBuilder.intercept(termsIterator), docLengths);
             metadataBuilder.setComponentsMetadata(indexMetas);
+            metadataBuilder.setNumRows(writer.getPostingsCount());
         }
 
         final SegmentMetadata segmentMetadata = metadataBuilder.build();
@@ -207,7 +207,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
                                                                                    indexContext,
                                                                                    indexFiles,
                                                                                    segmentMetadata);
-            assertThat(searcher, is(instanceOf(InvertedIndexSearcher.class)));
+            Assertions.assertThat(searcher).isInstanceOf(InvertedIndexSearcher.class);
             return searcher;
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -193,7 +193,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             MemtableTermsIterator termsIterator = new MemtableTermsIterator(null, null, iter);
             SegmentMetadata.ComponentMetadataMap indexMetas = writer.writeAll(metadataBuilder.intercept(termsIterator), docLengths);
             metadataBuilder.setComponentsMetadata(indexMetas);
-            metadataBuilder.setNumRows(writer.getPostingsCount());
+            metadataBuilder.setNumRows(docLengths.values().stream().mapToInt(i -> i).sum());
         }
 
         final SegmentMetadata segmentMetadata = metadataBuilder.build();

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -68,9 +68,7 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -182,6 +180,7 @@ public class KDTreeIndexBuilder
                                          UTF8Type.instance.fromString("d"));
             metadataBuilder.setKeyRange(SAITester.TEST_FACTORY.createTokenOnly(Murmur3Partitioner.instance.decorateKey(UTF8Type.instance.fromString("a")).getToken()),
                                         SAITester.TEST_FACTORY.createTokenOnly(Murmur3Partitioner.instance.decorateKey(UTF8Type.instance.fromString("b")).getToken()));
+            metadataBuilder.setNumRows(size);
             metadata = metadataBuilder.build();
         }
 
@@ -192,7 +191,7 @@ public class KDTreeIndexBuilder
             when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
 
             IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
-            assertThat(searcher, is(instanceOf(KDTreeIndexSearcher.class)));
+            assertThat(searcher).isInstanceOf(KDTreeIndexSearcher.class);
             return (KDTreeIndexSearcher) searcher;
         }
     }
@@ -293,7 +292,7 @@ public class KDTreeIndexBuilder
      */
     public static AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
     {
-        return new AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>>()
+        return new AbstractGuavaIterator<>()
         {
             private long currentTerm = 0;
             private int currentSegmentRowId = segmentRowIdOffset;
@@ -343,11 +342,13 @@ public class KDTreeIndexBuilder
     public static Iterator<ByteBuffer> decimalRange(final BigDecimal startInclusive, final BigDecimal endExclusive)
     {
         int n = endExclusive.subtract(startInclusive).intValueExact() * 10;
-        final Supplier<BigDecimal> generator = new Supplier<BigDecimal>() {
+        final Supplier<BigDecimal> generator = new Supplier<>()
+        {
             BigDecimal current = startInclusive;
 
             @Override
-            public BigDecimal get() {
+            public BigDecimal get()
+            {
                 BigDecimal result = current;
                 current = current.add(ONE_TENTH);
                 return result;
@@ -363,11 +364,13 @@ public class KDTreeIndexBuilder
     public static Iterator<ByteBuffer> bigIntegerRange(final BigInteger startInclusive, final BigInteger endExclusive)
     {
         int n = endExclusive.subtract(startInclusive).intValueExact();
-        final Supplier<BigInteger> generator = new Supplier<BigInteger>() {
+        final Supplier<BigInteger> generator = new Supplier<>()
+        {
             BigInteger current = startInclusive;
 
             @Override
-            public BigInteger get() {
+            public BigInteger get()
+            {
                 BigInteger result = current;
                 current = current.add(BigInteger.ONE);
                 return result;


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/13739

### What is the issue
The number of rows stored in SSTable's SAI index was incorrect for analyzed indexes and for indexes on collections as it was counting posting lists for each term. In non-analyzed or non-collection indexes there is a term per row, while in analyzed index there can be many terms in a row. This led to incorrect count of rows.

### What does this PR fix and why was it fixed
Fixes counting number of rows stored in SSTable SAI index.

Minor fixes of code warnings in the affected files.
