### PR TITLE
CNDB-14524: Reset view before calling GraphSearcher#search (#1826)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -339,6 +339,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         var graphAccessManager = searchers.get();
         var searcher = graphAccessManager.get();
         searcher.usePruning(usePruning);
+        searcher.setView(builder.getGraph().getView());
         try
         {
             var ssf = SearchScoreProvider.exact(queryVector, similarityFunction, vectorValues);

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -1044,4 +1044,35 @@ public class VectorTypeTest extends VectorTester.VersionedWithChecksums
         execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2");
     }
 
+    @Test
+    public void testMemtableInsertSearchInsertSearchHandling()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(embedding) USING 'StorageAttachedIndex' " +
+                    "WITH OPTIONS = {'similarity_function': 'dot_product', 'source_model': 'OTHER'}");
+
+        // Insert initial data
+        execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");
+        execute("INSERT INTO %s (id, embedding) VALUES ('row2', [0.9, 0.9, 0.9, 0.9, 0.9])");
+
+        // Query 100 times to try to guarantee all graph searchers are initialized
+        for (int i = 0; i < 100; i++)
+        {
+            // Initial vector search
+            UntypedResultSet initialSearch = execute("SELECT * FROM %s ORDER BY embedding ANN OF [0.8, 0.8, 0.8, 0.8, 0.8] LIMIT 1");
+            assertThat(initialSearch).hasSize(1);
+        }
+
+        // Update one of the rows (this update wasn't observed due to state leaked between queries previously)
+        execute("INSERT INTO %s (id, embedding) VALUES ('row3', [0.7, 0.7, 0.7, 0.7, 0.7])");
+
+        // Query 100 times to make sure it works as expected
+        for (int j = 0; j < 100; j++)
+        {
+            // Get all data to verify we have 2 rows
+            UntypedResultSet allData = execute("SELECT * FROM %s ORDER BY embedding ANN OF [0.8, 0.8, 0.8, 0.8, 0.8] LIMIT 1000");
+            assertThat(allData).hasSize(3);
+        }
+    }
+
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -984,4 +984,35 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
             assertRows(execute("SELECT ck FROM %s ORDER BY val ANN OF [1.0, 2.0, 3.0] LIMIT 2"), row(1));
         });
     }
+
+    @Test
+    public void testMemtableInsertSearchUpdateSearchHandling()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(embedding) USING 'StorageAttachedIndex' " +
+                    "WITH OPTIONS = {'similarity_function': 'dot_product', 'source_model': 'OTHER'}");
+
+        // Insert initial data
+        execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");
+        execute("INSERT INTO %s (id, embedding) VALUES ('row2', [0.9, 0.9, 0.9, 0.9, 0.9])");
+
+        // Query 100 times to try to guarantee all graph searchers are initialized
+        for (int i = 0; i < 100; i++)
+        {
+            // Initial vector search
+            UntypedResultSet initialSearch = execute("SELECT * FROM %s ORDER BY embedding ANN OF [0.8, 0.8, 0.8, 0.8, 0.8] LIMIT 1");
+            assertThat(initialSearch).hasSize(1);
+        }
+
+        // Update one of the rows (this update wasn't observed due to state leaked between queries previously)
+        execute("UPDATE %s SET embedding = [0.7, 0.7, 0.7, 0.7, 0.7] WHERE id = 'row1'");
+
+        // Query 100 times to make sure it works as expected
+        for (int j = 0; j < 100; j++)
+        {
+            // Get all data to verify we have 2 rows
+            UntypedResultSet allData = execute("SELECT * FROM %s ORDER BY embedding ANN OF [0.8, 0.8, 0.8, 0.8, 0.8] LIMIT 1000");
+            assertThat(allData).hasSize(2);
+        }
+    }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/14524

### What does this PR fix and why was it fixed
This jvector commit
https://github.com/datastax/jvector/commit/00a13a8a793009ffd13bb61374725653e0c50b87 changed the `GraphSearcher` contract, and we now need to acquire a new view before each query. The expected side effect is the creation of one additional object, `ConcurrentGraphIndexView`, which in turn just has a call to `completions.clock()`, a jvector construct that ensures a consistent view of the graph (concurrent updates will not be visible).

Cherry pick of https://github.com/datastax/cassandra/pull/1825

(cherry picked from commit 51879776ecff84fb358d7b55369a3f0376b346b3)
