### PR TITLE
CNDB-14306: Update ANN_USE_SYNTHETIC_SCORE to default to true for SAI version >EC

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.cql3.restrictions.Restrictions;
 import org.apache.cassandra.cql3.selection.SortedRowsBuilder;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.guardrails.Guardrails;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.sensors.SensorsCustomParams;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.Schema;
@@ -110,7 +111,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     // and the related code in
     //  - StatementRestrictions.addOrderingRestrictions
     //  - StorageAttachedIndexSearcher.PrimaryKeyIterator constructor
-    public static final boolean ANN_USE_SYNTHETIC_SCORE = Boolean.parseBoolean(System.getProperty("cassandra.sai.ann_use_synthetic_score", "false"));
+    public static final boolean ANN_USE_SYNTHETIC_SCORE = Boolean.parseBoolean(
+    System.getProperty("cassandra.sai.ann_use_synthetic_score", Version.current().after(Version.EC) ? "true" : "false"));
 
     private static final Logger logger = LoggerFactory.getLogger(SelectStatement.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(SelectStatement.logger, 1, TimeUnit.MINUTES);

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -178,6 +178,12 @@ public class Version implements Comparable<Version>
         return version;
     }
 
+    // Useful for handling features that need a two phase rollout.
+    public boolean after(Version other)
+    {
+        return version.compareTo(other.version) > 0;
+    }
+
     public boolean onOrAfter(Version other)
     {
         return version.compareTo(other.version) >= 0;

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
@@ -44,7 +44,12 @@ public class VersionTest
         for (Version version : Version.ALL)
         {
             if (previous != null)
+            {
                 assertTrue(previous.onOrAfter(version));
+                assertTrue(previous.after(version));
+                assertFalse(version.onOrAfter(previous));
+                assertFalse(version.after(previous));
+            }
             previous = version;
         }
     }
@@ -64,5 +69,34 @@ public class VersionTest
         assertThatThrownBy(() -> Version.parse("ab")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("a")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("abc")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testAfterMethod()
+    {
+        // Do some basic checks, doesn't need to be updated for each new format.
+        assertTrue(Version.ED.after(Version.EC));
+        assertTrue(Version.EC.after(Version.EB));
+        assertTrue(Version.EB.after(Version.DC));
+        assertTrue(Version.DC.after(Version.DB));
+        assertTrue(Version.DB.after(Version.CA));
+        assertTrue(Version.CA.after(Version.BA));
+        assertTrue(Version.BA.after(Version.AA));
+
+        assertFalse(Version.AA.after(Version.BA));
+        assertFalse(Version.AA.after(Version.AA));
+    }
+
+    @Test
+    public void testOnOrAfterMethod()
+    {
+        // Do some basic checks, doesn't need to be updated for each new format.
+        assertTrue(Version.ED.onOrAfter(Version.ED));
+        assertTrue(Version.ED.onOrAfter(Version.EC));
+        assertTrue(Version.CA.onOrAfter(Version.BA));
+        assertTrue(Version.BA.onOrAfter(Version.AA));
+
+        assertFalse(Version.AA.onOrAfter(Version.BA));
+        assertFalse(Version.BA.onOrAfter(Version.CA));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14306

### What does this PR fix and why was it fixed
When we upgrade past `EC`, we'll be able to send the scores instead of the vectors. The backwards compatibility for this will be covered in CNDB.