### PR TITLE
CNDB-14123: allows intercepting issues opening flushed sstables (#1742)

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1556,11 +1556,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                     // This can throw on remote storage, e.g. if a file cannot be uploaded
                     txn.prepareToCommit();
 
-                    // Open the underlying readers, the one that will be returne below by `finished()`.
+                    // Open the underlying readers, the one that will be returned below by `finished()`.
                     // Currently needs to be called before commit, because committing will close a certain number
                     // of resources used by the writers which are accessed to open the readers.
                     for (SSTableMultiWriter writer : flushResults)
-                        writer.openResult();
+                        writer.openResult(storageHandler);
                 }
                 catch (Throwable t)
                 {
@@ -2839,7 +2839,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         {
             try
             {
-                Collection<SSTableReader> sstables = memtableContent.finish(true);
+                Collection<SSTableReader> sstables = memtableContent.finish(true, storageHandler);
                 try (Refs sstableReferences = Refs.ref(sstables))
                 {
                     // This moves all references to placeIntoRefs, clearing sstableReferences

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +36,7 @@ import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTableMultiWriter;
+import org.apache.cassandra.io.sstable.StorageHandler;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
@@ -145,14 +148,14 @@ public class ShardedMultiWriter implements SSTableMultiWriter
     }
 
     @Override
-    public Collection<SSTableReader> finish(boolean openResult)
+    public Collection<SSTableReader> finish(boolean openResult, @Nullable StorageHandler storageHandler)
     {
         List<SSTableReader> sstables = new ArrayList<>(writers.length);
         for (SSTableWriter writer : writers)
             if (writer != null)
             {
                 boundaries.applyTokenSpaceCoverage(writer);
-                sstables.add(writer.finish(openResult));
+                sstables.add(writer.finish(openResult, storageHandler));
             }
         return sstables;
     }
@@ -168,11 +171,11 @@ public class ShardedMultiWriter implements SSTableMultiWriter
     }
 
     @Override
-    public void openResult()
+    public void openResult(@Nullable StorageHandler storageHandler)
     {
         for (SSTableWriter writer : writers)
             if (writer != null)
-                writer.openResult();
+                writer.openResult(storageHandler);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
@@ -108,7 +108,7 @@ public class CassandraStreamReceiver implements StreamReceiver
         SSTableMultiWriter sstable = file.getSSTable();
         try
         {
-            finished = sstable.finish(true);
+            finished = sstable.finish(true, cfs.getStorageHandler());
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/format/DefaultIndexComponentDiscovery.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/DefaultIndexComponentDiscovery.java
@@ -20,13 +20,19 @@ package org.apache.cassandra.index.sai.disk.format;
 
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.TableMetadata;
 
 public class DefaultIndexComponentDiscovery extends IndexComponentDiscovery
 {
     @Override
-    public SSTableIndexComponentsState discoverComponents(SSTableReader sstable) {
-        Descriptor descriptor = sstable.getDescriptor();
+    public SSTableIndexComponentsState discoverComponents(SSTableReader sstable)
+    {
+        return discoverComponents(sstable.getDescriptor(), sstable.metadata());
+    }
 
+    @Override
+    public SSTableIndexComponentsState discoverComponents(Descriptor descriptor, TableMetadata metadata)
+    {
         // Older versions might not have all components in the TOC, we should not trust it (fix for CNDB-13582):
         if (descriptor.version.version.compareTo("ca") < 0)
            return discoverComponentsFromDiskFallback(descriptor);

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentDiscovery.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponentDiscovery.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.TOCComponent;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.PathUtils;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NoSpamLogger;
 
@@ -80,10 +81,30 @@ public abstract class IndexComponentDiscovery
      * @return the discovered {@link ComponentsBuildId} to use for both per-sstable and each per-index components. The
      * returned build IDs should usually correspond to existing index components on disk but this is not a strong
      * asumption: if some group of components corresponding to the returned build ID has no completion marker or is
-     * missing files, the group will not be usuable (and the corresponding index/indexes will not be usable) but this
+     * missing files, the group will not be usuable (and the corresponding index/indexes will not be usable), but this
      * should be handled "gracefully" by callers.
      */
     public abstract SSTableIndexComponentsState discoverComponents(SSTableReader sstable);
+
+    /**
+     * Returns the set of groups of SAI components that should be used for the provided sstable.
+     * <p>
+     * Note that "discovery" in this method only means finding out the "build ID" (version and generation) that should
+     * be used for each group of components (per-sstable and per-index).
+     * <p>
+     * Please note that the {@link #discoverComponents(SSTableReader)} method should be prefered when a
+     * {@link SSTableReader} exists as some implementations may be more optimal or use additional checks when provided
+     * a reader.
+     *
+     * @param descriptor the descriptor of the sstable for which to discover components.
+     * @param metadata the metadata of the table the sstable belongs to.
+     * @return the discovered {@link ComponentsBuildId} to use for both per-sstable and each per-index component. The
+     * returned build IDs should usually correspond to existing index components on disk, but this is not a strong
+     * asumption: if some group of components corresponding to the returned build ID has no completion marker or is
+     * missing files, the group will not be usuable (and the corresponding index/indexes will not be usable), but this
+     * should be handled "gracefully" by callers.
+     */
+    public abstract SSTableIndexComponentsState discoverComponents(Descriptor descriptor, TableMetadata metadata);
 
     protected static IndexComponentType completionMarker(@Nullable String name)
     {

--- a/src/java/org/apache/cassandra/io/sstable/RangeAwareSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/RangeAwareSSTableWriter.java
@@ -112,7 +112,7 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
     }
 
     @Override
-    public Collection<SSTableReader> finish(boolean openResult)
+    public Collection<SSTableReader> finish(boolean openResult, StorageHandler storageHandler)
     {
         if (currentWriter != null)
             finishedWriters.add(currentWriter);
@@ -120,7 +120,7 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
         for (SSTableMultiWriter writer : finishedWriters)
         {
             if (writer.getBytesWritten() > 0)
-                finishedReaders.addAll(writer.finish(openResult));
+                finishedReaders.addAll(writer.finish(openResult, storageHandler));
             else
                 SSTableMultiWriter.abortOrDie(writer);
         }
@@ -134,10 +134,10 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
     }
 
     @Override
-    public void openResult()
+    public void openResult(StorageHandler storageHandler)
     {
-        finishedWriters.forEach(SSTableMultiWriter::openResult);
-        currentWriter.openResult();
+        finishedWriters.forEach(w -> w.openResult(storageHandler));
+        currentWriter.openResult(storageHandler);
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.io.sstable;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableId;
@@ -36,7 +38,7 @@ public interface SSTableMultiWriter extends Transactional
      */
     void append(UnfilteredRowIterator partition);
 
-    Collection<SSTableReader> finish(boolean openResult);
+    Collection<SSTableReader> finish(boolean openResult, @Nullable StorageHandler handler);
     Collection<SSTableReader> finished();
 
     /**
@@ -44,8 +46,13 @@ public interface SSTableMultiWriter extends Transactional
      * be called after `prepareToCommit` (so the writing is complete) but before `commit` (because committing closes
      * some of the resources used to create the underlying readers). When used, the readers can then be accessed by
      * calling `finished()`.
+     *
+     * @param storageHandler the underlying storage handler. This is used in case of a failure opening the
+     *                       SSTableReader(s) to call the `StorageHandler#onOpeningWrittenSSTableFailure` callback, which
+     *                       in some implementations may attempt to recover from the error. If `null`, the said callback
+     *                       will not be called on failure (and the exception will propagate).
      */
-    void openResult();
+    void openResult(@Nullable StorageHandler storageHandler);
 
     String getFilename();
     long getBytesWritten();

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -358,7 +358,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             assert writer.getFilePointer() > 0;
             writer.setRepairedAt(repairedAt);
             writer.prepareToCommit();
-            writer.openResult();
+            writer.openResult(null);
             SSTableReader reader = writer.finished();
             transaction.update(reader, false);
             preparedForCommit.add(reader);

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -268,7 +268,7 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
                     {
                         for (Map.Entry<DecoratedKey, PartitionUpdate.Builder> entry : b.entrySet())
                             writer.append(entry.getValue().build().unfilteredIterator());
-                        Collection<SSTableReader> finished = writer.finish(shouldOpenSSTables());
+                        Collection<SSTableReader> finished = writer.finish(shouldOpenSSTables(), null);
                         notifySSTableProduced(finished);
                     }
                 }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -142,7 +142,7 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
             if (writer == null)
                 return;
 
-            Collection<SSTableReader> finished = writer.finish(shouldOpenSSTables());
+            Collection<SSTableReader> finished = writer.finish(shouldOpenSSTables(), null);
             notifySSTableProduced(finished);
         }
         catch (Throwable t)

--- a/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
@@ -101,11 +101,11 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
         return super.doPostCleanup(accumulate);
     }
 
-    public Collection<SSTableReader> finish(boolean openResult)
+    public Collection<SSTableReader> finish(boolean openResult, StorageHandler storageHandler)
     {
         prepareToCommit();
         if (openResult)
-            writer.openResult();
+            writer.openResult(storageHandler);
         commit();
         return writer.finished();
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
@@ -127,7 +127,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     }
 
     @Override
-    public Collection<SSTableReader> finish(boolean openResult)
+    public Collection<SSTableReader> finish(boolean openResult, StorageHandler storageHandler)
     {
         for (SequentialWriter writer : componentWriters.values())
             writer.finish();
@@ -148,7 +148,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     }
 
     @Override
-    public void openResult()
+    public void openResult(StorageHandler storageHandler)
     {
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
@@ -49,9 +49,9 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
         writer.append(partition);
     }
 
-    public Collection<SSTableReader> finish(boolean openResult)
+    public Collection<SSTableReader> finish(boolean openResult, StorageHandler storageHandler)
     {
-        return Collections.singleton(writer.finish(openResult));
+        return Collections.singleton(writer.finish(openResult, storageHandler));
     }
 
     public Collection<SSTableReader> finished()
@@ -59,9 +59,9 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
         return Collections.singleton(writer.finished());
     }
 
-    public void openResult()
+    public void openResult(StorageHandler storageHandler)
     {
-        writer.openResult();
+        writer.openResult(storageHandler);
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
@@ -250,7 +250,7 @@ public abstract class SortedTableScrubber<R extends SSTableReaderWithFilter> imp
                 inOrderWriter.append(partition.unfilteredIterator());
             inOrderWriter.setRepairedAt(-1);
             inOrderWriter.setMaxDataAge(sstable.maxDataAge);
-            newInOrderSstable = inOrderWriter.finish(true);
+            newInOrderSstable = inOrderWriter.finish(true, null);
         }
         transaction.update(newInOrderSstable, false);
         outputHandler.warn("%d out of order partition (or partitions without of order rows) found while scrubbing %s; " +

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -232,6 +232,12 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter, 
         return openInternal(null, openReason);
     }
 
+    @Override
+    public void openResult(@javax.annotation.Nullable org.apache.cassandra.io.sstable.StorageHandler storageHandler)
+    {
+        txnProxy.openResult(storageHandler);
+    }
+
     /**
      * Encapsulates writing the index and filter for an SSTable. The state of this object is not valid until it has been closed.
      */

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -155,6 +155,12 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         return openInternal(openReason, NO_LENGTH_OVERRIDE, indexWriter::completedPartitionIndex);
     }
 
+    @Override
+    public void openResult(@javax.annotation.Nullable org.apache.cassandra.io.sstable.StorageHandler storageHandler)
+    {
+        txnProxy.openResult(storageHandler);
+    }
+
     /**
      * Encapsulates writing the index and filter for an SSTable. The state of this object is not valid until it has been closed.
      */

--- a/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
@@ -135,7 +135,7 @@ public class SerializationHeaderTest
                         Row row = BTreeRow.singleCellRow(clustering, cell);
                         sstableWriter.append(PartitionUpdate.singleRowUpdate(schema, schema.partitioner.decorateKey(value), row).unfilteredIterator());
                     }
-                    sstableWriter.finish(false);
+                    sstableWriter.finish(false, null);
                     txn.finish();
                 }
                 return descriptor;

--- a/test/unit/org/apache/cassandra/db/compaction/AntiCompactionTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/AntiCompactionTest.java
@@ -288,7 +288,7 @@ public class AntiCompactionTest
                 writer.append(builder.build().unfilteredIterator());
 
             }
-            Collection<SSTableReader> sstables = writer.finish(true);
+            Collection<SSTableReader> sstables = writer.finish(true, null);
             assertNotNull(sstables);
             assertEquals(1, sstables.size());
             return sstables.iterator().next();

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableCorruptionDetectionTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableCorruptionDetectionTest.java
@@ -130,7 +130,7 @@ public class SSTableCorruptionDetectionTest extends SSTableWriterTestBase
         }
         Util.flush(cfs);
 
-        ssTableReader = writer.finish(true);
+        ssTableReader = writer.finish(true, null);
         txn.update(ssTableReader, false);
         LifecycleTransaction.waitForDeletions();
     }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableFlushObserverTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableFlushObserverTest.java
@@ -169,7 +169,7 @@ public class SSTableFlushObserverTest
 
                 writer.append(new RowIterator(cfm, key, Collections.singletonList(buildRow(expected.get(key)))));
 
-                reader = writer.finish(true);
+                reader = writer.finish(true, null);
             }
             finally
             {

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
@@ -984,7 +984,7 @@ public class SSTableRewriterTest extends SSTableWriterTestBase
 
                     writer.append(builder.build().unfilteredIterator());
                 }
-                result.addAll(writer.finish(true));
+                result.addAll(writer.finish(true, null));
             }
         }
         return result;

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableUtils.java
@@ -231,7 +231,7 @@ public class SSTableUtils
             SerializationHeader header = appender.header();
             SSTableTxnWriter writer = SSTableTxnWriter.create(cfs, Descriptor.fromFileWithComponent(datafile, false).left, expectedSize, UNREPAIRED_SSTABLE, NO_PENDING_REPAIR, false, header);
             while (appender.append(writer)) { /* pass */ }
-            Collection<SSTableReader> readers = writer.finish(true);
+            Collection<SSTableReader> readers = writer.finish(true, null);
 
             // mark all components for removal
             if (cleanup)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTest.java
@@ -127,7 +127,7 @@ public class SSTableWriterTest extends SSTableWriterTestBase
                     builder.newRow("" + j).add("val", ByteBuffer.allocate(1000));
                 writer.append(builder.build().unfilteredIterator());
             }
-            SSTableReader sstable = writer.finish(true);
+            SSTableReader sstable = writer.finish(true, null);
             int datafiles = assertFileCounts(dir.tryListNames());
             assertEquals(datafiles, 1);
 
@@ -174,7 +174,7 @@ public class SSTableWriterTest extends SSTableWriterTestBase
                     builder.newRow("" + j).add("val", ByteBuffer.allocate(1000));
                 writer2.append(builder.build().unfilteredIterator());
             }
-            SSTableReader sstable = writer1.finish(true);
+            SSTableReader sstable = writer1.finish(true, null);
             txn.update(sstable, false);
 
             assertFileCounts(dir.tryListNames());
@@ -214,7 +214,7 @@ public class SSTableWriterTest extends SSTableWriterTestBase
             largeValue.newRow("clustering").add("val", ByteBuffer.allocate(2 * 1024 * 1024));
             writer1.append(largeValue.build().unfilteredIterator());
 
-            SSTableReader sstable = writer1.finish(true);
+            SSTableReader sstable = writer1.finish(true, null);
 
             txn.update(sstable, false);
 

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableZeroCopyWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableZeroCopyWriterTest.java
@@ -177,7 +177,7 @@ public class SSTableZeroCopyWriterTest
             }
         }
 
-        Collection<SSTableReader> readers = btzcw.finish(true);
+        Collection<SSTableReader> readers = btzcw.finish(true, null);
 
         SSTableReader reader = readers.toArray(new SSTableReader[0])[0];
 

--- a/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
@@ -588,7 +588,7 @@ public class ScrubTest
 
                     writer.append(update.unfilteredIterator());
                 }
-                writer.finish(false);
+                writer.finish(false, null);
             }
 
             try


### PR DESCRIPTION
For https://github.com/riptano/cndb/issues/14123, we want to be able to catch issues happening during the opening of just-flushed sstables to use shallow sstables. This commit enable this by adding a method to `StorageHandler` that is called on such issue, and allow to provide a "replacement" `SSTableReader` instance.

