### PR TITLE
Hcd-130 incremental repair failure during compaction

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -102,7 +103,6 @@ import org.apache.cassandra.db.memtable.ShardBoundaries;
 import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.repair.CassandraTableRepairManager;
-import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.db.streaming.CassandraStreamManager;
 import org.apache.cassandra.db.view.TableViews;
 import org.apache.cassandra.dht.AbstractBounds;
@@ -140,7 +140,6 @@ import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.repair.TableRepairManager;
 import org.apache.cassandra.repair.consistent.admin.PendingStat;
-import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.CompactionParams;
 import org.apache.cassandra.schema.CompactionParams.TombstoneOption;
 import org.apache.cassandra.schema.CompressionParams;
@@ -372,6 +371,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     private final BloomFilterTracker bloomFilterTracker = BloomFilterTracker.createMeterTracker();
 
     private final RequestTracker requestTracker = RequestTracker.instance;
+
+    private final ReentrantLock longRunningSerializedOperationsLock = new ReentrantLock();
 
     public static void shutdownPostFlushExecutor() throws InterruptedException
     {
@@ -2792,7 +2793,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     {
         // synchronize so that concurrent invocations don't re-enable compactions partway through unexpectedly,
         // and so we only run one major compaction at a time
-        synchronized (this)
+        longRunningSerializedOperationsLock.lock();
+        try
         {
             logger.trace("Cancelling in-progress compactions for {}", metadata.name);
             Iterable<ColumnFamilyStore> toInterruptFor = concatWith(interruptIndexes, interruptViews);
@@ -2804,14 +2806,9 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 CompactionManager.instance.waitForCessation(toInterruptFor, sstablesPredicate);
 
                 // doublecheck that we finished, instead of timing out
-                for (ColumnFamilyStore cfs : toInterruptFor)
-                {
-                    if (cfs.getTracker().getCompacting().stream().anyMatch(sstablesPredicate))
-                    {
-                        logger.warn("Unable to cancel in-progress compactions for {}.  Perhaps there is an unusually large row in progress somewhere, or the system is simply overloaded.", metadata.name);
-                        return null;
-                    }
-                }
+                if (!allCompactionsFinished(toInterruptFor, sstablesPredicate))
+                    return null;
+
                 logger.trace("Compactions successfully cancelled");
 
                 // run our task
@@ -2825,6 +2822,26 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 }
             }
         }
+        finally
+        {
+            longRunningSerializedOperationsLock.unlock();
+        }
+    }
+
+    private boolean allCompactionsFinished( Iterable<ColumnFamilyStore> cfss, Predicate<SSTableReader> sstablesPredicate)
+    {
+        for (ColumnFamilyStore cfs : cfss)
+        {
+            if (cfs.getTracker().getCompacting().stream().anyMatch(sstablesPredicate))
+            {
+                logger.warn("Unable to cancel in-progress compactions for {}.{}.  Perhaps there is an unusually " +
+                            "large row in progress somewhere, or the system is simply overloaded.", metadata.keyspace, metadata.name);
+                logger.debug("In-flight compactions: {}", Arrays.toString(cfs.getTracker().getCompacting().toArray()));
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static CompactionManager.CompactionPauser pauseCompactionStrategies(Iterable<ColumnFamilyStore> toPause)

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
@@ -171,7 +171,7 @@ public class BackgroundCompactions
         if (id == null || aggregate == null)
             throw new IllegalArgumentException("arguments cannot be null");
 
-        logger.debug("Submitting background compaction {}", id);
+        logger.debug("Submitting background compaction {} for {}.{}", id, metadata.keyspace, metadata.name);
         CompactionPick compaction = aggregate.getSelected();
 
         CompactionPick prev = compactions.put(id, compaction);

--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db.compaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
@@ -261,68 +262,88 @@ public interface ShardManager
     {
         if (coveredShards <= maxParallelism)
             return splitSSTablesInShards(sstables, operationRange, numShardsForDensity, maker);
-        // We may be in a simple case where we can reduce the number of shards by some power of 2.
-        int multiple = Integer.highestOneBit(coveredShards / maxParallelism);
-        if (maxParallelism * multiple == coveredShards)
-            return splitSSTablesInShards(sstables, operationRange, numShardsForDensity / multiple, maker);
 
         var shards = splitSSTablesInShards(sstables,
                                            operationRange,
                                            numShardsForDensity,
                                            (rangeSSTables, range) -> Pair.create(Set.copyOf(rangeSSTables), range));
+
         return applyMaxParallelism(maxParallelism, maker, shards);
     }
 
-    private static <T, R extends CompactionSSTable> List<T> applyMaxParallelism(int maxParallelism, BiFunction<Collection<R>, Range<Token>, T> maker, List<Pair<Set<R>, Range<Token>>> shards)
+    private static <T, R extends CompactionSSTable> List<T> applyMaxParallelism(int maxParallelism,
+                                                                                BiFunction<Collection<R>, Range<Token>, T> maker,
+                                                                                List<Pair<Set<R>, Range<Token>>> shards)
     {
-        int actualParallelism = shards.size();
-        if (maxParallelism >= actualParallelism)
-        {
-            // We can fit within the parallelism limit without grouping, because some ranges are empty.
-            // This is not expected to happen often, but if it does, take advantage.
-            List<T> tasks = new ArrayList<>();
-            for (Pair<Set<R>, Range<Token>> pair : shards)
-                tasks.add(maker.apply(pair.left, pair.right));
-            return tasks;
-        }
-
-        // Otherwise we have to group shards together. Define a target token span per task and greedily group
-        // to be as close to it as possible.
-        double spanPerTask = shards.stream().map(Pair::right).mapToDouble(t -> t.left.size(t.right)).sum() / maxParallelism;
-        double currentSpan = 0;
-        Set<R> currentSSTables = new HashSet<>();
-        Token rangeStart = null;
-        Token prevEnd = null;
+        Iterator<Pair<Set<R>, Range<Token>>> iter = shards.iterator();
         List<T> tasks = new ArrayList<>(maxParallelism);
-        for (var pair : shards)
-        {
-            final Token currentEnd = pair.right.right;
-            final Token currentStart = pair.right.left;
-            double span = currentStart.size(currentEnd);
-            if (rangeStart == null)
-                rangeStart = currentStart;
-            if (currentSpan + span >= spanPerTask - 0.001) // rounding error safety
-            {
-                boolean includeCurrent = currentSpan + span - spanPerTask <= spanPerTask - currentSpan;
-                if (includeCurrent)
-                    currentSSTables.addAll(pair.left);
-                tasks.add(maker.apply(currentSSTables, new Range<>(rangeStart, includeCurrent ? currentEnd : prevEnd)));
-                currentSpan -= spanPerTask;
-                rangeStart = null;
-                currentSSTables.clear();
-                if (!includeCurrent)
-                {
-                    currentSSTables.addAll(pair.left);
-                    rangeStart = currentStart;
-                }
-            }
-            else
-                currentSSTables.addAll(pair.left);
+        int shardsRemaining = shards.size();
+        int tasksRemaining = maxParallelism;
 
-            currentSpan += span;
-            prevEnd = currentEnd;
+        if (shardsRemaining > tasksRemaining)
+        {
+            double totalSpan = shards.stream().map(Pair::right).mapToDouble(r -> r.left.size(r.right)).sum();
+            double spanPerTask = totalSpan / maxParallelism;
+
+            Set<R> currentSSTables = new HashSet<>();
+            Token rangeStart = null;
+            double currentSpan = 0;
+
+            // While we have more shards to process than there are tasks, we need to bunch shards up into tasks.
+            while (shardsRemaining > tasksRemaining)
+            {
+                Pair<Set<R>, Range<Token>> pair = iter.next(); // shardsRemaining counts the shards so iter can't be exhausted at this point
+                Token currentStart = pair.right.left;
+                Token currentEnd = pair.right.right;
+                double span = currentStart.size(currentEnd);
+
+                if (rangeStart == null)
+                    rangeStart = currentStart;
+
+                currentSSTables.addAll(pair.left);
+                currentSpan += span;
+
+                // If there is only one task remaining, we should not issue it until we are processing the last shard.
+                // The latter condition is normally guaranteed, but floating point rounding has a very small chance of making the calculations wrong
+                if (currentSpan >= spanPerTask && tasksRemaining > 1)
+                {
+                    tasks.add(maker.apply(currentSSTables, new Range<>(rangeStart, currentEnd)));
+                    --tasksRemaining;
+                    currentSSTables = new HashSet<>();
+                    rangeStart = null;
+                    currentSpan = 0;
+                }
+                --shardsRemaining;
+            }
+
+            // At this point there are as many tasks remaining as there are shards
+            // (this includes the case of issuing a task for the last shard when only one task remains).
+
+            // Add any already collected sstables to the next task.
+            if (!currentSSTables.isEmpty())
+            {
+                assert shardsRemaining > 0;
+                Pair<Set<R>, Range<Token>> pair = iter.next(); // shardsRemaining counts the shards so iter can't be exhausted at this point
+                currentSSTables.addAll(pair.left);
+                Token currentEnd = pair.right.right;
+                tasks.add(maker.apply(currentSSTables, new Range<>(rangeStart, currentEnd)));
+                --tasksRemaining;
+                --shardsRemaining;
+            }
+            assert shardsRemaining == tasksRemaining : shardsRemaining + " != " + tasksRemaining;
         }
-        assert currentSSTables.isEmpty();
+
+        // If we still have tasks and shards to process, produce one task for each shard.
+        while (iter.hasNext())
+        {
+            Pair<Set<R>, Range<Token>> pair = iter.next(); // shardsRemaining counts the shards so iter can't be exhausted at this point
+            tasks.add(maker.apply(pair.left, pair.right));
+            --tasksRemaining;
+            --shardsRemaining;
+        }
+
+        assert tasks.size() == Math.min(maxParallelism, shards.size()) : tasks.size() + " != " + maxParallelism;
+        assert shardsRemaining == 0 : shardsRemaining + " != 0";
         return tasks;
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -259,12 +259,13 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             permittedParallelism = Integer.MAX_VALUE;
 
         List<AbstractCompactionTask> tasks = new ArrayList<>();
+        LifecycleTransaction txn = null;
         try
         {
             // Split the space into independently compactable groups.
             for (var aggregate : getMaximalAggregates())
             {
-                LifecycleTransaction txn = realm.tryModify(aggregate.getSelected().sstables(),
+                txn = realm.tryModify(aggregate.getSelected().sstables(),
                                                            OperationType.COMPACTION,
                                                            aggregate.getSelected().id());
 
@@ -284,6 +285,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         }
         catch (Throwable t)
         {
+            if (txn != null)
+                txn.close();
             throw rejectTasks(tasks, t);
         }
     }
@@ -414,9 +417,17 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                            selected.id());
         if (transaction != null)
         {
-            // This will ignore the range of the operation, which is fine.
-            backgroundCompactions.setSubmitted(this, transaction.opId(), aggregate);
-            createAndAddTasks(gcBefore, transaction, aggregate.operationRange(), aggregate.keepOriginals(), getShardingStats(aggregate), parallelism, tasks);
+            try
+            {
+                // This will ignore the range of the operation, which is fine.
+                backgroundCompactions.setSubmitted(this, transaction.opId(), aggregate);
+                createAndAddTasks(gcBefore, transaction, aggregate.operationRange(), aggregate.keepOriginals(), getShardingStats(aggregate), parallelism, tasks);
+            }
+            catch (Throwable e)
+            {
+                transaction.close();
+                throw e;
+            }
         }
         else
         {
@@ -687,8 +698,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                 sharedObserver)
         );
         compositeTransaction.completeInitialization();
-        assert tasks.size() <= parallelism;
-        assert tasks.size() <= coveredShardCount;
+        assert tasks.size() <= parallelism : "Task size: " + tasks.size() + " vs parallelism of: " + parallelism;
+        assert tasks.size() <= coveredShardCount : "Task size: " + tasks.size() + " vs covered shard count: " + coveredShardCount;
 
         if (tasks.isEmpty())
             transaction.close(); // this should not be reachable normally, close the transaction for safety

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTransactionClosingTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTransactionClosingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.db.compaction.unified.Controller;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.when;
+
+@RunWith(BMUnitRunner.class)
+public class UnifiedCompactionStrategyTransactionClosingTest extends BaseCompactionStrategyTest
+{
+    public static AtomicInteger txClosures = new AtomicInteger(0);
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        BaseCompactionStrategyTest.setUpClass();
+    }
+
+    @Before
+    public void setUp()
+    {
+        txClosures.set(0);
+        super.setUp();
+    }
+
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Throw exception to force tx closure",
+    targetClass = "org.apache.cassandra.db.compaction.UnifiedCompactionStrategy",
+    targetMethod = "createAndAddTasks",
+    action = "throw new org.apache.cassandra.db.compaction.CompactionInterruptedException" +
+             "(null, org.apache.cassandra.db.compaction.TableOperation$StopTrigger.UNIT_TESTS);"),
+    @BMRule(name = "Capture tx closure",
+    targetClass = "org.apache.cassandra.utils.concurrent.Transactional$AbstractTransactional",
+    targetMethod = "close",
+    action = "org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTransactionClosingTest.txClosures.incrementAndGet()")
+    })
+    public void testTransactionClosesGetMaximalTasks()
+    {
+        Set<SSTableReader> allSSTables = new HashSet<>();
+        allSSTables.addAll(mockNonOverlappingSSTables(12, 0, 100 << 20));
+        dataTracker.addInitialSSTables(allSSTables);
+
+        Controller controller = Mockito.mock(Controller.class);
+        when(controller.getNumShards(anyDouble())).thenReturn(10);
+        when(controller.parallelizeOutputShards()).thenReturn(true);
+        when(controller.maxConcurrentCompactions()).thenReturn(1000);
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
+
+        try
+        {
+            strategy.getMaximalTasks(0, false, 20);
+        }
+        catch (RuntimeException e)
+        {
+        }
+        assertTrue("The expected count of transaction close operations cannot be zero", txClosures.get() > 0);
+    }
+
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Throw exception to force tx closure",
+    targetClass = "org.apache.cassandra.db.compaction.BackgroundCompactions",
+    targetMethod = "setSubmitted",
+    action = "throw new org.apache.cassandra.db.compaction.CompactionInterruptedException" +
+             "(null, org.apache.cassandra.db.compaction.TableOperation$StopTrigger.UNIT_TESTS);"),
+    @BMRule(name = "Capture tx closure",
+    targetClass = "org.apache.cassandra.utils.concurrent.Transactional$AbstractTransactional",
+    targetMethod = "close",
+    action = "org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTransactionClosingTest.txClosures.incrementAndGet()")
+    })
+    public void testTransactionClosesCreateAndAddTasks()
+    {
+        Set<SSTableReader> allSSTables = new HashSet<>(mockNonOverlappingSSTables(12, 0, 100 << 20));
+        dataTracker.addInitialSSTables(allSSTables);
+
+        Controller controller = Mockito.mock(Controller.class);
+        when(controller.getNumShards(anyDouble())).thenReturn(10);
+        when(controller.parallelizeOutputShards()).thenReturn(true);
+        when(controller.maxConcurrentCompactions()).thenReturn(1000);
+
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
+        Collection<CompactionAggregate.UnifiedAggregate> maximals = strategy.getMaximalAggregates();
+
+        try
+        {
+            strategy.createAndAddTasks(0, maximals.iterator().next(), new ArrayList<>());
+        }
+        catch (RuntimeException e)
+        {
+        }
+
+        assertTrue("The expected count of transaction close operations cannot be zero", txClosures.get() > 0);
+    }
+}


### PR DESCRIPTION
### What is the issue
Concurrent and incremental repairs would spin fail or deadlock.

### What does this PR fix and why was it fixed
Concurrent and incremental repairs would spin fail. This patch:
- Removes an optimization failing to observe max parallelism
- Provides an improved algorithm to enforce max parallelism
- Closes transactions on some exceptions failing to be caught
- Removes a deadlock between cfs and the compaction strategy for long
running sequential operations