### PR TITLE
CNDB-14175: Create necessary tmp directories in SaiRandomizedTest before we run tests.

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/utils/SaiRandomizedTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/SaiRandomizedTest.java
@@ -18,9 +18,11 @@
 package org.apache.cassandra.index.sai.utils;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Random;
 
 import com.google.common.base.Preconditions;
+import org.apache.cassandra.io.util.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -31,8 +33,6 @@ import org.junit.rules.TestRule;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.io.compress.BufferType;
@@ -40,11 +40,23 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SequenceBasedSSTableId;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.SequentialWriterOption;
-import org.apache.cassandra.schema.TableMetadata;
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class SaiRandomizedTest extends RandomizedTest
 {
+
+    static
+    {
+        try
+        {
+            Files.createDirectories(FileUtils.getTempDir().toPath());
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Failed to create temporary directories", e);
+        }
+    }
+
     private static Thread.UncaughtExceptionHandler handler;
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
 The patch can be tested locally on `InvertedIndexSearcherTest`, for example.

### What is the issue
...
`InvertedSearcherTest` fails locally with:
```

java.io.IOException: No such file or directory

	at __randomizedtesting.SeedInfo.seed([515D37866AFB6CE1]:0)
	at java.base/java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.base/java.io.File.createTempFile(File.java:2129)
	at org.junit.rules.TemporaryFolder.createTemporaryFolderIn(TemporaryFolder.java:237)
	at org.junit.rules.TemporaryFolder.create(TemporaryFolder.java:147)
	at org.junit.rules.TemporaryFolder.before(TemporaryFolder.java:133)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
```
The test config points to -Djava.io.tmpdir=${build.dir}/test/cassandra but cassandra in test does not exist.
This seems to be the issue we faced in CNDB-10289 and we solved for Java distributed tests.


### What does this PR fix and why was it fixed
...
We create the directories before we run any tests. Now we can run the test