### PR TITLE
CNDB-14879: check for vector types in V7OnDiskFormat.perIndexComponentTypes() before checking if they're literals

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormat.java
@@ -39,6 +39,10 @@ public class V7OnDiskFormat extends V6OnDiskFormat
     @Override
     public Set<IndexComponentType> perIndexComponentTypes(AbstractType<?> validator)
     {
+        // Vector types are technically "literal" (frozen) but should not have DOC_LENGTHS
+        // which is only for text search BM25 functionality
+        if (validator.isVector())
+            return super.perIndexComponentTypes(validator);
         if (TypeUtil.isLiteral(validator))
             return LITERAL_COMPONENTS;
         return super.perIndexComponentTypes(validator);


### PR DESCRIPTION
### What is the issue
After CNDB-14854 vectors were being treated as literals and they are getting the DOC_LENGTHS component requirement but DOC_LENGTHS is only written by InvertedIndexWriter for text indexes, not for vector indexes


### What does this PR fix and why was it fixed
checks for vectors before checking for literals 
