### PR TITLE
HCD-153 C* 3.x nodes don't like the trailing sha in the version sent over gossip (VersionedValue)

### DIFF
--- a/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.gms;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
@@ -33,7 +34,9 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.net.MessagingService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -165,5 +168,35 @@ public class EndpointStateTest
         assertTrue(values.containsKey(ApplicationState.TOKENS));
         assertTrue(values.containsKey(ApplicationState.INTERNAL_IP));
         assertTrue(values.containsKey(ApplicationState.HOST_ID));
+    }
+
+    @Test
+    public void testCCReleaseVersion() throws IOException
+    {
+        String versionString = "4.0.11.0-0b982c438bfc";
+        String c3safeVersionString = "4.0.11.0";
+        VersionedValue releaseVersion = valueFactory.releaseVersion(versionString);
+
+        assertEquals(versionString, EndpointStateSerializer.filterValue(ApplicationState.RELEASE_VERSION, releaseVersion, MessagingService.VERSION_40).value);
+        assertEquals(c3safeVersionString, EndpointStateSerializer.filterValue(ApplicationState.RELEASE_VERSION, releaseVersion, MessagingService.VERSION_3014).value);
+
+        HeartBeatState hb = new HeartBeatState(0);
+        EndpointState state = new EndpointState(hb);
+        Map<ApplicationState, VersionedValue> states = new EnumMap<>(ApplicationState.class);
+        states.put(ApplicationState.RELEASE_VERSION, releaseVersion);
+        state.addApplicationStates(states);
+        assertEquals(versionString, state.getReleaseVersion().toString());
+
+        DataOutputBuffer buffer = new DataOutputBuffer();
+        EndpointState.serializer.serialize(state, buffer, MessagingService.VERSION_40);
+        DataInputBuffer input = new DataInputBuffer(buffer.buffer(), false);
+        EndpointState deserializedCurrent = EndpointState.serializer.deserialize(input, MessagingService.VERSION_40);
+        assertEquals(versionString, deserializedCurrent.getApplicationState(ApplicationState.RELEASE_VERSION).value);
+
+        buffer = new DataOutputBuffer();
+        EndpointState.serializer.serialize(state, buffer, MessagingService.VERSION_3014);
+        input = new DataInputBuffer(buffer.buffer(), false);
+        EndpointState deserializedOld = EndpointState.serializer.deserialize(input, MessagingService.VERSION_3014);
+        assertEquals(c3safeVersionString, deserializedOld.getApplicationState(ApplicationState.RELEASE_VERSION).value);
     }
 }


### PR DESCRIPTION
…

### What is the issue

VersionValue contains the CC version, which has a `-<sha>` suffix.
This isn't parsing in C* 3.x when it receives it in gossip.

```
ERROR [GossipStage:1] 2025-05-26 09:56:15,427 " CassandraDaemon.java:244 - Exception in thread ' Thread[GossipStage:1,5,main]
java.lang.IllegalArgumentException: Invalid version value: 4.0.11.0-90080e7b696d
  at org.apache.cassandra.utils.CassandraVersion.<init>(CassandraVersion.java:64)
  at org.apache.cassandra.gms.EndpointState.getReleaseVersion(EndpointState.java:180)
  at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
  at java.util.concurrent.ConcurrentHashMap$ValueSpliterator.tryAdvance(ConcurrentHashMap.java:3572)
  at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
  at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
  at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
  at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  at java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:516)
  at org.apache.cassandra.gms.Gossiper.anyEndpointOn30(Gossiper.java:1353)
  at org.apache.cassandra.gms.Gossiper.applyStateLocally(Gossiper.java:1335)
  at org.apache.cassandra.gms.GossipDigestAckVerbHandler.doVerb(GossipDigestAckVerbHandler.java:78)
  at org.apache.cassandra.net.MessageDeliveryTask.run(MessageDeliveryTask.java:69)
```

### What does this PR fix and why was it fixed

Remove the sha suffix in VersionedValue
