### PR TITLE
CNDB-13693: Make SAI's view referenceable to simplify locking query view

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -816,6 +816,27 @@ public class StorageAttachedIndex implements Index
         {
             indexContext.update(key, oldRow, newRow, mt, CassandraWriteContext.fromContext(writeContext).getGroup());
         }
+
+        @Override
+        public void partitionDelete(DeletionTime deletionTime)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
+
+        @Override
+        public void rangeTombstone(RangeTombstone tombstone)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
+
+        @Override
+        public void removeRow(Row row)
+        {
+            // Initialize the memtable index to ensure proper SAI views of the data
+            indexContext.initializeMemtableIndex(mt);
+        }
     }
 
     protected static abstract class IndexerAdapter implements Indexer
@@ -825,21 +846,6 @@ public class StorageAttachedIndex implements Index
 
         @Override
         public void finish() { }
-
-        @Override
-        public void partitionDelete(DeletionTime dt)
-        {
-        }
-
-        @Override
-        public void rangeTombstone(RangeTombstone rt)
-        {
-        }
-
-        @Override
-        public void removeRow(Row row)
-        {
-        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
@@ -507,33 +508,47 @@ public class CassandraOnHeapGraph<T> implements Accountable
     {
         // Retrieve the first compressed vectors for a segment with at least MAX_PQ_TRAINING_SET_SIZE rows
         // or the one with the most rows if none reach that size
-        var indexes = new ArrayList<>(indexContext.getView().getIndexes());
-        indexes.sort(Comparator.comparing(SSTableIndex::getSSTable, CompactionSSTable.maxTimestampDescending));
-
-        PqInfo cvi = null;
-        long maxRows = 0;
-        for (SSTableIndex index : indexes)
+        var view = indexContext.getReferencedView(TimeUnit.SECONDS.toNanos(5));
+        if (view == null)
         {
-            for (Segment segment : index.getSegments())
+            logger.warn("Unable to get view of already built indexes for {}", indexContext);
+            return null;
+        }
+
+        try
+        {
+            var indexes = new ArrayList<>(view.getIndexes());
+            indexes.sort(Comparator.comparing(SSTableIndex::getSSTable, CompactionSSTable.maxTimestampDescending));
+
+            PqInfo cvi = null;
+            long maxRows = 0;
+            for (SSTableIndex index : indexes)
             {
-                if (segment.metadata.numRows < maxRows)
-                    continue;
-
-                var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
-                var cv = searcher.getCompression();
-                if (matcher.apply(cv))
+                for (Segment segment : index.getSegments())
                 {
-                    // We can exit now because we won't find a better candidate
-                    var candidate = new PqInfo(searcher.getPQ(), searcher.containsUnitVectors(), segment.metadata.numRows);
-                    if (segment.metadata.numRows >= ProductQuantization.MAX_PQ_TRAINING_SET_SIZE)
-                        return candidate;
+                    if (segment.metadata.numRows < maxRows)
+                        continue;
 
-                    cvi = candidate;
-                    maxRows = segment.metadata.numRows;
+                    var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+                    var cv = searcher.getCompression();
+                    if (matcher.apply(cv))
+                    {
+                        // We can exit now because we won't find a better candidate
+                        var candidate = new PqInfo(searcher.getPQ(), searcher.containsUnitVectors(), segment.metadata.numRows);
+                        if (segment.metadata.numRows >= ProductQuantization.MAX_PQ_TRAINING_SET_SIZE)
+                            return candidate;
+
+                        cvi = candidate;
+                        maxRows = segment.metadata.numRows;
+                    }
                 }
             }
+            return cvi;
         }
-        return cvi;
+        finally
+        {
+            view.release();
+        }
     }
 
     private long writePQ(SequentialWriter writer, V5VectorPostingsWriter.RemappedPostings remapped, IndexContext indexContext) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -133,9 +133,9 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 // and creating the result retriever, we can retry without that index,
                 // because there may be other indexes that could be used to run the query.
                 // And if there are no good indexes left, we'd get a good contextual request error message.
-                if (e.context.isDropped() && retries < 8)
+                if (e.isDropped && retries < 8)
                 {
-                    logger.debug("Index " + e.context.getIndexName() + " dropped while preparing the query plan. Retrying.");
+                    logger.debug("Index " + e.indexName + " dropped while preparing the query plan. Retrying.");
                     retries++;
                     continue;
                 }
@@ -467,7 +467,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
      */
     public static class ScoreOrderedResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
     {
-        private final ColumnFamilyStore.RefViewFragment view;
+        private final ColumnFamilyStore.ViewFragment view;
         private final List<AbstractBounds<PartitionPosition>> keyRanges;
         private final boolean coversFullRing;
         private final CloseableIterator<PrimaryKeyWithSortKey> scoredPrimaryKeyIterator;
@@ -499,7 +499,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                                             ColumnMetadata orderedColumn)
         {
             IndexContext context = controller.getOrderer().context;
-            this.view = controller.getQueryView(context).view;
+            this.view = controller.getQueryView(context).viewFragment;
             this.keyRanges = controller.dataRanges().stream().map(DataRange::keyRange).collect(Collectors.toList());
             this.coversFullRing = keyRanges.size() == 1 && RangeUtil.coversFullRing(keyRanges.get(0));
 

--- a/src/java/org/apache/cassandra/index/sai/view/View.java
+++ b/src/java/org/apache/cassandra/index/sai/view/View.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
@@ -33,25 +34,36 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
+import org.apache.cassandra.index.sai.disk.EmptyIndex;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.IntervalTree;
+import org.apache.cassandra.utils.concurrent.RefCounted;
 
 public class View implements Iterable<SSTableIndex>
 {
-    private final Set<Descriptor> sstables;
     private final Map<Descriptor, SSTableIndex> view;
+    private final AtomicInteger references = new AtomicInteger(1);
+    private volatile boolean indexWasDropped;
 
     private final TermTree termTree;
     private final AbstractType<?> keyValidator;
     private final IntervalTree<Key, SSTableIndex, Interval<Key, SSTableIndex>> keyIntervalTree;
 
-    public View(IndexContext context, Collection<Descriptor> sstables, Collection<SSTableIndex> indexes)
+    /**
+     * Construct a threadsafe view.
+     * @param context the index context
+     * @param indexes the indexes. Note that the referencing logic for these indexes is handled
+     *                outside of this constructor and all indexes are assumed to have been referenced already.
+     *                The view will release the indexes when it is finally released.
+     */
+    public View(IndexContext context, Collection<SSTableIndex> indexes)
     {
         this.view = new HashMap<>();
-        this.sstables = new HashSet<>(sstables);
         this.keyValidator = context.keyValidator();
 
         AbstractType<?> validator = context.getValidator();
@@ -98,14 +110,40 @@ public class View implements Iterable<SSTableIndex>
         return view.values().iterator();
     }
 
-    public Collection<Descriptor> getSSTables()
-    {
-        return sstables;
-    }
-
     public Collection<SSTableIndex> getIndexes()
     {
         return view.values();
+    }
+
+    public boolean reference()
+    {
+        while (true)
+        {
+            int n = references.get();
+            if (n <= 0)
+                return false;
+            if (references.compareAndSet(n, n + 1))
+            {
+                return true;
+            }
+        }
+    }
+
+    public void release()
+    {
+        int n = references.decrementAndGet();
+        if (n == 0)
+            if (indexWasDropped)
+                view.values().forEach(SSTableIndex::markIndexDropped);
+            else
+                view.values().forEach(SSTableIndex::release);
+    }
+
+    public void markIndexWasDropped()
+    {
+        // This ordering allows us to guarantee that in flight queries will not be interrupted in problematic ways.
+        indexWasDropped = true;
+        release();
     }
 
     public int size()
@@ -113,11 +151,6 @@ public class View implements Iterable<SSTableIndex>
         return view.size();
     }
 
-    public @Nullable SSTableIndex getSSTableIndex(Descriptor descriptor)
-    {
-        return view.get(descriptor);
-    }
-    
     /**
      * Tells if an index for the given sstable exists.
      * It's equivalent to {@code getSSTableIndex(descriptor) != null }.
@@ -126,21 +159,6 @@ public class View implements Iterable<SSTableIndex>
     public boolean containsSSTableIndex(Descriptor descriptor)
     {
         return view.containsKey(descriptor);
-    }
-
-    /**
-     * Returns true if this view has been based on the Cassandra view containing given sstable.
-     * In other words, it tells if SAI was given a chance to load the index for the given sstable.
-     * It does not determine if the index exists and was actually loaded.
-     * To check the existence of the index, use {@link #containsSSTableIndex(Descriptor)}.
-     * <p>
-     * This method allows to distinguish a situation when the sstable has no index, the index is
-     * invalid, or was not loaded for whatever reason,
-     * from a situation where the view hasn't been updated yet to reflect the newly added sstable.
-     */
-    public boolean isAwareOfSSTable(Descriptor descriptor)
-    {
-        return sstables.contains(descriptor);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/SecondaryIndexManagerTest.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.index;
 
 import java.io.FileNotFoundException;
-import java.io.IOError;
 import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
@@ -194,16 +193,50 @@ public class SecondaryIndexManagerTest extends CQLTester
         assertEmpty(execute("SELECT * FROM %s WHERE a=1"));
         assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
-        // track sstable again: expect the query that needs the index cannot execute
+        // TODO why? This change reverts back to behavior from before https://github.com/datastax/cassandra/pull/1491,
+        // but it seems invalid.
+        // track sstable again: expect no rows to be read by index
         cfs.getTracker().addInitialSSTables(sstables);
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
-        assertThrows(IOError.class, () -> execute("SELECT * FROM %s WHERE c=1"));
+        assertEmpty(execute("SELECT * FROM %s WHERE c=1"));
 
         // remote reload should trigger index rebuild
         cfs.getTracker().notifySSTablesChanged(Collections.emptySet(), sstables, OperationType.REMOTE_RELOAD, Optional.empty(), null);
         waitForIndexBuilds(KEYSPACE, indexName); // this is needed because index build on remote reload is async
         assertRows(execute("SELECT * FROM %s WHERE a=1"), row(1, 1, 1));
         assertRows(execute("SELECT * FROM %s WHERE c=1"), row(1, 1, 1));
+    }
+
+    @Test
+    public void testPartialIndexRebuild()
+    {
+        String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+
+        assertMarkedAsBuilt(indexName);
+
+        execute("Insert into %s(a,b,c) VALUES(1,1,1)");
+        assertRows(execute("SELECT * FROM %s WHERE c=1"), row(1, 1, 1));
+        flush(KEYSPACE);
+
+        execute("Insert into %s(a,b,c) VALUES(2,2,2)");
+        flush(KEYSPACE);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        var sstables = cfs.getLiveSSTables().iterator();
+        SSTableReader sstableToRebuild = sstables.next();
+        assertTrue("Test needs two sstables to be valid", sstables.hasNext());
+
+        // This test only partially covers building an index. The bug it covers was only reproducible when sstables
+        // are not locally present due to logic in the StorageAttachedIndexGroup::prepareSSTablesToBuild method.
+        // In order to simplify things, we just assert that the indexes still present in the view are not released.
+        var indexMetadata = cfs.metadata().indexes.iterator().next();
+        var indexContext = ((StorageAttachedIndex) cfs.getIndexManager().getIndex(indexMetadata)).getIndexContext();
+        indexContext.prepareSSTablesForRebuild(Set.of(sstableToRebuild));
+
+        // The indexes in the view must not be released
+        for (var index : indexContext.getView().getIndexes())
+            assertFalse(index.isReleased());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -183,7 +183,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     }
 
     @Test
-    public void deletedInOtherSSTablesTest()
+    public void deletedInOtherSSTablesTest() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
@@ -199,9 +199,11 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
 
         execute("DELETE from %s WHERE pk = 0");
         execute("DELETE from %s WHERE pk = 1");
-        result = execute("SELECT * FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 1");
-        assertThat(result).hasSize(1);
-        assertContainsInt(result, "pk", 2);
+        beforeAndAfterFlush(() -> {
+            var r = execute("SELECT * FROM %s ORDER BY val ann of [0.5, 1.5, 2.5] LIMIT 1");
+            assertThat(r).hasSize(1);
+            assertContainsInt(r, "pk", 2);
+        });
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/view/IndexViewManagerTest.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
-import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -52,8 +51,14 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class IndexViewManagerTest extends SAITester
 {
@@ -179,7 +184,7 @@ public class IndexViewManagerTest extends SAITester
                 initialIndexes.add(mockSSTableIndex);
             }
 
-            IndexViewManager tracker = new IndexViewManager(columnContext, descriptors, initialIndexes);
+            IndexViewManager tracker = new IndexViewManager(columnContext, initialIndexes);
             View initialView = tracker.getView();
             assertEquals(2, initialView.size());
 
@@ -190,8 +195,8 @@ public class IndexViewManagerTest extends SAITester
             List<SSTableContext> flushedContexts = flushed.stream().map(s -> SSTableContext.create(s, loadDescriptor(s, store).perSSTableComponents())).collect(Collectors.toList());
 
             // concurrently update from both flush and compaction
-            Future<?> compaction = executor.submit(() -> tracker.update(initial, compacted, compactedContexts, true));
-            Future<?> flush = executor.submit(() -> tracker.update(none, flushed, flushedContexts, true));
+            Future<?> compaction = executor.submit(() -> tracker.update(initial, compactedContexts, true));
+            Future<?> flush = executor.submit(() -> tracker.update(none, flushedContexts, true));
 
             FBUtilities.waitOnFutures(Arrays.asList(compaction, flush));
 
@@ -201,7 +206,12 @@ public class IndexViewManagerTest extends SAITester
 
             for (SSTableIndex index : initialIndexes)
             {
-                assertEquals(1, ((MockSSTableIndex) index).releaseCount);
+                // Because of the race condition, it is released either once or twice. It won't be more
+                // because there are only two updates. The only real requirement is that it is released.
+                var releaseCount = ((MockSSTableIndex) index).releaseCount;
+                assertTrue("releaseCount should be 1 or 2 but it is " + releaseCount,
+                           releaseCount == 1 || releaseCount == 2);
+                assertTrue(index.isReleased());
             }
 
             // release original SSTableContext objects.
@@ -219,6 +229,32 @@ public class IndexViewManagerTest extends SAITester
         sstables.forEach(sstable -> sstable.selfRef().release());
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.MINUTES);
+    }
+
+
+    @Test
+    public void testMarkIndexWasDropped()
+    {
+        IndexContext mockContext = mock(IndexContext.class);
+        when(mockContext.isVector()).thenReturn(true);
+        SSTableReader sstable = mock(SSTableReader.class);
+        SSTableIndex index = mock(SSTableIndex.class);
+        when(index.reference()).thenReturn(true);
+        when(index.getSSTable()).thenReturn(sstable);
+        when(index.getIndexContext()).thenReturn(mockContext);
+
+        IndexViewManager tracker = new IndexViewManager(mockContext, Collections.singleton(index));
+        var view = tracker.getView();
+        // Now we have 2 references to the view.
+        assertTrue(view.reference());
+        // Invalidate and trigger markIndexWasDropped in the view, but not in the index since we have an extra ref.
+        tracker.invalidate(true);
+        // Assert index hasn't had markIndexDropped called yet.
+        verify(index, never()).markIndexDropped();
+        // Release and trigger/validate markIndexDropped in the index.
+        view.release();
+        verify(index, times(1)).markIndexDropped();
+        assertFalse(view.reference());
     }
 
     private IndexContext columnIndex(ColumnFamilyStore store, String indexName)


### PR DESCRIPTION
Fixes: https://github.com/riptano/cndb/issues/13693

The new design is to:

1. Make sai `View` reference-able so that it holds references to the underlying `SSTableIndex`s. When the `view` is released the final time, it releases the indexes. This moves all of the complexity of grabbing references to sstable update time and out of the query path, which seems like a generally good improvement.
2. Observe that `SSTableIndex` holds a reference to its associated sstable reader.

Note also that we need to create the memtable index on deletions in order to make the index-first solution work.

Also note that sstables indexes are added before they are removed on flush, so this change in design is safe for flush.

(cherry picked from commit 8f317826cdb0747124929b768a67a9c23cc45f5b)