### PR TITLE
CNDB-14232 fix flakiness in BM25 by createIndex

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -464,7 +464,7 @@ public class BM25Test extends SAITester
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, p int, v text)");
         createAnalyzedIndex();
-        execute("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
 
         // Insert documents with varying frequencies of the term "apple"
         execute("INSERT INTO %s (k, p, v) VALUES (1, 5, 'apple')");
@@ -535,7 +535,7 @@ public class BM25Test extends SAITester
     {
         createTable("CREATE TABLE %s (k1 int, k2 int, p int, v text, PRIMARY KEY (k1, k2))");
         createAnalyzedIndex();
-        execute("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(p) USING 'StorageAttachedIndex'");
 
         // Insert documents with varying frequencies of the term "apple"
         execute("INSERT INTO %s (k1, k2, p, v) VALUES (0, 1, 5, 'apple')");


### PR DESCRIPTION
### What is the issue
Few indexes were created with `execute` method, which doesn't check if an index is ready.

### What does this PR fix and why was it fixed
Fixes https://github.com/riptano/cndb/issues/14232

Changing `execute` to `createIndex` fixes the observed flakiness.