### PR TITLE
CNDB-14577: Compact all SSTables of a level shard if their number reaches a limit (#1873)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -951,6 +951,7 @@ public enum CassandraRelevantProperties
     UCS_L0_SHARDS_ENABLED("unified_compaction.l0_shards_enabled", "true"),
     UCS_MAX_ADAPTIVE_COMPACTIONS("unified_compaction.max_adaptive_compactions", "5"),
     UCS_MAX_SPACE_OVERHEAD("unified_compaction.max_space_overhead", "0.2"),
+    UCS_MAX_SSTABLES_PER_SHARD_FACTOR("unified_compaction.max_sstables_per_shard_factor", "10"),
     UCS_MIN_SSTABLE_SIZE("unified_compaction.min_sstable_size", "100MiB"),
     UCS_NUM_SHARDS("unified_compaction.num_shards"),
     UCS_OVERLAP_INCLUSION_METHOD("unified_compaction.overlap_inclusion_method"),

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -126,6 +126,7 @@ public class AdaptiveController extends Controller
                               Overlaps.InclusionMethod overlapInclusionMethod,
                               boolean parallelizeOutputShards,
                               boolean hasVectorType,
+                              double maxSstablesPerShardFactor,
                               int intervalSec,
                               int minScalingParameter,
                               int maxScalingParameter,
@@ -154,6 +155,7 @@ public class AdaptiveController extends Controller
               overlapInclusionMethod,
               parallelizeOutputShards,
               hasVectorType,
+              maxSstablesPerShardFactor,
               metadata);
 
         this.scalingParameters = scalingParameters;
@@ -184,6 +186,7 @@ public class AdaptiveController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   TableMetadata metadata,
                                   Map<String, String> options)
     {
@@ -292,6 +295,7 @@ public class AdaptiveController extends Controller
                                       overlapInclusionMethod,
                                       parallelizeOutputShards,
                                       hasVectorType,
+                                      maxSstablesPerShardFactor,
                                       intervalSec,
                                       minScalingParameter,
                                       maxScalingParameter,

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -76,6 +76,7 @@ public class StaticController extends Controller
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
                             boolean hasVectorType,
+                            double maxSstablesPerShardFactor,
                             TableMetadata metadata)
     {
         super(MonotonicClock.Global.preciseTime,
@@ -98,6 +99,7 @@ public class StaticController extends Controller
               overlapInclusionMethod,
               parallelizeOutputShards,
               hasVectorType,
+              maxSstablesPerShardFactor,
               metadata);
         this.scalingParameters = scalingParameters;
     }
@@ -120,6 +122,7 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   TableMetadata metadata,
                                   Map<String, String> options,
                                   boolean useVectorOptions)
@@ -182,6 +185,7 @@ public class StaticController extends Controller
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
                                     hasVectorType,
+                                    maxSstablesPerShardFactor,
                                     metadata);
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -224,6 +224,9 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
     @Option(name= {"-overlap-inclusion-method"}, description = "Overlap inclusion method, NONE, SINGLE or TRANSITIVE")
     Overlaps.InclusionMethod overlapInclusionMethod = Overlaps.InclusionMethod.TRANSITIVE;
 
+    @Option(name= {"-max-sstables-per-shard-factor"}, description = "Factor used to determine the maximum number of sstables per level shard")
+    double maxSstablesPerShardFactor = 10;
+
     @BeforeClass
     public static void setUpClass()
     {
@@ -414,6 +417,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          overlapInclusionMethod,
                                                          true,
                                                          false,
+                                                         maxSstablesPerShardFactor,
                                                          updateTimeSec,
                                                          minW,
                                                          maxW,
@@ -441,6 +445,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        overlapInclusionMethod,
                                                        true,
                                                        false,
+                                                       maxSstablesPerShardFactor,
                                                        metadata);
 
         return new UnifiedCompactionStrategy(strategyFactory, controller);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -87,6 +87,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                       true,
                                       false,
+                                      Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                       interval,
                                       minW,
                                       maxW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -626,6 +626,30 @@ public abstract class ControllerTest
         testBooleanOption(Controller.PARALLELIZE_OUTPUT_SHARDS_OPTION, Controller.DEFAULT_PARALLELIZE_OUTPUT_SHARDS, Controller::parallelizeOutputShards);
     }
 
+    @Test
+    public void testMaxSstablesPerShardFactor()
+    {
+        HashMap<String, String> options = new HashMap<>();
+        Controller controller = Controller.fromOptions(cfs, options);
+        assertEquals(Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "123.456");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(123.456, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "1e1000");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(Double.POSITIVE_INFINITY, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "0.9");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "invalid");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+    }
+
     public void testBooleanOption(String name, boolean defaultValue, Predicate<Controller> getter, String... extraSettings)
     {
         Controller controller = Controller.fromOptions(cfs, newOptions(extraSettings));

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -210,6 +210,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            metadata);
         super.testStartShutdown(controller);
     }
@@ -237,6 +238,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            metadata);
         super.testShutdownNotStarted(controller);
     }
@@ -264,6 +266,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            metadata);
         super.testStartAlreadyStarted(controller);
     }


### PR DESCRIPTION
CNDB-14577: [UCS by default does not compact many small non-overlapping sstables with very few
rows](https://github.com/riptano/cndb/issues/14577)

This PR limits the number of SSTables for a given compaction level shard by executing a major compaction of the shard instead of the regular compaction of overlapping SSTables if the number of SSTables reaches a threshold.

The threshold is controlled by the `max_sstables_per_shard_factor` setting:
```md
  `max_sstables_per_shard_factor` Limits the number of SSTables per shard. If the number of sstables in a shard
  exceeds this factor times the shard compaction threshold, a major compaction of the shard will be triggered.
  Some conditions like slow writes can lead to SSTables being very small, and never overlap with enough other SSTables
  to be compacted.
  So this setting is useful to prevent the number of SSTables in a shard from growing too large, which can cause
  problems due to the per-sstable overhead. Also these small SSTables may still have overlaps even if under the
  compaction threshold (eg. due to write replicas) and never compacting them wastes storage space.
  The default value is 10.
```
