### PR TITLE
CNDB-14797: Upgrade to jvector 4.0.0-rc1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -754,7 +754,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="4.0.0-beta.5" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="4.0.0-rc.1" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -31,6 +31,7 @@ import io.github.jbellis.jvector.graph.GraphIndex;
 import io.github.jbellis.jvector.graph.GraphSearcher;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.BQVectors;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
@@ -238,12 +239,12 @@ public class CassandraDiskAnn
             {
                 var asf = view.approximateScoreFunctionFor(queryVector, similarityFunction);
                 var rr = isRerankless ? null : view.rerankerFor(queryVector, similarityFunction);
-                ssp = new SearchScoreProvider(asf, rr);
+                ssp = new DefaultSearchScoreProvider(asf, rr);
             }
             else if (compressedVectors == null)
             {
                 // no compression, so we ignore isRerankless (except for setting rerankK to limit)
-                ssp = new SearchScoreProvider(view.rerankerFor(queryVector, similarityFunction));
+                ssp = new DefaultSearchScoreProvider(view.rerankerFor(queryVector, similarityFunction));
             }
             else
             {
@@ -254,7 +255,7 @@ public class CassandraDiskAnn
                          : similarityFunction;
                 var asf = compressedVectors.precomputedScoreFunctionFor(queryVector, sf);
                 var rr = isRerankless ? null : view.rerankerFor(queryVector, similarityFunction);
-                ssp = new SearchScoreProvider(asf, rr);
+                ssp = new DefaultSearchScoreProvider(asf, rr);
             }
             long start = System.nanoTime();
             var result = searcher.search(ssp, limit, rerankK, threshold, context.getAnnRerankFloor(), ordinalsMap.ignoringDeleted(acceptBits));

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -49,6 +49,7 @@ import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
+import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
 import io.github.jbellis.jvector.quantization.BinaryQuantization;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
@@ -341,7 +342,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         searcher.setView(builder.getGraph().getView());
         try
         {
-            var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
+            var ssf = DefaultSearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);
             long start = System.nanoTime();
             var result = searcher.search(ssf, limit, rerankK, threshold, 0.0f, bits);
             long elapsed = System.nanoTime() - start;
@@ -439,10 +440,10 @@ public class CassandraOnHeapGraph<T> implements Accountable
         try (var pqOutput = perIndexComponents.addOrGet(IndexComponentType.PQ).openOutput(true);
              var postingsOutput = perIndexComponents.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true);
              var indexWriter = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
+                               .withStartOffset(termsOffset)
                                .withVersion(Version.current().onDiskFormat().jvectorFileFormatVersion())
                                .withMapper(ordinalMapper)
                                .with(new InlineVectors(vectorValues.dimension()))
-                               .withStartOffset(termsOffset)
                                .build())
         {
             SAICodecUtils.writeHeader(pqOutput);


### PR DESCRIPTION
### What is the issue

Fixes https://github.com/riptano/cndb/issues/14797

### What does this PR fix and why was it fixed

Here is the list of commits included in the upgrade: https://github.com/datastax/jvector/compare/4.0.0-beta.5...4.0.0-rc.1

Here is a copy of the relevant `CHANGELOG.md` lines:

> #### [4.0.0-rc.1](https://github.com/datastax/jvector/compare/4.0.0-beta.6...4.0.0-rc.1)
> 
> - Fix issue when calling cleanup while concurrently executing searches [`#483`](https://github.com/datastax/jvector/pull/483)
> - Improve the efficiency and memory usage of GraphIndexBuilder.cleanup [`#477`](https://github.com/datastax/jvector/pull/477)
> - add PQ training benchmark [`#482`](https://github.com/datastax/jvector/pull/482)
> - Remove extraneous character from datasets.yml [`#484`](https://github.com/datastax/jvector/pull/484)
> - Upgrade YAML files to v5 after the format was introduced in the last update [`#478`](https://github.com/datastax/jvector/pull/478)
> - New chunked memory-mapped reader that supports &gt;2GB files [`61bffbe`](https://github.com/datastax/jvector/commit/61bffbe4f9b8dbc3a30e6a0292c077ffdd8d441a)
> - release 4.0.0-rc.1 [`6737596`](https://github.com/datastax/jvector/commit/673759684d406e41bd901b6ef2e6a1353c35cb79)
> - Fix comparison in TestADCGraphIndex [`b637f65`](https://github.com/datastax/jvector/commit/b637f658e89918cd39a767a8af35815bfa5ef28c)
> 
> #### [4.0.0-beta.6](https://github.com/datastax/jvector/compare/4.0.0-beta.5...4.0.0-beta.6)
> 
> > 13 June 2025
> - Add a new graph node using a search score [`#473`](https://github.com/datastax/jvector/pull/473)
> - chore(release): Bump tag version and update changelog [`#471`](https://github.com/datastax/jvector/pull/471)
> - Sequential disk writer (#475). Upgrades file format from 4 to 5 [`d0ccb32`](https://github.com/datastax/jvector/commit/d0ccb327207194b0f3640f5d11dcc93027645f09)
> - Allow empty sections in datasets.yml & add colbert-1M.yml [`2bf5f9a`](https://github.com/datastax/jvector/commit/2bf5f9a68b6b79fc1094c8760a70f2872eb09ec5)
> - chore (release): Start release version 4.0.0-beta.6 [`9a453a3`](https://github.com/datastax/jvector/commit/9a453a38660d77256e48da209c8bbcbadf2a93bb)
> 
> 