### PR TITLE
CNDB-13925: Prefer not analyzed indexes for contains queries

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -575,6 +575,16 @@ public enum Operator
         return this == LT || this == LTE || this == GT || this == GTE;
     }
 
+    /**
+     * Checks if this operator is any of the variations of contains ({@code [NOT] CONTAINS [KEY]}).
+     *
+     * @return {@code true} if this operator is any kind of contains operator, {@code false} otherwise.
+     */
+    public boolean isContains()
+    {
+        return this == CONTAINS || this == CONTAINS_KEY || this == NOT_CONTAINS || this == NOT_CONTAINS_KEY;
+    }
+
     @Override
     public String toString()
     {

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.ListSerializer;
+import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
@@ -564,6 +565,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
     // This holds CONTAINS, CONTAINS_KEY, NOT CONTAINS, NOT CONTAINS KEY and map[key] = value restrictions because we might want to have any combination of them.
     public static final class ContainsRestriction extends SingleColumnRestriction
     {
+        public static final String MULTIPLE_INDEXES_WARNING = "Multiple indexes found for CONTAINS restriction on %s. Using not-analyzed index %s";
+
         private final List<Term> values = new ArrayList<>(); // for CONTAINS
         private final List<Term> negativeValues = new ArrayList<>(); // for NOT_CONTAINS
         private final List<Term> keys = new ArrayList<>(); // for CONTAINS_KEY
@@ -730,6 +733,38 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         public int numberOfNegativeEntries()
         {
             return negativeEntryKeys.size();
+        }
+
+        @Override
+        public Index findSupportingIndex(IndexRegistry indexRegistry)
+        {
+            // if there are multiple supporting indexes, we prefer those without an analyzer (see CNDB-13925)
+            Index notAnalyzedIndex = null;
+            Index analyzedIndex = null;
+            for (Index index : indexRegistry.listIndexes())
+            {
+                if (isSupportedBy(index))
+                {
+                    if (index.getAnalyzer(null).isPresent())
+                        analyzedIndex = index;
+                    else
+                        notAnalyzedIndex = index;
+                }
+            }
+
+            if (notAnalyzedIndex != null)
+            {
+                // We prefer the not analyzed index, but if there was also an analyzed index, we warn the user.
+                // We use a client warning key so the warning is emitted just once per query.
+                if (analyzedIndex != null)
+                {
+                    String msg = String.format(MULTIPLE_INDEXES_WARNING, columnDef.name, notAnalyzedIndex.getIndexMetadata().name);
+                    ClientWarn.instance.warn(msg, "multiple_indexes_for_contains_on_" + columnDef.name);
+                }
+                return notAnalyzedIndex;
+            }
+
+            return analyzedIndex;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -1054,18 +1054,20 @@ public interface Index
             return indexes.stream().filter((i) -> i.supportsExpression(column, operator)).findFirst();
 
         // if we have a contains operator, we prefer indexes without an analyzer (see CNDB-13925)
-        T analyzedIndex = null;
+        T firstAnalyzedIndex = null;
         for (T index : indexes)
         {
             if (index.supportsExpression(column, operator))
             {
-                if (index.getAnalyzer(null).isPresent())
-                    analyzedIndex = index;
-                else
+                // we prefer indexes without an analyzer
+                if (index.getAnalyzer(null).isEmpty())
                     return Optional.of(index);
+
+                if (firstAnalyzedIndex == null)
+                    firstAnalyzedIndex = index;
             }
         }
 
-        return Optional.ofNullable(analyzedIndex);
+        return Optional.ofNullable(firstAnalyzedIndex);
     }
 }

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -71,6 +71,7 @@ import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.Clustering;
@@ -1261,19 +1262,21 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
         return indexes.stream().map(i -> i.getIndexMetadata().name).collect(Collectors.joining(","));
     }
 
-
-    public Optional<Index> getBestIndexFor(RowFilter.Expression expression)
+    @Override
+    public Optional<Index> getBestIndexFor(ColumnMetadata column, Operator operator)
     {
-        return indexes.values().stream().filter((i) -> i.supportsExpression(expression.column(), expression.operator())).findFirst();
+        return Index.getBestIndexFor(indexes.values(), column, operator);
     }
 
     public <T extends Index> Optional<T> getBestIndexFor(RowFilter.Expression expression, Class<T> indexType)
     {
-        return indexes.values()
-                      .stream()
-                      .filter(i -> indexType.isInstance(i) && i.supportsExpression(expression.column(), expression.operator()))
-                      .map(indexType::cast)
-                      .findFirst();
+        return Index.getBestIndexFor(indexes.values()
+                                            .stream()
+                                            .filter(indexType::isInstance)
+                                            .map(indexType::cast)
+                                            .collect(Collectors.toSet()),
+                                     expression.column(),
+                                     expression.operator());
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1270,13 +1270,12 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
     public <T extends Index> Optional<T> getBestIndexFor(RowFilter.Expression expression, Class<T> indexType)
     {
-        return Index.getBestIndexFor(indexes.values()
-                                            .stream()
-                                            .filter(indexType::isInstance)
-                                            .map(indexType::cast)
-                                            .collect(Collectors.toSet()),
-                                     expression.column(),
-                                     expression.operator());
+        Set<T> candidates = indexes.values()
+                                   .stream()
+                                   .filter(indexType::isInstance)
+                                   .map(indexType::cast)
+                                   .collect(Collectors.toSet());
+        return Index.getBestIndexFor(candidates, expression.column(), expression.operator());
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.index.sai.plan;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -162,16 +163,14 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
         if (expression.isUserDefined())
             return false;
 
-        boolean hasIndex = false;
-        for (StorageAttachedIndex index : allIndexes)
+        // collect the best index from those that support the specified expression
+        Optional<StorageAttachedIndex> index = Index.getBestIndexFor(allIndexes, expression.column(), expression.operator());
+        if (index.isPresent())
         {
-            if (index.supportsExpression(expression.column(), expression.operator()))
-            {
-                selectedIndexes.add(index);
-                hasIndex = true;
-            }
+            selectedIndexes.add(index.get());
+            return true;
         }
-        return hasIndex;
+        return false;
     }
 
     @Override
@@ -196,7 +195,7 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     }
 
     @Override
-    public Index.Searcher searcherFor(ReadCommand command)
+    public StorageAttachedIndexSearcher searcherFor(ReadCommand command)
     {
         return new StorageAttachedIndexSearcher(cfs,
                                                 queryMetrics,

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +99,30 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
     public ReadCommand command()
     {
         return command;
+    }
+
+    @VisibleForTesting
+    public final Set<String> plannedIndexes()
+    {
+        try
+        {
+            Plan plan = controller.buildPlan().optimize();
+            Set<String> indexes = new HashSet<>();
+            plan.forEach(node -> {
+                if (node instanceof Plan.IndexScan)
+                {
+                    Plan.IndexScan indexScan = (Plan.IndexScan) node;
+                    indexes.add(indexScan.getIndexName());
+                }
+                return Plan.ControlFlow.Continue;
+            });
+            return indexes;
+        }
+        finally
+        {
+            // we need to call this to clean up the resources opened by the plan
+            controller.abort();
+        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -108,14 +108,8 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         {
             Plan plan = controller.buildPlan().optimize();
             Set<String> indexes = new HashSet<>();
-            plan.forEach(node -> {
-                if (node instanceof Plan.IndexScan)
-                {
-                    Plan.IndexScan indexScan = (Plan.IndexScan) node;
-                    indexes.add(indexScan.getIndexName());
-                }
-                return Plan.ControlFlow.Continue;
-            });
+            plan.nodesOfType(Plan.IndexScan.class)
+                .forEach(s -> indexes.add(s.getIndexName()));
             return indexes;
         }
         finally

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -62,6 +62,7 @@ import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
@@ -73,6 +74,8 @@ import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.plan.QueryController;
+import org.apache.cassandra.index.sai.plan.StorageAttachedIndexQueryPlan;
+import org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.ResourceLeakDetector;
 import org.apache.cassandra.inject.ActionBuilder;
@@ -88,10 +91,12 @@ import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.MockSchema;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.lucene.codecs.CodecUtil;
+import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.inject.ActionBuilder.newActionBuilder;
 import static org.apache.cassandra.inject.Expression.expr;
@@ -957,6 +962,59 @@ public class SAITester extends CQLTester
             {
                 throw Throwables.unchecked(e);
             }
+        }
+    }
+
+    protected PlanSelectionAssertion assertThatPlanFor(String query, Object[]... expectedRows)
+    {
+        // First execute the query and check the number of rows returned
+        ClientWarn.instance.captureWarnings();
+        assertRowsIgnoringOrder(execute(query), expectedRows);
+        List<String> warnings = ClientWarn.instance.getWarnings();
+        ClientWarn.instance.resetWarnings();
+
+        ReadCommand command = parseReadCommand(query);
+        Index.QueryPlan queryPlan = command.indexQueryPlan();
+        if (queryPlan == null)
+            return new PlanSelectionAssertion(null, warnings);
+
+        StorageAttachedIndexQueryPlan saiQueryPlan = (StorageAttachedIndexQueryPlan) queryPlan;
+        Assertions.assertThat(saiQueryPlan).isNotNull();
+        StorageAttachedIndexSearcher searcher = saiQueryPlan.searcherFor(command);
+        Set<String> selectedIndexes = searcher.plannedIndexes();
+        return new PlanSelectionAssertion(selectedIndexes, warnings);
+    }
+
+    protected static class PlanSelectionAssertion
+    {
+        private final List<String> warnings;
+        private final Set<String> selectedIndexes;
+
+        public PlanSelectionAssertion(@Nullable Set<String> selectedIndexes, @Nullable List<String> warnings)
+        {
+            this.warnings = warnings;
+            this.selectedIndexes = selectedIndexes;
+        }
+
+        public PlanSelectionAssertion uses(String... indexes)
+        {
+            Assertions.assertThat(selectedIndexes)
+                      .isNotNull()
+                      .as("Expected to select only %s, but got: %s", indexes, selectedIndexes)
+                      .isEqualTo(Set.of(indexes));
+            return this;
+        }
+
+        public void doesntWarn()
+        {
+            Assert.assertNull(warnings);
+        }
+
+        public void warns(String expectedWarning)
+        {
+            Assert.assertNotNull(warnings);
+            Assert.assertEquals(1, warnings.size());
+            Assert.assertEquals(expectedWarning, warnings.get(0));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MultipleColumnIndexTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 
@@ -31,7 +32,7 @@ public class MultipleColumnIndexTest extends SAITester
     // types/collections/maps/MultiMap*Test tests
     // This is just testing that the indexes can be created
     @Test
-    public void canCreateMultipleMapIndexesOnSameColumn() throws Throwable
+    public void canCreateMultipleMapIndexesOnSameColumn()
     {
         createTable("CREATE TABLE %s (pk int, ck int, value map<int,int>, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(KEYS(value)) USING 'StorageAttachedIndex'");
@@ -58,7 +59,7 @@ public class MultipleColumnIndexTest extends SAITester
     }
 
     @Test
-    public void cannotHaveMultipleAnalyzingIndexesOnSameColumn() throws Throwable
+    public void cannotHaveMultipleAnalyzingIndexesOnSameColumn()
     {
         createTable("CREATE TABLE %s (pk int, ck int, value text, PRIMARY KEY(pk, ck))");
         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = { 'case_sensitive' : false }");
@@ -111,5 +112,237 @@ public class MultipleColumnIndexTest extends SAITester
             assertEquals(2, execute("SELECT * FROM %s WHERE text_map['k1'] != 'v2' AND text_map NOT CONTAINS KEY 'k3'").size());
             assertEquals(1, execute("SELECT * FROM %s WHERE text_map['k1'] != 'v2' AND text_map NOT CONTAINS KEY 'k3' AND text_map NOT CONTAINS KEY 'k5'").size());
         });
+    }
+    
+    @Test
+    public void testContainsWithAnalyzedAndNotAnalyzedOnList()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v list<text>)");
+
+        String insert = "INSERT INTO %s (k, v) VALUES (?, ?)";
+        Object[] row1 = new Object[]{ 1, list("Johann Strauss") };
+        Object[] row2 = new Object[]{ 2, list("Richard Strauss", "Johann Sebastian Bach") };
+        execute(insert, row1);
+        execute(insert, row2);
+
+        // Test with not analyzed index only
+        String notAnalyzedIndex = createIndex("CREATE CUSTOM INDEX not_analyzed ON %s(v) USING 'StorageAttachedIndex'");
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+
+        // Test with both analyzed and not analyzed indexes, it should prefer the not analyzed index
+        String analyzedIndex = createIndex("CREATE CUSTOM INDEX analyzed ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        String warning = String.format(SingleColumnRestriction.ContainsRestriction.MULTIPLE_INDEXES_WARNING, 'v', notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+
+        // Test with analyzed index only
+        dropIndex("DROP INDEX %s." + notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(analyzedIndex).doesntWarn();
+    }
+
+    @Test
+    public void testContainsWithAnalyzedAndNotAnalyzedOnSet()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v set<text>)");
+
+        String insert = "INSERT INTO %s (k, v) VALUES (?, ?)";
+        Object[] row1 = new Object[]{ 1, set("Johann Strauss") };
+        Object[] row2 = new Object[]{ 2, set("Richard Strauss", "Johann Sebastian Bach") };
+        execute(insert, row1);
+        execute(insert, row2);
+
+        // Test with not analyzed index only
+        String notAnalyzedIndex = createIndex("CREATE CUSTOM INDEX not_analyzed ON %s(v) USING 'StorageAttachedIndex'");
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+
+        // Test with both analyzed and not analyzed indexes, it should prefer the not analyzed index
+        String analyzedIndex = createIndex("CREATE CUSTOM INDEX analyzed ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        String warning = String.format(SingleColumnRestriction.ContainsRestriction.MULTIPLE_INDEXES_WARNING, 'v', notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+
+        // Test with analyzed index only
+        dropIndex("DROP INDEX %s." + notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(analyzedIndex).doesntWarn();
+    }
+
+    @Test
+    public void testContainsWithAnalyzedAndNotAnalyzedOnMap()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v map<int, text>)");
+
+        String insert = "INSERT INTO %s (k, v) VALUES (?, ?)";
+        Object[] row1 = new Object[]{ 1, map(0, "Johann Strauss") };
+        Object[] row2 = new Object[]{ 2, map(0, "Richard Strauss", 1, "Johann Sebastian Bach") };
+        execute(insert, row1);
+        execute(insert, row2);
+
+        // Test with not analyzed index only
+        String notAnalyzedIndex = createIndex("CREATE CUSTOM INDEX not_analyzed ON %s(v) USING 'StorageAttachedIndex'");
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+
+        // Test with both analyzed and not analyzed indexes, it should prefer the not analyzed index
+        String analyzedIndex = createIndex("CREATE CUSTOM INDEX analyzed ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        String warning = String.format(SingleColumnRestriction.ContainsRestriction.MULTIPLE_INDEXES_WARNING, 'v', notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+
+        // Test with analyzed index only
+        dropIndex("DROP INDEX %s." + notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann Strauss'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard Strauss'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Strauss'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Johann'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Richard'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS 'Debussy'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Johann'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Richard'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS 'Debussy'", row1, row2).uses(analyzedIndex).doesntWarn();
+    }
+
+    @Test
+    public void testContainsKeyWithAnalyzedAndNotAnalyzedOnMap()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v map<text, int>)");
+
+        String insert = "INSERT INTO %s (k, v) VALUES (?, ?)";
+        Object[] row1 = new Object[]{ 1, map("Johann Strauss", 0) };
+        Object[] row2 = new Object[]{ 2, map("Richard Strauss", 0, "Johann Sebastian Bach", 1) };
+        execute(insert, row1);
+        execute(insert, row2);
+
+        // Test with not analyzed index only
+        String notAnalyzedIndex = createIndex("CREATE CUSTOM INDEX not_analyzed ON %s(keys(v)) USING 'StorageAttachedIndex'");
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Strauss'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Debussy'").uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann Strauss'", row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard Strauss'", row1).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Strauss'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Debussy'", row1, row2).uses(notAnalyzedIndex).doesntWarn();
+
+        // Test with both analyzed and not analyzed indexes, it should prefer the not analyzed index
+        String analyzedIndex = createIndex("CREATE CUSTOM INDEX analyzed ON %s(keys(v)) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        String warning = String.format(SingleColumnRestriction.ContainsRestriction.MULTIPLE_INDEXES_WARNING, 'v', notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Strauss'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Debussy'").uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann Strauss'", row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard Strauss'", row1).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Strauss'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Debussy'", row1, row2).uses(notAnalyzedIndex).warns(warning);
+
+        // Test with analyzed index only
+        dropIndex("DROP INDEX %s." + notAnalyzedIndex);
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann Strauss'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard Strauss'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Strauss'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Johann'", row1, row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Richard'", row2).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v CONTAINS KEY 'Debussy'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Strauss'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Johann'").uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Richard'", row1).uses(analyzedIndex).doesntWarn();
+        assertThatPlanFor("SELECT * FROM %s WHERE v NOT CONTAINS KEY 'Debussy'", row1, row2).uses(analyzedIndex).doesntWarn();
     }
 }


### PR DESCRIPTION
Prefer not-analyzed indexes over analyzed indexes for contains queries, so they have a deterministic behaviour.
Also, emit a client warning when a not-analyzed index is selected over an analyzed index.

Otherwise, different points in the codebase will make different, pseudo-random decisions about what index should be used for a certain contains expression, leading to erratic behaviour.

Relevant Slack thread: https://datastax.slack.com/archives/C05LHP4HX5J/p1746005148167389
