### PR TITLE
CNDB-14481: Fix IllegalStateException in SegmentMetadataBuilder

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -492,21 +493,31 @@ public abstract class SegmentBuilder
 
     private long add(List<ByteBuffer> terms, PrimaryKey key, long sstableRowId)
     {
-        assert !flushed : "Cannot add to flushed segment.";
-        assert sstableRowId >= maxSSTableRowId;
+        if (terms.isEmpty())
+            return 0;
+
+        Preconditions.checkState(!flushed, "Cannot add to flushed segment");
+        Preconditions.checkArgument(sstableRowId >= maxSSTableRowId,
+                                    "rowId must be greater than or equal to the last rowId added: %s < %s", sstableRowId, maxSSTableRowId);
+        Preconditions.checkArgument(maxKey == null || key.compareTo(maxKey) >= 0,
+                                    "Key must be greater than or equal to the last key added: %s < %s", key, maxKey);
+
         minSSTableRowId = minSSTableRowId < 0 ? sstableRowId : minSSTableRowId;
         maxSSTableRowId = sstableRowId;
 
-        assert maxKey == null || maxKey.compareTo(key) <= 0;
         minKey = minKey == null ? key : minKey;
         maxKey = key;
 
         // Update term boundaries for all terms in this row
         for (ByteBuffer term : terms)
         {
+            assert term != null : "term must not be null";
             minTerm = TypeUtil.min(term, minTerm, termComparator, Version.current());
             maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.current());
         }
+
+        assert minTerm != null : "minTerm should not be null at this point";
+        assert maxTerm != null : "maxTerm should not be null at this point";
 
         // segmentRowIdOffset should encode sstableRowId into Integer
         int segmentRowId = Math.toIntExact(sstableRowId - segmentRowIdOffset);

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
@@ -99,14 +101,16 @@ public class SegmentMetadataBuilder
 
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
     {
-        assert minKey.compareTo(maxKey) <= 0: "minKey (" + minKey + ") must not be greater than (" + maxKey + ')';
+        Preconditions.checkNotNull(minKey, "minKey must not be null");
+        Preconditions.checkNotNull(maxKey, "maxKey must not be null");
+        Preconditions.checkArgument(minKey.compareTo(maxKey) <= 0, "minKey (" + minKey + ") must not be greater than (" + maxKey + ')');
         this.minKey = minKey;
         this.maxKey = maxKey;
     }
 
     public void setRowIdRange(long minRowId, long maxRowId)
     {
-        assert minRowId <= maxRowId: "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')';
+        Preconditions.checkArgument(minRowId <= maxRowId, "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')');
         this.minRowId = minRowId;
         this.maxRowId = maxRowId;
     }
@@ -120,6 +124,8 @@ public class SegmentMetadataBuilder
      */
     public void setTermRange(@Nonnull ByteBuffer minTerm, @Nonnull ByteBuffer maxTerm)
     {
+        Preconditions.checkNotNull(minTerm, "minTerm must not be null");
+        Preconditions.checkNotNull(maxTerm, "maxTerm must not be null");
         this.minTerm = minTerm;
         this.maxTerm = maxTerm;
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
@@ -30,7 +30,17 @@ import java.util.Arrays;
 public class AnalyzerTest extends SAITester
 {
     @Test
-    public void testEmpty()
+    public void testEmptyOnInitialBuild()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("INSERT INTO %s (k, v) VALUES (1, '')");
+        flush();
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'standard'};");
+    }
+
+    @Test
+    public void testEmptyOnCompaction()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
@@ -40,6 +50,17 @@ public class AnalyzerTest extends SAITester
         execute("INSERT INTO %s (k, v) VALUES (1, '')");
         flush();
         compact();
+    }
+
+    @Test
+    public void testEmptyWithStopwords()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'and then')");  // will yield no indexed terms
+        flush();
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'english'};");
+        assertEmpty(execute("SELECT * FROM %s WHERE v = 'and'"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
@@ -30,6 +30,19 @@ import java.util.Arrays;
 public class AnalyzerTest extends SAITester
 {
     @Test
+    public void testEmpty()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'standard'};");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'apple orange')");
+        flush();
+        execute("INSERT INTO %s (k, v) VALUES (1, '')");
+        flush();
+        compact();
+    }
+
+    @Test
     public void createAnalyzerWrongTypeTest()
     {
         createTable("CREATE TABLE %s (pk1 int, pk2 text, val int, val2 int, PRIMARY KEY((pk1, pk2)))");


### PR DESCRIPTION
If an index analyzer produced no terms for a row, the index
build could not complete and broke sstable flushing.

This commit makes the SegmentBuilder ignore the whole row
if there are no terms. Additionally more assertions / preconditions
have been added to improve diagnostics.

Fixes:
Failed to complete an index build
java.lang.IllegalStateException: Term range not set
	at org.apache.cassandra.index.sai.disk.v1.SegmentMetadataBuilder.build(SegmentMetadataBuilder.java:145)
	at org.apache.cassandra.index.sai.disk.v1.SegmentBuilder.flush(SegmentBuilder.java:470)
	at org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter.flushSegment(SSTableIndexWriter.java:286)
	at org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter.complete(SSTableIndexWriter.java:151)
