### PR TITLE
CNDB-13978: Don't count tombstones in DataLimits.Counter.CQLCounter#bytesCounted

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -24,16 +24,11 @@ import java.util.List;
 import java.util.StringJoiner;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.db.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.PageSize;
-import org.apache.cassandra.db.Clustering;
-import org.apache.cassandra.db.ClusteringComparator;
-import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.Slices;
-import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.aggregation.AggregationSpecification;
 import org.apache.cassandra.db.aggregation.GroupMaker;
 import org.apache.cassandra.db.aggregation.GroupingState;
@@ -630,14 +625,14 @@ public abstract class DataLimits
             {
                 rowsInCurrentPartition = 0;
                 hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.dataSize() : 0;
+                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.originalDataSize() : 0;
             }
 
             @Override
             public Row applyToRow(Row row)
             {
                 if (isLive(row))
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
                 return row;
             }
 
@@ -1112,7 +1107,7 @@ public abstract class DataLimits
                     }
                     hasReturnedRowsFromCurrentPartition = false;
                     hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                    staticRowBytes = hasLiveStaticRow ? staticRow.dataSize() : 0;
+                    staticRowBytes = hasLiveStaticRow ? staticRow.originalDataSize() : 0;
                 }
                 currentPartitionKey = partitionKey;
                 // If we are done we need to preserve the groupInCurrentPartition and rowsCountedInCurrentPartition
@@ -1178,7 +1173,7 @@ public abstract class DataLimits
                 if (isLive(row))
                 {
                     hasUnfinishedGroup = true;
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
                     hasReturnedRowsFromCurrentPartition = true;
                 }
 

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -309,6 +309,14 @@ public interface Row extends Unfiltered, Iterable<ColumnData>
 
     public int dataSize();
 
+    /**
+     * Returns the original data size in bytes of this row as it was returned by {@link #dataSize()} before purging it
+     * from all deletion info with {@link #purge}.
+     *
+     * @return the original data size of this row in bytes before purging
+     */
+    int originalDataSize();
+
     public long unsharedHeapSizeExcludingData();
 
     public String toString(TableMetadata metadata, boolean fullDetails);

--- a/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
@@ -280,6 +280,12 @@ public class RowWithSourceTable implements Row
     }
 
     @Override
+    public int originalDataSize()
+    {
+        return row.originalDataSize();
+    }
+
+    @Override
     public long unsharedHeapSizeExcludingData()
     {
         return row.unsharedHeapSizeExcludingData() + EMPTY_SIZE;

--- a/test/unit/org/apache/cassandra/cql3/PagingQueryTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PagingQueryTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -62,7 +63,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class PagingQueryTest extends CQLTester
 {
-    final int ROW_SIZE = 49; // size of internal representation
+    static final int ROW_SIZE = 49; // size of internal representation
 
     @Parameterized.Parameters(name = "aggregation_sub_page_size={0}")
     public static Collection<Object[]> generateParameters()
@@ -551,5 +552,49 @@ public class PagingQueryTest extends CQLTester
         for (int i = 0; i < arr.length; i++)
             arr[i] = (char) (32 + ThreadLocalRandom.current().nextInt(95));
         return new String(arr);
+    }
+
+    /**
+     * DSP-22813, DBPE-16245, DBPE-16378 and CNDB-13978: Test that count(*) aggregation queries return the correct
+     * number of rows, even if there are tombstones and paging is required.
+     * </p>
+     * Before the DSP-22813/DBPE-16245/DBPE-16378/CNDB-13978 fix these queries would stop counting after hitting the
+     * {@code aggregation_sub_page_size} page size, returning only the count of a single page.
+     */
+    @Test
+    public void testAggregationWithTomsbstones()
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2))");
+
+        int ks = 13;
+        int c1s = 17;
+        int c2s = 19;
+
+        // insert some data
+        for (int k = 0; k < ks; k++)
+        {
+            for (int c1 = 0; c1 < c1s; c1++)
+            {
+                for (int c2 = 0; c2 < c2s; c2++)
+                {
+                    execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, null)", k, c1, c2);
+                }
+            }
+
+            // test aggregation on single partition query
+            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
+            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
+            Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(c1s * c2s);
+        }
+
+        // test aggregation on range query
+        int numRows = execute("SELECT * FROM %s").size();
+        long count = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
+        Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(ks * c1s * c2s);
+
+        // test aggregation with group by
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k").size()).isEqualTo(ks);
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1").size()).isEqualTo(ks * c1s);
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1, c2").size()).isEqualTo(ks * c1s * c2s);
     }
 }

--- a/test/unit/org/apache/cassandra/guardrails/GuardrailPagingTest.java
+++ b/test/unit/org/apache/cassandra/guardrails/GuardrailPagingTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.cassandra.serializers.LongSerializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -87,13 +88,14 @@ public class GuardrailPagingTest extends GuardrailTester
     @Before
     public void setUp() throws Throwable
     {
+        DatabaseDescriptor.setAggregationSubPageSize(PageSize.inBytes(1024));
         DatabaseDescriptor.getGuardrailsConfig().page_size_failure_threshold_in_kb = pageSizeThresholdInKB;
 
-        createTable("CREATE TABLE IF NOT EXISTS %s (k INT, c INT, v TEXT, PRIMARY KEY(k, c))");
+        createTable("CREATE TABLE IF NOT EXISTS %s (k INT, c INT, v TEXT, a INT, PRIMARY KEY(k, c))");
 
         for (int i = 0; i < partitionCount; i++)
             for (int j = 0; j < rowsPerPartition; j++)
-                execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", i, j, "long long test message bla bla bla bla bla bla bla bla bla bla bla");
+                execute("INSERT INTO %s (k, c, v, a) VALUES (?, ?, ?, ?)", i, j, "long long test message bla bla bla bla bla bla bla bla bla bla bla", null);
     }
 
     @Test
@@ -121,7 +123,7 @@ public class GuardrailPagingTest extends GuardrailTester
         return (ResultMessage.Rows) prepared.statement.execute(queryState, options, System.nanoTime());
     }
 
-    private ResultMessage.Rows testQueryWithPagedByRows(String query, PageSize pageSize, int rowLimit) throws Throwable
+    private ResultMessage.Rows testQueryWithPagedByRows(String query, PageSize pageSize, int rowLimit)
     {
         ResultMessage.Rows result = selectWithPaging(query, pageSize, ClientState.forExternalCalls(AuthenticatedUser.ANONYMOUS_USER));
         Assertions.assertThat(result.result.rows.size()).isLessThan(rowLimit);
@@ -168,5 +170,24 @@ public class GuardrailPagingTest extends GuardrailTester
     {
         selectWithPaging(query, PageSize.inBytes(10 * 1024), ClientState.forInternalCalls());
         selectWithPaging(query, PageSize.inBytes(10 * 1024), ClientState.forExternalCalls(new AuthenticatedUser("cassandra")));
+    }
+
+    /**
+     * DSP-22813, DBPE-16245, DBPE-16378 and CNDB-13978: Test that count(*) aggregation queries return the correct
+     * number of rows, even if there are tombstones and paging is required.
+     * </p>
+     * Before the DSP-22813/DBPE-16245/DBPE-16378/CNDB-13978 fix these queries would stop counting after hitting the
+     * {@code page_size_failure_threshold_in_kb} guardrail, returning only the count of a single page.
+     */
+    @Test
+    public void testCountWithGuardrailIsAccurate()
+    {
+        // transform the tested query into an equivalent count(*) query with the same restrictions
+        String countQuery = query.replace("*", "count(*)");
+
+        // ask for more rows per page than can fit with the current guardrail
+        ResultMessage.Rows result = selectWithPaging(countQuery, PageSize.inRows(limit), ClientState.forExternalCalls(AuthenticatedUser.ANONYMOUS_USER));
+        Long rowsCounted = LongSerializer.instance.deserialize(result.result.rows.get(0).get(0));
+        Assertions.assertThat(rowsCounted.intValue()).isEqualTo(limit);
     }
 }


### PR DESCRIPTION
Modify CQL counters calculation of bytes counted to exclude cell tombstones. That way, the counters will count the same size in bytes for filtered and unfiltered base partition/row iterators.

This solves a bug where byte-based paging is wrongly considering replicas as exhausted if their responses contain tombstones. This leads to queries using byte-based paging returning fewer rows than expected. It includes all aggregation queries, where byte-based paging is always used internally. The problem is that replicas apply counters to unfiltered iterators, whereas the coordinator controls paging by applying counters to reconciled and filtered iterators.