### PR TITLE
CNDB-13847: Add Token::fromLongValue method to simplify SAI token creation

### DIFF
--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -368,6 +368,12 @@ public class Murmur3Partitioner implements IPartitioner
         }
 
         @Override
+        public Token fromLongValue(long token)
+        {
+            return new LongToken(token);
+        }
+
+        @Override
         public Token fromByteBuffer(ByteBuffer bytes, int position, int length)
         {
             return new LongToken(bytes.getLong(position));

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -41,6 +41,20 @@ public abstract class Token implements RingPosition<Token>, Serializable
         public abstract Token fromByteArray(ByteBuffer bytes);
 
         /**
+         * This method exists so that callers can create tokens from the primitive {@code long} value for this {@link Token}, if
+         * one exits. It is especially useful to skip ByteBuffer serde operations where performance is critical.
+         *
+         * @param token the primitive {@code long} value of this token
+         * @return the {@link Token} instance corresponding to the given primitive {@code long} value
+         *
+         * @throws UnsupportedOperationException if this {@link Token} is not backed by a primitive {@code long} value
+         */
+        public Token fromLongValue(long token)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
          * Produce a byte-comparable representation of the token.
          * See {@link Token#asComparableBytes}
          */

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -132,7 +132,6 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     private final RandomAccessReader reader;
     private final PrimaryKey.Factory primaryKeyFactory;
     private final SSTableId<?> sstableId;
-    private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private PartitionAwarePrimaryKeyMap(LongArray rowIdToToken,
                                         LongArray rowIdToOffset,
@@ -159,9 +158,8 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public PrimaryKey primaryKeyFromRowId(long sstableRowId)
     {
-        tokenBuffer.putLong(rowIdToToken.get(sstableRowId));
-        tokenBuffer.rewind();
-        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromByteArray(tokenBuffer), () -> supplier(sstableRowId));
+        long token = rowIdToToken.get(sstableRowId);
+        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromLongValue(token), () -> supplier(sstableRowId));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -152,7 +152,6 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     private final PrimaryKey.Factory primaryKeyFactory;
     private final ClusteringComparator clusteringComparator;
     private final SSTableId<?> sstableId;
-    private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private RowAwarePrimaryKeyMap(LongArray rowIdToToken,
                                   SortedTermsReader sortedTermsReader,
@@ -185,9 +184,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public PrimaryKey primaryKeyFromRowId(long sstableRowId)
     {
-        tokenBuffer.putLong(rowIdToToken.get(sstableRowId));
-        tokenBuffer.rewind();
-        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromByteArray(tokenBuffer), () -> supplier(sstableRowId));
+        long token = rowIdToToken.get(sstableRowId);
+        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromLongValue(token), () -> supplier(sstableRowId));
     }
 
     private long skinnyExactRowIdOrInvertedCeiling(PrimaryKey key)

--- a/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
+++ b/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
@@ -125,6 +125,11 @@ public class LengthPartitioner implements IPartitioner
             return new BigIntegerToken(ByteBufferUtil.toLong(bytes));
         }
 
+        public Token fromLongValue(long longValue)
+        {
+            return new BigIntegerToken(longValue);
+        }
+
         @Override
         public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
         {

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
@@ -77,5 +77,16 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
                 return Murmur3Partitioner.instance.getToken(key).token == token;
             });
     }
+
+    @Test
+    public void testFromLongValue()
+    {
+        qt().forAll(longs().between(Long.MIN_VALUE + 1, Long.MAX_VALUE))
+            .check(token -> {
+                Token fromLongValue = Murmur3Partitioner.instance.getTokenFactory().fromLongValue(token);
+                Token constructed = new Murmur3Partitioner.LongToken(token);
+                return constructed.equals(fromLongValue);
+            });
+    }
 }
 


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/13847

### What does this PR fix and why was it fixed
We already make use of the `Token#getLongValue` method in SAI, which only works for the Murmur partitioner, so I propose that we add a symmetric method that allows us to create tokens without converting a long to a byte buffer back to a long.
