### PR TITLE
CNDB-15086: Do not use LimitingRebufferer when limit is actually disabled

### DIFF
--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -217,7 +217,7 @@ public class FileHandle extends SharedCloseableImpl
                                 ? PrefetchingRebufferer.withPrefetching(rebuffererFactory)
                                 : rebuffererFactory.instantiateRebufferer();
 
-        if (limiter != null)
+        if (limiter != null && limiter.getRate() != Double.MAX_VALUE)
             rebufferer = new LimitingRebufferer(rebufferer, limiter, DiskOptimizationStrategy.MAX_BUFFER_SIZE);
         return rebufferer;
     }

--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -217,7 +217,7 @@ public class FileHandle extends SharedCloseableImpl
                                 ? PrefetchingRebufferer.withPrefetching(rebuffererFactory)
                                 : rebuffererFactory.instantiateRebufferer();
 
-        if (limiter != null && limiter.getRate() != Double.MAX_VALUE)
+        if (limiter != null && limiter.getRate() < Double.MAX_VALUE)
             rebufferer = new LimitingRebufferer(rebufferer, limiter, DiskOptimizationStrategy.MAX_BUFFER_SIZE);
         return rebufferer;
     }


### PR DESCRIPTION
### What is the issue
There is no need to create the LimitingRebufferer if rate limiting is actually disabled.

<img width="3588" height="2014" alt="image" src="https://github.com/user-attachments/assets/b5c6ad74-58da-4759-9c69-3a61c50bf846" />


### What does this PR fix and why was it fixed
Do not create the LimitingRebufferer when not needed.

Note: the compaction rate is supposed to be modifiable at runtime. This change allows to do so. Because the change applies only to the case we open a Rebufferer, for a FileHandle that is a short lived object.
