### PR TITLE
CNDB-14167: Set jvector_version on disk file format to 2

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -53,7 +53,7 @@ public class V3OnDiskFormat extends V2OnDiskFormat
     public static boolean JVECTOR_USE_PRUNING_DEFAULT = Boolean.parseBoolean(System.getProperty("cassandra.sai.jvector.use_pruning_default", "true"));
 
     // These are built to be backwards and forwards compatible. Not final only for testing.
-    public static int JVECTOR_VERSION = Integer.parseInt(System.getProperty("cassandra.sai.jvector_version", "4"));
+    public static int JVECTOR_VERSION = Integer.parseInt(System.getProperty("cassandra.sai.jvector_version", "2"));
     static
     {
         // JVector 3 is not compatible with the latest jvector changes, so we fail fast if the config is enabled.

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
@@ -34,7 +34,8 @@ public class VectorDotProductWithLengthTest extends VectorTester
     {
         super.setup();
         // we are testing unit vector detection which is part of the v3 changes, but continues in all subsequent versions
-        assert V3OnDiskFormat.JVECTOR_VERSION >= 3 : "This test assumes JVector version 3 or greater";
+        if (V3OnDiskFormat.JVECTOR_VERSION < 4)
+            V3OnDiskFormat.JVECTOR_VERSION = 4;
     }
 
     // This tests our detection of unit-length vectors used with dot product and PQ.


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14167

### What does this PR fix and why was it fixed
We upgraded to jvector 4 too soon. We need to use jvector 2 for a release cycle and then when we upgrade next, we can go to jvector 4. We needed a two phase release.

CNDB test PR: https://github.com/riptano/cndb/pull/14196
