### PR TITLE
CNDB-14614-re-merge: abort compaction task or index build if index is unloaded after tenant unassignment (#1766)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -70,7 +70,8 @@ public class SSTableIndexWriter implements PerIndexWriter
     private final IndexContext indexContext;
     private final long nowInSec = FBUtilities.nowInSeconds();
     private final NamedMemoryLimiter limiter;
-    private final BooleanSupplier isIndexValid;
+    private final BooleanSupplier isIndexDropped;
+    private final BooleanSupplier isIndexUnloaded;
     private final long keyCount;
 
     private boolean aborted = false;
@@ -79,13 +80,15 @@ public class SSTableIndexWriter implements PerIndexWriter
     private SegmentBuilder currentBuilder;
     private final List<SegmentMetadata> segments = new ArrayList<>();
 
-    public SSTableIndexWriter(IndexComponents.ForWrite perIndexComponents, NamedMemoryLimiter limiter, BooleanSupplier isIndexValid, long keyCount)
+    public SSTableIndexWriter(IndexComponents.ForWrite perIndexComponents, NamedMemoryLimiter limiter,
+                              BooleanSupplier isIndexDropped, BooleanSupplier isIndexUnloaded, long keyCount)
     {
         this.perIndexComponents = perIndexComponents;
         this.indexContext = perIndexComponents.context();
         Preconditions.checkNotNull(indexContext, "Provided components %s are the per-sstable ones, expected per-index ones", perIndexComponents);
         this.limiter = limiter;
-        this.isIndexValid = isIndexValid;
+        this.isIndexDropped = isIndexDropped;
+        this.isIndexUnloaded = isIndexUnloaded;
         this.keyCount = keyCount;
     }
 
@@ -224,11 +227,23 @@ public class SSTableIndexWriter implements PerIndexWriter
         if (aborted)
             return true;
 
-        if (isIndexValid.getAsBoolean())
+        boolean dropped = isIndexDropped.getAsBoolean();
+        boolean unloaded = isIndexUnloaded.getAsBoolean();
+        if (!dropped && !unloaded)
             return false;
 
-        abort(new RuntimeException(String.format("index %s is dropped", indexContext.getIndexName())));
-        return true;
+        String message = String.format("index %s is %s", indexContext.getIndexName(), dropped ? "dropped" : "unloaded");
+        RuntimeException runtimeException = new RuntimeException(message);
+
+        // abort index build for remove on disk index file
+        abort(runtimeException);
+
+        // if index is dropped, we can continue compaction task or index build without current index
+        if (dropped)
+            return true;
+
+        // if index is unloaded after unassigning tenant, fail the compaction task or index build to avoid incomplete index files
+        throw runtimeException;
     }
 
     private boolean addTerm(ByteBuffer term, PrimaryKey key, long sstableRowId, AbstractType<?> type) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -209,7 +209,7 @@ public class V1OnDiskFormat implements OnDiskFormat
             logger.debug(index.getIndexContext().logMessage("Starting a compaction index build. Global segment memory usage: {}"),
                          prettyPrintMemory(limiter.currentBytesUsed()));
 
-            return new SSTableIndexWriter(perIndexComponents, limiter, index.isIndexValid(), keyCount);
+            return new SSTableIndexWriter(perIndexComponents, limiter, index.isDropped(), index.isUnloaded(), keyCount);
         }
 
         return new MemtableIndexWriter(context.getPendingMemtableIndex(tracker),

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -155,7 +155,7 @@ public class SegmentFlushTest
                                                      MockSchema.newCFS("ks"));
 
         IndexComponents.ForWrite components = indexDescriptor.newPerIndexComponentsForWrite(indexContext);
-        SSTableIndexWriter writer = new SSTableIndexWriter(components, V1OnDiskFormat.SEGMENT_BUILD_MEMORY_LIMITER, () -> true, 2);
+        SSTableIndexWriter writer = new SSTableIndexWriter(components, V1OnDiskFormat.SEGMENT_BUILD_MEMORY_LIMITER, () -> false, () -> false, 2);
 
         List<DecoratedKey> keys = Arrays.asList(dk("1"), dk("2"));
         Collections.sort(keys);


### PR DESCRIPTION
When schema is unloaded after tenant unassignment, compaction task might finishes without corresponding index files, making index non-queryable.

Replace `isValid` with `isDropped` and `isUnloaded`. If index is dropped, compaction task or index build can proceed without the index, same behavior as before. If index is unloaded, compaction task or index build will be aborted to avoid completing without index files.

---

https://github.com/datastax/cassandra/pull/1754 was reverted because[ CNDB PR](https://github.com/riptano/cndb/pull/14179) compiled failed with wrong hash. Re-merge it again.

