### PR TITLE
CNDB-13822: Add ANN_OPTION use_pruning

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -38,8 +38,9 @@ import org.apache.cassandra.utils.FBUtilities;
 public class ANNOptions
 {
     public static final String RERANK_K_OPTION_NAME = "rerank_k";
+    public static final String USE_PRUNING_OPTION_NAME = "use_pruning";
 
-    public static final ANNOptions NONE = new ANNOptions(null);
+    public static final ANNOptions NONE = new ANNOptions(null, null);
 
     public static final Serializer serializer = new Serializer();
 
@@ -51,15 +52,22 @@ public class ANNOptions
     @Nullable
     public final Integer rerankK;
 
-    private ANNOptions(@Nullable Integer rerankK)
+    /**
+     * Whether to use pruning to speed up the ANN search. If {@code null}, the default value is used.
+     */
+    @Nullable
+    public final Boolean usePruning;
+
+    private ANNOptions(@Nullable Integer rerankK, @Nullable Boolean usePruning)
     {
         this.rerankK = rerankK;
+        this.usePruning = usePruning;
     }
 
-    public static ANNOptions create(@Nullable Integer rerankK)
+    public static ANNOptions create(@Nullable Integer rerankK, @Nullable Boolean usePruning)
     {
         // if all the options are null, return the NONE instance
-        return rerankK == null ? NONE : new ANNOptions(rerankK);
+        return rerankK == null && usePruning == null ? NONE : new ANNOptions(rerankK, usePruning);
     }
 
     /**
@@ -67,13 +75,16 @@ public class ANNOptions
      */
     public void validate(QueryState state, String keyspace, int limit)
     {
-        if (rerankK == null)
+        if (rerankK == null && usePruning == null)
             return;
 
-        if (rerankK < limit)
-            throw new InvalidRequestException(String.format("Invalid rerank_k value %d lesser than limit %d", rerankK, limit));
+        if (rerankK != null)
+        {
+            if (rerankK < limit)
+                throw new InvalidRequestException(String.format("Invalid rerank_k value %d lesser than limit %d", rerankK, limit));
 
-        Guardrails.annRerankKMaxValue.guard(rerankK, "ANN options", false, state);
+            Guardrails.annRerankKMaxValue.guard(rerankK, "ANN options", false, state);
+        }
 
         // Ensure that all nodes in the cluster are in a version that supports ANN options, including this one
         assert keyspace != null;
@@ -93,6 +104,7 @@ public class ANNOptions
     public static ANNOptions fromMap(Map<String, String> map)
     {
         Integer rerankK = null;
+        Boolean usePruning = null;
 
         for (Map.Entry<String, String> entry : map.entrySet())
         {
@@ -103,13 +115,17 @@ public class ANNOptions
             {
                 rerankK = parseRerankK(value);
             }
+            else if (name.equals(USE_PRUNING_OPTION_NAME))
+            {
+                usePruning = parseUsePruning(value);
+            }
             else
             {
                 throw new InvalidRequestException("Unknown ANN option: " + name);
             }
         }
 
-        return ANNOptions.create(rerankK);
+        return ANNOptions.create(rerankK, usePruning);
     }
 
     private static int parseRerankK(String value)
@@ -129,9 +145,28 @@ public class ANNOptions
         return rerankK;
     }
 
+    private static boolean parseUsePruning(String value)
+    {
+        value = value.toLowerCase();
+        if (!value.equals("true") && !value.equals("false"))
+            throw new InvalidRequestException(String.format("Invalid '%s' ANN option. Expected a boolean but found: %s",
+                                                            USE_PRUNING_OPTION_NAME, value));
+        return Boolean.parseBoolean(value);
+    }
+
     public String toCQLString()
     {
-        return String.format("{'%s': %d}", RERANK_K_OPTION_NAME, rerankK);
+        StringBuilder sb = new StringBuilder("{");
+        if (rerankK != null)
+            sb.append(String.format("'%s': %d", RERANK_K_OPTION_NAME, rerankK));
+        if (usePruning != null)
+        {
+            if (rerankK != null)
+                sb.append(", ");
+            sb.append(String.format("'%s': %b", USE_PRUNING_OPTION_NAME, usePruning));
+        }
+        sb.append("}");
+        return sb.toString();
     }
 
     @Override
@@ -140,13 +175,14 @@ public class ANNOptions
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ANNOptions that = (ANNOptions) o;
-        return Objects.equals(rerankK, that.rerankK);
+        return Objects.equals(rerankK, that.rerankK) &&
+               Objects.equals(usePruning, that.usePruning);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(rerankK);
+        return Objects.hash(rerankK, usePruning);
     }
 
     /**
@@ -166,9 +202,9 @@ public class ANNOptions
     {
         /** Bit flags mask to check if the rerank K option is present. */
         private static final int RERANK_K_MASK = 1;
-
+        private static final int USE_PRUNING_MASK = 2;
         /** Bit flags mask to check if there are any unknown options. It's the negation of all the known flags. */
-        private static final int UNKNOWN_OPTIONS_MASK = ~RERANK_K_MASK;
+        private static final int UNKNOWN_OPTIONS_MASK = ~(RERANK_K_MASK | USE_PRUNING_MASK);
 
         /*
          * If you add a new option, then update ANNOptionsTest.FutureANNOptions and possibly add a new test verifying
@@ -190,6 +226,8 @@ public class ANNOptions
 
             if (options.rerankK != null)
                 out.writeUnsignedVInt(options.rerankK);
+            if (options.usePruning != null)
+                out.writeBoolean(options.usePruning);
         }
 
         public ANNOptions deserialize(DataInputPlus in, int version) throws IOException
@@ -206,8 +244,9 @@ public class ANNOptions
                                       "new options that are not supported by this node.");
 
             Integer rerankK = hasRerankK(flags) ? (int) in.readUnsignedVInt() : null;
+            Boolean usePruning = hasUsePruning(flags) ? in.readBoolean() : null;
 
-            return ANNOptions.create(rerankK);
+            return ANNOptions.create(rerankK, usePruning);
         }
 
         public long serializedSize(ANNOptions options, int version)
@@ -221,6 +260,8 @@ public class ANNOptions
 
             if (options.rerankK != null)
                 size += TypeSizes.sizeofUnsignedVInt(options.rerankK);
+            if (options.usePruning != null)
+                size += TypeSizes.sizeof(options.usePruning);
 
             return size;
         }
@@ -234,6 +275,8 @@ public class ANNOptions
 
             if (options.rerankK != null)
                 flags |= RERANK_K_MASK;
+            if (options.usePruning != null)
+                flags |= USE_PRUNING_MASK;
 
             return flags;
         }
@@ -241,6 +284,11 @@ public class ANNOptions
         private static boolean hasRerankK(int flags)
         {
             return (flags & RERANK_K_MASK) == RERANK_K_MASK;
+        }
+
+        private static boolean hasUsePruning(int flags)
+        {
+            return (flags & USE_PRUNING_MASK) == USE_PRUNING_MASK;
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -49,6 +49,8 @@ public class V3OnDiskFormat extends V2OnDiskFormat
 
     public static volatile boolean WRITE_JVECTOR3_FORMAT = Boolean.parseBoolean(System.getProperty("cassandra.sai.write_jv3_format", "false"));
     public static final boolean ENABLE_LTM_CONSTRUCTION = Boolean.parseBoolean(System.getProperty("cassandra.sai.ltm_construction", "true"));
+    // JVector doesn't give us a way to access its default, so we set it here, but allow it to be overridden.
+    public static boolean JVECTOR_USE_PRUNING_DEFAULT = Boolean.parseBoolean(System.getProperty("cassandra.sai.jvector.use_pruning_default", "true"));
 
     // These are built to be backwards and forwards compatible. Not final only for testing.
     public static int JVECTOR_VERSION = Integer.parseInt(System.getProperty("cassandra.sai.jvector_version", "4"));

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -200,6 +200,7 @@ public class CassandraDiskAnn
      * @param limit the number of results to look for in the index (>= limit)
      * @param rerankK the number of results to look for in the index (>= limit)
      * @param threshold the minimum similarity score to accept
+     * @param usePruning whether to use pruning to speed up the search
      * @param acceptBits a Bits indicating which row IDs are acceptable, or null if no constraints
      * @param context unused (vestige from HNSW, retained in signature to allow calling both easily)
      * @param nodesVisitedConsumer a consumer that will be called with the number of nodes visited during the search
@@ -210,6 +211,7 @@ public class CassandraDiskAnn
                                                     int limit,
                                                     int rerankK,
                                                     float threshold,
+                                                    boolean usePruning,
                                                     Bits acceptBits,
                                                     QueryContext context,
                                                     IntConsumer nodesVisitedConsumer)
@@ -218,6 +220,9 @@ public class CassandraDiskAnn
 
         var graphAccessManager = searchers.get();
         var searcher = graphAccessManager.get();
+        // This searcher is reused across searches. We set here every time to ensure it is configured correctly
+        // for this search. Note that resume search in AutoResumingNodeScoreIterator will continue to use this setting.
+        searcher.usePruning(usePruning);
         try
         {
             var view = (GraphIndex.ScoringView) searcher.getView();
@@ -250,8 +255,8 @@ public class CassandraDiskAnn
             long elapsed = System.nanoTime() - start;
             if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
                 context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
-            Tracing.trace("DiskANN search for {}/{} visited {} nodes, reranked {} to return {} results from {}",
-                          limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
+            Tracing.trace("DiskANN search for {}/{} (usePruning: {}) visited {} nodes, reranked {} to return {} results from {}",
+                          limit, rerankK, usePruning, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
             columnQueryMetrics.onSearchResult(result, elapsed, false);
             context.addAnnGraphSearchLatency(elapsed);
             if (threshold > 0)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -321,7 +321,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
     /**
      * @return an itererator over {@link PrimaryKeyWithSortKey} in the graph's {@link SearchResult} order
      */
-    public CloseableIterator<SearchResult.NodeScore> search(QueryContext context, VectorFloat<?> queryVector, int limit, int rerankK, float threshold, Bits toAccept)
+    public CloseableIterator<SearchResult.NodeScore> search(QueryContext context, VectorFloat<?> queryVector, int limit, int rerankK, float threshold, boolean usePruning, Bits toAccept)
     {
         VectorValidation.validateIndexable(queryVector, similarityFunction);
 
@@ -332,14 +332,15 @@ public class CassandraOnHeapGraph<T> implements Accountable
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var graphAccessManager = searchers.get();
         var searcher = graphAccessManager.get();
+        searcher.usePruning(usePruning);
         try
         {
             var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
             long start = System.nanoTime();
             var result = searcher.search(ssf, limit, rerankK, threshold, 0.0f, bits);
             long elapsed = System.nanoTime() - start;
-            Tracing.trace("ANN search for {}/{} visited {} nodes, reranked {} to return {} results from {}",
-                          limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
+            Tracing.trace("ANN search for {}/{} (usePruning: {}) visited {} nodes, reranked {} to return {} results from {}",
+                          limit, rerankK, usePruning, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
             columnQueryMetrics.onSearchResult(result, elapsed, false);
             context.addAnnGraphSearchLatency(elapsed);
             if (threshold > 0)

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -37,6 +38,8 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+
+import static org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat.JVECTOR_USE_PRUNING_DEFAULT;
 
 /**
  * An SAI Orderer represents an index based order by clause.
@@ -55,7 +58,7 @@ public class Orderer
 
     // Vector search parameters
     private float[] vector;
-    private final Integer rerankK;
+    private final ANNOptions annOptions;
 
     // BM25 search parameter
     private List<ByteBuffer> queryTerms;
@@ -65,14 +68,14 @@ public class Orderer
      * @param context the index context, used to build the view of memtables and sstables for query execution.
      * @param operator the operator for the order by clause.
      * @param term the term to order by (not always relevant)
-     * @param rerankK optional rerank K parameter for ANN queries
+     * @param annOptions optional options for ANN queries
      */
-    public Orderer(IndexContext context, Operator operator, ByteBuffer term, @Nullable Integer rerankK)
+    public Orderer(IndexContext context, Operator operator, ByteBuffer term, ANNOptions annOptions)
     {
         this.context = context;
         assert ORDER_BY_OPERATORS.contains(operator) : "Invalid operator for order by clause " + operator;
         this.operator = operator;
-        this.rerankK = rerankK;
+        this.annOptions = annOptions;
         this.term = term;
     }
 
@@ -115,9 +118,21 @@ public class Orderer
     public int rerankKFor(int limit, VectorCompression vc)
     {
         assert isANN() : "rerankK is only valid for ANN queries";
-        return rerankK != null
-               ? rerankK
+        return annOptions.rerankK != null
+               ? annOptions.rerankK
                : context.getIndexWriterConfig().getSourceModel().rerankKFor(limit, vc);
+    }
+
+    /**
+     * Whether to use pruning to speed up the ANN search. If the AnnOption does not specify a value for usePruning,
+     * we use the default value, which is currently configured as an environment variable.
+     *
+     * @return the usePruning value to use in ANN search
+     */
+    public boolean usePruning()
+    {
+        assert isANN() : "usePruning is only valid for ANN queries";
+        return annOptions.usePruning != null ? annOptions.usePruning : JVECTOR_USE_PRUNING_DEFAULT;
     }
 
     public boolean isBM25()
@@ -135,9 +150,7 @@ public class Orderer
         var index = indexManager.getBestIndexFor(orderExpression, StorageAttachedIndex.class)
                                 .orElseThrow(() -> new IllegalStateException("No index found for order by clause"));
 
-        // Null if not specified explicitly in the CQL query.
-        Integer rerankK = filter.annOptions().rerankK;
-        return new Orderer(index.getIndexContext(), orderExpression.operator(), orderExpression.getIndexValue(), rerankK);
+        return new Orderer(index.getIndexContext(), orderExpression.operator(), orderExpression.getIndexValue(), filter.annOptions());
     }
 
     public static boolean isFilterExpressionOrderer(RowFilter.Expression expression)
@@ -149,9 +162,9 @@ public class Orderer
     public String toString()
     {
         String direction = isAscending() ? "ASC" : "DESC";
-        String rerankInfo = rerankK != null ? String.format(" (rerank_k=%d)", rerankK) : "";
+        String annOptionsString = annOptions != null ? annOptions.toCQLString() : "";
         if (isANN())
-            return context.getColumnName() + " ANN OF " + Arrays.toString(getVectorTerm()) + ' ' + direction + rerankInfo;
+            return context.getColumnName() + " ANN OF " + Arrays.toString(getVectorTerm()) + ' ' + direction + annOptionsString;
         if (isBM25())
             return context.getColumnName() + " BM25 OF " + TypeUtil.getString(term, context.getValidator()) + ' ' + direction;
         return context.getColumnName() + ' ' + direction;

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.VectorType;
@@ -211,7 +212,7 @@ public class VectorMemtableIndexTest extends SAITester
 
     private Orderer randomVectorOrderer()
     {
-        return new Orderer(indexContext, Operator.ANN, randomVectorSerialized(), null);
+        return new Orderer(indexContext, Operator.ANN, randomVectorSerialized(), ANNOptions.NONE);
     }
 
     private ByteBuffer randomVectorSerialized() {


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/13822

CNDB test pr https://github.com/riptano/cndb/pull/13826

### What does this PR fix and why was it fixed

SAI’s DiskANN/JVector engine currently **always searches with pruning enabled**, trading recall for latency.  That is fine for most workloads, but:

* **Threshold / bounded ANN queries** can lose matches when pruning exits early.
* Performance‑testing users need an easy way to turn pruning off to measure the recall/latency curve.

This patch introduces a per‑query **`use_pruning`** option so users and operators can choose the trade‑off that suits them.

---

#### New query option

```cql
WITH ann_options = {'use_pruning': true|false}
```

*When omitted we fall back to the node level default (see below).*  

#### Default behaviour

* Cluster‑wide default is controlled by the JVM system property:
  ```
  -Dcassandra.sai.jvector.use_pruning_default=<true|false>
  ```
  exposed as `V3OnDiskFormat.JVECTOR_USE_PRUNING_DEFAULT`.
* The property defaults to `true`, preserving existing behaviour.

#### Validation rules

* Value must be the literal `true` or `false` (case‑insensitive).
* Unknown ANN option keys continue to raise `InvalidRequestException`.

#### Usage

* `Orderer` computes the value of the `usePruning` option by using the `use_pruning` value if it is not null or the jvm default if it is null and passes it down to **all** `graph.search()` calls.
* Threshold / bounded ANN queries always pass `use_pruning = false` because correctness > latency for those paths (this is a net new change, but it's very minor and might not have any impact on those queries depending on the jvector implementation)

#### Compatibility

* We added one flag bit to `ANNOptions` serialization; older nodes ignore unknown bits, so mixed‑version clusters are fine (though they do throw an exception for unknown settings)

#### Tests added / updated

* Parsing, validation and transport round‑trips (`ANNOptionsTest`).
* Distributed smoke (`ANNOptionsDistributedTest`).
* Recall regression for pruning vs no‑pruning (`VectorSiftSmallTest.ensureDisablingPruningIncreasesRecall`).