### PR TITLE
CNDB-14847 CC5 Restore SSTableFormat.requireComponents method

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -397,7 +397,7 @@ public abstract class SSTable
         try
         {
             Set<Component> tocComponents = TOCComponent.loadTOC(descriptor);
-            Set<Component> requiredComponents = descriptor.getFormat().primaryComponents();
+            Set<Component> requiredComponents = descriptor.getFormat().requiredComponents();
             if (!tocComponents.containsAll(requiredComponents))
             {
                 logger.error("Cannot reload components from read TOC file for {}; the TOC does not contain all the required components for the sstable type and is like corrupted (components in TOC: {}, required by sstable format: {})",

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -60,6 +60,8 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
     Set<Component> allComponents();
 
 
+    Set<Component> requiredComponents();
+
     Set<Component> primaryComponents();
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -97,6 +97,11 @@ public class BigFormat extends AbstractSSTableFormat<BigTableReader, BigTableWri
                                                                                FILTER,
                                                                                STATS);
 
+        // Used by CNDB, preserved from CC 4.0
+        private static final Set<Component> REQUIRED_COMPONENTS = ImmutableSet.of(DATA,
+                                                                                  PRIMARY_INDEX,
+                                                                                  STATS);
+
         private static final Set<Component> PRIMARY_COMPONENTS = ImmutableSet.of(DATA,
                                                                                  PRIMARY_INDEX);
 
@@ -169,6 +174,12 @@ public class BigFormat extends AbstractSSTableFormat<BigTableReader, BigTableWri
     public Set<Component> allComponents()
     {
         return Components.ALL_COMPONENTS;
+    }
+
+    @Override
+    public Set<Component> requiredComponents()
+    {
+        return Components.REQUIRED_COMPONENTS;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java
@@ -82,6 +82,12 @@ public class BtiFormat extends AbstractSSTableFormat<BtiTableReader, BtiTableWri
 
         public final static Component ROW_INDEX = Types.ROW_INDEX.getSingleton();
 
+        // Used by CNDB, preserved from CC 4.0
+        private static final Set<Component> REQUIRED_COMPONENTS = ImmutableSet.of(DATA,
+                                                                                  PARTITION_INDEX,
+                                                                                  ROW_INDEX,
+                                                                                  STATS);
+
         private final static Set<Component> PRIMARY_COMPONENTS = ImmutableSet.of(DATA,
                                                                                  PARTITION_INDEX);
 
@@ -156,6 +162,12 @@ public class BtiFormat extends AbstractSSTableFormat<BtiTableReader, BtiTableWri
     public BtiTableReaderFactory getReaderFactory()
     {
         return readerFactory;
+    }
+
+    @Override
+    public Set<Component> requiredComponents()
+    {
+        return Components.REQUIRED_COMPONENTS;
     }
 
     @Override


### PR DESCRIPTION
### What is the issue
Fixes CNDB-14847, restoring `SSTableFormat.requiredComponents` method

### What does this PR fix and why was it fixed
Restores `SSTableFormat.requiredComponents` method to provide a list of expected components used in CNDB.

