### PR TITLE
CNDB-14348: Forbid BM25 queries on non-regular columns

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -84,6 +84,8 @@ public class StatementRestrictions
 
     public static final String GEO_DISTANCE_REQUIRES_INDEX_MESSAGE = "GEO_DISTANCE requires the vector column to be indexed";
     public static final String BM25_ORDERING_REQUIRES_ANALYZED_INDEX_MESSAGE = "BM25 ordering on column %s requires an analyzed index";
+    public static final String BM25_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE = "BM25 ordering on %s column %s is not supported. " +
+                                                                               "Only regular columns are supported.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE =
     "Ordering on non-clustering column %s requires the column to be indexed with a non-analyzed index.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE =
@@ -692,22 +694,29 @@ public class StatementRestrictions
                     throw new InvalidRequestException("Descending ANN ordering is not supported");
                 if (!ENABLE_SAI_GENERAL_ORDER_BY && ordering.expression instanceof Ordering.SingleColumn)
                     throw new InvalidRequestException("SAI based ORDER BY on non-vector column is not supported");
+
                 SingleRestriction restriction = ordering.expression.toRestriction();
+                ColumnMetadata column = restriction.getFirstColumn();
+
                 if (!restriction.hasSupportingIndex(indexRegistry))
                 {
-                    var type = restriction.getFirstColumn().type.asCQL3Type().getType();
+                    var type = column.type.asCQL3Type().getType();
                     // This is a slight hack, but once we support a way to order these types, we can remove it.
                     if (type instanceof IntegerType || type instanceof DecimalType)
                         throw new InvalidRequestException(String.format("SAI based ordering on column %s of type %s is not supported",
-                                                          restriction.getFirstColumn(),
-                                                          restriction.getFirstColumn().type.asCQL3Type()));
+                                                                        column,
+                                                                        column.type.asCQL3Type()));
                     if (ordering.expression instanceof Ordering.Bm25)
-                        throw new InvalidRequestException(String.format(BM25_ORDERING_REQUIRES_ANALYZED_INDEX_MESSAGE,
-                                                                        restriction.getFirstColumn()));
+                        throw new InvalidRequestException(String.format(BM25_ORDERING_REQUIRES_ANALYZED_INDEX_MESSAGE, column));
                     else
-                        throw new InvalidRequestException(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE,
-                                                                        restriction.getFirstColumn()));
+                        throw new InvalidRequestException(String.format(NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE, column));
                 }
+
+                if (ordering.expression instanceof Ordering.Bm25 && !column.isRegular())
+                    throw new InvalidRequestException(String.format(BM25_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE,
+                                                                    column.kind.name().toLowerCase().replace("_", " "),
+                                                                    column.name));
+
                 receiver.addRestriction(restriction, false);
             }
         }


### PR DESCRIPTION
BM25 queries don't work on indexes on non-regular columns. 

Until we have a way to support them, this PR simply forbids BM25 queries on non-regular columns. 

The creation of analyzed indexes in those columns is still allowed because they can be successfully queried with regular expression filters using equality and match operators.
