### PR TITLE
CNDB-14167: Set jvector_version on disk file format to 2 (#1757) (#1760)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -705,7 +705,7 @@ public enum CassandraRelevantProperties
     /** Controls the maximum number of index query intersections that will take part in a query */
     SAI_INTERSECTION_CLAUSE_LIMIT("cassandra.sai.intersection_clause_limit", "2"),
 
-    SAI_JVECTOR_VERSION("cassandra.sai.jvector_version", "4"),
+    SAI_JVECTOR_VERSION("cassandra.sai.jvector_version", "2"),
 
     /** Latest version to be used for SAI index writing */
     SAI_LATEST_VERSION("cassandra.sai.latest_version", "dc"),

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorDotProductWithLengthTest.java
@@ -34,7 +34,8 @@ public class VectorDotProductWithLengthTest extends VectorTester
     {
         super.setup();
         // we are testing unit vector detection which is part of the v3 changes, but continues in all subsequent versions
-        assert V3OnDiskFormat.JVECTOR_VERSION >= 3 : "This test assumes JVector version 3 or greater";
+        if (V3OnDiskFormat.JVECTOR_VERSION < 4)
+            V3OnDiskFormat.JVECTOR_VERSION = 4;
     }
 
     // This tests our detection of unit-length vectors used with dot product and PQ.


### PR DESCRIPTION
Fixes: https://github.com/riptano/cndb/issues/14167

We upgraded to jvector 4 too soon. We need to use jvector 2 for a release cycle and then when we upgrade next, we can go to jvector 4. We needed a two phase release.

CNDB test PR: https://github.com/riptano/cndb/pull/14196
