### PR TITLE
CNDB-13163: Fix incorrect data file length for early open sstables

### DIFF
--- a/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.utils.TimeUUID;
 public class WrappedLifecycleTransaction implements ILifecycleTransaction
 {
 
-    final ILifecycleTransaction delegate;
+    protected final ILifecycleTransaction delegate;
     public WrappedLifecycleTransaction(ILifecycleTransaction delegate)
     {
         this.delegate = delegate;

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
@@ -125,7 +125,7 @@ public class PartitionIndexBuilder implements AutoCloseable
         }
         finally
         {
-            fhBuilder.withLengthOverride(-1);
+            fhBuilder.withLengthOverride(FileHandle.Builder.NO_LENGTH_OVERRIDE);
         }
 
     }

--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -417,7 +417,7 @@ public class FileHandle extends SharedCloseableImpl
                 channel = channelProxyFactory.apply(file);
 
                 long fileLength = (compressionMetadata != null) ? compressionMetadata.compressedFileLength : channel.size();
-                long length = lengthOverride > 0 ? lengthOverride : fileLength;
+                long length = lengthOverride >= 0 ? lengthOverride : fileLength;
 
                 RebuffererFactory rebuffererFactory;
                 if (length == 0)

--- a/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
@@ -385,7 +385,7 @@ public class CancelCompactionsTest extends CQLTester
         {
             long first = i * 10;
             long last  = (i + 1) * 10 - 1;
-            sstables.add(MockSchema.sstable(startGeneration + i, 0, true, first, last, cfs));
+            sstables.add(MockSchema.sstable(startGeneration + i, -1, true, first, last, cfs));
         }
         cfs.disableAutoCompaction();
         cfs.addSSTables(sstables);

--- a/test/unit/org/apache/cassandra/io/sstable/EarlyOpenCachingTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/EarlyOpenCachingTest.java
@@ -149,7 +149,7 @@ public class EarlyOpenCachingTest extends CQLTester
                 firstKey = partition.partitionKey();
             lastKey = partition.partitionKey();
         }
-        assertEquals("Simple scanner does not iterate all content", firstKey, s.first);
-        assertEquals("Simple scanner does not iterate all content", lastKey, s.last);
+        assertEquals("Simple scanner does not iterate all content", s.first, firstKey);
+        assertEquals("Simple scanner does not iterate all content", s.last, lastKey);
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -154,7 +155,7 @@ public class SSTableWriterTestBase extends SchemaLoader
             assertFalse(CompactionManager.instance.submitMaximal(cfs, cfs.gcBefore((int) (System.currentTimeMillis() / 1000)), false).isEmpty());
     }
 
-    public static SSTableWriter getWriter(ColumnFamilyStore cfs, File directory, LifecycleTransaction txn, long repairedAt, TimeUUID pendingRepair, boolean isTransient)
+    public static SSTableWriter getWriter(ColumnFamilyStore cfs, File directory, ILifecycleTransaction txn, long repairedAt, TimeUUID pendingRepair, boolean isTransient)
     {
         Descriptor desc = cfs.newSSTableDescriptor(directory);
         return desc.getFormat().getWriterFactory().builder(desc)
@@ -170,12 +171,12 @@ public class SSTableWriterTestBase extends SchemaLoader
                    .build(txn, cfs);
     }
 
-    public static SSTableWriter getWriter(ColumnFamilyStore cfs, File directory, LifecycleTransaction txn)
+    public static SSTableWriter getWriter(ColumnFamilyStore cfs, File directory, ILifecycleTransaction txn)
     {
         return getWriter(cfs, directory, txn, 0, null, false);
     }
 
-    public static SSTableWriter getWriter(SSTableFormat<?, ?> format, ColumnFamilyStore cfs, File directory, LifecycleTransaction txn)
+    public static SSTableWriter getWriter(SSTableFormat<?, ?> format, ColumnFamilyStore cfs, File directory, ILifecycleTransaction txn)
     {
         Descriptor desc = cfs.newSSTableDescriptor(directory, format);
         return desc.getFormat().getWriterFactory().builder(desc)


### PR DESCRIPTION
### What is the issue
Failing `EarlyOpenCachingTest` due to incorrect assignment of data file length.

### What does this PR fix and why was it fixed
Passes the correct lengths to the early open sstable construction. This lets `SimpleSSTableScanner` correctly finish iteration.

This was already fixed in CC (as part of CNDB-9104).
