### PR TITLE
CNDB-13238: Fix flaky CounterLockManagerTest interruption tests that don't properly wait for a finally block to complete (#1820)

### DIFF
--- a/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/counters/CounterLockManagerTest.java
@@ -229,6 +229,9 @@ public class CounterLockManagerTest
 
         lockHandleHandles.forEach(CounterLockManager.LockHandle::release);
 
+        // other thread's finally block must finish releasing the locks for the following assert to be true
+        otherThread.join();
+
         if (manager.hasNumKeys())
             assertThat(manager.getNumKeys()).isZero();
     }


### PR DESCRIPTION
### What is the issue
The final assert in this test checks that the locks have been cleaned up. These need to be released twice; once by the main thread, and once in the finally block of a thread started by the test. The test waits for a CompletableFuture to be set by this thread, but it does not wait for the finally block to finish.

### What does this PR fix and why was it fixed
Join on the other thread in the test, which ensures the finally block completes before the last assertion that checks all refs to the locks have been released.
