### PR TITLE
CNDB-14460: Fix Nodes test flakiness resulting from unsafe interleaving of async operations in test scenarios

### DIFF
--- a/test/unit/org/apache/cassandra/nodes/NodesTest.java
+++ b/test/unit/org/apache/cassandra/nodes/NodesTest.java
@@ -100,6 +100,7 @@ public class NodesTest
     public void shutdownNodes() throws Throwable
     {
         Nodes.nodes().shutdown();
+        Nodes.nodes().awaitInflightUpdateCompletion();
     }
 
     @Test
@@ -196,7 +197,6 @@ public class NodesTest
         Nodes.peers().update(InetAddressAndPort.getByName("127.0.0.4"), NodesTest::fakePeer);
         assertNull(Nodes.peers().get(InetAddressAndPort.getByName("127.42.42.42")));
         Nodes.nodes().syncToDisk();
-        Nodes.nodes().shutdown();
 
         // Reopen the nodes to load the saved local and peer info
         Nodes.Instance.unsafeSetup(dir.toPath());
@@ -208,7 +208,6 @@ public class NodesTest
 
         Nodes.peers().remove(InetAddressAndPort.getByName("127.0.0.3"));
         Nodes.nodes().syncToDisk();
-        Nodes.nodes().shutdown();
 
         Nodes.Instance.unsafeSetup(dir.toPath());
 

--- a/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
+++ b/test/unit/org/apache/cassandra/nodes/virtual/LegacySystemKeyspaceToNodesTest.java
@@ -224,6 +224,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
         finally
         {
             nodes.shutdown();
+            nodes.awaitInflightUpdateCompletion();
         }
     }
 
@@ -304,6 +305,7 @@ public class LegacySystemKeyspaceToNodesTest extends CQLTester
         finally
         {
             nodes.shutdown();
+            nodes.awaitInflightUpdateCompletion();
         }
     }
 


### PR DESCRIPTION
### What is the issue
The singleton Nodes instance sequences operations that should not overlap by running them on a single-threaded executor. In some cases, these operations are executed in a synchronous manner, where the caller waits on the future. In other cases, they're executed asynchronously by queuing. In some tests, the singleton Nodes instance is shut down and replaced in an unsafe manner, to test cases where a node is restarted. This shut down does not terminate or wait on the executor, as the asynchronous tasks can safely be recovered on node restart. In the tests, however, these asynchronous operations can interleave with the newly created Nodes instance such that the operations no longer have the expected isolation, resulting in test failures.

Async operations can also interleave with the temporary directories backing a Nodes instance being deleted by Junit.

### What does this PR fix and why was it fixed
When unsafely replacing the singleton Nodes instance in tests, trigger a shutdown on the executors and await inflight tasks.

When shutting down at the end of a test, await inflight tasks.
