### PR TITLE
CNDB-14237-202505-fix: register composite compaction observer as additional obverser on top of UCS

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -453,6 +453,12 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
+    /// Return the num of in-progress compactions tracked by UCS
+    public int getCompactionInProgress()
+    {
+        return backgroundCompactions.getCompactionsInProgress().size();
+    }
+
     private static RuntimeException rejectTasks(Iterable<? extends AbstractCompactionTask> tasks, Throwable error)
     {
         for (var task : tasks)

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -405,20 +405,20 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     /// Used by CNDB where compaction aggregates come from etcd rather than the strategy.
     /// @return collection of `AbstractCompactionTask`, which could be either a `CompactionTask` or a `UnifiedCompactionTask`
     public synchronized Collection<AbstractCompactionTask> getNextBackgroundTasks(Collection<CompactionAggregate> aggregates, int gcBefore,
-                                                                                  @Nullable CompactionObserver additionObserver)
+                                                                                  @Nullable CompactionObserver additionalObserver)
     {
         controller.onStrategyBackgroundTaskRequest();
-        return createCompactionTasks(aggregates, gcBefore, additionObserver);
+        return createCompactionTasks(aggregates, gcBefore, additionalObserver);
     }
 
     private Collection<AbstractCompactionTask> createCompactionTasks(Collection<CompactionAggregate> aggregates, int gcBefore,
-                                                                     @Nullable CompactionObserver additionObserver)
+                                                                     @Nullable CompactionObserver additionalObserver)
     {
         Collection<AbstractCompactionTask> tasks = new ArrayList<>(aggregates.size());
         try
         {
             for (CompactionAggregate aggregate : aggregates)
-                createAndAddTasks(gcBefore, (CompactionAggregate.UnifiedAggregate) aggregate, tasks, additionObserver);
+                createAndAddTasks(gcBefore, (CompactionAggregate.UnifiedAggregate) aggregate, tasks, additionalObserver);
 
             return tasks;
         }
@@ -430,7 +430,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
     /// Create compaction tasks for the given aggregate and add them to the given tasks list.
     public void createAndAddTasks(int gcBefore, CompactionAggregate.UnifiedAggregate aggregate,
-                                  Collection<? super UnifiedCompactionTask> tasks, @Nullable CompactionObserver additionObserver)
+                                  Collection<? super UnifiedCompactionTask> tasks, @Nullable CompactionObserver additionalObserver)
     {
         CompactionPick selected = aggregate.getSelected();
         int parallelism = aggregate.getPermittedParallelism();
@@ -444,7 +444,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         {
             // This will ignore the range of the operation, which is fine.
             backgroundCompactions.setSubmitted(this, transaction.opId(), aggregate);
-            createAndAddTasks(gcBefore, transaction, aggregate.operationRange(), aggregate.keepOriginals(), getShardingStats(aggregate), parallelism, tasks, additionObserver);
+            createAndAddTasks(gcBefore, transaction, aggregate.operationRange(), aggregate.keepOriginals(), getShardingStats(aggregate), parallelism, tasks, additionalObserver);
         }
         else
         {

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 public class SharedCompactionObserverTest
@@ -199,6 +200,42 @@ public class SharedCompactionObserverTest
         verify(mockObserver2, times(1)).onInProgress(mockProgress);
 
         sharedCompactionObserver.onCompleted(operationId, null);
+        verify(mockObserver1, times(1)).onCompleted(operationId, null);
+        verify(mockObserver2, times(1)).onCompleted(operationId, null);
+    }
+
+    @Test
+    public void testMultipleObserverWithOnInProgressError()
+    {
+        CompactionObserver mockObserver1 = Mockito.mock(CompactionObserver.class);
+        CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
+        Mockito.doThrow(new RuntimeException("Injected Exception")).when(mockObserver1).onInProgress(any());
+
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+
+        sharedCompactionObserver.registerExpectedSubtask();
+        assertThatThrownBy(() -> sharedCompactionObserver.onInProgress(mockProgress)).isInstanceOf(RuntimeException.class);
+
+        // both onInProgress are called
+        verify(mockObserver1, times(1)).onInProgress(mockProgress);
+        verify(mockObserver2, times(1)).onInProgress(mockProgress);
+    }
+
+    @Test
+    public void testMultipleObserverWithOnCompleteError()
+    {
+        CompactionObserver mockObserver1 = Mockito.mock(CompactionObserver.class);
+        CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
+        Mockito.doThrow(new RuntimeException("Injected Exception")).when(mockObserver1).onCompleted(any(), any());
+
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onInProgress(mockProgress);
+        verify(mockObserver1, times(1)).onInProgress(mockProgress);
+        verify(mockObserver2, times(1)).onInProgress(mockProgress);
+
+        assertThatThrownBy(() -> sharedCompactionObserver.onCompleted(operationId, null)).isInstanceOf(RuntimeException.class);
         verify(mockObserver1, times(1)).onCompleted(operationId, null);
         verify(mockObserver2, times(1)).onCompleted(operationId, null);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
@@ -185,4 +185,21 @@ public class SharedCompactionObserverTest
         when(mockProgress2.operationId()).thenReturn(UUID.randomUUID());
         Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onInProgress(mockProgress2));
     }
+
+    @Test
+    public void testMultipleObserver()
+    {
+        CompactionObserver mockObserver1 = Mockito.mock(CompactionObserver.class);
+        CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onInProgress(mockProgress);
+        verify(mockObserver1, times(1)).onInProgress(mockProgress);
+        verify(mockObserver2, times(1)).onInProgress(mockProgress);
+
+        sharedCompactionObserver.onCompleted(operationId, null);
+        verify(mockObserver1, times(1)).onCompleted(operationId, null);
+        verify(mockObserver2, times(1)).onCompleted(operationId, null);
+    }
 }


### PR DESCRIPTION
### What is the issue

UCS didn't clear pending compaction tasks in `BackgroundCompactions#compactions`

### What does this PR fix and why was it fixed

Register both UCS and composite compaction observer for parallel compaction task: both UCS and CNDB are notified