### PR TITLE
CNDB-14848 CC5 remove unused duplicated constants from SchemaConstants

### DIFF
--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -220,19 +220,10 @@ public final class SchemaConstants
                            .build();
     }
     
-//    /**
-//     * @return whether or not the keyspace is a virtual keyspace (system_virtual_schema, system_views)
-//     */
-//    public static boolean isVirtualKeyspace(String keyspaceName)
-//    {
-//        return VIRTUAL_KEYSPACE_NAMES.contains(keyspaceName.toLowerCase());
-//    }
-//
     public static boolean isInternalKeyspace(String keyspaceName)
     {
         return isLocalSystemKeyspace(keyspaceName)
                || isReplicatedSystemKeyspace(keyspaceName);
-//               || isVirtualSystemKeyspace(keyspaceName);
     }
     
     /**

--- a/src/java/org/apache/cassandra/schema/SchemaConstants.java
+++ b/src/java/org/apache/cassandra/schema/SchemaConstants.java
@@ -51,8 +51,6 @@ public final class SchemaConstants
     public static final String VIRTUAL_SCHEMA = "system_virtual_schema";
 
     public static final String VIRTUAL_VIEWS = "system_views";
-    public static final String SCHEMA_VIRTUAL_KEYSPACE_NAME = "system_virtual_schema";
-    public static final String SYSTEM_VIEWS_KEYSPACE_NAME = "system_views";
 
     public static final String DUMMY_KEYSPACE_OR_TABLE_NAME = "--dummy--";
 
@@ -65,9 +63,6 @@ public final class SchemaConstants
 
     /* replicate system keyspace names (the ones with a "true" replication strategy) */
     public static final Set<String> REPLICATED_SYSTEM_KEYSPACE_NAMES = ImmutableSet.of(TRACE_KEYSPACE_NAME, AUTH_KEYSPACE_NAME, DISTRIBUTED_KEYSPACE_NAME);
-
-    /* virtual keyspace names */
-    public static final Set<String> VIRTUAL_KEYSPACE_NAMES = ImmutableSet.of(SCHEMA_VIRTUAL_KEYSPACE_NAME, SYSTEM_VIEWS_KEYSPACE_NAME);
 
     /**
      * Longest acceptable file name. Longer names lead to file write or read errors.
@@ -225,19 +220,19 @@ public final class SchemaConstants
                            .build();
     }
     
-    /**
-     * @return whether or not the keyspace is a virtual keyspace (system_virtual_schema, system_views)
-     */
-    public static boolean isVirtualKeyspace(String keyspaceName)
-    {
-        return VIRTUAL_KEYSPACE_NAMES.contains(keyspaceName.toLowerCase());
-    }
-
+//    /**
+//     * @return whether or not the keyspace is a virtual keyspace (system_virtual_schema, system_views)
+//     */
+//    public static boolean isVirtualKeyspace(String keyspaceName)
+//    {
+//        return VIRTUAL_KEYSPACE_NAMES.contains(keyspaceName.toLowerCase());
+//    }
+//
     public static boolean isInternalKeyspace(String keyspaceName)
     {
         return isLocalSystemKeyspace(keyspaceName)
-               || isReplicatedSystemKeyspace(keyspaceName)
-               || isVirtualKeyspace(keyspaceName);
+               || isReplicatedSystemKeyspace(keyspaceName);
+//               || isVirtualSystemKeyspace(keyspaceName);
     }
     
     /**


### PR DESCRIPTION
### What is the issue
Fixes CNDB-14848, removing unused, duplicated constants from `SchemaConstants`

### What does this PR fix and why was it fixed
`SchemaConstants` contains unused and duplicated constants left over from previous rebases.
