### PR TITLE
CNDB-14301: couple jvector file format and SAI version

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -213,6 +213,9 @@ public interface OnDiskFormat
      */
     ByteBuffer decodeFromTrie(ByteComparable value, AbstractType<?> type);
 
-
+    /**
+     * @return the JVector file format version that this on-disk format uses.
+     */
+    int jvectorFileFormatVersion();
 
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -52,14 +52,14 @@ public class Version implements Comparable<Version>
     public static final Version AA = new Version("aa", V1OnDiskFormat.instance, Version::aaFileNameFormat);
     // Stargazer
     public static final Version BA = new Version("ba", V2OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ba"));
-    // Converged Cassandra with JVector
+    // Converged Cassandra with JVector with file format version 2
     public static final Version CA = new Version("ca", V3OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ca"));
     // NOTE: use DB to prevent collisions with upstream file formats
     // Encode trie entries using their AbstractType to ensure trie entries are sorted for range queries and are prefix free.
     public static final Version DB = new Version("db", V4OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "db"));
     // revamps vector postings lists to cause fewer reads from disk
     public static final Version DC = new Version("dc", V5OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "dc"));
-    // histograms in index metadata
+    // histograms in index metadata; bump jvector file format version to 4
     public static final Version EB = new Version("eb", V6OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "eb"));
     // term frequencies index component (support for BM25)
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -324,4 +324,10 @@ public class V1OnDiskFormat implements OnDiskFormat
                indexComponentType == IndexComponentType.TERMS_DATA ||
                indexComponentType == IndexComponentType.POSTING_LISTS;
     }
+
+    @Override
+    public int jvectorFileFormatVersion()
+    {
+        throw new UnsupportedOperationException("JVector is not supported in V2OnDiskFormat");
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,8 +51,10 @@ public class V3OnDiskFormat extends V2OnDiskFormat
     // JVector doesn't give us a way to access its default, so we set it here, but allow it to be overridden.
     public static boolean JVECTOR_USE_PRUNING_DEFAULT = Boolean.parseBoolean(System.getProperty("cassandra.sai.jvector.use_pruning_default", "true"));
 
-    // These are built to be backwards and forwards compatible. Not final only for testing.
-    public static int JVECTOR_VERSION = Integer.parseInt(System.getProperty("cassandra.sai.jvector_version", "2"));
+    // We allow the version to be configured via a system property because of some legacy use cases, but it is
+    // generally not recommended to change this directly. Instead, use the cassandra.sai.latest.version system property
+    // to control the on-disk format version.
+    private final static int JVECTOR_VERSION = Integer.getInteger("cassandra.sai.jvector_version", 2);
     static
     {
         // JVector 3 is not compatible with the latest jvector changes, so we fail fast if the config is enabled.
@@ -118,5 +119,11 @@ public class V3OnDiskFormat extends V2OnDiskFormat
         if (validator.isVector())
             return VECTOR_COMPONENTS_V3;
         return super.perIndexComponentTypes(validator);
+    }
+
+    @Override
+    public int jvectorFileFormatVersion()
+    {
+        return JVECTOR_VERSION;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v6/V6OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v6/V6OnDiskFormat.java
@@ -51,4 +51,12 @@ public class V6OnDiskFormat extends V5OnDiskFormat
     {
         return v6IndexFeatureSet;
     }
+
+    @Override
+    public int jvectorFileFormatVersion()
+    {
+        // Before version EB, we used JVector format 2. Version DC introduced format 4, so we can start using it
+        // starting with version EB to ensure proper backward compatibility.
+        return 4;
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -75,6 +75,7 @@ import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.Segment;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
@@ -93,8 +94,6 @@ import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.lucene.util.StringHelper;
-
-import static org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat.JVECTOR_VERSION;
 
 public class CassandraOnHeapGraph<T> implements Accountable
 {
@@ -157,10 +156,11 @@ public class CassandraOnHeapGraph<T> implements Accountable
         vectorsByKey = forSearching ? new NonBlockingHashMap<>() : null;
         invalidVectorBehavior = forSearching ? InvalidVectorBehavior.FAIL : InvalidVectorBehavior.IGNORE;
 
+        int jvectorVersion = Version.current().onDiskFormat().jvectorFileFormatVersion();
         // This is only a warning since it's not a fatal error to write without hierarchy
-        if (indexConfig.isHierarchyEnabled() && V3OnDiskFormat.JVECTOR_VERSION < 4)
+        if (indexConfig.isHierarchyEnabled() && jvectorVersion < 4)
             logger.warn("Hierarchical graphs configured but node configured with V3OnDiskFormat.JVECTOR_VERSION {}. " +
-                        "Skipping setting for {}", V3OnDiskFormat.JVECTOR_VERSION, indexConfig.getIndexName());
+                        "Skipping setting for {}", jvectorVersion, indexConfig.getIndexName());
 
         builder = new GraphIndexBuilder(vectorValues,
                                         similarityFunction,
@@ -168,7 +168,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
                                         indexConfig.getConstructionBeamWidth(),
                                         indexConfig.getNeighborhoodOverflow(1.0f), // no overflow means add will be a bit slower but flush will be faster
                                         indexConfig.getAlpha(dimension > 3 ? 1.2f : 2.0f),
-                                        indexConfig.isHierarchyEnabled() && V3OnDiskFormat.JVECTOR_VERSION >= 4);
+                                        indexConfig.isHierarchyEnabled() && jvectorVersion >= 4);
         searchers = ThreadLocal.withInitial(() -> new GraphSearcherAccessManager(new GraphSearcher(builder.getGraph())));
     }
 
@@ -438,7 +438,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         try (var pqOutput = perIndexComponents.addOrGet(IndexComponentType.PQ).openOutput(true);
              var postingsOutput = perIndexComponents.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true);
              var indexWriter = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
-                               .withVersion(JVECTOR_VERSION)
+                               .withVersion(Version.current().onDiskFormat().jvectorFileFormatVersion())
                                .withMapper(ordinalMapper)
                                .with(new InlineVectors(vectorValues.dimension()))
                                .withStartOffset(termsOffset)
@@ -591,14 +591,14 @@ public class CassandraOnHeapGraph<T> implements Accountable
             return writer.position();
 
         // save (outside the synchronized block, this is io-bound not CPU)
-        cv.write(writer, JVECTOR_VERSION);
+        cv.write(writer, Version.current().onDiskFormat().jvectorFileFormatVersion());
         return writer.position();
     }
 
     static void writePqHeader(DataOutput writer, boolean unitVectors, CompressionType type)
     throws IOException
     {
-        if (V3OnDiskFormat.JVECTOR_VERSION >= 3)
+        if (Version.current().onDiskFormat().jvectorFileFormatVersion() >= 3)
         {
             // version and optional fields
             writer.writeInt(CassandraDiskAnn.PQ_MAGIC);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -73,6 +73,7 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentMetadata;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
@@ -90,7 +91,6 @@ import org.apache.cassandra.service.StorageService;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat.JVECTOR_VERSION;
 
 public class CompactionGraph implements Closeable, Accountable
 {
@@ -199,9 +199,10 @@ public class CompactionGraph implements Closeable, Accountable
         {
             throw new IllegalArgumentException("Unsupported compressor: " + compressor);
         }
-        if (indexConfig.isHierarchyEnabled() && V3OnDiskFormat.JVECTOR_VERSION < 4)
+        int jvectorVersion = Version.current().onDiskFormat().jvectorFileFormatVersion();
+        if (indexConfig.isHierarchyEnabled() && jvectorVersion < 4)
             logger.warn("Hierarchical graphs configured but node configured with V3OnDiskFormat.JVECTOR_VERSION {}. " +
-                        "Skipping setting for {}", V3OnDiskFormat.JVECTOR_VERSION, indexConfig.getIndexName());
+                        "Skipping setting for {}", jvectorVersion, indexConfig.getIndexName());
 
         builder = new GraphIndexBuilder(bsp,
                                         dimension,
@@ -209,7 +210,7 @@ public class CompactionGraph implements Closeable, Accountable
                                         indexConfig.getConstructionBeamWidth(),
                                         indexConfig.getNeighborhoodOverflow(1.2f),
                                         indexConfig.getAlpha(dimension > 3 ? 1.2f : 1.4f),
-                                        indexConfig.isHierarchyEnabled() && V3OnDiskFormat.JVECTOR_VERSION >= 4,
+                                        indexConfig.isHierarchyEnabled() && jvectorVersion >= 4,
                                         compactionSimdPool, compactionFjp);
 
         termsFile = perIndexComponents.addOrGet(IndexComponentType.TERMS_DATA).file();
@@ -226,7 +227,7 @@ public class CompactionGraph implements Closeable, Accountable
         return new OnDiskGraphIndexWriter.Builder(builder.getGraph(), termsFile.toPath())
                .withStartOffset(termsOffset)
                .with(new InlineVectors(dimension))
-               .withVersion(JVECTOR_VERSION);
+               .withVersion(Version.current().onDiskFormat().jvectorFileFormatVersion());
     }
 
     @Override
@@ -395,7 +396,7 @@ public class CompactionGraph implements Closeable, Accountable
             // write PQ (time to do this is negligible, don't bother doing it async)
             long pqOffset = pqOutput.getFilePointer();
             CassandraOnHeapGraph.writePqHeader(pqOutput.asSequentialWriter(), unitVectors, VectorCompression.CompressionType.PRODUCT_QUANTIZATION);
-            compressedVectors.write(pqOutput.asSequentialWriter(), JVECTOR_VERSION); // VSTODO old version until we add APQ
+            compressedVectors.write(pqOutput.asSequentialWriter(), Version.current().onDiskFormat().jvectorFileFormatVersion());
             long pqLength = pqOutput.getFilePointer() - pqOffset;
 
             // write postings asynchronously while we run cleanup()

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
@@ -19,23 +19,39 @@
 package org.apache.cassandra.index.sai.cql;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v3.V3OnDiskFormat;
 
+@RunWith(Parameterized.class)
 public class VectorDotProductWithLengthTest extends VectorTester
 {
-    @Override
-    public void setup() throws Throwable
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
     {
-        super.setup();
-        // we are testing unit vector detection which is part of the v3 changes, but continues in all subsequent versions
-        if (V3OnDiskFormat.JVECTOR_VERSION < 4)
-            V3OnDiskFormat.JVECTOR_VERSION = 4;
+        // we are testing unit vector detection which is part of the EB jvector changes, and will continue in all
+        // subsequent versions
+        return Stream.of(Version.EB).map(v -> new Object[]{ v}).collect(Collectors.toList());
+    }
+
+    @Before
+    public void setVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
     }
 
     // This tests our detection of unit-length vectors used with dot product and PQ.

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorIndexMixedVersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorIndexMixedVersionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+
+// We do not parameterize this test because it is not intended to run multiple versions at once.
+public class VectorIndexMixedVersionTest extends VectorTester
+{
+    // Versions in random order
+    final static List<Version> VERSIONS = getVersions();
+
+    private static List<Version> getVersions()
+    {
+        var versions = Lists.newArrayList(Version.CA, Version.DC, Version.EB);
+        Collections.shuffle(versions, getRandom().getRandom());
+        return versions;
+    }
+
+    @Test
+    public void testMultiVersionJVectorCompatibility() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, vec vector<float, 4>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+
+        // Note that we do not test the multi-version path where compaction produces different sstables, which is
+        // the norm in CNDB. If we had a way to compact individual sstables, we could.
+        disableCompaction();
+
+        for (var version : VERSIONS)
+        {
+            SAIUtil.setCurrentVersion(version);
+            for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
+                execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", i, randomVectorBoxed(4));
+            flush();
+        }
+
+        // Run basic query to confirm we can, no need to validate results
+        execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2");
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -174,7 +174,7 @@ public class VectorTester extends SAITester
     }
 
     /**
-     * {@link VectorTester} parameterized for {@link Version#CA} and {@link Version#DC}.
+     * {@link VectorTester} parameterized for {@link Version#CA}, {@link Version#DC}, and {@link Version#EB}.
      */
     @Ignore
     @RunWith(Parameterized.class)
@@ -186,14 +186,13 @@ public class VectorTester extends SAITester
         @Parameterized.Parameters(name = "{0}")
         public static Collection<Object[]> data()
         {
-            return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v }).collect(Collectors.toList());
+            // See Version file for explanation of changes associated with each version
+            return Stream.of(Version.CA, Version.DC, Version.EB).map(v -> new Object[]{ v }).collect(Collectors.toList());
         }
 
         @Before
-        @Override
-        public void setup() throws Throwable
+        public void setCurrentVersion() throws Throwable
         {
-            super.setup();
             SAIUtil.setCurrentVersion(version);
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -65,18 +65,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
-public class VectorTypeTest extends VectorTester
+public class VectorTypeTest extends VectorTester.Versioned
 {
-    @Parameterized.Parameter
-    public Version version;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data()
-    {
-        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
-    }
-
     private static final IPartitioner partitioner = Murmur3Partitioner.instance;
 
     @BeforeClass
@@ -84,14 +74,6 @@ public class VectorTypeTest extends VectorTester
     {
         System.setProperty("cassandra.custom_tracing_class", "org.apache.cassandra.tracing.TracingTestImpl");
         VectorTester.setUpClass();
-    }
-
-    @Before
-    @Override
-    public void setup() throws Throwable
-    {
-        super.setup();
-        SAIUtil.setCurrentVersion(version);
     }
 
     @Override
@@ -1114,21 +1096,10 @@ public class VectorTypeTest extends VectorTester
     }
 
     @Test
-    public void newJVectorOptionsTestVersion2()
+    public void newJVectorOptionsTest()
     {
-        newJVectorOptionsTest(2);
-    }
-    // We skip version 3 since it isn't supported anymore
-    @Test
-    public void newJVectorOptionsTestVersion4()
-    {
-        newJVectorOptionsTest(4);
-    }
-
-    public void newJVectorOptionsTest(int version)
-    {
+        // jvector version is tied to sai version, so the test parameterization covers all relevant cases.
         // Configure the version to ensure we don't fail for settings that are unsupported on earlier versions of jvector
-        V3OnDiskFormat.JVECTOR_VERSION = version;
 
         // This test ensures that we can set and retrieve new jvector parameters
         // (neighborhood_overflow, alpha, enable_hierarchy), and that they are honored at index build time.
@@ -1179,32 +1150,4 @@ public class VectorTypeTest extends VectorTester
         assertEquals(300,   config.getConstructionBeamWidth());
         assertEquals(VectorSimilarityFunction.EUCLIDEAN, config.getSimilarityFunction());
     }
-
-    @Test
-    public void testMultiVersionJVectorCompatibility() throws Throwable
-    {
-        createTable("CREATE TABLE %s (pk int, vec vector<float, 4>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
-
-        // Note that we do not test the multi-version path where compaction produces different sstables, which is
-        // the norm in CNDB. If we had a way to compact individual sstables, we could.
-        disableCompaction();
-
-        // Create index files for each valid version
-        for (int version = 2; version <= V3OnDiskFormat.JVECTOR_VERSION; version++)
-        {
-            // Version 3 is no longer supported, so there is mild risk that it isn't covered here, but we can't write
-            // it any more, so there isn't much we can do.
-            if (version == 3)
-                continue;
-            V3OnDiskFormat.JVECTOR_VERSION = version;
-            for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
-                execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", i, randomVectorBoxed(4));
-            flush();
-        }
-
-        // Run basic query to confirm we can, no need to validate results
-        execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2");
-    }
-
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14301

### What does this PR fix and why was it fixed
Make version `EB` use jvector file format 4. Also allow for some configurability in earlier versions just in case we have some clusters relying on that behavior.
