### PR TITLE
CNDB-14586: Fix StorageHandlerTest#testOnOpeningWrittenSSTableFailure on bigtable

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/StorageHandlerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/StorageHandlerTest.java
@@ -88,9 +88,10 @@ public class StorageHandlerTest
 
     @Test
     @BMRules(rules = {
-        @BMRule(name = "Fail reading partition index",
-                targetClass = "PartitionIndex",
-                targetMethod = "load",
+        @BMRule(name = "Fail opening reader",
+                isOverriding = true,
+                targetClass = "SortedTableWriter",
+                targetMethod = "openReader",
                 action = "throw new RuntimeException(\"Problem reading\")")
         }
     )


### PR DESCRIPTION
### What is the issue
This test injects a failure on opening written sstables using byteman. The injection point is only called for trie-index sstables, so the test fails on bigtable, as the expected error isn't thrown.

### What does this PR fix and why was it fixed
This PR retargets the failure injection to a shared method in the hierarchy of trie-index and bigtable sstables. This ensures we see the expected failure for both sstable families.
