### PR TITLE
CNDB-13724: reduce num of test keys in LongVectorTest to avoid jenkins timeout

### DIFF
--- a/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
+++ b/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
@@ -40,6 +40,7 @@ public class LongVectorTest extends SAITester
 {
     private static final Logger logger = org.slf4j.LoggerFactory.getLogger(LongVectorTest.class);
 
+    int numKeys = 100_000;
     int dimension = 16; // getRandom().nextIntBetween(128, 768);
 
     KeySet keysInserted = new KeySet();
@@ -67,7 +68,7 @@ public class LongVectorTest extends SAITester
         AtomicInteger counter = new AtomicInteger();
         long start = System.currentTimeMillis();
         var fjp = new ForkJoinPool(threadCount);
-        var keys = IntStream.range(0, 10_000_000).boxed().collect(Collectors.toList());
+        var keys = IntStream.range(0, numKeys).boxed().collect(Collectors.toList());
         Collections.shuffle(keys);
         var task = fjp.submit(() -> keys.stream().parallel().forEach(i ->
         {


### PR DESCRIPTION
### What is the issue

#13724 

### What does this PR fix and why was it fixed

reduce num of test keys and less flushes. Reduce the chances of hitting "too many open files"
