### PR TITLE
CNDB-14182: Add some null checks in InMemoryTrie

### DIFF
--- a/test/unit/org/apache/cassandra/db/tries/CellReuseTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/CellReuseTest.java
@@ -304,9 +304,9 @@ public class CellReuseTest
                    {
                        if (upd instanceof Boolean)
                        {
-                           if (upd != null && !((Boolean) upd))
+                           if (!((Boolean) upd))
                                throw new TestException();
-                           return null;
+                           return true;
                        }
                        else
                            return upd;


### PR DESCRIPTION
Currently returning a null from an Upserter may corrupt
the trie state which may end up in a serious problem.
It is better to crash instead.
