### PR TITLE
CNDB-14306: Update ANN_USE_SYNTHETIC_SCORE to default to true for SAI version >EC (#1787)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -145,7 +145,8 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 import static java.lang.String.format;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_ANN_USE_SYNTHETIC_SCORE;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNull;
@@ -172,7 +173,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     // and the related code in
     //  - StatementRestrictions.addOrderingRestrictions
     //  - StorageAttachedIndexSearcher.PrimaryKeyIterator constructor
-    public static final boolean ANN_USE_SYNTHETIC_SCORE = SAI_ANN_USE_SYNTHETIC_SCORE.getBoolean();
+    public static final boolean ANN_USE_SYNTHETIC_SCORE = CassandraRelevantProperties.SAI_ANN_USE_SYNTHETIC_SCORE
+        .getBoolean(Version.current().after(Version.EC));
 
     private static final Logger logger = LoggerFactory.getLogger(SelectStatement.class);
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(SelectStatement.logger, 1, TimeUnit.MINUTES);

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -177,6 +177,12 @@ public class Version implements Comparable<Version>
         return version;
     }
 
+    // Useful for handling features that need a two phase rollout.
+    public boolean after(Version other)
+    {
+        return version.compareTo(other.version) > 0;
+    }
+
     public boolean onOrAfter(Version other)
     {
         return version.compareTo(other.version) >= 0;

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/VersionTest.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class VersionTest
@@ -41,7 +42,12 @@ public class VersionTest
         for (Version version : Version.ALL)
         {
             if (previous != null)
+            {
                 assertTrue(previous.onOrAfter(version));
+                assertTrue(previous.after(version));
+                assertTrue(!version.onOrAfter(previous));
+                assertTrue(!version.after(previous));
+            }
             previous = version;
         }
     }
@@ -61,5 +67,34 @@ public class VersionTest
         assertThatThrownBy(() -> Version.parse("ab")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("a")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Version.parse("abc")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testAfterMethod()
+    {
+        // Do some basic checks, doesn't need to be updated for each new format.
+        assertTrue(Version.ED.after(Version.EC));
+        assertTrue(Version.EC.after(Version.EB));
+        assertTrue(Version.EB.after(Version.DC));
+        assertTrue(Version.DC.after(Version.DB));
+        assertTrue(Version.DB.after(Version.CA));
+        assertTrue(Version.CA.after(Version.BA));
+        assertTrue(Version.BA.after(Version.AA));
+
+        assertFalse(Version.AA.after(Version.BA));
+        assertFalse(Version.AA.after(Version.AA));
+    }
+
+    @Test
+    public void testOnOrAfterMethod()
+    {
+        // Do some basic checks, doesn't need to be updated for each new format.
+        assertTrue(Version.ED.onOrAfter(Version.ED));
+        assertTrue(Version.ED.onOrAfter(Version.EC));
+        assertTrue(Version.CA.onOrAfter(Version.BA));
+        assertTrue(Version.BA.onOrAfter(Version.AA));
+
+        assertFalse(Version.AA.onOrAfter(Version.BA));
+        assertFalse(Version.BA.onOrAfter(Version.CA));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14306

### What does this PR fix and why was it fixed
When we upgrade past `EC`, we'll be able to send the scores instead of the vectors. The backwards compatibility for this will be covered in CNDB.
