### PR TITLE
CNDB-14983: Fix MetadataSerializerTest#testSerializationWithEncryption under bigtable test profile.

### DIFF
--- a/test/unit/org/apache/cassandra/io/sstable/metadata/MetadataSerializerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/metadata/MetadataSerializerTest.java
@@ -155,7 +155,7 @@ public class MetadataSerializerTest
         MetadataSerializer serializer = new MetadataSerializer();
         File statsFile = serialize(originalMetadata, serializer, SSTableFormat.Type.current().info.getLatestVersion(), true);
 
-        Descriptor desc = new Descriptor(statsFile.parent(), "", "", new SequenceBasedSSTableId(0), SSTableFormat.Type.BTI);
+        Descriptor desc = new Descriptor(statsFile.parent(), "", "", new SequenceBasedSSTableId(0), SSTableFormat.Type.current());
         try (RandomAccessReader in = RandomAccessReader.open(statsFile))
         {
             Map<MetadataType, MetadataComponent> deserialized = serializer.deserialize(desc, in, EnumSet.allOf(MetadataType.class));


### PR DESCRIPTION
### What is the issue
The test serializes with the current SSTableFormat Type but hardcoded the type to BTI on the descriptor. Test failure can be reproduced by `ant test-bigtable -Dtest.name=MetadataSerializerTest`

### What does this PR fix and why was it fixed
Now, the descriptor is also initialized with the current type.