### PR TITLE
CNDB-13905 provide total point count to BKDWriter

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -176,7 +176,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             try (NumericIndexWriter writer = new NumericIndexWriter(perIndexComponents,
                                                                     TypeUtil.fixedSizeOf(termComparator),
                                                                     maxSegmentRowId,
-                                                                    // Due to stale entries in IndexMemtable, we may have more indexed rows than num of rowIds.
+                                                                    // The number of postings is unknown. Also, there are stale entries in IndexMemtable.
                                                                     Integer.MAX_VALUE,
                                                                     indexContext().getIndexWriterConfig()))
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -170,7 +170,7 @@ public abstract class SegmentBuilder
             try (NumericIndexWriter writer = new NumericIndexWriter(components,
                                                                     TypeUtil.fixedSizeOf(termComparator),
                                                                     maxSegmentRowId,
-                                                                    rowCount,
+                                                                    kdTreeRamBuffer.numPoints(),
                                                                     indexWriterConfig))
             {
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDTreeRamBuffer.java
@@ -84,6 +84,11 @@ public class BKDTreeRamBuffer implements Accountable
         return numRows;
     }
 
+    public long numPoints()
+    {
+        return numPoints;
+    }
+
     public long addPackedValue(int segmentRowId, BytesRef value)
     {
         ensureOpen();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDWriter.java
@@ -339,15 +339,15 @@ public class BKDWriter implements Closeable
             assert valueInOrder(valueCount + leafCount,
                                 0, lastPackedValue, packedValue, 0, docID, lastDocID);
 
+            if (valueCount + leafCount > totalPointCount)
+            {
+                throw new IllegalStateException("totalPointCount=" + totalPointCount + " was passed when we were created, but we just hit " + (valueCount + leafCount) + " values");
+            }
+
             System.arraycopy(packedValue, 0, leafValues, leafCount * packedBytesLength, packedBytesLength);
             leafDocs[leafCount] = docID;
             docsSeen.set(docID);
             leafCount++;
-
-            if (valueCount > totalPointCount)
-            {
-                throw new IllegalStateException("totalPointCount=" + totalPointCount + " was passed when we were created, but we just hit " + pointCount + " values");
-            }
 
             if (leafCount == maxPointsInLeafNode)
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
@@ -32,7 +32,6 @@ import org.apache.cassandra.index.sai.disk.io.IndexOutput;
 import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.oldlucene.MutablePointValues;
-import org.apache.lucene.index.PointValues;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriter.java
@@ -58,31 +58,31 @@ public class NumericIndexWriter implements Closeable
 
     /**
      * @param maxSegmentRowId maximum possible segment row ID, used to create `maxDoc` for kd-tree
-     * @param numRows must be greater than number of added rowIds, only used for validation.
+     * @param totalPointCount must be greater than number of added rowIds, only used for validation.
      */
     public NumericIndexWriter(IndexComponents.ForWrite components,
                               int bytesPerDim,
                               int maxSegmentRowId,
-                              int numRows,
+                              long totalPointCount,
                               IndexWriterConfig config) throws IOException
     {
-        this(components, MAX_POINTS_IN_LEAF_NODE, bytesPerDim, maxSegmentRowId, numRows, config);
+        this(components, MAX_POINTS_IN_LEAF_NODE, bytesPerDim, maxSegmentRowId, totalPointCount, config);
     }
 
     public NumericIndexWriter(IndexComponents.ForWrite components,
                               int maxPointsInLeafNode,
                               int bytesPerDim,
                               int maxSegmentRowId,
-                              int numRows,
+                              long totalPointCount,
                               IndexWriterConfig config) throws IOException
     {
         checkArgument(maxSegmentRowId >= 0,
                       "[%s] maxRowId must be non-negative value, but got %s",
                       config.getIndexName(), maxSegmentRowId);
 
-        checkArgument(numRows >= 0,
-                      "[$s] numRows must be non-negative value, but got %s",
-                      config.getIndexName(), numRows);
+        checkArgument(totalPointCount >= 0,
+                      "[$s] totalPointCount must be non-negative value, but got %s",
+                      config.getIndexName(), totalPointCount);
 
         this.components = components;
         this.bytesPerDim = bytesPerDim;
@@ -92,7 +92,7 @@ public class NumericIndexWriter implements Closeable
                                     bytesPerDim,
                                     maxPointsInLeafNode,
                                     BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP,
-                                    numRows,
+                                    totalPointCount,
                                     true, null,
                                     components.addOrGet(IndexComponentType.KD_TREE).byteOrder());
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.util.FileHandle;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.hamcrest.MatcherAssert;
 
 import static org.apache.cassandra.index.sai.metrics.QueryEventListeners.NO_OP_BKD_LISTENER;
 import static org.apache.lucene.index.PointValues.Relation.CELL_CROSSES_QUERY;
@@ -407,9 +408,9 @@ public class BKDReaderTest extends SaiRandomizedTest
 
         final SegmentMetadata.ComponentMetadataMap metadata = writer.writeAll(buffer.asPointValues());
         final long bkdPosition = metadata.get(IndexComponentType.KD_TREE).root;
-        assertThat(bkdPosition, is(greaterThan(0L)));
+        MatcherAssert.assertThat(bkdPosition, is(greaterThan(0L)));
         final long postingsPosition = metadata.get(IndexComponentType.KD_TREE_POSTING_LISTS).root;
-        assertThat(postingsPosition, is(greaterThan(0L)));
+        MatcherAssert.assertThat(postingsPosition, is(greaterThan(0L)));
 
         FileHandle kdtreeHandle = components.get(IndexComponentType.KD_TREE).createFileHandle();
         FileHandle kdtreePostingsHandle = components.get(IndexComponentType.KD_TREE_POSTING_LISTS).createFileHandle();

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/BKDReaderTest.java
@@ -402,35 +402,10 @@ public class BKDReaderTest extends SaiRandomizedTest
                                                                  maxPointsPerLeaf,
                                                                  Integer.BYTES,
                                                                  Math.toIntExact(buffer.numRows()),
-                                                                 buffer.numRows(),
+                                                                 buffer.numPoints(),
                                                                  new IndexWriterConfig("test", 2, 8));
 
         final SegmentMetadata.ComponentMetadataMap metadata = writer.writeAll(buffer.asPointValues());
-        final long bkdPosition = metadata.get(IndexComponentType.KD_TREE).root;
-        assertThat(bkdPosition, is(greaterThan(0L)));
-        final long postingsPosition = metadata.get(IndexComponentType.KD_TREE_POSTING_LISTS).root;
-        assertThat(postingsPosition, is(greaterThan(0L)));
-
-        FileHandle kdtreeHandle = components.get(IndexComponentType.KD_TREE).createFileHandle();
-        FileHandle kdtreePostingsHandle = components.get(IndexComponentType.KD_TREE_POSTING_LISTS).createFileHandle();
-        return new BKDReader(indexContext,
-                             kdtreeHandle,
-                             bkdPosition,
-                             kdtreePostingsHandle,
-                             postingsPosition);
-    }
-
-    private BKDReader finishAndOpenReaderOneDim(int maxPointsPerLeaf, MutableOneDimPointValues values, int numRows) throws IOException
-    {
-        IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
-        final NumericIndexWriter writer = new NumericIndexWriter(components,
-                                                                 maxPointsPerLeaf,
-                                                                 Integer.BYTES,
-                                                                 Math.toIntExact(numRows),
-                                                                 numRows,
-                                                                 new IndexWriterConfig("test", 2, 8));
-
-        final SegmentMetadata.ComponentMetadataMap metadata = writer.writeAll(values);
         final long bkdPosition = metadata.get(IndexComponentType.KD_TREE).root;
         assertThat(bkdPosition, is(greaterThan(0L)));
         final long postingsPosition = metadata.get(IndexComponentType.KD_TREE_POSTING_LISTS).root;

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.carrotsearch.hppc.IntArrayList;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
@@ -47,7 +46,6 @@ import org.apache.cassandra.utils.AbstractGuavaIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
-import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Counter;

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/NumericIndexWriterTest.java
@@ -87,14 +87,13 @@ public class NumericIndexWriterTest extends SaiRandomizedTest
 
         final MutableOneDimPointValues pointValues = ramBuffer.asPointValues();
 
-        int docCount = pointValues.getDocCount();
-
         SegmentMetadata.ComponentMetadataMap indexMetas;
 
         IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
         try (NumericIndexWriter writer = new NumericIndexWriter(components,
                                                                 Integer.BYTES,
-                                                                docCount, docCount,
+                                                                pointValues.getDocCount(),
+                                                                pointValues.size(),
                                                                 IndexWriterConfig.defaultConfig("test")))
         {
             indexMetas = writer.writeAll(pointValues);


### PR DESCRIPTION
#1695 fixed the calculation of row count to be actually the row count and not number of postings/points. However, BKDWriter was expecting number of points behind the row count.

Fixes https://github.com/riptano/cndb/issues/13905

Renames confusing numRows arguments to totalPointCount in methods
propagating the value to BKDWriter, which expects the total point
count. Fixes to provide total point counts instead of row counts.

In the most of tests the point count and the row count are equivalent.
One unused test is removed.

This PR also brings #1715, which corrects the assert condition on expected number of points and improve the error message. This also makes down the code coverage below accepted minimum.

Also fixes few IntelliJ warnings in affected files.