### PR TITLE
CNDB-13553 aggregate document frequencies on entire node

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -498,12 +498,7 @@ public class IndexContext
         try
         {
             for (MemtableIndex index : memtables)
-            {
-                if (index instanceof TrieMemtableIndex)
-                    builder.add(((TrieMemtableIndex)index).eagerSearch(expression, keyRange));
-                else
-                    builder.add(index.search(context, expression, keyRange));
-            }
+                builder.add(index.search(context, expression, keyRange));
 
             return builder.build();
         }

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -72,6 +72,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeUnionIterator;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableKeyRangeIterator;
+import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
@@ -498,7 +499,10 @@ public class IndexContext
         {
             for (MemtableIndex index : memtables)
             {
-                builder.add(index.search(context, expression, keyRange, limit));
+                if (index instanceof TrieMemtableIndex)
+                    builder.add(((TrieMemtableIndex)index).eagerSearch(expression, keyRange));
+                else
+                    builder.add(index.search(context, expression, keyRange));
             }
 
             return builder.build();

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -476,12 +476,12 @@ public class IndexContext
         else
         {
             Expression negExpression = expression.negated();
-            KeyRangeIterator matchedKeys = searchMemtable(context, memtables, negExpression, keyRange, Integer.MAX_VALUE);
+            KeyRangeIterator matchedKeys = searchMemtable(context, memtables, negExpression, keyRange);
             return KeyRangeAntiJoinIterator.create(allKeys, matchedKeys);
         }
     }
 
-    public KeyRangeIterator searchMemtable(QueryContext context, Collection<MemtableIndex> memtables, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit)
+    public KeyRangeIterator searchMemtable(QueryContext context, Collection<MemtableIndex> memtables, Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         if (expression.getOp().isNonEquality())
         {

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -47,7 +47,6 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
-import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -154,7 +154,7 @@ public class SSTableIndex
      *
      * @return an approximate number of the matching rows
      */
-    public long approximateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
     {
         return searchableIndex.estimateMatchingRowsCount(predicate, keyRange);
     }

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -228,7 +228,7 @@ public class SSTableIndex
         else
         {
             Expression negExpression = expression.negated();
-            KeyRangeIterator matchedKeys = searchableIndex.search(negExpression, keyRange, context, defer, Integer.MAX_VALUE);
+            KeyRangeIterator matchedKeys = searchableIndex.search(negExpression, keyRange, context, defer);
             return KeyRangeAntiJoinIterator.create(allKeys, matchedKeys);
         }
     }
@@ -236,15 +236,14 @@ public class SSTableIndex
     public KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
-                                   boolean defer,
-                                   int limit) throws IOException
+                                   boolean defer) throws IOException
     {
         if (expression.getOp().isNonEquality())
         {
             return getNonEqIterator(expression, keyRange, context, defer);
         }
 
-        return searchableIndex.search(expression, keyRange, context, defer, limit);
+        return searchableIndex.search(expression, keyRange, context, defer);
     }
 
     public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeAntiJoinIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
+import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -55,6 +56,7 @@ import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CloseableIterator;
+import org.apache.cassandra.utils.Throwables;
 
 /**
  * SSTableIndex is created for each column index on individual sstable to track per-column indexer.
@@ -145,9 +147,39 @@ public class SSTableIndex
         return searchableIndex.getApproximateTermCount();
     }
 
-    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    /**
+     * Estimates the number of rows that would be returned by this index given the predicate using the index
+     * histogram.
+     * Note that this is not a guarantee of the number of rows that will actually be returned.
+     *
+     * @return an approximate number of the matching rows
+     */
+    public long approximateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
     {
         return searchableIndex.estimateMatchingRowsCount(predicate, keyRange);
+    }
+
+    /**
+     * Counts the number of rows that would be returned by this index given the predicate.
+     *
+     * @return the row count
+     */
+    public long getMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext)
+    {
+        queryContext.checkpoint();
+        queryContext.addSstablesHit(1);
+        assert !isReleased();
+
+        try (KeyRangeIterator keyIterator = search(predicate, keyRange, queryContext, false))
+        {
+            return keyIterator.getMaxKeys();
+        }
+        catch (Throwable e)
+        {
+            if (logger.isDebugEnabled() && !(e instanceof AbortedOperationException))
+                logger.debug(String.format("Failed search an index %s.", getSSTable()), e);
+            throw Throwables.cleaned(e);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
@@ -96,8 +96,7 @@ public class EmptyIndex implements SearchableIndex
     public KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
-                                   boolean defer,
-                                   int limit) throws IOException
+                                   boolean defer) throws IOException
     {
         return KeyRangeIterator.empty();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -69,7 +69,7 @@ public interface SearchableIndex extends Closeable
     KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
-                                   boolean defer, int limit) throws IOException;
+                                   boolean defer) throws IOException;
 
     List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
                                                                   Expression slice,

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +33,6 @@ import org.apache.cassandra.index.sai.plan.QueryController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.Slice;
 import org.apache.cassandra.db.Slices;
@@ -75,6 +73,7 @@ import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static org.apache.cassandra.index.sai.disk.PostingList.END_OF_STREAM;
+import static org.apache.cassandra.index.sai.disk.v1.SegmentMetadata.INVALID_TOTAL_TERM_COUNT;
 
 /**
  * Executes {@link Expression}s against the trie-based terms dictionary for an individual index segment.
@@ -244,9 +243,10 @@ public class InvertedIndexSearcher extends IndexSearcher
         };
         return BM25Utils.computeScores(it,
                                        queryTerms,
-                                       orderer.getBm25stats(),
+                                       orderer.bm25stats,
                                        indexContext,
-                                       sstable.descriptor.id);
+                                       sstable.descriptor.id,
+                                       metadata.totalTermCount == INVALID_TOTAL_TERM_COUNT);
     }
 
     @Override
@@ -262,15 +262,6 @@ public class InvertedIndexSearcher extends IndexSearcher
         }
 
         var queryTerms = orderer.getQueryTerms();
-        // compute documentFrequencies from either histogram or an index search
-        var documentFrequencies = new HashMap<ByteBuffer, Long>();
-        // any index new enough to support BM25 should also support histograms
-        assert metadata.version.onDiskFormat().indexFeatureSet().hasTermsHistogram();
-        for (ByteBuffer term : queryTerms)
-        {
-            long matches = metadata.estimateNumRowsMatching(new Expression(indexContext).add(Operator.ANALYZER_MATCHES, term));
-            documentFrequencies.put(term, matches);
-        }
         var analyzer = indexContext.getAnalyzerFactory().create();
         var it = keys.stream()
                      .map(pk -> EagerDocTF.createFromDocument(pk, readColumn(sstable, pk), analyzer, queryTerms))
@@ -278,9 +269,10 @@ public class InvertedIndexSearcher extends IndexSearcher
                      .iterator();
         return BM25Utils.computeScores(CloseableIterator.wrap(it),
                                        queryTerms,
-                                       orderer.getBm25stats(),
+                                       orderer.bm25stats,
                                        indexContext,
-                                       sstable.descriptor.id);
+                                       sstable.descriptor.id,
+                                       metadata.totalTermCount == INVALID_TOTAL_TERM_COUNT);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -139,10 +139,9 @@ public class Segment implements Closeable
      * @param keyRange   key range specific in read command, used by ANN index
      * @param context    to track per sstable cache and per query metrics
      * @param defer      create the iterator in a deferred state
-     * @param limit      the num of rows to returned, used by ANN index
      * @return range iterator of {@link PrimaryKey} that matches given expression
      */
-    public KeyRangeIterator search(Expression expression, AbstractBounds<PartitionPosition> keyRange, QueryContext context, boolean defer, int limit) throws IOException
+    public KeyRangeIterator search(Expression expression, AbstractBounds<PartitionPosition> keyRange, QueryContext context, boolean defer) throws IOException
     {
         return index.search(expression, keyRange, context, defer);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -177,8 +177,7 @@ public class V1SearchableIndex implements SearchableIndex
     public KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
-                                   boolean defer,
-                                   int limit) throws IOException
+                                   boolean defer) throws IOException
     {
         KeyRangeConcatIterator.Builder rangeConcatIteratorBuilder = KeyRangeConcatIterator.builder(segments.size());
 
@@ -188,7 +187,7 @@ public class V1SearchableIndex implements SearchableIndex
             {
                 if (segment.intersects(keyRange))
                 {
-                    rangeConcatIteratorBuilder.add(segment.search(expression, keyRange, context, defer, limit));
+                    rangeConcatIteratorBuilder.add(segment.search(expression, keyRange, context, defer));
                 }
             }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.Throwables;
 
+import static org.apache.cassandra.index.sai.disk.v1.SegmentMetadata.INVALID_TOTAL_TERM_COUNT;
 import static org.apache.cassandra.index.sai.virtual.SegmentsSystemView.CELL_COUNT;
 import static org.apache.cassandra.index.sai.virtual.SegmentsSystemView.COLUMN_NAME;
 import static org.apache.cassandra.index.sai.virtual.SegmentsSystemView.COMPONENT_METADATA;
@@ -106,7 +107,9 @@ public class V1SearchableIndex implements SearchableIndex
             this.maxTerm = metadatas.stream().map(m -> m.maxTerm).max(TypeUtil.comparator(indexContext.getValidator(), version)).orElse(null);
 
             this.numRows = metadatas.stream().mapToLong(m -> m.numRows).sum();
-            this.approximateTermCount = metadatas.stream().mapToLong(m -> m.totalTermCount).sum();
+            this.approximateTermCount = metadatas.stream()
+                                                 .mapToLong(m -> m.totalTermCount == INVALID_TOTAL_TERM_COUNT ? 0 : m.totalTermCount)
+                                                 .sum();
 
             this.minSSTableRowId = metadatas.get(0).minSSTableRowId;
             this.maxSSTableRowId = metadatas.get(metadatas.size() - 1).maxSSTableRowId;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -217,14 +217,14 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCountUsingFirstShard(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCountUsingAllShards(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -58,7 +58,6 @@ import org.apache.cassandra.index.sai.memory.MemoryIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
-import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyListUtil;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithScore;
@@ -196,7 +195,7 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public KeyRangeIterator search(QueryContext context, Expression expr, AbstractBounds<PartitionPosition> keyRange, int limit)
+    public KeyRangeIterator search(QueryContext context, Expression expr, AbstractBounds<PartitionPosition> keyRange)
     {
         if (expr.getOp() != Expression.Op.BOUNDED_ANN)
             throw new IllegalArgumentException(indexContext.logMessage("Only BOUNDED_ANN is supported, received: " + expr));

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -217,9 +217,15 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
+        throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
+    }
+
+    @Override
+    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    {
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
     }
 

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeTermIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeTermIterator.java
@@ -66,17 +66,17 @@ public class KeyRangeTermIterator extends KeyRangeIterator
 
 
     @SuppressWarnings("resource")
-    public static KeyRangeTermIterator build(final Expression e, QueryView view, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, boolean defer, int limit)
+    public static KeyRangeTermIterator build(final Expression e, QueryView view, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, boolean defer)
     {
-        KeyRangeIterator rangeIterator = buildRangeIterator(e, view, keyRange, queryContext, defer, limit);
+        KeyRangeIterator rangeIterator = buildRangeIterator(e, view, keyRange, queryContext, defer);
         return new KeyRangeTermIterator(rangeIterator, view.sstableIndexes, queryContext);
     }
 
-    private static KeyRangeIterator buildRangeIterator(final Expression e, QueryView view, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, boolean defer, int limit)
+    private static KeyRangeIterator buildRangeIterator(final Expression e, QueryView view, AbstractBounds<PartitionPosition> keyRange, QueryContext queryContext, boolean defer)
     {
         final List<KeyRangeIterator> tokens = new ArrayList<>(1 + view.sstableIndexes.size());
 
-        KeyRangeIterator memtableIterator = e.context.searchMemtable(queryContext, view.memtableIndexes, e, keyRange, limit);
+        KeyRangeIterator memtableIterator = e.context.searchMemtable(queryContext, view.memtableIndexes, e, keyRange);
         if (memtableIterator != null)
             tokens.add(memtableIterator);
 
@@ -88,7 +88,7 @@ public class KeyRangeTermIterator extends KeyRangeIterator
                 queryContext.addSstablesHit(1);
                 assert !index.isReleased();
 
-                KeyRangeIterator keyIterator = index.search(e, keyRange, queryContext, defer, limit);
+                KeyRangeIterator keyIterator = index.search(e, keyRange, queryContext, defer);
 
                 if (keyIterator == null || !keyIterator.hasNext())
                     continue;

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -84,17 +84,18 @@ public interface MemtableIndex extends MemtableOrdering
      * @param keyRange   the key range to search within
      * @return an approximate number of the matching rows
      */
-    long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    long estimateMatchingRowsCountUsingFirstShard(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     /**
      * Estimates the number of rows that would be returned by this index given the predicate.
+     * It estimates from all relevant shards individually.
      * Note that this is not a guarantee of the number of rows that will actually be returned.
      *
      * @param expression predicate to match
      * @param keyRange   the key range to search within
      * @return an estimated number of the matching rows
      */
-    long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    long estimateMatchingRowsCountUsingAllShards(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -73,7 +73,7 @@ public interface MemtableIndex extends MemtableOrdering
     void update(DecoratedKey key, Clustering clustering, ByteBuffer oldValue, ByteBuffer newValue, Memtable memtable, OpOrder.Group opGroup);
     void update(DecoratedKey key, Clustering clustering, Iterator<ByteBuffer> oldValues, Iterator<ByteBuffer> newValues, Memtable memtable, OpOrder.Group opGroup);
 
-    KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange, int limit);
+    KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -75,6 +75,25 @@ public interface MemtableIndex extends MemtableOrdering
 
     KeyRangeIterator search(QueryContext queryContext, Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
+    /**
+     * Estimates the number of rows that would be returned by this index given the predicate.
+     * It is extrapolated from the first shard.
+     * Note that this is not a guarantee of the number of rows that will actually be returned.
+     *
+     * @param expression predicate to match
+     * @param keyRange   the key range to search within
+     * @return an approximate number of the matching rows
+     */
+    long approximateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+
+    /**
+     * Estimates the number of rows that would be returned by this index given the predicate.
+     * Note that this is not a guarantee of the number of rows that will actually be returned.
+     *
+     * @param expression predicate to match
+     * @param keyRange   the key range to search within
+     * @return an estimated number of the matching rows
+     */
     long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -431,9 +431,10 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                        .iterator();
         return BM25Utils.computeScores(CloseableIterator.wrap(it),
                                        queryTerms,
-                                       orderer.getBm25stats(),
+                                       orderer.bm25stats,
                                        indexContext,
-                                       memtable);
+                                       memtable,
+                                       false);
     }
 
     @Nullable

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
-import org.apache.cassandra.index.sai.utils.BM25Utils;
+import org.apache.cassandra.index.sai.utils.DocBm25Stats;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 
@@ -65,7 +65,7 @@ public class Orderer
     private List<ByteBuffer> queryTerms;
 
     // BM25 aggregated statistics
-    private BM25Utils.DocStats bm25stats;
+    public final DocBm25Stats bm25stats = new DocBm25Stats();
 
     /**
      * Create an orderer for the given index context, operator, and term.
@@ -200,15 +200,5 @@ public class Orderer
         }
         queryTerms = new ArrayList<>(uniqueTerms);
         return queryTerms;
-    }
-
-    public BM25Utils.DocStats getBm25stats()
-    {
-        return bm25stats;
-    }
-
-    public void setBm25stats(BM25Utils.DocStats bm25stats)
-    {
-        this.bm25stats = bm25stats;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -63,7 +63,9 @@ public class Orderer
 
     // BM25 search parameter
     private List<ByteBuffer> queryTerms;
-    public final BM25Utils.AggDocsStats bm25Stats = new BM25Utils.AggDocsStats();
+
+    // BM25 aggregated statistics
+    private BM25Utils.DocStats bm25stats;
 
     /**
      * Create an orderer for the given index context, operator, and term.
@@ -198,5 +200,15 @@ public class Orderer
         }
         queryTerms = new ArrayList<>(uniqueTerms);
         return queryTerms;
+    }
+
+    public BM25Utils.DocStats getBm25stats()
+    {
+        return bm25stats;
+    }
+
+    public void setBm25stats(BM25Utils.DocStats bm25stats)
+    {
+        this.bm25stats = bm25stats;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -691,7 +691,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                     orderer.bm25stats.add(index.getRowCount(),
                                           index.getApproximateTermCount(),
                                           termAndExpressions,
-                                          termExpression -> index.estimateMatchingRowsCount(termExpression, mergeRange));
+                                          termExpression -> index.estimateMatchingRowsCountUsingAllShards(termExpression, mergeRange));
                 for (SSTableIndex index : view.sstableIndexes)
                     orderer.bm25stats.add(index.getRowCount(),
                                           index.getApproximateTermCount(),
@@ -927,10 +927,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         long rowCount = 0;
         for (MemtableIndex index : queryView.memtableIndexes)
-            rowCount += index.approximateMatchingRowsCount(predicate, mergeRange);
+            rowCount += index.estimateMatchingRowsCountUsingFirstShard(predicate, mergeRange);
 
         for (SSTableIndex index : queryView.sstableIndexes)
-            rowCount += index.approximateMatchingRowsCount(predicate, mergeRange);
+            rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);
 
         return rowCount;
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -452,7 +452,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private KeyRangeIterator buildIterator(Expression predicate)
     {
         QueryView view = getQueryView(predicate.context);
-        return KeyRangeTermIterator.build(predicate, view, mergeRange, queryContext, false, Integer.MAX_VALUE);
+        return KeyRangeTermIterator.build(predicate, view, mergeRange, queryContext, false);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
@@ -77,11 +77,11 @@ public class BM25Utils
         private final long docCount;
         private double avgDocLength;
 
-        public DocStats(Map<ByteBuffer, Long> frequencies, AggDocsStats aggStats)
+        public DocStats(Map<ByteBuffer, Long> frequencies, long docCount, long totalTermCount)
         {
             this.frequencies = frequencies;
-            this.docCount = aggStats.docCount;
-            this.avgDocLength = (double) aggStats.totalTermCount / aggStats.docCount;
+            this.docCount = docCount;
+            this.avgDocLength = (double) totalTermCount / docCount;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
@@ -148,10 +148,9 @@ public class BM25Utils
         }
 
         // An index format before {@link Version#ED} doesn't store the total term count
-        // on the disk to read it back. Thus, if the average document length is unknown
-        // due to the old format version, it is calculated in the old way.
+        // on the disk to read it back. Thus, for the old format version it is calculated in the old way.
         double oldAvgDocLength;
-        if (isOldFormat && docStats.getAvgDocLength() == 0 && !documents.isEmpty())
+        if (isOldFormat && !documents.isEmpty())
             oldAvgDocLength = totalTermCount / documents.size();
         else
             oldAvgDocLength = 0;

--- a/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Term frequencies across all documents.  Each document is only counted once.
+ */
+public class DocBm25Stats
+{
+    public Map<ByteBuffer, Long> getFrequencies()
+    {
+        return frequencies;
+    }
+
+    private final Map<ByteBuffer, Long> frequencies = new HashMap<>();
+    private long docCount;
+    private long totalTermCount;
+    private double avgDocLength;
+
+    public long getDocCount()
+    {
+        return docCount;
+    }
+
+    public double getAvgDocLength()
+    {
+        return avgDocLength;
+    }
+
+    public void setAvgDocLength(double avgDocLength)
+    {
+        this.avgDocLength = avgDocLength;
+    }
+
+    public void add(long docCount, long totalTermCount, List<Pair<ByteBuffer, Expression>> termAndExpressions, DocumentFrequencyEstimator estimator)
+    {
+        this.docCount += docCount;
+        this.totalTermCount += totalTermCount;
+        if (this.docCount > 0 && this.totalTermCount > 0)
+            this.avgDocLength = (double) this.totalTermCount / this.docCount;
+        for (Pair<ByteBuffer, Expression> pair : termAndExpressions)
+            frequencies.merge(pair.left,
+                              estimator.estimate(pair.right),
+                              Long::sum);
+    }
+
+    @FunctionalInterface
+    public interface DocumentFrequencyEstimator
+    {
+        long estimate(Expression predicate);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
@@ -49,11 +49,6 @@ public class DocBm25Stats
         return avgDocLength;
     }
 
-    public void setAvgDocLength(double avgDocLength)
-    {
-        this.avgDocLength = avgDocLength;
-    }
-
     public void add(long docCount, long totalTermCount, List<Pair<ByteBuffer, Expression>> termAndExpressions, DocumentFrequencyEstimator estimator)
     {
         this.docCount += docCount;

--- a/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/DocBm25Stats.java
@@ -62,7 +62,7 @@ public class DocBm25Stats
             this.avgDocLength = (double) this.totalTermCount / this.docCount;
         for (Pair<ByteBuffer, Expression> pair : termAndExpressions)
             frequencies.merge(pair.left,
-                              estimator.estimate(pair.right),
+                              Math.min(estimator.estimate(pair.right), docCount),
                               Long::sum);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -770,6 +770,16 @@ public class BM25Test extends SAITester
         executeQuery(Arrays.asList(1, 2), "SELECT * FROM %s ORDER BY body BM25 OF 'hi' LIMIT 4");
     }
 
+    // ID 10: total words = 12, climate occurrences = 4
+    // ID 18: total words = 13, climate occurrences = 4
+    // ID 0: total words = 16, climate occurrences = 3
+    // ID 15: total words = 11, climate occurrences = 2
+    // ID 5: total words = 13, climate occurrences = 2
+    // ID 11: total words = 12, climate occurrences = 1
+    // ID 17: total words = 14, climate occurrences = 1
+    private static final List<Integer> CLIMATE_QUERY_RESULTS = Arrays.asList(10, 18, 0, 15, 5, 11, 17);
+    private static final List<Integer> CLIMATE_QUERY_SCORE_5_RESULTS = Arrays.asList(10, 18, 0);
+
     @Test
     public void testCollections() throws Throwable
     {
@@ -789,26 +799,19 @@ public class BM25Test extends SAITester
 
         beforeAndAfterFlush(
         () -> {
-            // ID 10: total words = 12, climate occurrences = 4
-            // ID 18: total words = 13, climate occurrences = 4
-            // ID 0: total words = 16, climate occurrences = 3
-            // ID 15: total words = 11, climate occurrences = 2
-            // ID 5: total words = 13, climate occurrences = 2
-            // ID 11: total words = 12, climate occurrences = 1
-            // ID 17: total words = 14, climate occurrences = 1
-            executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+            executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
-            executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+            executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
-            executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s WHERE bodyset CONTAINS 'climate' ORDER BY body BM25 OF ? LIMIT 10",
+            executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s WHERE bodyset CONTAINS 'climate' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
             executeQuery(Arrays.asList(15, 5, 11, 17), "SELECT * FROM %s WHERE bodyset CONTAINS 'health' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
-            executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s WHERE map_category CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
+            executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s WHERE map_category CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
             executeQuery(Arrays.asList(18, 15, 5, 11, 17), "SELECT * FROM %s WHERE map_category CONTAINS 'Health' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
-            executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s WHERE map_body CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
+            executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s WHERE map_body CONTAINS 'Climate' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
             executeQuery(Arrays.asList(10, 18, 15, 5, 11, 17), "SELECT * FROM %s WHERE map_body CONTAINS 'health' ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");
@@ -847,21 +850,21 @@ public class BM25Test extends SAITester
         insertPrimitiveData(10, 20);
 
         // The same result as in testCollections above
-        executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
-        executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
         flush();
-        executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
-        executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
         compact();
-        executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
-        executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -856,7 +856,7 @@ public class BM25Test extends SAITester
                 "climate");
 
         flush();
-        executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(CLIMATE_QUERY_RESULTS, Arrays.asList(10, 18, 0, 5, 15, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
         executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
@@ -1160,6 +1160,14 @@ public class BM25Test extends SAITester
         assertResult(execute(query, values), expected);
         prepare(query);
         assertResult(execute(query, values), expected);
+    }
+
+    private void executeQuery(List<Integer> expected, List<Integer> expectedEC, String query, Object... values) throws Throwable
+    {
+        if (testVersion == Version.EC)
+            executeQuery(expectedEC, query, values);
+        else
+            executeQuery(expected, query, values);
     }
 
     private void assertResult(UntypedResultSet result, List<Integer> expected)

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -846,24 +846,18 @@ public class BM25Test extends SAITester
         flush();
         insertPrimitiveData(10, 20);
 
-        // One memtable, one sstable - different result from the reference in testCollections
-        // ID 0 and 5 contain 3 and 2 climate occurrences correspondingly,
-        // while ID 10 and 18 - 4 climate occurrences. However,
-        // since the segment with 0-9 IDs have only 2 rows with climate and 10-19 - 5,
-        // 0 and 5 win over 10 and 18.
-        executeQuery(Arrays.asList(0, 5, 10, 18, 15, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        // The same result as in testCollections above
+        executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
-        executeQuery(Arrays.asList(0, 10, 18), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
-        // Flush into Two sstables - same result as the different above
         flush();
-        executeQuery(Arrays.asList(0, 5, 10, 18, 15, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
-        executeQuery(Arrays.asList(0, 10, 18), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+        executeQuery(Arrays.asList(10, 18, 0), "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");
 
-        // Compact into one sstable - same as reference from testCollections
         compact();
         executeQuery(Arrays.asList(10, 18, 0, 15, 5, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                 "climate");

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -850,22 +850,28 @@ public class BM25Test extends SAITester
         insertPrimitiveData(10, 20);
 
         // The same result as in testCollections above
-        executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
-        executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
+        executeQuery(CLIMATE_QUERY_RESULTS,
+                     Arrays.asList(0, 10, 5, 18, 15, 11, 17),
+                     "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+                     "climate");
+        executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS,
+                     Arrays.asList(0, 10, 18),
+                     "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
+                     "climate");
 
         flush();
-        executeQuery(CLIMATE_QUERY_RESULTS, Arrays.asList(10, 18, 0, 5, 15, 11, 17), "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
+        executeQuery(CLIMATE_QUERY_RESULTS,
+                     Arrays.asList(10, 18, 0, 5, 15, 11, 17),
+                     "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
+                     "climate");
         executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
+                     "climate");
 
         compact();
         executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
+                     "climate");
         executeQuery(CLIMATE_QUERY_SCORE_5_RESULTS, "SELECT * FROM %s WHERE score = 5 ORDER BY body BM25 OF ? LIMIT 10",
-                "climate");
+                     "climate");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -18,6 +18,7 @@ package org.apache.cassandra.index.sai.cql;
 
 
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -35,6 +36,7 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.utils.BM25Utils;
+import org.apache.cassandra.index.sai.utils.DocBm25Stats;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.index.sai.cql.BM25Test.*;
@@ -332,11 +334,15 @@ public class FeaturesVersionSupportTest extends VectorTester
     private void assertNumRowsAndTotalTermsSSTable(String indexName, int expectedNumRows, int expectedTotalTermsCount
     )
     {
-        BM25Utils.AggDocsStats aggDocStats = new BM25Utils.AggDocsStats();
+        long rowCount = 0;
+        long termCount = 0;
         for (SSTableIndex sstableIndex : getIndexContext(indexName).getView())
-            aggDocStats.add(sstableIndex.getRowCount(), sstableIndex.getApproximateTermCount());
-        assertEquals(expectedNumRows, aggDocStats.getDocCount());
+        {
+            rowCount += sstableIndex.getRowCount();
+            termCount += sstableIndex.getApproximateTermCount();
+        }
+        assertEquals(expectedNumRows, rowCount);
         if (expectedTotalTermsCount > 0)
-            assertEquals(expectedTotalTermsCount, aggDocStats.getTotalTermCount());
+            assertEquals(expectedTotalTermsCount, termCount);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LuceneUpdateDeleteTest.java
@@ -665,7 +665,7 @@ public class LuceneUpdateDeleteTest extends SAITester
         var builder = KeyRangeUnionIterator.builder();
         // Because there are many
         for (var memtableIndex : sai.getIndexContext().getLiveMemtables().values())
-            builder.add(memtableIndex.search(queryContext, expression, range, 10));
+            builder.add(memtableIndex.search(queryContext, expression, range));
         try (var rangeIterator = builder.build())
         {
             for (Integer expectedResult : expectedResults)

--- a/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
@@ -448,7 +448,7 @@ public class NonNumericTermsDistributionTest extends SAITester
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.approximateMatchingRowsCount(expression, wholeRange);
         return onDiskCount;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
@@ -448,7 +448,7 @@ public class NonNumericTermsDistributionTest extends SAITester
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.approximateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
         return onDiskCount;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
@@ -250,7 +250,7 @@ public class NumericTermsDistributionTest extends SAITester
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.approximateMatchingRowsCount(expression, wholeRange);
 
         assertEstimateCorrect(expectedCount, roundingValue, uncertainty, onDiskCount);
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
@@ -250,7 +250,7 @@ public class NumericTermsDistributionTest extends SAITester
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.approximateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
 
         assertEstimateCorrect(expectedCount, roundingValue, uncertainty, onDiskCount);
     }

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
@@ -197,7 +197,7 @@ public abstract class TrieMemtableIndexTestBase extends SAITester
 
             Set<Integer> foundKeys = new HashSet<>();
 
-            try (KeyRangeIterator iterator = memtableIndex.search(new QueryContext(), expression, keyRange, 0))
+            try (KeyRangeIterator iterator = memtableIndex.search(new QueryContext(), expression, keyRange))
             {
                 while (iterator.hasNext())
                 {
@@ -320,7 +320,7 @@ public abstract class TrieMemtableIndexTestBase extends SAITester
         expression.add(Operator.EQ, Int32Type.instance.decompose(value));
         AbstractBounds<PartitionPosition> keyRange = new Range<>(partitioner.getMinimumToken().minKeyBound(),
                                                                  partitioner.getMinimumToken().minKeyBound());
-        var result = memtableIndex.search(new QueryContext(), expression, keyRange, 0);
+        var result = memtableIndex.search(new QueryContext(), expression, keyRange);
         // Confirm the partition keys are as expected in the provided order and that we have no more results
         for (int partitionKey : partitionKeys)
             assertEquals(makeKey(cfs.metadata(), partitionKey), result.next().partitionKey());

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -75,7 +75,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         createTables();
 
         RowCountTest test = new RowCountTest(Operator.NEQ, 25);
-        test.doTest(Version.DB, INT, 97.0);
+        test.doTest(Version.DB, INT, 79.9);
         test.doTest(Version.EB, INT, 97.0);
         // Truncated numeric types planned differently
         test.doTest(Version.DB, DECIMAL, 97.0);
@@ -83,9 +83,9 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         test.doTest(Version.EB, VARINT, 97.0);
 
         test = new RowCountTest(Operator.LT, 50);
-        test.doTest(Version.DB, INT, 48);
+        test.doTest(Version.DB, INT, 49.9);
         test.doTest(Version.EB, INT, 48);
-        test.doTest(Version.DB, DECIMAL, 48);
+        test.doTest(Version.DB, DECIMAL, 51);
         test.doTest(Version.EB, DECIMAL, 48);
 
         test = new RowCountTest(Operator.LT, 150);
@@ -95,9 +95,9 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         test.doTest(Version.EB, DECIMAL, 97);
 
         test = new RowCountTest(Operator.EQ, 31);
-        test.doTest(Version.DB, INT, 15);
+        test.doTest(Version.DB, INT, 1);
         test.doTest(Version.EB, INT, 0);
-        test.doTest(Version.DB, DECIMAL, 15);
+        test.doTest(Version.DB, DECIMAL, 1);
         test.doTest(Version.EB, DECIMAL, 0);
     }
 
@@ -169,7 +169,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
 
             assertEquals(expectedRows, root.expectedRows(), 0.1);
             assertEquals(expectedRows, planNode.expectedKeys(), 0.1);
-            assertEquals(expectedRows / totalRows, planNode.selectivity(), 0.001);
+            assertEquals(expectedRows / totalRows, planNode.selectivity(), 0.01);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -75,7 +75,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         createTables();
 
         RowCountTest test = new RowCountTest(Operator.NEQ, 25);
-        test.doTest(Version.DB, INT, 79.9);
+        test.doTest(Version.DB, INT, 97.0);
         test.doTest(Version.EB, INT, 97.0);
         // Truncated numeric types planned differently
         test.doTest(Version.DB, DECIMAL, 97.0);
@@ -83,9 +83,9 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         test.doTest(Version.EB, VARINT, 97.0);
 
         test = new RowCountTest(Operator.LT, 50);
-        test.doTest(Version.DB, INT, 49.9);
+        test.doTest(Version.DB, INT, 48);
         test.doTest(Version.EB, INT, 48);
-        test.doTest(Version.DB, DECIMAL, 51);
+        test.doTest(Version.DB, DECIMAL, 48);
         test.doTest(Version.EB, DECIMAL, 48);
 
         test = new RowCountTest(Operator.LT, 150);
@@ -95,9 +95,9 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
         test.doTest(Version.EB, DECIMAL, 97);
 
         test = new RowCountTest(Operator.EQ, 31);
-        test.doTest(Version.DB, INT, 1);
+        test.doTest(Version.DB, INT, 15);
         test.doTest(Version.EB, INT, 0);
-        test.doTest(Version.DB, DECIMAL, 1);
+        test.doTest(Version.DB, DECIMAL, 15);
         test.doTest(Version.EB, DECIMAL, 0);
     }
 


### PR DESCRIPTION
Aggregates document frequencies for each query term for entire node before passing to calculate BM25 scores. This removes unbalanced and inconsistent results between different splits to SSTables and MemTables. As the result the test, which was demonstrating this inconsistency, is fixed to provide the same result. The same result is moved into shared constants.

For SSTables created with older version total count is not stored and thus the document frequencies are not aggregated on those SSTables. Thus, the old way of calculating the average document frequencies per segment is used. This also creates difference in the test result for `EC` vs newer versions.

Document frequencies are calculated by searching the query terms, which gives more reliable statistics than using terms distribution histogram, but slower. Another possible approach is to get statistics from posting lists.

Also search API method of MemtableIndex is cleaned from unused argument limit.

Some unused imports were removed in relevant files.

Fixes https://github.com/riptano/cndb/issues/13553