### PR TITLE
CNDB-14361 use node's total document and term counts

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -47,7 +47,6 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
-import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -346,11 +345,6 @@ public class SSTableIndex
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context, List<PrimaryKey> keys, Orderer orderer, int limit, long totalRows) throws IOException
     {
         return searchableIndex.orderResultsBy(context, keys, orderer, limit, totalRows);
-    }
-
-    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
-    {
-        docsStats.add(getRowCount(), getApproximateTermCount());
     }
 
     public String toString()

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -133,6 +134,16 @@ public class SSTableIndex
     public long getRowCount()
     {
         return searchableIndex.getRowCount();
+    }
+
+    /**
+     * Returns the total number of terms in all indexed rows of this index.
+     * This number is approximate because it does not account for any deletions
+     * that may have occurred since the index was built.
+     */
+    public long getApproximateTermCount()
+    {
+        return searchableIndex.getApproximateTermCount();
     }
 
     public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
@@ -335,6 +346,11 @@ public class SSTableIndex
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context, List<PrimaryKey> keys, Orderer orderer, int limit, long totalRows) throws IOException
     {
         return searchableIndex.orderResultsBy(context, keys, orderer, limit, totalRows);
+    }
+
+    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
+    {
+        docsStats.add(getRowCount(), getApproximateTermCount());
     }
 
     public String toString()

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -348,11 +348,6 @@ public class SSTableIndex
         return searchableIndex.orderResultsBy(context, keys, orderer, limit, totalRows);
     }
 
-    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
-    {
-        docsStats.add(getRowCount(), getApproximateTermCount());
-    }
-
     public String toString()
     {
         return MoreObjects.toStringHelper(this)

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -345,6 +346,11 @@ public class SSTableIndex
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context, List<PrimaryKey> keys, Orderer orderer, int limit, long totalRows) throws IOException
     {
         return searchableIndex.orderResultsBy(context, keys, orderer, limit, totalRows);
+    }
+
+    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
+    {
+        docsStats.add(getRowCount(), getApproximateTermCount());
     }
 
     public String toString()

--- a/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
@@ -51,6 +51,12 @@ public class EmptyIndex implements SearchableIndex
     }
 
     @Override
+    public long getApproximateTermCount()
+    {
+        return 0;
+    }
+
+    @Override
     public long minSSTableRowId()
     {
         return -1;

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -52,6 +52,8 @@ public interface SearchableIndex extends Closeable
 
     public long getRowCount();
 
+    long getApproximateTermCount();
+
     public long minSSTableRowId();
 
     public long maxSSTableRowId();

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -48,37 +48,37 @@ import org.apache.cassandra.utils.CloseableIterator;
  */
 public interface SearchableIndex extends Closeable
 {
-    public long indexFileCacheSize();
+    long indexFileCacheSize();
 
-    public long getRowCount();
+    long getRowCount();
 
     long getApproximateTermCount();
 
-    public long minSSTableRowId();
+    long minSSTableRowId();
 
-    public long maxSSTableRowId();
+    long maxSSTableRowId();
 
-    public ByteBuffer minTerm();
+    ByteBuffer minTerm();
 
-    public ByteBuffer maxTerm();
+    ByteBuffer maxTerm();
 
-    public DecoratedKey minKey();
+    DecoratedKey minKey();
 
-    public DecoratedKey maxKey();
+    DecoratedKey maxKey();
 
-    public KeyRangeIterator search(Expression expression,
+    KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
                                    boolean defer, int limit) throws IOException;
 
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+    List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
                                                                   Expression slice,
                                                                   AbstractBounds<PartitionPosition> keyRange,
                                                                   QueryContext context,
                                                                   int limit,
                                                                   long totalRows) throws IOException;
 
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context,
+    List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context,
                                                                          List<PrimaryKey> keys,
                                                                          Orderer orderer,
                                                                          int limit,
@@ -86,7 +86,7 @@ public interface SearchableIndex extends Closeable
 
     List<Segment> getSegments();
 
-    public void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
+    void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
 
     long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -75,6 +74,7 @@ public class V1SearchableIndex implements SearchableIndex
     private final ByteBuffer maxTerm;
     private final long minSSTableRowId, maxSSTableRowId;
     private final long numRows;
+    private final long approximateTermCount;
     private PerIndexFiles indexFiles;
 
     public V1SearchableIndex(SSTableContext sstableContext, IndexComponents.ForRead perIndexComponents)
@@ -106,6 +106,7 @@ public class V1SearchableIndex implements SearchableIndex
             this.maxTerm = metadatas.stream().map(m -> m.maxTerm).max(TypeUtil.comparator(indexContext.getValidator(), version)).orElse(null);
 
             this.numRows = metadatas.stream().mapToLong(m -> m.numRows).sum();
+            this.approximateTermCount = metadatas.stream().mapToLong(m -> m.totalTermCount).sum();
 
             this.minSSTableRowId = metadatas.get(0).minSSTableRowId;
             this.maxSSTableRowId = metadatas.get(metadatas.size() - 1).maxSSTableRowId;
@@ -128,6 +129,12 @@ public class V1SearchableIndex implements SearchableIndex
     public long getRowCount()
     {
         return numRows;
+    }
+
+    @Override
+    public long getApproximateTermCount()
+    {
+        return approximateTermCount;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
@@ -40,16 +40,11 @@ public abstract class AbstractMemtableIndex implements MemtableIndex
     }
 
     /**
-     * @return num of rows in the memtable index
-     */
-    protected abstract int indexedRows();
-
-    /**
      * Called when index is updated
      */
     protected void onIndexUpdated()
     {
-        if (flushThresholdMaxRows > 0 && indexedRows() >= flushThresholdMaxRows)
+        if (flushThresholdMaxRows > 0 && getRowCount() >= flushThresholdMaxRows)
             memtable.signalFlushRequired(ColumnFamilyStore.FlushReason.INDEX_MEMTABLE_LIMIT, true);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -218,7 +218,7 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -225,12 +225,6 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
-    {
-        throw new UnsupportedOperationException("Calculating BM25 document aggregates not supported by vector indexes");
-    }
-
-    @Override
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(QueryContext context,
                                                                   Orderer orderer,
                                                                   Expression slice,
@@ -464,9 +458,15 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public int indexedRows()
+    public int getRowCount()
     {
         return graph.size();
+    }
+
+    @Override
+    public long getApproximateTermCount()
+    {
+        throw new UnsupportedOperationException("Getting number of terms not supported by vector indexes");
     }
 
     public SegmentMetadata.ComponentMetadataMap writeData(IndexComponents.ForWrite perIndexComponents) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -218,7 +218,7 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.index.sai.memory.MemoryIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyListUtil;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithScore;
@@ -221,6 +222,12 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
+    }
+
+    @Override
+    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
+    {
+        throw new UnsupportedOperationException("Calculating BM25 document aggregates not supported by vector indexes");
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.MemtableOrdering;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -76,6 +77,8 @@ public interface MemtableIndex extends MemtableOrdering
     KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit);
 
     long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+
+    void addBm25DocsStats(BM25Utils.AggDocsStats docsStats);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -75,7 +75,7 @@ public interface MemtableIndex extends MemtableOrdering
 
     KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit);
 
-    long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
-import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.MemtableOrdering;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
@@ -78,12 +77,23 @@ public interface MemtableIndex extends MemtableOrdering
 
     long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
-    void addBm25DocsStats(BM25Utils.AggDocsStats docsStats);
-
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 
     static MemtableIndex createIndex(IndexContext indexContext, Memtable mt)
     {
         return indexContext.isVector() ? new VectorMemtableIndex(indexContext, mt) : new TrieMemtableIndex(indexContext, mt);
     }
+
+    /**
+     * @return num of rows in the memtable index
+     */
+    int getRowCount();
+
+    /**
+     * Approximate total count of terms in the memtable index.
+     * The count is approximate because some deletions are not accounted for in the current implementation.
+     *
+     * @return total count of terms for indexes rows.
+     */
+    long getApproximateTermCount();
 }

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -75,7 +75,7 @@ public interface MemtableIndex extends MemtableOrdering
 
     KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit);
 
-    long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongConsumer;
 import javax.annotation.Nullable;

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -448,7 +448,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         assert orderer.isBM25();
         List<ByteBuffer> queryTerms = orderer.getQueryTerms();
         AbstractAnalyzer analyzer = indexContext.getAnalyzerFactory().create();
-        BM25Utils.DocStats docStats = new BM25Utils.DocStats(documentFrequencies, indexedRows(), approximateTotalTermCount());
+        BM25Utils.DocStats docStats = new BM25Utils.DocStats(documentFrequencies, orderer.bm25Stats);
         Iterator<BM25Utils.DocTF> it = stream
                                        .map(pk -> BM25Utils.EagerDocTF.createFromDocument(pk, getCellForKey(pk), analyzer, queryTerms))
                                        .filter(Objects::nonNull)

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -38,6 +38,7 @@ import com.google.common.util.concurrent.Runnables;
 
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -406,9 +407,8 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         if (orderer.isBM25())
         {
             HashMap<ByteBuffer, Long> documentFrequencies = new HashMap<>();
-            // We only need to get the document frequencies for the shards that contain the keys.
-            Range<PartitionPosition> range = Range.makeRowRange(keys.get(0).partitionKey().getToken(),
-                                                                keys.get(keys.size() - 1).partitionKey().getToken());
+            // Use full range, since no filter should be applied for the term frequencies.
+            AbstractBounds<PartitionPosition> range = DataRange.allData(memtable.metadata().partitioner).keyRange();
             for (ByteBuffer term : orderer.getQueryTerms())
             {
                 Expression expression = new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term);

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -46,7 +46,6 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.memtable.ShardBoundaries;
 import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.analyzer.AbstractAnalyzer;
@@ -117,7 +116,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public int indexedRows()
+    public int getRowCount()
     {
         int size = 0;
         for (MemoryIndex memoryIndex : rangeIndexes)
@@ -131,7 +130,8 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
      *
      * @return total count of terms for indexes rows.
      */
-    public long approximateTotalTermCount()
+    @Override
+    public long getApproximateTermCount()
     {
         long count = 0;
         for (MemoryIndex memoryIndex : rangeIndexes)
@@ -458,12 +458,6 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                        docStats,
                                        indexContext,
                                        memtable);
-    }
-
-    @Override
-    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
-    {
-        docsStats.add(indexedRows(), approximateTotalTermCount());
     }
 
     @Nullable

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -376,16 +376,16 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = getEndShardForBounds(keyRange);
         return rangeIndexes[startShard].estimateMatchingRowsCount(expression, keyRange) * (endShard - startShard + 1);
     }
 
-    // In the BM25 logic, approximateMatchingRowsCount is not accurate enough because we use the result to compute the
+    // In the BM25 logic, estimateMatchingRowsCount is not accurate enough because we use the result to compute the
     // document score.
-    private long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    private long completeEstimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = getEndShardForBounds(keyRange);
@@ -412,7 +412,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
             for (ByteBuffer term : orderer.getQueryTerms())
             {
                 Expression expression = new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term);
-                documentFrequencies.put(term, estimateMatchingRowsCount(expression, range));
+                documentFrequencies.put(term, completeEstimateMatchingRowsCount(expression, range));
             }
             return orderByBM25(keys.stream(), documentFrequencies, orderer);
         }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -376,16 +376,16 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = getEndShardForBounds(keyRange);
         return rangeIndexes[startShard].estimateMatchingRowsCount(expression, keyRange) * (endShard - startShard + 1);
     }
 
-    // In the BM25 logic, estimateMatchingRowsCount is not accurate enough because we use the result to compute the
+    // In the BM25 logic, approximateMatchingRowsCount is not accurate enough because we use the result to compute the
     // document score.
-    private long completeEstimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    private long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         int startShard = boundaries.getShardForToken(keyRange.left.getToken());
         int endShard = getEndShardForBounds(keyRange);
@@ -412,7 +412,7 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
             for (ByteBuffer term : orderer.getQueryTerms())
             {
                 Expression expression = new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term);
-                documentFrequencies.put(term, completeEstimateMatchingRowsCount(expression, range));
+                documentFrequencies.put(term, estimateMatchingRowsCount(expression, range));
             }
             return orderByBM25(keys.stream(), documentFrequencies, orderer);
         }

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -460,6 +460,12 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                        memtable);
     }
 
+    @Override
+    public void addBm25DocsStats(BM25Utils.AggDocsStats docsStats)
+    {
+        docsStats.add(indexedRows(), approximateTotalTermCount());
+    }
+
     @Nullable
     private org.apache.cassandra.db.rows.Cell<?> getCellForKey(PrimaryKey key)
     {

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 
@@ -62,6 +63,7 @@ public class Orderer
 
     // BM25 search parameter
     private List<ByteBuffer> queryTerms;
+    public final BM25Utils.AggDocsStats bm25Stats = new BM25Utils.AggDocsStats();
 
     /**
      * Create an orderer for the given index context, operator, and term.

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -929,7 +929,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         long rowCount = 0;
         for (MemtableIndex index : queryView.memtableIndexes)
-            rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);
+            rowCount += index.approximateMatchingRowsCount(predicate, mergeRange);
 
         for (SSTableIndex index : queryView.sstableIndexes)
             rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -929,7 +929,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         long rowCount = 0;
         for (MemtableIndex index : queryView.memtableIndexes)
-            rowCount += index.approximateMatchingRowsCount(predicate, mergeRange);
+            rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);
 
         for (SSTableIndex index : queryView.sstableIndexes)
             rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);

--- a/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
@@ -44,6 +44,28 @@ public class BM25Utils
     private static final float K1 = 1.2f;  // BM25 term frequency saturation parameter
     private static final float B = 0.75f;  // BM25 length normalization parameter
 
+    public static class AggDocsStats
+    {
+        private long docCount;
+        private long totalTermCount;
+
+        public void add(long docCount, long totalTermCount)
+        {
+            this.docCount += docCount;
+            this.totalTermCount += totalTermCount;
+        }
+
+        public long getDocCount()
+        {
+            return docCount;
+        }
+
+        public long getTotalTermCount()
+        {
+            return totalTermCount;
+        }
+    }
+
     /**
      * Term frequencies across all documents.  Each document is only counted once.
      */
@@ -55,11 +77,11 @@ public class BM25Utils
         private final long docCount;
         private double avgDocLength;
 
-        public DocStats(Map<ByteBuffer, Long> frequencies, long docCount, long totalTermCount)
+        public DocStats(Map<ByteBuffer, Long> frequencies, AggDocsStats aggStats)
         {
             this.frequencies = frequencies;
-            this.docCount = docCount;
-            this.avgDocLength = (double) totalTermCount / docCount;
+            this.docCount = aggStats.docCount;
+            this.avgDocLength = (double) aggStats.totalTermCount / aggStats.docCount;
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -316,8 +316,8 @@ public class FeaturesVersionSupportTest extends VectorTester
         {
             MemtableIndex memIndex = getIndexContext(indexName).getLiveMemtables().get(memtable);
             assert memIndex instanceof TrieMemtableIndex;
-            rowCount += ((TrieMemtableIndex) memIndex).indexedRows();
-            termCount += ((TrieMemtableIndex) memIndex).approximateTotalTermCount();
+            rowCount += ((TrieMemtableIndex) memIndex).getRowCount();
+            termCount += ((TrieMemtableIndex) memIndex).getApproximateTermCount();
         }
         assertEquals(expectedNumRows, rowCount);
         if (expectedTotalTermsCount >= 0)
@@ -334,9 +334,7 @@ public class FeaturesVersionSupportTest extends VectorTester
     {
         BM25Utils.AggDocsStats aggDocStats = new BM25Utils.AggDocsStats();
         for (SSTableIndex sstableIndex : getIndexContext(indexName).getView())
-        {
-            sstableIndex.addBm25DocsStats(aggDocStats);
-        }
+            aggDocStats.add(sstableIndex.getRowCount(), sstableIndex.getApproximateTermCount());
         assertEquals(expectedNumRows, aggDocStats.getDocCount());
         if (expectedTotalTermsCount > 0)
             assertEquals(expectedTotalTermsCount, aggDocStats.getTotalTermCount());

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +34,7 @@ import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.index.sai.cql.BM25Test.*;
@@ -332,23 +332,13 @@ public class FeaturesVersionSupportTest extends VectorTester
     private void assertNumRowsAndTotalTermsSSTable(String indexName, int expectedNumRows, int expectedTotalTermsCount
     )
     {
-        long indexRowCount = 0;
-        long segmentRowCount = 0;
-        long totalTermCount = 0;
+        BM25Utils.AggDocsStats aggDocStats = new BM25Utils.AggDocsStats();
         for (SSTableIndex sstableIndex : getIndexContext(indexName).getView())
         {
-            indexRowCount += sstableIndex.getRowCount();
-            for (var segment : sstableIndex.getSegments())
-            {
-                var metadata = segment.metadata;
-                Assert.assertNotNull(metadata);
-                segmentRowCount += metadata.numRows;
-                totalTermCount += metadata.totalTermCount;
-            }
+            sstableIndex.addBm25DocsStats(aggDocStats);
         }
-        assertEquals(indexRowCount, segmentRowCount);
-        assertEquals(expectedNumRows, indexRowCount);
-        if (expectedTotalTermsCount >= 0)
-            assertEquals(expectedTotalTermsCount, totalTermCount);
+        assertEquals(expectedNumRows, aggDocStats.getDocCount());
+        if (expectedTotalTermsCount > 0)
+            assertEquals(expectedTotalTermsCount, aggDocStats.getTotalTermCount());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -952,7 +951,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         var indexes = sai.getIndexContext().getLiveMemtables().values();
         assertEquals("Expect just one memtable index", 1, indexes.size());
         var vectorIndex = (VectorMemtableIndex) indexes.iterator().next();
-        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.indexedRows());
+        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.getRowCount());
 
         // Flush to build the on disk graph (before the fix, flush failed due to a row having two vectors)
         flush();


### PR DESCRIPTION
### What is the issue

BM25 score needs to use document average length aggregated on entire node.
Also a bug was discovered, which was introduced by #1789: term frequencies don't
include documents filtered by other predicates, which makes inconsistent result
between query plans.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/14361

Changes that BM25 score uses document count and term count aggregated
on entire node instead of per segment. Fixes a bug in calculating term frequencies, so
they count all documents.

As the work added more code duplication all duplicated code is
refactored in getTopKRows methods.

In addition removes unnecessary public modifier in afffected interface.