### PR TITLE
CNDB-13902: Fix incorrect results of min / max in-built functions on clustering columns in descending order - port CASSANDRA-20295

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/AbstractFunction.java
@@ -45,7 +45,7 @@ public abstract class AbstractFunction implements Function
     {
         this.name = name;
         this.argTypes = argTypes;
-        this.returnType = returnType;
+        this.returnType = returnType != null ? returnType.unwrap() : null;
     }
 
     public FunctionName name()

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -2163,4 +2163,84 @@ public class AggregationTest extends CQLTester
         Assert.assertEquals(1, aggregates.size());
         Assert.assertFalse(aggregates.one().getBoolean("deterministic"));
     }
+
+    @Test
+    public void testMaxAggregationDescending()
+    {
+        createTable("CREATE TABLE %s (a int, b int, primary key (a, b)) WITH CLUSTERING ORDER BY (b DESC)");
+
+        execute("INSERT INTO %s (a, b) VALUES (1, 1000)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 1)");
+
+        assertRows(execute("SELECT count(b), max(b) as max FROM %s WHERE a = 1"),
+                   row(3L, 1000));
+
+        execute("INSERT INTO %s (a, b) VALUES (2, 4000)");
+        execute("INSERT INTO %s (a, b) VALUES (3, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (4, 0)");
+
+        assertRows(execute("SELECT count(b), max(b) as max FROM %s"),
+                   row(6L, 4000));
+    }
+
+    @Test
+    public void testMinAggregationDescending()
+    {
+        createTable("CREATE TABLE %s (a int, b int, primary key (a, b)) WITH CLUSTERING ORDER BY (b DESC)");
+
+        execute("INSERT INTO %s (a, b) VALUES (1, 1000)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 1)");
+
+        assertRows(execute("SELECT count(b), min(b) as min FROM %s WHERE a = 1"),
+                   row(3L, 1));
+
+        execute("INSERT INTO %s (a, b) VALUES (2, 4000)");
+        execute("INSERT INTO %s (a, b) VALUES (3, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (4, 0)");
+
+        assertRows(execute("SELECT count(b), min(b) as min FROM %s"),
+                   row(6L, 0));
+    }
+
+    @Test
+    public void testMaxAggregationAscending()
+    {
+        createTable("CREATE TABLE %s (a int, b int, primary key (a, b)) WITH CLUSTERING ORDER BY (b ASC)");
+
+        execute("INSERT INTO %s (a, b) VALUES (1, 1000)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 1)");
+
+        assertRows(execute("SELECT count(b), max(b) as max FROM %s WHERE a = 1"),
+                   row(3L, 1000));
+
+        execute("INSERT INTO %s (a, b) VALUES (2, 4000)");
+        execute("INSERT INTO %s (a, b) VALUES (3, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (4, 5)");
+
+        assertRows(execute("SELECT count(b), max(b) as max FROM %s"),
+                   row(6L, 4000));
+    }
+
+    @Test
+    public void testMinAggregationAscending()
+    {
+        createTable("CREATE TABLE %s (a int, b int, primary key (a, b)) WITH CLUSTERING ORDER BY (b ASC)");
+
+        execute("INSERT INTO %s (a, b) VALUES (1, 1000)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (1, 1)");
+
+        assertRows(execute("SELECT count(b), min(b) as min FROM %s WHERE a = 1"),
+                   row(3L, 1));
+
+        execute("INSERT INTO %s (a, b) VALUES (2, 4000)");
+        execute("INSERT INTO %s (a, b) VALUES (3, 100)");
+        execute("INSERT INTO %s (a, b) VALUES (4, 0)");
+
+        assertRows(execute("SELECT count(b), min(b) as min FROM %s"),
+                   row(6L, 0));
+    }
 }


### PR DESCRIPTION
### What is the issue
...
Incorrect results of min / max in-built functions on clustering columns in descending order

### What does this PR fix and why was it fixed
...
Port CASSANDRA-20295