### PR TITLE
CNDB-14317: Optimize doc freq computation for memtable BM25 queries

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -126,9 +126,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
 
     /**
      * Approximate total count of terms in the memory index.
-     * The count is approximate because some deletions are not accounted for. For example, given a table with the
-     * following schema: CREATE TABLE %s (k int PRIMARY KEY, v text), DELETE FROM %s WHERE k=2 does not update the SAI
-     * index, but DELETE v FROM %s WHERE k = 2 does.
+     * The count is approximate because some deletions are not accounted for in the current implementation.
      *
      * @return total count of terms for indexes rows.
      */
@@ -351,7 +349,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
             for (ByteBuffer term : queryTerms)
             {
                 Expression expr = new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term);
-                // getMaxKeys() counts all rows that match the expressin for shards within the key range. The key
+                // getMaxKeys() counts all rows that match the expression for shards within the key range. The key
                 // range is not applied to the search results yet, so there is a small chance for overcounting if
                 // the key range filters within a shard. This is assumed to be acceptable because the on disk
                 // estimate also uses the key range to skip irrelevant sstable segments but does not apply the key

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -131,7 +131,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
 
     /**
      * Approximate total count of terms in the memory index.
-     * The count is approximate because deletions are not accounted for.
+     * The count is approximate because range deletions are not accounted for.
      *
      * @return total count of terms for indexes rows.
      */

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -126,7 +126,9 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
 
     /**
      * Approximate total count of terms in the memory index.
-     * The count is approximate because range deletions are not accounted for.
+     * The count is approximate because some deletions are not accounted for. For example, given a table with the
+     * following schema: CREATE TABLE %s (k int PRIMARY KEY, v text), DELETE FROM %s WHERE k=2 does not update the SAI
+     * index, but DELETE v FROM %s WHERE k = 2 does.
      *
      * @return total count of terms for indexes rows.
      */

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -479,7 +479,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
 
     private int getEndShardForBounds(AbstractBounds<PartitionPosition> bounds)
     {
-        var position = bounds.right;
+        PartitionPosition position = bounds.right;
         return position.isMinimum() ? boundaries.shardCount() - 1
                                     : boundaries.getShardForToken(position.getToken());
     }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
@@ -320,6 +321,20 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         return builder.build();
     }
 
+    public KeyRangeIterator eagerSearch(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    {
+        int startShard = boundaries.getShardForToken(keyRange.left.getToken());
+        int endShard = keyRange.right.isMinimum() ? boundaries.shardCount() - 1 : boundaries.getShardForToken(keyRange.right.getToken());
+
+        KeyRangeConcatIterator.Builder builder = KeyRangeConcatIterator.builder(endShard - startShard + 1);
+        for (int shard = startShard; shard <= endShard; ++shard)
+        {
+            assert rangeIndexes[shard] != null;
+            builder.add(rangeIndexes[shard].search(expression, keyRange));
+        }
+        return builder.build();
+    }
+
     @Override
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext queryContext,
                                                                   Orderer orderer,
@@ -334,10 +349,21 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         {
             // Intersect iterators to find documents containing all terms
             List<ByteBuffer> queryTerms = orderer.getQueryTerms();
-            List<KeyRangeIterator> termIterators = keyIteratorsPerTerm(queryContext, keyRange, queryTerms);
+            Map<ByteBuffer, Long> documentFrequencies = new HashMap<>();
+            List<KeyRangeIterator> termIterators = new ArrayList<>(queryTerms.size());
+            for (ByteBuffer term : queryTerms)
+            {
+                Expression expr = new Expression(indexContext);
+                expr.add(Operator.ANALYZER_MATCHES, term);
+                // Because this is an in memory, eager search, the max keys is exact and cumulative over all shards.
+                // Also, the key range is not eagerly applied, so the
+                KeyRangeIterator iterator = eagerSearch(expr, keyRange);
+                documentFrequencies.put(term, iterator.getMaxKeys());
+                termIterators.add(iterator);
+            }
             KeyRangeIterator intersectedIterator = KeyRangeIntersectionIterator.builder(termIterators).build();
 
-            return List.of(orderByBM25(Streams.stream(intersectedIterator), orderer));
+            return List.of(orderByBM25(Streams.stream(intersectedIterator), documentFrequencies, orderer));
         }
         else
         {
@@ -351,25 +377,27 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         }
     }
 
-    private List<KeyRangeIterator> keyIteratorsPerTerm(QueryContext queryContext, AbstractBounds<PartitionPosition> keyRange, List<ByteBuffer> queryTerms)
-    {
-        List<KeyRangeIterator> termIterators = new ArrayList<>(queryTerms.size());
-        for (ByteBuffer term : queryTerms)
-        {
-            Expression expr = new Expression(indexContext);
-            expr.add(Operator.ANALYZER_MATCHES, term);
-            KeyRangeIterator iterator = search(queryContext, expr, keyRange, Integer.MAX_VALUE);
-            termIterators.add(iterator);
-        }
-        return termIterators;
-    }
-
     @Override
     public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = keyRange.right.isMinimum() ? boundaries.shardCount() - 1 : boundaries.getShardForToken(keyRange.right.getToken());
         return rangeIndexes[startShard].estimateMatchingRowsCount(expression, keyRange) * (endShard - startShard + 1);
+    }
+
+    // In the BM25 logic, estimateMatchingRowsCount is not accurate enough because we use the result to compute the
+    // document score.
+    private long completeEstimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    {
+        int startShard = boundaries.getShardForToken(keyRange.left.getToken());
+        int endShard = keyRange.right.isMinimum() ? boundaries.shardCount() - 1 : boundaries.getShardForToken(keyRange.right.getToken());
+        long count = 0;
+        for (int shard = startShard; shard <= endShard; ++shard)
+        {
+            assert rangeIndexes[shard] != null;
+            count += rangeIndexes[shard].estimateMatchingRowsCount(expression, keyRange);
+        }
+        return count;
     }
 
     @Override
@@ -379,8 +407,19 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
             return CloseableIterator.emptyIterator();
 
         if (orderer.isBM25())
-            return orderByBM25(keys.stream(), orderer);
+        {
+            HashMap<ByteBuffer, Long> documentFrequencies = new HashMap<>();
+            // We don't want to filter the document frequencies, so we use the whole range
+            DataRange dataRange = DataRange.allData(memtable.metadata().partitioner);
+            for (ByteBuffer term : orderer.getQueryTerms())
+            {
+                Expression expression = new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term);
+                documentFrequencies.put(term, completeEstimateMatchingRowsCount(expression, dataRange.keyRange()));
+            }
+            return orderByBM25(keys.stream(), documentFrequencies, orderer);
+        }
         else
+        {
             return SortingIterator.createCloseable(
                 orderer.getComparator(),
                 keys,
@@ -403,14 +442,15 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                 },
                 Runnables.doNothing()
             );
+        }
     }
 
-    private CloseableIterator<PrimaryKeyWithSortKey> orderByBM25(Stream<PrimaryKey> stream, Orderer orderer)
+    private CloseableIterator<PrimaryKeyWithSortKey> orderByBM25(Stream<PrimaryKey> stream, Map<ByteBuffer, Long> documentFrequencies, Orderer orderer)
     {
         assert orderer.isBM25();
         List<ByteBuffer> queryTerms = orderer.getQueryTerms();
         AbstractAnalyzer analyzer = indexContext.getAnalyzerFactory().create();
-        BM25Utils.DocStats docStats = computeDocumentFrequencies(queryTerms, analyzer);
+        BM25Utils.DocStats docStats = new BM25Utils.DocStats(documentFrequencies, indexedRows(), approximateTotalTermCount());
         Iterator<BM25Utils.DocTF> it = stream
                                        .map(pk -> BM25Utils.EagerDocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
                                        .filter(Objects::nonNull)
@@ -420,54 +460,6 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                        docStats,
                                        indexContext,
                                        memtable);
-    }
-
-    /**
-     * Count document frequencies for each term using brute force
-     */
-    private BM25Utils.DocStats computeDocumentFrequencies(List<ByteBuffer> queryTerms, AbstractAnalyzer docAnalyzer)
-    {
-        var documentFrequencies = new HashMap<ByteBuffer, Long>();
-
-        // count all documents in the queried column
-        try (var it = memtable.makePartitionIterator(ColumnFilter.selection(RegularAndStaticColumns.of(indexContext.getDefinition())),
-                                                     DataRange.allData(memtable.metadata().partitioner)))
-        {
-            while (it.hasNext())
-            {
-                var partitions = it.next();
-                while (partitions.hasNext())
-                {
-                    var unfiltered = partitions.next();
-                    if (!unfiltered.isRow())
-                        continue;
-                    var row = (Row) unfiltered;
-                    var cell = row.getCell(indexContext.getDefinition());
-                    if (cell == null)
-                        continue;
-
-                    Set<ByteBuffer> queryTermsPerDoc = new HashSet<>(queryTerms.size());
-                    docAnalyzer.reset(cell.buffer());
-                    try
-                    {
-                        while (docAnalyzer.hasNext())
-                        {
-                            ByteBuffer term = docAnalyzer.next();
-                            if (queryTerms.contains(term))
-                                queryTermsPerDoc.add(term);
-                        }
-                    }
-                    finally
-                    {
-                        docAnalyzer.end();
-                    }
-                    for (ByteBuffer term : queryTermsPerDoc)
-                        documentFrequencies.merge(term, 1L, Long::sum);
-
-                }
-            }
-        }
-        return new BM25Utils.DocStats(documentFrequencies, indexedRows(), approximateTotalTermCount());
     }
 
     @Nullable


### PR DESCRIPTION
- **CNDB-14317: Optimize doc freq computation for memtable BM25 queries**
- **Update approximateTotalTermCount() javadoc**

### What is the issue
Fixes https://github.com/riptano/cndb/issues/14317

### What does this PR fix and why was it fixed
We optimize the in memory BM25 computation by using the trie to get the number of rows matching a query term. This change removes a memtable scan and analyze by replacing it with calls to the index to get the number of docs. There are no new tests because it is expected to maintain the same semantics. I will review the test coverage to verify that assertion.
