### PR TITLE
HCD-180: Cherrypick HCD-179 and HCD-178 into HCD-1.2.3

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -589,7 +589,7 @@
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.15"/>
           <dependency groupId="commons-io" artifactId="commons-io" version="2.6" scope="test"/>
-          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.11"/>
+          <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.18.0"/>
           <dependency groupId="org.apache.commons" artifactId="commons-math3" version="3.2"/>
           <dependency groupId="org.antlr" artifactId="antlr" version="3.5.2" scope="provided">
             <exclusion groupId="org.antlr" artifactId="stringtemplate"/>


### PR DESCRIPTION
The rationale is to remediate CVE-2025-48924.
The version before the upgrade was 3.11.