### PR TITLE
CNDB-14291: Fix flaky SingleNodeQueryFailureTest

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/SingleNodeQueryFailureTest.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.KeyFetcher;
 import org.apache.cassandra.index.sai.disk.v1.TermsReader;
 import org.apache.cassandra.index.sai.disk.v1.postings.PostingsReader;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.utils.Throwables;
@@ -46,6 +47,10 @@ public class SingleNodeQueryFailureTest extends SAITester
     public void setup() throws Throwable
     {
         requireNetwork();
+
+        // Disable query optimization for this test so all indexes are queried,
+        // and we can inject failures into any of them.
+        QueryController.QUERY_OPT_LEVEL = 0;
     }
 
     @After


### PR DESCRIPTION
The tests in SingleNodeQueryFailureTest suite inject failures
into the code paths executed by a test query that uses two indexes.
This commit disables the query optimizer because it was interfering
by removing an index from the plan so sometimes
the path with the injected failure was not taken.

Fixes https://github.com/riptano/cndb/issues/14291
