### PR TITLE
CNDB-13483: Fix loading PQ file when disabled_reads is true

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -528,6 +528,13 @@ public enum CassandraRelevantProperties
     SAI_INDEX_READS_DISABLED("cassandra.sai.disabled_reads", "false"),
 
     /**
+     * Only takes effect when SAI_INDEX_READS_DISABLED is true. If true, creates a lazy index searcher that only loads
+     * segment metadata and has the ability to load extra files, like the PQ file for vector indexes. Currently only
+     * affects vector indexes. Other indexes fall back to the empty index searcher when SAI_INDEX_READS_DISABLED is true.
+     */
+    SAI_INDEX_LOAD_SEGMENT_METADATA_ONLY("cassandra.sai.load_segment_metadata_only", "true"),
+
+    /**
      * Allows custom implementation of {@link SensorsFactory} to optionally create
      * and configure {@link org.apache.cassandra.sensors.RequestSensors} instances.
      */

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.index.sai.disk.SearchableIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.Segment;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v1.V1SearchableIndex;
@@ -56,7 +57,6 @@ import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.SSTableIdFactory;
 import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CloseableIterator;
 
@@ -147,10 +147,10 @@ public class SSTableIndex
         return searchableIndex instanceof V1SearchableIndex;
     }
 
-    public FileHandle pq()
+    public PerIndexFiles indexFiles()
     {
         assert searchableIndex instanceof V1MetadataOnlySearchableIndex;
-        return ((V1MetadataOnlySearchableIndex) searchableIndex).pq();
+        return ((V1MetadataOnlySearchableIndex) searchableIndex).indexFiles();
     }
 
     public long indexFileCacheSize()

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.virtual.SimpleDataSet;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.v1.Segment;
+import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
@@ -83,6 +84,8 @@ public interface SearchableIndex extends Closeable
                                                                          long totalRows) throws IOException;
 
     List<Segment> getSegments();
+
+    List<SegmentMetadata> getSegmentMetadatas();
 
     public void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
 

--- a/src/java/org/apache/cassandra/index/sai/disk/V1MetadataOnlySearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/V1MetadataOnlySearchableIndex.java
@@ -176,9 +176,9 @@ public class V1MetadataOnlySearchableIndex implements SearchableIndex
         return metadatas;
     }
 
-    public FileHandle pq()
+    public PerIndexFiles indexFiles()
     {
-        return indexFiles.pq();
+        return indexFiles;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -36,6 +36,8 @@ import org.apache.cassandra.index.sai.disk.SearchableIndex;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
+import org.apache.cassandra.index.sai.disk.v5.V5OnDiskOrdinalsMap;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
@@ -93,6 +95,16 @@ public interface OnDiskFormat
      * @throws IOException
      */
     public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable) throws IOException;
+
+    /**
+     * Create a new {@link OnDiskOrdinalsMap} for the provided {@link PerIndexFiles} and {@link SegmentMetadata}.
+     * Only used by vector indexes currently.
+     *
+     * @param indexFiles
+     * @param segmentMetadata
+     * @return
+     */
+    public OnDiskOrdinalsMap newOnDiskOrdinalsMap(PerIndexFiles indexFiles, SegmentMetadata segmentMetadata);
 
     /**
      * Create a new {@link SearchableIndex} for an on-disk index. This is held by the {@SSTableIndex}

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -393,17 +393,34 @@ public class SSTableIndexWriter implements PerIndexWriter
 
     private static boolean allRowsHaveVectorsInWrittenSegments(IndexContext indexContext)
     {
-        // TODO should we load all of these for this op?
+        // TODO should we load all of these for this op? It seems very unlikely that we want to consider the whole
+        // table when checking if all rows have vectors. A single empty vector will be enough to make this false,
+        // but that should really only impact that table.
         for (SSTableIndex index : indexContext.getView().getIndexes())
         {
-            for (Segment segment : index.getSegments())
+            if (index.areSegmentsLoaded())
             {
-                if (segment.getIndexSearcher() instanceof  V2VectorIndexSearcher)
-                    return true; // V2 doesn't know, so we err on the side of being optimistic.  See comments in CompactionGraph
-                var searcher = (V5VectorIndexSearcher) segment.getIndexSearcher();
-                var structure = searcher.getPostingsStructure();
-                if (structure == V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY)
-                    return false;
+                for (Segment segment : index.getSegments())
+                {
+                    if (segment.getIndexSearcher() instanceof V2VectorIndexSearcher)
+                        return true; // V2 doesn't know, so we err on the side of being optimistic.  See comments in CompactionGraph
+                    var searcher = (V5VectorIndexSearcher) segment.getIndexSearcher();
+                    var structure = searcher.getPostingsStructure();
+                    if (structure == V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY)
+                        return false;
+                }
+            }
+            else
+            {
+                for (SegmentMetadata sm : index.getSegmentMetadatas())
+                {
+                    // May result in downloading file, but this metadata is valuable
+                    try (var odm = index.getVersion().onDiskFormat().newOnDiskOrdinalsMap(index.indexFiles(), sm))
+                    {
+                        if (odm.getStructure() == V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY)
+                            return false;
+                    }
+                }
             }
         }
         return true;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -413,9 +413,10 @@ public class SSTableIndexWriter implements PerIndexWriter
     {
         var pqComponent = perIndexComponents.get(IndexComponentType.PQ);
         assert pqComponent != null; // we always have a PQ component even if it's not actually PQ compression
-        try (var fhBuilder = StorageProvider.instance.indexBuildTimeFileHandleBuilderFor(pqComponent))
+        try (var fhBuilder = StorageProvider.instance.indexBuildTimeFileHandleBuilderFor(pqComponent);
+             var fh = fhBuilder.complete())
         {
-            return ProductQuantizationFetcher.maybeReadPqFromSegment(segments.get(segments.size() - 1), fhBuilder.complete());
+            return ProductQuantizationFetcher.maybeReadPqFromSegment(segments.get(segments.size() - 1), fh);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -49,6 +49,8 @@ import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.format.OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v5.V5OnDiskOrdinalsMap;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.metrics.AbstractMetrics;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
@@ -163,6 +165,12 @@ public class V1OnDiskFormat implements OnDiskFormat
     public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable) throws IOException
     {
         return new PartitionAwarePrimaryKeyMap.PartitionAwarePrimaryKeyMapFactory(perSSTableComponents, sstable, primaryKeyFactory);
+    }
+
+    @Override
+    public OnDiskOrdinalsMap newOnDiskOrdinalsMap(PerIndexFiles indexFiles, SegmentMetadata segmentMetadata)
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -253,6 +253,12 @@ public class V1SearchableIndex implements SearchableIndex
     }
 
     @Override
+    public List<SegmentMetadata> getSegmentMetadatas()
+    {
+        return metadatas;
+    }
+
+    @Override
     public void populateSystemView(SimpleDataSet dataset, SSTableReader sstable)
     {
         Token.TokenFactory tokenFactory = sstable.metadata().partitioner.getTokenFactory();

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v1.V1OnDiskFormat;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
@@ -106,6 +107,13 @@ public class V2OnDiskFormat extends V1OnDiskFormat
     public PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable)
     {
         return new RowAwarePrimaryKeyMap.RowAwarePrimaryKeyMapFactory(perSSTableComponents, primaryKeyFactory, sstable);
+    }
+
+    @Override
+    public OnDiskOrdinalsMap newOnDiskOrdinalsMap(PerIndexFiles indexFiles, SegmentMetadata segmentMetadata)
+    {
+        var postingListsMetadata = segmentMetadata.componentMetadatas.get(IndexComponentType.POSTING_LISTS);
+        return new V2OnDiskOrdinalsMap(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v5/V5OnDiskFormat.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.IndexSearcher;
 import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v4.V4OnDiskFormat;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskOrdinalsMap;
 
 public class V5OnDiskFormat extends V4OnDiskFormat
 {
@@ -35,6 +37,13 @@ public class V5OnDiskFormat extends V4OnDiskFormat
     public static boolean writeV5VectorPostings()
     {
         return Version.latest().onOrAfter(Version.DC);
+    }
+
+    @Override
+    public OnDiskOrdinalsMap newOnDiskOrdinalsMap(PerIndexFiles indexFiles, SegmentMetadata segmentMetadata)
+    {
+        var postingListsMetadata = segmentMetadata.componentMetadatas.get(IndexComponentType.POSTING_LISTS);
+        return new V5OnDiskOrdinalsMap(indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/ProductQuantizationFetcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/ProductQuantizationFetcher.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import io.github.jbellis.jvector.quantization.ProductQuantization;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SSTableIndex;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
+import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
+import org.apache.cassandra.io.util.FileHandle;
+
+public class ProductQuantizationFetcher
+{
+
+    /**
+     * Return the best previous CompressedVectors for this column that matches the `matcher` predicate.
+     * "Best" means the most recent one that hits the row count target of {@link ProductQuantization#MAX_PQ_TRAINING_SET_SIZE},
+     * or the one with the most rows if none are larger than that.
+     */
+    public static PqInfo getPqIfPresent(IndexContext indexContext) throws IOException
+    {
+        // TODO when compacting, this view is likely the whole table, is it worth only considering the sstables that
+        //  are being compacted?
+        // Flatten all segments, sorted by size then timestamp (size is capped to MAX_PQ_TRAINING_SET_SIZE)
+        var sortedSegments = indexContext.getView().getIndexes().stream()
+                                         .flatMap(CustomSegmentSorter::streamSegments)
+                                         .filter(customSegment -> customSegment.numRowsOrMaxPQTrainingSetSize > CassandraOnHeapGraph.MIN_PQ_ROWS)
+                                         .sorted()
+                                         .iterator();
+
+        while (sortedSegments.hasNext())
+        {
+            var customSegment = sortedSegments.next();
+            // Because we sorted based on size then timestamp, this is the best match (assuming it exists)
+            var pqInfo = customSegment.getPqInfo();
+            if (pqInfo != null)
+                return pqInfo;
+        }
+
+        return null;  // nothing matched
+    }
+
+    public static class PqInfo
+    {
+        public final ProductQuantization pq;
+        /** an empty Optional indicates that the index was written with an older version that did not record this information */
+        public final boolean unitVectors;
+        public final long rowCount;
+
+        public PqInfo(ProductQuantization pq, boolean unitVectors, long rowCount)
+        {
+            this.pq = pq;
+            this.unitVectors = unitVectors;
+            this.rowCount = rowCount;
+        }
+    }
+
+    private static class CustomSegmentSorter implements Comparable<CustomSegmentSorter>
+    {
+        private final SSTableIndex sstableIndex;
+        private final int numRowsOrMaxPQTrainingSetSize;
+        private final long timestamp;
+        private final int segmentPosition;
+
+        private CustomSegmentSorter(SSTableIndex sstableIndex, long numRows, int segmentPosition)
+        {
+            this.sstableIndex = sstableIndex;
+            // TODO give the size cost of larger PQ sets, is it worth trying to get the PQ object closest to this
+            // value? I'm concerned that we'll grab something pretty large for mem.
+            this.numRowsOrMaxPQTrainingSetSize = (int) Math.min(numRows, ProductQuantization.MAX_PQ_TRAINING_SET_SIZE);
+            this.timestamp = sstableIndex.getSSTable().getMaxTimestamp();
+            this.segmentPosition = segmentPosition;
+        }
+
+        private PqInfo getPqInfo() throws IOException
+        {
+            if (sstableIndex.areSegmentsLoaded())
+            {
+                var segment = sstableIndex.getSegments().get(segmentPosition);
+                V2VectorIndexSearcher searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+                // Skip segments that don't have PQ
+                if (VectorCompression.CompressionType.PRODUCT_QUANTIZATION != searcher.getCompression().type)
+                    return null;
+
+                // Because we sorted based on size then timestamp, this is the best match
+                return new PqInfo(searcher.getPQ(), searcher.containsUnitVectors(), segment.metadata.numRows);
+            }
+            else
+            {
+                // We have to load from disk here
+                var segmentMetadata = sstableIndex.getSegmentMetadatas().get(segmentPosition);
+                // Returns null if wrong uses wrong compression type.
+                return maybeReadPqFromSegment(segmentMetadata, sstableIndex.pq());
+            }
+        }
+
+        @Override
+        public int compareTo(CustomSegmentSorter o)
+        {
+            // Sort by size descending, then timestamp descending for sstables
+            int cmp = Long.compare(numRowsOrMaxPQTrainingSetSize, o.numRowsOrMaxPQTrainingSetSize);
+            if (cmp != 0)
+                return cmp;
+            return Long.compare(timestamp, o.timestamp);
+        }
+
+        private static Stream<CustomSegmentSorter> streamSegments(SSTableIndex index)
+        {
+            var results = new ArrayList<CustomSegmentSorter>();
+
+            var metadatas = index.getSegmentMetadatas();
+            for (int i = 0; i < metadatas.size(); i++)
+                results.add(new CustomSegmentSorter(index, metadatas.get(i).numRows, i));
+
+            return results.stream();
+        }
+    }
+
+    /**
+     * Takes a segment metadata and file handle and returns the PQ info if the segment has PQ that uses
+     * compression type {@link VectorCompression.CompressionType#PRODUCT_QUANTIZATION}.
+     *
+     * @param sm segment metadata
+     * @param fh PQ file handle, closed by this method
+     * @return PqInfo if the segment has PQ, null otherwise
+     * @throws IOException if an I/O error occurs
+     */
+    public static PqInfo maybeReadPqFromSegment(SegmentMetadata sm, FileHandle fh) throws IOException
+    {
+        try (fh; var reader = fh.createReader())
+        {
+            long offset = sm.componentMetadatas.get(IndexComponentType.PQ).offset;
+            // close parallel to code in CassandraDiskANN constructor, but different enough
+            // (we only want the PQ codebook) that it's difficult to extract into a common method
+            reader.seek(offset);
+            boolean unitVectors;
+            if (reader.readInt() == CassandraDiskAnn.PQ_MAGIC)
+            {
+                reader.readInt(); // skip over version
+                unitVectors = reader.readBoolean();
+            }
+            else
+            {
+                unitVectors = true;
+                reader.seek(offset);
+            }
+            var compressionType = VectorCompression.CompressionType.values()[reader.readByte()];
+            if (compressionType == VectorCompression.CompressionType.PRODUCT_QUANTIZATION)
+            {
+                var pq = ProductQuantization.load(reader);
+                return new PqInfo(pq, unitVectors, sm.numRows);
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/13483

### Initial Commits
- **CNDB-13483: Fix loading PQ file when disabled_reads is true**
- **Refactor code to pull PQ fetching logic into single class**
- **Add comment asking about reducing memory utilization when loading PQ**
- **Fix the broken allRowsHaveVectorsInWrittenSegments method**

### What does this PR fix and why was it fixed
The `cassandra.sai.disabled_reads` prevents us from reading previous PQ objects during compaction, which leads to less efficient graph construction. This fixes that by adding a new searchable index that is capable of discovering/downloading/cleaning up the right index files to get that information.

I also have a tangential bug fix for code that was also impacted by the `disabled_reads` setting. However, there is a follow up question to ask if it is a valid implementation.