### PR TITLE
CNDB-14392: Use QueryView's MemtableIndex references for search (#1799)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -455,7 +455,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private KeyRangeIterator buildIterator(Expression predicate)
     {
         QueryView view = getQueryView(predicate.context);
-        return KeyRangeTermIterator.build(predicate, view.sstableIndexes, mergeRange, queryContext, false, Integer.MAX_VALUE);
+        return KeyRangeTermIterator.build(predicate, view, mergeRange, queryContext, false, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryView.java
@@ -55,8 +55,8 @@ import org.apache.cassandra.utils.NoSpamLogger;
 public class QueryView implements AutoCloseable
 {
     final ColumnFamilyStore.RefViewFragment viewFragment;
-    final Set<SSTableIndex> sstableIndexes;
-    final Set<MemtableIndex> memtableIndexes;
+    public final Set<SSTableIndex> sstableIndexes;
+    public final Set<MemtableIndex> memtableIndexes;
     final IndexContext indexContext;
 
     public QueryView(ColumnFamilyStore.RefViewFragment viewFragment,

--- a/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/DropIndexWhileQueryingTest.java
@@ -16,8 +16,14 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.TopKProcessor;
 import org.apache.cassandra.inject.ActionBuilder;
@@ -25,14 +31,35 @@ import org.apache.cassandra.inject.Injection;
 import org.apache.cassandra.inject.Injections;
 import org.apache.cassandra.inject.InvokePointBuilder;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.apache.cassandra.inject.InvokePointBuilder.newInvokePoint;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class DropIndexWhileQueryingTest extends SAITester
 {
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static Collection<Object> data()
+    {
+        return Version.ALL.stream()
+                          .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .map(v -> new Object[]{ v})
+                          .collect(Collectors.toList());
+    }
+
+    @Before
+    public void setCurrentSAIVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
     // See CNDB-10732
     @Test
     public void testDropIndexWhileQuerying() throws Throwable
@@ -53,7 +80,18 @@ public class DropIndexWhileQueryingTest extends SAITester
     }
 
     @Test
-    public void testFallbackToAnotherIndex() throws Throwable
+    public void testFallbackToAnotherIndexMemtable() throws Throwable
+    {
+        testFallbackToAnotherIndex(false);
+    }
+
+    @Test
+    public void testFallbackToAnotherIndexSSTable() throws Throwable
+    {
+        testFallbackToAnotherIndex(true);
+    }
+
+    public void testFallbackToAnotherIndex(boolean flush) throws Throwable
     {
         createTable("CREATE TABLE %s (k text PRIMARY KEY, x int, y text, z text)");
 
@@ -62,13 +100,18 @@ public class DropIndexWhileQueryingTest extends SAITester
         String indexName2 = createIndex("CREATE CUSTOM INDEX ON %s(z) USING 'StorageAttachedIndex'");
         waitForTableIndexesQueryable();
 
-        injectIndexDrop("drop_index_1", indexName1, "buildIterator", true);
-        injectIndexDrop("drop_index_2", indexName2, "buildIterator", true);
+        // TODO this isn't the right place to drop the iterator when we have the histograms. getQueryView
+        // might be better but it might get called at the wrong time and might not lead to the right
+        // coverage for the fallback logic this test is meant to cover.
+        injectIndexDropInGetQueryView("drop_index_1", indexName1);
+        injectIndexDropInGetQueryView("drop_index_2", indexName2);
 
         execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k1", 0, "y0", "z0"); // match
         execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k2", 0, "y1", "z2"); // no match
         execute("INSERT INTO %s (k, x, y, z) VALUES (?, ?, ?, ?)", "k3", 5, "y2", "z0"); // no match
         String query = "SELECT * FROM %s WHERE x = 0 AND y = 'y0' AND z = 'z0'";
+        if (flush)
+            flush();
         assertRowCount(execute(query), 1);
     }
 
@@ -103,6 +146,32 @@ public class DropIndexWhileQueryingTest extends SAITester
         Injections.inject(injection);
         injection.enable();
         assertTrue("Injection should be enabled", injection.isEnabled());
+    }
+
+    private static void injectIndexDropInGetQueryView(String injectionName, String indexName) throws Throwable
+    {
+        // Inject a byteman rule that will drop the index when the getQueryView method is called only for that particular index.
+        InvokePointBuilder invokePoint = newInvokePoint().onClass(QueryController.class).onMethod("getQueryView");
+        Injection injection = Injections.newCustom(injectionName)
+                                        .add(invokePoint.atEntry())
+                                        .add(ActionBuilder
+                                             .newActionBuilder()
+                                             .actions()
+                                             .doAction("org.apache.cassandra.index.sai.cql.DropIndexWhileQueryingTest" +
+                                                       ".dropIndexForBytemanInjections(\"" + indexName + "\", $1);"))
+                                        .build();
+        Injections.inject(injection);
+        injection.enable();
+        assertTrue("Injection should be enabled", injection.isEnabled());
+    }
+
+
+    // the method is used by the byteman rule to drop the index conditionally when running with given context
+    @SuppressWarnings("unused")
+    public static void dropIndexForBytemanInjections(String indexName, IndexContext context)
+    {
+        if (context.getIndexName().equals(indexName))
+            dropIndexForBytemanInjections(indexName);
     }
 
     // the method is used by the byteman rule to drop the index

--- a/test/unit/org/apache/cassandra/index/sai/plan/FlushIndexWhileQueryingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/FlushIndexWhileQueryingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.plan;
+
+import java.util.concurrent.ForkJoinPool;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test to cover edge cases related to memtable flush during query execution.
+ */
+public class FlushIndexWhileQueryingTest extends SAITester
+{
+    @Test
+    public void testFlushAfterQueryViewBuildEqualityQuery() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, x int)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (k, x) VALUES (?, ?)", "a", 0);
+        execute("INSERT INTO %s (k, x) VALUES (?, ?)", "b", 0);
+        execute("INSERT INTO %s (k, x) VALUES (?, ?)", "c", 1);
+
+        testFlushAfterQueryViewBuiltBeforeQueryExecution("SELECT k FROM %s WHERE x = 0", 2);
+    }
+
+    @Test
+    public void testFlushAfterQueryViewBuildNotContainsQuery() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, x set<int>)");
+
+        createIndex("CREATE CUSTOM INDEX ON %s(x) USING 'StorageAttachedIndex'");
+
+        execute("INSERT INTO %s (k, x) VALUES ('a', {1, 2, 3})");
+        execute("INSERT INTO %s (k, x) VALUES ('b', {1, 2, 3})");
+        execute("INSERT INTO %s (k, x) VALUES ('c', {1, 2, 4})");
+
+        testFlushAfterQueryViewBuiltBeforeQueryExecution("SELECT k FROM %s WHERE x NOT CONTAINS 3", 1);
+    }
+
+    private void testFlushAfterQueryViewBuiltBeforeQueryExecution(String query, int expectedRowCount) throws Throwable
+    {
+        // We use a barrier to trigger flush at precisely the right time
+        var viewBuildPoint = InvokePointBuilder.newInvokePoint().onClass(QueryView.Builder.class).onMethod("build").atExit();
+        var viewBuildBarrier = Injections.newBarrier("pause_query_view_build", 2, false).add(viewBuildPoint).build();
+        var getViewPoint = InvokePointBuilder.newInvokePoint().onClass(QueryController.class).onMethod("getQueryView").atExit();
+        var getViewBarrier = Injections.newBarrier("pause_get_query_view", 2, false).add(getViewPoint).build();
+        Injections.inject(viewBuildBarrier, getViewBarrier);
+
+        // Flush in a separate thread to allow the query to run concurrently
+        ForkJoinPool.commonPool().submit(() -> {
+            try
+            {
+                viewBuildBarrier.arrive();
+                flush();
+                getViewBarrier.arrive();
+            }
+            catch (InterruptedException t)
+            {
+                throw new RuntimeException(t);
+            }
+        });
+
+        assertRowCount(execute(query), expectedRowCount);
+        assertEquals("Confirm that we hit the barrier", 0, viewBuildBarrier.getCount());
+        assertEquals("Confirm that we hit the barrier", 0, getViewBarrier.getCount());
+    }
+}


### PR DESCRIPTION
- **Create a failing test**
- **Parameterize DropIndexWhileQueryingTest, making it fail**
- **CNDB-14392: Use QueryView's MemtableIndex references for search**

### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14392

### What does this PR fix and why was it fixed
We incorrectly use the `liveMemtables` at search time instead of the `QueryView.memtables` for the memory index search. This leads to incorrect behavior when a memtable is flushed or dropped after we acquire the `QueryView` and before we search the `liveMemtables`. The solution is easy: use the referenced `QueryView` to get the memtables
