### PR TITLE
CNDB-13830: Fix KD-tree metrics test

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -439,7 +439,7 @@ public enum CassandraRelevantProperties
      * Number of polls without gossip state change to consider gossip as settled.
      */
     GOSSIP_SETTLE_POLL_SUCCESSES_REQUIRED("cassandra.gossip_settle_poll_success_required", "3"),
-    
+
     IGNORED_SCHEMA_CHECK_ENDPOINTS("cassandra.skip_schema_check_for_endpoints"),
     IGNORED_SCHEMA_CHECK_VERSIONS("cassandra.skip_schema_check_for_versions"),
     IGNORE_CORRUPTED_SCHEMA_TABLES("cassandra.ignore_corrupted_schema_tables"),

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -126,12 +126,12 @@ public class TableQueryMetrics extends AbstractMetrics
             sstablesHit = Metrics.histogram(createMetricName("SSTableIndexesHit"), false);
             segmentsHit = Metrics.histogram(createMetricName("IndexSegmentsHit"), false);
 
-            kdTreePostingsSkips = Metrics.histogram(createMetricName("KDTreePostingsSkips"), false);
+            kdTreePostingsSkips = Metrics.histogram(createMetricName("KDTreePostingsSkips"), true);
 
             kdTreePostingsNumPostings = Metrics.histogram(createMetricName("KDTreePostingsNumPostings"), false);
             kdTreePostingsDecodes = Metrics.histogram(createMetricName("KDTreePostingsDecodes"), false);
 
-            postingsSkips = Metrics.histogram(createMetricName("PostingsSkips"), false);
+            postingsSkips = Metrics.histogram(createMetricName("PostingsSkips"), true);
             postingsDecodes = Metrics.histogram(createMetricName("PostingsDecodes"), false);
 
             partitionReads = Metrics.histogram(createMetricName("PartitionReads"), false);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractMetricsTest extends SAITester
         }, 60, TimeUnit.SECONDS);
     }
 
-    protected void waitForVerifyHistogram(ObjectName name, long count)
+    protected void waitForHistogramCountEquals(ObjectName name, long count)
     {
         waitForAssert(() -> {
             try
@@ -74,6 +74,22 @@ public abstract class AbstractMetricsTest extends SAITester
             }
         }, 10, TimeUnit.SECONDS);
     }
+
+    protected void waitForHistogramMeanBetween(ObjectName name, double min, double max)
+    {
+        waitForAssert(() -> {
+            try
+            {
+                double mean = (double) jmxConnection.getAttribute(name, "Mean");
+                assertTrue("Median " + mean + " is not between " + min + " and " + max, mean >= min && mean <= max);
+            }
+            catch (Throwable ex)
+            {
+                throw Throwables.unchecked(ex);
+            }
+        }, 10, TimeUnit.SECONDS);
+    }
+
 
     protected void waitForGreaterThanZero(ObjectName name)
     {

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -118,7 +118,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
         assertEquals(0L, getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")));
         assertEquals(0L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 0);
+        waitForHistogramCountEquals(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 0);
 
         flush(KEYSPACE, table);
 
@@ -130,7 +130,8 @@ public class IndexMetricsTest extends AbstractMetricsTest
         assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
         assertEquals(0L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
+        waitForHistogramCountEquals(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
+        waitForHistogramMeanBetween(objectName("MemtableIndexFlushCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1.0, 1000000.0);
 
         compact(KEYSPACE, table);
 
@@ -147,7 +148,8 @@ public class IndexMetricsTest extends AbstractMetricsTest
         assertTrue((Long)getMetricValue(objectName("DiskUsedBytes", KEYSPACE, table, index, "IndexMetrics")) > 0);
         assertEquals(1L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
 
-        waitForVerifyHistogram(objectName("CompactionSegmentCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
+        waitForHistogramCountEquals(objectName("CompactionSegmentCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1);
+        waitForHistogramMeanBetween(objectName("CompactionSegmentCellsPerSecond", KEYSPACE, table, index, "IndexMetrics"), 1.0, 1000000.0);
     }
 
     private void assertIndexQueryCount(String index, long expectedCount)


### PR DESCRIPTION
The test for KD-tree posting list was meant to run a query that
performs skips and then verifies if the skip metric has been
bumped up.

Unfortunately there were several problems with it:
* the query didn't do skips because the clause intersection got
  optimized out by the SAI optimizer
* the test for the metric didn't inspect the metric value, but only
  checked if the metric was updated; so essentially it boiled down
  to checking if the index was used
* the metric value incorrectly recorded queries with no skips, because
  the histogram was configured to not allow zeroes.

In addition, the usage of index is dependent on the version of the
optimizer, so that made the test behave differently between DC and EC
index version. Now that we disable the optimizer for this test,
that difference is gone.

Fixes https://github.com/riptano/cndb/issues/13830
