### PR TITLE
CNDB-13693: Make SAI's view referenceable to simplify locking query view

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
@@ -276,6 +277,12 @@ public class IndexContext
     public MemtableIndex initializeMemtableIndex(Memtable memtable)
     {
         return liveMemtables.computeIfAbsent(memtable, mt -> MemtableIndex.createIndex(this, mt));
+    }
+
+    @VisibleForTesting
+    public @Nullable MemtableIndex getMemtableIndex(Memtable memtable)
+    {
+        return liveMemtables.get(memtable);
     }
 
     public void index(DecoratedKey key, Row row, Memtable memtable, OpOrder.Group opGroup)

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -272,9 +272,14 @@ public class IndexContext
         return cfs.getPartitioner();
     }
 
+    public MemtableIndex initializeMemtableIndex(Memtable memtable)
+    {
+        return liveMemtables.computeIfAbsent(memtable, mt -> MemtableIndex.createIndex(this, mt));
+    }
+
     public void index(DecoratedKey key, Row row, Memtable memtable, OpOrder.Group opGroup)
     {
-        MemtableIndex target = liveMemtables.computeIfAbsent(memtable, mt -> MemtableIndex.createIndex(this, mt));
+        MemtableIndex target = initializeMemtableIndex(memtable);
 
         long start = System.nanoTime();
 

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -579,11 +579,10 @@ public class IndexContext
      * @return A set of SSTables which have attached to them invalid index components.
      */
     public Set<SSTableContext> onSSTableChanged(Collection<SSTableReader> oldSSTables,
-                                                Collection<SSTableReader> newSSTables,
                                                 Collection<SSTableContext> newContexts,
                                                 boolean validate)
     {
-        return viewManager.update(oldSSTables, newSSTables, newContexts, validate);
+        return viewManager.update(oldSSTables, newContexts, validate);
     }
 
     public ColumnMetadata getDefinition()

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
@@ -277,12 +276,6 @@ public class IndexContext
     public MemtableIndex initializeMemtableIndex(Memtable memtable)
     {
         return liveMemtables.computeIfAbsent(memtable, mt -> MemtableIndex.createIndex(this, mt));
-    }
-
-    @VisibleForTesting
-    public @Nullable MemtableIndex getMemtableIndex(Memtable memtable)
-    {
-        return liveMemtables.get(memtable);
     }
 
     public void index(DecoratedKey key, Row row, Memtable memtable, OpOrder.Group opGroup)

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -658,6 +658,16 @@ public class IndexContext
         return viewManager.getView();
     }
 
+    public View getReferencedView()
+    {
+        do
+        {
+            View view = viewManager.getView();
+            if (view.reference())
+                return view;
+        } while (true);
+    }
+
     /**
      * @return total number of per-index open files
      */
@@ -713,16 +723,6 @@ public class IndexContext
     public ConcurrentMap<Memtable, MemtableIndex> getLiveMemtables()
     {
         return liveMemtables;
-    }
-
-    public @Nullable MemtableIndex getMemtableIndex(Memtable memtable)
-    {
-        return liveMemtables.get(memtable);
-    }
-
-    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
-    {
-        return getView().getSSTableIndex(descriptor);
     }
 
     public boolean supports(Operator op)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -806,6 +806,27 @@ public class StorageAttachedIndex implements Index
         {
             indexContext.update(key, oldRow, newRow, mt, CassandraWriteContext.fromContext(writeContext).getGroup());
         }
+
+        @Override
+        public void partitionDelete(DeletionTime deletionTime)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
+
+        @Override
+        public void rangeTombstone(RangeTombstone tombstone)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
+
+        @Override
+        public void removeRow(Row row)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
     }
 
     protected static abstract class IndexerAdapter implements Indexer
@@ -815,21 +836,6 @@ public class StorageAttachedIndex implements Index
 
         @Override
         public void finish() { }
-
-        @Override
-        public void partitionDelete(DeletionTime dt)
-        {
-        }
-
-        @Override
-        public void rangeTombstone(RangeTombstone rt)
-        {
-        }
-
-        @Override
-        public void removeRow(Row row)
-        {
-        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -319,7 +319,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             // Avoid validation for index files just written following Memtable flush. ZCS streaming should
             // validate index checksum.
             boolean validate = notice.fromStreaming() || !notice.memtable().isPresent();
-            onSSTableChanged(Collections.emptySet(), Lists.newArrayList(notice.added), indices, validate);
+            onSSTableChanged(Collections.emptySet(), notice.added, indices, validate);
         }
         else if (notification instanceof SSTableListChangedNotification)
         {
@@ -359,7 +359,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
      * @return the set of column indexes that were marked as non-queryable as a result of their per-SSTable index
      * files being corrupt or being unable to successfully update their views
      */
-    public synchronized Set<StorageAttachedIndex> onSSTableChanged(Collection<SSTableReader> removed, Collection<SSTableReader> added,
+    public synchronized Set<StorageAttachedIndex> onSSTableChanged(Collection<SSTableReader> removed, Iterable<SSTableReader> added,
                                                             Set<StorageAttachedIndex> indexes, boolean validate)
     {
         Optional<Set<SSTableContext>> optValid = contextManager.update(removed, added, validate, indices);
@@ -374,7 +374,7 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
 
         for (StorageAttachedIndex index : indexes)
         {
-            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, added, optValid.get(), validate);
+            Set<SSTableContext> invalid = index.getIndexContext().onSSTableChanged(removed, optValid.get(), validate);
 
             if (!invalid.isEmpty())
             {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
 import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.WriteContext;
 import org.apache.cassandra.db.filter.RowFilter;
@@ -225,6 +227,18 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             public void removeRow(Row row)
             {
                 forEach(indexer -> indexer.removeRow(row));
+            }
+
+            @Override
+            public void partitionDelete(DeletionTime deletionTime)
+            {
+                forEach(indexer -> indexer.partitionDelete(deletionTime));
+            }
+
+            @Override
+            public void rangeTombstone(RangeTombstone tombstone)
+            {
+                forEach(indexer -> indexer.rangeTombstone(tombstone));
             }
 
             private void forEach(Consumer<Index.Indexer> action)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
@@ -507,7 +508,13 @@ public class CassandraOnHeapGraph<T> implements Accountable
     {
         // Retrieve the first compressed vectors for a segment with at least MAX_PQ_TRAINING_SET_SIZE rows
         // or the one with the most rows if none reach that size
-        var view = indexContext.getReferencedView();
+        var view = indexContext.getReferencedView(TimeUnit.SECONDS.toNanos(5));
+        if (view == null)
+        {
+            logger.warn("Unable to get view of already built indexes for {}", indexContext);
+            return null;
+        }
+
         try
         {
             var indexes = new ArrayList<>(view.getIndexes());

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -502,33 +502,41 @@ public class CassandraOnHeapGraph<T> implements Accountable
     {
         // Retrieve the first compressed vectors for a segment with at least MAX_PQ_TRAINING_SET_SIZE rows
         // or the one with the most rows if none reach that size
-        var indexes = new ArrayList<>(indexContext.getView().getIndexes());
-        indexes.sort(Comparator.comparing(SSTableIndex::getSSTable, CompactionSSTable.maxTimestampDescending));
-
-        PqInfo cvi = null;
-        long maxRows = 0;
-        for (SSTableIndex index : indexes)
+        var view = indexContext.getReferencedView();
+        try
         {
-            for (Segment segment : index.getSegments())
+            var indexes = new ArrayList<>(view.getIndexes());
+            indexes.sort(Comparator.comparing(SSTableIndex::getSSTable, CompactionSSTable.maxTimestampDescending));
+
+            PqInfo cvi = null;
+            long maxRows = 0;
+            for (SSTableIndex index : indexes)
             {
-                if (segment.metadata.numRows < maxRows)
-                    continue;
-
-                var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
-                var cv = searcher.getCompression();
-                if (matcher.apply(cv))
+                for (Segment segment : index.getSegments())
                 {
-                    // We can exit now because we won't find a better candidate
-                    var candidate = new PqInfo(searcher.getPQ(), searcher.containsUnitVectors(), segment.metadata.numRows);
-                    if (segment.metadata.numRows >= ProductQuantization.MAX_PQ_TRAINING_SET_SIZE)
-                        return candidate;
+                    if (segment.metadata.numRows < maxRows)
+                        continue;
 
-                    cvi = candidate;
-                    maxRows = segment.metadata.numRows;
+                    var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+                    var cv = searcher.getCompression();
+                    if (matcher.apply(cv))
+                    {
+                        // We can exit now because we won't find a better candidate
+                        var candidate = new PqInfo(searcher.getPQ(), searcher.containsUnitVectors(), segment.metadata.numRows);
+                        if (segment.metadata.numRows >= ProductQuantization.MAX_PQ_TRAINING_SET_SIZE)
+                            return candidate;
+
+                        cvi = candidate;
+                        maxRows = segment.metadata.numRows;
+                    }
                 }
             }
+            return cvi;
         }
-        return cvi;
+        finally
+        {
+            view.release();
+        }
     }
 
     private long writePQ(SequentialWriter writer, V5VectorPostingsWriter.RemappedPostings remapped, IndexContext indexContext) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -449,7 +449,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private KeyRangeIterator buildIterator(Expression predicate)
     {
         QueryView view = getQueryView(predicate.context);
-        return KeyRangeTermIterator.build(predicate, view.referencedIndexes, mergeRange, queryContext, false, Integer.MAX_VALUE);
+        return KeyRangeTermIterator.build(predicate, view.sstableIndexes, mergeRange, queryContext, false, Integer.MAX_VALUE);
     }
 
     /**
@@ -460,7 +460,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     QueryView getQueryView(IndexContext context) throws QueryView.Builder.MissingIndexException
     {
         return queryViews.computeIfAbsent(context,
-                                          c -> new QueryView.Builder(c, mergeRange, queryContext).build());
+                                          c -> new QueryView.Builder(c, mergeRange).build());
 
     }
 
@@ -720,7 +720,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private List<CloseableIterator<PrimaryKeyWithSortKey>> searchSSTables(QueryView queryView, SSTableSearcher searcher)
     {
         List<CloseableIterator<PrimaryKeyWithSortKey>> results = new ArrayList<>();
-        for (var index : queryView.referencedIndexes)
+        for (var index : queryView.sstableIndexes)
         {
             try
             {

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -123,7 +123,7 @@ public class QueryView implements AutoCloseable
          * Acquire references to all the memtables, memtable indexes, sstables, and sstable indexes required for the
          * given expression.
          */
-        protected QueryView build() throws IllegalStateException
+        protected QueryView build() throws MissingIndexException
         {
             var sstableIndexes = new HashSet<SSTableIndex>();
             View saiView = null;

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -130,6 +130,9 @@ public class QueryView implements AutoCloseable
             try
             {
                 // Get memtables first in case we are in the middle of flushing one.
+                // Note that we get the memtables from the index context, which is updated via notifications after
+                // the index context's view is updated, which guarantees a complete and correct view of the table in
+                // favor of possibly duplicated search on a recently flushed memtable and its corresponding sstable.
                 var memtableIndexes = new HashSet<>(indexContext.getLiveMemtables().values());
                 // This is an atomic operation to get an already referenced view of all current local indexes for the table
                 saiView = indexContext.getReferencedView();

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -18,8 +18,8 @@
 
 package org.apache.cassandra.index.sai.plan;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -31,8 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.lifecycle.SSTableSet;
-import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
@@ -40,38 +38,35 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
-import org.apache.cassandra.index.sai.utils.RangeUtil;
+import org.apache.cassandra.index.sai.view.View;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.MonotonicClock;
-import org.apache.cassandra.utils.NoSpamLogger;
 
 
 public class QueryView implements AutoCloseable
 {
-    final ColumnFamilyStore.RefViewFragment view;
-    final Set<SSTableIndex> referencedIndexes;
+    final View saiView;
+    final ColumnFamilyStore.ViewFragment viewFragment;
+    final Set<SSTableIndex> sstableIndexes;
     final Set<MemtableIndex> memtableIndexes;
-    final IndexContext indexContext;
 
-    public QueryView(ColumnFamilyStore.RefViewFragment view,
-                     Set<SSTableIndex> referencedIndexes,
-                     Set<MemtableIndex> memtableIndexes,
-                     IndexContext indexContext)
+    public QueryView(View saiView,
+                     ColumnFamilyStore.ViewFragment viewFragment,
+                     Set<SSTableIndex> sstableIndexes,
+                     Set<MemtableIndex> memtableIndexes)
     {
-
-        this.view = view;
-        this.referencedIndexes = referencedIndexes;
+        this.saiView = saiView;
+        this.viewFragment = viewFragment;
+        this.sstableIndexes = sstableIndexes;
         this.memtableIndexes = memtableIndexes;
-        this.indexContext = indexContext;
     }
 
     @Override
     public void close()
     {
-        view.release();
-        referencedIndexes.forEach(SSTableIndex::release);
+        saiView.release();
     }
 
     /**
@@ -79,7 +74,7 @@ public class QueryView implements AutoCloseable
      */
     public long getTotalSStableRows()
     {
-        return view.sstables.stream().mapToLong(SSTableReader::getTotalRows).sum();
+        return viewFragment.sstables.stream().mapToLong(SSTableReader::getTotalRows).sum();
     }
 
     /**
@@ -91,17 +86,13 @@ public class QueryView implements AutoCloseable
     {
         private static final Logger logger = LoggerFactory.getLogger(Builder.class);
 
-        private final ColumnFamilyStore cfs;
         private final IndexContext indexContext;
         private final AbstractBounds<PartitionPosition> range;
-        private final QueryContext queryContext;
 
-        Builder(IndexContext indexContext, AbstractBounds<PartitionPosition> range, QueryContext queryContext)
+        Builder(IndexContext indexContext, AbstractBounds<PartitionPosition> range)
         {
-            this.cfs = indexContext.columnFamilyStore();
             this.indexContext = indexContext;
             this.range = range;
-            this.queryContext = queryContext;
         }
 
         /**
@@ -111,29 +102,18 @@ public class QueryView implements AutoCloseable
         static class MissingIndexException extends RuntimeException
         {
             final IndexContext context;
-            final String dataObjectName;
 
-            private MissingIndexException(IndexContext context, String dataObjectName)
+            private MissingIndexException(IndexContext context)
             {
                 super();
                 this.context = context;
-                this.dataObjectName = dataObjectName;
-            }
-
-            public static MissingIndexException forSSTable(IndexContext context, Descriptor descriptor)
-            {
-                return new MissingIndexException(context, "sstable " + descriptor);
-            }
-
-            public static MissingIndexException forMemtable(IndexContext context, Memtable memtable)
-            {
-                return new MissingIndexException(context, "memtable " + memtable);
             }
 
             @Override
             public String getMessage()
             {
-                return "Index " + context.getIndexName() + " not found for " + dataObjectName;
+                return context.isDropped() ? "Index " + context.getIndexName() + " was dropped."
+                                           : "Unable to acquire lock on index view: " + context.getIndexName() + ".";
             }
         }
 
@@ -141,171 +121,53 @@ public class QueryView implements AutoCloseable
          * Acquire references to all the memtables, memtable indexes, sstables, and sstable indexes required for the
          * given expression.
          */
-        protected QueryView build() throws MissingIndexException
+        protected QueryView build() throws IllegalStateException
         {
-            var referencedIndexes = new HashSet<SSTableIndex>();
-            ColumnFamilyStore.RefViewFragment refViewFragment = null;
-
-            // We must use the canonical view in order for the equality check for source sstable/memtable
-            // to work correctly.
-            var filter = RangeUtil.coversFullRing(range)
-                         ? View.selectFunction(SSTableSet.CANONICAL)
-                         : View.select(SSTableSet.CANONICAL, s -> RangeUtil.intersects(s, range));
-
-
+            var sstableIndexes = new HashSet<SSTableIndex>();
             try
             {
-                // Keeps track of which memtables we've already tried to match the index to.
-                // If we fail to match the index to the memtable for the first time, we have to retry
-                // because the memtable could be flushed and its index removed between the moment we
-                // got the view and the moment we did the lookup.
-                // If we get the same memtable in the view again, and there is no index,
-                // then the missing index is not due to a concurrent modification, but it doesn't contain indexed
-                // data, so we can ignore it.
-                var processedMemtables = new HashSet<Memtable>();
-
-
-                var start = MonotonicClock.approxTime.now();
-                Memtable unmatchedMemtable = null;
-                Descriptor unmatchedSStable = null;
-
-                // This loop will spin only if there is a mismatch between the view managed by IndexViewManager
-                // and the view managed by Cassandra Tracker. Such a mismatch can happen at the moment when
-                // the sstable or memtable sets are updated, e.g. on flushes or compactions. The mismatch
-                // should last only until all Tracker notifications get processed by SAI
-                // (which doesn't involve I/O and should be very fast). We expect the mismatch to resolve in order
-                // of nanoceconds, but the timeout is large enough just in case of unpredictable performance hiccups.
-                outer:
+                long start = MonotonicClock.approxTime.now();
                 while (!MonotonicClock.approxTime.isAfter(start + TimeUnit.MILLISECONDS.toNanos(2000)))
                 {
-                    // cleanup after the previous iteration if we're retrying
-                    release(referencedIndexes);
-                    release(refViewFragment);
+                    // Get memtables first in case we are in the middle of flushing one.
+                    var memtableIndexes = new HashSet<>(indexContext.getLiveMemtables().values());
+                    // This is an atomic operation to get the current view of all local indexes for the table
+                    var saiView = indexContext.getView();
+                    if (!saiView.reference())
+                        continue;
 
-                    // Prevent exceeding the query timeout
-                    queryContext.checkpoint();
+                    // Can happen if we are spinning and index is dropped. We check after getting a reference.
+                    if (!indexContext.isIndexed())
+                        throw new MissingIndexException(indexContext);
 
-                    // Lock a consistent view of memtables and sstables.
-                    // A consistent view is required for correctness of order by and vector queries.
-                    refViewFragment = cfs.selectAndReference(filter);
-                    var indexView = indexContext.getView();
-
-                    // Lookup the indexes corresponding to memtables:
-                    var memtableIndexes = new HashSet<MemtableIndex>();
-                    for (Memtable memtable : refViewFragment.memtables)
+                    var sstableReaders = new ArrayList<SSTableReader>(saiView.size());
+                    // These are already referenced because they are referenced by the same view we just referenced.
+                    // TODO review saiView.match() method for boolean predicates.
+                    for (var index : saiView.getIndexes())
                     {
-                        // Empty memtables have no index but that's not a problem, we can ignore them.
-                        if (memtable.getLiveDataSize() == 0)
-                            continue;
-
-                        MemtableIndex index = indexContext.getMemtableIndex(memtable);
-                        if (index != null)
-                        {
-                            memtableIndexes.add(index);
-                        }
-                        else if (indexContext.isDropped())
-                        {
-                            // Index was dropped deliberately by the user.
-                            // We cannot recover here.
-                            throw MissingIndexException.forMemtable(indexContext, memtable);
-                        }
-                        else if (!processedMemtables.contains(memtable))
-                        {
-                            // We can end up here if a flush happened right after we referenced the refViewFragment
-                            // but before looking up the memtable index.
-                            // In that case, we need to retry with the updated view
-                            // (we expect the updated view to not contain this memtable).
-
-                            // Remember this metable to protect from infinite looping in case we have a permanent
-                            // inconsistency between the index set and the memtable set.
-                            processedMemtables.add(memtable);
-
-                            unmatchedMemtable = memtable;
-                            continue outer;
-                        }
-                        // If the memtable was non-empty, the index context hasn't been dropped, but the
-                        // index doesn't exist on the second attempt, then his means there is no indexed data
-                        // in that memtable. In this case we just continue without it.
-                        // Memtable indexes are created lazily, on the first insert, therefore a missing index
-                        // is a normal situation.
-                    }
-
-                    // Lookup and reference the indexes corresponding to the sstables:
-                    for (SSTableReader sstable : refViewFragment.sstables)
-                    {
-                        // Empty sstables are ok to not have the index.
-                        if (sstable.getTotalRows() == 0)
-                            continue;
-
-                        // If the IndexViewManager never saw this sstable, then we need to spin.
-                        // Let's hope in the next iteration we get the indexView based on the same sstable set
-                        // as the refViewFragment.
-                        if (!indexView.isAwareOfSSTable(sstable.descriptor))
-                        {
-                            if (MonotonicClock.approxTime.isAfter(start + 100))
-                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                 "Spinning trying to get the index for sstable {} because index view is out of sync", sstable.descriptor);
-
-                            unmatchedSStable = sstable.descriptor;
-                            continue outer;
-                        }
-
-                        SSTableIndex index = indexView.getSSTableIndex(sstable.descriptor);
-
-                        // The IndexViewManager got the update about this sstable, but there is no index for the sstable
-                        // (e.g. index was dropped or got corrupt, etc.). In this case retrying won't fix it.
-                        if (index == null)
-                            throw MissingIndexException.forSSTable(indexContext, sstable.descriptor);
-
                         if (!indexInRange(index))
                             continue;
-
-                        // It is unlikely but possible the index got unreferenced just between the moment we grabbed the
-                        // refViewFragment and getting here. In that case we won't be able to reference it and we have
-                        // to retry.
-                        if (!index.reference())
-                        {
-
-                            if (MonotonicClock.approxTime.isAfter(start + 100))
-                                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.SECONDS,
-                                                 "Spinning trying to get the index for sstable {} because index was released", sstable.descriptor);
-
-                            unmatchedSStable = sstable.descriptor;
-                            continue outer;
-                        }
-
-                        referencedIndexes.add(index);
+                        sstableIndexes.add(index);
+                        sstableReaders.add(index.getSSTable());
                     }
 
-                    // freeze referencedIndexes and memtableIndexes, so we can safely give access to them
-                    // without risking something messes them up
-                    // (this was added after KeyRangeTermIterator messed them up which led to a bug)
-                    return new QueryView(refViewFragment,
-                                         Collections.unmodifiableSet(referencedIndexes),
-                                         Collections.unmodifiableSet(memtableIndexes),
-                                         indexContext);
+                    var memtables = new ArrayList<Memtable>(memtableIndexes.size());
+                    for (var index : memtableIndexes)
+                    {
+                        var memtable = index.getMemtable();
+                        memtables.add(memtable);
+                    }
+
+                    var viewFragment = new ColumnFamilyStore.ViewFragment(sstableReaders, memtables);
+                    return new QueryView(saiView, viewFragment, sstableIndexes, memtableIndexes);
                 }
-
-                if (unmatchedMemtable != null)
-                    throw MissingIndexException.forMemtable(indexContext, unmatchedMemtable);
-                if (unmatchedSStable != null)
-                    throw MissingIndexException.forSSTable(indexContext, unmatchedSStable);
-
-                // This should be unreachable, because whenever we retry, we always set unmatchedMemtable
-                // or unmatchedSSTable, so we'd log a better message above.
-                throw new AssertionError("Failed to build QueryView for index " + indexContext.getIndexName());
-            }
-            catch (MissingIndexException e)
-            {
-                release(referencedIndexes);
-                release(refViewFragment);
-                throw e;
+                throw new MissingIndexException(indexContext);
             }
             finally
             {
                 if (Tracing.isTracing())
                 {
-                    var groupedIndexes = referencedIndexes.stream().collect(
+                    var groupedIndexes = sstableIndexes.stream().collect(
                     Collectors.groupingBy(i -> i.getIndexContext().getIndexName(), Collectors.counting()));
                     var summary = groupedIndexes.entrySet().stream()
                                                 .map(e -> String.format("%s (%s sstables)", e.getKey(), e.getValue()))
@@ -313,19 +175,6 @@ public class QueryView implements AutoCloseable
                     Tracing.trace("Querying storage-attached indexes {}", summary);
                 }
             }
-        }
-
-        private void release(ColumnFamilyStore.RefViewFragment refViewFragment)
-        {
-            if (refViewFragment != null)
-                refViewFragment.release();
-        }
-
-        private void release(Collection<SSTableIndex> indexes)
-        {
-            for (var index : indexes)
-                index.release();
-            indexes.clear();
         }
 
         // I've removed the concept of "most selective index" since we don't actually have per-sstable

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -135,7 +135,9 @@ public class QueryView implements AutoCloseable
                 // favor of possibly duplicated search on a recently flushed memtable and its corresponding sstable.
                 var memtableIndexes = new HashSet<>(indexContext.getLiveMemtables().values());
                 // This is an atomic operation to get an already referenced view of all current local indexes for the table
-                saiView = indexContext.getReferencedView();
+                saiView = indexContext.getReferencedView(TimeUnit.SECONDS.toNanos(5));
+                if (saiView == null)
+                    throw new MissingIndexException(indexContext);
 
                 // Now that we referenced a view, need to confirm that the view we referenced isn't somehow invalid.
                 if (!indexContext.isIndexed())

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -101,19 +101,21 @@ public class QueryView implements AutoCloseable
          */
         static class MissingIndexException extends RuntimeException
         {
-            final IndexContext context;
+            final boolean isDropped;
+            final String indexName;
 
             private MissingIndexException(IndexContext context)
             {
                 super();
-                this.context = context;
+                this.isDropped = context.isDropped();
+                this.indexName = context.getIndexName();
             }
 
             @Override
             public String getMessage()
             {
-                return context.isDropped() ? "Index " + context.getIndexName() + " was dropped."
-                                           : "Unable to acquire lock on index view: " + context.getIndexName() + ".";
+                return isDropped ? "Index " + indexName + " was dropped."
+                                 : "Unable to acquire lock on index view: " + indexName + '.';
             }
         }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -135,7 +135,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 // And if there are no good indexes left, we'd get a good contextual request error message.
                 if (e.isDropped && retries < 8)
                 {
-                    logger.debug("Index " + e.context.getIndexName() + " dropped while preparing the query plan. Retrying.");
+                    logger.debug("Index " + e.indexName + " dropped while preparing the query plan. Retrying.");
                     retries++;
                     continue;
                 }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -467,7 +467,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
      */
     public static class ScoreOrderedResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
     {
-        private final ColumnFamilyStore.RefViewFragment view;
+        private final ColumnFamilyStore.ViewFragment view;
         private final List<AbstractBounds<PartitionPosition>> keyRanges;
         private final boolean coversFullRing;
         private final CloseableIterator<PrimaryKeyWithSortKey> scoredPrimaryKeyIterator;
@@ -499,7 +499,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                                             ColumnMetadata orderedColumn)
         {
             IndexContext context = controller.getOrderer().context;
-            this.view = controller.getQueryView(context).view;
+            this.view = controller.getQueryView(context).viewFragment;
             this.keyRanges = controller.dataRanges().stream().map(DataRange::keyRange).collect(Collectors.toList());
             this.coversFullRing = keyRanges.size() == 1 && RangeUtil.coversFullRing(keyRanges.get(0));
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -133,7 +133,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 // and creating the result retriever, we can retry without that index,
                 // because there may be other indexes that could be used to run the query.
                 // And if there are no good indexes left, we'd get a good contextual request error message.
-                if (e.context.isDropped() && retries < 8)
+                if (e.isDropped && retries < 8)
                 {
                     logger.debug("Index " + e.context.getIndexName() + " dropped while preparing the query plan. Retrying.");
                     retries++;

--- a/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
+++ b/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
@@ -129,7 +129,8 @@ public class IndexViewManager
             }
 
             newView = new View(context, referencedSSTableIndexes);
-        } while (newView == null || !viewRef.compareAndSet(currentView, newView));
+        }
+        while (newView == null || !viewRef.compareAndSet(currentView, newView));
 
         // These were referenced when created and then the ones we are keeping were re-referenced if they made it into
         // the newViewIndexes.

--- a/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
+++ b/src/java/org/apache/cassandra/index/sai/view/IndexViewManager.java
@@ -191,7 +191,7 @@ public class IndexViewManager
         View oldView, newView = null;
         do
         {
-            // We skip referencing becuase we do not use its indexes.
+            // We skip referencing because we do not use its indexes.
             oldView = viewRef.get();
             if (newView != null)
                 newView.release();

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -194,10 +194,12 @@ public class SecondaryIndexManagerTest extends CQLTester
         assertEmpty(execute("SELECT * FROM %s WHERE a=1"));
         assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
-        // track sstable again: expect the query that needs the index cannot execute
+        // TODO why? This change reverts back to behavior from before https://github.com/datastax/cassandra/pull/1491,
+        // but it seems invalid.
+        // track sstable again: expect no rows to be read by index
         cfs.getTracker().addInitialSSTables(sstables);
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
-        assertThrows(IOError.class, () -> execute("SELECT * FROM %s WHERE c=1"));
+        assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.index;
 
 import java.io.FileNotFoundException;
-import java.io.IOError;
 import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
@@ -206,6 +205,38 @@ public class SecondaryIndexManagerTest extends CQLTester
         waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
         assertRows(execute("SELECT * FROM %s WHERE c=1"), row(1, 1, 1));
+    }
+
+    @Test
+    public void testPartialIndexRebuild()
+    {
+        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+
+        assertMarkedAsBuilt(indexName);
+
+        execute("Insert into %s(a,b,c) VALUES(1,1,1)");
+        assertRows(execute("SELECT * FROM %s WHERE c=1"), row(1, 1, 1));
+        flush(KEYSPACE);
+
+        execute("Insert into %s(a,b,c) VALUES(2,2,2)");
+        flush(KEYSPACE);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        var sstables = cfs.getLiveSSTables().iterator();
+        SSTableReader sstableToRebuild = sstables.next();
+        assertTrue("Test needs two sstables to be valid", sstables.hasNext());
+
+        // This test only partially covers building an index. The bug it covers was only reproducible when sstables
+        // are not locally present due to logic in the StorageAttachedIndexGroup::prepareSSTablesToBuild method.
+        // In order to simplify things, we just assert that the indexes still present in the view are not released.
+        var indexMetadata = cfs.metadata().indexes.iterator().next();
+        var indexContext = ((StorageAttachedIndex) cfs.getIndexManager().getIndex(indexMetadata)).getIndexContext();
+        indexContext.prepareSSTablesForRebuild(Set.of(sstableToRebuild));
+
+        // The indexes in the view must not be released
+        for (var index : indexContext.getView().getIndexes())
+            assertFalse(index.isReleased());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -862,7 +862,7 @@ public class BM25Test extends SAITester
 
         for (var memtable : getCurrentColumnFamilyStore().getAllMemtables())
         {
-            MemtableIndex memIndex = getIndexContext(indexName).getMemtableIndex(memtable);
+            MemtableIndex memIndex = getIndexContext(indexName).getLiveMemtables().get(memtable);
             assert memIndex instanceof TrieMemtableIndex;
             rowCount = Arrays.stream(((TrieMemtableIndex) memIndex).getRangeIndexes())
                              .map(index -> ((TrieMemoryIndex) index).getDocLengths().size())

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -183,7 +183,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     }
 
     @Test
-    public void deletedInOtherSSTablesTest()
+    public void deletedInOtherSSTablesTest() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
@@ -199,9 +199,11 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
 
         execute("DELETE from %s WHERE pk = 0");
         execute("DELETE from %s WHERE pk = 1");
-        result = execute("SELECT * FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 1");
-        assertThat(result).hasSize(1);
-        assertContainsInt(result, "pk", 2);
+        beforeAndAfterFlush(() -> {
+            var r = execute("SELECT * FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 1");
+            assertThat(r).hasSize(1);
+            assertContainsInt(r, "pk", 2);
+        });
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -207,8 +206,11 @@ public class IndexViewManagerTest extends SAITester
 
             for (SSTableIndex index : initialIndexes)
             {
-                // Since there is a race, we expect these to be released at least 2 times, but it could be more.
-                assertTrue("Expected at least 2 releases",2 <= ((MockSSTableIndex) index).releaseCount);
+                // Because of the race condition, it is released either once or twice. It won't be more
+                // because there are only two updates. The only real requirement is that it is released.
+                var releaseCount = ((MockSSTableIndex) index).releaseCount;
+                assertTrue("releaseCount should be 1 or 2 but it is " + releaseCount,
+                           releaseCount == 1 || releaseCount == 2);
                 assertTrue(index.isReleased());
             }
 


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/13693

### What does this PR fix and why was it fixed

The new design is to:

1. Make sai `View` reference-able so that it holds references to the underlying `SSTableIndex`s. When the `view` is released the final time, it releases the indexes. This moves all of the complexity of grabbing references to sstable update time and out of the query path, which seems like a generally good improvement.
2. Observe that `SSTableIndex` holds a reference to its associated sstable reader.

Note also that we need to create the memtable index on deletions in order to make the index-first solution work.

Also note that sstables indexes are added before they are removed on flush, so this change in design is safe for flush.