### PR TITLE
CNDB-13441: Name dtest jar appropriately for publishing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2137,13 +2137,16 @@
   </target>
 
   <target name="dtest-jar" depends="build-test, build" description="Create dtest-compatible jar, including all dependencies">
+    <sequential>
       <jar jarfile="${build.dir}/dtest-${base.version}.jar">
-          <zipgroupfileset dir="${build.lib}" includes="*.jar" excludes="META-INF/*.SF"/>
-          <zipgroupfileset dir="${build.dir.lib}/jars" includes="javassist-*.jar,reflections-*.jar" excludes="META-INF/*.SF"/>
-          <fileset dir="${build.classes.main}"/>
-          <fileset dir="${test.classes}"/>
-          <fileset dir="${test.conf}" />
+        <zipgroupfileset dir="${build.lib}" includes="*.jar" excludes="META-INF/*.SF"/>
+        <zipgroupfileset dir="${build.dir.lib}/jars" includes="javassist-*.jar,reflections-*.jar" excludes="META-INF/*.SF"/>
+        <fileset dir="${build.classes.main}"/>
+        <fileset dir="${test.classes}"/>
+        <fileset dir="${test.conf}" />
       </jar>
+      <copy tofile="${build.dir}/${final.name}-dtest.jar" file="${build.dir}/dtest-${base.version}.jar"/>
+    </sequential>
   </target>
 
   <target name="test-jvm-dtest" depends="maybe-build-test" description="Execute in-jvm dtests">


### PR DESCRIPTION
### What is the issue

Issue: https://github.com/riptano/cndb/issues/13441

### What does this PR fix and why was it fixed
When the build script generates `dtest.jar`, we copy it with a name suitable for publishing by Maven

Note that many tests failed on this PR because it needs https://github.com/riptano/jenkins-pipeline-lib/pull/228 to work properly