### PR TITLE
CC5 fix CNDB-9443 to allow scheduled executors to be created with a specified number of threads instead of only single threaded.

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/ExecutorFactory.java
+++ b/src/java/org/apache/cassandra/concurrent/ExecutorFactory.java
@@ -115,10 +115,32 @@ public interface ExecutorFactory extends ExecutorBuilderFactory.Jmxable<Executor
      * @param executeOnShutdown if false, waiting tasks will be cancelled on shutdown
      * @param name the name of the executor, the executor's thread group, and of any worker threads
      * @param priority the thread priority of workers
+     * @param threads the number of threads in the pool
+     * @return a {@link ScheduledExecutorPlus}
+     */
+    default ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, int threads) { return scheduled(executeOnShutdown, name, priority, NORMAL, threads); }
+
+    /**
+     * @param executeOnShutdown if false, waiting tasks will be cancelled on shutdown
+     * @param name the name of the executor, the executor's thread group, and of any worker threads
+     * @param priority the thread priority of workers
      * @param simulatorSemantics indicate special semantics for the executor under simulation
      * @return a {@link ScheduledExecutorPlus}
      */
-    ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics);
+    default ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics)
+    {
+        return scheduled(executeOnShutdown, name, priority, simulatorSemantics, 1);
+    }
+
+    /**
+     * @param executeOnShutdown if false, waiting tasks will be cancelled on shutdown
+     * @param name the name of the executor, the executor's thread group, and of any worker threads
+     * @param priority the thread priority of workers
+     * @param simulatorSemantics indicate special semantics for the executor under simulation
+     * @param threads the number of threads in the pool
+     * @return a {@link ScheduledExecutorPlus}
+     */
+    ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics, int threads);
 
     /**
      * Create and start a new thread to execute {@code runnable}
@@ -282,9 +304,9 @@ public interface ExecutorFactory extends ExecutorBuilderFactory.Jmxable<Executor
         }
 
         @Override
-        public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics)
+        public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics, int threads)
         {
-            ScheduledThreadPoolExecutorPlus executor = new ScheduledThreadPoolExecutorPlus(newThreadFactory(name, priority));
+            ScheduledThreadPoolExecutorPlus executor = new ScheduledThreadPoolExecutorPlus(threads, newThreadFactory(name, priority));
             if (!executeOnShutdown)
                 executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
             return executor;

--- a/src/java/org/apache/cassandra/concurrent/ScheduledThreadPoolExecutorPlus.java
+++ b/src/java/org/apache/cassandra/concurrent/ScheduledThreadPoolExecutorPlus.java
@@ -69,9 +69,9 @@ public class ScheduledThreadPoolExecutorPlus extends ScheduledThreadPoolExecutor
         }
     };
 
-    ScheduledThreadPoolExecutorPlus(NamedThreadFactory threadFactory)
+    ScheduledThreadPoolExecutorPlus(int corePoolSize, NamedThreadFactory threadFactory)
     {
-        super(1, threadFactory);
+        super(corePoolSize, threadFactory);
         setRejectedExecutionHandler(rejectedExecutionHandler);
     }
 

--- a/test/simulator/main/org/apache/cassandra/simulator/systems/InterceptingExecutorFactory.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/systems/InterceptingExecutorFactory.java
@@ -307,7 +307,7 @@ public class InterceptingExecutorFactory implements ExecutorFactory, Closeable
     }
 
     @Override
-    public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics)
+    public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics, int threads)
     {
         switch (simulatorSemantics)
         {

--- a/test/unit/org/apache/cassandra/concurrent/SimulatedExecutorFactory.java
+++ b/test/unit/org/apache/cassandra/concurrent/SimulatedExecutorFactory.java
@@ -141,7 +141,7 @@ public class SimulatedExecutorFactory implements ExecutorFactory, Clock
     }
 
     @Override
-    public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics)
+    public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics, int threads)
     {
         return new ForwardingScheduledExecutorPlus(new UnorderedScheduledExecutorService());
     }

--- a/test/unit/org/apache/cassandra/repair/FuzzTestBase.java
+++ b/test/unit/org/apache/cassandra/repair/FuzzTestBase.java
@@ -233,9 +233,9 @@ public abstract class FuzzTestBase extends CQLTester.InMemory
             }
 
             @Override
-            public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics)
+            public ScheduledExecutorPlus scheduled(boolean executeOnShutdown, String name, int priority, SimulatorSemantics simulatorSemantics, int threads)
             {
-                return delegate.scheduled(executeOnShutdown, name, priority, simulatorSemantics);
+                return delegate.scheduled(executeOnShutdown, name, priority, simulatorSemantics, threads);
             }
 
             private boolean shouldMock()


### PR DESCRIPTION
### What is the issue
Fixes CNDB-9443.

CNDB 4.0 makes use of scheduled executors with multiple threads, for example, in `RemoteStorageHandler`:
```
sharedSSTableExecutorService = new DebuggableScheduledThreadPoolExecutor(NUM_SSTABLE_THREADS, "StorageSSTableThread", Thread.NORM_PRIORITY);
```

But CC/CC 5.0 only supports single threaded scheduled executors:
```
sharedSSTableExecutorService = executorFactory().scheduled(false, "StorageSSTableThread", Thread.NORM_PRIORITY);
```

Without this fix, `RemoteStorageHandler` is not able to load sstables fast enough to satisfy tests like `RegionBootsrapTest.testBootstrap`.

### What does this PR fix and why was it fixed
This PR adds support for scheduled executors with more than one thread (pool size) as expected by CNDB.