### PR TITLE
CNDB-14239: expose index components validation method with no side-effect

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
@@ -80,5 +80,8 @@ public interface IndexComponent
         IndexOutputWriter openOutput(boolean append) throws IOException;
 
         void createEmpty() throws IOException;
+
+        /** Deletes the underlying component file if it exists. */
+        void delete();
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -21,9 +21,13 @@ package org.apache.cassandra.index.sai.disk.format;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.lifecycle.Tracker;
@@ -79,6 +83,8 @@ import org.apache.cassandra.utils.bytecomparable.ByteComparable;
  */
 public interface IndexComponents
 {
+    Logger logger = LoggerFactory.getLogger(IndexComponents.class);
+
     /**
      * SSTable this is the group of.
      */
@@ -190,6 +196,12 @@ public interface IndexComponents
      */
     interface ForRead extends IndexComponents
     {
+        /**
+         * Get the component of the provided type if present.
+         *
+         * @param component the type of the component to retrieve.
+         * @return the component, or {@code null} if the group has no such component.
+         */
         IndexComponent.ForRead get(IndexComponentType component);
 
         /**
@@ -210,11 +222,38 @@ public interface IndexComponents
         /**
          * Validates this group and its components.
          * <p>
-         * This method both check that the group has all the components that it should have, and that the content of
-         * those components are, as far as this method can determine, valid.
+         * This is a shortcut for {@link #isValid(boolean, Consumer)} when nothing particular is done for
+         * invalid components.
+         *
+         * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
+         *                         basic checks on the header and footers will be performed.
+         * @return whether the group is valid.
+         */
+        default boolean isValid(boolean validateChecksum)
+        {
+            return isValid(validateChecksum, c -> {});
+        }
+
+        /**
+         * Validates this group and its components.
          * <p>
-         * If the group is invalid, then it will be invalidated by calling {@link #invalidate}. Specifics about what
-         * failed validation is also be logged.
+         * This method checks that the group has all the components that it should have, and that the content of
+         * those components are, as far as this method can determine, valid. Specifics about what failed validation
+         * is also be logged.
+         *
+         * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
+         *                         basic checks on the header and footers will be performed.
+         * @param onInvalidComponent called on any component that is present but whose content appears invalid/corrupted
+         *                           (what is checked depends on {@code validateChecksum}).
+         * @return whether the group is valid.
+         */
+        boolean isValid(boolean validateChecksum, Consumer<IndexComponent> onInvalidComponent);
+
+        /**
+         * Validate this group and its components, and invalidate the group if it is invalid.
+         * <p>
+         * This method is a shortcut for a call to {@link #isValid(boolean, Consumer)} that deletes corrupted components
+         * if this is the configured behavior, followed by a call {@link #invalidate} if the validation fails.
          *
          * @param sstable the sstable object for which the component are validated (which should correspond to
          *               {@code this.descriptor()}). This must be provided so if some components are invalid, they
@@ -225,7 +264,26 @@ public interface IndexComponents
          *                         basic checks on the header and footers will be performed.
          * @return whether the group is valid.
          */
-        boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum);
+        default boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum)
+        {
+            boolean isValid = isValid(validateChecksum, invalid -> {
+                if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
+                {
+                    // We delete the corrupted file. Yes, this may break ongoing reads to that component, but
+                    // if something is wrong with the file, we're rather fail loudly from that point on than
+                    // risking reading and returning corrupted data.
+                    forWrite().getForWrite(invalid.componentType()).delete();
+                    // Note that invalidation will also delete the completion marker
+                }
+                else
+                {
+                    logger.debug("Leaving believed-corrupt component {} of SSTable {} in place because {} is false", invalid.componentType(), descriptor(), CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getKey());
+                }
+            });
+            if (!isValid)
+                invalidate(sstable, tracker);
+            return isValid;
+        }
 
         /**
          * Marks the group as invalid/broken.
@@ -265,6 +323,16 @@ public interface IndexComponents
          * been added.
          */
         IndexComponent.ForWrite addOrGet(IndexComponentType component);
+
+        /**
+         * Get the component of the provided type if present.
+         * <p>
+         * This is the same as {@link #get}, except that it preserve the type information that is a "for write" object.
+         *
+         * @param component the type of the component to retrieve.
+         * @return the component, or {@code null} if the group has no such component.
+         */
+        IndexComponent.ForWrite getForWrite(IndexComponentType component);
 
         /**
          * Delete the files of all the components in this writer (and remove them so that the group will be empty

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
@@ -338,19 +339,6 @@ public class IndexDescriptor
                              message);
     }
 
-    private static void deleteComponentFile(File file)
-    {
-        logger.debug("Deleting storage attached index component file {}", file);
-        try
-        {
-            IOUtils.deleteFilesIfExist(file.toPath());
-        }
-        catch (IOException e)
-        {
-            logger.warn("Unable to delete storage attached index component file {} due to {}.", file, e.getMessage(), e);
-        }
-    }
-
     private class IndexComponentsImpl implements IndexComponents.ForWrite
     {
         private final @Nullable IndexContext context;
@@ -417,7 +405,7 @@ public class IndexDescriptor
         }
 
         @Override
-        public boolean validateComponents(SSTable sstable, Tracker tracker, boolean validateChecksum)
+        public boolean isValid(boolean validateChecksum, Consumer<IndexComponent> onInvalidComponent)
         {
             if (isEmpty())
                 return true;
@@ -434,24 +422,10 @@ public class IndexDescriptor
                 else if (!onDiskFormat().validateIndexComponent(component, validateChecksum))
                 {
                     logger.warn(logMessage("Invalid/corrupted component {} for SSTable {}"), expected, descriptor);
-                    if (CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
-                    {
-                        // We delete the corrupted file. Yes, this may break ongoing reads to that component, but
-                        // if something is wrong with the file, we're rather fail loudly from that point on than
-                        // risking reading and returning corrupted data.
-                        deleteComponentFile(component.file());
-                        // Note that invalidation will also delete the completion marker
-                    }
-                    else
-                    {
-                        logger.debug("Leaving believed-corrupt component {} of SSTable {} in place because {} is false", expected, descriptor, CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getKey());
-                    }
-
+                    onInvalidComponent.accept(component);
                     isValid = false;
                 }
             }
-            if (!isValid)
-                invalidate(sstable, tracker);
             return isValid;
         }
 
@@ -475,7 +449,7 @@ public class IndexDescriptor
             // break ongoing operations here.
             var marker = components.remove(completionMarkerComponent());
             if (marker != null)
-                deleteComponentFile(marker.file());
+                marker.delete();
 
             // Keeping legacy behavior if immutable components is disabled.
             if (!buildId.version().useImmutableComponentFiles() && CassandraRelevantProperties.DELETE_CORRUPT_SAI_COMPONENTS.getBoolean())
@@ -528,12 +502,17 @@ public class IndexDescriptor
         }
 
         @Override
+        public IndexComponent.ForWrite getForWrite(IndexComponentType component)
+        {
+            IndexComponentImpl info = components.get(component);
+            Preconditions.checkNotNull(info, "SSTable %s has no %s component for build %s (context: %s)", descriptor, component, buildId, context);
+            return info;
+        }
+
+        @Override
         public void forceDeleteAllComponents()
         {
-            components.values()
-                      .stream()
-                      .map(IndexComponentImpl::file)
-                      .forEach(IndexDescriptor::deleteComponentFile);
+            components.values().forEach(IndexComponentImpl::delete);
             components.clear();
         }
 
@@ -694,6 +673,21 @@ public class IndexDescriptor
             public void createEmpty() throws IOException
             {
                 com.google.common.io.Files.touch(file().toJavaIOFile());
+            }
+
+            @Override
+            public void delete()
+            {
+                File file = file();
+                logger.debug("Deleting storage attached index component file {}", file);
+                try
+                {
+                    IOUtils.deleteFilesIfExist(file.toPath());
+                }
+                catch (IOException e)
+                {
+                    logger.warn("Unable to delete storage attached index component file {} due to {}.", file, e.getMessage(), e);
+                }
             }
 
             @Override

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -132,13 +132,13 @@ public class SAITester extends CQLTester
 
     protected static final Injections.Counter perSSTableValidationCounter = addConditions(Injections.newCounter("PerSSTableValidationCounter")
                                                                                       .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
-                                                                                                           .onMethod("validateComponents")),
+                                                                                                           .onMethod("isValid")),
                                                                                           b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
     ).build();
 
     protected static final Injections.Counter perColumnValidationCounter = addConditions(Injections.newCounter("PerColumnValidationCounter")
                                                                                      .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
-                                                                                                          .onMethod("validateComponents")),
+                                                                                                          .onMethod("isValid")),
                                                                                          b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
     ).build();
 


### PR DESCRIPTION
The existing `IndexComponents#validateComponents` method validates some group of index components files (ensure we have all the files we should have, and ensure they looks valid), but it also has some side-effect backed in. It potentially deletes invalid components it found, and invalidate the whole group if validation fails, which rewrite the sstable TOC and whatnot.

For CNDB, it would be useful to be able to validate components on reload without necessarily triggering the side effects, and the plan is to rely on such no-side-effect variant in the patch for https://github.com/riptano/cndb/issues/14239. But I'd argue having this variant make sense in general and could easily have other uses later, and the changes are trivially backward compatible (they only introduce 2 new methods.