### PR TITLE
CNDB-10308: Fix flaky BinLogTest (#1840)

### DIFF
--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -158,6 +158,7 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.Throwables;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ThrowingRunnable;
 import org.hamcrest.Matcher;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.defaultanswers.ForwardsInvocations;
@@ -754,6 +755,18 @@ public class Util
                   .pollDelay(0, TimeUnit.MILLISECONDS)
                   .atMost(timeout, timeUnit)
                   .untilAsserted(() -> assertThat(message, actualSupplier.get(), matcher));
+    }
+
+    public static void spinAssert(String message, ThrowingRunnable assertion, long timeout, TimeUnit timeUnit) {
+        Awaitility.await()
+                  .pollInterval(Duration.ofMillis(100))
+                  .pollDelay(0, TimeUnit.MILLISECONDS)
+                  .atMost(timeout, timeUnit)
+                  .untilAsserted(assertion);
+    }
+
+    public static void spinAssert(ThrowingRunnable assertion, int timeoutInSeconds) {
+        spinAssert(null, assertion, timeoutInSeconds, TimeUnit.SECONDS);
     }
 
     public static void joinThread(Thread thread) throws InterruptedException


### PR DESCRIPTION
The original test was timing dependent and
assumed segments were rolled while the code was waiting in Thread.sleep. A hiccup in performance could violate that assumption and cause rolling the segments at a different point in time, leading to the deleted segment contain fewer entries than expected by the test, and hence leaving more entries in the current segment.

The test has been rewritten to not rely on timing at all. Byteman injections are used to detect that the deletion of rolled segment happened. The test doesn't require a particular exact number of entries to be left in the current segment, but checks the total number of segments and the minimum number of entries instead.
