### PR TITLE
CNDB-13833: Fix QueryTimeoutTest on JDK22

### DIFF
--- a/test/unit/org/apache/cassandra/inject/Injections.java
+++ b/test/unit/org/apache/cassandra/inject/Injections.java
@@ -578,7 +578,7 @@ public class Injections
         public PauseBuilder(String name, long timeout)
         {
             super(String.format("pause/%s/%s", name, UUID.randomUUID().toString()));
-            actionBuilder.actions().doAction(expr("Thread.sleep").args(timeout));
+            actionBuilder.actions().doAction(expr("Thread.sleep").args(timeout+"L"));
         }
 
         /**


### PR DESCRIPTION
### What is the issue
...
QueryTimeoutTest on JDK22 fails on JDK22
### What does this PR fix and why was it fixed
...
We need to be explicit about the usage of long in `thread.sleep`

