### PR TITLE
CNDB-7237: add metrics to track replica response sizes

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -435,6 +435,8 @@ public enum CassandraRelevantProperties
     TABLE_METRICS_DEFAULT_HISTOGRAMS_AGGREGATION("cassandra.table_metrics_default_histograms_aggregation", TableMetrics.MetricsAggregation.INDIVIDUAL.name()),
     // Determines if table metrics should be also exported to shared global metric
     TABLE_METRICS_EXPORT_GLOBALS("cassandra.table_metrics_export_globals", "true"),
+    // Enable/disable replica response size metrics collection
+    REPLICA_RESPONSE_SIZE_METRICS_ENABLED("cassandra.replica_response_size_metrics_enabled", "true"),
     FILE_CACHE_SIZE_IN_MB("cassandra.file_cache_size_in_mb", "2048"),
     CUSTOM_HINTS_RATE_LIMITER_FACTORY("cassandra.custom_hints_rate_limiter_factory"),
 

--- a/src/java/org/apache/cassandra/db/MultiRangeReadResponse.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadResponse.java
@@ -108,6 +108,12 @@ public abstract class MultiRangeReadResponse extends ReadResponse
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean supportsResponseSizeTracking()
+    {
+        return false;
+    }
+
     /**
      * A local response that is not meant to be serialized or used for caching remote endpoint's multi-range response.
      */
@@ -232,6 +238,12 @@ public abstract class MultiRangeReadResponse extends ReadResponse
 
         @Override
         public boolean isDigestResponse()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean supportsResponseSizeTracking()
         {
             return false;
         }

--- a/src/java/org/apache/cassandra/db/ReadResponse.java
+++ b/src/java/org/apache/cassandra/db/ReadResponse.java
@@ -76,6 +76,18 @@ public abstract class ReadResponse
     public abstract boolean isDigestResponse();
 
     /**
+     * Indicates whether this response type supports response size tracking for metrics.
+     * Some response types (like MultiRangeReadResponse) may not support payload size calculation
+     * and will throw UnsupportedOperationException when attempting to serialize for size calculation.
+     * 
+     * @return true if this response supports size tracking, false otherwise
+     */
+    public boolean supportsResponseSizeTracking()
+    {
+        return true;
+    }
+
+    /**
      * Creates a string of the requested partition in this read response suitable for debugging.
      */
     public String toDebugString(ReadCommand command, DecoratedKey key)

--- a/src/java/org/apache/cassandra/metrics/ReplicaResponseSizeMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ReplicaResponseSizeMetrics.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+/**
+ * Metrics for tracking result sizes coming from replicas/writers to coordinators.
+ */
+public class ReplicaResponseSizeMetrics
+{
+    private static final String TYPE = "ReplicaResponseSize";
+    
+    /**
+     * Controls whether replica response size metrics collection is enabled.
+     */
+    private static final boolean METRICS_ENABLED = CassandraRelevantProperties.REPLICA_RESPONSE_SIZE_METRICS_ENABLED.getBoolean();
+    
+    /** Total bytes received from replicas in response messages */
+    public static final Counter totalBytesReceived = Metrics.counter(DefaultNameFactory.createMetricName(TYPE, "TotalBytesReceived", null));
+    
+    /** Histogram of response sizes from replicas */
+    public static final Histogram bytesReceivedPerResponse = Metrics.histogram(DefaultNameFactory.createMetricName(TYPE, "BytesReceivedPerResponse", null), true);
+    
+    /** Total bytes received from replicas in read responses */
+    public static final Counter readResponseBytesReceived = Metrics.counter(DefaultNameFactory.createMetricName(TYPE, "ReadResponseBytesReceived", null));
+    
+    /** Histogram of read response sizes from replicas */
+    public static final Histogram readResponseBytesPerResponse = Metrics.histogram(DefaultNameFactory.createMetricName(TYPE, "ReadResponseBytesPerResponse", null), true);
+    
+    /** Total bytes received from replicas in write responses */
+    public static final Counter writeResponseBytesReceived = Metrics.counter(DefaultNameFactory.createMetricName(TYPE, "WriteResponseBytesReceived", null));
+    
+    /** Histogram of write response sizes from replicas */
+    public static final Histogram writeResponseBytesPerResponse = Metrics.histogram(DefaultNameFactory.createMetricName(TYPE, "WriteResponseBytesPerResponse", null), true);
+    
+    /**
+     * Check if metrics collection is enabled
+     * @return true if metrics are enabled, false otherwise
+     */
+    public static boolean isMetricsEnabled()
+    {
+        return METRICS_ENABLED;
+    }
+    
+    /**
+     * Record the size of a read response received from a replica
+     * @param responseSize the size of the response in bytes
+     */
+    public static void recordReadResponseSize(int responseSize)
+    {
+        if (!METRICS_ENABLED)
+            return;
+            
+        totalBytesReceived.inc(responseSize);
+        bytesReceivedPerResponse.update(responseSize);
+        readResponseBytesReceived.inc(responseSize);
+        readResponseBytesPerResponse.update(responseSize);
+    }
+    
+    /**
+     * Record the size of a write response received from a replica
+     * @param responseSize the size of the response in bytes
+     */
+    public static void recordWriteResponseSize(int responseSize)
+    {
+        if (!METRICS_ENABLED)
+            return;
+            
+        totalBytesReceived.inc(responseSize);
+        bytesReceivedPerResponse.update(responseSize);
+        writeResponseBytesReceived.inc(responseSize);
+        writeResponseBytesPerResponse.update(responseSize);
+    }
+}

--- a/src/java/org/apache/cassandra/service/DatacenterSyncWriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/DatacenterSyncWriteResponseHandler.java
@@ -73,6 +73,7 @@ public class DatacenterSyncWriteResponseHandler<T> extends AbstractWriteResponse
 
     public void onResponse(Message<T> message)
     {
+        trackReplicaResponseSize(message);
         try
         {
             String dataCenter = message == null

--- a/src/java/org/apache/cassandra/service/WriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/WriteResponseHandler.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.metrics.ReplicaResponseSizeMetrics;
 
 /**
  * Handles blocking writes for ONE, ANY, TWO, THREE, QUORUM, and ALL consistency levels.
@@ -64,6 +65,7 @@ public class WriteResponseHandler<T> extends AbstractWriteResponseHandler<T>
     @Override
     public void onResponse(Message<T> m)
     {
+        trackReplicaResponseSize(m);
         if (responsesUpdater.decrementAndGet(this) == 0)
             signal();
         //Must be last after all subclass processing

--- a/test/unit/org/apache/cassandra/metrics/ReplicaResponseSizeMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ReplicaResponseSizeMetricsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.codahale.metrics.Snapshot;
+
+import static org.junit.Assert.*;
+
+public class ReplicaResponseSizeMetricsTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        // Note: Counter metrics cannot be reset, so tests track deltas
+    }
+    
+    @Test
+    public void testReadResponseMetrics()
+    {
+        long initialTotal = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        long initialRead = ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount();
+        
+        int responseSize = 1024;
+        ReplicaResponseSizeMetrics.recordReadResponseSize(responseSize);
+        
+        assertEquals(initialTotal + responseSize, ReplicaResponseSizeMetrics.totalBytesReceived.getCount());
+        assertEquals(initialRead + responseSize, ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount());
+        
+        Snapshot readSnapshot = ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getSnapshot();
+        assertTrue(readSnapshot.size() > 0);
+        assertTrue(readSnapshot.getMax() >= responseSize);
+    }
+    
+    @Test
+    public void testWriteResponseMetrics()
+    {
+        long initialTotal = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        long initialWrite = ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount();
+        
+        int responseSize = 256;
+        ReplicaResponseSizeMetrics.recordWriteResponseSize(responseSize);
+        
+        assertEquals(initialTotal + responseSize, ReplicaResponseSizeMetrics.totalBytesReceived.getCount());
+        assertEquals(initialWrite + responseSize, ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount());
+        
+        Snapshot writeSnapshot = ReplicaResponseSizeMetrics.writeResponseBytesPerResponse.getSnapshot();
+        assertTrue(writeSnapshot.size() > 0);
+    }
+    
+    @Test
+    public void testMultipleResponses()
+    {
+        long initialTotal = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        
+        int[] sizes = {100, 200, 300, 400, 500};
+        int expectedTotal = 0;
+        
+        for (int size : sizes)
+        {
+            // Alternate between read and write responses
+            if (size % 2 == 0)
+                ReplicaResponseSizeMetrics.recordReadResponseSize(size);
+            else
+                ReplicaResponseSizeMetrics.recordWriteResponseSize(size);
+            expectedTotal += size;
+        }
+        
+        assertEquals(initialTotal + expectedTotal, ReplicaResponseSizeMetrics.totalBytesReceived.getCount());
+        
+        Snapshot totalSnapshot = ReplicaResponseSizeMetrics.bytesReceivedPerResponse.getSnapshot();
+        assertTrue(totalSnapshot.size() >= sizes.length);
+        assertTrue(totalSnapshot.getMean() > 0);
+    }
+}

--- a/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
+++ b/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.metrics.ReplicaResponseSizeMetrics;
 
 import static org.apache.cassandra.net.NoPayload.noPayload;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -329,5 +330,88 @@ public class WriteResponseHandlerTest
         return Message.builder(Verb.ECHO_REQ, noPayload)
                       .from(targets.get(target).endpoint())
                       .build();
+    }
+
+    /**
+     * Test that write response metrics are properly collected for remote responses
+     */
+    @Test
+    public void testWriteResponseMetricsForRemoteResponses() throws Throwable
+    {
+        long initialTotalBytes = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        long initialWriteBytes = ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount();
+        long initialHistogramCount = ReplicaResponseSizeMetrics.writeResponseBytesPerResponse.getCount();
+        
+        AbstractWriteResponseHandler<?> handler = createWriteResponseHandler(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.EACH_QUORUM, System.nanoTime());
+        
+        handler.onResponse(createDummyMessage(0)); // Remote replica in DC1
+        handler.onResponse(createDummyMessage(1)); // Remote replica in DC1
+        
+        handler.get();
+        
+        assertTrue("Total bytes metric should have increased",
+                   ReplicaResponseSizeMetrics.totalBytesReceived.getCount() >= initialTotalBytes);
+        assertTrue("Write bytes metric should have increased", 
+                   ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount() >= initialWriteBytes);
+        assertTrue("Histogram count should have increased by at least 2", 
+                   ReplicaResponseSizeMetrics.writeResponseBytesPerResponse.getCount() >= initialHistogramCount + 2);
+    }
+
+    /**
+     * Test that write response metrics are NOT collected for local responses
+     */
+    @Test
+    public void testWriteResponseMetricsSkippedForLocalResponses() throws Throwable
+    {
+        long initialTotalBytes = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        long initialWriteBytes = ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount();
+        
+        AbstractWriteResponseHandler<?> handler = createWriteResponseHandler(ConsistencyLevel.ONE, ConsistencyLevel.ONE, System.nanoTime());
+        
+        // Simulate a local response (message.from() == null)
+        handler.onResponse(null);
+        
+        handler.get();
+        
+        // Check that metrics were NOT updated for local response
+        assertEquals("Total bytes should not change for local responses", 
+                     initialTotalBytes, ReplicaResponseSizeMetrics.totalBytesReceived.getCount());
+        assertEquals("Write bytes should not change for local responses", 
+                     initialWriteBytes, ReplicaResponseSizeMetrics.writeResponseBytesReceived.getCount());
+    }
+
+    /**
+     * Test that metrics collection handles errors gracefully
+     */
+    @Test
+    public void testWriteResponseMetricsHandlesExceptionsGracefully() throws Throwable
+    {
+        AbstractWriteResponseHandler<?> handler = createWriteResponseHandler(ConsistencyLevel.ONE, ConsistencyLevel.ONE, System.nanoTime());
+        
+        // Send a normal response first to satisfy consistency
+        handler.onResponse(createDummyMessage(0));
+        
+        handler.get();
+        
+        // The metrics collection handles null payloads and other edge cases gracefully
+    }
+
+    /**
+     * Test that write response metrics track all responses, including those after consistency is met
+     */
+    @Test  
+    public void testWriteResponseMetricsTracksAllResponses() throws Throwable
+    {
+        long initialHistogramCount = ReplicaResponseSizeMetrics.writeResponseBytesPerResponse.getCount();
+        
+        AbstractWriteResponseHandler<?> handler = createWriteResponseHandler(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.EACH_QUORUM, System.nanoTime());
+        
+        handler.onResponse(createDummyMessage(0));
+        handler.onResponse(createDummyMessage(1));
+        handler.onResponse(createDummyMessage(2)); // Extra response after consistency met
+        
+        // All 3 responses should be tracked in metrics
+        assertTrue("All responses should be tracked, not just those meeting consistency",
+                   ReplicaResponseSizeMetrics.writeResponseBytesPerResponse.getCount() >= initialHistogramCount + 3);
     }
 }

--- a/test/unit/org/apache/cassandra/service/reads/ReadCallbackTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/ReadCallbackTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.service.reads;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.EmptyIterators;
+import org.apache.cassandra.db.MultiRangeReadCommand;
+import org.apache.cassandra.db.MultiRangeReadResponse;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.PartitionRangeReadCommand;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.ReadResponse;
+import org.apache.cassandra.db.SimpleBuilders;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.partitions.SingletonUnfilteredPartitionIterator;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.Bounds;
+import org.apache.cassandra.locator.EndpointsForToken;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.metrics.ReplicaResponseSizeMetrics;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.QueryInfoTracker;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.locator.ReplicaUtils.full;
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for ReadCallback replica response size metrics tracking.
+ * This test class verifies that read responses from replicas are properly tracked in metrics.
+ */
+public class ReadCallbackTest extends AbstractReadResponseTest
+{
+    private SinglePartitionReadCommand command;
+    private EndpointsForToken targetReplicas;
+    
+    @Before
+    public void setUp()
+    {
+        dk = dk("key1");
+        nowInSec = FBUtilities.nowInSeconds();
+        command = SinglePartitionReadCommand.fullPartitionRead(cfm, nowInSec, dk);
+        targetReplicas = EndpointsForToken.of(dk.getToken(), full(EP1), full(EP2), full(EP3));
+    }
+    
+    /**
+     * Test that read response metrics are properly collected for remote responses
+     */
+    @Test
+    public void testReadResponseMetricsForRemoteResponses() throws Throwable
+    {
+        long initialTotalBytes = ReplicaResponseSizeMetrics.totalBytesReceived.getCount();
+        long initialReadBytes = ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount();
+        long initialHistogramCount = ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount();
+        
+        ReplicaPlan.SharedForTokenRead plan = plan(ConsistencyLevel.QUORUM, targetReplicas);
+        DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = 
+            new DigestResolver<>(command, plan, queryStartNanoTime(), noopReadTracker());
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = 
+            new ReadCallback<>(resolver, command, plan, queryStartNanoTime());
+        
+        PartitionUpdate.Builder updateBuilder = PartitionUpdate.builder(cfm, dk, cfm.regularAndStaticColumns(), 1);
+        updateBuilder.add(createRow(1000, 1, "value1"));
+        PartitionUpdate update = updateBuilder.build();
+        ReadResponse readResponse = command.createResponse(iter(update), command.executionController().getRepairedDataInfo());
+        
+        callback.onResponse(createReadResponseMessage(readResponse, EP1));
+        callback.onResponse(createReadResponseMessage(readResponse, EP2));
+        
+        callback.awaitResults();
+        
+        assertTrue("Total bytes metric should have increased",
+                   ReplicaResponseSizeMetrics.totalBytesReceived.getCount() > initialTotalBytes);
+        assertTrue("Read bytes metric should have increased", 
+                   ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount() > initialReadBytes);
+        assertTrue("Histogram count should have increased by at least 2", 
+                   ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount() >= initialHistogramCount + 2);
+    }
+    
+    
+    /**
+     * Test that read response metrics track all responses, including those after consistency is met
+     */
+    @Test
+    public void testReadResponseMetricsTracksAllResponses() throws Throwable
+    {
+        long initialHistogramCount = ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount();
+        
+        ReplicaPlan.SharedForTokenRead plan = plan(ConsistencyLevel.QUORUM, targetReplicas);
+        DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = 
+            new DigestResolver<>(command, plan, queryStartNanoTime(), noopReadTracker());
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = 
+            new ReadCallback<>(resolver, command, plan, queryStartNanoTime());
+        
+        PartitionUpdate.Builder updateBuilder = PartitionUpdate.builder(cfm, dk, cfm.regularAndStaticColumns(), 1);
+        updateBuilder.add(createRow(1000, 1, "value1"));
+        PartitionUpdate update = updateBuilder.build();
+        ReadResponse readResponse = command.createResponse(iter(update), command.executionController().getRepairedDataInfo());
+        
+        callback.onResponse(createReadResponseMessage(readResponse, EP1));
+        callback.onResponse(createReadResponseMessage(readResponse, EP2));
+        callback.onResponse(createReadResponseMessage(readResponse, EP3)); // Extra response after consistency met
+        
+        assertTrue("All responses should be tracked, not just those meeting consistency",
+                   ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount() >= initialHistogramCount + 3);
+    }
+    
+    /**
+     * Test that metrics collection handles unsupported responses
+     */
+    @Test
+    public void testReadResponseMetricsHandlesUnsupportedResponse() throws Throwable
+    {
+        ReplicaPlan.SharedForTokenRead plan = plan(ConsistencyLevel.ONE, targetReplicas);
+        DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = 
+            new DigestResolver<>(command, plan, queryStartNanoTime(), noopReadTracker());
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = 
+            new ReadCallback<>(resolver, command, plan, queryStartNanoTime());
+        
+        // Test with a response that doesn't support size tracking
+        ReadResponse unsupportedResponse = new TestUnsupportedReadResponse();
+        Message<ReadResponse> message = Message.builder(Verb.READ_RSP, unsupportedResponse)
+                                               .from(EP1)
+                                               .build();
+        
+        // This should not throw an exception even though the response doesn't support tracking
+        callback.onResponse(message);
+    }
+    
+    /**
+     * Test that MultiRangeReadResponse doesn't cause exceptions in metrics tracking
+     */
+    @Test
+    public void testReadResponseMetricsWithMultiRangeReadResponse() throws Throwable
+    {
+        long initialHistogramCount = ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount();
+        
+        PartitionRangeReadCommand partitionRangeCommand = PartitionRangeReadCommand.allDataRead(cfm, nowInSec);
+        
+        AbstractBounds<PartitionPosition> keyRange = new Bounds<>(dk.getToken().minKeyBound(), dk.getToken().maxKeyBound());
+        MultiRangeReadCommand multiRangeCommand = MultiRangeReadCommand.create(partitionRangeCommand, 
+                                                                                Collections.singletonList(keyRange), 
+                                                                                false);
+        
+        ReplicaPlan.SharedForTokenRead plan = plan(ConsistencyLevel.QUORUM, targetReplicas);
+        DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = 
+            new DigestResolver<>(command, plan, queryStartNanoTime(), noopReadTracker());
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = 
+            new ReadCallback<>(resolver, command, plan, queryStartNanoTime());
+        
+        PartitionUpdate.Builder updateBuilder = PartitionUpdate.builder(cfm, dk, cfm.regularAndStaticColumns(), 1);
+        updateBuilder.add(createRow(1000, 1, "value1"));
+        PartitionUpdate update = updateBuilder.build();
+        UnfilteredPartitionIterator data = iter(update);
+        
+        ReadResponse multiRangeResponse = multiRangeCommand.createResponse(data, null);
+        
+        Message<ReadResponse> message = Message.builder(Verb.READ_RSP, multiRangeResponse)
+                                               .from(EP1)
+                                               .build();
+        
+        // Should handle gracefully without exceptions
+        callback.onResponse(message);
+        
+        // Another response to meet consistency
+        callback.onResponse(createReadResponseMessage(
+            command.createResponse(iter(update), command.executionController().getRepairedDataInfo()), EP2));
+        
+        callback.awaitResults();
+        
+        // Verify we didn't increment metrics for the MultiRangeReadResponse since it doesn't support tracking
+        // But we should have incremented for the regular response
+        assertTrue("Regular response should still be tracked",
+                   ReplicaResponseSizeMetrics.readResponseBytesPerResponse.getCount() > initialHistogramCount);
+    }
+    
+    /**
+     * Test that digest responses are handled correctly for metrics
+     */
+    @Test
+    public void testReadResponseMetricsWithDigestResponses() throws Throwable
+    {
+        long initialReadBytes = ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount();
+        
+        ReplicaPlan.SharedForTokenRead plan = plan(ConsistencyLevel.QUORUM, targetReplicas);
+        DigestResolver<EndpointsForToken, ReplicaPlan.ForTokenRead> resolver = 
+            new DigestResolver<>(command, plan, queryStartNanoTime(), noopReadTracker());
+        ReadCallback<EndpointsForToken, ReplicaPlan.ForTokenRead> callback = 
+            new ReadCallback<>(resolver, command, plan, queryStartNanoTime());
+        
+        ReadResponse digestResponse = ReadResponse.createDigestResponse(iter(PartitionUpdate.emptyUpdate(cfm, dk)), command);
+        
+        callback.onResponse(createReadResponseMessage(digestResponse, EP1));
+        callback.onResponse(createReadResponseMessage(digestResponse, EP2));
+        
+        assertTrue("Digest responses should also be tracked in metrics",
+                   ReplicaResponseSizeMetrics.readResponseBytesReceived.getCount() > initialReadBytes);
+    }
+    
+    // Helper methods
+    
+    private Message<ReadResponse> createReadResponseMessage(ReadResponse response, InetAddressAndPort from)
+    {
+        return Message.builder(Verb.READ_RSP, response)
+                      .from(from)
+                      .build();
+    }
+    
+    private Row createRow(long timestamp, int clustering, String value)
+    {
+        SimpleBuilders.RowBuilder builder = new SimpleBuilders.RowBuilder(cfm, Integer.toString(clustering));
+        builder.timestamp(timestamp).add("c1", value);
+        return builder.build();
+    }
+    
+    private long queryStartNanoTime()
+    {
+        return System.nanoTime();
+    }
+    
+    private ReplicaPlan.SharedForTokenRead plan(ConsistencyLevel consistencyLevel, EndpointsForToken replicas)
+    {
+        return ReplicaPlan.shared(new ReplicaPlan.ForTokenRead(ks, ks.getReplicationStrategy(), consistencyLevel, replicas, replicas));
+    }
+    
+    // Test implementation that doesn't support response size tracking
+    private static class TestUnsupportedReadResponse extends ReadResponse
+    {
+        @Override
+        public UnfilteredPartitionIterator makeIterator(ReadCommand command)
+        {
+            return EmptyIterators.unfilteredPartition(command.metadata());
+        }
+        
+        @Override
+        public ByteBuffer digest(ReadCommand command)
+        {
+            return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+        }
+        
+        @Override
+        public ByteBuffer repairedDataDigest()
+        {
+            return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+        }
+        
+        @Override
+        public boolean isRepairedDigestConclusive()
+        {
+            return false;
+        }
+        
+        @Override
+        public boolean mayIncludeRepairedDigest()
+        {
+            return false;
+        }
+        
+        @Override
+        public boolean isDigestResponse()
+        {
+            return false;
+        }
+        
+        @Override
+        public boolean supportsResponseSizeTracking()
+        {
+            return false; // This response type doesn't support size tracking
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue
Fixes #7237

### What does this PR fix and why was it fixed
Adds metrics to track both read and write responses in bytes
