### PR TITLE
CNDB-13565: allow to set memtable shard lock fairness via JMX and a system property (#1785)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.db.compaction.unified.Reservations;
+import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.db.virtual.LogMessagesTable;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.compress.AdaptiveCompressor;
@@ -898,6 +899,17 @@ public enum CassandraRelevantProperties
      * Allows to set custom current trie index format. This node will produce sstables in this format.
      */
     TRIE_INDEX_FORMAT_VERSION("cassandra.trie_index_format_version", "cc"),
+
+    /**
+     * Number of shards for TrieMemtable. If not specified, defaults to {@link TrieMemtable#autoShardCount}
+     */
+    TRIE_MEMTABLE_SHARD_COUNT("cassandra.trie.memtable.shard.count"),
+
+    /**
+     * Whether to use fair locking for TrieMemtable shard locks. Defaults to false.
+     */
+    TRIE_MEMTABLE_SHARD_LOCK_FAIRNESS("cassandra.trie.memtable.shard.lock.fairness", "false"),
+
     TRIGGERS_DIR("cassandra.triggers_dir"),
     TRUNCATE_BALLOT_METADATA("cassandra.truncate_ballot_metadata"),
     /**

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtableConfigMXBean.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtableConfigMXBean.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+public interface TrieMemtableConfigMXBean
+{
+    public void setShardCount(String numShards);
+
+    public String getShardCount();
+
+    public void setLockFairness(String fairness);
+
+    public String getLockFairness();
+}

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -46,7 +46,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static java.lang.String.format;
-import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TRIE_MEMTABLE_SHARD_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -61,7 +61,7 @@ public class AlterTest extends CQLTester
     {
         // AlterTest uses Murmur3 partitioner, but injects OrderPreservingPartitioner.StringToken
         // into TokenMetadata; expect trouble
-        MEMTABLE_SHARD_COUNT.setString("1");
+        TRIE_MEMTABLE_SHARD_COUNT.setString("1");
         CQLTester.setUpClass();
         assertThat(AbstractShardedMemtable.getDefaultShardCount()).isEqualTo(1);;
     }

--- a/test/unit/org/apache/cassandra/db/memtable/TrieMemtableConfigTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/TrieMemtableConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import java.io.IOException;
+import javax.management.Attribute;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.db.memtable.TrieMemtable.TRIE_MEMTABLE_CONFIG_OBJECT_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class TrieMemtableConfigTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        startJMXServer();
+        createMBeanServerConnection();
+    }
+
+    @Test
+    public void testShardCountSetByJMX() throws MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException, IOException, InvalidAttributeValueException
+    {
+        jmxConnection.setAttribute(new ObjectName(TRIE_MEMTABLE_CONFIG_OBJECT_NAME), new Attribute("ShardCount", "7"));
+        assertEquals(7, Integer.parseInt(new TrieMemtable.TrieMemtableConfig().getShardCount()));
+    }
+
+    @Test
+    public void testAutoShardCount() throws MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException, IOException, InvalidAttributeValueException
+    {
+        jmxConnection.setAttribute(new ObjectName(TRIE_MEMTABLE_CONFIG_OBJECT_NAME), new Attribute("ShardCount", "auto"));
+        assertEquals(4 * FBUtilities.getAvailableProcessors(), Integer.parseInt(new TrieMemtable.TrieMemtableConfig().getShardCount()));
+    }
+
+    @Test
+    public void testShardLockFairnessSetByJMX() throws MalformedObjectNameException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException, IOException, InvalidAttributeValueException
+    {
+        assertEquals(false, Boolean.parseBoolean(new TrieMemtable.TrieMemtableConfig().getLockFairness()));
+        jmxConnection.setAttribute(new ObjectName(TRIE_MEMTABLE_CONFIG_OBJECT_NAME), new Attribute("LockFairness", "TrUe"));
+        assertEquals(true, Boolean.parseBoolean(new TrieMemtable.TrieMemtableConfig().getLockFairness()));
+    }
+}


### PR DESCRIPTION
### What is the issue

Memtable shard lock (required for `put`) is non-fair. We suspect this leads to elevated latencies in case of bursty load, as in #13565

### What does this PR fix and why was it fixed

This change introduces `cassandra.trie.memtable.shard.lock.fairness system` property and `LockFairness` property
of `org.apache.cassandra.db:type=TrieMemtableConfig` JMX object to configure it persistently or on-line.
The on-line change is effective once a new memtable is created (i.e. after flush). If forcing a flush is not desired, one can watch `BytesFlushed` metric for the table
