### PR TITLE
CNDB-12972: Enhance controller config file handling for long names an…

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -65,6 +65,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.Meter;
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.cache.AutoSavingCache;
@@ -258,9 +259,9 @@ public class CompactionManager implements CompactionManagerMBean
                             file.delete();
                         }
                     }
-                    else if (names.length == 3)
+                    else if (names.length == 3) // if keyspace/table names are long, we include table id as a 3rd component while the keyspace and table names are abbreviated
                     {
-                        TableId tableId = TableId.fromString(names[2]);
+                        TableId tableId = TableId.fromHexString(names[2]);
                         //table exists so keep the file
                         if (Schema.instance.getTableMetadata(tableId) == null)
                         {

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileReader;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.Overlaps;
@@ -72,8 +73,7 @@ public class StaticController extends Controller
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
                             boolean hasVectorType,
-                            String keyspaceName,
-                            String tableName)
+                            TableMetadata metadata)
     {
         super(MonotonicClock.preciseTime,
               env,
@@ -94,10 +94,9 @@ public class StaticController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              metadata);
         this.scalingParameters = scalingParameters;
-        this.keyspaceName = keyspaceName;
-        this.tableName = tableName;
     }
 
     static Controller fromOptions(Environment env,
@@ -118,8 +117,7 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
-                                  String keyspaceName,
-                                  String tableName,
+                                  TableMetadata metadata,
                                   Map<String, String> options,
                                   boolean useVectorOptions)
     {
@@ -133,7 +131,7 @@ public class StaticController extends Controller
 
         long currentFlushSize = flushSizeOverride;
 
-        File f = getControllerConfigPath(keyspaceName, tableName);
+        File f = getControllerConfigPath(metadata);
         try
         {
             JSONParser jsonParser = new JSONParser();
@@ -181,8 +179,7 @@ public class StaticController extends Controller
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
                                     hasVectorType,
-                                    keyspaceName,
-                                    tableName);
+                                    metadata);
     }
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
@@ -229,7 +226,7 @@ public class StaticController extends Controller
     @Override
     public void storeControllerConfig()
     {
-        storeOptions(keyspaceName, tableName, scalingParameters, getFlushSizeBytes());
+        storeOptions(metadata, scalingParameters, getFlushSizeBytes());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/schema/TableId.java
+++ b/src/java/org/apache/cassandra/schema/TableId.java
@@ -61,7 +61,7 @@ public class TableId
         return new TableId(UUID.fromString(idString));
     }
 
-    private static TableId fromHexString(String nonDashUUID)
+    public static TableId fromHexString(String nonDashUUID)
     {
         ByteBuffer bytes = ByteBufferUtil.hexToBytes(nonDashUUID);
         long msb = bytes.getLong(0);

--- a/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CompactionControllerConfigTest.java
@@ -31,10 +31,12 @@ import org.apache.cassandra.db.compaction.unified.AdaptiveController;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.StaticController;
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.schema.TableMetadata;
 
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
 import static org.apache.cassandra.distributed.shared.FutureUtils.waitOn;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CompactionControllerConfigTest extends TestBaseImpl
 {
@@ -53,6 +55,7 @@ public class CompactionControllerConfigTest extends TestBaseImpl
             cluster.get(1).runOnInstance(() ->
                                              {
                                                  ColumnFamilyStore cfs = Keyspace.open("ks").getColumnFamilyStore("tbl");
+                                                 ColumnFamilyStore cfs2 = Keyspace.open("ks").getColumnFamilyStore("tbl2");
                                                  UnifiedCompactionContainer container = (UnifiedCompactionContainer) cfs.getCompactionStrategy();
                                                  UnifiedCompactionStrategy ucs = (UnifiedCompactionStrategy) container.getStrategies().get(0);
                                                  Controller controller = ucs.getController();
@@ -63,12 +66,12 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                                  //manually write new scaling parameters and flushSizeBytes to see if they are picked up on restart
                                                  int[] scalingParameters = new int[32];
                                                  Arrays.fill(scalingParameters, 5);
-                                                 AdaptiveController.storeOptions("ks", "tbl", scalingParameters, 10 << 20);
+                                                 AdaptiveController.storeOptions(cfs.metadata(), scalingParameters, 10 << 20);
 
 
                                                  //write different scaling parameters to second table to make sure each table keeps its own configuration
                                                  Arrays.fill(scalingParameters, 8);
-                                                 AdaptiveController.storeOptions("ks", "tbl2", scalingParameters, 10 << 20);
+                                                 AdaptiveController.storeOptions(cfs2.metadata(), scalingParameters, 10 << 20);
                                              });
             waitOn(cluster.get(1).shutdown());
             cluster.get(1).startup();
@@ -119,7 +122,7 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              //manually write new flushSizeBytes to see if it is picked up on restart
                                              int[] scalingParameters = new int[32];
                                              Arrays.fill(scalingParameters, 0);
-                                             AdaptiveController.storeOptions("ks", "tbl", scalingParameters, 10 << 20);
+                                             AdaptiveController.storeOptions(cfs.metadata(), scalingParameters, 10 << 20);
                                          });
             waitOn(cluster.get(1).shutdown());
             cluster.get(1).startup();
@@ -157,20 +160,22 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                          {
                                              //logs should show that scaling parameters and flush size are written to a file for each table
                                              CompactionManager.storeControllerConfig();
+                                             TableMetadata metadata = standardCFMD("does_not", "exist").build();
 
                                              //store controller config for a table that does not exist to see if it is removed by the cleanup method
                                              int[] scalingParameters = new int[32];
                                              Arrays.fill(scalingParameters, 5);
-                                             AdaptiveController.storeOptions("does_not", "exist", scalingParameters, 10 << 20);
+
+                                             AdaptiveController.storeOptions(metadata, scalingParameters, 10 << 20);
 
                                              //verify that the file was created
-                                             assert Controller.getControllerConfigPath("does_not", "exist").exists();
+                                             assert Controller.getControllerConfigPath(metadata).exists();
 
                                              //cleanup method should remove the file corresponding to the table "does_not.exist"
                                              CompactionManager.cleanupControllerConfig();
 
                                              //verify that the file was deleted
-                                             assert !Controller.getControllerConfigPath("does_not", "exist").exists();
+                                             assert !Controller.getControllerConfigPath(metadata).exists();
 
                                          });
 
@@ -189,12 +194,13 @@ public class CompactionControllerConfigTest extends TestBaseImpl
                                              // try to store controller config for a table with a long name
                                              String keyspaceName = "g38373639353166362d356631322d343864652d393063362d653862616534343165333764_tpch";
                                              String longTableName = "test_create_k8yq1r75bpzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+                                             TableMetadata metadata = standardCFMD(keyspaceName, longTableName).build();
                                              int[] scalingParameters = new int[32];
                                              Arrays.fill(scalingParameters, 5);
-                                             AdaptiveController.storeOptions(keyspaceName, longTableName, scalingParameters, 10 << 20);
+                                             AdaptiveController.storeOptions(metadata, scalingParameters, 10 << 20);
 
-                                             // verify that the file wasn't created
-                                             assert !Controller.getControllerConfigPath(keyspaceName, longTableName).exists();
+                                             // verify that the file WAS created (CNDB-12972)
+                                             assert Controller.getControllerConfigPath(metadata).exists();
                                          });
         }
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.inject.Inject;
 
 import com.google.common.collect.Iterables;
@@ -60,7 +59,6 @@ import io.airlift.airline.Command;
 import io.airlift.airline.HelpOption;
 import io.airlift.airline.Option;
 import io.airlift.airline.SingleCommand;
-
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -69,9 +67,9 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.compaction.unified.AdaptiveController;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.CostsCalculator;
+import org.apache.cassandra.db.compaction.unified.Environment;
 import org.apache.cassandra.db.compaction.unified.Reservations;
 import org.apache.cassandra.db.compaction.unified.StaticController;
-import org.apache.cassandra.db.compaction.unified.Environment;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.dht.IPartitioner;
@@ -79,6 +77,7 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ExpMovingAverage;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MonotonicClock;
@@ -87,7 +86,9 @@ import org.apache.cassandra.utils.Overlaps;
 import org.apache.cassandra.utils.PageAware;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 /**
@@ -389,6 +390,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
         int[] Ws = new int[] { W };
         int[] previousWs = new int[] { W };
         double maxSpaceOverhead = 0.2;
+        TableMetadata metadata = standardCFMD(keyspace, table).build();
 
         Controller controller = adaptive
                                 ? new AdaptiveController(MonotonicClock.preciseTime,
@@ -417,8 +419,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          gain,
                                                          minCost,
                                                          maxAdaptiveCompactions,
-                                                         "ks",
-                                                         "tbl")
+                                                         metadata)
                                 : new StaticController(new SimulatedEnvironment(counters, valueSize),
                                                        Ws,
                                                        new double[] { o },
@@ -439,8 +440,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        overlapInclusionMethod,
                                                        true,
                                                        false,
-                                                       "ks",
-                                                       "tbl");
+                                                       metadata);
 
         return new UnifiedCompactionStrategy(strategyFactory, controller);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -93,8 +93,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       threshold,
                                       minCost,
                                       maxAdaptiveCompactions,
-                                      keyspaceName,
-                                      tableName);
+                                      metadata);
     }
 
     @Test
@@ -128,7 +127,7 @@ public class AdaptiveControllerTest extends ControllerTest
 
         int[] scalingParameters = new int[30];
         Arrays.fill(scalingParameters, 1);
-        AdaptiveController.storeOptions(keyspaceName, tableName, scalingParameters, 10 << 20);
+        AdaptiveController.storeOptions(metadata, scalingParameters, 10 << 20);
 
         Controller controller = testFromOptions(true, options);
         assertTrue(controller instanceof AdaptiveController);
@@ -139,7 +138,7 @@ public class AdaptiveControllerTest extends ControllerTest
             assertEquals(1, controller.getPreviousScalingParameter(i));
         }
         int[] emptyScalingParameters = {};
-        AdaptiveController.storeOptions(keyspaceName, tableName, emptyScalingParameters, 10 << 20);
+        AdaptiveController.storeOptions(metadata, emptyScalingParameters, 10 << 20);
 
         Controller controller2 = testFromOptions(true, options);
         assertTrue(controller2 instanceof AdaptiveController);
@@ -149,7 +148,7 @@ public class AdaptiveControllerTest extends ControllerTest
             assertEquals(3, controller2.getScalingParameter(i));
             assertEquals(3, controller2.getPreviousScalingParameter(i));
         }
-        AdaptiveController.getControllerConfigPath(keyspaceName, tableName).delete();
+        AdaptiveController.getControllerConfigPath(metadata).delete();
 
         Map<String, String> options2 = new HashMap<>();
         options2.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -44,11 +44,14 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MovingAverage;
 import org.apache.cassandra.utils.Overlaps;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.internal.creation.MockSettingsImpl;
 
 import static junit.framework.TestCase.assertNull;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -83,7 +86,6 @@ public abstract class ControllerTest
     @Mock
     ColumnFamilyStore cfs;
 
-    @Mock
     TableMetadata metadata;
 
     @Mock
@@ -121,11 +123,13 @@ public abstract class ControllerTest
     public void setUp()
     {
         MockitoAnnotations.initMocks(this);
+        metadata = Mockito.mock(TableMetadata.class, new MockSettingsImpl<>()
+                                                     .useConstructor(standardCFMD(keyspaceName, tableName))
+                                                     .defaultAnswer(Answers.RETURNS_SMART_NULLS));
 
         when(strategy.getMetadata()).thenReturn(metadata);
         when(strategy.getEstimatedRemainingTasks()).thenReturn(0);
 
-        when(metadata.toString()).thenReturn("");
         when(replicationStrategy.getReplicationFactor()).thenReturn(ReplicationFactor.fullOnly(3));
         when(cfs.makeUCSEnvironment()).thenAnswer(invocation -> new RealEnvironment(cfs));
         when(cfs.getKeyspaceReplicationStrategy()).thenReturn(replicationStrategy);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.schema.SchemaConstants;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -214,8 +213,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testStartShutdown(controller);
     }
 
@@ -242,8 +240,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testShutdownNotStarted(controller);
     }
 
@@ -270,8 +267,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testStartAlreadyStarted(controller);
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of controller configuration files in the compaction subsystem of Apache Cassandra. The changes focus on consolidating constants, enhancing file naming logic to support very long table/keyspace names.

In particular - controller configuration files consists of keyspace and table names, separated by dot and a fixed suffix. This scheme is retained as long as the while filename does not exceed 255 chars. If it does, keyspace and table names are abbreviated and a third component is added - table id. 

In a situation when the keyspace and table names needs to be resolved from the file name, the code examines the filename whether it has 2 or 3 components (delimited by dots). If 2, follow the legacy pattern, if 3, ignore keyspace and table names, and read just the table id. Table id is then used to resolve metadata from schema.

The change is forward compatible because:
- for normal keyspace and table names lengths, the 2 components scheme is still readable by the new  version
- for long keyspace and tables names lengths, the file was not created at all

The change is backward compatible because:
- for normal keyspace and table names lengths, the 2 components scheme is retained, thus the old version will still able to resolve it
- for long keyspace and table names lengths, the 3 components schema will be wrongly resolved and lead to deletion of the controller file as wrongly resolved keyspace and table names would not be found. This is compatible with the current behaviour of the old version because in such a case, the controller config file would not be created at all.
