### PR TITLE
CNDB-14153: Fix SAI updates (non-null solution)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -71,6 +71,7 @@ import org.apache.cassandra.index.sai.utils.PrimaryKeyWithByteComparable;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.utils.AbstractGuavaIterator;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.BinaryHeap;
 import org.apache.cassandra.utils.CloseableIterator;
@@ -288,21 +289,23 @@ public class TrieMemoryIndex extends MemoryIndex
     public Iterator<Pair<ByteComparable.Preencoded, List<PkWithFrequency>>> iterator()
     {
         Iterator<Map.Entry<ByteComparable.Preencoded, PrimaryKeys>> iterator = data.entrySet().iterator();
-        return new Iterator<>()
+        return new AbstractGuavaIterator<>()
         {
             @Override
-            public boolean hasNext()
+            public Pair<ByteComparable.Preencoded, List<PkWithFrequency>> computeNext()
             {
-                return iterator.hasNext();
-            }
+                while (iterator.hasNext())
+                {
+                    Map.Entry<ByteComparable.Preencoded, PrimaryKeys> entry = iterator.next();
+                    PrimaryKeys primaryKeys = entry.getValue();
+                    if (primaryKeys.isEmpty())
+                        continue;
 
-            @Override
-            public Pair<ByteComparable.Preencoded, List<PkWithFrequency>> next()
-            {
-                Map.Entry<ByteComparable.Preencoded, PrimaryKeys> entry = iterator.next();
-                var pairs = new ArrayList<PkWithFrequency>(entry.getValue().size());
-                Iterators.addAll(pairs, entry.getValue().iterator());
-                return Pair.create(entry.getKey(), pairs);
+                    var pairs = new ArrayList<PkWithFrequency>(primaryKeys.size());
+                    Iterators.addAll(pairs, primaryKeys.iterator());
+                    return Pair.create(entry.getKey(), pairs);
+                }
+                return endOfData();
             }
         };
     }
@@ -638,11 +641,7 @@ public class TrieMemoryIndex extends MemoryIndex
                 return existing;
 
             heapAllocations.add(existing.remove(neww));
-            if (!existing.isEmpty())
-                return existing;
-
-            heapAllocations.add(-PrimaryKeys.unsharedHeapSize());
-            return null;
+            return existing;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -351,7 +351,7 @@ public class TrieMemoryIndex extends MemoryIndex
     {
         final ByteComparable prefix = expression.lower == null ? ByteComparable.EMPTY : asByteComparable(expression.lower.value.encoded);
         final PrimaryKeys primaryKeys = data.get(prefix);
-        if (primaryKeys == null)
+        if (primaryKeys == null || primaryKeys.keys().isEmpty())
         {
             return KeyRangeIterator.empty();
         }
@@ -891,10 +891,12 @@ public class TrieMemoryIndex extends MemoryIndex
             if (primaryKeysIterator.hasNext())
                 return new PrimaryKeyWithByteComparable(indexContext, memtable, primaryKeysIterator.next(), byteComparableTerm);
 
-            if (iterator.hasNext())
+            while (iterator.hasNext())
             {
                 var entry = iterator.next();
                 primaryKeysIterator = entry.getValue().keys().iterator();
+                if (!primaryKeysIterator.hasNext())
+                    continue;
                 byteComparableTerm = entry.getKey();
                 return new PrimaryKeyWithByteComparable(indexContext, memtable, primaryKeysIterator.next(), byteComparableTerm);
             }

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
@@ -287,14 +287,13 @@ public abstract class TrieMemtableIndexTestBase extends SAITester
         // Update row 1 to remove 2 and 3, keep 1, add 7 and 8 (note we have to manually match the 1,2,3 from above)
         updateRowWithCollection(1, List.of(1, 2, 3).iterator(), List.of(1, 7, 8).iterator());
 
-        // We net 1 new PrimaryKeys object.
-        expectedOnHeap += PrimaryKeys.unsharedHeapSize();
+        // We get 2 new PrimaryKeys objects.
+        expectedOnHeap += PrimaryKeys.unsharedHeapSize() * 2;
         assertEquals(expectedOnHeap, trieMemoryIndex.estimatedTrieValuesMemoryUsed());
 
         updateRowWithCollection(1, List.of(1, 7, 8).iterator(), List.of(1, 4, 8).iterator());
 
-        // We remove a PrimaryKeys object without adding any new keys to the trie.
-        expectedOnHeap -= PrimaryKeys.unsharedHeapSize();
+        // For now, we don't remove the old PrimaryKeys objects, so we don't change the heap size
         assertEquals(expectedOnHeap, trieMemoryIndex.estimatedTrieValuesMemoryUsed());
 
         // Run additional queries to ensure values


### PR DESCRIPTION
- **Add failing test**
- **CNDB-14153: Fix SAI updates (non-null solution)**

### What is the issue
Fixes https://github.com/riptano/cndb/issues/14153

### What does this PR fix and why was it fixed
This is meant as an alternative to https://github.com/datastax/cassandra/pull/1749. It fixes https://github.com/riptano/cndb/issues/14153 by never returning `null` from the `UpsertTransformer`.

#1749 is a more memory efficient solution, but has additional complexity, which is why I am proposing this as an alternative.