### PR TITLE
CNDB-14725: add SSTableFlushObserver#onSSTableWriterSwitched to flush SAI segment builder for written shards without waiting for entire transaction to complete

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PerIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PerIndexWriter.java
@@ -47,6 +47,12 @@ public interface PerIndexWriter
     void complete(Stopwatch stopwatch) throws IOException;
 
     /**
+     * Called when current sstable writer is switched during sharded compaction to free any in-memory resources associated
+     * with the sstable for current index without waiting for full transaction to complete
+     */
+    void onSSTableWriterSwitched(Stopwatch stopwatch) throws IOException;
+
+    /**
      * Aborts accumulating data. Allows to clean up resources on error.
      * 
      * Note: Implementations should be idempotent, i.e. safe to call multiple times without producing undesirable side-effects.

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -144,6 +144,13 @@ public class MemtableIndexWriter implements PerIndexWriter
         }
     }
 
+    @Override
+    public void onSSTableWriterSwitched(Stopwatch stopwatch) throws IOException
+    {
+        // no-op for memtable index where all terms are already inside memory index, we can't get rid of memory index
+        // until full flush are completed
+    }
+
     private long flush(DecoratedKey minKey, DecoratedKey maxKey, AbstractType<?> termComparator, MemtableTermsIterator terms, int maxSegmentRowId) throws IOException
     {
         long numPostings;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -141,6 +141,18 @@ public class SSTableIndexWriter implements PerIndexWriter
     }
 
     @Override
+    public void onSSTableWriterSwitched(Stopwatch stopwatch) throws IOException
+    {
+        if (maybeAbort())
+            return;
+
+        boolean emptySegment = currentBuilder == null || currentBuilder.isEmpty();
+        logger.debug("Flushing index {} with {}buffered data on sstable writer switched...", indexContext.getIndexName(), emptySegment ? "no " : "");
+        if (!emptySegment)
+            flushSegment();
+    }
+
+    @Override
     public void complete(Stopwatch stopwatch) throws IOException
     {
         if (maybeAbort())
@@ -320,8 +332,9 @@ public class SSTableIndexWriter implements PerIndexWriter
                 if (indexContext.getIndexMetrics() != null)
                     indexContext.getIndexMetrics().compactionSegmentBytesPerSecond.update((long)(segmentBytes / flushMillis * 1000.0));
 
-                logger.debug("Flushed segment with {} cells for a total of {} in {} ms",
-                             (long) rowCount, FBUtilities.prettyPrintMemory((long) segmentBytes), flushMillis);
+                logger.debug("Flushed segment with {} cells for a total of {} in {} ms for index {} with starting row id {} for sstable {}",
+                             (long) rowCount, FBUtilities.prettyPrintMemory((long) segmentBytes), flushMillis, indexContext.getIndexName(),
+                             segmentMetadata.minSSTableRowId, perIndexComponents.descriptor());
             }
 
             // Builder memory is released against the limiter at the conclusion of a successful
@@ -400,9 +413,10 @@ public class SSTableIndexWriter implements PerIndexWriter
         }
 
         long globalBytesUsed = limiter.increment(builder.totalBytesAllocated());
-        logger.debug("Created new segment builder while flushing SSTable {}. Global segment memory usage now at {}",
+        logger.debug("Created new segment builder while flushing SSTable {}. Global segment memory usage now at {} with {} active segment builders",
                      perIndexComponents.descriptor(),
-                     FBUtilities.prettyPrintMemory(globalBytesUsed));
+                     FBUtilities.prettyPrintMemory(globalBytesUsed),
+                     SegmentBuilder.ACTIVE_BUILDER_COUNT.get() - 1);
 
         return builder;
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -303,6 +303,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
 
         currentlyOpenedEarlyAt = 0;
         bytesWritten += writer.getFilePointer();
+        writer.onSSTableWriterSwitched();
         writer = newWriter;
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFlushObserver.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFlushObserver.java
@@ -107,6 +107,14 @@ public interface SSTableFlushObserver
     void complete(SSTable sstable);
 
     /**
+     * Called when current sstable writer is switched during sharded compaction to free any in-memory resources associated
+     * with the sstable without waiting for full transaction to complete
+     */
+    default void onSSTableWriterSwitched()
+    {
+    }
+
+    /**
      * Clean up resources on error. There should be no side effects if called multiple times.
      */
     default void abort(Throwable accumulator) {}

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -354,6 +354,12 @@ public abstract class SSTableWriter extends SSTable implements Transactional
          }
     }
 
+    // notify sstable flush observer about sstable writer switched
+    public final void onSSTableWriterSwitched()
+    {
+        observers.forEach(SSTableFlushObserver::onSSTableWriterSwitched);
+    }
+
     public final Throwable commit(Throwable accumulate)
     {
         return txnProxy().commit(accumulate);

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -23,6 +23,10 @@ package org.apache.cassandra.index.sai.functional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.InstanceNotFoundException;
 
@@ -47,6 +51,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter;
+import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.metrics.AbstractMetricsTest;
 import org.apache.cassandra.inject.ActionBuilder;
 import org.apache.cassandra.inject.Expression;
@@ -62,9 +67,11 @@ import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.concurrent.Refs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -391,6 +398,55 @@ public class CompactionTest extends AbstractMetricsTest
         assertThatThrownBy(() -> executeNet("SELECT id1 FROM %s WHERE v2='0'"))
                 .isInstanceOf(InvalidQueryException.class)
                 .hasMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE);
+    }
+
+    @Test
+    public void testSegmentBuilderFlushWithShardedCompaction() throws Throwable
+    {
+        int shards = 64;
+        String createTable = "CREATE TABLE %s (id1 TEXT PRIMARY KEY, v1 INT, v2 TEXT) WITH compaction = " +
+                             "{'class' : 'UnifiedCompactionStrategy', 'enabled' : false, 'base_shard_count': " + shards + ", 'min_sstable_size': '1KiB' }";
+        createTable(createTable);
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+        disableCompaction(keyspace(), currentTable());
+
+        int rowsPerSSTable = 2000;
+        int numSSTables = 4;
+        int key = 0;
+        for (int s = 0; s < numSSTables; s++)
+        {
+            for (int i = 0; i < rowsPerSSTable; i++)
+            {
+                execute("INSERT INTO %s (id1, v1, v2) VALUES (?, 0, '01e2wefnewirui32e21e21wre')", Integer.toString(key++));
+            }
+            flush();
+        }
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try
+        {
+            Future<?> future = executor.submit(() -> {
+                getCurrentColumnFamilyStore().forceMajorCompaction(false, 1);
+                waitForCompactions();
+            });
+
+            // verify that it's not accumulating segment builders
+            while (!future.isDone())
+            {
+                // ACTIVE_BUILDER_COUNT starts from 1. There are 2 segments for 2 indexes
+                assertThat(SegmentBuilder.ACTIVE_BUILDER_COUNT.get()).isGreaterThanOrEqualTo(1).isLessThanOrEqualTo(3);
+            }
+            future.get(30, TimeUnit.SECONDS);
+
+            // verify results are sharded
+            assertThat(getCurrentColumnFamilyStore().getLiveSSTables()).hasSize(shards);
+        }
+        finally
+        {
+            executor.shutdown();
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        }
     }
 
     protected int getOpenIndexFiles()


### PR DESCRIPTION
This reduces memory usage during sharded compaction.

### What is the issue

https://github.com/riptano/cndb/issues/14725 OOM during SAI compaction with large num of shards

### What does this PR fix and why was it fixed

Flush segment builder when sstable writer is switched to free memory without waiting full compaction to complete
