### PR TITLE
CNDB-13994: trigger memtable flush when index memtable reaches size threshold or expiration period. Default disabled.

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -24,7 +24,6 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.compress.AdaptiveCompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
-import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.sensors.SensorsFactory;
@@ -373,7 +372,16 @@ public enum CassandraRelevantProperties
     VECTOR_FLOAT_ONLY("cassandra.float_only_vectors", "true"),
     /** Enables use of vector type. True by default. **/
     VECTOR_TYPE_ALLOWED("cassandra.vector_type_allowed", "true"),
-
+    // Use non-positive value to disable it. Period in millis to trigger a flush for memtable
+    FLUSH_PERIOD_IN_MILLIS("cassandra.flush_period_in_millis", "-1"),
+    // Use non-positive value to disable it. When num of rows in SAI non-vector memtable index reaches the threshold, it triggers flush
+    SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS("cassandra.sai.non_vector_flush_threshold_max_rows", "-1"),
+    // Use non-positive value to disable it. Period in millis to trigger a flush for SAI non-vector memtable index.
+    SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.non_vector_flush_period_in_millis", "-1"),
+    // Use non-positive value to disable it. When num of rows in SAI vector memtable index reaches the threshold, it triggers flush
+    SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS("cassandra.sai.vector_flush_threshold_max_rows", "-1"),
+    // Use non-positive value to disable it. Period in millis to trigger a flush for SAI vector memtable index.
+    SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.vector_flush_period_in_millis", "-1"),
     /**
      * Whether to disable auto-compaction
      */

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -86,6 +86,7 @@ import org.apache.cassandra.cache.RowCacheSentinel;
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
@@ -128,6 +129,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.StartupException;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.internal.CassandraIndex;
 import org.apache.cassandra.index.transactions.UpdateTransaction;
@@ -258,7 +260,10 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         UNIT_TESTS, // explicitly requested flush needed for a test
         /** Flush performed to a remote storage. Used by remote commit log replay */
         REMOTE_REPLAY,
-        BATCHLOG_REPLAY
+        BATCHLOG_REPLAY,
+        TRIE_LIMIT,
+        INDEX_MEMTABLE_LIMIT,
+        INDEX_MEMTABLE_PERIOD_EXPIRED,
     }
 
     private static final String[] COUNTER_NAMES = new String[]{"table", "count", "error", "value"};
@@ -1963,6 +1968,29 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     public OpOrder readOrdering()
     {
         return readOrdering;
+    }
+
+    @Override
+    public int getMemtableFlushPeriodInMs()
+    {
+        int flushPeriodInMs = metadata().params.memtableFlushPeriodInMs;
+        flushPeriodInMs = pickSmallerFlushPeriod(flushPeriodInMs, CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.getInt());
+
+        // When creating CFS, indexManager is initialized after memtable, we need to handle null here; Later when SAI
+        // is initialized, SAI will force flush to create new memtable with proper flush period.
+        if (indexManager == null)
+            return flushPeriodInMs;
+
+        for (Index index : indexManager.listIndexes())
+            flushPeriodInMs = pickSmallerFlushPeriod(flushPeriodInMs, index.getFlushPeriodInMs());
+        return flushPeriodInMs;
+    }
+
+    private static int pickSmallerFlushPeriod(int period1, int period2)
+    {
+        if (period1 > 0 && period2 > 0)
+            return Math.min(period1, period2);
+        return period1 > 0 ? period1 : period2;
     }
 
     public Map<UUID, PendingStat> getPendingRepairStats()

--- a/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
@@ -19,8 +19,11 @@
 package org.apache.cassandra.db.memtable;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -200,7 +203,7 @@ public abstract class AbstractAllocatorMemtable extends AbstractMemtableWithComm
 
     void scheduleFlush()
     {
-        int period = metadata().params.memtableFlushPeriodInMs;
+        int period = owner.getMemtableFlushPeriodInMs();
         if (period > 0)
             scheduleFlush(owner, period);
     }
@@ -222,7 +225,7 @@ public abstract class AbstractAllocatorMemtable extends AbstractMemtableWithComm
 
     private void flushIfPeriodExpired()
     {
-        int period = metadata().params.memtableFlushPeriodInMs;
+        int period = owner.getMemtableFlushPeriodInMs();
         if (period > 0 && (System.nanoTime() - creationNano >= TimeUnit.MILLISECONDS.toNanos(period)))
         {
             if (isClean())

--- a/src/java/org/apache/cassandra/db/memtable/Memtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/Memtable.java
@@ -180,6 +180,11 @@ public interface Memtable extends Comparable<Memtable>
          * Get the op-order primitive that protects data for the duration of reads.
          */
         public OpOrder readOrdering();
+
+        /**
+         * Get the memtable flush period in millis based on schema config or system configs
+         */
+        int getMemtableFlushPeriodInMs();
     }
 
     // Main write and read operations
@@ -339,6 +344,14 @@ public interface Memtable extends Comparable<Memtable>
                                  ownershipRatioOffHeap * 100);
         }
     }
+
+    /**
+     * Signal underlying memtable that flush is required for given reason
+     *
+     * @param flushReason reason to flush
+     * @param skipIfSignaled skip signaling if memtable is already requested to switch
+     */
+    void signalFlushRequired(ColumnFamilyStore.FlushReason flushReason, boolean skipIfSignaled);
 
     /**
      * Adjust the used on-heap space by the given size (e.g. to reflect memory used by a non-table-based index).

--- a/src/java/org/apache/cassandra/db/memtable/PersistentMemoryMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/PersistentMemoryMemtable.java
@@ -91,6 +91,7 @@ extends SkipListMemtable        // to test framework
         case SHUTDOWN: // Called to flush data before shutdown.
         case INTERNALLY_FORCED: // Called to ensure ordering and persistence of system table events.
         case MEMTABLE_PERIOD_EXPIRED: // The specified memtable expiration time elapsed.
+        case INDEX_MEMTABLE_PERIOD_EXPIRED: // The specified memtable expiration time elapsed.
         case INDEX_TABLE_FLUSH: // Flush requested on index table because main table is flushing.
         case STREAMS_RECEIVED: // Flush to save streamed data that was written to memtable.
             return false;   // do not do anything
@@ -130,6 +131,8 @@ extends SkipListMemtable        // to test framework
 
         case MEMTABLE_LIMIT: // The memtable size limit is reached, and this table was selected for flushing.
                              // Also passed if we call owner.signalLimitReached()
+        case TRIE_LIMIT:     // Trie size limt is reached
+        case INDEX_MEMTABLE_LIMIT: // Index memtable size limit is reached
         case COMMITLOG_DIRTY: // Commitlog thinks it needs to keep data from this table.
             // Neither of the above should happen as we specify writesAreDurable and don't use an allocator/cleaner.
             throw new AssertionError();

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -122,6 +122,12 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             {
                 return null;
             }
+
+            @Override
+            public int getMemtableFlushPeriodInMs()
+            {
+                return -1;
+            }
         });
     }
 
@@ -134,6 +140,12 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
     public void addMemoryUsageTo(MemoryUsage stats)
     {
         super.addMemoryUsageTo(stats);
+    }
+
+    @Override
+    public void signalFlushRequired(ColumnFamilyStore.FlushReason flushReason, boolean skipIfSignaled)
+    {
+        owner.signalFlushRequired(this, flushReason);
     }
 
     public boolean isClean()

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -246,13 +246,20 @@ public class TrieMemtable extends AbstractAllocatorMemtable
         MemtableShard shard = shards[boundaries.getShardForKey(key)];
         long colUpdateTimeDelta = shard.put(update, indexer, opGroup);
 
-        if (shard.data.reachedAllocatedSizeThreshold() && !switchRequested.getAndSet(true))
-        {
-            logger.info("Scheduling flush due to trie size limit reached.");
-            owner.signalFlushRequired(this, ColumnFamilyStore.FlushReason.MEMTABLE_LIMIT);
-        }
+        if (shard.data.reachedAllocatedSizeThreshold())
+            signalFlushRequired(ColumnFamilyStore.FlushReason.TRIE_LIMIT, true);
 
         return colUpdateTimeDelta;
+    }
+
+    @Override
+    public void signalFlushRequired(ColumnFamilyStore.FlushReason flushReason, boolean skipIfSignaled)
+    {
+        if (!switchRequested.getAndSet(true) || !skipIfSignaled)
+        {
+            logger.info("Scheduling flush for table {} due to {}", this.metadata.get(), flushReason);
+            owner.signalFlushRequired(this, flushReason);
+        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
@@ -227,13 +227,20 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
         MemtableShard shard = shards[boundaries.getShardForKey(key)];
         long colUpdateTimeDelta = shard.put(key, update, indexer, opGroup);
 
-        if (shard.data.reachedAllocatedSizeThreshold() && !switchRequested.getAndSet(true))
-        {
-            logger.info("Scheduling flush due to trie size limit reached.");
-            owner.signalFlushRequired(this, ColumnFamilyStore.FlushReason.MEMTABLE_LIMIT);
-        }
+        if (shard.data.reachedAllocatedSizeThreshold())
+            signalFlushRequired(ColumnFamilyStore.FlushReason.TRIE_LIMIT, true);
 
         return colUpdateTimeDelta;
+    }
+
+    @Override
+    public void signalFlushRequired(ColumnFamilyStore.FlushReason flushReason, boolean skipIfSignaled)
+    {
+        if (!switchRequested.getAndSet(true) || !skipIfSignaled)
+        {
+            logger.info("Scheduling flush for table {} due to {}", this.metadata.get(), flushReason);
+            owner.signalFlushRequired(this, flushReason);
+        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -242,6 +242,14 @@ public interface Index
     }
 
     /**
+     * @return Period in millis to trigger a flush for indexes in the group. Non-positive value to disable it.
+     */
+    default int getFlushPeriodInMs()
+    {
+        return -1;
+    }
+
+    /**
      * Returns true if index initialization should be skipped, false if it should run
      * (via {@link #getInitializationTask()}); defaults to skipping based on {@link IndexBuildDecider#onInitialBuild()}
      * decision.

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -768,6 +768,15 @@ public class StorageAttachedIndex implements Index
             indexContext.validate(key, row);
     }
 
+
+    @Override
+    public int getFlushPeriodInMs()
+    {
+        return indexContext.isVector()
+               ? CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.getInt()
+               : CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.getInt();
+    }
+
     /**
      * This method is called by the startup tasks to find SSTables that don't have indexes. The method is
      * synchronized so that the view is unchanged between validation and the selection of non-indexed SSTables.

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -34,7 +34,6 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/IndexWriterConfig.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
@@ -370,8 +369,7 @@ public class IndexWriterConfig
             }
         }
 
-        return new IndexWriterConfig(indexName, skip, minLeaves, maximumNodeConnections, queueSize,
-                                   similarityFunction, sourceModel, neighborhoodOverflow, alpha, enableHierarchy);
+        return new IndexWriterConfig(indexName, skip, minLeaves, maximumNodeConnections, queueSize, similarityFunction, sourceModel, neighborhoodOverflow, alpha, enableHierarchy);
     }
 
     public static IndexWriterConfig defaultConfig(String indexName)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.memory.MemtableIndex;
+
+public abstract class AbstractMemtableIndex implements MemtableIndex
+{
+    protected final IndexContext indexContext;
+    protected final Memtable memtable;
+
+    private final int flushThresholdMaxRows;
+
+    public AbstractMemtableIndex(IndexContext indexContext, Memtable memtable)
+    {
+        this.indexContext = indexContext;
+        this.memtable = memtable;
+        this.flushThresholdMaxRows = indexContext.isVector() ? CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.getInt()
+                                                             : CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.getInt();
+    }
+
+    /**
+     * @return num of rows in the memtable index
+     */
+    protected abstract int indexedRows();
+
+    /**
+     * Called when index is updated
+     */
+    protected void onIndexUpdated()
+    {
+        if (flushThresholdMaxRows > 0 && indexedRows() >= flushThresholdMaxRows)
+            memtable.signalFlushRequired(ColumnFamilyStore.FlushReason.INDEX_MEMTABLE_LIMIT, true);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -55,7 +55,6 @@ import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.memory.MemoryIndex;
-import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
@@ -78,13 +77,12 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.pow;
 
-public class VectorMemtableIndex implements MemtableIndex
+public class VectorMemtableIndex extends AbstractMemtableIndex
 {
     private static final Logger logger = LoggerFactory.getLogger(VectorMemtableIndex.class);
     private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
     public static int GLOBAL_BRUTE_FORCE_ROWS = Integer.MAX_VALUE; // not final so test can inject its own setting
 
-    private final IndexContext indexContext;
     private final ColumnQueryMetrics.VectorIndexMetrics columnQueryMetrics;
     private final CassandraOnHeapGraph<PrimaryKey> graph;
     private final LongAdder writeCount = new LongAdder();
@@ -95,20 +93,18 @@ public class VectorMemtableIndex implements MemtableIndex
     private PrimaryKey maximumKey;
 
     private final NavigableSet<PrimaryKey> primaryKeys = new ConcurrentSkipListSet<>();
-    private final Memtable mt;
 
     public VectorMemtableIndex(IndexContext indexContext, Memtable mt)
     {
-        this.indexContext = indexContext;
+        super(indexContext, mt);
         this.columnQueryMetrics = (ColumnQueryMetrics.VectorIndexMetrics) indexContext.getColumnQueryMetrics();
         this.graph = new CassandraOnHeapGraph<>(indexContext, true, mt);
-        this.mt = mt;
     }
 
     @Override
     public Memtable getMemtable()
     {
-        return mt;
+        return memtable;
     }
 
     @Override
@@ -120,6 +116,7 @@ public class VectorMemtableIndex implements MemtableIndex
         var primaryKey = indexContext.keyFactory().create(key, clustering);
         long allocatedBytes = index(primaryKey, value);
         memtable.markExtraOnHeapUsed(allocatedBytes, opGroup);
+        onIndexUpdated();
     }
 
     private long index(PrimaryKey primaryKey, ByteBuffer value)
@@ -175,6 +172,8 @@ public class VectorMemtableIndex implements MemtableIndex
                 primaryKeys.remove(primaryKey);
                 removedCount.increment();
             }
+
+            onIndexUpdated();
         }
     }
 
@@ -394,7 +393,7 @@ public class VectorMemtableIndex implements MemtableIndex
         var score = similarityFunction.compare(queryVector, vector);
         if (score < threshold)
             return null;
-        return new PrimaryKeyWithScore(indexContext, mt, key, score);
+        return new PrimaryKeyWithScore(indexContext, memtable, key, score);
     }
 
     private int maxBruteForceRows(int rerankK, int nPermittedOrdinals, int graphSize)
@@ -457,7 +456,8 @@ public class VectorMemtableIndex implements MemtableIndex
         return graph.preFlush(ordinalMapper);
     }
 
-    public int size()
+    @Override
+    public int indexedRows()
     {
         return graph.size();
     }
@@ -583,7 +583,7 @@ public class VectorMemtableIndex implements MemtableIndex
                 SearchResult.NodeScore nodeScore = nodeScores.next();
                 primaryKeysForNode = graph.keysFromOrdinal(nodeScore.node)
                                           .stream()
-                                          .map(pk -> new PrimaryKeyWithScore(indexContext, mt, pk, nodeScore.score))
+                                          .map(pk -> new PrimaryKeyWithScore(indexContext, memtable, pk, nodeScore.score))
                                           .iterator();
                 if (primaryKeysForNode.hasNext())
                     return primaryKeysForNode.next();

--- a/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
@@ -85,9 +85,15 @@ public abstract class MemoryIndex
     public abstract ByteBuffer getMaxTerm();
 
     /**
+     * @return num of rows in the memory index
+     */
+    public abstract int indexedRows();
+
+    /**
      * Iterate all Term->PrimaryKeys mappings in sorted order
      */
     public abstract Iterator<Pair<ByteComparable.Preencoded, List<PkWithFrequency>>> iterator();
+
 
     public static class PkWithFrequency
     {

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongConsumer;
 import javax.annotation.Nullable;
@@ -90,6 +91,7 @@ public class TrieMemoryIndex extends MemoryIndex
     private final PrimaryKeysRemover primaryKeysRemover;
     private final boolean analyzerTransformsValue;
     private final Map<PrimaryKey, Integer> docLengths = new HashMap<>();
+    private final AtomicInteger indexedRows = new AtomicInteger(0);
 
     private final Memtable memtable;
     private AbstractBounds<PartitionPosition> keyBounds;
@@ -126,6 +128,12 @@ public class TrieMemoryIndex extends MemoryIndex
     public synchronized Map<PrimaryKey, Integer> getDocLengths()
     {
         return docLengths;
+    }
+
+    @Override
+    public int indexedRows()
+    {
+        return indexedRows.get();
     }
 
     public synchronized void add(DecoratedKey key,
@@ -259,6 +267,10 @@ public class TrieMemoryIndex extends MemoryIndex
                                 + primaryKey.ramBytesUsed() // TODO do we count these bytes?
                                 + Integer.BYTES;
                 onHeapAllocationsTracker.accept(heapUsed);
+            }
+            else
+            {
+                indexedRows.incrementAndGet();
             }
 
             // memory used by the trie

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.AbstractMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeConcatIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIntersectionIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
@@ -78,7 +79,7 @@ import org.apache.cassandra.utils.SortingIterator;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
-public class TrieMemtableIndex implements MemtableIndex
+public class TrieMemtableIndex extends AbstractMemtableIndex
 {
     private final ShardBoundaries boundaries;
     private final MemoryIndex[] rangeIndexes;
@@ -88,7 +89,6 @@ public class TrieMemtableIndex implements MemtableIndex
     private final LongAdder estimatedOnHeapMemoryUsed = new LongAdder();
     private final LongAdder estimatedOffHeapMemoryUsed = new LongAdder();
 
-    private final Memtable memtable;
     private final Context sensorContext;
     private final RequestTracker requestTracker;
 
@@ -100,11 +100,11 @@ public class TrieMemtableIndex implements MemtableIndex
     @VisibleForTesting
     public TrieMemtableIndex(IndexContext indexContext, Memtable memtable, int shardCount)
     {
+        super(indexContext, memtable);
         this.boundaries = indexContext.columnFamilyStore().localRangeSplits(shardCount);
         this.rangeIndexes = new MemoryIndex[boundaries.shardCount()];
         this.indexContext = indexContext;
         this.validator = indexContext.getValidator();
-        this.memtable = memtable;
         for (int shard = 0; shard < boundaries.shardCount(); shard++)
         {
             this.rangeIndexes[shard] = new TrieMemoryIndex(indexContext, memtable, boundaries.getBounds(shard));
@@ -117,6 +117,15 @@ public class TrieMemtableIndex implements MemtableIndex
     public Memtable getMemtable()
     {
         return memtable;
+    }
+
+    @Override
+    public int indexedRows()
+    {
+        int size = 0;
+        for (MemoryIndex memoryIndex : rangeIndexes)
+            size += memoryIndex.indexedRows();
+        return size;
     }
 
     @VisibleForTesting
@@ -208,6 +217,7 @@ public class TrieMemtableIndex implements MemtableIndex
                                                                  sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                          });
         writeCount.increment();
+        onIndexUpdated();
     }
 
     @Override
@@ -236,6 +246,7 @@ public class TrieMemtableIndex implements MemtableIndex
                                                                 estimatedOffHeapMemoryUsed.add(allocatedBytes);
                                                             });
         writeCount.increment();
+        onIndexUpdated();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -44,7 +44,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheLoader;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -2877,6 +2876,66 @@ public class StorageProxy implements StorageProxyMBean
         ConsistencyLevel newCL = ConsistencyLevel.valueOf(cl.trim().toUpperCase());
         DatabaseDescriptor.setIdealConsistencyLevel(newCL);
         return String.format("Updating ideal consistency level new value: %s old value %s", newCL, original.toString());
+    }
+
+    @Override
+    public int getNonIndexMemtableFlushPeriodInSeconds()
+    {
+        return CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.getInt();
+    }
+
+    @Override
+    public void setNonIndexMemtableFlushPeriodInSeconds(int flushPeriodInSeconds)
+    {
+        CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.setInt(flushPeriodInSeconds);
+    }
+
+    @Override
+    public int getVectorIndexMemtableFlushPeriodInSecond()
+    {
+        return CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.getInt();
+    }
+
+    @Override
+    public void setVectorMemtableFlushPeriodInSecond(int flushPeriodInSecond)
+    {
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(flushPeriodInSecond);
+    }
+
+    @Override
+    public int getNonVectorIndexMemtableFlushPeriodInSecond()
+    {
+        return CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.getInt();
+    }
+
+    @Override
+    public void setNonVectorMemtableFlushPeriodInSecond(int flushPeriodInSecond)
+    {
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(flushPeriodInSecond);
+    }
+
+    @Override
+    public int getVectorIndexMemtableFlushMaxRows()
+    {
+        return CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.getInt();
+    }
+
+    @Override
+    public void setVectorMemtableFlushMaxRows(int threshold)
+    {
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.setInt(threshold);
+    }
+
+    @Override
+    public int getNonVectorIndexMemtableFlushMaxRows()
+    {
+        return CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.getInt();
+    }
+
+    @Override
+    public void setNonVectorMemtableFlushPeriodMaxRows(int threshold)
+    {
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.setInt(threshold);
     }
 
     @Deprecated

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -74,6 +74,26 @@ public interface StorageProxyMBean
     public String getIdealConsistencyLevel();
     public String setIdealConsistencyLevel(String cl);
 
+    // Default memtable flush period for tables without indexes. New value will take effect when new memtable is created
+    public int getNonIndexMemtableFlushPeriodInSeconds();
+    public void setNonIndexMemtableFlushPeriodInSeconds(int flushPeriodInSeconds);
+
+    // Default memtable flush period for tables with vector SAI indexes. New value will take effect when new memtable is created
+    public int getVectorIndexMemtableFlushPeriodInSecond();
+    public void setVectorMemtableFlushPeriodInSecond(int flushPeriodInSecond);
+
+    // Default memtable flush period for tables with non-vector SAI indexes. New value will take effect when new index memtable is created
+    public int getNonVectorIndexMemtableFlushPeriodInSecond();
+    public void setNonVectorMemtableFlushPeriodInSecond(int flushPeriodInSecond);
+
+    // When num of rows in SAI vector memtable index reaches the threshold, it triggers flush. New value will take effect when new memtable index is created
+    public int getVectorIndexMemtableFlushMaxRows();
+    public void setVectorMemtableFlushMaxRows(int threshold);
+
+    // When num of rows in SAI non-vector memtable index reaches the threshold, it triggers flush. New value will take effect when new memtable index is created
+    public int getNonVectorIndexMemtableFlushMaxRows();
+    public void setNonVectorMemtableFlushPeriodMaxRows(int threshold);
+
     /**
      * Tracking and reporting of variances in the repaired data set across replicas at read time
      */

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -720,6 +720,11 @@ public class ColumnFamilyStoreTest
             }
 
             @Override
+            public void signalFlushRequired(ColumnFamilyStore.FlushReason flushReason, boolean skipIfSignaled)
+            {
+            }
+
+            @Override
             public void markExtraOnHeapUsed(long additionalSpace, OpOrder.Group opGroup)
             {
             }

--- a/test/unit/org/apache/cassandra/db/memtable/FlushConfigTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/FlushConfigTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.awaitility.Awaitility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlushConfigTest extends CQLTester
+{
+    @Before
+    public void setup() throws Throwable
+    {
+        CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.reset();
+
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.reset();
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.reset();
+
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.reset();
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.reset();
+    }
+
+    @Test
+    public void testFlushPeriod()
+    {
+        CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.setInt(5000);
+        createTable("CREATE TABLE %s (pk int, v1 int, v2 text, PRIMARY KEY(pk))");
+
+        int rowCount = 15;
+        for (int i = 1; i <= rowCount; i++)
+            execute("INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", i, i, String.valueOf(i));
+
+        Awaitility.await("Memtable flushed")
+                  .atMost(30, TimeUnit.SECONDS)
+                  .untilAsserted(() -> assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(1));
+    }
+
+    @Test
+    public void testTrieIndexFlushThreshold()
+    {
+        int maxRows = 10;
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.setInt(maxRows);
+
+        createTable("CREATE TABLE %s (pk int, v1 int, v2 text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
+
+        int rowCount = 25;
+        for (int i = 1; i <= rowCount; i++)
+        {
+            execute("INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", i, i, String.valueOf(i));
+
+            int sstables = (i / maxRows);
+            if (i % maxRows == 0)
+            {
+                Awaitility.await("Memtable flushed")
+                          .atMost(30, TimeUnit.SECONDS)
+                          .untilAsserted(() -> assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(sstables));
+            }
+            else
+            {
+                assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(sstables);
+            }
+        }
+
+        // flush remaining memtable
+        getCurrentColumnFamilyStore().forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(3);
+    }
+
+    @Test
+    public void testTrieIndexFlushPeriod()
+    {
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(5000);
+        createTable("CREATE TABLE %s (pk int, v1 int, v2 text, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
+
+        int rowCount = 15;
+        for (int i = 1; i <= rowCount; i++)
+            execute("INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", i, i, String.valueOf(i));
+
+        Awaitility.await("Memtable flushed")
+                  .atMost(30, TimeUnit.SECONDS)
+                  .untilAsserted(() -> assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(1));
+    }
+
+
+    @Test
+    public void testVectorFlushThreshold()
+    {
+        int maxRows = 10;
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.setInt(maxRows);
+
+        int dimension = 2048;
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimension));
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        int vectorCount = 25;
+        List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(dimension)).collect(Collectors.toList());
+
+        int pk = 0;
+        for (int i = 0; i < vectorCount; i++)
+        {
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'A', ?)", pk++, vectors.get(i));
+
+            int sstables = pk / maxRows;
+            if (pk % maxRows == 0)
+            {
+                Awaitility.await("Memtable flushed")
+                          .atMost(30, TimeUnit.SECONDS)
+                          .untilAsserted(() -> assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(sstables));
+            }
+            else
+            {
+                assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(sstables);
+            }
+        }
+        // flush remaining memtable
+        getCurrentColumnFamilyStore().forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
+        assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(3);
+    }
+
+    @Test
+    public void testVectorFlushPeriod()
+    {
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(5000);
+        int dimension = 2048;
+        createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimension));
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        int vectorCount = 15;
+        List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(dimension)).collect(Collectors.toList());
+
+        int pk = 0;
+        for (Vector<Float> vector : vectors)
+            execute("INSERT INTO %s (pk, str_val, val) VALUES (?, 'A', ?)", pk++, vector);
+
+        Awaitility.await("Memtable flushed")
+                  .atMost(30, TimeUnit.SECONDS)
+                  .untilAsserted(() -> assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(1));
+    }
+
+    @Test
+    public void testMultipleFlushPeriodConfigs()
+    {
+        testMultipleFlushPeriodConfigs(5000, 6000, 7000, 8000,
+                                       5000,
+                                       5000,
+                                       5000);
+        testMultipleFlushPeriodConfigs(8000, 7000, 6000, 5000,
+                                       7000,
+                                       6000,
+                                       5000);
+        testMultipleFlushPeriodConfigs(-1, 7000, -1, -1,
+                                       7000,
+                                       7000,
+                                       7000);
+        testMultipleFlushPeriodConfigs(8000, -1, 7000, -1,
+                                       8000,
+                                       7000,
+                                       7000);
+        testMultipleFlushPeriodConfigs(-1, -1, -1, 5000,
+                                       -1,
+                                       -1,
+                                       5000);
+        testMultipleFlushPeriodConfigs(-1, -1, -1, -1,
+                                       -1,
+                                       -1,
+                                       -1);
+    }
+
+    private void testMultipleFlushPeriodConfigs(int schemaFlushPeriodInMs, int systemFlushPeriodInMs, int vectorFlushPeriodInMiss, int nonVectorFlushPeriodInMiss,
+                                                int withoutIndex, int withVector, int withAllIndexes)
+    {
+        CassandraRelevantProperties.FLUSH_PERIOD_IN_MILLIS.setInt(systemFlushPeriodInMs);
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(vectorFlushPeriodInMiss);
+        CassandraRelevantProperties.SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS.setInt(nonVectorFlushPeriodInMiss);
+
+        createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 1024>, PRIMARY KEY(pk)) with MEMTABLE_FLUSH_PERIOD_IN_MS=" + Math.max(0, schemaFlushPeriodInMs));
+        int config = Math.min(schemaFlushPeriodInMs, systemFlushPeriodInMs);
+        assertThat(getCurrentColumnFamilyStore().getMemtableFlushPeriodInMs()).isEqualTo(withoutIndex);
+
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        config = Math.min(config, vectorFlushPeriodInMiss);
+        assertThat(getCurrentColumnFamilyStore().getMemtableFlushPeriodInMs()).isEqualTo(withVector);
+
+        createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+        config = Math.min(config, nonVectorFlushPeriodInMiss);
+        assertThat(getCurrentColumnFamilyStore().getMemtableFlushPeriodInMs()).isEqualTo(withAllIndexes);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -86,7 +86,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -1529,6 +1528,7 @@ public class NativeIndexDDLTest extends SAITester
         assertEquals(singletonList(3L), toSize.apply(iterator.next()));
         assertEquals(Arrays.asList(2L, 1L), toSize.apply(iterator.next()));
     }
+
 
     @Test
     public void shouldRejectLargeStringTerms()

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -28,12 +28,14 @@ import java.util.stream.IntStream;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -55,6 +57,13 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
     public static void loadModel() throws Throwable
     {
         word2vec = Glove.parse(VectorLocalTest.class.getClassLoader().getResourceAsStream("glove.3K.50d.txt"));
+    }
+
+    @After
+    public void cleanupConfigs()
+    {
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS.reset();
+        CassandraRelevantProperties.SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS.reset();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -952,7 +952,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         var indexes = sai.getIndexContext().getLiveMemtables().values();
         assertEquals("Expect just one memtable index", 1, indexes.size());
         var vectorIndex = (VectorMemtableIndex) indexes.iterator().next();
-        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.size());
+        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.indexedRows());
 
         // Flush to build the on disk graph (before the fix, flush failed due to a row having two vectors)
         flush();


### PR DESCRIPTION
- allow triggering memtable flush when SAI memtable indexed rows reaches threshold, default -1 as disabled. Can be enable via -Dcassandra.sai.vector_flush_threshold_max_rows and -Dcassandra.sai.non_vector_flush_threshold_max_rows

- allow triggering memtable flush after expiration period based on index type. Default negative value as disabled. Can be enabled via -Dcassandra.flush_period_in_millis, -Dcassandra.sai.non_vector_flush_period_in_millis and -Dcassandra.sai.vector_flush_period_in_millis

- added JMX mbean to update configs at runtime