### PR TITLE
CNDB-12972: Enhance controller config file handling for long names (#1862)

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.FSError;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileReader;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.Overlaps;
@@ -75,8 +76,7 @@ public class StaticController extends Controller
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
                             boolean hasVectorType,
-                            String keyspaceName,
-                            String tableName)
+                            TableMetadata metadata)
     {
         super(MonotonicClock.Global.preciseTime,
               env,
@@ -97,10 +97,9 @@ public class StaticController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              metadata);
         this.scalingParameters = scalingParameters;
-        this.keyspaceName = keyspaceName;
-        this.tableName = tableName;
     }
 
     static Controller fromOptions(Environment env,
@@ -121,8 +120,7 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
-                                  String keyspaceName,
-                                  String tableName,
+                                  TableMetadata metadata,
                                   Map<String, String> options,
                                   boolean useVectorOptions)
     {
@@ -136,7 +134,7 @@ public class StaticController extends Controller
 
         long currentFlushSize = flushSizeOverride;
 
-        File f = getControllerConfigPath(keyspaceName, tableName);
+        File f = getControllerConfigPath(metadata);
         try
         {
             JSONParser jsonParser = new JSONParser();
@@ -184,8 +182,7 @@ public class StaticController extends Controller
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
                                     hasVectorType,
-                                    keyspaceName,
-                                    tableName);
+                                    metadata);
     }
 
     public static Map<String, String> validateOptions(Map<String, String> options) throws ConfigurationException
@@ -232,7 +229,7 @@ public class StaticController extends Controller
     @Override
     public void storeControllerConfig()
     {
-        storeOptions(keyspaceName, tableName, scalingParameters, getFlushSizeBytes());
+        storeOptions(metadata, scalingParameters, getFlushSizeBytes());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/schema/TableId.java
+++ b/src/java/org/apache/cassandra/schema/TableId.java
@@ -66,6 +66,14 @@ public class TableId
         return new TableId(UUID.fromString(idString));
     }
 
+    public static TableId fromHexString(String nonDashUUID)
+    {
+        ByteBuffer bytes = ByteBufferUtil.hexToBytes(nonDashUUID);
+        long msb = bytes.getLong(0);
+        long lsb = bytes.getLong(8);
+        return fromUUID(new UUID(msb, lsb));
+    }
+
     @Nullable
     public static Pair<String, TableId> tableNameAndIdFromFilename(String filename)
     {
@@ -77,14 +85,6 @@ public class TableId
         String tableName = filename.substring(0, dash);
 
         return Pair.create(tableName, id);
-    }
-
-    private static TableId fromHexString(String nonDashUUID)
-    {
-        ByteBuffer bytes = ByteBufferUtil.hexToBytes(nonDashUUID);
-        long msb = bytes.getLong(0);
-        long lsb = bytes.getLong(8);
-        return fromUUID(new UUID(msb, lsb));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -77,6 +77,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ExpMovingAverage;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MonotonicClock;
@@ -86,6 +87,7 @@ import org.apache.cassandra.utils.TimeUUID;
 import org.mockito.Mockito;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.LOG_DIR;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -389,6 +391,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
         int[] Ws = new int[] { W };
         int[] previousWs = new int[] { W };
         double maxSpaceOverhead = 0.2;
+        TableMetadata metadata = standardCFMD(keyspace, table).build();
 
         Controller controller = adaptive
                                 ? new AdaptiveController(MonotonicClock.Global.preciseTime,
@@ -417,8 +420,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          gain,
                                                          minCost,
                                                          maxAdaptiveCompactions,
-                                                         "ks",
-                                                         "tbl")
+                                                         metadata)
                                 : new StaticController(new SimulatedEnvironment(counters, valueSize),
                                                        Ws,
                                                        new double[] { o },
@@ -439,8 +441,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        overlapInclusionMethod,
                                                        true,
                                                        false,
-                                                       "ks",
-                                                       "tbl");
+                                                       metadata);
 
         return new UnifiedCompactionStrategy(strategyFactory, controller);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -93,8 +93,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       threshold,
                                       minCost,
                                       maxAdaptiveCompactions,
-                                      keyspaceName,
-                                      tableName);
+                                      metadata);
     }
 
     @Test
@@ -128,7 +127,7 @@ public class AdaptiveControllerTest extends ControllerTest
 
         int[] scalingParameters = new int[30];
         Arrays.fill(scalingParameters, 1);
-        AdaptiveController.storeOptions(keyspaceName, tableName, scalingParameters, 10 << 20);
+        AdaptiveController.storeOptions(metadata, scalingParameters, 10 << 20);
 
         Controller controller = testFromOptions(true, options);
         assertTrue(controller instanceof AdaptiveController);
@@ -139,7 +138,7 @@ public class AdaptiveControllerTest extends ControllerTest
             assertEquals(1, controller.getPreviousScalingParameter(i));
         }
         int[] emptyScalingParameters = {};
-        AdaptiveController.storeOptions(keyspaceName, tableName, emptyScalingParameters, 10 << 20);
+        AdaptiveController.storeOptions(metadata, emptyScalingParameters, 10 << 20);
 
         Controller controller2 = testFromOptions(true, options);
         assertTrue(controller2 instanceof AdaptiveController);
@@ -149,7 +148,7 @@ public class AdaptiveControllerTest extends ControllerTest
             assertEquals(3, controller2.getScalingParameter(i));
             assertEquals(3, controller2.getPreviousScalingParameter(i));
         }
-        AdaptiveController.getControllerConfigPath(keyspaceName, tableName).delete();
+        AdaptiveController.getControllerConfigPath(metadata).delete();
 
         Map<String, String> options2 = new HashMap<>();
         options2.put(AdaptiveController.MIN_SCALING_PARAMETER, "-10");

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -44,11 +44,14 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MovingAverage;
 import org.apache.cassandra.utils.Overlaps;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.internal.creation.MockSettingsImpl;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.UCS_OVERRIDE_UCS_CONFIG_FOR_VECTOR_TABLES;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -84,7 +87,6 @@ public abstract class ControllerTest
     @Mock
     ColumnFamilyStore cfs;
 
-    @Mock
     TableMetadata metadata;
 
     @Mock
@@ -122,11 +124,13 @@ public abstract class ControllerTest
     public void setUp()
     {
         MockitoAnnotations.initMocks(this);
+        metadata = Mockito.mock(TableMetadata.class, new MockSettingsImpl<>()
+                                                     .useConstructor(standardCFMD(keyspaceName, tableName))
+                                                     .defaultAnswer(Answers.RETURNS_SMART_NULLS));
 
         when(strategy.getMetadata()).thenReturn(metadata);
         when(strategy.getEstimatedRemainingTasks()).thenReturn(0);
 
-        when(metadata.toString()).thenReturn("");
         when(replicationStrategy.getReplicationFactor()).thenReturn(ReplicationFactor.fullOnly(3));
         when(cfs.makeUCSEnvironment()).thenAnswer(invocation -> new RealEnvironment(cfs));
         when(cfs.getKeyspaceReplicationStrategy()).thenReturn(replicationStrategy);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -210,8 +210,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testStartShutdown(controller);
     }
 
@@ -238,8 +237,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testShutdownNotStarted(controller);
     }
 
@@ -266,8 +264,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
-                                                           keyspaceName,
-                                                           tableName);
+                                                           metadata);
         super.testStartAlreadyStarted(controller);
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of controller configuration files in the compaction subsystem of Apache Cassandra. The changes focus on consolidating constants, enhancing file naming logic to support very long table/keyspace names.

In particular - controller configuration files consists of keyspace and table names, separated by dot and a fixed suffix. This scheme is retained as long as the while filename does not exceed 255 chars. If it does, keyspace and table names are abbreviated and a third component is added - table id.

In a situation when the keyspace and table names needs to be resolved from the file name, the code examines the filename whether it has 2 or 3 components (delimited by dots). If 2, follow the legacy pattern, if 3, ignore keyspace and table names, and read just the table id. Table id is then used to resolve metadata from schema.

The change is forward compatible because:
- for normal keyspace and table names lengths, the 2 components scheme is still readable by the new version
- for long keyspace and tables names lengths, the file was not created at all

The change is backward compatible because:
- for normal keyspace and table names lengths, the 2 components scheme is retained, thus the old version will still able to resolve it
- for long keyspace and table names lengths, the 3 components schema will be wrongly resolved and lead to deletion of the controller file as wrongly resolved keyspace and table names would not be found. This is compatible with the current behaviour of the old version because in such a case, the controller config file would not be created at all.
