### PR TITLE
CC5 fix AlterTest

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -29,7 +29,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.memtable.AbstractShardedMemtable;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.memtable.SkipListMemtable;
 import org.apache.cassandra.db.memtable.TestMemtable;
@@ -47,7 +46,6 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.config.CassandraRelevantProperties.TRIE_MEMTABLE_SHARD_COUNT;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -63,7 +61,6 @@ public class AlterTest extends CQLTester
         // into TokenMetadata; expect trouble
         TRIE_MEMTABLE_SHARD_COUNT.setString("1");
         CQLTester.setUpClass();
-        assertThat(AbstractShardedMemtable.getDefaultShardCount()).isEqualTo(1);;
     }
 
     @Test


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/14954
### What does this PR fix and why was it fixed
Fixes CC5 test failure by removing an assert that was likely due to a rebase mistake.
```
        assertThat(AbstractShardedMemtable.getDefaultShardCount()).isEqualTo(1);;
```
The assert comes from a CC ticket, STAR-840, but this assert does not appear on `main` branch in `AlterTest`. In fact `AbstractShardedMemtable` is a CC 5.0 only class.
Without digging more into the history of how/why this got added ... it's not needed here since the `main` branch version does not have any similar check.
