### PR TITLE
HCD-178: Upgrade commons-lang3 from 3.11 to 3.18.0 (#1919)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -359,7 +359,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.13.0</version>
+        <version>3.18.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The rationale is to remediate CVE-2025-48924.
The version before the upgrade was 3.11.

CNDB PR: https://github.com/riptano/cndb/pull/14956

