### PR TITLE
CNDB-14477: Validate SAI Components in Verifier

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/Verifier.java
+++ b/src/java/org/apache/cassandra/db/compaction/Verifier.java
@@ -399,9 +399,6 @@ public class Verifier implements Closeable
         try
         {
             var indexManager = realm.getIndexManager();
-            if (indexManager == null && !sstable.metadata().indexes.isEmpty())
-                throw new IllegalStateException("Cannot verify index components for " + sstable + " because the index manager is not available");
-
             for (IndexMetadata indexMetadata : sstable.metadata().indexes)
             {
                 var index = indexManager.getIndexGroup(indexMetadata);

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -860,6 +860,21 @@ public interface Index
         Set<Component> activeComponents(SSTableReader sstable);
 
         /**
+         * Validate the sstable-attached components belonging to the group that are currently "active" for the
+         * provided sstable.
+         * <p>
+         * The "active" components are the components that are currently in use, meaning that if a given component
+         * of the sstable exists with multiple versions or generation on disk, only the most recent version/generation
+         * is the active one.
+         *
+         * @param sstable          the sstable to validate components for.
+         * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
+         *                         basic checks on the header and footers will be performed.
+         * @throws org.apache.cassandra.io.sstable.CorruptSSTableException if validation fails
+         */
+        void validateComponents(SSTableReader sstable, boolean validateChecksum);
+
+        /**
          * @return true if this index group is capable of supporting multiple contains restrictions, false otherwise
          */
         default boolean supportsMultipleContains()

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -862,7 +862,7 @@ public interface Index
 
         /**
          * Validate the sstable-attached components belonging to the group that are currently "active" for the
-         * provided sstable.
+         * provided sstable. Method is side effect free.
          * <p>
          * The "active" components are those returned by {@link #activeComponents}.
          *

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -864,9 +864,7 @@ public interface Index
          * Validate the sstable-attached components belonging to the group that are currently "active" for the
          * provided sstable.
          * <p>
-         * The "active" components are the components that are currently in use, meaning that if a given component
-         * of the sstable exists with multiple versions or generation on disk, only the most recent version/generation
-         * is the active one.
+         * The "active" components are those returned by {@link #activeComponents}.
          *
          * @param sstable          the sstable to validate components for.
          * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.lucene.index.CorruptIndexException;
 
 
 /**
@@ -870,9 +871,9 @@ public interface Index
          * @param sstable          the sstable to validate components for.
          * @param validateChecksum if {@code true}, the checksum of the components will be validated. Otherwise, only
          *                         basic checks on the header and footers will be performed.
-         * @throws org.apache.cassandra.io.sstable.CorruptSSTableException if validation fails
+         * @throws CorruptIndexException if the validation fails.
          */
-        void validateComponents(SSTableReader sstable, boolean validateChecksum);
+        void validateComponents(SSTableReader sstable, boolean validateChecksum) throws CorruptIndexException;
 
         /**
          * @return true if this index group is capable of supporting multiple contains restrictions, false otherwise

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -256,6 +256,11 @@ public interface IndexRegistry
             {
                 return null;
             }
+
+            @Override
+            public void validateComponents(SSTableReader sstable, boolean validateChecksum)
+            {
+            }
         };
 
         public void registerIndex(Index index, Index.Group.Key groupKey, Supplier<Index.Group> groupSupplier)

--- a/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/SingletonIndexGroup.java
@@ -147,4 +147,10 @@ public class SingletonIndexGroup implements Index.Group
         // Same rermarks as for `componentsForNewBuid`.
         return Collections.emptySet();
     }
+
+    @Override
+    public void validateComponents(SSTableReader sstable, boolean validateChecksum)
+    {
+        // Same remarks as for `componentsForNewBuid`.
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -314,14 +314,13 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     public void validateComponents(SSTableReader sstable, boolean validateChecksum) throws CorruptIndexException
     {
         IndexDescriptor indexDescriptor = descriptorFor(sstable);
-        if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, baseCfs.getTracker(), validateChecksum))
+        if (!indexDescriptor.perSSTableComponents().isValid(validateChecksum))
             throw new CorruptIndexException("Failed validation of per-SSTable components", sstable.getFilename());
 
         for (StorageAttachedIndex index : indices)
         {
             IndexContext ctx = index.getIndexContext();
-            if (!indexDescriptor.perIndexComponents(ctx)
-                                .validateComponents(sstable, baseCfs.getTracker(), validateChecksum))
+            if (!indexDescriptor.perIndexComponents(ctx).isValid(validateChecksum))
                 throw new CorruptIndexException("Failed validation of per-column components for " + ctx, sstable.getFilename());
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -414,7 +414,7 @@ public class IndexDescriptor
             for (IndexComponentType expected : expectedComponentsForVersion())
             {
                 var component = components.get(expected);
-                if (component == null)
+                if (component == null || !component.file().exists())
                 {
                     logger.warn(logMessage("Missing index component {} from SSTable {}"), expected, descriptor);
                     isValid = false;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -232,7 +232,7 @@ public class V1OnDiskFormat implements OnDiskFormat
     public boolean validateIndexComponent(IndexComponent.ForRead component, boolean checksum)
     {
         if (component.isCompletionMarker())
-            return true;
+            return component.file().exists();
 
         // starting with v3, vector components include proper headers and checksum; skip for earlier versions
         IndexContext context = component.parent().context();

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -232,7 +232,7 @@ public class V1OnDiskFormat implements OnDiskFormat
     public boolean validateIndexComponent(IndexComponent.ForRead component, boolean checksum)
     {
         if (component.isCompletionMarker())
-            return component.file().exists();
+            return true;
 
         // starting with v3, vector components include proper headers and checksum; skip for earlier versions
         IndexContext context = component.parent().context();

--- a/test/unit/org/apache/cassandra/index/CustomIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/CustomIndexTest.java
@@ -1687,6 +1687,11 @@ public class CustomIndexTest extends CQLTester
             {
                 return Collections.emptySet();
             }
+
+            @Override
+            public void validateComponents(SSTableReader sstable, boolean validateChecksum)
+            {
+            }
         }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.functional;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.Verifier;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class VerifyTest extends SAITester
+{
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+    }
+
+    @Before
+    public void setVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    private static final String TABLE = "verify_test";
+    private static final String INDEX_NAME = "value_idx";
+
+    @Before
+    public void setup()
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value int)");
+        createIndex("CREATE CUSTOM INDEX " + INDEX_NAME + " ON %s(value) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+    }
+
+    @Test
+    public void testVerifyCorrectSAIComponents()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with SAI components
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyExtendedSAIComponents()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with extended verification
+        try (Verifier verifier = new Verifier(cfs, sstable, false, 
+                                             Verifier.options()
+                                                    .invokeDiskFailurePolicy(true)
+                                                    .extendedVerification(true)
+                                                    .build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyCorruptSAIComponent() throws IOException
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Corrupt a component file (META component)
+        IndexComponentType componentToCorrupt = IndexComponentType.META;
+        File fileToCorrupt = indexDescriptor.perIndexComponents(indexContext).get(componentToCorrupt).file().toJavaIOFile();
+
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Truncate the file to corrupt it
+            file.setLength(3);
+        }
+
+        // Verify should detect the corruption
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testVerifyMissingCompletionMarker() throws IOException
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Delete the completion marker
+        boolean deleted = indexDescriptor.perIndexComponents(indexContext)
+                                         .get(IndexComponentType.COLUMN_COMPLETION_MARKER)
+                                         .file()
+                                         .tryDelete();
+        assertTrue("Failed to delete completion marker", deleted);
+
+        // Verify should detect the missing completion marker
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testVerifyQuickSkipsChecksumValidation()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify with quick option should skip checksum validation
+        try (Verifier verifier = new Verifier(cfs, sstable, false, 
+                                             Verifier.options()
+                                                    .invokeDiskFailurePolicy(true)
+                                                    .quick(true)
+                                                    .build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyAfterCompaction()
+    {
+        // Insert data and flush to create multiple SSTables
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        flush();
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        flush();
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        // Force compaction
+        CompactionManager.instance.performMaximal(cfs, false);
+
+        // Verify the compacted SSTable
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyMultipleIndices()
+    {
+        // Create a new table with multiple indices
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value1 int, value2 text)");
+        createIndex("CREATE CUSTOM INDEX value1_idx ON %s(value1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX value2_idx ON %s(value2) USING 'StorageAttachedIndex'");
+
+        // Insert data and flush
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (1, 100, 'text1')");
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (2, 200, 'text2')");
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (3, 300, 'text3')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with multiple indices
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyLiteralIndex()
+    {
+        // Create a table with a literal (text) column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, text_value text)");
+        createIndex("CREATE CUSTOM INDEX text_idx ON %s(text_value) USING 'StorageAttachedIndex'");
+
+        // Need to disable again because we created a new table
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with text values
+        execute("INSERT INTO %s (pk, text_value) VALUES (1, 'apple')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (2, 'banana')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (3, 'cherry')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with literal index
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyVectorIndex()
+    {
+        // Skip test if version doesn't support vector indexes
+        if (!version.onOrAfter(Version.JVECTOR_EARLIEST))
+            return;
+
+        // Create a table with a vector column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, vec vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX vector_idx ON %s(vec) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with vector values
+        execute("INSERT INTO %s (pk, vec) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (2, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (3, [3.0, 4.0, 5.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with vector index
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyCorruptVectorIndex() throws IOException
+    {
+        // Skip test if version doesn't support vector indexes
+        if (!version.onOrAfter(Version.JVECTOR_EARLIEST))
+            return;
+
+        // Create a table with a vector column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, vec vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX vector_idx ON %s(vec) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with vector values
+        execute("INSERT INTO %s (pk, vec) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (2, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (3, [3.0, 4.0, 5.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our vector index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Corrupt a component file
+        IndexComponentType componentToCorrupt = IndexComponentType.TERMS_DATA;
+        File fileToCorrupt = indexDescriptor.perIndexComponents(indexContext).get(componentToCorrupt).file().toJavaIOFile();
+
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Truncate the file to corrupt it
+            file.setLength(3);
+        }
+
+        // Verify should detect the corruption
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testVerifyAnalyzedTextIndex()
+    {
+        // Create a table with a text column and an analyzer
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, text_value text)");
+        createIndex("CREATE CUSTOM INDEX analyzed_idx ON %s(text_value) USING 'StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with text values
+        execute("INSERT INTO %s (pk, text_value) VALUES (1, 'The quick brown fox')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (2, 'jumps over the lazy dog')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (3, 'Lorem ipsum dolor sit amet')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with analyzed text index
+        try (Verifier verifier = new Verifier(cfs, sstable, false, Verifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    // Helper method to get the IndexContext from a StorageAttachedIndex
+    private IndexContext getIndexContext(StorageAttachedIndex index) throws RuntimeException
+    {
+        try
+        {
+            // Use reflection to access the indexContext field
+            java.lang.reflect.Field field = StorageAttachedIndex.class.getDeclaredField("indexContext");
+            field.setAccessible(true);
+            return (IndexContext) field.get(index);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to get IndexContext", e);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -352,7 +353,8 @@ public class VerifyTest extends SAITester
         }
     }
 
-    @Test
+    // TODO make test work by fixing https://github.com/riptano/cndb/issues/14501
+    @Ignore
     public void testVerifyCorruptVectorIndex() throws IOException
     {
         // Skip test if version doesn't support vector indexes


### PR DESCRIPTION
- **CNDB-14477: Validate SAI Components in Verifier**
- **Add follow up comment to vector corruption check**

### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14477

### What does this PR fix and why was it fixed
This PR leverages the existing SAI verification framework and wires it up to the `Verifier` logic in the code compaction code.
