### PR TITLE
CNDB-14577: Compact all SSTables of a level shard if their number rea…

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -998,7 +998,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
             for (Level level : entry.getValue())
             {
-                Collection<CompactionAggregate.UnifiedAggregate> aggregates = level.getCompactionAggregates(arena, controller, spaceAvailable);
+                Collection<CompactionAggregate.UnifiedAggregate> aggregates = level.getCompactionAggregates(arena, controller, getShardManager(), spaceAvailable);
                 // Note: We allow empty aggregates into the list of pending compactions. The pending compactions list
                 // is for progress tracking only, and it is helpful to see empty levels there.
                 pending.addAll(aggregates);
@@ -1507,14 +1507,96 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                 logger.trace("Level: {}", this);
         }
 
+        private List<CompactionAggregate.UnifiedAggregate> getOversizeShardsAggregates(Arena arena,
+                                                                               Controller controller,
+                                                                               ShardManager shardManager)
+        {
+            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
+            double shardThreshold = fanout * controller.getMaxSstablesPerShardFactor();
+            if (sstables.size() > shardThreshold)
+            {
+                List<Set<CompactionSSTable>> groups = shardManager.splitSSTablesInShards(sstables,
+                                                                                         controller.getNumShards(max),
+                                                                                         (sstableShard, shardRange) -> Sets.newHashSet(sstableShard));
+
+                Set<CompactionSSTable> sstablesInOversizeGroup = new HashSet<>();
+                for (Set<CompactionSSTable> ssTables : groups)
+                {
+                    if (ssTables.size() > shardThreshold)
+                    {
+                        sstablesInOversizeGroup.addAll(ssTables);
+                    }
+                }
+
+                if (!sstablesInOversizeGroup.isEmpty())
+                {
+                    // Now combine the groups that share an sstable so that we have valid independent transactions.
+                    // Only keep the groups that were combined with an oversize group.
+                    groups = Overlaps.combineSetsWithCommonElement(groups);
+                    List<CompactionSSTable> unbucketed =  new ArrayList<>();
+
+                    for (Set<CompactionSSTable> group : groups)
+                    {
+                        boolean inOverSizeGroup = false;
+                        for (CompactionSSTable sstable : group)
+                        {
+                            if (sstablesInOversizeGroup.contains(sstable))
+                            {
+                                inOverSizeGroup = true;
+                                break;
+                            }
+                        }
+                        if (inOverSizeGroup)
+                        {
+                            aggregates.add(
+                            CompactionAggregate.createUnified(group,
+                                                              Overlaps.maxOverlap(group,
+                                                                                  CompactionSSTable.startsAfter,
+                                                                                  CompactionSSTable.firstKeyComparator,
+                                                                                  CompactionSSTable.lastKeyComparator),
+                                                              createPick(controller, nextTimeUUID(), index, group),
+                                                              Collections.emptyList(),
+                                                              arena,
+                                                              this)
+                            );
+                        }
+                        else
+                        {
+                            unbucketed.addAll(group);
+                        }
+                    }
+                    // Add all unbucketed sstables separately. Note that this will list the level (with its set of sstables)
+                    // even if it does not need compaction.
+                    if (!unbucketed.isEmpty())
+                        aggregates.add(CompactionAggregate.createUnified(unbucketed,
+                                                                         maxOverlap,
+                                                                         CompactionPick.EMPTY,
+                                                                         Collections.emptySet(),
+                                                                         arena,
+                                                                         this));
+                    return aggregates;
+                }
+            }
+            return aggregates;
+        }
+
         /// Return the compaction aggregate
         Collection<CompactionAggregate.UnifiedAggregate> getCompactionAggregates(Arena arena,
                                                                                  Controller controller,
+                                                                                 ShardManager shardManager,
                                                                                  long spaceAvailable)
         {
             if (logger.isTraceEnabled())
                 logger.trace("Creating compaction aggregate with sstable set {}", sstables);
 
+            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
+
+            if (sstables.isEmpty())
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("No sstables in level {} of arena {}, skipping compaction", this, arena);
+                return aggregates;
+            }
 
             // Note that adjacent overlap sets may include deduplicated sstable
             List<Set<CompactionSSTable>> overlaps = Overlaps.constructOverlapSets(sstables,
@@ -1531,9 +1613,19 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                       this::makeBucket,
                                                                       unbucketed::addAll);
 
-            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
-            for (Bucket bucket : buckets)
-                aggregates.add(bucket.constructAggregate(controller, spaceAvailable, arena));
+            if (!buckets.isEmpty())
+            {
+                for (Bucket bucket : buckets)
+                    aggregates.add(bucket.constructAggregate(controller, spaceAvailable, arena));
+            }
+            else
+            {
+                // CNDB-14577: If there are no overlaps, we look if some shards have too many SSTables.
+                // If that's the case, we perform a major compaction on those shards.
+                List<CompactionAggregate.UnifiedAggregate> oversizeShardsAggregates = getOversizeShardsAggregates(arena, controller, shardManager);
+                if (!oversizeShardsAggregates.isEmpty())
+                    return oversizeShardsAggregates;
+            }
 
             // Add all unbucketed sstables separately. Note that this will list the level (with its set of sstables)
             // even if it does not need compaction.

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -123,6 +123,7 @@ public class AdaptiveController extends Controller
                               Overlaps.InclusionMethod overlapInclusionMethod,
                               boolean parallelizeOutputShards,
                               boolean hasVectorType,
+                              double maxSstablesPerShardFactor,
                               int intervalSec,
                               int minScalingParameter,
                               int maxScalingParameter,
@@ -151,7 +152,8 @@ public class AdaptiveController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              maxSstablesPerShardFactor);
 
         this.scalingParameters = scalingParameters;
         this.previousScalingParameters = previousScalingParameters;
@@ -183,6 +185,7 @@ public class AdaptiveController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options)
@@ -292,6 +295,7 @@ public class AdaptiveController extends Controller
                                       overlapInclusionMethod,
                                       parallelizeOutputShards,
                                       hasVectorType,
+                                      maxSstablesPerShardFactor,
                                       intervalSec,
                                       minScalingParameter,
                                       maxScalingParameter,

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -72,6 +72,7 @@ public class StaticController extends Controller
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
                             boolean hasVectorType,
+                            double maxSstablesPerShardFactor,
                             String keyspaceName,
                             String tableName)
     {
@@ -94,7 +95,8 @@ public class StaticController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              maxSstablesPerShardFactor);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
         this.tableName = tableName;
@@ -118,6 +120,7 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options,
@@ -181,6 +184,7 @@ public class StaticController extends Controller
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
                                     hasVectorType,
+                                    maxSstablesPerShardFactor,
                                     keyspaceName,
                                     tableName);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -222,6 +222,9 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
     @Option(name= {"-overlap-inclusion-method"}, description = "Overlap inclusion method, NONE, SINGLE or TRANSITIVE")
     Overlaps.InclusionMethod overlapInclusionMethod = Overlaps.InclusionMethod.TRANSITIVE;
 
+    @Option(name= {"-max-sstables-per-shard-factor"}, description = "Factor used to determine the maximum number of sstables per level shard")
+    double maxSstablesPerShardFactor = 10;
+
     @BeforeClass
     public static void setUpClass()
     {
@@ -411,6 +414,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          overlapInclusionMethod,
                                                          true,
                                                          false,
+                                                         maxSstablesPerShardFactor,
                                                          updateTimeSec,
                                                          minW,
                                                          maxW,
@@ -439,6 +443,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        overlapInclusionMethod,
                                                        true,
                                                        false,
+                                                       maxSstablesPerShardFactor,
                                                        "ks",
                                                        "tbl");
 

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -204,6 +204,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         long minimalSizeBytes = m << 20;
 
         Controller controller = Mockito.mock(Controller.class);
+        ShardManager shardManager = Mockito.mock(ShardManager.class);
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getNumShards(anyDouble())).thenReturn(1);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
@@ -264,7 +265,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertEquals(i, level.getIndex());
 
                 Collection<CompactionAggregate.UnifiedAggregate> compactionAggregates =
-                level.getCompactionAggregates(entry.getKey(), controller, dataSetSizeBytes);
+                level.getCompactionAggregates(entry.getKey(), controller, shardManager, dataSetSizeBytes);
 
                 long selectedCount = compactionAggregates.stream()
                                                          .filter(a -> !a.isEmpty())
@@ -322,8 +323,9 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         long minimalSizeBytes = m << 20;
 
         Controller controller = Mockito.mock(Controller.class);
+        ShardManager shardManager = Mockito.mock(ShardManager.class);
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
-        when(controller.getNumShards(anyDouble())).thenReturn(1);
+        when(controller.getNumShards(anyDouble())).thenReturn(16);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
@@ -378,7 +380,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertEquals(i, level.getIndex());
 
                 Collection<CompactionAggregate.UnifiedAggregate> compactionAggregates =
-                    level.getCompactionAggregates(entry.getKey(), controller, dataSetSizeBytes);
+                    level.getCompactionAggregates(entry.getKey(), controller, shardManager, dataSetSizeBytes);
 
                 Set<CompactionSSTable> selectedSSTables = new HashSet<>();
                 for (CompactionAggregate.UnifiedAggregate aggregate : compactionAggregates)
@@ -747,6 +749,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(10.0);
         when(controller.getMaxSpaceOverhead()).thenReturn(maxSpaceOverhead);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSstableSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(maxCount);
@@ -1343,6 +1346,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(10.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
@@ -1971,6 +1975,48 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         testBucketSelection(repeats(4, arr(6, 3)), arr(6, 6), Overlaps.InclusionMethod.TRANSITIVE, 4, 2, 3);
     }
 
+    // We use a level with only non-overlapping SSTables, so there won't be any standard bucketing compaction.
+    // The per-shard threshold is fanout(3) * maxSstablesPerShardFactor(10) = 30.
+    // We use a number of SSTables per shard just superior to the per-shard threshold.
+    // We use a total number of SSTables just superior to numShards * sstablesPerShard so the SSTables are not aligned
+    // with the shard boundaries. This means that all shards will have an SSTable in common with the next shard.
+    // We drop the SSTables that cross the boundaries between the first and second shard, and between the second and
+    // third shard.
+    // In the end, we get 3 groups of shards with SSTables in common:
+    // - a group with the first shard which has perShardThreshold + 1 SSTables, so will get compacted.
+    // - a group with the second shard which has perShardThreshold SSTables, so will not get compacted.
+    // - a group with the rest of the shards, one of those shards having perShardThreshold + 1 SSTables, so will get compacted.
+    @Test
+    public void testBucketSelectionNonOverlapping()
+    {
+        int numShards = 16;
+        double maxSstablesPerShardFactor = 10.0;
+        int perShardThreshold = (int) (3 * maxSstablesPerShardFactor);
+        int sstablesPerShard = perShardThreshold + 1;
+        testBucketSelection(arr(numShards * sstablesPerShard + 1),
+                            arr(sstablesPerShard, sstablesPerShard * (numShards - 2)),
+                            Overlaps.InclusionMethod.TRANSITIVE,
+                            numShards,
+                            maxSstablesPerShardFactor,
+                            perShardThreshold,
+                            sstablesPerShard, sstablesPerShard * 2);
+    }
+
+    // Same as testBucketSelectionNonOverlapping, but with an infinite maxSstablesPerShardFactor
+    // to deactivate compaction of oversize shards.
+    @Test
+    public void testBucketSelectionNonOverlappingInfiniteFactor()
+    {
+        int numShards = 16;
+        int sstablesPerShard = (3 * 10) + 1;
+        testBucketSelection(arr(numShards * sstablesPerShard + 1),
+                            arr(),
+                            Overlaps.InclusionMethod.TRANSITIVE,
+                            numShards,
+                            Double.POSITIVE_INFINITY,
+                            numShards * sstablesPerShard - 1,
+                            sstablesPerShard, sstablesPerShard * 2);
+    }
 
     private int[] arr(int... values)
     {
@@ -2007,6 +2053,11 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     public void testBucketSelection(int[] counts, int[] expecteds, Overlaps.InclusionMethod overlapInclusionMethod, int expectedRemaining, int... dropFromFirst)
     {
+        testBucketSelection(counts, expecteds, overlapInclusionMethod, 16, 10.0, expectedRemaining, dropFromFirst);
+    }
+
+    public void testBucketSelection(int[] counts, int[] expecteds, Overlaps.InclusionMethod overlapInclusionMethod, int numShards, double maxSstablesPerShardFactor, int expectedRemaining, int... dropFromFirst)
+    {
         Set<SSTableReader> allSSTables = new HashSet<>();
         int fanout = counts.length;
         for (int i = 0; i < fanout; ++i)
@@ -2025,6 +2076,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getFanout(anyInt())).thenCallRealMethod();
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
+        when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(maxSstablesPerShardFactor);
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) (90 << 20));
         when(controller.overlapInclusionMethod()).thenReturn(overlapInclusionMethod);
@@ -2082,7 +2135,6 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
             assertEquals(1.3333, pick.overheadToDataRatio(), 0.0001);
         }
 
-        Mockito.when(controller.getNumShards(anyDouble())).thenReturn(16);  // co-prime with counts to ensure multiple sstables fall in each shard
         // Make sure getMaxOverlapsMap does not fail.
         System.out.println(strategy.getMaxOverlapsMap());
 

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -87,6 +87,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                       true,
                                       false,
+                                      Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                       interval,
                                       minW,
                                       maxW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -619,6 +619,30 @@ public abstract class ControllerTest
         testBooleanOption(Controller.PARALLELIZE_OUTPUT_SHARDS_OPTION, Controller.DEFAULT_PARALLELIZE_OUTPUT_SHARDS, Controller::parallelizeOutputShards);
     }
 
+    @Test
+    public void testMaxSstablesPerShardFactor()
+    {
+        HashMap<String, String> options = new HashMap<>();
+        Controller controller = Controller.fromOptions(cfs, options);
+        assertEquals(Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "123.456");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(123.456, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "1e1000");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(Double.POSITIVE_INFINITY, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "0.9");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "invalid");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+    }
+
     public void testBooleanOption(String name, boolean defaultValue, Predicate<Controller> getter, String... extraSettings)
     {
         Controller controller = Controller.fromOptions(cfs, newOptions(extraSettings));

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -214,6 +214,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testStartShutdown(controller);
@@ -242,6 +243,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testShutdownNotStarted(controller);
@@ -270,6 +272,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testStartAlreadyStarted(controller);


### PR DESCRIPTION
…ches a limit (#1873)

CNDB-14577: [UCS by default does not compact many small non-overlapping sstables with very few
rows](https://github.com/riptano/cndb/issues/14577)

This PR limits the number of SSTables for a given compaction level shard by executing a major compaction of the shard instead of the regular compaction of overlapping SSTables if the number of SSTables reaches a threshold.

The threshold is controlled by the `max_sstables_per_shard_factor` setting:
```md
  `max_sstables_per_shard_factor` Limits the number of SSTables per shard. If the number of sstables in a shard
  exceeds this factor times the shard compaction threshold, a major compaction of the shard will be triggered.
  Some conditions like slow writes can lead to SSTables being very small, and never overlap with enough other SSTables
  to be compacted.
  So this setting is useful to prevent the number of SSTables in a shard from growing too large, which can cause
  problems due to the per-sstable overhead. Also these small SSTables may still have overlaps even if under the
  compaction threshold (eg. due to write replicas) and never compacting them wastes storage space.
  The default value is 10.
```

---------

### What is the issue
...

### What does this PR fix and why was it fixed
...
