### PR TITLE
CNDB-14722: handle OOM error for compaction task (#1856)

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
@@ -487,6 +487,11 @@ public class BackgroundCompactionRunner implements Runnable
             t = t instanceof FSError ? t : new FSWriteError(t);
             JVMStabilityInspector.inspectThrowable(t);
         }
+        else if (Throwables.isCausedBy(t, OutOfMemoryError.class))
+        {
+            logger.error("Encountered out of memory error on {}", cfs, t);
+            JVMStabilityInspector.inspectThrowable(t);
+        }
         else if (t instanceof CompactionInterruptedException)
         {
             logger.warn(String.format("Aborting background compaction of %s due to interruption", cfs), Throwables.unwrapped(t));


### PR DESCRIPTION
### What is the issue

CNDB-14722: OOM error is not handled by error handler

https://github.com/riptano/cndb/pull/14726/files

### What does this PR fix and why was it fixed

Handle OOM error for compaction tasks
