### PR TITLE
CNDB-14602: Fix bytes-based paging for partition deletions

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -625,14 +625,14 @@ public abstract class DataLimits
             {
                 rowsInCurrentPartition = 0;
                 hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.originalDataSize() : 0;
+                staticRowBytes = hasLiveStaticRow && bytesLimit != NO_LIMIT ? staticRow.dataSizeBeforePurge() : 0;
             }
 
             @Override
             public Row applyToRow(Row row)
             {
                 if (isLive(row))
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSizeBeforePurge() : 0);
                 return row;
             }
 
@@ -1107,7 +1107,7 @@ public abstract class DataLimits
                     }
                     hasReturnedRowsFromCurrentPartition = false;
                     hasLiveStaticRow = !staticRow.isEmpty() && isLive(staticRow);
-                    staticRowBytes = hasLiveStaticRow ? staticRow.originalDataSize() : 0;
+                    staticRowBytes = hasLiveStaticRow ? staticRow.dataSizeBeforePurge() : 0;
                 }
                 currentPartitionKey = partitionKey;
                 // If we are done we need to preserve the groupInCurrentPartition and rowsCountedInCurrentPartition
@@ -1173,7 +1173,7 @@ public abstract class DataLimits
                 if (isLive(row))
                 {
                     hasUnfinishedGroup = true;
-                    incrementRowCount(bytesLimit != NO_LIMIT ? row.originalDataSize() : 0);
+                    incrementRowCount(bytesLimit != NO_LIMIT ? row.dataSizeBeforePurge() : 0);
                     hasReturnedRowsFromCurrentPartition = true;
                 }
 

--- a/src/java/org/apache/cassandra/db/rows/BTreeRow.java
+++ b/src/java/org/apache/cassandra/db/rows/BTreeRow.java
@@ -531,7 +531,7 @@ public class BTreeRow extends AbstractRow
         return update(info, deletion, BTree.transformAndFilter(btree, function), false);
     }
 
-    private Row update(LivenessInfo info, Deletion deletion, Object[] newTree, boolean preserveOriginalDataSize)
+    private Row update(LivenessInfo info, Deletion deletion, Object[] newTree, boolean preserveDataSizeBeforePurge)
     {
         if (btree == newTree && info == this.primaryKeyLivenessInfo && deletion == this.deletion)
             return this;
@@ -541,7 +541,7 @@ public class BTreeRow extends AbstractRow
 
         int minDeletionTime = minDeletionTime(newTree, info, deletion.time());
 
-        int dataSizeBeforePurge = preserveOriginalDataSize ? dataSizeBeforePurge() : -1;
+        int dataSizeBeforePurge = preserveDataSizeBeforePurge ? dataSizeBeforePurge() : -1;
         return BTreeRow.create(clustering, info, deletion, newTree, minDeletionTime, dataSizeBeforePurge);
     }
 

--- a/src/java/org/apache/cassandra/db/rows/BTreeRow.java
+++ b/src/java/org/apache/cassandra/db/rows/BTreeRow.java
@@ -91,14 +91,14 @@ public class BTreeRow extends AbstractRow
     /**
      * The original data size of this row before purging it, or -1 if it hasn't been purged.
      */
-    private final int originalDataSize;
+    private final int dataSizeBeforePurge;
 
     private BTreeRow(Clustering<?> clustering,
                      LivenessInfo primaryKeyLivenessInfo,
                      Deletion deletion,
                      Object[] btree,
                      int minLocalDeletionTime,
-                     int originalDataSize)
+                     int dataSizeBeforePurge)
     {
         assert !deletion.isShadowedBy(primaryKeyLivenessInfo);
         this.clustering = clustering;
@@ -106,7 +106,7 @@ public class BTreeRow extends AbstractRow
         this.deletion = deletion;
         this.btree = btree;
         this.minLocalDeletionTime = minLocalDeletionTime;
-        this.originalDataSize = originalDataSize;
+        this.dataSizeBeforePurge = dataSizeBeforePurge;
     }
 
     private BTreeRow(Clustering<?> clustering,
@@ -144,9 +144,9 @@ public class BTreeRow extends AbstractRow
                                   Deletion deletion,
                                   Object[] btree,
                                   int minDeletionTime,
-                                  int originalDataSize)
+                                  int dataSizeBeforePurge)
     {
-        return new BTreeRow(clustering, primaryKeyLivenessInfo, deletion, btree, minDeletionTime, originalDataSize);
+        return new BTreeRow(clustering, primaryKeyLivenessInfo, deletion, btree, minDeletionTime, dataSizeBeforePurge);
     }
 
     public static BTreeRow create(Clustering<?> clustering,
@@ -508,6 +508,7 @@ public class BTreeRow extends AbstractRow
              : new BTreeRow(clustering, primaryKeyLivenessInfo, Deletion.regular(newDeletion), btree, Integer.MIN_VALUE);
     }
 
+    @Override
     public Row purge(DeletionPurger purger, int nowInSec, boolean enforceStrictLiveness)
     {
         if (!hasDeletion(nowInSec))
@@ -520,16 +521,17 @@ public class BTreeRow extends AbstractRow
         if (enforceStrictLiveness && newDeletion.isLive() && newInfo.isEmpty())
             return null;
 
-        return transformAndFilter(newInfo, newDeletion, (cd) -> cd.purge(purger, nowInSec));
+        Function<ColumnData, ColumnData> columnDataPurger = (cd) -> cd.purge(purger, nowInSec);
+        return update(newInfo, newDeletion, BTree.transformAndFilter(btree, columnDataPurger), true);
     }
 
     @Override
     public Row transformAndFilter(LivenessInfo info, Deletion deletion, Function<ColumnData, ColumnData> function)
     {
-        return update(info, deletion, BTree.transformAndFilter(btree, function));
+        return update(info, deletion, BTree.transformAndFilter(btree, function), false);
     }
 
-    private Row update(LivenessInfo info, Deletion deletion, Object[] newTree)
+    private Row update(LivenessInfo info, Deletion deletion, Object[] newTree, boolean preserveOriginalDataSize)
     {
         if (btree == newTree && info == this.primaryKeyLivenessInfo && deletion == this.deletion)
             return this;
@@ -538,7 +540,9 @@ public class BTreeRow extends AbstractRow
             return null;
 
         int minDeletionTime = minDeletionTime(newTree, info, deletion.time());
-        return BTreeRow.create(clustering, info, deletion, newTree, minDeletionTime, originalDataSize());
+
+        int dataSizeBeforePurge = preserveOriginalDataSize ? dataSizeBeforePurge() : -1;
+        return BTreeRow.create(clustering, info, deletion, newTree, minDeletionTime, dataSizeBeforePurge);
     }
 
     @Override
@@ -549,7 +553,7 @@ public class BTreeRow extends AbstractRow
 
     public Row transform(Function<ColumnData, ColumnData> function)
     {
-        return update(primaryKeyLivenessInfo, deletion, BTree.transform(btree, function));
+        return update(primaryKeyLivenessInfo, deletion, BTree.transform(btree, function), false);
     }
 
     @Override
@@ -569,9 +573,9 @@ public class BTreeRow extends AbstractRow
     }
 
     @Override
-    public int originalDataSize()
+    public int dataSizeBeforePurge()
     {
-        return originalDataSize >= 0 ? originalDataSize : dataSize();
+        return dataSizeBeforePurge >= 0 ? dataSizeBeforePurge : dataSize();
     }
 
     public long unsharedHeapSizeExcludingData()

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -315,7 +315,7 @@ public interface Row extends Unfiltered, Iterable<ColumnData>
      *
      * @return the original data size of this row in bytes before purging
      */
-    int originalDataSize();
+    int dataSizeBeforePurge();
 
     public long unsharedHeapSizeExcludingData();
 

--- a/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
@@ -280,9 +280,9 @@ public class RowWithSourceTable implements Row
     }
 
     @Override
-    public int originalDataSize()
+    public int dataSizeBeforePurge()
     {
-        return row.originalDataSize();
+        return row.dataSizeBeforePurge();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/cql3/PagingAggregationQueryTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PagingAggregationQueryTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.assertj.core.api.Assertions;
+
+@RunWith(Parameterized.class)
+public class PagingAggregationQueryTest extends CQLTester
+{
+    public static final int NUM_PARTITIONS = 100;
+
+    @Parameterized.Parameters(name = "aggregation_sub_page_size={0} data_size={1} flush={2}")
+    public static Collection<Object[]> generateParameters()
+    {
+        List<Object[]> params = new ArrayList<>();
+        for (PageSize pageSize : Arrays.asList(PageSize.inBytes(1024), PageSize.NONE))
+            for (DataSize dataSize : DataSize.values())
+                for (boolean flush : new boolean[]{ true, false })
+                    params.add(new Object[]{ pageSize, dataSize, flush });
+        return params;
+    }
+
+    /**
+     * The regular column value to be inserted.
+     * It will use different sizes to change the number of rows that fit in a page.
+     */
+    private final ByteBuffer value;
+
+    /**
+     * Whether to flush after each type of mutation.
+     */
+    private final boolean flush;
+
+    public enum DataSize
+    {
+        NULL(-1),
+        SMALL(10), // multiple rows per page
+        LARGE(2000); // one row per page
+
+        private final int size;
+
+        DataSize(int size)
+        {
+            this.size = size;
+        }
+
+        public ByteBuffer value()
+        {
+            return size == -1 ? null : ByteBuffer.allocate(size);
+        }
+    }
+
+    public PagingAggregationQueryTest(PageSize subPageSize, DataSize dataSize, boolean flush)
+    {
+        DatabaseDescriptor.setAggregationSubPageSize(subPageSize);
+        this.value = dataSize.value();
+        this.flush = flush;
+        enableCoordinatorExecution();
+    }
+
+    /**
+     * DSP-22813, DBPE-16245, DBPE-16378 and CNDB-13978: Test that count(*) aggregation queries return the correct
+     * number of rows, even if there are tombstones and paging is required.
+     * </p>
+     * Before the DSP-22813/DBPE-16245/DBPE-16378/CNDB-13978 fix these queries would stop counting after hitting the
+     * {@code aggregation_sub_page_size} page size, returning only the count of a single page.
+     */
+    @Test
+    public void testAggregationWithCellTomsbstones()
+    {
+        // we are only interested in the NULL value case, which produces cell tombstones
+        Assume.assumeTrue(value == null && !flush);
+
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v blob, PRIMARY KEY (k, c1, c2))");
+
+        int ks = 13;
+        int c1s = 17;
+        int c2s = 19;
+
+        // insert some data
+        for (int k = 0; k < ks; k++)
+        {
+            for (int c1 = 0; c1 < c1s; c1++)
+            {
+                for (int c2 = 0; c2 < c2s; c2++)
+                {
+                    execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, null)", k, c1, c2);
+                }
+            }
+
+            // test aggregation on single partition query
+            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
+            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
+            Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(c1s * c2s);
+        }
+
+        // test aggregation on range query
+        int numRows = execute("SELECT * FROM %s").size();
+        long count = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
+        Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(ks * c1s * c2s);
+
+        // test aggregation with group by
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k").size()).isEqualTo(ks);
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1").size()).isEqualTo(ks * c1s);
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1, c2").size()).isEqualTo(ks * c1s * c2s);
+    }
+
+    @Test
+    public void testAggregationWithRowDeletions()
+    {
+        createTable("CREATE TABLE %s (k bigint, c int, v blob, PRIMARY KEY(k, c))");
+
+        int numClusterings = 7;
+
+        // insert some clusterings, and flush
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            // insert some clusterings
+            for (int c = 1; c <= numClusterings; c++)
+            {
+                execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", k, c, value);
+            }
+        }
+        maybeFlush();
+
+        // for each partition, delete the first and last clustering
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            execute("DELETE FROM %s WHERE k = ? AND c = ?", k, 1);
+            execute("DELETE FROM %s WHERE k = ? AND c = ?", k, numClusterings);
+
+            // test aggregation on single partition query
+            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
+            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
+            Assertions.assertThat(count)
+                      .isEqualTo(numRows)
+                      .isEqualTo(numClusterings - 2);
+            long maxK = execute("SELECT max(k) FROM %s WHERE k=?", k).one().getLong("system.max(k)");
+            Assertions.assertThat(maxK).isEqualTo(k);
+            int maxC = execute("SELECT max(c) FROM %s WHERE k=?", k).one().getInt("system.max(c)");
+            Assertions.assertThat(maxC).isEqualTo(numClusterings - 1);
+        }
+
+        // test aggregation on range query
+        int selectRows = execute("SELECT * FROM %s").size();
+        long selectCountRows = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
+        Assertions.assertThat(selectCountRows)
+                  .isEqualTo(selectRows)
+                  .isEqualTo(NUM_PARTITIONS * (numClusterings - 2));
+        long maxK = execute("SELECT max(k) FROM %s").one().getLong("system.max(k)");
+        Assertions.assertThat(maxK).isEqualTo(NUM_PARTITIONS);
+        int maxC = execute("SELECT max(c) FROM %s").one().getInt("system.max(c)");
+        Assertions.assertThat(maxC).isEqualTo(numClusterings - 1);
+
+        // test aggregation with group by
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k").size()).isEqualTo(NUM_PARTITIONS);
+        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c").size()).isEqualTo(NUM_PARTITIONS * (numClusterings - 2));
+    }
+
+    @Test
+    public void testAggregationWithPartitionDeletionWithoutClustering()
+    {
+        createTable("CREATE TABLE %s (k bigint PRIMARY KEY, v blob)");
+
+        // insert some partitions, and flush
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            execute("INSERT INTO %s (k, v) VALUES (?, ?)", k, value);
+        }
+        maybeFlush();
+
+        // delete all the partitions, and flush
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            execute("DELETE FROM %s WHERE k = ?", k);
+        }
+        maybeFlush();
+
+        // re-insert part of the data, using the same partitions
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            execute("INSERT INTO %s (k) VALUES (?)", k);
+
+            // test aggregation on single partition query
+            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
+            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
+            Assertions.assertThat(count)
+                      .isEqualTo(numRows)
+                      .isEqualTo(1);
+            long max = execute("SELECT max(k) FROM %s WHERE k=?", k).one().getLong("system.max(k)");
+            Assertions.assertThat(max).isEqualTo(k);
+        }
+
+        // test aggregation on range query
+        int selectRows = execute("SELECT * FROM %s").size();
+        long selectCountRows = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
+        Assertions.assertThat(selectCountRows)
+                  .isEqualTo(selectRows)
+                  .isEqualTo(NUM_PARTITIONS);
+        long max = execute("SELECT max(k) FROM %s").one().getLong("system.max(k)");
+        Assertions.assertThat(max).isEqualTo(NUM_PARTITIONS);
+    }
+
+    @Test
+    public void testAggregationWithPartitionDeletionWithClustering()
+    {
+        createTable("CREATE TABLE %s (k bigint, c int, v blob, PRIMARY KEY(k, c))");
+
+        int numClusteringsBeforeDeletion = 10;
+        int numClusteringsAfterDeletion = 7;
+
+        // insert some partitions, and flush
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            for (int c = 1; c <= numClusteringsBeforeDeletion; c++)
+            {
+                execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", k, c, value);
+            }
+        }
+        maybeFlush();
+
+        // delete all the partitions, and flush
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            execute("DELETE FROM %s WHERE k = ?", k);
+        }
+        maybeFlush();
+
+        // re-insert part of the data, using the same partitions
+        for (long k = 1; k <= NUM_PARTITIONS; k++)
+        {
+            for (int c = 1; c <= numClusteringsAfterDeletion; c++)
+            {
+                execute("INSERT INTO %s (k, c) VALUES (?, ?)", k, c);
+            }
+
+            // test aggregation on single partition query
+            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
+            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
+            Assertions.assertThat(count)
+                      .isEqualTo(numRows)
+                      .isEqualTo(numClusteringsAfterDeletion);
+            long max = execute("SELECT max(k) FROM %s WHERE k=?", k).one().getLong("system.max(k)");
+            Assertions.assertThat(max).isEqualTo(k);
+        }
+
+        // test aggregation on range query
+        int selectRows = execute("SELECT * FROM %s").size();
+        long selectCountRows = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
+        Assertions.assertThat(selectCountRows)
+                  .isEqualTo(selectRows)
+                  .isEqualTo(NUM_PARTITIONS * numClusteringsAfterDeletion);
+        long max = execute("SELECT max(k) FROM %s").one().getLong("system.max(k)");
+        Assertions.assertThat(max).isEqualTo(NUM_PARTITIONS);
+    }
+
+    private void maybeFlush()
+    {
+        if (flush)
+            flush();
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/PagingQueryTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PagingQueryTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -552,49 +551,5 @@ public class PagingQueryTest extends CQLTester
         for (int i = 0; i < arr.length; i++)
             arr[i] = (char) (32 + ThreadLocalRandom.current().nextInt(95));
         return new String(arr);
-    }
-
-    /**
-     * DSP-22813, DBPE-16245, DBPE-16378 and CNDB-13978: Test that count(*) aggregation queries return the correct
-     * number of rows, even if there are tombstones and paging is required.
-     * </p>
-     * Before the DSP-22813/DBPE-16245/DBPE-16378/CNDB-13978 fix these queries would stop counting after hitting the
-     * {@code aggregation_sub_page_size} page size, returning only the count of a single page.
-     */
-    @Test
-    public void testAggregationWithTomsbstones()
-    {
-        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2))");
-
-        int ks = 13;
-        int c1s = 17;
-        int c2s = 19;
-
-        // insert some data
-        for (int k = 0; k < ks; k++)
-        {
-            for (int c1 = 0; c1 < c1s; c1++)
-            {
-                for (int c2 = 0; c2 < c2s; c2++)
-                {
-                    execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, null)", k, c1, c2);
-                }
-            }
-
-            // test aggregation on single partition query
-            int numRows = execute("SELECT * FROM %s WHERE k=?", k).size();
-            long count = execute("SELECT COUNT(*) FROM %s WHERE k=?", k).one().getLong("count");
-            Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(c1s * c2s);
-        }
-
-        // test aggregation on range query
-        int numRows = execute("SELECT * FROM %s").size();
-        long count = execute("SELECT COUNT(*) FROM %s").one().getLong("count");
-        Assertions.assertThat(count).isEqualTo(numRows).isEqualTo(ks * c1s * c2s);
-
-        // test aggregation with group by
-        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k").size()).isEqualTo(ks);
-        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1").size()).isEqualTo(ks * c1s);
-        Assertions.assertThat(execute("SELECT COUNT(*) FROM %s GROUP BY k, c1, c2").size()).isEqualTo(ks * c1s * c2s);
     }
 }


### PR DESCRIPTION
Only preserve the original data size or rows in case of purging.
