### PR TITLE
CNDB-14159: Fix DOC_LENGTHS offset calculations (#1745)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -209,7 +209,7 @@ public class InvertedIndexSearcher extends IndexSearcher
 
         var pkm = primaryKeyMapFactory.newPerSSTablePrimaryKeyMap();
         var merged = IntersectingPostingList.intersect(postingLists);
-        var docLengthsReader = new DocLengthsReader(docLengths, docLengthsMeta);
+        var docLengthsReader = new DocLengthsReader(docLengths, docLengthsMeta, version);
 
         // Wrap the iterator with resource management
         var it = new AbstractIterator<BM25Utils.DocTF>() { // Anonymous class extends AbstractIterator

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/trie/InvertedIndexWriter.java
@@ -103,7 +103,7 @@ public class InvertedIndexWriter implements Closeable
         // Write doc lengths
         if (docLengthsWriter != null)
         {
-            long docLengthsOffset = docLengthsWriter.getFilePointer();
+            long docLengthsOffset = docLengthsWriter.getStartOffset();
             docLengthsWriter.writeDocLengths(docLengths);
             long docLengthsLength = docLengthsWriter.getFilePointer() - docLengthsOffset;
             components.put(IndexComponentType.DOC_LENGTHS, -1, docLengthsOffset, docLengthsLength);

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -73,6 +73,7 @@ import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.ResourceLeakDetector;
@@ -228,6 +229,14 @@ public class SAITester extends CQLTester
     {
         // Enable the optimizer by default. If there are any tests that need to disable it, they can do so explicitly.
         QueryController.QUERY_OPT_LEVEL = 1;
+
+    }
+
+    @Before
+    public void resetLastValidSegmentRowId() throws Throwable
+    {
+        // Don't want this setting to impact peer tests
+        SegmentBuilder.updateLastValidSegmentRowId(-1);
     }
 
     @After


### PR DESCRIPTION
### What is the issue
Addresses some of the issues discovered by
https://github.com/riptano/cndb/issues/14159

### What does this PR fix and why was it fixed

First I added tests that show the issue. Then, I fixed it by setting `EC` will to still have the "bug" where the ComponentMetadata will point to just after the header while ED and beyond will point to the header.

There are no places we use the header other than the SystemView to get info about the length (which was wrong due to not including the header). However, these do not affect the validation of the header, so I propose that we leave them as is and just fix it header other than the SystemView to get info about the length (which was wrong due to not including the header). However, these do not affect the validation of the header, so I propose that we leave them as is and just fix it in ED.
