### PR TITLE
CNDB-11666: Batch clusterings into single SAI partition post-filtering reads

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -372,6 +372,9 @@ public enum CassandraRelevantProperties
     /** Whether to optimize query plans */
     SAI_QUERY_OPTIMIZATION_LEVEL("cassandra.sai.query_optimization_level", "1"),
 
+    /** Controls the number of rows read in a single batch when fetching rows for a partition key */
+    SAI_PARTITION_ROW_BATCH_SIZE("cassandra.sai.partition_row_batch_size", "100"),
+
     /** Whether vector type only allows float vectors. True by default. **/
     VECTOR_FLOAT_ONLY("cassandra.float_only_vectors", "true"),
     /** Enables use of vector type. True by default. **/

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.slf4j.Logger;
@@ -87,6 +88,7 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.InsertionOrderedNavigableSet;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Throwables;
@@ -121,6 +123,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
     private final PrimaryKey.Factory keyFactory;
     private final PrimaryKey firstPrimaryKey;
+
+    private final NavigableSet<Clustering<?>> nextClusterings;
 
     final Plan.Factory planFactory;
 
@@ -178,6 +182,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         this.keyFactory = PrimaryKey.factory(cfs.metadata().comparator, indexFeatureSet);
         this.firstPrimaryKey = keyFactory.createTokenOnly(mergeRange.left.getToken());
+        this.nextClusterings = new InsertionOrderedNavigableSet<>(cfs.metadata().comparator);
         var tableMetrics = new Plan.TableMetrics(estimateTotalAvailableRows(ranges),
                                                  avgCellsPerRow(),
                                                  avgRowSizeInBytes(),
@@ -295,16 +300,24 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     /**
      * Get an iterator over the rows for this partition key. Builds a search view that includes all memtables and all
      * {@link SSTableSet#LIVE} sstables.
-     * @param key
+     * @param keys
      * @param executionController
      * @return
      */
-    public UnfilteredRowIterator getPartition(PrimaryKey key, ReadExecutionController executionController)
+    public UnfilteredRowIterator getPartition(List<PrimaryKey> keys, ReadExecutionController executionController)
     {
-        if (key == null)
-            throw new IllegalArgumentException("non-null key required");
+        if (keys == null)
+            throw new IllegalArgumentException("non-null keys required");
+        if (keys.isEmpty())
+            throw new IllegalArgumentException("At least one primary key is required!");
 
-        SinglePartitionReadCommand partition = getPartitionReadCommand(key, executionController);
+        SinglePartitionReadCommand partition = SinglePartitionReadCommand.create(cfs.metadata(),
+                                                                                 command.nowInSec(),
+                                                                                 command.columnFilter(),
+                                                                                 RowFilter.NONE,
+                                                                                 DataLimits.NONE,
+                                                                                 keys.get(0).partitionKey(),
+                                                                                 makeFilter(keys));
         return partition.queryMemtableAndDisk(cfs, executionController);
     }
 
@@ -801,6 +814,29 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         else
             return new ClusteringIndexNamesFilter(FBUtilities.singleton(key.clustering(), cfs.metadata().comparator),
                                                   clusteringIndexFilter.isReversed());
+    }
+
+    private ClusteringIndexFilter makeFilter(List<PrimaryKey> keys)
+    {
+        PrimaryKey firstKey = keys.get(0);
+
+        assert !indexFeatureSet.isRowAware() ||
+               cfs.metadata().comparator.size() == 0 && firstKey.hasEmptyClustering() ||
+               cfs.metadata().comparator.size() > 0 && (!firstKey.hasEmptyClustering() || cfs.metadata().hasStaticColumns()):
+        "PrimaryKey " + firstKey + " clustering does not match table. There should be a clustering of size " + cfs.metadata().comparator.size();
+
+        ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(firstKey.partitionKey());
+        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering())
+        {
+            return clusteringIndexFilter;
+        }
+        else
+        {
+            nextClusterings.clear();
+            for (PrimaryKey key : keys)
+                nextClusterings.add(key.clustering());
+            return new ClusteringIndexNamesFilter(nextClusterings, clusteringIndexFilter.isReversed());
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.index.sai.plan;
 import java.io.IOError;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -39,6 +40,8 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -79,9 +82,20 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
 {
     private static final Logger logger = LoggerFactory.getLogger(StorageAttachedIndexSearcher.class);
 
+    private static final int PARTITION_ROW_BATCH_SIZE = CassandraRelevantProperties.SAI_PARTITION_ROW_BATCH_SIZE.getInt();
+
     private final ReadCommand command;
     private final QueryController controller;
     private final QueryContext queryContext;
+
+    private static final FastThreadLocal<List<PrimaryKey>> nextKeys = new FastThreadLocal<>()
+    {
+        @Override
+        protected List<PrimaryKey> initialValue()
+        {
+            return new ArrayList<>(PARTITION_ROW_BATCH_SIZE);
+        }
+    };
 
     public StorageAttachedIndexSearcher(ColumnFamilyStore cfs,
                                         TableQueryMetrics tableQueryMetrics,
@@ -190,7 +204,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         return controller.buildFilter();
     }
 
-    private static class ResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
+    private class ResultRetriever extends AbstractIterator<UnfilteredRowIterator> implements UnfilteredPartitionIterator
     {
         private final PrimaryKey firstPrimaryKey;
         private final Iterator<DataRange> keyRanges;
@@ -202,6 +216,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         private final ReadExecutionController executionController;
         private final QueryContext queryContext;
         private final PrimaryKey.Factory keyFactory;
+        private final int partitionRowBatchSize;
 
         private PrimaryKey lastKey;
 
@@ -222,6 +237,9 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             this.keyFactory = controller.primaryKeyFactory();
 
             this.firstPrimaryKey = controller.firstPrimaryKey();
+
+            // Ensure we don't fetch larger batches than the provided LIMIT to avoid fetching keys we won't use:
+            this.partitionRowBatchSize = Math.min(PARTITION_ROW_BATCH_SIZE, command.limits().count());
         }
 
         @Override
@@ -247,7 +265,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             // saying this iterator must not return the same partition twice.
             skipToNextPartition();
 
-            UnfilteredRowIterator iterator = nextRowIterator(this::nextSelectedKeyInRange);
+            UnfilteredRowIterator iterator = nextRowIterator(this::nextSelectedKeysInRange);
             return iterator != null
                    ? iteratePartition(iterator)
                    : endOfData();
@@ -261,15 +279,15 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
          *
          * @return an iterator or null if all keys were tried with no success
          */
-        private @Nullable UnfilteredRowIterator nextRowIterator(@Nonnull Supplier<PrimaryKey> keySupplier)
+        private @Nullable UnfilteredRowIterator nextRowIterator(@Nonnull Supplier<List<PrimaryKey>> keySupplier)
         {
             UnfilteredRowIterator iterator = null;
             while (iterator == null)
             {
-                PrimaryKey key = keySupplier.get();
-                if (key == null)
+                List<PrimaryKey> keys = keySupplier.get();
+                if (keys.isEmpty())
                     return null;
-                iterator = apply(key);
+                iterator = apply(keys);
             }
             return iterator;
         }
@@ -309,51 +327,67 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             return key;
         }
 
-        /**
-         * Returns the next available key contained by one of the keyRanges and selected by the queryController.
-         * If the next key falls out of the current key range, it skips to the next key range, and so on.
-         * If no more keys acceptd by the controller are available, returns null.
-         */
-         private @Nullable PrimaryKey nextSelectedKeyInRange()
+        private void fillNextSelectedKeysInPartition(DecoratedKey partitionKey, List<PrimaryKey> nextPrimaryKeys)
         {
-            PrimaryKey key;
-            do
+            while (operation.hasNext()
+                   && operation.peek().partitionKey().equals(partitionKey)
+                   && nextPrimaryKeys.size() < partitionRowBatchSize)
             {
-                key = nextKeyInRange();
+                PrimaryKey key = nextKey();
+
+                if (key == null)
+                    break;
+
+                if (!controller.selects(key) || key.equals(lastKey))
+                    continue;
+
+                nextPrimaryKeys.add(key);
+                lastKey = key;
             }
-            while (key != null && !controller.selects(key));
-            return key;
         }
 
         /**
-         * Retrieves the next primary key that belongs to the given partition and is selected by the query controller.
-         * The underlying key iterator is advanced only if the key belongs to the same partition.
-         * <p>
-         * Returns null if:
-         * <ul>
-         *   <li>there are no more keys</li>
-         *   <li>the next key is beyond the upper bound</li>
-         *   <li>the next key belongs to a different partition</li>
-         * </ul>
-         * </p>
+         * Retrieves the next batch of primary keys (i.e. up to {@link #partitionRowBatchSize} of them) that are
+         * contained by one of the query key ranges and selected by the {@link QueryController}. If the next key falls
+         * out of the current key range, it skips to the next key range, and so on. If no more keys accepted by
+         * the controller are available, and empty list is returned.
+         *
+         * @return a list of up to {@link #partitionRowBatchSize} primary keys
          */
-        private @Nullable PrimaryKey nextSelectedKeyInPartition(DecoratedKey partitionKey)
+        private List<PrimaryKey> nextSelectedKeysInRange()
         {
-            PrimaryKey key;
+            List<PrimaryKey> threadLocalNextKeys = nextKeys.get();
+            threadLocalNextKeys.clear();
+            PrimaryKey firstKey;
+
             do
             {
-                if (!operation.hasNext())
-                    return null;
-                PrimaryKey minKey = operation.peek();
-                if (!minKey.token().equals(partitionKey.getToken()))
-                    return null;
-                if (minKey.partitionKey() != null && !minKey.partitionKey().equals(partitionKey))
-                    return null;
+                firstKey = nextKeyInRange();
 
-                key = nextKey();
+                if (firstKey == null)
+                    return Collections.emptyList();
             }
-            while (key != null && !controller.selects(key));
-            return key;
+            while (!controller.selects(firstKey) || firstKey.equals(lastKey));
+
+            lastKey = firstKey;
+            threadLocalNextKeys.add(firstKey);
+            fillNextSelectedKeysInPartition(firstKey.partitionKey(), threadLocalNextKeys);
+            return threadLocalNextKeys;
+        }
+
+        /**
+         * Retrieves the next batch of primary keys (i.e. up to {@link #partitionRowBatchSize} of them) that belong to
+         * the given partition and are selected by the query controller, advancing the underlying iterator only while
+         * the next key belongs to that partition.
+         *
+         * @return a list of up to {@link #partitionRowBatchSize} primary keys within the given partition
+         */
+        private List<PrimaryKey> nextSelectedKeysInPartition(DecoratedKey partitionKey)
+        {
+            List<PrimaryKey> threadLocalNextKeys = nextKeys.get();
+            threadLocalNextKeys.clear();
+            fillNextSelectedKeysInPartition(partitionKey, threadLocalNextKeys);
+            return threadLocalNextKeys;
         }
 
         /**
@@ -426,7 +460,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                     while (!currentIter.hasNext())
                     {
                         currentIter.close();
-                        currentIter = nextRowIterator(() -> nextSelectedKeyInPartition(partitionKey));
+                        currentIter = nextRowIterator(() -> nextSelectedKeysInPartition(partitionKey));
                         if (currentIter == null)
                             return endOfData();
                     }
@@ -442,20 +476,9 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             };
         }
 
-        public UnfilteredRowIterator apply(PrimaryKey key)
+        public UnfilteredRowIterator apply(List<PrimaryKey> keys)
         {
-            // Key reads are lazy, delayed all the way to this point.
-            // We don't want key.equals(lastKey) because some PrimaryKey implementations consider more than just
-            // partition key and clustering for equality. This can break lastKey skipping, which is necessary for
-            // correctness when PrimaryKey doesn't have a clustering (as otherwise, the same partition may get
-            // filtered and considered as a result multiple times).
-            // we need a non-null partitionKey here, as we want to construct a SinglePartitionReadCommand
-            Preconditions.checkNotNull(key.partitionKey(), "Partition key must not be null");
-            if (lastKey != null && key.partitionKey().equals(lastKey.partitionKey()) && key.clustering().equals(lastKey.clustering()))
-                return null;
-            lastKey = key;
-
-            UnfilteredRowIterator partition = controller.getPartition(key, executionController);
+            UnfilteredRowIterator partition = controller.getPartition(keys, executionController);
             queryContext.addPartitionsRead(1);
             queryContext.checkpoint();
             return applyIndexFilter(partition, filterTree, queryContext);

--- a/src/java/org/apache/cassandra/utils/InsertionOrderedNavigableSet.java
+++ b/src/java/org/apache/cassandra/utils/InsertionOrderedNavigableSet.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.SortedSet;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * A {@link NavigableSet} that enforces in-order insertion of elements. This is helpful when we
+ * have an already-ordered collection with no duplicates and want constant time insertion.
+ * <p>
+ * Note: Not all methods of {@link NavigableSet} are implemented.
+ *
+ * @param <E> the type of elements maintained by this set
+ */
+public class InsertionOrderedNavigableSet<E> implements NavigableSet<E>
+{
+    private final ArrayList<E> elements;
+    private final Comparator<? super E> comparator;
+
+    public InsertionOrderedNavigableSet(Comparator<? super E> comparator)
+    {
+        this.elements = new ArrayList<>();
+        this.comparator = comparator;
+    }
+
+    @Override
+    public E lower(E e)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E floor(E e)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E ceiling(E e)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E higher(E e)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E pollFirst()
+    {
+        if (isEmpty())
+            return null;
+
+        return elements.remove(0);
+    }
+
+    @Override
+    public E pollLast()
+    {
+        if (isEmpty())
+            return null;
+
+        return elements.remove(size() - 1);
+    }
+
+    @Override
+    public int size()
+    {
+        return elements.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return elements.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        return elements.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator()
+    {
+        return elements.iterator();
+    }
+
+    @Override
+    public Object[] toArray()
+    {
+        return elements.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a)
+    {
+        return elements.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e)
+    {
+        if (!isEmpty() && comparator.compare(e, last()) <= 0)
+            throw new IllegalStateException("Cannot add element " + e + " as it is not greater than the current last element " + last());
+
+        return elements.add(e);
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        return elements.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c)
+    {
+        return elements.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c)
+    {
+        boolean modified = false;
+        for (E element : c)
+            if (add(element))
+                modified = true;
+        return modified;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c)
+    {
+        return elements.retainAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c)
+    {
+        return elements.removeAll(c);
+    }
+
+    @Override
+    public void clear()
+    {
+        elements.clear();
+    }
+
+    @Override
+    public NavigableSet<E> descendingSet()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<E> descendingIterator()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NavigableSet<E> subSet(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NavigableSet<E> headSet(E toElement, boolean inclusive)
+    {
+        Preconditions.checkNotNull(toElement);
+
+        if (isEmpty())
+            return Collections.emptyNavigableSet();
+
+        NavigableSet<E> head = new InsertionOrderedNavigableSet<>(comparator);
+
+        for (E element : elements)
+        {
+            int comparison = comparator.compare(element, toElement);
+            if (comparison > 0 || comparison == 0 && !inclusive)
+                break;
+
+            head.add(element);
+        }
+
+        return head;
+    }
+
+    @Override
+    public NavigableSet<E> tailSet(E fromElement, boolean inclusive)
+    {
+        Preconditions.checkNotNull(fromElement);
+
+        if (isEmpty())
+            return Collections.emptyNavigableSet();
+
+        NavigableSet<E> tail = new InsertionOrderedNavigableSet<>(comparator);
+
+        for (E element : elements)
+        {
+            int comparison = comparator.compare(element, fromElement);
+            if (comparison < 0 || comparison == 0 && !inclusive)
+                continue;
+
+            tail.add(element);
+        }
+
+        return tail;
+    }
+
+    @Override
+    public Comparator<? super E> comparator()
+    {
+        return comparator;
+    }
+
+    @Override
+    public SortedSet<E> subSet(E fromElement, E toElement)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedSet<E> headSet(E toElement)
+    {
+        return headSet(toElement, false);
+    }
+
+    @Override
+    public SortedSet<E> tailSet(E fromElement)
+    {
+        return tailSet(fromElement, true);
+    }
+
+    @Override
+    public E first()
+    {
+        if (isEmpty())
+            throw new NoSuchElementException();
+
+        return elements.get(0);
+    }
+
+    @Override
+    public E last()
+    {
+        if (isEmpty())
+            throw new NoSuchElementException();
+
+        return elements.get(size() - 1);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InsertionOrderedNavigableSet<?> that = (InsertionOrderedNavigableSet<?>) o;
+        return Objects.equals(elements, that.elements) && Objects.equals(comparator, that.comparator);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(elements, comparator);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/LargePartitionsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LargePartitionsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.assertj.core.api.Assertions;
+
+@RunWith(Parameterized.class)
+public class LargePartitionsTest extends VectorTester
+{
+    public static final int NUM_PARTITIONS = 10;
+    public static final int LARGE_PARTITION_SIZE = CassandraRelevantProperties.SAI_PARTITION_ROW_BATCH_SIZE.getInt() * 4;
+
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+    }
+
+    @Before
+    public void setup() throws Throwable
+    {
+        super.setup();
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    @Test
+    public void testLargePartition() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, t text, a text, v vector<float, 2>, PRIMARY KEY (k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(t) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard'}");
+        if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+            createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+        for (int k = 0; k < NUM_PARTITIONS; k++)
+        {
+            for (int c = 0; c < LARGE_PARTITION_SIZE; c++)
+            {
+                int n = c % 2;
+                String t = "t_" + n;
+                String a = "other a_" + n;
+                Vector<Float> v = vector(1.0f, n);
+                execute("INSERT INTO %s (k, c, n, t, a, v) VALUES (?, ?, ?, ?, ?, ?)", k, c, n, t, a, v);
+            }
+        }
+
+        beforeAndAfterFlush( () -> {
+
+            // test filtering with single partition queries
+            int numExpectedRows = LARGE_PARTITION_SIZE / 2;
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 AND n = 1").size()).isEqualTo(numExpectedRows);
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 AND t = 't_1'").size()).isEqualTo(numExpectedRows);
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 AND a = 'a_1'").size()).isEqualTo(numExpectedRows);
+
+            // test filtering with range queries
+            numExpectedRows = NUM_PARTITIONS * LARGE_PARTITION_SIZE / 2;
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE n = 1").size()).isEqualTo(numExpectedRows);
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE t = 't_1'").size()).isEqualTo(numExpectedRows);
+            Assertions.assertThat(execute("SELECT * FROM %s WHERE a = 'a_1'").size()).isEqualTo(numExpectedRows);
+
+            // the generic ORDER BY
+            if (version.after(Version.AA))
+            {
+                Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 ORDER BY n LIMIT " + LARGE_PARTITION_SIZE).size()).isEqualTo(LARGE_PARTITION_SIZE);
+                Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 ORDER BY t LIMIT " + LARGE_PARTITION_SIZE).size()).isEqualTo(LARGE_PARTITION_SIZE);
+
+                Assertions.assertThat(execute("SELECT * FROM %s ORDER BY n LIMIT " + LARGE_PARTITION_SIZE).size()).isEqualTo(LARGE_PARTITION_SIZE);
+                Assertions.assertThat(execute("SELECT * FROM %s ORDER BY t LIMIT " + LARGE_PARTITION_SIZE).size()).isEqualTo(LARGE_PARTITION_SIZE);
+            }
+
+            // test ANN
+            if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+            {
+                int limit = CassandraRelevantProperties.SAI_PARTITION_ROW_BATCH_SIZE.getInt() + 1;
+                Assertions.assertThat(execute("SELECT * FROM %s WHERE k = 2 ORDER BY v ANN OF [1, 1] LIMIT " + limit).size()).isEqualTo(limit);
+                Assertions.assertThat(execute("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT " + limit).size()).isEqualTo(limit);
+            }
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -364,8 +364,8 @@ public class QueryMetricsTest extends AbstractMetricsTest
         int actualRows = rows.all().size();
         assertEquals(3, actualRows);
 
-        //TODO This needs revisiting with STAR-903 because we are now reading rows one at a time
-        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), Version.current() == Version.AA ? 2 : 3);
+        // This is 2 due to partition read batching.
+        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), 2);
         waitForHistogramCountEquals(objectNameNoIndex("RowsFiltered", keyspace, table, PER_QUERY_METRIC_TYPE), 1);
         waitForEquals(objectNameNoIndex("TotalRowsFiltered", keyspace, table, TABLE_QUERY_METRIC_TYPE), 3);
     }

--- a/test/unit/org/apache/cassandra/utils/InsertionOrderedNavigableSetTest.java
+++ b/test/unit/org/apache/cassandra/utils/InsertionOrderedNavigableSetTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.SortedSet;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class InsertionOrderedNavigableSetTest
+{
+    private final Comparator<Integer> naturalOrder = Integer::compareTo;
+
+    @Test
+    public void testEmptySet()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+        assertFalse(set.contains(1));
+        assertEquals(naturalOrder, set.comparator());
+        assertNull(set.pollFirst());
+        assertNull(set.pollLast());
+    }
+
+    @Test
+    public void testAddInOrder()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        
+        assertTrue(set.add(1));
+        assertTrue(set.add(2));
+        assertTrue(set.add(3));
+        
+        assertEquals(3, set.size());
+        assertFalse(set.isEmpty());
+        assertEquals(Integer.valueOf(1), set.first());
+        assertEquals(Integer.valueOf(3), set.last());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddOutOfOrder()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(2);
+        set.add(1); // Should throw IllegalStateException
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddEqual()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(1); // Should throw IllegalStateException
+    }
+
+    @Test
+    public void testPollFirst()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        assertEquals(Integer.valueOf(1), set.pollFirst());
+        assertEquals(2, set.size());
+        assertEquals(Integer.valueOf(2), set.first());
+    }
+
+    @Test
+    public void testPollLast()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        assertEquals(Integer.valueOf(3), set.pollLast());
+        assertEquals(2, set.size());
+        assertEquals(Integer.valueOf(2), set.last());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFirstOnEmpty()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.first();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testLastOnEmpty()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.last();
+    }
+
+    @Test
+    public void testContains()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(3);
+        set.add(5);
+        
+        assertTrue(set.contains(1));
+        assertTrue(set.contains(3));
+        assertTrue(set.contains(5));
+        assertFalse(set.contains(2));
+        assertFalse(set.contains(4));
+    }
+
+    @Test
+    public void testRemove()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        assertTrue(set.remove(2));
+        assertEquals(2, set.size());
+        assertFalse(set.contains(2));
+        assertFalse(set.remove(4));
+    }
+
+    @Test
+    public void testIterator()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        Iterator<Integer> iter = set.iterator();
+        assertTrue(iter.hasNext());
+        assertEquals(Integer.valueOf(1), iter.next());
+        assertEquals(Integer.valueOf(2), iter.next());
+        assertEquals(Integer.valueOf(3), iter.next());
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void testToArray()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        Object[] array = set.toArray();
+        assertArrayEquals(new Object[]{1, 2, 3}, array);
+        
+        Integer[] typedArray = set.toArray(new Integer[0]);
+        assertArrayEquals(new Integer[]{1, 2, 3}, typedArray);
+    }
+
+    @Test
+    public void testContainsAll()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        assertTrue(set.containsAll(Arrays.asList(1, 2)));
+        assertTrue(set.containsAll(Arrays.asList(1, 2, 3)));
+        assertFalse(set.containsAll(Arrays.asList(1, 2, 4)));
+    }
+
+    @Test
+    public void testAddAll()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        
+        assertTrue(set.addAll(Arrays.asList(1, 2, 3)));
+        assertEquals(3, set.size());
+        assertFalse(set.addAll(Collections.emptyList()));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddAllOutOfOrder()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(2);
+        set.addAll(Arrays.asList(1, 3)); // Should fail on 1
+    }
+
+    @Test
+    public void testRetainAll()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        
+        assertTrue(set.retainAll(Arrays.asList(2, 3)));
+        assertEquals(2, set.size());
+        assertTrue(set.contains(2));
+        assertTrue(set.contains(3));
+        assertFalse(set.contains(1));
+        assertFalse(set.contains(4));
+    }
+
+    @Test
+    public void testRemoveAll()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        
+        assertTrue(set.removeAll(Arrays.asList(2, 3)));
+        assertEquals(2, set.size());
+        assertTrue(set.contains(1));
+        assertTrue(set.contains(4));
+        assertFalse(set.contains(2));
+        assertFalse(set.contains(3));
+    }
+
+    @Test
+    public void testClear()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        
+        set.clear();
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+    }
+
+    @Test
+    public void testHeadSet()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        set.add(5);
+        
+        NavigableSet<Integer> head = set.headSet(3, false);
+        assertEquals(2, head.size());
+        assertTrue(head.contains(1));
+        assertTrue(head.contains(2));
+        assertFalse(head.contains(3));
+        
+        NavigableSet<Integer> headInclusive = set.headSet(3, true);
+        assertEquals(3, headInclusive.size());
+        assertTrue(headInclusive.contains(3));
+        
+        SortedSet<Integer> headDefault = set.headSet(3);
+        assertEquals(2, headDefault.size());
+        assertFalse(headDefault.contains(3));
+    }
+
+    @Test
+    public void testTailSet()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        set.add(5);
+        
+        NavigableSet<Integer> tail = set.tailSet(3, false);
+        assertEquals(2, tail.size());
+        assertTrue(tail.contains(4));
+        assertTrue(tail.contains(5));
+        assertFalse(tail.contains(3));
+        
+        NavigableSet<Integer> tailInclusive = set.tailSet(3, true);
+        assertEquals(3, tailInclusive.size());
+        assertTrue(tailInclusive.contains(3));
+        
+        SortedSet<Integer> tailDefault = set.tailSet(3);
+        assertEquals(3, tailDefault.size());
+        assertTrue(tailDefault.contains(3));
+    }
+
+    @Test
+    public void testHeadSetEmpty()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        NavigableSet<Integer> head = set.headSet(3, true);
+        assertTrue(head.isEmpty());
+    }
+
+    @Test
+    public void testTailSetEmpty()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        NavigableSet<Integer> tail = set.tailSet(3, true);
+        assertTrue(tail.isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testHeadSetNull()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.headSet(null, true);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testTailSetNull()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.tailSet(null, true);
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        InsertionOrderedNavigableSet<Integer> set1 = new InsertionOrderedNavigableSet<>(naturalOrder);
+        InsertionOrderedNavigableSet<Integer> set2 = new InsertionOrderedNavigableSet<>(naturalOrder);
+        
+        assertEquals(set1, set2);
+        assertEquals(set1.hashCode(), set2.hashCode());
+        
+        set1.add(1);
+        set1.add(2);
+        
+        set2.add(1);
+        set2.add(2);
+        
+        assertEquals(set1, set2);
+        assertEquals(set1.hashCode(), set2.hashCode());
+        
+        set2.add(3);
+        assertNotEquals(set1, set2);
+    }
+
+    @Test
+    public void testEqualsWithDifferentComparator()
+    {
+        InsertionOrderedNavigableSet<Integer> set1 = new InsertionOrderedNavigableSet<>(naturalOrder);
+        InsertionOrderedNavigableSet<Integer> set2 = new InsertionOrderedNavigableSet<>(Integer::compareTo);
+        
+        // Even though comparators are functionally equivalent, they're different objects
+        assertNotEquals(set1, set2);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLower()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.lower(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFloor()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.floor(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCeiling()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.ceiling(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testHigher()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.higher(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDescendingSet()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.descendingSet();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDescendingIterator()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.descendingIterator();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSubSetWithBooleans()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.subSet(1, true, 3, true);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSubSet()
+    {
+        InsertionOrderedNavigableSet<Integer> set = new InsertionOrderedNavigableSet<>(naturalOrder);
+        set.subSet(1, 3);
+    }
+
+    @Test
+    public void testCustomComparator()
+    {
+        Comparator<String> lengthComparator = Comparator.comparing(String::length);
+        InsertionOrderedNavigableSet<String> set = new InsertionOrderedNavigableSet<>(lengthComparator);
+        
+        set.add("a");
+        set.add("bb");
+        set.add("ccc");
+        
+        assertEquals("a", set.first());
+        assertEquals("ccc", set.last());
+        assertEquals(lengthComparator, set.comparator());
+    }
+}


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/11666
Ports: https://issues.apache.org/jira/browse/CASSANDRA-19497

May fix: https://github.com/riptano/cndb/issues/14822

### What does this PR fix and why was it fixed
Here is a draft of porting the fix from upstream. Initial validation shows improved performance that gets much closer to the `aa` performance for low selectivity queries.

Test results from many different versions show that this patch gets us from ~39 qps to ~418 qps, giving us a 10x increase in throughput.

```
$ latte list --tag ondisk
File ─────────────────────────────────────────────────────────────────────────────────────────────   Workload   Function   Timestamp ─────────   Tags ──────────────────────────   Params   Rate   Thrpt. [req/s]   P50 [ms]   P99 [ms]
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.p128.t1.c1.20250716.124318.json                         wide.rn    hc         2025-07-16 12:42:17   ondisk, ec, cc                                              7526       15.5       36.6
./wide.Test_Cluster.5.0.5-SNAPSHOT.ondisk.5.0.p128.t1.c1.20250716.125436.json                        wide.rn    hc         2025-07-16 12:53:35   ondisk, 5.0                                                 4634       23.7       95.3
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main.aa.p128.t1.c1.20250716.131838.json              wide.rn    hc         2025-07-16 13:17:37   ondisk, cc, main, aa                                        1182      106.1      191.8
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main-with-11666.aa.p128.t1.c1.20250717.002057.json   wide.rn    hc         2025-07-17 00:19:57   ondisk, cc, main-with-11666, aa                             1105      116.2      187.0
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main-with-11666.ec.p128.t1.c1.20250717.002614.json   wide.rn    hc         2025-07-17 00:25:13   ondisk, cc, main-with-11666, ec                             6041       20.1       33.6
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.ec.cc.p128.t1.c1.20250716.124531.json                   wide.rn    lc         2025-07-16 12:44:26   ondisk, ec, cc                                                39     3147.0     3432.9
./wide.Test_Cluster.5.0.5-SNAPSHOT.ondisk.5.0.p128.t1.c1.20250716.125619.json                        wide.rn    lc         2025-07-16 12:55:18   ondisk, 5.0                                                  289      439.0      550.2
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main.aa.p128.t1.c1.20250716.131640.json              wide.rn    lc         2025-07-16 13:15:39   ondisk, cc, main, aa                                         509      243.7      372.8
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main-with-11666.aa.p128.t1.c1.20250717.001941.json   wide.rn    lc         2025-07-17 00:18:40   ondisk, cc, main-with-11666, aa                              511      241.6      360.3
./wide.Test_Cluster.4.0.11.0-SNAPSHOT.ondisk.cc.main-with-11666.ec.p128.t1.c1.20250717.002441.json   wide.rn    lc         2025-07-17 00:23:40   ondisk, cc, main-with-11666, ec                              418      299.8      388.4
```