### PR TITLE
HCD-179 Guardrail defaults for on-prem

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1538,12 +1538,12 @@ enable_drop_compact_storage: false
   # column_value_size_failure_threshold_in_kb: -1
 
   # Failure threshold to prevent creating more columns per table than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # columns_per_table_failure_threshold: -1
+  # Default 200. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # columns_per_table_failure_threshold: 200
 
   # Failure threshold to prevent creating more fields in user-defined-type than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # fields_per_udt_failure_threshold: -1
+  # Default 100. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # fields_per_udt_failure_threshold: 100
 
   # Guardrail to warn or fail when creating a vector column with more dimensions than threshold.
   # Default vector_dimensions_warn_threshold is -1 to disable, may differ if emulate_dbaas_defaults is enabled
@@ -1552,12 +1552,12 @@ enable_drop_compact_storage: false
   # vector_dimensions_failure_threshold: 8192
 
   # Warning threshold to warn when encountering larger size of collection data than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # collection_size_warn_threshold_in_kb: -1
+  # Default 10Mb. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # collection_size_warn_threshold_in_kb: 10240
 
   # Warning threshold to warn when encountering more elements in collection than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # items_per_collection_warn_threshold: -1
+  # Default 200. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # items_per_collection_warn_threshold: 200
 
   # Whether read-before-write operation is allowed, eg. setting list element by index, removing list element
   # by index. Note: LWT is always allowed.
@@ -1565,8 +1565,8 @@ enable_drop_compact_storage: false
   # read_before_write_list_operations_enabled: true
 
   # Failure threshold to prevent creating more secondary index per table than threshold (does not apply to CUSTOM INDEX StorageAttachedIndex)
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # secondary_index_per_table_failure_threshold: -1
+  # Default 0. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # secondary_index_per_table_failure_threshold: 0
 
   # Failure threshold for number of StorageAttachedIndex per table (only applies to CUSTOM INDEX StorageAttachedIndex)
   # Default is 10 (same when emulate_dbaas_defaults is enabled)
@@ -1577,16 +1577,16 @@ enable_drop_compact_storage: false
   # sai_indexes_total_failure_threshold: 100
 
   # Failure threshold to prevent creating more materialized views per table than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # materialized_view_per_table_failure_threshold: -1
+  # Default 0. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # materialized_view_per_table_failure_threshold: 0
 
   # Warn threshold to warn creating more tables than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # tables_warn_threshold: -1
+  # Default 100. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # tables_warn_threshold: 100
 
   # Failure threshold to prevent creating more tables than threshold.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # tables_failure_threshold: -1
+  # Default 200. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # tables_failure_threshold: 200
 
   # Preventing creating tables with provided configurations.
   # Default all properties are allowed, may differ if emulate_dbaas_defaults is enabled
@@ -1597,8 +1597,8 @@ enable_drop_compact_storage: false
   # user_timestamps_enabled: true
 
   # Preventing query with provided consistency levels
-  # Default all consistency levels are allowed.
-  # write_consistency_levels_disallowed:
+  # Default ANY is disallowed
+  # write_consistency_levels_disallowed: ANY
 
   # Failure threshold to prevent providing larger paging by bytes than threshold, also served as a hard paging limit
   # when paging by rows is used.
@@ -1607,16 +1607,16 @@ enable_drop_compact_storage: false
 
   # Failure threshold to prevent IN query creating size of cartesian product exceeding threshold, eg.
   # "a in (1,2,...10) and b in (1,2...10)" results in cartesian product of 100.
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # in_select_cartesian_product_failure_threshold: -1
+  # Default 25. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # in_select_cartesian_product_failure_threshold: 25
 
   # Failure threshold to prevent IN query containing more partition keys than threshold
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # partition_keys_in_select_failure_threshold: -1
+  # Default 20. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # partition_keys_in_select_failure_threshold: 20
 
   # Warning threshold to warn when local disk usage exceeding threshold. Valid values: (1, 100]
-  # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled
-  # disk_usage_percentage_warn_threshold: -1
+  # Default 70. -1 to disable, may differ if emulate_dbaas_defaults is enabled
+  # disk_usage_percentage_warn_threshold: 70
 
   # Failure threshold to reject write requests if replica disk usage exceeding threshold. Valid values: (1, 100]
   # Default -1 to disable, may differ if emulate_dbaas_defaults is enabled

--- a/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/guardrails/GuardrailsConfig.java
@@ -162,8 +162,8 @@ public class GuardrailsConfig
         // for read requests
         enforceDefault(page_size_failure_threshold_in_kb, v -> page_size_failure_threshold_in_kb = v, NO_LIMIT, 512);
 
-        enforceDefault(in_select_cartesian_product_failure_threshold, v -> in_select_cartesian_product_failure_threshold = v, NO_LIMIT, 25);
-        enforceDefault(partition_keys_in_select_failure_threshold, v -> partition_keys_in_select_failure_threshold = v, NO_LIMIT, 20);
+        enforceDefault(in_select_cartesian_product_failure_threshold, v -> in_select_cartesian_product_failure_threshold = v, 25, 25);
+        enforceDefault(partition_keys_in_select_failure_threshold, v -> partition_keys_in_select_failure_threshold = v, 20, 20);
 
         enforceDefault(tombstone_warn_threshold, v -> tombstone_warn_threshold = v, 1000, 1000);
         enforceDefault(tombstone_failure_threshold, v -> tombstone_failure_threshold = v, 100000, 100000);
@@ -190,25 +190,25 @@ public class GuardrailsConfig
         // We use a LinkedHashSet just for the sake of preserving the ordering in error messages
         enforceDefault(write_consistency_levels_disallowed,
                        v -> write_consistency_levels_disallowed = ImmutableSet.copyOf(v),
-                       Collections.<String>emptySet(),
+                       Collections.<String>singleton("ANY"),
                        new LinkedHashSet<>(Arrays.asList("ANY", "ONE", "LOCAL_ONE")));
 
         // for schema
         enforceDefault(counter_enabled, v -> counter_enabled = v, true, true);
 
-        enforceDefault(fields_per_udt_failure_threshold, v -> fields_per_udt_failure_threshold = v, -1L, 10L);
-        enforceDefault(collection_size_warn_threshold_in_kb, v -> collection_size_warn_threshold_in_kb = v, -1L, 5 * 1024L);
-        enforceDefault(items_per_collection_warn_threshold, v -> items_per_collection_warn_threshold = v, -1L, 20L);
+        enforceDefault(fields_per_udt_failure_threshold, v -> fields_per_udt_failure_threshold = v, 100L, 10L);
+        enforceDefault(collection_size_warn_threshold_in_kb, v -> collection_size_warn_threshold_in_kb = v, 10240L, 5 * 1024L);
+        enforceDefault(items_per_collection_warn_threshold, v -> items_per_collection_warn_threshold = v, 200L, 20L);
 
         enforceDefault(vector_dimensions_warn_threshold, v -> vector_dimensions_warn_threshold = v, -1, -1);
         enforceDefault(vector_dimensions_failure_threshold, v -> vector_dimensions_failure_threshold = v, 8192, 8192);
 
-        enforceDefault(columns_per_table_failure_threshold, v -> columns_per_table_failure_threshold = v, -1L, 50L);
-        enforceDefault(secondary_index_per_table_failure_threshold, v -> secondary_index_per_table_failure_threshold = v, NO_LIMIT, 1);
-        enforceDefault(sasi_indexes_per_table_failure_threshold, v -> sasi_indexes_per_table_failure_threshold = v, NO_LIMIT, 0);
-        enforceDefault(materialized_view_per_table_failure_threshold, v -> materialized_view_per_table_failure_threshold = v, NO_LIMIT, 2);
-        enforceDefault(tables_warn_threshold, v -> tables_warn_threshold = v, -1L, 100L);
-        enforceDefault(tables_failure_threshold, v -> tables_failure_threshold = v, -1L, 200L);
+        enforceDefault(columns_per_table_failure_threshold, v -> columns_per_table_failure_threshold = v, 200L, 50L);
+        enforceDefault(secondary_index_per_table_failure_threshold, v -> secondary_index_per_table_failure_threshold = v, 0, 1);
+        enforceDefault(sasi_indexes_per_table_failure_threshold, v -> sasi_indexes_per_table_failure_threshold = v, 0, 0);
+        enforceDefault(materialized_view_per_table_failure_threshold, v -> materialized_view_per_table_failure_threshold = v, 0, 2);
+        enforceDefault(tables_warn_threshold, v -> tables_warn_threshold = v, 100L, 100L);
+        enforceDefault(tables_failure_threshold, v -> tables_failure_threshold = v, 200L, 200L);
 
         enforceDefault(table_properties_disallowed,
                        v -> table_properties_disallowed = ImmutableSet.copyOf(v),
@@ -226,7 +226,7 @@ public class GuardrailsConfig
                                                           .collect(Collectors.toList())));
 
         // for node status
-        enforceDefault(disk_usage_percentage_warn_threshold, v -> disk_usage_percentage_warn_threshold = v, NO_LIMIT, 70);
+        enforceDefault(disk_usage_percentage_warn_threshold, v -> disk_usage_percentage_warn_threshold = v, 70, 70);
         enforceDefault(disk_usage_percentage_failure_threshold, v -> disk_usage_percentage_failure_threshold = v, NO_LIMIT, 80);
         enforceDefault(disk_usage_max_disk_size_in_gb, v -> disk_usage_max_disk_size_in_gb = v, (long) NO_LIMIT, (long) NO_LIMIT);
 

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -66,6 +66,7 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PathUtils;
+import org.apache.cassandra.locator.SimpleSnitch;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.KeyspaceMetadata;
@@ -362,6 +363,9 @@ public class StartupChecks
         {
             if (Murmur3Partitioner.instance != DatabaseDescriptor.getPartitioner())
                 logger.warn("Not using murmur3 partitioner ({}). {}", DatabaseDescriptor.getPartitioner().getClass().getName(), WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getEndpointSnitch() instanceof SimpleSnitch)
+                logger.warn("SimpleSnitch is only for dev/test environments. {}", WARN_SUFFIX);
 
             if (DatabaseDescriptor.getNumTokens() > 16)
                 logger.warn("num_tokens {} too high. Values over 16 poorly impact repairs and node bootstrapping/decommissioning. {}",


### PR DESCRIPTION

### What is the issue

Guardrail defaults weren't set for HCD.

### What does this PR fix and why was it fixed

Set on-prem guardrail defaults to be (keeping in mind these can be changed by operators on-prem, so they are first and foremost important teachings to give)::

```
columns_per_table_failure_threshold: 200
fields_per_udt_failure_threshold: 100
collection_size_warn_threshold_in_kb: 10240
items_per_collection_warn_threshold: 200
secondary_index_per_table_failure_threshold: 0
sasi_indexes_per_table_failure_threshold: 0
materialized_view_per_table_failure_threshold: 0
tables_warn_threshold: 100
tables_failure_threshold: 200
in_select_cartesian_product_failure_threshold: 25
partition_keys_in_select_failure_threshold: 20
disk_usage_percentage_warn_threshold: 70
write_consistency_levels_disallowed: ANY
```

Also add a startup warning when SimpleSnitch is used.

