### PR TITLE
CNDB-13925: Prefer not analyzed indexes for contains queries (#1718)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -591,12 +591,13 @@ public enum Operator
     }
 
     /**
-     * Checks if this operator is CONTAINS operator.
-     * @return {@code true} if this operator is a CONTAINS operator, {@code false} otherwise.
+     * Checks if this operator is any of the variations of contains ({@code [NOT] CONTAINS [KEY]}).
+     *
+     * @return {@code true} if this operator is any kind of contains operator, {@code false} otherwise.
      */
     public boolean isContains()
     {
-        return this == CONTAINS;
+        return this == CONTAINS || this == CONTAINS_KEY || this == NOT_CONTAINS || this == NOT_CONTAINS_KEY;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -1162,4 +1162,41 @@ public interface Index
             throw new IllegalArgumentException("Unrecognized code: " + code);
         }
     }
+
+    /**
+     * Returns the best index for a given column and operator among the specified collection of indexes.
+     * </p>
+     * The best index is simply the first one that supports the column and operator, because we shouldn't have multiple
+     * indexes for the same column and operator, so we can just return the first one. The only exception to this is when
+     * the operator is {@code [NOT] CONTAINS [KEY]}, in which case the best index be the first one that doesn't use an
+     * analyzer.
+     *
+     * @param indexes a collection on indexes
+     * @param column a column
+     * @param operator an operator
+     * @return the best index for the column and operator among the specified indexes
+     */
+    static <T extends Index> Optional<T> getBestIndexFor(Collection<T> indexes, ColumnMetadata column, Operator operator)
+    {
+        // we simply return the first index that supports the expression, unless it's a contains operator
+        if (!operator.isContains())
+            return indexes.stream().filter((i) -> i.supportsExpression(column, operator)).findFirst();
+
+        // if we have a contains operator, we prefer indexes without an analyzer (see CNDB-13925)
+        T firstAnalyzedIndex = null;
+        for (T index : indexes)
+        {
+            if (index.supportsExpression(column, operator))
+            {
+                // we prefer indexes without an analyzer
+                if (index.getAnalyzer(null).isEmpty())
+                    return Optional.of(index);
+
+                if (firstAnalyzedIndex == null)
+                    firstAnalyzedIndex = index;
+            }
+        }
+
+        return Optional.ofNullable(firstAnalyzedIndex);
+    }
 }

--- a/src/java/org/apache/cassandra/index/IndexRegistry.java
+++ b/src/java/org/apache/cassandra/index/IndexRegistry.java
@@ -95,7 +95,7 @@ public interface IndexRegistry
         }
 
         @Override
-        public Optional<Index> getBestIndexFor(RowFilter.Expression expression)
+        public Optional<Index> getBestIndexFor(ColumnMetadata column, Operator operator)
         {
             return Optional.empty();
         }
@@ -293,7 +293,7 @@ public interface IndexRegistry
         }
 
         @Override
-        public Optional<Index> getBestIndexFor(RowFilter.Expression expression)
+        public Optional<Index> getBestIndexFor(ColumnMetadata column, Operator operator)
         {
             return Optional.empty();
         }
@@ -329,7 +329,12 @@ public interface IndexRegistry
         return Optional.empty();
     }
 
-    Optional<Index> getBestIndexFor(RowFilter.Expression expression);
+    Optional<Index> getBestIndexFor(ColumnMetadata column, Operator operator);
+
+    default Optional<Index> getBestIndexFor(RowFilter.Expression expression)
+    {
+        return getBestIndexFor(expression.column(), expression.operator());
+    }
 
     /**
      * Called at write time to ensure that values present in the update

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.index.sai.plan;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -165,16 +166,14 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
         if (expression.isUserDefined())
             return false;
 
-        boolean hasIndex = false;
-        for (StorageAttachedIndex index : allIndexes)
+        // collect the best index from those that support the specified expression
+        Optional<StorageAttachedIndex> index = Index.getBestIndexFor(allIndexes, expression.column(), expression.operator());
+        if (index.isPresent())
         {
-            if (index.supportsExpression(expression.column(), expression.operator()))
-            {
-                selectedIndexes.add(index);
-                hasIndex = true;
-            }
+            selectedIndexes.add(index.get());
+            return true;
         }
-        return hasIndex;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Prefer not-analyzed indexes over analyzed indexes for contains queries, so they have a deterministic behaviour.
Also, emit a client warning when a not-analyzed index is selected over an analyzed index.

Otherwise, different points in the codebase will make different, pseudo-random decisions about what index should be used for a certain contains expression, leading to erratic behaviour.
