### PR TITLE
CNDB-12407: lazily load token in PrimaryKeyWithSource (#1500)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PostingListKeyRangeIterator.java
@@ -115,8 +115,7 @@ public class PostingListKeyRangeIterator extends KeyRangeIterator
             if (rowId == PostingList.END_OF_STREAM)
                 return endOfData();
 
-            PrimaryKey primaryKey = primaryKeyMap.primaryKeyFromRowId(rowId);
-            return new PrimaryKeyWithSource(primaryKey, primaryKeyMap.getSSTableId(), rowId);
+            return new PrimaryKeyWithSource(primaryKeyMap, rowId, searcherContext.minimumKey, searcherContext.maximumKey);
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +35,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.disk.ModernResettableByteBuffersIndexOutput;
 import org.apache.cassandra.index.sai.disk.PostingList;
+import org.apache.cassandra.index.sai.disk.PrimaryKeyWithSource;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.io.IndexInput;
@@ -134,9 +137,12 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     private static final Logger logger = LoggerFactory.getLogger(SegmentMetadata.class);
 
     @SuppressWarnings("resource")
-    private SegmentMetadata(IndexInput input, IndexContext context, Version version) throws IOException
+    private SegmentMetadata(IndexInput input, IndexContext context, Version version, SSTableContext sstableContext, boolean loadFullResolutionBounds) throws IOException
     {
-        PrimaryKey.Factory primaryKeyFactory = context.keyFactory();
+        if (!loadFullResolutionBounds)
+            logger.warn("Loading segment metadata without full primary key boundary resolution. Some ORDER BY queries" +
+                        " may not work correctly.");
+
         AbstractType<?> termsType = context.getValidator();
 
         this.version = version;
@@ -144,8 +150,39 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         this.numRows = input.readLong();
         this.minSSTableRowId = input.readLong();
         this.maxSSTableRowId = input.readLong();
-        this.minKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
-        this.maxKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
+
+        if (loadFullResolutionBounds)
+        {
+            // Skip the min/max partition keys since we want the fully resolved PrimaryKey for better semantics.
+            // Also, these values are not always correct for flushed sstables, but the min/max row ids are, which
+            // provides further justification for skipping them.
+            skipBytes(input);
+            skipBytes(input);
+
+            // Get the fully qualified PrimaryKey min and max objects to ensure that we skip several edge cases related
+            // to possibly confusing equality semantics. The main issue is how we handl PrimaryKey objects that
+            // are not fully qualified when doing a binary search on a collection of PrimaryKeyWithSource objects.
+            // By materializing the fully qualified PrimaryKey objects, we get the right binary search result.
+            final PrimaryKey min, max;
+            try (var pkm = sstableContext.primaryKeyMapFactory().newPerSSTablePrimaryKeyMap())
+            {
+                // We need to load eagerly to allow us to close the partition key map.
+                min = pkm.primaryKeyFromRowId(minSSTableRowId).loadDeferred();
+                max = pkm.primaryKeyFromRowId(maxSSTableRowId).loadDeferred();
+            }
+
+            this.minKey = new PrimaryKeyWithSource(min, sstableContext.sstable.getId(), minSSTableRowId, min, max);
+            this.maxKey = new PrimaryKeyWithSource(max, sstableContext.sstable.getId(), maxSSTableRowId, min, max);
+        }
+        else
+        {
+            assert sstableContext == null;
+            // Only valid in some very specific tests.
+            PrimaryKey.Factory primaryKeyFactory = context.keyFactory();
+            this.minKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
+            this.maxKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
+        }
+
         this.minTerm = readBytes(input);
         this.maxTerm = readBytes(input);
         TermsDistribution td = null;
@@ -164,7 +201,27 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     }
 
     @SuppressWarnings("resource")
-    public static List<SegmentMetadata> load(MetadataSource source, IndexContext context) throws IOException
+    public static List<SegmentMetadata> load(MetadataSource source, IndexContext context, SSTableContext sstableContext) throws IOException
+    {
+        return load(source, context, sstableContext, true);
+    }
+
+    /**
+     * This is only visible for testing because the SegmentFlushTest creates fake boundary scenarios that break
+     * normal assumptions about the min/max row ids mapping to specific positions in the per-sstable index components.
+     * Only set loadFullResolutionBounds to false in tests when you are sure that is the only possible solution.
+     */
+    @VisibleForTesting
+    @SuppressWarnings("resource")
+    public static List<SegmentMetadata> loadForTesting(MetadataSource source, IndexContext context) throws IOException
+    {
+        return load(source, context, null, false);
+    }
+
+    /**
+     * Only set loadFullResolutionBounds to false in tests when you are sure that is exactly what you want.
+     */
+    private static List<SegmentMetadata> load(MetadataSource source, IndexContext context, SSTableContext sstableContext, boolean loadFullResolutionBounds) throws IOException
     {
 
         IndexInput input = source.get(NAME);
@@ -175,7 +232,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
 
         for (int i = 0; i < segmentCount; i++)
         {
-            segmentMetadata.add(new SegmentMetadata(input, context, source.getVersion()));
+            segmentMetadata.add(new SegmentMetadata(input, context, source.getVersion(), sstableContext, loadFullResolutionBounds));
         }
 
         return segmentMetadata;
@@ -298,6 +355,12 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         byte[] bytes = new byte[len];
         input.readBytes(bytes, 0, len);
         return ByteBuffer.wrap(bytes);
+    }
+
+    private static void skipBytes(IndexInput input) throws IOException
+    {
+        int len = input.readVInt();
+        input.skipBytes(len);
     }
 
     static void writeBytes(ByteBuffer buf, IndexOutput out)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.plan.Orderer;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.index.sai.utils.PrimaryKeyListUtil;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithScore;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.RangeUtil;
@@ -306,10 +307,10 @@ public class VectorMemtableIndex implements MemtableIndex
         // Compute the keys that exist in the current memtable and their corresponding graph ordinals
         var keysInGraph = new HashSet<PrimaryKey>();
         var relevantOrdinals = new IntHashSet();
-        keys.stream()
-            .dropWhile(k -> k.compareTo(minimumKey) < 0)
-            .takeWhile(k -> k.compareTo(maximumKey) <= 0)
-            .forEach(k ->
+
+        var keysInRange = PrimaryKeyListUtil.getKeysInRange(keys, minimumKey, maximumKey);
+
+        keysInRange.forEach(k ->
         {
             var v = graph.vectorForKey(k);
             if (v == null)

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -663,8 +663,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     private List<PrimaryKey> materializeKeys(KeyRangeIterator source)
     {
-        // Skip to the first key in the range
-        source.skipTo(primaryKeyFactory().createTokenOnly(mergeRange.left.getToken()));
+        // Skip to the first key (which is really just a token) in the range if it is not the minimum token
+        if (!mergeRange.left.isMinimum())
+            source.skipTo(firstPrimaryKey);
+
         if (!source.hasNext())
             return List.of();
 

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyListUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyListUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PrimaryKeyListUtil
+{
+
+    /** Create a sublist of the keys within the provided bounds (inclusive) */
+    public static List<PrimaryKey> getKeysInRange(List<PrimaryKey> keys, PrimaryKey minKey, PrimaryKey maxKey)
+    {
+        int minIndex = PrimaryKeyListUtil.findBoundaryIndex(keys, minKey, false);
+        int maxIndex = PrimaryKeyListUtil.findBoundaryIndex(keys, maxKey, true);
+        return keys.subList(minIndex, maxIndex);
+    }
+
+    private static int findBoundaryIndex(List<PrimaryKey> keys, PrimaryKey key, boolean findMax)
+    {
+        int index = Collections.binarySearch(keys, key);
+
+        if (index < 0)
+            return -index - 1;
+
+        // When findMax is true, we are finding an exclusive upper bound, but binary search is inclusive, so we
+        // increment by 1 to get the exclusive upper bound.
+        return findMax ? index + 1 : index;
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByUpdateDeleteTest.java
@@ -18,22 +18,12 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.plan.QueryController;
 
 public class GenericOrderByUpdateDeleteTest extends SAITester
 {
-
-    @Before
-    public void setup() throws Throwable
-    {
-        // Enable the optimizer by default. If there are any tests that need to disable it, they can do so explicitly.
-        QueryController.QUERY_OPT_LEVEL = 1;
-    }
-
     @Test
     public void testPreparedQueries() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -109,6 +109,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     public void testHybridSearchHoleInClusteringColumnOrdering() throws Throwable
     {
         setMaxBruteForceRows(0);
+        QueryController.QUERY_OPT_LEVEL = 0;
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -890,27 +890,20 @@ public class VectorTypeTest extends VectorTester.VersionedWithChecksums
 
         // start a filter-then-sort query asynchronously that will get blocked in the injected barrier
         QueryController.QUERY_OPT_LEVEL = 0;
-        try
-        {
-            ExecutorService executor = Executors.newFixedThreadPool(1);
-            String select = "SELECT k FROM %s WHERE c=1 ORDER BY v ANN OF [1, 1] LIMIT 100";
-            Future<UntypedResultSet> future = executor.submit(() -> execute(select));
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        String select = "SELECT k FROM %s WHERE c=1 ORDER BY v ANN OF [1, 1] LIMIT 100";
+        Future<UntypedResultSet> future = executor.submit(() -> execute(select));
 
-            // once the query is blocked, delete one of the vectors and flush, so the postings for the vector are removed
-            waitForAssert(() -> Assert.assertEquals(1, barrier.getCount()));
-            execute("DELETE v FROM %s WHERE k = 1");
-            flush();
+        // once the query is blocked, delete one of the vectors and flush, so the postings for the vector are removed
+        waitForAssert(() -> Assert.assertEquals(1, barrier.getCount()));
+        execute("DELETE v FROM %s WHERE k = 1");
+        flush();
 
-            // release the barrier to resume the query, which should succeed
-            barrier.countDown();
-            assertRows(future.get(), row(2));
+        // release the barrier to resume the query, which should succeed
+        barrier.countDown();
+        assertRows(future.get(), row(2));
 
-            assertEquals(0, executor.shutdownNow().size());
-        }
-        finally
-        {
-            QueryController.QUERY_OPT_LEVEL = 1;
-        }
+        assertEquals(0, executor.shutdownNow().size());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.index.sai.cql;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -34,15 +33,6 @@ import static org.junit.Assert.assertEquals;
 
 public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
 {
-    @Before
-    public void setup() throws Throwable
-    {
-        super.setup();
-
-        // Enable the optimizer by default. If there are any tests that need to disable it, they can do so explicitly.
-        QueryController.QUERY_OPT_LEVEL = 1;
-    }
-
     // partition delete won't trigger UpdateTransaction#onUpdated
     @Test
     public void partitionDeleteVectorInMemoryTest()

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -176,7 +176,9 @@ public class SegmentFlushTest
         MetadataSource source = MetadataSource.loadMetadata(components);
 
         // verify segment count
-        List<SegmentMetadata> segmentMetadatas = SegmentMetadata.load(source, indexContext);
+        // We use a custome loader that skips resolving the full primary key bounds because we don't actually have
+        // a complete segment where the min/max row ids map to token positions in the per sstable index file.
+        List<SegmentMetadata> segmentMetadatas = SegmentMetadata.loadForTesting(source, indexContext);
         assertEquals(segments, segmentMetadatas.size());
 
         // verify segment metadata

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIteratorTest.java
@@ -377,7 +377,8 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
 
         union = buildUnion(intersectionA, intersectionB);
         assertEquals(convert(2L, 3L, 7L, 8L), convert(union));
-        assertEquals(KeyRangeUnionIterator.class, union.getClass());
+        // Because the iterators are disjoint, the constructor optimizes the union and returns a concat iterator
+        assertEquals(KeyRangeConcatIterator.class, union.getClass());
 
         // union of one intersected intersection and one non-intersected intersection
         intersectionA = buildIntersection(arr(1L, 2L, 3L), arr(2L, 3L, 4L ));


### PR DESCRIPTION
This implements one of the possible fixes for
https://github.com/riptano/cndb/issues/12407.

This PR skips loading the PrimaryKey's token in the case where the sstables/memtables do not overlap, which is particularly helpful as datasets become more compacted (especially after major compaction).

It is implemented via a subtle change to the `PrimaryKeyWithSource` class that only loads the token info when the token is needed. We avoid this check by first checking to see if the sstable ranges overlap or if the key is contained in the sstable range. If it is not contained, we can short circuit the logic and avoid loading the primary key from disk. This results in a significant optimization for SAI hybrid queries that search-then-sort.

CNDB PR with passing tests: https://github.com/riptano/cndb/pull/12444

- [x] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
- [x] Use `NoSpamLogger` for log lines that may appear frequently in the logs
- [x] Verify test results on Butler
- [x] Test coverage for new/modified code is > 80%
- [x] Proper code formatting
- [x] Proper title for each commit staring with the project-issue number, like CNDB-1234
- [x] Each commit has a meaningful description
- [x] Each commit is not very long and contains related changes
- [x] Renames, moves and reformatting are in distinct commits

### What is the issue
...

### What does this PR fix and why was it fixed
...
