### PR TITLE
CNDB-14481: Fix IllegalStateException in SegmentMetadataBuilder (#1808)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.index.sai.disk.format;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+
+import org.apache.lucene.index.CorruptIndexException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -286,7 +288,7 @@ public interface IndexComponents
             {
                 invalidate(sstable, tracker);
                 if (rethrow)
-                    throw new UncheckedIOException(new IOException("Invalid SAI components for " + descriptor()));
+                    throw new UncheckedIOException(new CorruptIndexException("Invalid SAI components for " + descriptor(), descriptor().toString()));
             }
             return isValid;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadataBuilder.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.TermsIterator;
@@ -99,14 +101,16 @@ public class SegmentMetadataBuilder
 
     public void setKeyRange(@Nonnull PrimaryKey minKey, @Nonnull PrimaryKey maxKey)
     {
-        assert minKey.compareTo(maxKey) <= 0: "minKey (" + minKey + ") must not be greater than (" + maxKey + ')';
+        Preconditions.checkNotNull(minKey, "minKey must not be null");
+        Preconditions.checkNotNull(maxKey, "maxKey must not be null");
+        Preconditions.checkArgument(minKey.compareTo(maxKey) <= 0, "minKey (" + minKey + ") must not be greater than (" + maxKey + ')');
         this.minKey = minKey;
         this.maxKey = maxKey;
     }
 
     public void setRowIdRange(long minRowId, long maxRowId)
     {
-        assert minRowId <= maxRowId: "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')';
+        Preconditions.checkArgument(minRowId <= maxRowId, "minRowId (" + minRowId + ") must not be greater than (" + maxRowId + ')');
         this.minRowId = minRowId;
         this.maxRowId = maxRowId;
     }
@@ -120,6 +124,8 @@ public class SegmentMetadataBuilder
      */
     public void setTermRange(@Nonnull ByteBuffer minTerm, @Nonnull ByteBuffer maxTerm)
     {
+        Preconditions.checkNotNull(minTerm, "minTerm must not be null");
+        Preconditions.checkNotNull(maxTerm, "maxTerm must not be null");
         this.minTerm = minTerm;
         this.maxTerm = maxTerm;
     }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -136,13 +136,13 @@ public class SAITester extends CQLTester
     protected static final Injections.Counter perSSTableValidationCounter = addConditions(Injections.newCounter("PerSSTableValidationCounter")
                                                                                       .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
                                                                                                            .onMethod("isValid")),
-                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+                                                                                          b -> b.not().when(expr(Expression.THIS).method("isPerIndexGroup").args())
     ).build();
 
     protected static final Injections.Counter perColumnValidationCounter = addConditions(Injections.newCounter("PerColumnValidationCounter")
                                                                                      .add(newInvokePoint().onClass("IndexDescriptor$IndexComponentsImpl")
                                                                                                           .onMethod("isValid")),
-                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args()).and().not().when(expr("$validateChecksum"))
+                                                                                         b -> b.when(expr(Expression.THIS).method("isPerIndexGroup").args())
     ).build();
 
     protected static ColumnIdentifier V1_COLUMN_IDENTIFIER = ColumnIdentifier.getInterned("v1", true);

--- a/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AnalyzerTest.java
@@ -124,4 +124,38 @@ public class AnalyzerTest extends SAITester
                   .isInstanceOf(InvalidRequestException.class)
                   .hasMessageContaining("Cannot use an analyzer on " + column + " because it's a frozen collection.");
     }
+
+    @Test
+    public void testEmptyOnInitialBuild()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("INSERT INTO %s (k, v) VALUES (1, '')");
+        flush();
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'standard'};");
+    }
+
+    @Test
+    public void testEmptyOnCompaction()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'standard'};");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'apple orange')");
+        flush();
+        execute("INSERT INTO %s (k, v) VALUES (1, '')");
+        flush();
+        compact();
+    }
+
+    @Test
+    public void testEmptyWithStopwords()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("INSERT INTO %s (k, v) VALUES (1, 'and then')");  // will yield no indexed terms
+        flush();
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {" +
+                    "'index_analyzer': 'english'};");
+        assertEmpty(execute("SELECT * FROM %s WHERE v = 'and'"));
+    }
 }


### PR DESCRIPTION
If an index analyzer produced no terms for a row, the index build could not complete and broke sstable flushing.

This commit makes the SegmentBuilder ignore the whole row if there are no terms. Additionally more assertions / preconditions have been added to improve diagnostics.

Fixes:
Failed to complete an index build
java.lang.IllegalStateException: Term range not set at
org.apache.cassandra.index.sai.disk.v1.SegmentMetadataBuilder.build(SegmentMetadataBuilder.java:145) at
org.apache.cassandra.index.sai.disk.v1.SegmentBuilder.flush(SegmentBuilder.java:470) at
org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter.flushSegment(SSTableIndexWriter.java:286) at
org.apache.cassandra.index.sai.disk.v1.SSTableIndexWriter.complete(SSTableIndexWriter.java:151)
