### PR TITLE
CNDB-14308 Port CNDB-13848-followup 3508620089

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java
@@ -74,9 +74,9 @@ public class FilterComponent
 
     public static void save(IFilter filter, Descriptor descriptor, boolean deleteOnFailure) throws IOException
     {
-        if (!(filter instanceof BloomFilter))
+        if (!filter.isSerializable())
         {
-            logger.info("Skipped saving bloom filter {} for {} to disk", filter, descriptor);
+            logger.info("Skipped saving non-serializable bloom filter {} for {} to disk", filter, descriptor);
             return;
         }
 

--- a/src/java/org/apache/cassandra/utils/BloomFilter.java
+++ b/src/java/org/apache/cassandra/utils/BloomFilter.java
@@ -204,6 +204,12 @@ public class BloomFilter extends WrappedSharedCloseable implements IFilter
     }
 
     @Override
+    public boolean isSerializable()
+    {
+        return true;
+    }
+
+    @Override
     public String toString()
     {
         return "BloomFilter[hashCount=" + hashCount + ";capacity=" + bitset.capacity() + ']';

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -163,6 +163,12 @@ public class FilterFactory
         }
 
         @Override
+        public boolean isSerializable()
+        {
+            return false;
+        }
+
+        @Override
         public String toString()
         {
             return "AlwaysPresentFilter";

--- a/src/java/org/apache/cassandra/utils/IFilter.java
+++ b/src/java/org/apache/cassandra/utils/IFilter.java
@@ -59,4 +59,11 @@ public interface IFilter extends SharedCloseable
     long offHeapSize();
 
     boolean isInformative();
+
+    /**
+     * This is used to avoid creating empty file for filters that do not support serialization
+     *
+     * @return true if current filter supports serialization to disk
+     */
+    boolean isSerializable();
 }


### PR DESCRIPTION
### What is the issue
CNDB-14308: Port CNDB-13848-followup 3508620089 to main-5.0

### What does this PR fix and why was it fixed
This PR is porting the following commit from main branch to main-5.0 branch.

CNDB-13848-followup: add IFilterSerializer interface to avoid type casting during serializaion. (#1711)	3508620089	Zhao Yang <zhaoyangsingapore@gmail.com>	Apr 28, 2025 at 1:57 AM

This 5.0 changes here are much simplified from the main branch version, due to :
* differences in the bloom filter implementation (there is only one location, `FilterComponent.save`, that saves/flushes the bloom filter compared to several places in main.
* main code changed from direct field access to the bloom filter serializer to using a getter, and 5.0 already uses `BloomFilterSerializer.forVersion` to access the serializer based on old/new serialization format.
* main branch `IFilterSerializer` and `IFilterDeserializer` interfaces are not needed in 5.0

The remaining change ported here is the addition of `isSerializable` to the 5.0 `IFilter` interface and implementations.
