### PR TITLE
CNDB-13905: Fix valueCount check and error message in BKDWriter

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
@@ -339,15 +339,15 @@ public class BKDWriter implements Closeable
             assert valueInOrder(valueCount + leafCount,
                                 0, lastPackedValue, packedValue, 0, docID, lastDocID);
 
+            if (valueCount + leafCount > totalPointCount)
+            {
+                throw new IllegalStateException("totalPointCount=" + totalPointCount + " was passed when we were created, but we just hit " + (valueCount + leafCount) + " values");
+            }
+
             System.arraycopy(packedValue, 0, leafValues, leafCount * packedBytesLength, packedBytesLength);
             leafDocs[leafCount] = docID;
             docsSeen.set(docID);
             leafCount++;
-
-            if (valueCount > totalPointCount)
-            {
-                throw new IllegalStateException("totalPointCount=" + totalPointCount + " was passed when we were created, but we just hit " + pointCount + " values");
-            }
 
             if (leafCount == maxPointsInLeafNode)
             {


### PR DESCRIPTION
The check wasn't counting the values added in the current leaf, so it allowed to add more points than it should. The error message was always reporting 0 values because it used the value from the wrong variable (updated on finish). 