### PR TITLE
CNDB-14683: Cherry-pick fix for flaky LogTransactionTest (#1870)

### DIFF
--- a/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
@@ -1535,7 +1535,7 @@ public class LogTransactionTest extends AbstractTransactionalTest
         return ILogTransactionsFactory.instance.createLogAwareFileLister()
                                                .list(folder.toPath(), (file, type) -> match.contains(type), onTxnErr)
                                                .stream()
-                                               .map(File::toCanonical)
+                                               .flatMap(LogTransactionTest::toCanonicalIgnoringNotFound)
                                                .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
### What is the issue
This test is flaky. It stresses the log transaction framework by intentionally creating a race between transaction file cleanup and the listing of temporary files. It sometimes throws an exception during canonicalization of a file that has been removed, but this canonicalization is being done by the testing code, not the transaction code, and it does not indicate misbehavior by the log transaction.

### What does this PR fix and why was it fixed
Cherry-picks the fix for this in newer apache/cassandra releases. This ignores exceptions due to files not being found during canonicalization.

original patch authored by Jon Meredith, reviewed by Josh McKenzie for CASSANDRA-17286
