### PR TITLE
CNDB-14680 CC5 Apply generic CompactionSSTable type params needed by CNDB for EtcdSStable

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionSSTable.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionSSTable.java
@@ -76,7 +76,7 @@ public interface CompactionSSTable
      */
     AbstractBounds<Token> getBounds();
 
-    Interval<PartitionPosition, SSTableReader> getInterval();
+    <S extends CompactionSSTable> Interval<PartitionPosition, S> getInterval();
 
     /**
      * @return the length in bytes of the all on-disk components' file size for this SSTable.

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -538,9 +538,9 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     }
 
     @Override
-    public Interval<PartitionPosition, SSTableReader> getInterval()
+    public <S extends CompactionSSTable> Interval<PartitionPosition, S> getInterval()
     {
-        return interval;
+        return (Interval<PartitionPosition, S>) interval;
     }
 
     @Override


### PR DESCRIPTION
### What is the issue
Fixes CNDB-14680

Tying to build CNDB using CC 5.04.0 results in compilation failures in uses of `SSTableIntervalTree.buildIntervals` because that method expects a collection of `SSTableReader` but CNDB uses `EtcdSSTable` instead.

### What does this PR fix and why was it fixed
CNDB uses `EctdSSTable` in place of `SSTableReader` and CNDB uses of `SSTableIntervalTree.buildIntervals` get compile errors due to CC expecting `SSTableReader` params.

There were CC changes made in STAR-13 and STAR-791 that replace `Interval<PartitionPosition, SSTableReader>` with `<S extends CompactionSSTable> Interval<PartitionPosition, S>` so that `EtcdSSTable`, which does implement `CompactionSSTable` can be used in place of `SSTableRead`. 

These changes didn't get applied during the C* 5.0.4 rebase, likely because a) C* 5.0 already contains much/most of the changes that were made in STAR-13/STAR-791 for CC 4.0, and b) CC code itself does not require these changes to compile or run - they are intended for CNDB, and went unnoticed until now.

