### PR TITLE
CNDB-13437: add replacement API to TokenMetadata for token replacement with different address (#1666)

### DIFF
--- a/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/DynamicEndpointSnitch.java
@@ -476,8 +476,14 @@ public class DynamicEndpointSnitch extends AbstractEndpointSnitch implements Lat
     }
 
     @Override
-    public Predicate<Replica> filterByAffinity(String keyspace)
+    public Predicate<Replica> filterByAffinityForReads(String keyspace)
     {
-        return subsnitch.filterByAffinity(keyspace);
+        return subsnitch.filterByAffinityForReads(keyspace);
+    }
+
+    @Override
+    public Predicate<InetAddressAndPort> filterByAffinityForWrites(String keyspace)
+    {
+        return subsnitch.filterByAffinityForWrites(keyspace);
     }
 }

--- a/src/java/org/apache/cassandra/locator/IEndpointSnitch.java
+++ b/src/java/org/apache/cassandra/locator/IEndpointSnitch.java
@@ -118,11 +118,22 @@ public interface IEndpointSnitch
     }
 
     /**
-     * Filters the given {@code addresses} by affinity to the given keyspace.
+     * Filters the given {@code addresses} by affinity to the given keyspace for read requests.
      * <br/><br/>
      * Always returns true by default.
      */
-    default Predicate<Replica> filterByAffinity(String keyspace)
+    default Predicate<Replica> filterByAffinityForReads(String keyspace)
+    {
+        return replica -> true;
+    }
+
+
+    /**
+     * Filters the given {@code addresses} by affinity to the given keyspace for write requests.
+     * <br/><br/>
+     * Always returns true by default.
+     */
+    default Predicate<InetAddressAndPort> filterByAffinityForWrites(String keyspace)
     {
         return replica -> true;
     }

--- a/src/java/org/apache/cassandra/locator/ReplicaPlans.java
+++ b/src/java/org/apache/cassandra/locator/ReplicaPlans.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -66,7 +67,6 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.service.reads.AlwaysSpeculativeRetryPolicy;
 import org.apache.cassandra.service.reads.SpeculativeRetryPolicy;
 import org.apache.cassandra.utils.FBUtilities;
-
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.filter;
@@ -245,12 +245,16 @@ public class ReplicaPlans
         IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
         Multimap<String, InetAddressAndPort> localEndpoints = HashMultimap.create(topology.getDatacenterRacks()
                                                                                           .get(snitch.getLocalDatacenter()));
+
         // Replicas are picked manually:
         //  - replicas should be alive according to the failure detector
         //  - replicas should be in the local datacenter
         //  - choose min(2, number of qualifying candiates above)
         //  - allow the local node to be the only replica only if it's a single-node DC
         Collection<InetAddressAndPort> chosenEndpoints = filterBatchlogEndpoints(preferLocalRack, snitch.getLocalRack(), localEndpoints);
+
+        Predicate<InetAddressAndPort> endpointPredicate = snitch.filterByAffinityForWrites(keyspaceName);
+        chosenEndpoints = chosenEndpoints.stream().filter(endpointPredicate).collect(Collectors.toSet());;
 
         // Batchlog is hosted by either one node or two nodes from different racks.
         ConsistencyLevel consistencyLevel = chosenEndpoints.size() == 1 ? ConsistencyLevel.ONE : ConsistencyLevel.TWO;
@@ -472,6 +476,12 @@ public class ReplicaPlans
     {
         assert liveAndDown.replicationStrategy() == live.replicationStrategy()
                : "ReplicaLayout liveAndDown and live should be derived from the same replication strategy.";
+
+        // used by CNDB to filter out write replicas
+        IEndpointSnitch endpointSnitch = DatabaseDescriptor.getEndpointSnitch();
+        Predicate<InetAddressAndPort> writeEndpointFilter = endpointSnitch.filterByAffinityForWrites(keyspace.getName());
+        live = live.filter(r -> writeEndpointFilter.test(r.endpoint()));
+
         AbstractReplicationStrategy replicationStrategy = liveAndDown.replicationStrategy();
         EndpointsForToken contacts = selector.select(consistencyLevel, liveAndDown, live);
         assureSufficientLiveReplicasForWrite(replicationStrategy, consistencyLevel, live.all(), liveAndDown.pending());
@@ -724,9 +734,9 @@ public class ReplicaPlans
         AbstractReplicationStrategy replicationStrategy = keyspace.getReplicationStrategy();
         IEndpointSnitch endpointSnitch = DatabaseDescriptor.getEndpointSnitch();
         EndpointsForToken candidates = candidatesForRead(keyspace, indexQueryPlan, consistencyLevel, ReplicaLayout.forTokenReadLiveSorted(replicationStrategy, token).natural())
-                                       .filter(endpointSnitch.filterByAffinity(keyspace.getName()));
+                                       .filter(endpointSnitch.filterByAffinityForReads(keyspace.getName()));
         EndpointsForToken contacts = contactForRead(replicationStrategy, consistencyLevel, retry.equals(AlwaysSpeculativeRetryPolicy.INSTANCE), candidates)
-                                     .filter(endpointSnitch.filterByAffinity(keyspace.getName()));
+                                     .filter(endpointSnitch.filterByAffinityForReads(keyspace.getName()));
 
         assureSufficientLiveReplicasForRead(replicationStrategy, consistencyLevel, contacts);
         return new ReplicaPlan.ForTokenRead(keyspace, replicationStrategy, consistencyLevel, candidates, contacts);
@@ -748,9 +758,9 @@ public class ReplicaPlans
         AbstractReplicationStrategy replicationStrategy = keyspace.getReplicationStrategy();
         IEndpointSnitch endpointSnitch = DatabaseDescriptor.getEndpointSnitch();
         EndpointsForRange candidates = candidatesForRead(keyspace, indexQueryPlan, consistencyLevel, ReplicaLayout.forRangeReadLiveSorted(replicationStrategy, range).natural())
-                                       .filter(endpointSnitch.filterByAffinity(keyspace.getName()));
+                                       .filter(endpointSnitch.filterByAffinityForReads(keyspace.getName()));
         EndpointsForRange contacts = contactForRead(replicationStrategy, consistencyLevel, false, candidates)
-                                     .filter(endpointSnitch.filterByAffinity(keyspace.getName()));
+                                     .filter(endpointSnitch.filterByAffinityForReads(keyspace.getName()));
 
         assureSufficientLiveReplicasForRead(replicationStrategy, consistencyLevel, contacts);
         return new ReplicaPlan.ForRangeRead(keyspace, replicationStrategy, consistencyLevel, range, candidates, contacts, vnodeCount);

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2002,7 +2002,7 @@ public class StorageProxy implements StorageProxyMBean
         // CASSANDRA-13043: filter out those endpoints not accepting clients yet, maybe because still bootstrapping
         // We have a keyspace, so filter by affinity too
         replicas = replicas.filter(IFailureDetector.isReplicaAlive)
-                           .filter(snitch.filterByAffinity(keyspace.getName()));
+                           .filter(snitch.filterByAffinityForReads(keyspace.getName()));
 
         // CASSANDRA-17411: filter out endpoints that are not alive
         replicas = replicas.filter(replica -> FailureDetector.instance.isAlive(replica.endpoint()));

--- a/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
+++ b/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.locator;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.UUID;
@@ -40,6 +41,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.service.StorageService;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
@@ -393,5 +395,54 @@ public class TokenMetadataTest
         ver = metadata.getRingVersion();
         metadata.removeEndpoint(ep3);
         assertEquals(ver, metadata.getRingVersion());
+    }
+
+    @Test
+    public void testUpdateAddressForNormalTokens() throws UnknownHostException
+    {
+        final InetAddressAndPort first = InetAddressAndPort.getByName("127.0.0.1");
+        final InetAddressAndPort second = InetAddressAndPort.getByName("127.0.0.6");
+
+        tmd.updateNormalToken(token(ONE), first);
+        tmd.updateNormalToken(token(SIX), second);
+
+        assertEquals(tmd.getTokens(first).size(), 1);
+        assertEquals(tmd.getTokens(first).iterator().next(), token(ONE));
+
+        assertEquals(tmd.getTokens(second).size(), 1);
+        assertEquals(tmd.getTokens(second).iterator().next(), token(SIX));
+
+        InetAddressAndPort updatedNode = InetAddressAndPort.getByName("127.0.0.10");
+        assertThatThrownBy(() -> tmd.updateAddressForNormalTokens(Collections.singleton(token(SIX)), first, updatedNode))
+                          .hasMessageContaining("different set of tokens");
+        tmd.updateAddressForNormalTokens(Collections.singleton(token(ONE)), first, updatedNode);
+
+        assertEquals(tmd.getTokens(updatedNode).size(), 1);
+        assertEquals(tmd.getTokens(updatedNode).iterator().next(), token(ONE));
+
+        assertEquals(tmd.getTokens(second).size(), 1);
+        assertEquals(tmd.getTokens(second).iterator().next(), token(SIX));
+    }
+
+    @Test
+    public void testUpdateAddressForHostId() throws UnknownHostException
+    {
+        final InetAddressAndPort first = InetAddressAndPort.getByName("127.0.0.1");
+        UUID firstId = UUID.randomUUID();
+
+        final InetAddressAndPort second = InetAddressAndPort.getByName("127.0.0.6");
+        UUID secondId = UUID.randomUUID();
+
+        tmd.updateHostId(firstId, first);
+        tmd.updateHostId(secondId, second);
+
+        assertEquals(tmd.getHostId(first), firstId);
+        assertEquals(tmd.getHostId(second), secondId);
+
+        InetAddressAndPort updatedNode = InetAddressAndPort.getByName("127.0.0.10");
+        tmd.updateAddressForHostId(secondId, second, updatedNode);
+
+        assertEquals(tmd.getHostId(first), firstId);
+        assertEquals(tmd.getHostId(updatedNode), secondId);
     }
 }


### PR DESCRIPTION
- add `IEndpointSnitch#filterByAffinityForWrite` and rename `filterByAffinity` to `filterByAffinityForReads`
