### PR TITLE
CNDB-14374: Fix flaky test testIndexExceptionsTwoIndexesOn3NodeCluster

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -173,8 +173,7 @@ public class IndexAvailabilityTest extends TestBaseImpl
     public void testIndexExceptionsTwoIndexesOn3NodeCluster() throws Exception
     {
         try (Cluster cluster = init(Cluster.build(3)
-                .withConfig(config -> config.with(GOSSIP)
-                                                          .with(NETWORK))
+                .withConfig(config -> config.with(GOSSIP).with(NETWORK))
                 .start()))
         {
             String ks2 = "ks2";
@@ -200,16 +199,11 @@ public class IndexAvailabilityTest extends TestBaseImpl
 
             cluster.schemaChange(String.format(CREATE_INDEX, index1, ks2, cf1, "v1"));
             cluster.schemaChange(String.format(CREATE_INDEX, index2, ks2, cf1, "v2"));
-            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index1, node), Index.Status.BUILD_SUCCEEDED));
-            for (IInvokableInstance node : cluster.get(2, 1, 3))
-                for (IInvokableInstance replica : cluster.get(1, 2, 3))
-                    waitForIndexingStatus(node, ks2, index1, replica, Index.Status.BUILD_SUCCEEDED);
+            waitForIndexQueryable(cluster, ks2);
 
             // Mark only index2 as building on node3, leave index1 in BUILD_SUCCEEDED state
             markIndexBuilding(cluster.get(3), ks2, cf1, index2);
-            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.FULL_REBUILD_STARTED));
-            for (IInvokableInstance node : cluster.get(1, 2, 3))
-                waitForIndexingStatus(node, ks2, index2, cluster.get(3), Index.Status.FULL_REBUILD_STARTED);
+            cluster.forEach(node -> waitForIndexingStatus(node, ks2, index2, cluster.get(3), Index.Status.FULL_REBUILD_STARTED));
 
             assertThatThrownBy(() ->
                     executeOnAllCoordinators(cluster,
@@ -220,9 +214,7 @@ public class IndexAvailabilityTest extends TestBaseImpl
 
             // Mark only index2 as failing/building on node2, leave index1 in BUILD_SUCCEEDED state
             markIndexBuilding(cluster.get(2), ks2, cf1, index2);
-            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.FULL_REBUILD_STARTED));
-            for (IInvokableInstance node : cluster.get(1, 2, 3))
-                waitForIndexingStatus(node, ks2, index2, cluster.get(2), Index.Status.FULL_REBUILD_STARTED);
+            cluster.forEach(node -> waitForIndexingStatus(node, ks2, index2, cluster.get(2), Index.Status.FULL_REBUILD_STARTED));
 
             assertThatThrownBy(() ->
                     executeOnAllCoordinators(cluster,
@@ -233,12 +225,13 @@ public class IndexAvailabilityTest extends TestBaseImpl
 
             // Mark only index2 as failing on node1, leave index1 in BUILD_SUCCEEDED state
             markIndexNonQueryable(cluster.get(1), ks2, cf1, index2);
-            cluster.forEach(node -> expectedNodeIndexQueryability.put(NodeIndex.create(ks2, index2, node), Index.Status.BUILD_FAILED));
-            for (IInvokableInstance node : cluster.get(1, 2, 3))
-                waitForIndexingStatus(node, ks2, index2, cluster.get(1), Index.Status.BUILD_FAILED);
+            cluster.forEach(node -> waitForIndexingStatus(node, ks2, index2, cluster.get(1), Index.Status.BUILD_FAILED));
 
             assertThatThrownBy(() ->
-                    executeOnAllCoordinators(cluster, "SELECT pk FROM " + ks2 + '.' + cf1 + " WHERE v1=0 AND v2=0", ConsistencyLevel.LOCAL_QUORUM, 0))
+                    executeOnAllCoordinators(cluster,
+                            "SELECT pk FROM " + ks2 + '.' + cf1 + " WHERE v1=0 AND v2=0",
+                            ConsistencyLevel.LOCAL_QUORUM,
+                            0))
                     .hasMessageMatching("^Operation failed - received 0 responses and 2 failures: INDEX_BUILD_IN_PROGRESS from .+, INDEX_NOT_AVAILABLE from .+$");
         }
     }


### PR DESCRIPTION
### What is the issue
...
The test was flaky because we were not waiting for some indexing status to get propagated before running queries

### What does this PR fix and why was it fixed
...
Wait for all statuses before running test queries to get deterministic results
