### PR TITLE
CNDB-14242: Upgrade jvector to 4.0.0-beta.5 (#1773)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1248,7 +1248,7 @@
       <dependency>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector</artifactId>
-        <version>4.0.0-beta.4</version>
+        <version>4.0.0-beta.5</version>
       </dependency>
       <dependency>
         <groupId>com.carrotsearch.randomizedtesting</groupId>


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/14242

Commits:
https://github.com/datastax/jvector/compare/4.0.0-beta.4...4.0.0-beta.5

CNDB test pr https://github.com/riptano/cndb/pull/14243
