### PR TITLE
Revert preconditions added by CNDB-14481

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -491,28 +490,21 @@ public abstract class SegmentBuilder
         if (terms.isEmpty())
             return 0;
 
-        Preconditions.checkState(!flushed, "Cannot add to flushed segment");
-        Preconditions.checkArgument(sstableRowId >= maxSSTableRowId,
-                                    "rowId must be greater than or equal to the last rowId added: %s < %s", sstableRowId, maxSSTableRowId);
-        Preconditions.checkArgument(maxKey == null || key.compareTo(maxKey) >= 0,
-                                    "Key must be greater than or equal to the last key added: %s < %s", key, maxKey);
-
+        assert !flushed : "Cannot add to flushed segment.";
+        assert sstableRowId >= maxSSTableRowId;
         minSSTableRowId = minSSTableRowId < 0 ? sstableRowId : minSSTableRowId;
         maxSSTableRowId = sstableRowId;
 
+        assert maxKey == null || maxKey.compareTo(key) <= 0;
         minKey = minKey == null ? key : minKey;
         maxKey = key;
 
         // Update term boundaries for all terms in this row
         for (ByteBuffer term : terms)
         {
-            assert term != null : "term must not be null";
             minTerm = TypeUtil.min(term, minTerm, termComparator, Version.current());
             maxTerm = TypeUtil.max(term, maxTerm, termComparator, Version.current());
         }
-
-        assert minTerm != null : "minTerm should not be null at this point";
-        assert maxTerm != null : "maxTerm should not be null at this point";
 
         rowCount++;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -30,8 +30,6 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import com.google.common.base.Preconditions;
-
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
@@ -92,16 +90,14 @@ public class SegmentMetadataBuilder
 
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
     {
-        Preconditions.checkNotNull(minKey, "minKey must not be null");
-        Preconditions.checkNotNull(maxKey, "maxKey must not be null");
-        Preconditions.checkArgument(minKey.compareTo(maxKey) <= 0, "minKey (" + minKey + ") must not be greater than (" + maxKey + ')');
+        assert minKey.compareTo(maxKey) <= 0: "minKey (" + minKey + ") must not be greater than (" + maxKey + ')';
         this.minKey = minKey;
         this.maxKey = maxKey;
     }
 
     public void setRowIdRange(long minRowId, long maxRowId)
     {
-        Preconditions.checkArgument(minRowId <= maxRowId, "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')');
+        assert minRowId <= maxRowId: "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')';
         this.minRowId = minRowId;
         this.maxRowId = maxRowId;
     }
@@ -115,8 +111,6 @@ public class SegmentMetadataBuilder
      */
     public void setTermRange(@Nonnull ByteBuffer minTerm, @Nonnull ByteBuffer maxTerm)
     {
-        Preconditions.checkNotNull(minTerm, "minTerm must not be null");
-        Preconditions.checkNotNull(maxTerm, "maxTerm must not be null");
         this.minTerm = minTerm;
         this.maxTerm = maxTerm;
     }


### PR DESCRIPTION
To avoid the risk that stricter checking would break something,
this commit reverts changes to asserts / preconditions made
by CNDB-14481. The fix for the bug and the new tests added
by CNDB-14481 are left intact.
