### PR TITLE
CNDB-9018: cache SSTable:CompactionMetadata in order to not read from storage multiple times

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderBuilder.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.io.sstable.format;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -40,6 +41,7 @@ import org.apache.cassandra.io.sstable.IndexSummary;
 import org.apache.cassandra.io.sstable.IndexSummaryBuilder;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.big.BigTableReader;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
@@ -71,6 +73,7 @@ public abstract class SSTableReaderBuilder
     protected final long maxDataAge;
     protected final Set<Component> components;
     protected final StatsMetadata statsMetadata;
+    protected final Optional<CompactionMetadata> compactionMetadata;
     protected final SSTableReader.OpenReason openReason;
     protected final SerializationHeader header;
 
@@ -86,6 +89,7 @@ public abstract class SSTableReaderBuilder
                                 long maxDataAge,
                                 Set<Component> components,
                                 StatsMetadata statsMetadata,
+                                Optional<CompactionMetadata> compactionMetadata,
                                 SSTableReader.OpenReason openReason,
                                 SerializationHeader header)
     {
@@ -95,6 +99,7 @@ public abstract class SSTableReaderBuilder
         this.maxDataAge = maxDataAge;
         this.components = components;
         this.statsMetadata = statsMetadata;
+        this.compactionMetadata = compactionMetadata;
         this.openReason = openReason;
         this.header = header;
         this.readerFactory = descriptor.getFormat().getReaderFactory();
@@ -271,10 +276,11 @@ public abstract class SSTableReaderBuilder
                          long maxDataAge,
                          Set<Component> components,
                          StatsMetadata statsMetadata,
+                         Optional<CompactionMetadata> compactionMetadata,
                          SSTableReader.OpenReason openReason,
                          SerializationHeader header)
         {
-            super(descriptor, metadataRef, maxDataAge, components, statsMetadata, openReason, header);
+            super(descriptor, metadataRef, maxDataAge, components, statsMetadata, compactionMetadata, openReason, header);
         }
 
         public SSTableReaderBuilder.ForWriter dfile(FileHandle dfile)
@@ -317,9 +323,10 @@ public abstract class SSTableReaderBuilder
                         TableMetadataRef metadataRef,
                         Set<Component> components,
                         StatsMetadata statsMetadata,
+                        Optional<CompactionMetadata> compactionMetadata,
                         SerializationHeader header)
         {
-            super(descriptor, metadataRef, System.currentTimeMillis(), components, statsMetadata, SSTableReader.OpenReason.NORMAL, header);
+            super(descriptor, metadataRef, System.currentTimeMillis(), components, statsMetadata, compactionMetadata, SSTableReader.OpenReason.NORMAL, header);
         }
 
         @Override
@@ -381,9 +388,10 @@ public abstract class SSTableReaderBuilder
                        boolean isOffline,
                        Set<Component> components,
                        StatsMetadata statsMetadata,
+                       Optional<CompactionMetadata> compactionMetadata,
                        SerializationHeader header)
         {
-            super(descriptor, metadataRef, System.currentTimeMillis(), components, statsMetadata, SSTableReader.OpenReason.NORMAL, header);
+            super(descriptor, metadataRef, System.currentTimeMillis(), components, statsMetadata, compactionMetadata, SSTableReader.OpenReason.NORMAL, header);
             this.validationMetadata = validationMetadata;
             this.isOffline = isOffline;
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -405,17 +405,6 @@ public abstract class SSTableWriter extends SSTable implements Transactional
                                                   header);
     }
 
-    protected StatsMetadata statsMetadata()
-    {
-        return (StatsMetadata) finalizeMetadata().get(MetadataType.STATS);
-    }
-
-    // NotNull
-    protected CompactionMetadata compactionMetadata()
-    {
-        return (CompactionMetadata) finalizeMetadata().get(MetadataType.COMPACTION);
-    }
-
     public void releaseMetadataOverhead()
     {
         metadataCollector.release();

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -53,6 +53,7 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.StorageHandler;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
@@ -394,7 +395,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
         }
     }
 
-    protected Map<MetadataType, MetadataComponent> finalizeMetadata()
+    protected final Map<MetadataType, MetadataComponent> finalizeMetadata()
     {
         return metadataCollector.finalizeMetadata(getPartitioner().getClass().getCanonicalName(),
                                                   metadata().params.bloomFilterFpChance,
@@ -407,6 +408,12 @@ public abstract class SSTableWriter extends SSTable implements Transactional
     protected StatsMetadata statsMetadata()
     {
         return (StatsMetadata) finalizeMetadata().get(MetadataType.STATS);
+    }
+
+    // NotNull
+    protected CompactionMetadata compactionMetadata()
+    {
+        return (CompactionMetadata) finalizeMetadata().get(MetadataType.COMPACTION);
     }
 
     public void releaseMetadataOverhead()

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.StorageHandler;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
@@ -348,6 +349,7 @@ public abstract class SortedTableWriter extends SSTableWriter
             maxDataAge = System.currentTimeMillis();
 
         StatsMetadata stats = statsMetadata();
+        CompactionMetadata compactionMetadata = compactionMetadata();
 
         int dataBufferSize = optimizationStrategy.bufferSize(stats.estimatedPartitionSize.percentile(DatabaseDescriptor.getDiskOptimizationEstimatePercentile()));
         // Note that creating the `CompressionMetadata` below does not read from disk: the compression metadata is
@@ -364,7 +366,7 @@ public abstract class SortedTableWriter extends SSTableWriter
         DecoratedKey lastMinimized = getMinimalKey(last);
         try
         {
-            SSTableReader reader = openReader(reason, dfile, stats);
+            SSTableReader reader = openReader(reason, dfile, stats, Optional.of(compactionMetadata));
             reader.first = firstMinimized;
             reader.last = lastMinimized;
             return reader;
@@ -380,7 +382,7 @@ public abstract class SortedTableWriter extends SSTableWriter
         }
     }
 
-    abstract protected SSTableReader openReader(SSTableReader.OpenReason reason, FileHandle dataFileHandle, StatsMetadata stats);
+    abstract protected SSTableReader openReader(SSTableReader.OpenReason reason, FileHandle dataFileHandle, StatsMetadata stats, Optional<CompactionMetadata> compactionMetadata);
 
     abstract protected SequentialWriterOption writerOption();
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -348,8 +348,9 @@ public abstract class SortedTableWriter extends SSTableWriter
         if (maxDataAge < 0)
             maxDataAge = System.currentTimeMillis();
 
-        StatsMetadata stats = statsMetadata();
-        CompactionMetadata compactionMetadata = compactionMetadata();
+        Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+        StatsMetadata stats = (StatsMetadata) finalMetadata.get(MetadataType.STATS);
+        CompactionMetadata compactionMetadata = (CompactionMetadata) finalMetadata.get(MetadataType.COMPACTION);
 
         int dataBufferSize = optimizationStrategy.bufferSize(stats.estimatedPartitionSize.percentile(DatabaseDescriptor.getDiskOptimizationEstimatePercentile()));
         // Note that creating the `CompressionMetadata` below does not read from disk: the compression metadata is

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.io.sstable.format.big;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -49,6 +50,8 @@ import org.apache.cassandra.io.sstable.format.SSTableReaderBuilder;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
 import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.DataPosition;
 import org.apache.cassandra.io.util.File;
@@ -193,8 +196,9 @@ public class BigTableWriter extends SortedTableWriter
         if (boundary == null)
             return false;
 
-        StatsMetadata stats = statsMetadata();
-        CompactionMetadata compactionMetadata = compactionMetadata();
+        Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+        StatsMetadata stats = (StatsMetadata) finalMetadata.get(MetadataType.STATS);
+        CompactionMetadata compactionMetadata = (CompactionMetadata) finalMetadata.get(MetadataType.COMPACTION);
         assert boundary.indexLength > 0 && boundary.dataLength > 0;
         // open the reader early
         IndexSummary indexSummary = iwriter.summary.build(metadata().partitioner, boundary);

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -70,6 +71,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReadsListener.SkippingReaso
 import org.apache.cassandra.io.sstable.format.ScrubPartitionIterator;
 import org.apache.cassandra.io.sstable.format.big.BigTableRowIndexEntry;
 import org.apache.cassandra.io.sstable.format.trieindex.PartitionIndex.IndexPosIterator;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
@@ -116,9 +118,10 @@ public class TrieIndexSSTableReader extends SSTableReader
     @VisibleForTesting
     public static final double fpChanceTolerance = Double.parseDouble(System.getProperty(Config.PROPERTY_PREFIX + "bloom_filter_fp_chance_tolerance", "0.000001"));
 
-    TrieIndexSSTableReader(Descriptor desc, Set<Component> components, TableMetadataRef metadata, Long maxDataAge, StatsMetadata sstableMetadata, OpenReason openReason, SerializationHeader header, FileHandle dfile, FileHandle rowIndexFile, PartitionIndex partitionIndex, IFilter bf)
+    TrieIndexSSTableReader(Descriptor desc, Set<Component> components, TableMetadataRef metadata, Long maxDataAge, StatsMetadata sstableMetadata, Optional<CompactionMetadata> compactionMetadata,
+                           OpenReason openReason, SerializationHeader header, FileHandle dfile, FileHandle rowIndexFile, PartitionIndex partitionIndex, IFilter bf)
     {
-        super(desc, components, metadata, maxDataAge, sstableMetadata, openReason, header, null, dfile, null, bf);
+        super(desc, components, metadata, maxDataAge, sstableMetadata, compactionMetadata, openReason, header, null, dfile, null, bf);
         this.rowIndexFile = rowIndexFile;
         this.partitionIndex = partitionIndex;
     }
@@ -138,6 +141,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                                   metadata,
                                                                   maxDataAge,
                                                                   sstableMetadata,
+                                                                  compactionMetadata,
                                                                   openReason,
                                                                   header,
                                                                   dfile.sharedCopy(),
@@ -164,6 +168,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                IFilter bf,
                                                long maxDataAge,
                                                StatsMetadata sstableMetadata,
+                                               Optional<CompactionMetadata> compactionMetadata,
                                                OpenReason openReason,
                                                SerializationHeader header)
     {
@@ -171,7 +176,7 @@ public class TrieIndexSSTableReader extends SSTableReader
 
         // Make sure the SSTableReader internalOpen part does the same.
         assert desc.getFormat() == TrieIndexFormat.instance;
-        TrieIndexSSTableReader reader = new TrieIndexSSTableReader(desc, components, metadata, maxDataAge, sstableMetadata, openReason, header, dfile, rowIndexFile, partitionIndex, bf);
+        TrieIndexSSTableReader reader = new TrieIndexSSTableReader(desc, components, metadata, maxDataAge, sstableMetadata, compactionMetadata, openReason, header, dfile, rowIndexFile, partitionIndex, bf);
         reader.first = partitionIndex.firstKey();
         reader.last = partitionIndex.lastKey();
 
@@ -185,6 +190,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                IFilter bf,
                                                long maxDataAge,
                                                StatsMetadata sstableMetadata,
+                                               Optional<CompactionMetadata> compactionMetadata,
                                                OpenReason openReason,
                                                SerializationHeader header)
     {
@@ -192,7 +198,7 @@ public class TrieIndexSSTableReader extends SSTableReader
 
         // Make sure the SSTableReader internalOpen part does the same.
         assert desc.getFormat() == TrieIndexFormat.instance;
-        return new TrieIndexSSTableReader(desc, components, metadata, maxDataAge, sstableMetadata, openReason, header, dfile, null, null, bf);
+        return new TrieIndexSSTableReader(desc, components, metadata, maxDataAge, sstableMetadata, compactionMetadata, openReason, header, dfile, null, null, bf);
     }
 
     @Override
@@ -958,6 +964,7 @@ public class TrieIndexSSTableReader extends SSTableReader
 
         ValidationMetadata validationMetadata = (ValidationMetadata) sstableMetadata.get(MetadataType.VALIDATION);
         StatsMetadata statsMetadata = (StatsMetadata) sstableMetadata.get(MetadataType.STATS);
+        CompactionMetadata compactionMetadata = (CompactionMetadata) sstableMetadata.get(MetadataType.COMPACTION);
         SerializationHeader.Component header = (SerializationHeader.Component) sstableMetadata.get(MetadataType.HEADER);
 
         // Check if sstable is created using same partitioner.
@@ -1006,6 +1013,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                                   bloomFilter,
                                                                   System.currentTimeMillis(),
                                                                   statsMetadata,
+                                                                  Optional.ofNullable(compactionMetadata),
                                                                   OpenReason.NORMAL,
                                                                   header.toHeader(descriptor.toString(), metadata.get(), descriptor.version, isOffline));
                 }
@@ -1019,6 +1027,7 @@ public class TrieIndexSSTableReader extends SSTableReader
                                                               bloomFilter,
                                                               System.currentTimeMillis(),
                                                               statsMetadata,
+                                                              Optional.ofNullable(compactionMetadata),
                                                               OpenReason.NORMAL,
                                                               header.toHeader(descriptor.toString(), metadata.get(), descriptor.version, isOffline));
             }

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -951,7 +951,7 @@ public class TrieIndexSSTableReader extends SSTableReader
 
         checkRequiredComponents(descriptor, components, validate);
 
-        EnumSet<MetadataType> types = EnumSet.of(MetadataType.VALIDATION, MetadataType.STATS, MetadataType.HEADER);
+        EnumSet<MetadataType> types = EnumSet.of(MetadataType.VALIDATION, MetadataType.STATS, MetadataType.HEADER, MetadataType.COMPACTION);
         Map<MetadataType, MetadataComponent> sstableMetadata;
         try
         {

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
@@ -23,6 +23,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -55,6 +56,8 @@ import org.apache.cassandra.io.sstable.format.SSTableReaderBuilder;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
 import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.BufferedDataOutputStreamPlus;
 import org.apache.cassandra.io.util.DataOutputStreamPlus;
@@ -193,8 +196,9 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
 
         return iwriter.buildPartial(dataLength, partitionIndex ->
         {
-            StatsMetadata stats = statsMetadata();
-            CompactionMetadata compactionMetadata = compactionMetadata();
+            Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+            StatsMetadata stats = (StatsMetadata) finalMetadata.get(MetadataType.STATS);
+            CompactionMetadata compactionMetadata = (CompactionMetadata) finalMetadata.get(MetadataType.COMPACTION);
 
             FileHandle ifile = iwriter.rowIndexFHBuilder.withLength(iwriter.rowIndexFile.getLastFlushOffset()).complete();
             // With trie indices it is no longer necessary to limit the file size; just make sure indices and data

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -69,7 +69,7 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     public ForwardingSSTableReader(SSTableReader delegate)
     {
         super(delegate.descriptor, SSTable.componentsFor(delegate.descriptor),
-              TableMetadataRef.forOfflineTools(delegate.metadata()), delegate.maxDataAge, delegate.getSSTableMetadata(),
+              TableMetadataRef.forOfflineTools(delegate.metadata()), delegate.maxDataAge, delegate.getSSTableMetadata(), delegate.getCompactionMetadataNoLoad(),
               delegate.openReason, delegate.header, delegate.indexSummary, delegate.dfile, delegate.ifile, delegate.bf);
         this.delegate = delegate;
         this.first = delegate.first;

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -69,7 +69,7 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     public ForwardingSSTableReader(SSTableReader delegate)
     {
         super(delegate.descriptor, SSTable.componentsFor(delegate.descriptor),
-              TableMetadataRef.forOfflineTools(delegate.metadata()), delegate.maxDataAge, delegate.getSSTableMetadata(), delegate.getCompactionMetadataNoLoad(),
+              TableMetadataRef.forOfflineTools(delegate.metadata()), delegate.maxDataAge, delegate.getSSTableMetadata(), delegate.getCompactionMetadataUnsafe(),
               delegate.openReason, delegate.header, delegate.indexSummary, delegate.dfile, delegate.ifile, delegate.bf);
         this.delegate = delegate;
         this.first = delegate.first;

--- a/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
@@ -1346,6 +1346,7 @@ public class LogTransactionTest extends AbstractTransactionalTest
                                                           new AlwaysPresentFilter(),
                                                           1L,
                                                           metadata,
+                                                          null,
                                                           SSTableReader.OpenReason.NORMAL,
                                                           header);
         reader.first = reader.last = MockSchema.readerBounds(generation);

--- a/test/unit/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormatUtil.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexFormatUtil.java
@@ -76,6 +76,6 @@ public class TrieIndexFormatUtil
                                                         .get(MetadataType.STATS);
         return TrieIndexSSTableReader.internalOpen(desc, components, metadata, ifile, dfile,
                                                    partitionIndex.sharedCopy(), FilterFactory.AlwaysPresent,
-                                                   1, sstableMetadata, OpenReason.NORMAL, header);
+                                                   1, sstableMetadata, null, OpenReason.NORMAL, header);
     }
 }

--- a/test/unit/org/apache/cassandra/io/util/WriteAndReadTest.java
+++ b/test/unit/org/apache/cassandra/io/util/WriteAndReadTest.java
@@ -77,7 +77,7 @@ public class WriteAndReadTest
 
         protected MockSSTableReader(Descriptor desc, Set<Component> components, TableMetadataRef metadata, FileHandle dfile, FileHandle ifile)
         {
-            super(desc, components, metadata, 1000, null, OpenReason.NORMAL, null, null, dfile, ifile, null);
+            super(desc, components, metadata, 1000, null, null, OpenReason.NORMAL, null, null, dfile, ifile, null);
         }
 
         public void setup(boolean trackHotness)

--- a/test/unit/org/apache/cassandra/schema/MockSchema.java
+++ b/test/unit/org/apache/cassandra/schema/MockSchema.java
@@ -186,7 +186,7 @@ public class MockSchema
                                                               .get(MetadataType.STATS);
             SSTableReader reader = SSTableReader.internalOpen(descriptor, components, cfs.metadata,
                                                               fileHandle.sharedCopy(), fileHandle.sharedCopy(), indexSummary.sharedCopy(),
-                                                              new AlwaysPresentFilter(), 1L, metadata, SSTableReader.OpenReason.NORMAL, header);
+                                                              new AlwaysPresentFilter(), 1L, metadata, null, SSTableReader.OpenReason.NORMAL, header);
             reader.first = readerBounds(firstToken);
             reader.last = readerBounds(lastToken);
             if (!keepRef)


### PR DESCRIPTION
### What is the issue
Every time you call getApproximateKeyCount Cassandra reads from storage and deserialize CompactionMetadata, and in order to do it it also reads CompressionMetadata in case of Compression.

```
  at org.apache.cassandra.io.util.PathUtils.newFileChannel(PathUtils.java:113)
        at org.apache.cassandra.io.util.PathUtils.newReadChannel(PathUtils.java:91)
        at org.apache.cassandra.io.util.File.newReadChannel(File.java:597)
        at org.apache.cassandra.io.util.FileInputStreamPlus.<init>(FileInputStreamPlus.java:39)
        at org.apache.cassandra.io.util.File.newInputStream(File.java:634)
        at org.apache.cassandra.io.compress.CompressionMetadata.<init>(CompressionMetadata.java:170)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:138)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:130)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:115)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.getEncryptor(MetadataSerializer.java:345)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:216)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:162)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:170)
        at org.apache.cassandra.io.sstable.format.SSTableReader.getApproximateKeyCount(SSTableReader.java:347)
```


### What does this PR fix and why was it fixed
CompactionMetadata is immutable, we can cache it instead of reading and deserializing from storage every time-

TODO: there are cases in the code in which it seems that CompactionMetadata may not be present, these are all to check

