### PR TITLE
CNDB-14691 add DoD link to CNDB repo (#1857)

### DIFF
--- a/.github/workflows/pr_checklist.md
+++ b/.github/workflows/pr_checklist.md
@@ -1,4 +1,5 @@
 ### Checklist before you submit for review
+- [ ] This PR adheres to [the Definition of Done](https://github.com/riptano/cndb/blob/main/DEFINITION_OF_DONE.md)
 - [ ] Make sure there is a PR in the CNDB project updating the Converged Cassandra version
 - [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
 - [ ] Verify test results on Butler


### PR DESCRIPTION
Port CNDB-14691 0ae1c79446 to main-5.0

commit 0ae1c794468a2bdc619919c831f044dce1f8374a
Author: Jaroslaw Grabowski [jaroslaw.grabowski@datastax.com](mailto:jaroslaw.grabowski@datastax.com)
Date: Tue Jul 29 17:01:54 2025 +0200

CNDB-14691 add DoD link to CNDB repo (#1857)
