### PR TITLE
CNDB-141284: use `ByteBuffer.remaining` instead of `limit` to asset size (#1755)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -252,7 +252,7 @@ public class TrieMemoryIndex extends MemoryIndex
 
                 try
                 {
-                    data.putSingleton(encodedTerm, primaryKey, transformer, term.limit() <= MAX_RECURSIVE_KEY_LENGTH);
+                    data.putSingleton(encodedTerm, primaryKey, transformer, term.remaining() <= MAX_RECURSIVE_KEY_LENGTH);
                 }
                 catch (TrieSpaceExhaustedException e)
                 {


### PR DESCRIPTION
The data inserted into the trie in `TrieMemoryIndex` is `encodedTerm`, which is built from `term` and only on the "available" bytes (between `term.position()` and `term.limit()`). But the check that decides to use the (more efficient) recursive path or not uses `term.limit()` to assess the size of `encodedTerm`. If `term.position()` is not 0, this is incorrect, and can lead to using the less optimal pass completely unecessarily. This has been shown to happen when investigating https://github.com/riptano/cndb/issues/14153: the non-recursive path was taken even for boolean values (because the nodes were using `offheap_buffers`; with `offheap_objects`, the buffers getting to `TriMemoryIndex` are 0-positioned).

See https://github.com/riptano/cndb/issues/14184.
