### PR TITLE
CNDB-14077: Reduce compaction thread pool size to match num of physical cores

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -78,8 +78,10 @@ public abstract class SegmentBuilder
 {
     private static final Logger logger = LoggerFactory.getLogger(SegmentBuilder.class);
 
-    /** for parallelism within a single compaction */
-    public static final ExecutorService compactionExecutor = new DebuggableThreadPoolExecutor(Runtime.getRuntime().availableProcessors(),
+    /** for parallelism within a single compaction
+     *  see comments to JVector PhysicalCoreExecutor -- HT tends to cause contention for the SIMD units
+     */
+    public static final ExecutorService compactionExecutor = new DebuggableThreadPoolExecutor(Runtime.getRuntime().availableProcessors() / 2,
                                                                                               1,
                                                                                               TimeUnit.MINUTES,
                                                                                               new ArrayBlockingQueue<>(10 * Runtime.getRuntime().availableProcessors()),


### PR DESCRIPTION
### What is the issue
Relates to https://github.com/riptano/cndb/issues/14077, but doesn't necessarily solve it.

### What does this PR fix and why was it fixed
When we are parallelizing vector graph insertions, we want to set the number of threads to the physical cores, not the virtual ones. This should improve efficiency and in my limited testing reduces the number of concurrent updates to the ConcurrentNeighborMap during a build of the sift 1M dataset.

My data:
For normal graph construction before this change, I saw `19412` retries in the `insertDiverse` method. 
For normal graph construction with this change, I saw `9371` retries in the `insertDiverse` method. 
For normal graph + hierarchy before this change, I saw `22500` retries in the `insertDiverse` method. 
For graph `{'similarity_function' : 'euclidean', 'enable_hierarchy': 'true', 'construction_beam_width': '200', 'maximum_node_connections': '32'}`, without this change I saw `58773` retries and with the change I saw `27775`.

The graph construction times fluctuated with the change, but I'm not sure time matters significantly since my mac does not have simd:
```
$ sysctl -n machdep.cpu.features
FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTES64 MON DSCPL VMX EST TM2 SSSE3 FMA CX16 TPR PDCM SSE4.1 SSE4.2 x2APIC MOVBE POPCNT AES PCID XSAVE OSXSAVE SEGLIM64 TSCTMR AVX1.0 RDRAND F16C
```