### PR TITLE
CNDB-14361 use node's total document and term counts (#1791)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -135,6 +135,16 @@ public class SSTableIndex implements Comparable<SSTableIndex>
         return searchableIndex.getRowCount();
     }
 
+    /**
+     * Returns the total number of terms in all indexed rows of this index.
+     * This number is approximate because it does not account for any deletions
+     * that may have occurred since the index was built.
+     */
+    public long getApproximateTermCount()
+    {
+        return searchableIndex.getApproximateTermCount();
+    }
+
     public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
     {
         return searchableIndex.estimateMatchingRowsCount(predicate, keyRange);

--- a/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
@@ -51,6 +51,12 @@ public class EmptyIndex implements SearchableIndex
     }
 
     @Override
+    public long getApproximateTermCount()
+    {
+        return 0;
+    }
+
+    @Override
     public long minSSTableRowId()
     {
         return -1;

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -48,35 +48,37 @@ import org.apache.cassandra.utils.CloseableIterator;
  */
 public interface SearchableIndex extends Closeable
 {
-    public long indexFileCacheSize();
+    long indexFileCacheSize();
 
-    public long getRowCount();
+    long getRowCount();
 
-    public long minSSTableRowId();
+    long getApproximateTermCount();
 
-    public long maxSSTableRowId();
+    long minSSTableRowId();
 
-    public ByteBuffer minTerm();
+    long maxSSTableRowId();
 
-    public ByteBuffer maxTerm();
+    ByteBuffer minTerm();
 
-    public DecoratedKey minKey();
+    ByteBuffer maxTerm();
 
-    public DecoratedKey maxKey();
+    DecoratedKey minKey();
 
-    public KeyRangeIterator search(Expression expression,
+    DecoratedKey maxKey();
+
+    KeyRangeIterator search(Expression expression,
                                    AbstractBounds<PartitionPosition> keyRange,
                                    QueryContext context,
                                    boolean defer, int limit) throws IOException;
 
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
+    List<CloseableIterator<PrimaryKeyWithSortKey>> orderBy(Orderer orderer,
                                                                   Expression slice,
                                                                   AbstractBounds<PartitionPosition> keyRange,
                                                                   QueryContext context,
                                                                   int limit,
                                                                   long totalRows) throws IOException;
 
-    public List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context,
+    List<CloseableIterator<PrimaryKeyWithSortKey>> orderResultsBy(QueryContext context,
                                                                          List<PrimaryKey> keys,
                                                                          Orderer orderer,
                                                                          int limit,
@@ -84,7 +86,7 @@ public interface SearchableIndex extends Closeable
 
     List<Segment> getSegments();
 
-    public void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
+    void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
 
     long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -74,6 +74,7 @@ public class V1SearchableIndex implements SearchableIndex
     private final ByteBuffer maxTerm;
     private final long minSSTableRowId, maxSSTableRowId;
     private final long numRows;
+    private final long approximateTermCount;
     private PerIndexFiles indexFiles;
 
     public V1SearchableIndex(SSTableContext sstableContext, IndexComponents.ForRead perIndexComponents)
@@ -105,6 +106,7 @@ public class V1SearchableIndex implements SearchableIndex
             this.maxTerm = metadatas.stream().map(m -> m.maxTerm).max(TypeUtil.comparator(indexContext.getValidator(), version)).orElse(null);
 
             this.numRows = metadatas.stream().mapToLong(m -> m.numRows).sum();
+            this.approximateTermCount = metadatas.stream().mapToLong(m -> m.totalTermCount).sum();
 
             this.minSSTableRowId = metadatas.get(0).minSSTableRowId;
             this.maxSSTableRowId = metadatas.get(metadatas.size() - 1).maxSSTableRowId;
@@ -127,6 +129,12 @@ public class V1SearchableIndex implements SearchableIndex
     public long getRowCount()
     {
         return numRows;
+    }
+
+    @Override
+    public long getApproximateTermCount()
+    {
+        return approximateTermCount;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/AbstractMemtableIndex.java
@@ -40,16 +40,11 @@ public abstract class AbstractMemtableIndex implements MemtableIndex
     }
 
     /**
-     * @return num of rows in the memtable index
-     */
-    protected abstract int indexedRows();
-
-    /**
      * Called when index is updated
      */
     protected void onIndexUpdated()
     {
-        if (flushThresholdMaxRows > 0 && indexedRows() >= flushThresholdMaxRows)
+        if (flushThresholdMaxRows > 0 && getRowCount() >= flushThresholdMaxRows)
             memtable.signalFlushRequired(ColumnFamilyStore.FlushReason.INDEX_MEMTABLE_LIMIT, true);
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -457,9 +457,15 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public int indexedRows()
+    public int getRowCount()
     {
         return graph.size();
+    }
+
+    @Override
+    public long getApproximateTermCount()
+    {
+        throw new UnsupportedOperationException("Getting number of terms not supported by vector indexes");
     }
 
     public SegmentMetadata.ComponentMetadataMap writeData(IndexComponents.ForWrite perIndexComponents) throws IOException

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -83,4 +83,17 @@ public interface MemtableIndex extends MemtableOrdering
     {
         return indexContext.isVector() ? new VectorMemtableIndex(indexContext, mt) : new TrieMemtableIndex(indexContext, mt);
     }
+
+    /**
+     * @return num of rows in the memtable index
+     */
+    int getRowCount();
+
+    /**
+     * Approximate total count of terms in the memtable index.
+     * The count is approximate because some deletions are not accounted for in the current implementation.
+     *
+     * @return total count of terms for indexes rows.
+     */
+    long getApproximateTermCount();
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.utils.BM25Utils;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 
@@ -62,6 +63,7 @@ public class Orderer
 
     // BM25 search parameter
     private List<ByteBuffer> queryTerms;
+    public final BM25Utils.AggDocsStats bm25Stats = new BM25Utils.AggDocsStats();
 
     /**
      * Create an orderer for the given index context, operator, and term.

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -601,31 +601,9 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                                                                       orderer.context.getIndexName()));
         }
 
-        List<CloseableIterator<PrimaryKeyWithSortKey>> memtableResults = new ArrayList<>();
-        try
-        {
-            QueryView view = getQueryView(orderer.context);
-            for (MemtableIndex index : view.memtableIndexes)
-                memtableResults.addAll(index.orderBy(queryContext, orderer, predicate, mergeRange, softLimit));
-
-            var totalRows = view.getTotalSStableRows();
-            SSTableSearcher searcher = index -> index.orderBy(orderer, predicate, mergeRange, queryContext, softLimit, totalRows);
-            var sstableResults = searchSSTables(view, searcher);
-            sstableResults.addAll(memtableResults);
-            return MergeIterator.getNonReducingCloseable(sstableResults, orderer.getComparator());
-        }
-        catch (QueryView.Builder.MissingIndexException e)
-        {
-            if (orderer.context.isDropped())
-                throw invalidRequest(TopKProcessor.INDEX_MAY_HAVE_BEEN_DROPPED);
-            else
-                throw new IllegalStateException("Index not found but hasn't been dropped", e);
-        }
-        catch (Throwable t)
-        {
-            FileUtils.closeQuietly(memtableResults);
-            throw t;
-        }
+        MemtableSearcher memtableSearcher = index -> index.orderBy(queryContext, orderer, predicate, mergeRange, softLimit);
+        SSTableSearcher ssTableSearcher = (index, totalRows) -> index.orderBy(orderer, predicate, mergeRange, queryContext, softLimit, totalRows);
+        return searchTopKRows(memtableSearcher, ssTableSearcher);
     }
 
     /**
@@ -685,23 +663,41 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(List<PrimaryKey> sourceKeys, int softLimit)
     {
         Tracing.logAndTrace(logger, "SAI predicates produced {} keys", sourceKeys.size());
-        List<CloseableIterator<PrimaryKeyWithSortKey>> memtableResults = null;
+
+        MemtableSearcher memtableSearcher = index -> List.of(index.orderResultsBy(queryContext,
+                                                                                  sourceKeys,
+                                                                                  orderer,
+                                                                                  softLimit));
+        SSTableSearcher ssTableSearcher = (index, totalRows) -> index.orderResultsBy(queryContext,
+                                                                                     sourceKeys,
+                                                                                     orderer,
+                                                                                     softLimit,
+                                                                                     totalRows);
+        return searchTopKRows(memtableSearcher, ssTableSearcher);
+    }
+
+
+    private CloseableIterator<PrimaryKeyWithSortKey> searchTopKRows(MemtableSearcher memtableSearcher, SSTableSearcher ssTableSearcher)
+    {
+        List<CloseableIterator<PrimaryKeyWithSortKey>> memtableResults = new ArrayList<>();
         try
         {
             QueryView view = getQueryView(orderer.context);
-            memtableResults = view.memtableIndexes.stream()
-                                                  .map(index -> index.orderResultsBy(queryContext,
-                                                                                     sourceKeys,
-                                                                                     orderer,
-                                                                                     softLimit))
-                                                  .collect(Collectors.toList());
-            var totalRows = view.getTotalSStableRows();
-            SSTableSearcher ssTableSearcher = index -> index.orderResultsBy(queryContext,
-                                                                            sourceKeys,
-                                                                            orderer,
-                                                                            softLimit,
-                                                                            totalRows);
-            var sstableScoredPrimaryKeyIterators = searchSSTables(view, ssTableSearcher);
+            if (orderer.isBM25())
+            {
+                // Calculate counts on indexes
+                for (MemtableIndex index : view.memtableIndexes)
+                    orderer.bm25Stats.add(index.getRowCount(), index.getApproximateTermCount());
+                for (SSTableIndex index : view.sstableIndexes)
+                    orderer.bm25Stats.add(index.getRowCount(), index.getApproximateTermCount());
+                // No documents indexed, the iterator will be empty
+                if (orderer.bm25Stats.getDocCount() == 0)
+                    return CloseableIterator.emptyIterator();
+            }
+
+            for (MemtableIndex index : view.memtableIndexes)
+                memtableResults.addAll(memtableSearcher.search(index));
+            List<CloseableIterator<PrimaryKeyWithSortKey>> sstableScoredPrimaryKeyIterators = searchSSTables(view, ssTableSearcher);
             sstableScoredPrimaryKeyIterators.addAll(memtableResults);
             return MergeIterator.getNonReducingCloseable(sstableScoredPrimaryKeyIterators, orderer.getComparator());
         }
@@ -714,18 +710,23 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         }
         catch (Throwable t)
         {
-            if (memtableResults != null)
+            if (!memtableResults.isEmpty())
                 FileUtils.closeQuietly(memtableResults);
             throw t;
         }
-
     }
 
 
     @FunctionalInterface
     interface SSTableSearcher
     {
-        List<CloseableIterator<PrimaryKeyWithSortKey>> search(SSTableIndex index) throws Exception;
+        List<CloseableIterator<PrimaryKeyWithSortKey>> search(SSTableIndex index, long totalRows) throws Exception;
+    }
+
+    @FunctionalInterface
+    interface MemtableSearcher
+    {
+        List<CloseableIterator<PrimaryKeyWithSortKey>> search(MemtableIndex index);
     }
 
     /**
@@ -736,11 +737,12 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private List<CloseableIterator<PrimaryKeyWithSortKey>> searchSSTables(QueryView queryView, SSTableSearcher searcher)
     {
         List<CloseableIterator<PrimaryKeyWithSortKey>> results = new ArrayList<>();
+        long totalRows = queryView.getTotalSStableRows();
         for (var index : queryView.sstableIndexes)
         {
             try
             {
-                var iterators = searcher.search(index);
+                var iterators = searcher.search(index, totalRows);
                 results.addAll(iterators);
             }
             catch (Throwable ex)

--- a/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/BM25Utils.java
@@ -44,6 +44,28 @@ public class BM25Utils
     private static final float K1 = 1.2f;  // BM25 term frequency saturation parameter
     private static final float B = 0.75f;  // BM25 length normalization parameter
 
+    public static class AggDocsStats
+    {
+        private long docCount;
+        private long totalTermCount;
+
+        public void add(long docCount, long totalTermCount)
+        {
+            this.docCount += docCount;
+            this.totalTermCount += totalTermCount;
+        }
+
+        public long getDocCount()
+        {
+            return docCount;
+        }
+
+        public long getTotalTermCount()
+        {
+            return totalTermCount;
+        }
+    }
+
     /**
      * Term frequencies across all documents.  Each document is only counted once.
      */
@@ -55,11 +77,11 @@ public class BM25Utils
         private final long docCount;
         private double avgDocLength;
 
-        public DocStats(Map<ByteBuffer, Long> frequencies, long docCount, long totalTermCount)
+        public DocStats(Map<ByteBuffer, Long> frequencies, AggDocsStats aggStats)
         {
             this.frequencies = frequencies;
-            this.docCount = docCount;
-            this.avgDocLength = (double) totalTermCount / docCount;
+            this.docCount = aggStats.docCount;
+            this.avgDocLength = (double) aggStats.totalTermCount / aggStats.docCount;
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -316,8 +316,8 @@ public class FeaturesVersionSupportTest extends VectorTester
         {
             MemtableIndex memIndex = getIndexContext(indexName).getLiveMemtables().get(memtable);
             assert memIndex instanceof TrieMemtableIndex;
-            rowCount += ((TrieMemtableIndex) memIndex).indexedRows();
-            termCount += ((TrieMemtableIndex) memIndex).approximateTotalTermCount();
+            rowCount += ((TrieMemtableIndex) memIndex).getRowCount();
+            termCount += ((TrieMemtableIndex) memIndex).getApproximateTermCount();
         }
         assertEquals(expectedNumRows, rowCount);
         if (expectedTotalTermsCount >= 0)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -951,7 +951,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         var indexes = sai.getIndexContext().getLiveMemtables().values();
         assertEquals("Expect just one memtable index", 1, indexes.size());
         var vectorIndex = (VectorMemtableIndex) indexes.iterator().next();
-        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.indexedRows());
+        assertEquals("We dont' remove vectors, so we're still stuck with it", 2, vectorIndex.getRowCount());
 
         // Flush to build the on disk graph (before the fix, flush failed due to a row having two vectors)
         flush();


### PR DESCRIPTION
### What is the issue

BM25 score needs to use document average length aggregated on entire node.
Also a bug was discovered, which was introduced by #1789: term frequencies don't
include documents filtered by other predicates, which makes inconsistent result
between query plans.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/14361

Changes that BM25 score uses document count and term count aggregated on entire node instead of per segment. Fixes a bug in calculating term frequencies, so
they count all documents.

As the work added more code duplication all duplicated code is refactored in getTopKRows methods.

In addition removes unnecessary public modifier in afffected interface.
