### PR TITLE
CNDB-14275 Port commits from main

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -720,6 +720,7 @@ public enum CassandraRelevantProperties
     SAI_VALIDATE_TERMS_AT_COORDINATOR("cassandra.sai.validate_terms_at_coordinator", "true"),
     /** Controls the maximum top-k limit for vector search */
     SAI_VECTOR_SEARCH_MAX_TOP_K("cassandra.sai.vector_search.max_top_k", "1000"),
+    SAI_VECTOR_USE_PRUNING_DEFAULT("cassandra.sai.jvector.use_pruning_default", "1000"),
     SAI_WRITE_JVECTOR3_FORMAT("cassandra.sai.write_jv3_format", "false"),
 
     SCHEMA_PULL_INTERVAL_MS("cassandra.schema_pull_interval_ms", "60000"),

--- a/src/java/org/apache/cassandra/db/filter/ANNOptions.java
+++ b/src/java/org/apache/cassandra/db/filter/ANNOptions.java
@@ -80,8 +80,8 @@ public class ANNOptions
 
         if (rerankK != null)
         {
-            if (rerankK < limit)
-                throw new InvalidRequestException(String.format("Invalid rerank_k value %d lesser than limit %d", rerankK, limit));
+            if (rerankK > 0 && rerankK < limit)
+                throw new InvalidRequestException(String.format("Invalid rerank_k value %d greater than 0 and less than limit %d", rerankK, limit));
 
             Guardrails.annRerankKMaxValue.guard(rerankK, "ANN options", false, state);
         }

--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -377,6 +377,12 @@ public class Murmur3Partitioner implements IPartitioner
         }
 
         @Override
+        public Token fromLongValue(long token)
+        {
+            return new LongToken(token);
+        }
+
+        @Override
         public Token fromByteBuffer(ByteBuffer bytes, int position, int length)
         {
             return new LongToken(bytes.getLong(position));

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -41,6 +41,20 @@ public abstract class Token implements RingPosition<Token>, Serializable
         public abstract Token fromByteArray(ByteBuffer bytes);
 
         /**
+         * This method exists so that callers can create tokens from the primitive {@code long} value for this {@link Token}, if
+         * one exits. It is especially useful to skip ByteBuffer serde operations where performance is critical.
+         *
+         * @param token the primitive {@code long} value of this token
+         * @return the {@link Token} instance corresponding to the given primitive {@code long} value
+         *
+         * @throws UnsupportedOperationException if this {@link Token} is not backed by a primitive {@code long} value
+         */
+        public Token fromLongValue(long token)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
          * Produce a byte-comparable representation of the token.
          * See {@link Token#asComparableBytes}
          */

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -146,6 +146,7 @@ public class MemtableIndexWriter implements PerIndexWriter
 
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
+        long numPostings;
         long numRows;
         SegmentMetadataBuilder metadataBuilder = new SegmentMetadataBuilder(0, perIndexComponents);
         SegmentMetadata.ComponentMetadataMap indexMetas;
@@ -166,7 +167,8 @@ public class MemtableIndexWriter implements PerIndexWriter
                       );
 
                 indexMetas = writer.writeAll(metadataBuilder.intercept(terms), docLengths);
-                numRows = writer.getPostingsCount();
+                numPostings = writer.getPostingsCount();
+                numRows = docLengths.size();
             }
         }
         else
@@ -180,18 +182,20 @@ public class MemtableIndexWriter implements PerIndexWriter
             {
                 ImmutableOneDimPointValues values = ImmutableOneDimPointValues.fromTermEnum(terms, termComparator);
                 indexMetas = writer.writeAll(metadataBuilder.intercept(values));
-                numRows = writer.getPointCount();
+                numPostings = writer.getPointCount();
+                numRows = numPostings;
             }
         }
 
         // If no rows were written we need to delete any created column index components
         // so that the index is correctly identified as being empty (only having a completion marker)
-        if (numRows == 0)
+        if (numPostings == 0)
         {
             perIndexComponents.forceDeleteAllComponents();
             return 0;
         }
 
+        metadataBuilder.setNumRows(numRows);
         metadataBuilder.setKeyRange(pkFactory.createPartitionKeyOnly(minKey), pkFactory.createPartitionKeyOnly(maxKey));
         metadataBuilder.setRowIdRange(terms.getMinSSTableRowId(), terms.getMaxSSTableRowId());
         metadataBuilder.setTermRange(terms.getMinTerm(), terms.getMaxTerm());
@@ -203,7 +207,7 @@ public class MemtableIndexWriter implements PerIndexWriter
             SegmentMetadata.write(writer, Collections.singletonList(metadata));
         }
 
-        return numRows;
+        return numPostings;
     }
 
     private boolean writeFrequencies()

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -142,7 +142,6 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     private final IKeyFetcher keyFetcher;
     private final PrimaryKey.Factory primaryKeyFactory;
     private final SSTableId<?> sstableId;
-    private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private PartitionAwarePrimaryKeyMap(LongArray rowIdToToken,
                                         LongArray rowIdToOffset,
@@ -168,9 +167,8 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public PrimaryKey primaryKeyFromRowId(long sstableRowId)
     {
-        tokenBuffer.putLong(rowIdToToken.get(sstableRowId));
-        tokenBuffer.rewind();
-        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromByteArray(tokenBuffer), () -> supplier(sstableRowId));
+        long token = rowIdToToken.get(sstableRowId);
+        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromLongValue(token), () -> supplier(sstableRowId));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.index.sai.disk.v1;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -113,6 +113,7 @@ public class SSTableIndexWriter implements PerIndexWriter
         if (indexContext.getDefinition().isStatic() != row.isStatic())
             return;
 
+        boolean addedRow = false;
         if (indexContext.isNonFrozenCollection())
         {
             Iterator<ByteBuffer> valueIterator = indexContext.getValuesOf(row, nowInSec);
@@ -121,7 +122,7 @@ public class SSTableIndexWriter implements PerIndexWriter
                 while (valueIterator.hasNext())
                 {
                     ByteBuffer value = valueIterator.next();
-                    addTerm(TypeUtil.asIndexBytes(value.duplicate(), indexContext.getValidator()), key, sstableRowId, indexContext.getValidator());
+                    addedRow = addTerm(TypeUtil.asIndexBytes(value.duplicate(), indexContext.getValidator()), key, sstableRowId, indexContext.getValidator());
                 }
             }
         }
@@ -129,8 +130,13 @@ public class SSTableIndexWriter implements PerIndexWriter
         {
             ByteBuffer value = indexContext.getValueOf(key.partitionKey(), row, nowInSec);
             if (value != null)
-                addTerm(TypeUtil.asIndexBytes(value.duplicate(), indexContext.getValidator()), key, sstableRowId, indexContext.getValidator());
+            {
+                addedRow = addTerm(TypeUtil.asIndexBytes(value.duplicate(), indexContext.getValidator()), key, sstableRowId, indexContext.getValidator());
+            }
         }
+        if (addedRow)
+            currentBuilder.incRowCount();
+
     }
 
     @Override
@@ -225,10 +231,10 @@ public class SSTableIndexWriter implements PerIndexWriter
         return true;
     }
 
-    private void addTerm(ByteBuffer term, PrimaryKey key, long sstableRowId, AbstractType<?> type) throws IOException
+    private boolean addTerm(ByteBuffer term, PrimaryKey key, long sstableRowId, AbstractType<?> type) throws IOException
     {
         if (!indexContext.validateMaxTermSize(key.partitionKey(), term))
-            return;
+            return false;
 
         if (currentBuilder == null)
         {
@@ -241,10 +247,11 @@ public class SSTableIndexWriter implements PerIndexWriter
         }
 
         if (term.remaining() == 0 && TypeUtil.skipsEmptyValue(indexContext.getValidator()))
-            return;
+            return false;
 
         long allocated = currentBuilder.analyzeAndAdd(term, type, key, sstableRowId);
         limiter.increment(allocated);
+        return true;
     }
 
     private boolean shouldFlush(long sstableRowId)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -464,6 +464,7 @@ public abstract class SegmentBuilder
         metadataBuilder.setKeyRange(minKey, maxKey);
         metadataBuilder.setRowIdRange(minSSTableRowId, maxSSTableRowId);
         metadataBuilder.setTermRange(minTerm, maxTerm);
+        metadataBuilder.setNumRows(getRowCount());
 
         flushInternal(metadataBuilder);
         return metadataBuilder.build();
@@ -501,8 +502,6 @@ public abstract class SegmentBuilder
             minTerm = TypeUtil.min(term, minTerm, termComparator, Version.latest());
             maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.latest());
         }
-
-        rowCount++;
 
         // segmentRowIdOffset should encode sstableRowId into Integer
         int segmentRowId = Math.toIntExact(sstableRowId - segmentRowIdOffset);
@@ -598,6 +597,11 @@ public abstract class SegmentBuilder
     int getRowCount()
     {
         return rowCount;
+    }
+
+    void incRowCount()
+    {
+        rowCount++;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -86,6 +86,11 @@ public class SegmentMetadataBuilder
         this.termsDistributionBuilder = new TermsDistribution.Builder(context.getValidator(), byteComparableVersion, histogramSize, mostFrequentTermsCount);
     }
 
+    public void setNumRows(long numRows)
+    {
+        this.numRows = numRows;
+    }
+
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
     {
         assert minKey.compareTo(maxKey) <= 0: "minKey (" + minKey + ") must not be greater than (" + maxKey + ')';
@@ -129,7 +134,6 @@ public class SegmentMetadataBuilder
         if (built)
             throw new IllegalStateException("Segment metadata already built, no more additions allowed");
 
-        numRows += rowCount;
         termsDistributionBuilder.add(term, rowCount);
     }
 
@@ -360,7 +364,7 @@ public class SegmentMetadataBuilder
         }
 
         @Override
-        public void close() throws IOException
+        public void close()
         {
             if (lastTerm != null)
             {
@@ -371,5 +375,3 @@ public class SegmentMetadataBuilder
     }
 
 }
-
-

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -152,7 +152,6 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     private final PrimaryKey.Factory primaryKeyFactory;
     private final ClusteringComparator clusteringComparator;
     private final SSTableId<?> sstableId;
-    private final ByteBuffer tokenBuffer = ByteBuffer.allocate(Long.BYTES);
 
     private RowAwarePrimaryKeyMap(LongArray rowIdToToken,
                                   SortedTermsReader sortedTermsReader,
@@ -185,9 +184,8 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public PrimaryKey primaryKeyFromRowId(long sstableRowId)
     {
-        tokenBuffer.putLong(rowIdToToken.get(sstableRowId));
-        tokenBuffer.rewind();
-        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromByteArray(tokenBuffer), () -> supplier(sstableRowId));
+        long token = rowIdToToken.get(sstableRowId);
+        return primaryKeyFactory.createDeferred(partitioner.getTokenFactory().fromLongValue(token), () -> supplier(sstableRowId));
     }
 
     private long skinnyExactRowIdOrInvertedCeiling(PrimaryKey key)

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -36,13 +36,7 @@ import org.apache.cassandra.index.sai.disk.v1.PerIndexFiles;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2OnDiskFormat;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_ENABLE_EDGES_CACHE;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_ENABLE_JVECTOR_DELETES;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_ENABLE_LTM_CONSTRUCTION;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_ENABLE_RERANK_FLOOR;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_JVECTOR_VERSION;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_REDUCE_TOPK_ACROSS_SSTABLES;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_WRITE_JVECTOR3_FORMAT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.*;
 
 /**
  * Different vector components compared to V2OnDiskFormat (supporting DiskANN/jvector instead of HNSW/lucene).
@@ -56,6 +50,8 @@ public class V3OnDiskFormat extends V2OnDiskFormat
 
     public static volatile boolean WRITE_JVECTOR3_FORMAT = SAI_WRITE_JVECTOR3_FORMAT.getBoolean();
     public static final boolean ENABLE_LTM_CONSTRUCTION = SAI_ENABLE_LTM_CONSTRUCTION.getBoolean();
+    // JVector doesn't give us a way to access its default, so we set it here, but allow it to be overridden.
+    public static boolean JVECTOR_USE_PRUNING_DEFAULT = SAI_VECTOR_USE_PRUNING_DEFAULT.getBoolean();
 
     // These are built to be backwards and forwards compatible. Not final only for testing.
     public static int JVECTOR_VERSION = SAI_JVECTOR_VERSION.getInt();

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIterator.java
@@ -26,12 +26,10 @@ import org.apache.cassandra.index.sai.utils.RowIdWithMeta;
 import org.apache.cassandra.index.sai.utils.RowIdWithScore;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.AbstractIterator;
-import org.apache.cassandra.utils.SortingIterator;
 
 
 /**
- * An iterator over {@link RowIdWithMeta} that lazily consumes from a {@link SortingIterator} of
- * {@link RowWithApproximateScore}.
+ * An iterator over {@link RowIdWithMeta} that lazily consumes from a {@link NodeQueue} of approximate scores.
  * <p>
  * The idea is that we maintain the same level of accuracy as we would get from a graph search, by re-ranking the top
  * `k` best approximate scores at a time with the full resolution vectors to return the top `limit`.

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -329,6 +329,10 @@ public class CassandraOnHeapGraph<T> implements Accountable
         // search() errors out when an empty graph is passed to it
         if (vectorValues.size() == 0)
             return CloseableIterator.emptyIterator();
+        // This configuration indicates rerankless search, but that is only applicable to disk search, so we set
+        // rerankK to limit and otherwise ignore the setting.
+        if (rerankK <= 0)
+            rerankK = limit;
 
         Bits bits = hasDeletions ? BitsUtil.bitsIgnoringDeleted(toAccept, postingsByOrdinal) : toAccept;
         var graphAccessManager = searchers.get();

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -37,6 +38,8 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+
+import static org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat.JVECTOR_USE_PRUNING_DEFAULT;
 
 /**
  * An SAI Orderer represents an index based order by clause.
@@ -55,7 +58,7 @@ public class Orderer
 
     // Vector search parameters
     private float[] vector;
-    private final Integer rerankK;
+    private final ANNOptions annOptions;
 
     // BM25 search parameter
     private List<ByteBuffer> queryTerms;
@@ -65,14 +68,14 @@ public class Orderer
      * @param context the index context, used to build the view of memtables and sstables for query execution.
      * @param operator the operator for the order by clause.
      * @param term the term to order by (not always relevant)
-     * @param rerankK optional rerank K parameter for ANN queries
+     * @param annOptions optional options for ANN queries
      */
-    public Orderer(IndexContext context, Operator operator, ByteBuffer term, @Nullable Integer rerankK)
+    public Orderer(IndexContext context, Operator operator, ByteBuffer term, ANNOptions annOptions)
     {
         this.context = context;
         assert ORDER_BY_OPERATORS.contains(operator) : "Invalid operator for order by clause " + operator;
         this.operator = operator;
-        this.rerankK = rerankK;
+        this.annOptions = annOptions;
         this.term = term;
     }
 
@@ -115,9 +118,21 @@ public class Orderer
     public int rerankKFor(int limit, VectorCompression vc)
     {
         assert isANN() : "rerankK is only valid for ANN queries";
-        return rerankK != null
-               ? rerankK
+        return annOptions.rerankK != null
+               ? annOptions.rerankK
                : context.getIndexWriterConfig().getSourceModel().rerankKFor(limit, vc);
+    }
+
+    /**
+     * Whether to use pruning to speed up the ANN search. If the AnnOption does not specify a value for usePruning,
+     * we use the default value, which is currently configured as an environment variable.
+     *
+     * @return the usePruning value to use in ANN search
+     */
+    public boolean usePruning()
+    {
+        assert isANN() : "usePruning is only valid for ANN queries";
+        return annOptions.usePruning != null ? annOptions.usePruning : JVECTOR_USE_PRUNING_DEFAULT;
     }
 
     public boolean isBM25()
@@ -135,9 +150,7 @@ public class Orderer
         var index = indexManager.getBestIndexFor(orderExpression, StorageAttachedIndex.class)
                                 .orElseThrow(() -> new IllegalStateException("No index found for order by clause"));
 
-        // Null if not specified explicitly in the CQL query.
-        Integer rerankK = filter.annOptions().rerankK;
-        return new Orderer(index.getIndexContext(), orderExpression.operator(), orderExpression.getIndexValue(), rerankK);
+        return new Orderer(index.getIndexContext(), orderExpression.operator(), orderExpression.getIndexValue(), filter.annOptions());
     }
 
     public static boolean isFilterExpressionOrderer(RowFilter.Expression expression)
@@ -149,9 +162,9 @@ public class Orderer
     public String toString()
     {
         String direction = isAscending() ? "ASC" : "DESC";
-        String rerankInfo = rerankK != null ? String.format(" (rerank_k=%d)", rerankK) : "";
+        String annOptionsString = annOptions != null ? annOptions.toCQLString() : "";
         if (isANN())
-            return context.getColumnName() + " ANN OF " + Arrays.toString(getVectorTerm()) + ' ' + direction + rerankInfo;
+            return context.getColumnName() + " ANN OF " + Arrays.toString(getVectorTerm()) + ' ' + direction + annOptionsString;
         if (isBM25())
             return context.getColumnName() + " BM25 OF " + TypeUtil.getString(term, context.getValidator()) + ' ' + direction;
         return context.getColumnName() + ' ' + direction;

--- a/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
@@ -74,6 +74,12 @@ public class FilterComponent
 
     public static void save(IFilter filter, Descriptor descriptor, boolean deleteOnFailure) throws IOException
     {
+        if (!(filter instanceof BloomFilter))
+        {
+            logger.info("Skipped saving bloom filter {} for {} to disk", filter, descriptor);
+            return;
+        }
+
         File filterFile = descriptor.fileFor(Components.FILTER);
         try (FileOutputStreamPlus stream = filterFile.newOutputStream(File.WriteMode.OVERWRITE))
         {

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -161,6 +161,12 @@ public class FilterFactory
         {
             return false;
         }
+
+        @Override
+        public String toString()
+        {
+            return "AlwaysPresentFilter";
+        }
     }
 
     public interface FilterFactoryMetrics

--- a/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
+++ b/src/java/org/apache/cassandra/utils/obs/MemoryLimiter.java
@@ -39,7 +39,8 @@ public class MemoryLimiter
     {
         assert bytesCount >= 0;
         long bytesCountAfterAllocation = this.currentMemory.addAndGet(bytesCount);
-        if (bytesCountAfterAllocation >= maxMemory)
+        // if overflow or exceeded max memory
+        if (bytesCountAfterAllocation < 0 || bytesCountAfterAllocation >= maxMemory)
         {
             this.currentMemory.addAndGet(-bytesCount);
 

--- a/test/simulator/main/org/apache/cassandra/simulator/utils/CountingCollection.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/utils/CountingCollection.java
@@ -51,4 +51,10 @@ public class CountingCollection<T> extends AbstractCollection<T>
     {
         return count;
     }
+
+    @Override
+    public String toString()
+    {
+        return "AlwaysPresentFilter";
+    }
 }

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -91,6 +91,8 @@ public class ANNOptionsTest extends CQLTester
         execute("SELECT * FROM %s WHERE k=0 ORDER BY v ANN OF [1, 1] WITH ann_options = {}");
 
         // correct queries with specific ANN options - rerank_k
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': -1}");
+        execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': 0}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 10}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 11}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 1000}");
@@ -105,14 +107,6 @@ public class ANNOptionsTest extends CQLTester
         // correct queries with both options
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 10, 'use_pruning': true}");
         execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'use_pruning': false, 'rerank_k': 20}");
-
-        // Queries with invalid ann options that will eventually be valid when we support disabling reranking
-        assertInvalidThrowMessage("Invalid rerank_k value -1 lesser than limit 100",
-                                  InvalidRequestException.class,
-                                  "SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': -1}");
-        assertInvalidThrowMessage("Invalid rerank_k value 0 lesser than limit 100",
-                                  InvalidRequestException.class,
-                                  "SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100 WITH ann_options = {'rerank_k': 0}");
 
         // Queries that exceed the failure threshold for the guardrail. Specifies a protocol version to trigger
         // validation in the coordinator.
@@ -154,7 +148,7 @@ public class ANNOptionsTest extends CQLTester
                                   baseQuery + " WITH ann_options = {'rerank_k': 'a'}");
 
         // ANN options with rerank lesser than limit
-        assertInvalidThrowMessage("Invalid rerank_k value 10 lesser than limit 100",
+        assertInvalidThrowMessage("Invalid rerank_k value 10 greater than 0 and less than limit 100",
                                   InvalidRequestException.class,
                                   baseQuery + "LIMIT 100 WITH ann_options = {'rerank_k': 10}");
 
@@ -226,13 +220,15 @@ public class ANNOptionsTest extends CQLTester
         testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1]", ANNOptions.NONE);
         testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ann_options = {}", ANNOptions.NONE);
 
-        // TODO re-enable this test when we support negative rerank_k values
         // some random negative values, all should be accepted and not be mapped to NONE
-//        String negativeQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': %d}";
-//        QuickTheory.qt()
-//                   .withExamples(100)
-//                   .forAll(integers().allPositive())
-//                   .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i)));
+        String negativeQuery = "SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': %d}";
+        QuickTheory.qt()
+                   .withExamples(100)
+                   .forAll(integers().allPositive())
+                   .checkAssert(i -> testTransport(String.format(negativeQuery, -i), ANNOptions.create(-i, null)));
+
+        // rerankK = 0 must also work
+        testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10 WITH ann_options = {'rerank_k': 0}", ANNOptions.create(0, null));
 
         // test use_pruning values
         testTransport("SELECT * FROM %s ORDER BY v ANN OF [1, 1] WITH ann_options = {'use_pruning': true}", 

--- a/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
+++ b/test/unit/org/apache/cassandra/dht/LengthPartitioner.java
@@ -125,6 +125,11 @@ public class LengthPartitioner implements IPartitioner
             return new BigIntegerToken(ByteBufferUtil.toLong(bytes));
         }
 
+        public Token fromLongValue(long longValue)
+        {
+            return new BigIntegerToken(longValue);
+        }
+
         @Override
         public Token fromComparableBytes(ByteSource.Peekable comparableBytes, ByteComparable.Version version)
         {

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
@@ -77,5 +77,16 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
                 return Murmur3Partitioner.instance.getToken(key).token == token;
             });
     }
+
+    @Test
+    public void testFromLongValue()
+    {
+        qt().forAll(longs().between(Long.MIN_VALUE + 1, Long.MAX_VALUE))
+            .check(token -> {
+                Token fromLongValue = Murmur3Partitioner.instance.getTokenFactory().fromLongValue(token);
+                Token constructed = new Murmur3Partitioner.LongToken(token);
+                return constructed.equals(fromLongValue);
+            });
+    }
 }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -21,12 +21,17 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.cassandra.index.sai.SSTableIndex;
+import org.apache.cassandra.index.sai.memory.MemtableIndex;
+import org.apache.cassandra.index.sai.memory.TrieMemoryIndex;
+import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -814,6 +819,71 @@ public class BM25Test extends SAITester
                 "climate");
         executeQuery(Arrays.asList(11, 19, 1), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
+    }
+
+    /**
+     * Asserts that memtable SAI index maintains expected row count, which is, then,
+     * used to store row count in SSTable SAI index and its segments. This is also
+     * asserted.
+     */
+    @Test
+    public void testIndexMetaForNumRows()
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, category text, score int, " +
+                    "title text, body text, bodyset set<text>, " +
+                    "map_category map<int, text>, map_body map<text, text>)");
+        String bodyIndexName = createAnalyzedIndex("body", true);
+        String scoreIndexName = createIndex("CREATE CUSTOM INDEX ON %s (score) USING 'StorageAttachedIndex'");
+        String mapIndexName = createIndex("CREATE CUSTOM INDEX ON %s (map_category) USING 'StorageAttachedIndex'");
+        insertCollectionData();
+
+        assertNumRowsMemtable(scoreIndexName, DATASET.length);
+        assertNumRowsMemtable(bodyIndexName, DATASET.length);
+        assertNumRowsMemtable(mapIndexName, DATASET.length);
+        execute("DELETE FROM %s WHERE id = ?", 5);
+        flush();
+        assertNumRowsSSTable(scoreIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(bodyIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 1);
+        execute("DELETE FROM %s WHERE id = ?", 10);
+        flush();
+        assertNumRowsSSTable(scoreIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(bodyIndexName, DATASET.length - 1);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 1);
+        compact();
+        assertNumRowsSSTable(scoreIndexName, DATASET.length - 2);
+        assertNumRowsSSTable(bodyIndexName, DATASET.length - 2);
+        assertNumRowsSSTable(mapIndexName, DATASET.length - 2);
+    }
+
+    private void assertNumRowsMemtable(String indexName, int expectedNumRows)
+    {
+        int rowCount = 0;
+
+        for (var memtable : getCurrentColumnFamilyStore().getAllMemtables())
+        {
+            MemtableIndex memIndex = getIndexContext(indexName).getMemtableIndex(memtable);
+            assert memIndex instanceof TrieMemtableIndex;
+            rowCount = Arrays.stream(((TrieMemtableIndex) memIndex).getRangeIndexes())
+                             .map(index -> ((TrieMemoryIndex) index).getDocLengths().size())
+                             .mapToInt(Integer::intValue).sum();
+        }
+        assertEquals(expectedNumRows, rowCount);
+    }
+
+    private void assertNumRowsSSTable(String indexName, int expectedNumRows)
+    {
+        long indexRowCount = 0;
+        long segmentRowCount = 0;
+        for (SSTableIndex sstableIndex : getIndexContext(indexName).getView())
+        {
+            indexRowCount += sstableIndex.getRowCount();
+            segmentRowCount += sstableIndex.getSegments().stream()
+                                           .map(s -> Objects.requireNonNull(s.metadata).numRows)
+                                           .mapToLong(Long::longValue).sum();
+        }
+        assertEquals(indexRowCount, segmentRowCount);
+        assertEquals(expectedNumRows, indexRowCount);
     }
 
     private final static Object[][] DATASET =

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -88,10 +88,18 @@ public class VectorSiftSmallTest extends VectorTester
         double previousRecall = 0;
         int limit = 10;
         int strictlyIncreasedCount = 0;
-        // Testing shows that we acheive 100% recall at about rerank_k = 45, so no need to go higher
+
+        // First test with rerank_k = 0, which should have the worst recall
+        double zeroRerankRecall = testRecall(limit, queryVectors, groundTruth, 0, null);
+
+        // Testing shows that we achieve 100% recall at about rerank_k = 45, so no need to go higher
         for (int rerankK = limit; rerankK <= 50; rerankK += 5)
         {
             var recall = testRecall(limit, queryVectors, groundTruth, rerankK, null);
+            // All recalls should be better than rerank_k = 0
+            assertTrue("Recall for rerank_k = " + rerankK + " should be at least as good as with rerank_k = 0",
+                      recall >= zeroRerankRecall);
+
             // Recall varies, so we can only assert that it does not get worse on a per-run basis. However, it should
             // get better strictly at least some of the time
             assertTrue("Recall for rerank_k = " + rerankK + " is " + recall, recall >= previousRecall);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcherTest.java
@@ -49,9 +49,8 @@ import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
+import org.assertj.core.api.Assertions;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -194,6 +193,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
             MemtableTermsIterator termsIterator = new MemtableTermsIterator(null, null, iter);
             SegmentMetadata.ComponentMetadataMap indexMetas = writer.writeAll(metadataBuilder.intercept(termsIterator), docLengths);
             metadataBuilder.setComponentsMetadata(indexMetas);
+            metadataBuilder.setNumRows(docLengths.values().stream().mapToInt(i -> i).sum());
         }
 
         final SegmentMetadata segmentMetadata = metadataBuilder.build();
@@ -207,7 +207,7 @@ public class InvertedIndexSearcherTest extends SaiRandomizedTest
                                                                                    indexContext,
                                                                                    indexFiles,
                                                                                    segmentMetadata);
-            assertThat(searcher, is(instanceOf(InvertedIndexSearcher.class)));
+            Assertions.assertThat(searcher).isInstanceOf(InvertedIndexSearcher.class);
             return searcher;
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/kdtree/KDTreeIndexBuilder.java
@@ -68,9 +68,7 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -182,6 +180,7 @@ public class KDTreeIndexBuilder
                                          UTF8Type.instance.fromString("d"));
             metadataBuilder.setKeyRange(SAITester.TEST_FACTORY.createTokenOnly(Murmur3Partitioner.instance.decorateKey(UTF8Type.instance.fromString("a")).getToken()),
                                         SAITester.TEST_FACTORY.createTokenOnly(Murmur3Partitioner.instance.decorateKey(UTF8Type.instance.fromString("b")).getToken()));
+            metadataBuilder.setNumRows(size);
             metadata = metadataBuilder.build();
         }
 
@@ -192,7 +191,7 @@ public class KDTreeIndexBuilder
             when(sstableContext.usedPerSSTableComponents()).thenReturn(indexDescriptor.perSSTableComponents());
 
             IndexSearcher searcher = Version.latest().onDiskFormat().newIndexSearcher(sstableContext, indexContext, indexFiles, metadata);
-            assertThat(searcher, is(instanceOf(KDTreeIndexSearcher.class)));
+            assertThat(searcher).isInstanceOf(KDTreeIndexSearcher.class);
             return (KDTreeIndexSearcher) searcher;
         }
     }
@@ -293,7 +292,7 @@ public class KDTreeIndexBuilder
      */
     public static AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>> singleOrd(Iterator<ByteBuffer> terms, AbstractType<?> type, int segmentRowIdOffset, int size)
     {
-        return new AbstractGuavaIterator<Pair<ByteComparable.Preencoded, IntArrayList>>()
+        return new AbstractGuavaIterator<>()
         {
             private long currentTerm = 0;
             private int currentSegmentRowId = segmentRowIdOffset;
@@ -343,11 +342,13 @@ public class KDTreeIndexBuilder
     public static Iterator<ByteBuffer> decimalRange(final BigDecimal startInclusive, final BigDecimal endExclusive)
     {
         int n = endExclusive.subtract(startInclusive).intValueExact() * 10;
-        final Supplier<BigDecimal> generator = new Supplier<BigDecimal>() {
+        final Supplier<BigDecimal> generator = new Supplier<>()
+        {
             BigDecimal current = startInclusive;
 
             @Override
-            public BigDecimal get() {
+            public BigDecimal get()
+            {
                 BigDecimal result = current;
                 current = current.add(ONE_TENTH);
                 return result;
@@ -363,11 +364,13 @@ public class KDTreeIndexBuilder
     public static Iterator<ByteBuffer> bigIntegerRange(final BigInteger startInclusive, final BigInteger endExclusive)
     {
         int n = endExclusive.subtract(startInclusive).intValueExact();
-        final Supplier<BigInteger> generator = new Supplier<BigInteger>() {
+        final Supplier<BigInteger> generator = new Supplier<>()
+        {
             BigInteger current = startInclusive;
 
             @Override
-            public BigInteger get() {
+            public BigInteger get()
+            {
                 BigInteger result = current;
                 current = current.add(BigInteger.ONE);
                 return result;

--- a/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/VectorMemtableIndexTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.VectorType;
@@ -212,7 +213,7 @@ public class VectorMemtableIndexTest extends SAITester
 
     private Orderer randomVectorOrderer()
     {
-        return new Orderer(indexContext, Operator.ANN, randomVectorSerialized(), null);
+        return new Orderer(indexContext, Operator.ANN, randomVectorSerialized(), ANNOptions.NONE);
     }
 
     private ByteBuffer randomVectorSerialized() {

--- a/test/unit/org/apache/cassandra/inject/Injections.java
+++ b/test/unit/org/apache/cassandra/inject/Injections.java
@@ -612,7 +612,7 @@ public class Injections
         public PauseBuilder(String name, long timeout)
         {
             super(String.format("pause/%s/%s", name, UUID.randomUUID()));
-            actionBuilder.actions().doAction(expr("Thread.sleep").args(timeout));
+            actionBuilder.actions().doAction(expr("Thread.sleep").args(timeout+"L"));
         }
 
         /**


### PR DESCRIPTION
### What is the issue
CNDB-14275 Port commits from main to main-5.0

### What does this PR fix and why was it fixed
This PR is porting the following commits from main branch to main-5.0 branch.


CNDB-13739 count numRows correctly in SSTable SAI (#1695)	cb3ee3d02c	Ruslan Fomkin <ruslan.fomkin@datastax.com>	Apr 25, 2025 at 2:06 AM
* minor conflicts in `SSTableIndexWriter` due to original usage of `TypeUtil.encode` being now `TypeUtil.asIndexBytes` in 5.0

CNDB-13847: Add Token::fromLongValue method to simplify SAI token creation (#1709)	7d52230c8e	Michael Marshall <michael.marshall@datastax.com>	Apr 24, 2025 at 7:41 AM
* No conflicts

CNDB-13848: avoid serializing AlwaysPresentFilter when BF memory limit is reached (#1710)	1458fedf14	Zhao Yang <zhaoyangsingapore@gmail.com>	Apr 24, 2025 at 1:13 AM
* Checks for `filter instanceOf BloomFilter` collapsed into the `FilterComponent.save` method because 5.0 has done a lot of refactoring here. This covers the original commit changes to `SSTableReader.saveBloomFilter`, `BigTableWriter.flushBf`, `TrieIndexSSTableReader.recreateBloomFilter`, and `TrieIndexSSTableWriter.flushBf`.
* `AlwaysPresentFilter.toString` goes instead to `FilterFactory.AlwaysPresentFilter.toString`.

CNDB-13625: Implement rerankless vector search through ANN_OPTIONS (#1705)	053fc12481	Michael Marshall <michael.marshall@datastax.com>	Apr 23, 2025 at 9:54 AM
* trivial conflict on Tracing.trace statement in CassandraDiskAnn

CNDB-13833: Fix QueryTimeoutTest on JDK22	6c2cd8d30e	Ekaterina Dimitrova <ekaterina.dimitrova@datastax.com>	Apr 23, 2025 at 8:11 AM
* trivial conflict that I don't remember - it's a one line change

CNDB-13822: Add ANN_OPTION use_pruning (#1704)	9cd80cec1a	Michael Marshall <michael.marshall@datastax.com>	Apr 22, 2025 at 9:39 PM
* Added CassandraRelevantProperties entry:
  `SAI_VECTOR_USE_PRUNING_DEFAULT("cassandra.sai.jvector.use_pruning_default", "1000"),`

CNDB-13689: use NodeQueue::pushMany to decrease time complexity to build heap (#1693)	df81d9aec4	Michael Marshall <michael.marshall@datastax.com>	Apr 22, 2025 at 9:17 AM
* no merge conflicts

 
