### PR TITLE
CNDB-14159: Fix DOC_LENGTHS offset calculations

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/DocLengthsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/DocLengthsReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.io.IndexInputReader;
 import org.apache.cassandra.index.sai.utils.IndexFileUtils;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
@@ -29,23 +30,31 @@ import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.lucene.codecs.CodecUtil;
 
+/**
+ * Reads the component written by {@link org.apache.cassandra.index.sai.disk.v1.trie.DocLengthsWriter}.
+ */
 @NotThreadSafe
 public class DocLengthsReader implements Closeable
 {
     private final IndexInputReader input;
-    private final SegmentMetadata.ComponentMetadata componentMetadata;
+    private final long offset;
+    private final long upperBound;
 
-    public DocLengthsReader(FileHandle fileHandle, SegmentMetadata.ComponentMetadata componentMetadata)
+    public DocLengthsReader(FileHandle fileHandle, SegmentMetadata.ComponentMetadata componentMetadata, Version version)
     {
         this.input = IndexFileUtils.instance.openInput(fileHandle);
-        this.componentMetadata = componentMetadata;
+        // Version EC skipped the header in the doc lengths component metadata.
+        int headerAdjustment = Version.EC.equals(version) ? 0 : SAICodecUtils.headerSize();
+        this.offset = componentMetadata.offset + headerAdjustment;
+        // The offset + length get you the end of the file for all relevant versions.
+        this.upperBound = componentMetadata.offset + componentMetadata.length;
     }
 
     public int get(int rowID) throws IOException
     {
         // Account for header size in offset calculation
-        long position = componentMetadata.offset + (long) rowID * Integer.BYTES;
-        if (position >= componentMetadata.offset + componentMetadata.length)
+        long position = offset + (long) rowID * Integer.BYTES;
+        if (position >= upperBound)
             return 0;
         input.seek(position);
         return input.readInt();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -209,7 +209,7 @@ public class InvertedIndexSearcher extends IndexSearcher
 
         var pkm = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
         var merged = IntersectingPostingList.intersect(postingLists);
-        var docLengthsReader = new DocLengthsReader(docLengths, docLengthsMeta);
+        var docLengthsReader = new DocLengthsReader(docLengths, docLengthsMeta, version);
 
         // Wrap the iterator with resource management
         var it = new AbstractIterator<BM25Utils.DocTF>() { // Anonymous class extends AbstractIterator

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
@@ -103,7 +103,7 @@ public class InvertedIndexWriter implements Closeable
         // Write doc lengths
         if (docLengthsWriter != null)
         {
-            long docLengthsOffset = docLengthsWriter.getFilePointer();
+            long docLengthsOffset = docLengthsWriter.getStartOffset();
             docLengthsWriter.writeDocLengths(docLengths);
             long docLengthsLength = docLengthsWriter.getFilePointer() - docLengthsOffset;
             components.put(IndexComponentType.DOC_LENGTHS, -1, docLengthsOffset, docLengthsLength);

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -72,6 +72,7 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.ResourceLeakDetector;
@@ -220,6 +221,14 @@ public class SAITester extends CQLTester
     {
         // Enable the optimizer by default. If there are any tests that need to disable it, they can do so explicitly.
         QueryController.QUERY_OPT_LEVEL = 1;
+
+    }
+
+    @Before
+    public void resetLastValidSegmentRowId() throws Throwable
+    {
+        // Don't want this setting to impact peer tests
+        SegmentBuilder.updateLastValidSegmentRowId(-1);
     }
 
     @After

--- a/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/SegmentsSystemViewTest.java
@@ -22,8 +22,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.SAIUtil;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -52,8 +59,24 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the virtual table exposing SSTable index segment metadata.
  */
+@RunWith(Parameterized.class)
 public class SegmentsSystemViewTest extends SAITester
 {
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+    }
+
+    @Before
+    public void setupVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
     private static final String SELECT = String.format("SELECT %s, %s, %s, %s " +
                                                        "FROM %s.%s WHERE %s = '%s' AND %s = ?",
                                                        SegmentsSystemView.SEGMENT_ROW_ID_OFFSET,


### PR DESCRIPTION
### What is the issue
Addresses some of the issues discovered by https://github.com/riptano/cndb/issues/14159

### What does this PR fix and why was it fixed

First I added tests that show the issue. Then, I fixed it by setting `EC` will to still have the "bug" where the ComponentMetadata will point to just after the header while ED and beyond will point to the header.

There are no places we use the header other than the SystemView to get info about the length (which was wrong due to not including the header). However, these do not affect the validation of the header, so I propose that we leave them as is and just fix it header other than the SystemView to get info about the length (which was wrong due to not including the header). However, these do not affect the validation of the header, so I propose that we leave them as is and just fix it in ED.