### PR TITLE
CNDB-13563: Fix ReducingKeyIteratorTest#testTotalAndReadBytesManySSTables

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/ReducingKeyIteratorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ReducingKeyIteratorTest.java
@@ -18,13 +18,11 @@
 package org.apache.cassandra.io.sstable;
 
 import java.io.IOException;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.SchemaLoader;
@@ -32,7 +30,8 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.compaction.CompactionManager;
-import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.db.lifecycle.SSTableSet;
+import org.apache.cassandra.db.lifecycle.View;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
@@ -47,11 +46,12 @@ public class ReducingKeyIteratorTest
     public static void setup() throws Exception
     {
         SchemaLoader.prepareServer();
-        CompactionManager.instance.disableAutoCompaction();
 
         SchemaLoader.createKeyspace(KEYSPACE1,
                                     KeyspaceParams.simple(1),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD));
+        // schema must exist before we can disable compaction on it
+        CompactionManager.instance.disableAutoCompaction();
     }
 
     @After
@@ -92,14 +92,17 @@ public class ReducingKeyIteratorTest
             store.forceBlockingFlush(UNIT_TESTS);
         }
 
-        Set<SSTableReader> sstables = store.getLiveSSTables();
-        ReducingKeyIterator reducingIterator = new ReducingKeyIterator(sstables);
-
-        while (reducingIterator.hasNext())
+        try (ColumnFamilyStore.RefViewFragment viewFragment = store.selectAndReference(View.selectFunction(SSTableSet.LIVE));
+             ReducingKeyIterator reducingIterator = new ReducingKeyIterator(viewFragment.sstables))
         {
-            Assert.assertTrue(reducingIterator.getTotalBytes() >= reducingIterator.getBytesRead());
-            reducingIterator.next();
+            // verify we have the expected number of sstables
+            Assert.assertEquals(tableCount, viewFragment.sstables.size());
+            while (reducingIterator.hasNext())
+            {
+                Assert.assertTrue(reducingIterator.getTotalBytes() >= reducingIterator.getBytesRead());
+                reducingIterator.next();
+            }
+            Assert.assertEquals(reducingIterator.getTotalBytes(), reducingIterator.getBytesRead());
         }
-        Assert.assertEquals(reducingIterator.getTotalBytes(), reducingIterator.getBytesRead());
     }
 }


### PR DESCRIPTION
### What is the issue
This test doesn't disable compaction and doesn't retain a reference to the sstables, so it can run with an unexpected amount of sstables and also race with the removal of the sstables backing the ReducingKeyIterator, which causes a variety of memory safety issues. This test fails approximately 1/30 times when multiplexed in CI.

### What does this PR fix and why was it fixed
This fixes several issues. First, it disables compaction after the schema is created. Second, it fulfills the contract of ReducingKeyIteratorTest by taking references to the sstables, which should be superfluous with compactions disabled, but I prefer testing the contract. Third, it verifies that nothing is changing the number of sstables in the system (which would have caught the previous compaction misconfiguration).
