### PR TITLE
Use binary search in ShardBoundaries#getShardForToken

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
+++ b/src/java/org/apache/cassandra/db/memtable/ShardBoundaries.java
@@ -68,12 +68,11 @@ public class ShardBoundaries
      */
     public int getShardForToken(Token tk)
     {
-        for (int i = 0; i < boundaries.length; i++)
-        {
-            if (tk.compareTo(boundaries[i]) <= 0)   // boundaries are end-inclusive
-                return i;
-        }
-        return boundaries.length;
+        int idx = Arrays.binarySearch(boundaries, tk);
+        // boundaries are end-inclusive, so an exact match is the correct shard
+        if (idx >= 0)
+            return idx;
+        return -idx - 1;
     }
 
     /**


### PR DESCRIPTION
### What is the issue
There is not an issue yet. I am submitting this PR to run tests and to start a discussion about the implementation.

### What does this PR fix and why was it fixed
We currently scan shards in the `getShardForToken` method. Given that we have a sorted array and that this method is called multiple times for writes and reads, it seems worth considering a switch from an `O(n)` operation to an `O(n log(n))` operation. This would like need further performance testing. I am just submitting to start a discussion.