### PR TITLE
CNDB-14153: Fix SAI updates (non-null solution) (#1751)

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemtableIndexTestBase.java
@@ -289,14 +289,13 @@ public abstract class TrieMemtableIndexTestBase extends SAITester
         // Update row 1 to remove 2 and 3, keep 1, add 7 and 8 (note we have to manually match the 1,2,3 from above)
         updateRowWithCollection(1, List.of(1, 2, 3).iterator(), List.of(1, 7, 8).iterator());
 
-        // We net 1 new PrimaryKeys object.
-        expectedOnHeap += PrimaryKeys.unsharedHeapSize();
+        // We get 2 new PrimaryKeys objects.
+        expectedOnHeap += PrimaryKeys.unsharedHeapSize() * 2;
         assertEquals(expectedOnHeap, trieMemoryIndex.estimatedTrieValuesMemoryUsed());
 
         updateRowWithCollection(1, List.of(1, 7, 8).iterator(), List.of(1, 4, 8).iterator());
 
-        // We remove a PrimaryKeys object without adding any new keys to the trie.
-        expectedOnHeap -= PrimaryKeys.unsharedHeapSize();
+        // For now, we don't remove the old PrimaryKeys objects, so we don't change the heap size
         assertEquals(expectedOnHeap, trieMemoryIndex.estimatedTrieValuesMemoryUsed());
 
         // Run additional queries to ensure values


### PR DESCRIPTION
- **Add failing test**
- **CNDB-14153: Fix SAI updates (non-null solution)**

### What is the issue
Fixes https://github.com/riptano/cndb/issues/14153

### What does this PR fix and why was it fixed
This is meant as an alternative to
https://github.com/datastax/cassandra/pull/1749. It fixes https://github.com/riptano/cndb/issues/14153 by never returning `null` from the `UpsertTransformer`.

#1749 is a more memory efficient solution, but has additional complexity, which is why I am proposing this as an alternative.
