### PR TITLE
CNDB-14773: avoid Int2IntHashMap overflow in RAMStringIndexer and imp…

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/RAMPostingSlices.java
@@ -49,6 +49,11 @@ class RAMPostingSlices
         this.includeFrequencies = includeFrequencies;
     }
 
+    long arrayMemoryUsage()
+    {
+        return postingStarts.length * 4L + postingUptos.length * 4L + sizes.length * 4L;
+    }
+
     /**
      * Creates and returns a PostingList for the given term ID.
      */

--- a/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RAMStringIndexerTest.java
@@ -78,6 +78,26 @@ public class RAMStringIndexerTest extends SaiRandomizedTest
     }
 
     @Test
+    public void testLargeNumberOfDocs()
+    {
+        int maxDocsSize = 1000;
+        RAMStringIndexer indexer = new RAMStringIndexer(false, maxDocsSize);
+
+        int startingRowId = 0;
+        int i = 0;
+        while (i++ < maxDocsSize)
+        {
+            int rowId = startingRowId + i;
+            indexer.addAll(List.of(new BytesRef("0")), rowId);
+
+            if (i < maxDocsSize)
+                assertFalse(indexer.requiresFlush());
+        }
+
+        assertTrue(indexer.requiresFlush());
+    }
+
+    @Test
     public void testWithFrequencies() throws Exception
     {
         RAMStringIndexer indexer = new RAMStringIndexer(true);


### PR DESCRIPTION
…rove memory track to include array memory usage (#1885)

### What is the issue
#14773: Int2IntHashMap overflow when num of docs reaches 348_966_081

### What does this PR fix and why was it fixed

Trigger segment flush before overflow and include array memory usage to avoid undercounting memory usage
