### PR TITLE
CNDB-14773: avoid Int2IntHashMap overflow in RAMStringIndexer and improve memory track to include array memory usage

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
@@ -49,6 +49,11 @@ class RAMPostingSlices
         this.includeFrequencies = includeFrequencies;
     }
 
+    long arrayMemoryUsage()
+    {
+        return postingStarts.length * 4L + postingUptos.length * 4L + sizes.length * 4L;
+    }
+
     /**
      * Creates and returns a PostingList for the given term ID.
      */

--- a/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
@@ -74,7 +74,11 @@ public class RAMStringIndexer
 
     public long estimatedBytesUsed()
     {
-        return termsBytesUsed.get() + slicesBytesUsed.get();
+        // record the array memory usage from Int2IntHashMap docLengths:
+        //  * array size is capacity * 2
+        //  * 4 bytes per int
+        long docLengthsMemoryUsage = docLengths.capacity() * 2 * 4L;
+        return docLengthsMemoryUsage + termsBytesUsed.get() + slicesBytesUsed.get() + slices.arrayMemoryUsage();
     }
 
     public boolean requiresFlush()

--- a/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMStringIndexer.java
@@ -46,7 +46,7 @@ public class RAMStringIndexer
      *
      * Pick 300_000_000 for simplicity to trigger segment flush.
      */
-    private static final int MAX_DOC_LENGTHS = 300_000_000;
+    private static final int MAX_DOCS_SIZE = 300_000_000;
 
     private final BytesRefHash termsHash;
     private final RAMPostingSlices slices;
@@ -57,11 +57,19 @@ public class RAMStringIndexer
     private int[] lastSegmentRowID = new int[RAMPostingSlices.DEFAULT_TERM_DICT_SIZE];
 
     private final boolean writeFrequencies;
+    private final int maxDocSize;
     private final Int2IntHashMap docLengths = new Int2IntHashMap(Integer.MIN_VALUE);
 
     public RAMStringIndexer(boolean writeFrequencies)
     {
+        this(writeFrequencies, MAX_DOCS_SIZE);
+    }
+
+    @VisibleForTesting
+    RAMStringIndexer(boolean writeFrequencies, int maxDocSize)
+    {
         this.writeFrequencies = writeFrequencies;
+        this.maxDocSize = maxDocSize;
         termsBytesUsed = Counter.newCounter();
         slicesBytesUsed = Counter.newCounter();
 
@@ -90,7 +98,7 @@ public class RAMStringIndexer
         // fail to add a term.
         return termsBytesUsed.get() >= MAX_BLOCK_BYTE_POOL_SIZE || slicesBytesUsed.get() >= MAX_BLOCK_BYTE_POOL_SIZE
                // to avoid Int2IntHashMap new capacity overflow
-               || docLengths.size() >= MAX_DOC_LENGTHS;
+               || docLengths.size() >= maxDocSize;
     }
 
     public boolean isEmpty()

--- a/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
@@ -26,10 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.disk.format.IndexComponent;
-import org.apache.cassandra.index.sai.disk.v1.trie.InvertedIndexWriter;
 import org.apache.cassandra.index.sai.utils.SaiRandomizedTest;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -76,6 +75,26 @@ public class RAMStringIndexerTest extends SaiRandomizedTest
             // The min and max are configured, not calculated.
             assertArrayEquals("0".getBytes(), terms.getMinTerm().array());
             assertArrayEquals("2".getBytes(), terms.getMaxTerm().array());
+        }
+    }
+
+    @Ignore // this is memory consuming and takes 2 minutes to run
+    @Test
+    public void testLargeNumberOfDocs() throws Exception
+    {
+        RAMStringIndexer indexer = new RAMStringIndexer(false);
+
+        int rowsToAdd = 400_000_000;
+        // max doc size 348_966_081
+        int startingRowId = 0;
+        int i = 0;
+        while (i++ < rowsToAdd)
+        {
+            if (indexer.requiresFlush())
+                indexer = new RAMStringIndexer(false);
+
+            int rowId = startingRowId + i;
+            indexer.addAll(List.of(new BytesRef("0")), rowId);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
@@ -78,24 +78,24 @@ public class RAMStringIndexerTest extends SaiRandomizedTest
         }
     }
 
-    @Ignore // this is memory consuming and takes 2 minutes to run
     @Test
-    public void testLargeNumberOfDocs() throws Exception
+    public void testLargeNumberOfDocs()
     {
-        RAMStringIndexer indexer = new RAMStringIndexer(false);
+        int maxDocsSize = 1000;
+        RAMStringIndexer indexer = new RAMStringIndexer(false, maxDocsSize);
 
-        int rowsToAdd = 400_000_000;
-        // max doc size 348_966_081
         int startingRowId = 0;
         int i = 0;
-        while (i++ < rowsToAdd)
+        while (i++ < maxDocsSize)
         {
-            if (indexer.requiresFlush())
-                indexer = new RAMStringIndexer(false);
-
             int rowId = startingRowId + i;
             indexer.addAll(List.of(new BytesRef("0")), rowId);
+
+            if (i < maxDocsSize)
+                assertFalse(indexer.requiresFlush());
         }
+
+        assertTrue(indexer.requiresFlush());
     }
 
     @Test


### PR DESCRIPTION
### What is the issue
#14773: Int2IntHashMap overflow when num of docs reaches 348_966_081

### What does this PR fix and why was it fixed

Trigger segment flush before overflow and include array memory usage to avoid undercounting memory usage