### PR TITLE
CNDB-14501: Enable checksum for jvector index files starting at version EC (#1841)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -85,7 +85,7 @@ public class IndexDescriptor
     // TODO Because indexes can be added at any time to existing data, the Version of a column index
     // may not match the Version of the base sstable.  OnDiskFormat + IndexFeatureSet + IndexDescriptor
     // was not designed with this in mind, leading to some awkwardness, notably in IFS where some features
-    // are per-sstable (`isRowAware`) and some are per-column (`hasVectorIndexChecksum`).
+    // are per-sstable (`isRowAware`) and some are per-column (`hasTermsHistogram`).
 
     public final Descriptor descriptor;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexFeatureSet.java
@@ -38,11 +38,6 @@ public interface IndexFeatureSet
     boolean isRowAware();
 
     /**
-     * @return true if vector index files include a checksum at the end
-     */
-    boolean hasVectorIndexChecksum();
-
-    /**
      * @return true if index metadata contains term histograms for fast cardinality estimation
      */
     boolean hasTermsHistogram();
@@ -64,7 +59,6 @@ public interface IndexFeatureSet
     class Accumulator
     {
         boolean isRowAware = true;
-        boolean hasVectorIndexChecksum = true;
         boolean hasTermsHistogram = true;
         boolean complete = false;
 
@@ -83,8 +77,6 @@ public interface IndexFeatureSet
             assert !complete : "Cannot accumulate after complete has been called";
             if (!indexFeatureSet.isRowAware())
                 isRowAware = false;
-            if (!indexFeatureSet.hasVectorIndexChecksum())
-                hasVectorIndexChecksum = false;
             if (!indexFeatureSet.hasTermsHistogram())
                 hasTermsHistogram = false;
         }
@@ -104,12 +96,6 @@ public interface IndexFeatureSet
                 public boolean isRowAware()
                 {
                     return isRowAware;
-                }
-
-                @Override
-                public boolean hasVectorIndexChecksum()
-                {
-                    return hasVectorIndexChecksum;
                 }
 
                 @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -52,7 +52,9 @@ public class Version implements Comparable<Version>
     public static final Version AA = new Version("aa", V1OnDiskFormat.instance, Version::aaFileNameFormat);
     // Stargazer
     public static final Version BA = new Version("ba", V2OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ba"));
-    // Converged Cassandra with JVector
+    // Converged Cassandra with JVector with file format version 2
+    // Note: vector index checksums for TERMS files were computed in two different ways for this version. As such,
+    // we do not validate checksums for this version or any subsequent version until EC.
     public static final Version CA = new Version("ca", V3OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ca"));
     // NOTE: use DB to prevent collisions with upstream file formats
     // Encode trie entries using their AbstractType to ensure trie entries are sorted for range queries and are prefix free.
@@ -61,7 +63,9 @@ public class Version implements Comparable<Version>
     public static final Version DC = new Version("dc", V5OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "dc"));
     // histograms in index metadata
     public static final Version EB = new Version("eb", V6OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "eb"));
-    // term frequencies index component (support for BM25)
+    // term frequencies index component (support for BM25); bump jvector file format version to 4
+    // Start validating vector index component checksums, except for the TERMS_FILE because it's checksum is non-standard
+    // and isn't easily validated when an sstable index has multiple segments within the TERMS_FILE.
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));
     // total terms count serialization in index metadata
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java
@@ -134,12 +134,6 @@ public class V1OnDiskFormat implements OnDiskFormat
         }
 
         @Override
-        public boolean hasVectorIndexChecksum()
-        {
-            return false;
-        }
-
-        @Override
         public boolean hasTermsHistogram()
         {
             return false;
@@ -236,13 +230,10 @@ public class V1OnDiskFormat implements OnDiskFormat
         if (component.isCompletionMarker())
             return;
 
-        // starting with v3, vector components include proper headers and checksum; skip for earlier versions
+        // We do not validate vector components until V7, so we skip for earlier versions
         IndexContext context = component.parent().context();
-        if (isVectorDataComponent(context, component.componentType())
-            && !component.parent().onDiskFormat().indexFeatureSet().hasVectorIndexChecksum())
-        {
+        if (isVectorDataComponent(context, component.componentType()))
             return;
-        }
 
         Version earliest = getExpectedEarliestVersion(context, component.componentType());
         try (IndexInput input = component.openInput())

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -75,12 +75,6 @@ public class V2OnDiskFormat extends V1OnDiskFormat
         }
 
         @Override
-        public boolean hasVectorIndexChecksum()
-        {
-            return false;
-        }
-
-        @Override
         public boolean hasTermsHistogram()
         {
             return false;

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -83,12 +83,6 @@ public class V3OnDiskFormat extends V2OnDiskFormat
         }
 
         @Override
-        public boolean hasVectorIndexChecksum()
-        {
-            return false;
-        }
-
-        @Override
         public boolean hasTermsHistogram()
         {
             return false;

--- a/src/java/org/apache/cassandra/index/sai/disk/v6/V6OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v6/V6OnDiskFormat.java
@@ -34,12 +34,6 @@ public class V6OnDiskFormat extends V5OnDiskFormat
         }
 
         @Override
-        public boolean hasVectorIndexChecksum()
-        {
-            return false;
-        }
-
-        @Override
         public boolean hasTermsHistogram()
         {
             return true;

--- a/src/java/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormat.java
@@ -18,16 +18,30 @@
 
 package org.apache.cassandra.index.sai.disk.v7;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v6.V6OnDiskFormat;
+import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
+import org.apache.cassandra.utils.Throwables;
+import org.apache.lucene.store.IndexInput;
 
 public class V7OnDiskFormat extends V6OnDiskFormat
 {
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     public static final V7OnDiskFormat instance = new V7OnDiskFormat();
 
     private static final Set<IndexComponentType> LITERAL_COMPONENTS = EnumSet.of(IndexComponentType.COLUMN_COMPLETION_MARKER,
@@ -55,5 +69,46 @@ public class V7OnDiskFormat extends V6OnDiskFormat
         // so we can safely start writing it for versions EC (V7) and later while maintaining proper backward
         // compatibility.
         return 4;
+    }
+
+    @Override
+    public void validateIndexComponent(IndexComponent.ForRead component, boolean checksum)
+    {
+        if (component.isCompletionMarker())
+            return;
+
+        IndexContext context = component.parent().context();
+        if (context != null && context.isVector() && component.parent().version().onOrAfter(Version.EC))
+        {
+            try (IndexInput input = component.openInput())
+            {
+                // We can't validate TERMS_DATA with checksum because the checksum was computed incorrectly through
+                // V7. See https://github.com/riptano/cndb/issues/14656. We can still call the basic validate method
+                // which does not check the checksum. (The issue is in the way the checksum was computed. It didn't
+                // include the header/footer bytes, and for multi-segment builds, it didn't include the bytes from
+                // all previous segments, which is the design for all index components to date.)
+                if (!checksum || component.componentType() == IndexComponentType.TERMS_DATA)
+                    SAICodecUtils.validate(input, getExpectedEarliestVersion(context, component.componentType()));
+                else
+                    SAICodecUtils.validateChecksum(input, getExpectedEarliestVersion(context, component.componentType()));
+            }
+            catch (Throwable e)
+            {
+                logger.warn(component.parent().logMessage("{} failed for index component {} on SSTable {}"),
+                            (checksum ? "Checksum validation" : "Validation"),
+                            component,
+                            component.parent().descriptor(),
+                            e);
+                if (e instanceof IOException)
+                    throw new UncheckedIOException((IOException) e);
+                if (e.getCause() instanceof IOException)
+                    throw new UncheckedIOException((IOException) e.getCause());
+                throw Throwables.unchecked(e);
+            }
+        }
+        else
+        {
+            super.validateIndexComponent(component, checksum);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/SAICodecUtils.java
@@ -75,6 +75,8 @@ public class SAICodecUtils
         writeChecksum(out);
     }
 
+    // Warning: this method produces an incomplete checksum when using other Lucene tooling because it computes
+    // the checksum without including the FOOTER_MAGIC and 0. See https://github.com/riptano/cndb/issues/14501.
     public static void writeFooter(RandomAccessWriter braw, long checksum) throws IOException
     {
         var out = toLuceneOutput(braw);

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -391,16 +391,9 @@ public class SAITester extends CQLTester
                 if (indexDescriptor.isIndexEmpty(context))
                     continue;
                 
-                // For vector indexes, only validate checksums if the version supports it
-                boolean validateChecksum = true;
-                if (context.isVector() && !indexDescriptor.perSSTableComponents().onDiskFormat().indexFeatureSet().hasVectorIndexChecksum())
-                {
-                    // Vector components don't have checksums in versions prior to v7, so we skip checksum validation
-                    validateChecksum = false;
-                }
-                
-                if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), validateChecksum, false)
-                    || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), validateChecksum, false))
+                // Checksum validation is now handled internally by the OnDiskFormat's validateIndexComponent method
+                if (!indexDescriptor.perSSTableComponents().validateComponents(sstable, cfs.getTracker(), true, false)
+                    || !indexDescriptor.perIndexComponents(context).validateComponents(sstable, cfs.getTracker(), true, false))
                     return false;
             }
         }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormatIntegrationTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormatIntegrationTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.v7;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.format.IndexComponent;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class V7OnDiskFormatIntegrationTest extends SAITester
+{
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        // Test with versions EC and later which support checksum validation
+        return Version.ALL.stream()
+                         .filter(v -> v.onOrAfter(Version.EC))
+                         .map(v -> new Object[]{ v })
+                         .collect(Collectors.toList());
+    }
+
+    @Before
+    public void setVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    @Before
+    public void setup()
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX value_idx ON %s(value) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+    }
+
+    @Test
+    public void testValidateComponentChecksumForVectorIndex() throws IOException
+    {
+        execute("INSERT INTO %s (pk, value) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (2, [4.0, 5.0, 6.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (3, [7.0, 8.0, 9.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        IndexComponent.ForRead component = indexDescriptor.perIndexComponents(indexContext)
+                                                         .get(IndexComponentType.META);
+
+        V7OnDiskFormat.instance.validateIndexComponent(component, true);
+    }
+
+    @Test
+    public void testValidateComponentDetectsCorruption() throws IOException
+    {
+        execute("INSERT INTO %s (pk, value) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (2, [4.0, 5.0, 6.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (3, [7.0, 8.0, 9.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // For vector indexes, use PQ component instead of POSTING_LISTS
+        IndexComponentType componentType = IndexComponentType.PQ;
+        IndexComponent.ForRead component = indexDescriptor.perIndexComponents(indexContext).get(componentType);
+        java.io.File fileToCorrupt = component.file().toJavaIOFile();
+
+        long originalSize = fileToCorrupt.length();
+
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Corrupt the file more severely to ensure checksum failure
+            if (originalSize > 20)
+            {
+                file.seek(10);
+                file.write(new byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF});
+                
+                file.seek(originalSize / 2);
+                file.write(new byte[]{(byte)0xDE, (byte)0xAD, (byte)0xBE, (byte)0xEF});
+                
+                file.seek(originalSize - 10);
+                file.write(new byte[]{(byte)0xBA, (byte)0xAD, (byte)0xCA, (byte)0xFE});
+            }
+        }
+
+        try
+        {
+            V7OnDiskFormat.instance.validateIndexComponent(component, true);
+            fail("Expected validation to fail due to corruption");
+        }
+        catch (UncheckedIOException e)
+        {
+            // Expected - checksum validation should detect corruption
+        }
+    }
+
+    @Test
+    public void testSkipChecksumValidationForTermsData() throws IOException
+    {
+        execute("INSERT INTO %s (pk, value) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (2, [4.0, 5.0, 6.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (3, [7.0, 8.0, 9.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        IndexComponent.ForRead component = indexDescriptor.perIndexComponents(indexContext)
+                                                         .get(IndexComponentType.TERMS_DATA);
+
+        java.io.File fileToCorrupt = component.file().toJavaIOFile();
+        long originalSize = fileToCorrupt.length();
+
+        // Corrupt the TERMS_DATA file
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Corrupt the TERMS_DATA file
+            if (originalSize > 20)
+            {
+                file.seek(originalSize / 2);
+                file.write(new byte[]{(byte)0xDE, (byte)0xAD, (byte)0xBE, (byte)0xEF});
+            }
+        }
+
+        // For TERMS_DATA, checksum validation is skipped due to known issue
+        // So this should not throw even though file is corrupted
+        V7OnDiskFormat.instance.validateIndexComponent(component, true);
+    }
+
+    @Test
+    public void testValidateWithoutChecksumFlag() throws IOException
+    {
+        execute("INSERT INTO %s (pk, value) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, value) VALUES (2, [4.0, 5.0, 6.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        IndexComponent.ForRead component = indexDescriptor.perIndexComponents(indexContext)
+                                                         .get(IndexComponentType.META);
+
+        // Should validate successfully without checksum
+        V7OnDiskFormat.instance.validateIndexComponent(component, false);
+    }
+
+    // Helper method to get the IndexContext from a StorageAttachedIndex
+    private IndexContext getIndexContext(StorageAttachedIndex index) throws RuntimeException
+    {
+        try
+        {
+            java.lang.reflect.Field field = StorageAttachedIndex.class.getDeclaredField("indexContext");
+            field.setAccessible(true);
+            return (IndexContext) field.get(index);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to get IndexContext", e);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormatTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v7/V7OnDiskFormatTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.v7;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class V7OnDiskFormatTest extends SAITester
+{
+    private final V7OnDiskFormat format = V7OnDiskFormat.instance;
+
+    @Test
+    public void testPerIndexComponentTypesForVectorType()
+    {
+        // Create a vector type with float elements
+        VectorType<Float> vectorType = VectorType.getInstance(FloatType.instance, 3);
+        
+        // Get component types for vector
+        Set<IndexComponentType> vectorComponents = format.perIndexComponentTypes(vectorType);
+        
+        // Vector types should not include DOC_LENGTHS
+        assertFalse("Vector types should not have DOC_LENGTHS component", 
+                   vectorComponents.contains(IndexComponentType.DOC_LENGTHS));
+        
+        // But should have other components
+        assertTrue(vectorComponents.contains(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(vectorComponents.contains(IndexComponentType.META));
+        
+        // Should call parent perIndexComponentTypes for vector types
+        // Verify it has the expected components from parent (VECTOR_COMPONENTS_V3)
+        assertTrue(vectorComponents.contains(IndexComponentType.PQ));
+        assertTrue(vectorComponents.contains(IndexComponentType.TERMS_DATA));
+        assertTrue(vectorComponents.contains(IndexComponentType.POSTING_LISTS));
+    }
+
+    @Test
+    public void testPerIndexComponentTypesForLiteralType()
+    {
+        // Test with a literal type (UTF8Type)
+        Set<IndexComponentType> literalComponents = format.perIndexComponentTypes(UTF8Type.instance);
+        
+        // Literal types should include DOC_LENGTHS for BM25 functionality
+        assertTrue("Literal types should have DOC_LENGTHS component", 
+                  literalComponents.contains(IndexComponentType.DOC_LENGTHS));
+        assertTrue(literalComponents.contains(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(literalComponents.contains(IndexComponentType.META));
+        assertTrue(literalComponents.contains(IndexComponentType.TERMS_DATA));
+        assertTrue(literalComponents.contains(IndexComponentType.POSTING_LISTS));
+        
+        // Should have exactly these 5 components for literal types
+        assertEquals(5, literalComponents.size());
+    }
+
+    @Test
+    public void testPerIndexComponentTypesForNonLiteralType()
+    {
+        // Test with a non-literal type (Int32Type)
+        Set<IndexComponentType> nonLiteralComponents = format.perIndexComponentTypes(Int32Type.instance);
+        
+        // Non-literal types should not have DOC_LENGTHS
+        assertFalse("Non-literal types should not have DOC_LENGTHS component", 
+                   nonLiteralComponents.contains(IndexComponentType.DOC_LENGTHS));
+        
+        // Should have other components from parent
+        assertTrue(nonLiteralComponents.contains(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(nonLiteralComponents.contains(IndexComponentType.META));
+        assertTrue(nonLiteralComponents.contains(IndexComponentType.KD_TREE));
+        assertTrue(nonLiteralComponents.contains(IndexComponentType.KD_TREE_POSTING_LISTS));
+    }
+
+    @Test
+    public void testJvectorFileFormatVersion()
+    {
+        // V7 should return format version 4
+        assertEquals("V7OnDiskFormat should use JVector format version 4", 4, format.jvectorFileFormatVersion());
+    }
+
+    @Test
+    public void testPerIndexComponentTypesForVectorTypeMultipleDimensions()
+    {
+        // Test with different vector dimensions
+        VectorType<Float> smallVector = VectorType.getInstance(FloatType.instance, 2);
+        VectorType<Float> largeVector = VectorType.getInstance(FloatType.instance, 128);
+        
+        Set<IndexComponentType> smallComponents = format.perIndexComponentTypes(smallVector);
+        Set<IndexComponentType> largeComponents = format.perIndexComponentTypes(largeVector);
+        
+        // Both should not have DOC_LENGTHS
+        assertFalse(smallComponents.contains(IndexComponentType.DOC_LENGTHS));
+        assertFalse(largeComponents.contains(IndexComponentType.DOC_LENGTHS));
+        
+        // Both should have the same set of components
+        assertEquals(smallComponents, largeComponents);
+    }
+
+    @Test
+    public void testPerIndexComponentTypesConsistency()
+    {
+        // Test that calling perIndexComponentTypes multiple times returns consistent results
+        VectorType<Float> vectorType = VectorType.getInstance(FloatType.instance, 5);
+        
+        Set<IndexComponentType> firstCall = format.perIndexComponentTypes(vectorType);
+        Set<IndexComponentType> secondCall = format.perIndexComponentTypes(vectorType);
+        
+        // Results should be equal
+        assertEquals(firstCall, secondCall);
+        
+        // Also test with literal type
+        Set<IndexComponentType> firstLiteral = format.perIndexComponentTypes(UTF8Type.instance);
+        Set<IndexComponentType> secondLiteral = format.perIndexComponentTypes(UTF8Type.instance);
+        
+        assertEquals(firstLiteral, secondLiteral);
+    }
+
+    @Test
+    public void testPerIndexComponentTypesForFrozenType()
+    {
+        // Test with a frozen type that is not vector (should behave like non-literal)
+        // Frozen types might have different behavior
+        Set<IndexComponentType> frozenComponents = format.perIndexComponentTypes(Int32Type.instance.freeze());
+        
+        // Frozen non-literal types should not have DOC_LENGTHS
+        assertFalse("Frozen non-literal types should not have DOC_LENGTHS component", 
+                   frozenComponents.contains(IndexComponentType.DOC_LENGTHS));
+    }
+
+    @Test
+    public void testVectorComponentsDoNotIncludeDocLengths()
+    {
+        // vector types should not have DOC_LENGTHS even though they are technically "literal" (frozen) types
+        VectorType<Float> vectorType = VectorType.getInstance(FloatType.instance, 10);
+        
+        Set<IndexComponentType> components = format.perIndexComponentTypes(vectorType);
+        
+        assertFalse("Vector types should not include DOC_LENGTHS component",
+                   components.contains(IndexComponentType.DOC_LENGTHS));
+        
+        Set<IndexComponentType> textComponents = format.perIndexComponentTypes(UTF8Type.instance);
+        assertTrue("Text types should include DOC_LENGTHS component",
+                  textComponents.contains(IndexComponentType.DOC_LENGTHS));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VerifyTest.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.functional;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.io.sstable.IVerifier;
+import org.apache.cassandra.utils.OutputHandler;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class VerifyTest extends SAITester
+{
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+    }
+
+    @Before
+    public void setVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    private static final String TABLE = "verify_test";
+    private static final String INDEX_NAME = "value_idx";
+
+    @Before
+    public void setup()
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value int)");
+        createIndex("CREATE CUSTOM INDEX " + INDEX_NAME + " ON %s(value) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+    }
+
+    @Test
+    public void testVerifyCorrectSAIComponents()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with SAI components
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyExtendedSAIComponents()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with extended verification
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, 
+                                             IVerifier.options()
+                                                    .invokeDiskFailurePolicy(true)
+                                                    .extendedVerification(true)
+                                                    .build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyCorruptSAIComponent() throws IOException
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Corrupt a component file (META component)
+        IndexComponentType componentToCorrupt = IndexComponentType.META;
+        File fileToCorrupt = indexDescriptor.perIndexComponents(indexContext).get(componentToCorrupt).file().toJavaIOFile();
+
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Truncate the file to corrupt it
+            file.setLength(3);
+        }
+
+        // Verify should detect the corruption
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testVerifyMissingCompletionMarker() throws IOException
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Delete the completion marker
+        boolean deleted = indexDescriptor.perIndexComponents(indexContext)
+                                         .get(IndexComponentType.COLUMN_COMPLETION_MARKER)
+                                         .file()
+                                         .tryDelete();
+        assertTrue("Failed to delete completion marker", deleted);
+
+        // Verify should detect the missing completion marker
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testVerifyQuickSkipsChecksumValidation()
+    {
+        // Insert data and flush to create an SSTable with SAI components
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify with quick option should skip checksum validation
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, 
+                                             IVerifier.options()
+                                                    .invokeDiskFailurePolicy(true)
+                                                    .quick(true)
+                                                    .build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyAfterCompaction()
+    {
+        // Insert data and flush to create multiple SSTables
+        execute("INSERT INTO %s (pk, value) VALUES (1, 100)");
+        flush();
+        execute("INSERT INTO %s (pk, value) VALUES (2, 200)");
+        flush();
+        execute("INSERT INTO %s (pk, value) VALUES (3, 300)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        // Force compaction
+        CompactionManager.instance.performMaximal(cfs, false);
+
+        // Verify the compacted SSTable
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyMultipleIndices()
+    {
+        // Create a new table with multiple indices
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, value1 int, value2 text)");
+        createIndex("CREATE CUSTOM INDEX value1_idx ON %s(value1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX value2_idx ON %s(value2) USING 'StorageAttachedIndex'");
+
+        // Insert data and flush
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (1, 100, 'text1')");
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (2, 200, 'text2')");
+        execute("INSERT INTO %s (pk, value1, value2) VALUES (3, 300, 'text3')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with multiple indices
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyLiteralIndex()
+    {
+        // Create a table with a literal (text) column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, text_value text)");
+        createIndex("CREATE CUSTOM INDEX text_idx ON %s(text_value) USING 'StorageAttachedIndex'");
+
+        // Need to disable again because we created a new table
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with text values
+        execute("INSERT INTO %s (pk, text_value) VALUES (1, 'apple')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (2, 'banana')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (3, 'cherry')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with literal index
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyVectorIndex()
+    {
+        // Skip test if version doesn't support vector indexes
+        if (!version.onOrAfter(Version.JVECTOR_EARLIEST))
+            return;
+
+        // Create a table with a vector column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, vec vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX vector_idx ON %s(vec) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with vector values
+        execute("INSERT INTO %s (pk, vec) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (2, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (3, [3.0, 4.0, 5.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with vector index
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyCorruptVectorIndex() throws IOException
+    {
+        // Skip test if version doesn't support vector indexes
+        if (!version.onOrAfter(Version.JVECTOR_EARLIEST))
+            return;
+
+        // Create a table with a vector column
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, vec vector<float, 3>)");
+        createIndex("CREATE CUSTOM INDEX vector_idx ON %s(vec) USING 'StorageAttachedIndex'");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with vector values
+        execute("INSERT INTO %s (pk, vec) VALUES (1, [1.0, 2.0, 3.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (2, [2.0, 3.0, 4.0])");
+        execute("INSERT INTO %s (pk, vec) VALUES (3, [3.0, 4.0, 5.0])");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Get the index context for our vector index
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        StorageAttachedIndex index = group.getIndexes().iterator().next();
+        IndexContext indexContext = getIndexContext(index);
+
+        // Load the index descriptor
+        IndexDescriptor indexDescriptor = IndexDescriptor.load(sstable, Collections.singleton(indexContext));
+
+        // Corrupt a component file
+        IndexComponentType componentToCorrupt = IndexComponentType.TERMS_DATA;
+        File fileToCorrupt = indexDescriptor.perIndexComponents(indexContext).get(componentToCorrupt).file().toJavaIOFile();
+
+        try (RandomAccessFile file = new RandomAccessFile(fileToCorrupt, "rw"))
+        {
+            // Truncate the file to corrupt it
+            file.setLength(3);
+        }
+
+        // We didn't start validating these files until version EC
+        boolean verifyShouldFail = version.onOrAfter(Version.EC);
+        // Verify should detect the corruption
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            if (verifyShouldFail)
+                fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err)
+        {
+            if (!verifyShouldFail)
+                fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyAnalyzedTextIndex()
+    {
+        // Create a table with a text column and an analyzer
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, text_value text)");
+        createIndex("CREATE CUSTOM INDEX analyzed_idx ON %s(text_value) USING 'StorageAttachedIndex' " +
+                    "WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        CompactionManager.instance.disableAutoCompaction();
+
+        // Insert data with text values
+        execute("INSERT INTO %s (pk, text_value) VALUES (1, 'The quick brown fox')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (2, 'jumps over the lazy dog')");
+        execute("INSERT INTO %s (pk, text_value) VALUES (3, 'Lorem ipsum dolor sit amet')");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Verify the SSTable with analyzed text index
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException: " + err.getMessage());
+        }
+    }
+
+    // Helper method to get the IndexContext from a StorageAttachedIndex
+    private IndexContext getIndexContext(StorageAttachedIndex index) throws RuntimeException
+    {
+        try
+        {
+            // Use reflection to access the indexContext field
+            java.lang.reflect.Field field = StorageAttachedIndex.class.getDeclaredField("indexContext");
+            field.setAccessible(true);
+            return (IndexContext) field.get(index);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to get IndexContext", e);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/format/SortedTableVerifierTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/SortedTableVerifierTest.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.sstable.format;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.index.SecondaryIndexManager;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.IVerifier;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.utils.OutputHandler;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SortedTableVerifierTest
+{
+    private static final String KEYSPACE = "SortedTableVerifierTest";
+    private static final String TABLE = "test";
+
+    @BeforeClass
+    public static void defineSchema() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE,
+                                    KeyspaceParams.simple(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE, TABLE));
+    }
+
+    @Before
+    public void setup()
+    {
+        Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE).truncateBlocking();
+    }
+
+    /**
+     * Utility method to create a verifier and invoke the protected verifyStorageAttachedIndexes method
+     * 
+     * @param sstable The SSTable to verify
+     * @param cfs The ColumnFamilyStore (can be a spy/mock)
+     * @param isOffline Whether the verifier is in offline mode
+     * @param options The verifier options
+     * @return The verifier instance (for additional verification if needed)
+     */
+    private SortedTableVerifier<?> createVerifierAndInvokeMethod(SSTableReader sstable, 
+                                                                  ColumnFamilyStore cfs,
+                                                                  boolean isOffline,
+                                                                  IVerifier.Options options) throws Exception
+    {
+        OutputHandler outputHandler = new OutputHandler.LogOutput();
+        SortedTableVerifier<?> verifier = (SortedTableVerifier<?>) sstable.getVerifier(cfs, outputHandler, isOffline, options);
+        
+        invokeVerifyStorageAttachedIndexes(verifier);
+        
+        return verifier;
+    }
+    
+    /**
+     * Overloaded version for tests that need a custom OutputHandler
+     */
+    private SortedTableVerifier<?> createVerifierAndInvokeMethod(SSTableReader sstable,
+                                                                  ColumnFamilyStore cfs,
+                                                                  OutputHandler outputHandler,
+                                                                  boolean isOffline,
+                                                                  IVerifier.Options options) throws Exception
+    {
+        SortedTableVerifier<?> verifier = (SortedTableVerifier<?>) sstable.getVerifier(cfs, outputHandler, isOffline, options);
+        
+        invokeVerifyStorageAttachedIndexes(verifier);
+        
+        return verifier;
+    }
+    
+    /**
+     * Helper method to invoke the protected verifyStorageAttachedIndexes method via reflection
+     */
+    private static void invokeVerifyStorageAttachedIndexes(SortedTableVerifier<?> verifier) throws Exception
+    {
+        Method method = SortedTableVerifier.class.getDeclaredMethod("verifyStorageAttachedIndexes");
+        method.setAccessible(true);
+        method.invoke(verifier);
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesWithNoRealm() throws Exception
+    {
+        // Test when realm is null - should return early without validation
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).build();
+            
+            try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, null, false, options))
+            {
+                // Should return early without throwing
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesOffline() throws Exception
+    {
+        // Test when isOffline is true - should return early without validation
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).build();
+            
+            try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, cfs, true, options))
+            {
+                // Should return early without throwing
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesWithNoIndexManager() throws Exception
+    {
+        // Test when index manager is null
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(null);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).build();
+            
+            try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, spyCfs, false, options))
+            {
+                // Should log but not throw
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesSuccess() throws Exception
+    {
+        // Test successful validation
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean())).thenReturn(true);
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).build();
+            
+            try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, spyCfs, false, options))
+            {
+                verify(mockIndexManager).validateSSTableAttachedIndexes(any(), eq(true), eq(true));
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesQuickMode() throws Exception
+    {
+        // Test quick mode - should skip checksum validation
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean())).thenReturn(true);
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).quick(true).build();
+            
+            try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, spyCfs, false, options))
+            {
+                verify(mockIndexManager).validateSSTableAttachedIndexes(any(), eq(true), eq(false));
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesValidationFails() throws Exception
+    {
+        // Test when validation returns false (should throw IOException)
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean())).thenReturn(false);
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(true).build();
+            
+            try
+            {
+                try (SortedTableVerifier<?> verifier = createVerifierAndInvokeMethod(sstable, spyCfs, false, options))
+                {
+                    // Should not reach here
+                }
+                fail("Expected CorruptSSTableException");
+            }
+            catch (Exception e)
+            {
+                // InvocationTargetException wraps the actual exception
+                Throwable cause = e.getCause();
+                if (cause instanceof CorruptSSTableException)
+                {
+                    // Expected
+                }
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesIllegalStateException() throws Exception
+    {
+        // Test when IllegalStateException is thrown (incomplete indexes)
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean()))
+            .thenThrow(new IllegalStateException("Incomplete index"));
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            OutputHandler outputHandler = mock(OutputHandler.class);
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(true).build();
+            
+            try (SortedTableVerifier<?> verifier = (SortedTableVerifier<?>) sstable.getVerifier(spyCfs, outputHandler, false, options))
+            {
+                // Use reflection to call protected method
+                try
+                {
+                    invokeVerifyStorageAttachedIndexes(verifier);
+                    fail("Expected CorruptSSTableException");
+                }
+                catch (Exception e)
+                {
+                    // InvocationTargetException wraps the actual exception
+                    Throwable cause = e.getCause();
+                    if (cause instanceof CorruptSSTableException)
+                    {
+                        verify(outputHandler).warn(any(IllegalStateException.class));
+                    }
+                    else
+                    {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testVerifyStorageAttachedIndexesUncheckedIOException() throws Exception
+    {
+        // Test when UncheckedIOException is thrown (checksum validation failure)
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean()))
+            .thenThrow(new UncheckedIOException(new IOException("Checksum mismatch")));
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            OutputHandler outputHandler = mock(OutputHandler.class);
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(true).build();
+            
+            try (SortedTableVerifier<?> verifier = (SortedTableVerifier<?>) sstable.getVerifier(spyCfs, outputHandler, false, options))
+            {
+                // Use reflection to call protected method
+                try
+                {
+                    invokeVerifyStorageAttachedIndexes(verifier);
+                    fail("Expected CorruptSSTableException");
+                }
+                catch (Exception e)
+                {
+                    // InvocationTargetException wraps the actual exception
+                    Throwable cause = e.getCause();
+                    if (cause instanceof CorruptSSTableException)
+                    {
+                        verify(outputHandler).warn(any(UncheckedIOException.class));
+                    }
+                    else
+                    {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+
+    @Test  
+    public void testVerifyStorageAttachedIndexesGenericThrowable() throws Exception
+    {
+        // Test when generic Throwable is thrown
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        
+        SecondaryIndexManager mockIndexManager = mock(SecondaryIndexManager.class);
+        when(mockIndexManager.validateSSTableAttachedIndexes(any(), eq(true), anyBoolean()))
+            .thenThrow(new RuntimeException("Unexpected error"));
+        
+        ColumnFamilyStore spyCfs = spy(cfs);
+        when(spyCfs.getIndexManager()).thenReturn(mockIndexManager);
+        
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+        {
+            OutputHandler outputHandler = mock(OutputHandler.class);
+            IVerifier.Options options = IVerifier.options().invokeDiskFailurePolicy(false).build();
+            
+            try (SortedTableVerifier<?> verifier = (SortedTableVerifier<?>) sstable.getVerifier(spyCfs, outputHandler, false, options))
+            {
+                // Use reflection to call protected method
+                try
+                {
+                    invokeVerifyStorageAttachedIndexes(verifier);
+                    fail("Expected RuntimeException");
+                }
+                catch (Exception e)
+                {
+                    // InvocationTargetException wraps the actual exception
+                    Throwable cause = e.getCause();
+                    if (cause instanceof RuntimeException)
+                    {
+                        verify(outputHandler).warn(any(RuntimeException.class));
+                    }
+                    else
+                    {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/riptano/cndb/issues/14501

CNDB test pr: https://github.com/riptano/cndb/pull/14660

This PR introduces vector index checksum validation starting with files in version `EC` at above. For non terms files, we compute the checksum correctly. For terms files, we skip validation of the checksum because it is not computed correctly. There is a new issue to track fixing the checksum logic on those TERMS files
https://github.com/riptano/cndb/issues/14656.

I implemented the version-dependent validation by overriding `V7OnDiskFormat#validateIndexComponent`. This allows us to validate new files while skipping the old ones. In doing so, I removed the misleading `IndexFeatureSet` method for checksums. The modified comment describes why that feature didn't make sense as an index-level feature.
