### PR TITLE
CNDB-14650: allow mixed mode repair

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -249,6 +249,13 @@ public enum CassandraRelevantProperties
      */
     REPAIR_PARENT_SESSION_LISTENER("cassandra.custom_parent_repair_session_listener_class"),
 
+    /**
+     * Allow repair in mixed major version clusters. When false (default), repair operations
+     * will fail in clusters with mixed major versions unless explicitly allowed.
+     * Set to true to allow repair during rolling upgrades.
+     */
+    ALLOW_MIXED_REPAIR("cassandra.allow_mixed_repair", "false"),
+
     //cassandra properties (without the "cassandra." prefix)
 
     /**


### PR DESCRIPTION
### What is the issue
Fixes #14650

### What does this PR fix and why was it fixed
OSS disallows mixed version repair because the streaming compatibility story is somewhat unknown between versions.  This patch allows overriding this with -Dcassandra.allow_mixed_repair=true
