### PR TITLE
CNDB-11317 Remove DSE in favour of more generic DB

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -22,8 +22,8 @@ and running, and demonstrate some simple reads and writes. For a more-complete g
 
 First, we'll unpack our archive:
 
-  $ tar -zxvf dse-db-$VERSION.tar.gz
-  $ cd dse-db-$VERSION
+  $ tar -zxvf ds-db-$VERSION.tar.gz
+  $ cd ds-db-$VERSION
 
 After that we start the server. Running the startup script with the -f argument will cause
 Cassandra to remain in the foreground and log to standard out; it can be stopped with ctrl-C.

--- a/bin/cassandra.in.sh
+++ b/bin/cassandra.in.sh
@@ -30,7 +30,7 @@ CLASSPATH="$CASSANDRA_CONF"
 # compiled classes. NOTE: This isn't needed by the startup script,
 # it's just used here in constructing the classpath.
 if [ -d $CASSANDRA_HOME/build ] ; then
-    jars_cnt="`ls -1 $CASSANDRA_HOME/build/dse-db*.jar | grep -v 'javadoc.jar' | grep -v 'sources.jar' | wc -l | xargs echo`"
+    jars_cnt="`ls -1 $CASSANDRA_HOME/build/ds*-db*.jar | grep -v 'javadoc.jar' | grep -v 'sources.jar' | wc -l | xargs echo`"
     if [ "$jars_cnt" -gt 1 ]; then
         dir="`cd $CASSANDRA_HOME/build; pwd`"
         echo "There are JAR artifacts for multiple versions in the $dir directory. Please clean the project with 'ant realclean' and build it again." 1>&2
@@ -38,8 +38,8 @@ if [ -d $CASSANDRA_HOME/build ] ; then
     fi
 
     if [ "$jars_cnt" = "1" ]; then
-        dse_db_bin="`ls -1 $CASSANDRA_HOME/build/dse-db*.jar | grep -v javadoc | grep -v sources`"
-        CLASSPATH="$CLASSPATH:$dse_db_bin"
+        ds_db_bin="`ls -1 $CASSANDRA_HOME/build/ds-db*.jar | grep -v javadoc | grep -v sources`"
+        CLASSPATH="$CLASSPATH:$ds_db_bin"
     fi
 fi
 
@@ -119,16 +119,16 @@ JAVA_VERSION=${JVM_VERSION%%.*}
 if [ "$JVM_VERSION" = "1.8.0" ]  ; then
     JVM_PATCH_VERSION=${jvmver#*_}
     if [ "$JVM_VERSION" \< "1.8" ] || [ "$JVM_VERSION" \> "1.8.2" ] ; then
-        echo "DSE DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer). Java $JVM_VERSION is not supported."
+        echo "DS DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer). Java $JVM_VERSION is not supported."
         exit 1;
     fi
     if [ "$JVM_PATCH_VERSION" -lt 151 ] ; then
-        echo "DSE DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer). Java 8 update $JVM_PATCH_VERSION is not supported."
+        echo "DS DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer). Java 8 update $JVM_PATCH_VERSION is not supported."
         exit 1;
     fi
     JAVA_VERSION=8
 elif [ "$JVM_VERSION" \< "11" ] ; then
-    echo "DSE DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer)."
+    echo "DS DB 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer)."
     exit 1;
 fi
 

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project basedir="." default="jar" name="dse-db"
+<project basedir="." default="jar" name="ds-db"
          xmlns:artifact="antlib:org.apache.maven.artifact.ant"
          xmlns:if="ant:if"
          xmlns:unless="ant:unless">
@@ -560,8 +560,8 @@
             description="Define dependencies and dependency versions">
       <!-- The parent pom defines the versions of all dependencies -->
       <artifact:pom id="parent-pom"
-                    groupId="com.datastax.dse"
-                    artifactId="dse-db-parent"
+                    groupId="com.datastax.db"
+                    artifactId="db-parent"
                     packaging="pom"
                     version="${version}"
                     url="https://datastax.com"
@@ -654,7 +654,7 @@
 
           <dependency groupId="org.apache.ant" artifactId="ant-junit" version="1.10.12" scope="test"/>
 
-          <dependency groupId="com.datastax.dse" artifactId="dse-db-all" version="${version}" />
+          <dependency groupId="com.datastax.db" artifactId="db-all" version="${version}" />
           <dependency groupId="io.dropwizard.metrics" artifactId="metrics-core" version="3.1.5" />
           <dependency groupId="io.dropwizard.metrics" artifactId="metrics-jvm" version="3.1.5" />
           <dependency groupId="io.dropwizard.metrics" artifactId="metrics-logback" version="3.1.5" />
@@ -815,8 +815,8 @@
       <!-- each dependency set then defines the subset of the dependencies for that dependency set -->
       <artifact:pom id="build-deps-pom"
                     artifactId="cassandra-build-deps">
-        <parent groupId="com.datastax.dse"
-                artifactId="dse-db-parent"
+        <parent groupId="com.datastax.db"
+                artifactId="db-parent"
                 version="${version}"
                 relativePath="${final.name}-parent.pom"/>
 
@@ -851,11 +851,11 @@
 
       <!-- now the pom's for artifacts being deployed to Maven Central -->
       <artifact:pom id="all-pom"
-                    artifactId="dse-db-all"
+                    artifactId="db-all"
                     url="https://datastax.com"
                     name="DataStax DB">
-        <parent groupId="com.datastax.dse"
-                artifactId="dse-db-parent"
+        <parent groupId="com.datastax.db"
+                artifactId="db-parent"
                 version="${version}"
                 relativePath="${final.name}-parent.pom"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>

--- a/pylib/cassandra-cqlsh-tests.sh
+++ b/pylib/cassandra-cqlsh-tests.sh
@@ -61,7 +61,7 @@ export TESTSUITE_NAME="cqlshlib.python${python_version}.jdk${java_version}"
 pushd ${CASSANDRA_DIR} >/dev/null
 
 # check project is already built. no cleaning is done, so jenkins unstash works, beware.
-[[ -f "${BUILD_DIR}/dse-db-${version}.jar" ]] || [[ -f "${BUILD_DIR}/dse-db-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${BUILD_DIR} with: $(ls ${BUILD_DIR})"; exit 1; }
+[[ -f "${BUILD_DIR}/ds-db-${version}.jar" ]] || [[ -f "${BUILD_DIR}/ds-db-${version}-SNAPSHOT.jar" ]] || { echo "Project must be built first. Use \`ant jar\`. Build directory is ${BUILD_DIR} with: $(ls ${BUILD_DIR})"; exit 1; }
 
 # Set up venv with dtest dependencies
 set -e # enable immediate exit if venv setup fails

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -30,10 +30,10 @@ CLASSPATH="$CASSANDRA_CONF"
 # compiled classes. NOTE: This isn't needed by the startup script,
 # it's just used here in constructing the classpath.
 if [ -d $CASSANDRA_HOME/build ] ; then
-    #dse_db_bin="$CASSANDRA_HOME/build/classes/main"
-    dse_db_bin=`ls -1 $CASSANDRA_HOME/build/dse-db*.jar`
-    dse_db_bin="$dse_db_bin:$CASSANDRA_HOME/build/classes/stress:$CASSANDRA_HOME/build/classes/fqltool"
-    CLASSPATH="$CLASSPATH:$dse_db_bin"
+    #ds_db_bin="$CASSANDRA_HOME/build/classes/main"
+    ds_db_bin=`ls -1 $CASSANDRA_HOME/build/ds-db*.jar`
+    ds_db_bin="$ds_db_bin:$CASSANDRA_HOME/build/classes/stress:$CASSANDRA_HOME/build/classes/fqltool"
+    CLASSPATH="$CLASSPATH:$ds_db_bin"
 fi
 
 # the default location for commitlogs, sstables, and saved caches


### PR DESCRIPTION
### What is the issue

Converged Cassandra embodies some of the advanced functionality from DSE Core but product-wise is not related with DSE anymore being used in Astra and HCD.

### What does this PR fix and why was it fixed

Renames artifacts names and maven coordinates when shipping them as part of HCD to prevent confusion with former DSE product.

This has been discussed and was agreed that artifact to be named com.datastax.db:db-all instead of com.datastax.dse:dse-db-all.

Previous change for reference: https://github.com/datastax/cassandra/pull/62 ([STAR-172](https://datastax.jira.com/browse/STAR-172))
