### PR TITLE
CNDB-14239: expose index components validation method with no side-effect (#1794)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java
@@ -80,5 +80,8 @@ public interface IndexComponent
         IndexOutputWriter openOutput(boolean append) throws IOException;
 
         void createEmpty() throws IOException;
+
+        /** Deletes the underlying component file if it exists. */
+        void delete();
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -135,14 +135,14 @@ public class SAITester extends CQLTester
 
     protected static final Injections.Counter perSSTableValidationCounter = addConditions(Injections.newCounter("PerSSTableValidationCounter")
                                                                                       .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
-                                                                                                           .onMethod("validateComponents")),
-                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args())
+                                                                                                           .onMethod("isValid")),
+                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
     ).build();
 
     protected static final Injections.Counter perColumnValidationCounter = addConditions(Injections.newCounter("PerColumnValidationCounter")
                                                                                      .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
-                                                                                                          .onMethod("validateComponents")),
-                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args())
+                                                                                                          .onMethod("isValid")),
+                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
     ).build();
 
     protected static ColumnIdentifier V1_COLUMN_IDENTIFIER = ColumnIdentifier.getInterned("v1", true);


### PR DESCRIPTION
The existing `IndexComponents#validateComponents` method validates some group of index components files (ensure we have all the files we should have, and ensure they looks valid), but it also has some side-effect backed in. It potentially deletes invalid components it found, and invalidate the whole group if validation fails, which rewrite the sstable TOC and whatnot.

For CNDB, it would be useful to be able to validate components on reload without necessarily triggering the side effects, and the plan is to rely on such no-side-effect variant in the patch for
https://github.com/riptano/cndb/issues/14239. But I'd argue having this variant make sense in general and could easily have other uses later, and the changes are trivially backward compatible (they only introduce 2 new methods.

