### PR TITLE
CNDB-13978: Don't count tombstones in DataLimits.Counter.CQLCounter#bytesCounted (#1735)

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -24,16 +24,11 @@ import java.util.List;
 import java.util.StringJoiner;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.db.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.PageSize;
-import org.apache.cassandra.db.Clustering;
-import org.apache.cassandra.db.ClusteringComparator;
-import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.db.Slices;
-import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.aggregation.AggregationSpecification;
 import org.apache.cassandra.db.aggregation.GroupMaker;
 import org.apache.cassandra.db.aggregation.GroupingState;
@@ -633,14 +628,14 @@ public abstract class DataLimits
             {
                 rowsInCurrentPartition = 0;
                 hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.dataSize() : 0;
+                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.originalDataSize() : 0;
             }
 
             @Override
             public Row applyToRow(Row row)
             {
                 if (isLive(row))
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
                 return row;
             }
 
@@ -1115,7 +1110,7 @@ public abstract class DataLimits
                     }
                     hasReturnedRowsFromCurrentPartition = false;
                     hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                    staticRowBytes = hasLiveStaticRow ? staticRow.dataSize() : 0;
+                    staticRowBytes = hasLiveStaticRow ? staticRow.originalDataSize() : 0;
                 }
                 currentPartitionKey = partitionKey;
                 // If we are done we need to preserve the groupInCurrentPartition and rowsCountedInCurrentPartition
@@ -1181,7 +1176,7 @@ public abstract class DataLimits
                 if (isLive(row))
                 {
                     hasUnfinishedGroup = true;
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
                     hasReturnedRowsFromCurrentPartition = true;
                 }
 

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -325,6 +325,14 @@ public interface Row extends Unfiltered, Iterable<ColumnData>, IMeasurableMemory
 
     public int dataSize();
 
+    /**
+     * Returns the original data size in bytes of this row as it was returned by {@link #dataSize()} before purging it
+     * from all deletion info with {@link #purge}.
+     *
+     * @return the original data size of this row in bytes before purging
+     */
+    int originalDataSize();
+
     public long unsharedHeapSizeExcludingData();
 
     public String toString(TableMetadata metadata, boolean fullDetails);

--- a/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
@@ -286,6 +286,12 @@ public class RowWithSourceTable implements Row
     }
 
     @Override
+    public int originalDataSize()
+    {
+        return row.originalDataSize();
+    }
+
+    @Override
     public long unsharedHeapSizeExcludingData()
     {
         return row.unsharedHeapSizeExcludingData() + EMPTY_SIZE;


### PR DESCRIPTION
Modify CQL counters calculation of rows data size to include cell deletions even after the row has been purged. That way, the counters will count the same size in bytes for filtered and unfiltered base partition/row iterators.

This solves a bug where byte-based paging is wrongly considering replicas as exhausted if their responses contain tombstones. This leads to queries using byte-based paging returning fewer rows than expected. It includes all aggregation queries, where byte-based paging is always used internally. The problem is that replicas apply counters to unfiltered iterators, whereas the coordinator controls paging by applying counters to reconciled and filtered iterators.
