### PR TITLE
CNDB-13625: Implement rerankless vector search through ANN_OPTIONS

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -70,8 +70,8 @@ public class ANNOptions
         if (rerankK == null)
             return;
 
-        if (rerankK < limit)
-            throw new InvalidRequestException(String.format("Invalid rerank_k value %d lesser than limit %d", rerankK, limit));
+        if (rerankK > 0 && rerankK < limit)
+            throw new InvalidRequestException(String.format("Invalid rerank_k value %d greater than 0 and less than limit %d", rerankK, limit));
 
         Guardrails.annRerankKMaxValue.guard(rerankK, "ANN options", false, state);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -269,6 +269,8 @@ public class V2VectorIndexSearcher extends IndexSearcher
 
     private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, SegmentRowIdOrdinalPairs segmentOrdinalPairs, int limit, int rerankK) throws IOException
     {
+        // We allow for negative rerankK, but for our cost calculations, it only makes sense to use 0 here.
+        rerankK = Math.max(0, rerankK);
         // If we use compressed vectors, we still have to order rerankK results using full resolution similarity
         // scores, so only use the compressed vectors when there are enough vectors to make it worthwhile.
         double twoPassCost = segmentOrdinalPairs.size() * CostCoefficients.ANN_SIMILARITY_COST
@@ -288,20 +290,28 @@ public class V2VectorIndexSearcher extends IndexSearcher
                                                                 VectorFloat<?> queryVector,
                                                                 SegmentRowIdOrdinalPairs segmentOrdinalPairs,
                                                                 int limit,
-                                                                int rerankK) throws IOException
+                                                                int rerankK)
     {
         // Use the jvector NodeQueue to avoid unnecessary object allocations since this part of the code operates on
         // many rows.
         var approximateScores = new NodeQueue(new BoundedLongHeap(segmentOrdinalPairs.size()), NodeQueue.Order.MAX_HEAP);
         var similarityFunction = indexContext.getIndexWriterConfig().getSimilarityFunction();
         var scoreFunction = cv.precomputedScoreFunctionFor(queryVector, similarityFunction);
+        columnQueryMetrics.onBruteForceNodesVisited(segmentOrdinalPairs.size());
+
+        if (rerankK <= 0)
+        {
+            // Rerankless search, so we go straight to the NodeQueueRowIdIterator.
+            var iter = segmentOrdinalPairs.mapToSegmentRowIdScoreIterator(scoreFunction);
+            approximateScores.pushMany(iter, segmentOrdinalPairs.size());
+            return new NodeQueueRowIdIterator(approximateScores);
+        }
 
         // Store the index of the (rowId, ordinal) pair from the segmentOrdinalPairs in the NodeQueue so that we can
         // retrieve both values with O(1) lookup when we need to resolve the full resolution score in the
         // BruteForceRowIdIterator.
         var iter = segmentOrdinalPairs.mapToIndexScoreIterator(scoreFunction);
         approximateScores.pushMany(iter, segmentOrdinalPairs.size());
-        columnQueryMetrics.onBruteForceNodesVisited(segmentOrdinalPairs.size());
         var reranker = new CloseableReranker(similarityFunction, queryVector, graph.getView());
         return new BruteForceRowIdIterator(approximateScores, segmentOrdinalPairs, reranker, limit, rerankK, columnQueryMetrics);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -198,7 +198,9 @@ public class CassandraDiskAnn
     /**
      * @param queryVector the query vector
      * @param limit the number of results to look for in the index (>= limit)
-     * @param rerankK the number of results to look for in the index (>= limit)
+     * @param rerankK the number of quantized results to look for in the index (>= limit or < 0). If rerankK is
+     *                non-positive, then we will use limit as the value and will skip reranking. Rerankless search
+     *                only applies when the graph has compressed vectors.
      * @param threshold the minimum similarity score to accept
      * @param acceptBits a Bits indicating which row IDs are acceptable, or null if no constraints
      * @param context unused (vestige from HNSW, retained in signature to allow calling both easily)
@@ -215,6 +217,9 @@ public class CassandraDiskAnn
                                                     IntConsumer nodesVisitedConsumer)
     {
         VectorValidation.validateIndexable(queryVector, similarityFunction);
+        boolean isRerankless = rerankK <= 0;
+        if (isRerankless)
+            rerankK = limit;
 
         var graphAccessManager = searchers.get();
         var searcher = graphAccessManager.get();
@@ -227,11 +232,12 @@ public class CassandraDiskAnn
             if (features.contains(FeatureId.FUSED_ADC))
             {
                 var asf = view.approximateScoreFunctionFor(queryVector, similarityFunction);
-                var rr = view.rerankerFor(queryVector, similarityFunction);
+                var rr = !isRerankless ? view.rerankerFor(queryVector, similarityFunction) : null;
                 ssp = new SearchScoreProvider(asf, rr);
             }
             else if (compressedVectors == null)
             {
+                // no compression, so we ignore isRerankless (except for setting rerankK to limit)
                 ssp = new SearchScoreProvider(view.rerankerFor(queryVector, similarityFunction));
             }
             else
@@ -242,7 +248,7 @@ public class CassandraDiskAnn
                          ? VectorSimilarityFunction.COSINE
                          : similarityFunction;
                 var asf = compressedVectors.precomputedScoreFunctionFor(queryVector, sf);
-                var rr = view.rerankerFor(queryVector, similarityFunction);
+                var rr = !isRerankless ? view.rerankerFor(queryVector, similarityFunction) : null;
                 ssp = new SearchScoreProvider(asf, rr);
             }
             long start = System.nanoTime();
@@ -250,8 +256,8 @@ public class CassandraDiskAnn
             long elapsed = System.nanoTime() - start;
             if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
                 context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
-            Tracing.trace("DiskANN search for {}/{} visited {} nodes, reranked {} to return {} results from {}",
-                          limit, rerankK, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
+            Tracing.trace("DiskANN search for {}/{} rerankless={} visited {} nodes, reranked {} to return {} results from {}",
+                          limit, rerankK, isRerankless, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
             columnQueryMetrics.onSearchResult(result, elapsed, false);
             context.addAnnGraphSearchLatency(elapsed);
             if (threshold > 0)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -198,7 +198,7 @@ public class CassandraDiskAnn
     /**
      * @param queryVector the query vector
      * @param limit the number of results to look for in the index (>= limit)
-     * @param rerankK the number of quantized results to look for in the index (>= limit or < 0). If rerankK is
+     * @param rerankK the number of quantized results to look for in the index (>= limit or <= 0). If rerankK is
      *                non-positive, then we will use limit as the value and will skip reranking. Rerankless search
      *                only applies when the graph has compressed vectors.
      * @param threshold the minimum similarity score to accept
@@ -237,7 +237,7 @@ public class CassandraDiskAnn
             if (features.contains(FeatureId.FUSED_ADC))
             {
                 var asf = view.approximateScoreFunctionFor(queryVector, similarityFunction);
-                var rr = !isRerankless ? view.rerankerFor(queryVector, similarityFunction) : null;
+                var rr = isRerankless ? null : view.rerankerFor(queryVector, similarityFunction);
                 ssp = new SearchScoreProvider(asf, rr);
             }
             else if (compressedVectors == null)
@@ -253,7 +253,7 @@ public class CassandraDiskAnn
                          ? VectorSimilarityFunction.COSINE
                          : similarityFunction;
                 var asf = compressedVectors.precomputedScoreFunctionFor(queryVector, sf);
-                var rr = !isRerankless ? view.rerankerFor(queryVector, similarityFunction) : null;
+                var rr = isRerankless ? null : view.rerankerFor(queryVector, similarityFunction);
                 ssp = new SearchScoreProvider(asf, rr);
             }
             long start = System.nanoTime();
@@ -261,7 +261,7 @@ public class CassandraDiskAnn
             long elapsed = System.nanoTime() - start;
             if (V3OnDiskFormat.ENABLE_RERANK_FLOOR)
                 context.updateAnnRerankFloor(result.getWorstApproximateScoreInTopK());
-            Tracing.trace("DiskANN search for {}/{} rerankless={}, usePruning: {} visited {} nodes, reranked {} to return {} results from {}",
+            Tracing.trace("DiskANN search for {}/{} rerankless={}, usePruning={} visited {} nodes, reranked {} to return {} results from {}",
                           limit, rerankK, isRerankless, usePruning, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
             columnQueryMetrics.onSearchResult(result, elapsed, false);
             context.addAnnGraphSearchLatency(elapsed);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -328,6 +328,10 @@ public class CassandraOnHeapGraph<T> implements Accountable
         // search() errors out when an empty graph is passed to it
         if (vectorValues.size() == 0)
             return CloseableIterator.emptyIterator();
+        // This configuration indicates rerankless search, but that is only applicable to disk search, so we set
+        // rerankK to limit and otherwise ignore the setting.
+        if (rerankK <= 0)
+            rerankK = limit;
 
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var graphAccessManager = searchers.get();

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -198,13 +198,15 @@ public class ANNOptionsTest extends CQLTester
         testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1]", ANNOptions.NONE);
         testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ann_options = {}", ANNOptions.NONE);
 
-        // TODO re-enable this test when we support negative rerank_k values
         // some random negative values, all should be accepted and not be mapped to NONE
-//        String negativeQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': %d}";
-//        QuickTheory.qt()
-//                   .withExamples(100)
-//                   .forAll(integers().allPositive())
-//                   .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i)));
+        String negativeQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': %d}";
+        QuickTheory.qt()
+                   .withExamples(100)
+                   .forAll(integers().allPositive())
+                   .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i)));
+
+        // rerankK = 0 must also work
+        testTransport("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 0}", ANNOptions.create(0));
 
         // some random positive values, all should be accepted
         String positiveQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT %d WITH ann_options = {'rerank_k': %<d}";

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -91,18 +91,12 @@ public class ANNOptionsTest extends CQLTester
         execute("SELECT * FROM %s WHERE k=0 ORDER BY v ANN OF [1, 1] WITH ann_options = {}");
 
         // correct queries with specific ANN options
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': -1}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': 0}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 10}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 11}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 1000}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': '1000'}");
-
-        // Queries with invalid ann options that will eventually be valid when we support disabling reranking
-        assertInvalidThrowMessage("Invalid rerank_k value -1 lesser than limit 100",
-                                  InvalidRequestException.class,
-                                  "SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': -1}");
-        assertInvalidThrowMessage("Invalid rerank_k value 0 lesser than limit 100",
-                                  InvalidRequestException.class,
-                                  "SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': 0}");
 
         // Queries that exceed the failure threshold for the guardrail. Specifies a protocol version to trigger
         // validation in the coordinator.
@@ -206,7 +200,7 @@ public class ANNOptionsTest extends CQLTester
                    .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i)));
 
         // rerankK = 0 must also work
-        testTransport("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 0}", ANNOptions.create(0));
+        testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 0}", ANNOptions.create(0));
 
         // some random positive values, all should be accepted
         String positiveQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT %d WITH ann_options = {'rerank_k': %<d}";

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -138,7 +138,7 @@ public class ANNOptionsTest extends CQLTester
                                   baseQuery + " WITH ann_options = {'rerank_k': 'a'}");
 
         // ANN options with rerank lesser than limit
-        assertInvalidThrowMessage("Invalid rerank_k value 10 lesser than limit 100",
+        assertInvalidThrowMessage("Invalid rerank_k value 10 greater than 0 and less than limit 100",
                                   InvalidRequestException.class,
                                   baseQuery + "LIMIT 100 WITH ann_options = {'rerank_k': 10}");
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -18,9 +18,13 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.stream.IntStream;
+
 import org.junit.Test;
 
 import org.apache.cassandra.index.sai.plan.QueryController;
+
+import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
 
 public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
 {
@@ -213,5 +217,37 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
             assertRows(execute("SELECT i FROM %s WHERE c <= 1 ORDER BY v ANN OF [1,1] LIMIT 1"), row(1));
             assertRows(execute("SELECT i FROM %s WHERE c >= 1 ORDER BY v ANN OF [1,1] LIMIT 1"), row(1));
         });
+    }
+
+    @Test
+    public void testReranklessHybidSearch()
+    {
+        // Want to test the search then order path
+        QueryController.QUERY_OPT_LEVEL = 0;
+
+        createTable("CREATE TABLE %s (pk int, val int, vec vector<float, 128>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Insert many rows in parallel
+        IntStream.range(0, MIN_PQ_ROWS * 2).parallel().forEach(i -> {
+            execute("INSERT INTO %s (pk, val, vec) VALUES (?, ?, ?)", i, i, randomVectorBoxed(128));
+        });
+
+        flush();
+
+        // Search the graph with rerankless search. We restrict val to 1/4th of the dataset
+        setMaxBruteForceRows(0);
+        var result = execute("SELECT pk FROM %s WHERE val < ? ORDER BY vec ANN OF ? LIMIT 10 with ann_options = { 'rerank_k': 0 }", MIN_PQ_ROWS / 2, randomVectorBoxed(128));
+        // Just testing that we can run the query, so only assert that we got results
+        assertRowCount(result, 10);
+
+        // Now search with brute force (skipping the graph). We restrict to 1/10th of the dataset to trigger brute force.
+        setMaxBruteForceRows(MIN_PQ_ROWS * 2);
+        result = execute("SELECT pk FROM %s WHERE val < ? ORDER BY vec ANN OF ? LIMIT 10 with ann_options = { 'rerank_k': 0 }", MIN_PQ_ROWS / 5, randomVectorBoxed(128));
+        assertRowCount(result, 10);
+        // Also ensure that a negative rerank_k value works
+        result = execute("SELECT pk FROM %s WHERE val < ? ORDER BY vec ANN OF ? LIMIT 10 with ann_options = { 'rerank_k': -1 }", MIN_PQ_ROWS / 5, randomVectorBoxed(128));
+        assertRowCount(result, 10);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -220,7 +220,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     }
 
     @Test
-    public void testReranklessHybidSearch()
+    public void testReranklessHybridSearch()
     {
         // Want to test the search then order path
         QueryController.QUERY_OPT_LEVEL = 0;

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -85,10 +85,18 @@ public class VectorSiftSmallTest extends VectorTester
         double previousRecall = 0;
         int limit = 10;
         int strictlyIncreasedCount = 0;
-        // Testing shows that we acheive 100% recall at about rerank_k = 45, so no need to go higher
+
+        // First test with rerank_k = 0, which should have the worst recall
+        double zeroRerankRecall = testRecall(limit, queryVectors, groundTruth, 0);
+
+        // Testing shows that we achieve 100% recall at about rerank_k = 45, so no need to go higher
         for (int rerankK = limit; rerankK <= 50; rerankK += 5)
         {
             var recall = testRecall(limit, queryVectors, groundTruth, rerankK);
+            // All recalls should be better than rerank_k = 0
+            assertTrue("Recall for rerank_k = " + rerankK + " should be at least as good as with rerank_k = 0",
+                      recall >= zeroRerankRecall);
+
             // Recall varies, so we can only assert that it does not get worse on a per-run basis. However, it should
             // get better strictly at least some of the time
             assertTrue("Recall for rerank_k = " + rerankK + " is " + recall, recall >= previousRecall);


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/13625

### What does this PR fix and why was it fixed
When `rerank_k` is non-positive, we will skip reranking where possible.

A minor note: this change is not strictly backwards compatible because of the original implementation. However, it will fail quickly if the coordinator accepts the value but the writer does not, and since this is only a query-time parameter, I propose that we move forward and accept the net-new value that was previously disallowed.

This PR will have conflicts with https://github.com/riptano/cndb/pull/13826. I plan on merging that PR and then resolving conflicts here.
